### PR TITLE
Make the settings shell own tab state

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -112,7 +112,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/settings_speed_source_transport.ts` | Speed-source settings transport wrapper over the UI-local settings and OBD APIs |
 | `app/features/settings_speed_source_workflow.ts` | DOM-free speed-source workflow/controller for draft state, validation, save/load orchestration, and background OBD rescans |
 | `app/views/analysis_panel.tsx` | Preact owner for the analysis-settings shell that mounts the full tab surface and exposes the typed bridge consumed by analysis and car-selection modules |
-| `app/views/settings_shell.tsx` | Preact owner for the shared settings tab chrome and tab-panel wrappers that mount the per-tab panel hosts and expose the settings navigation bridge |
+| `app/views/settings_shell.tsx` | Preact owner for the shared settings tab chrome and tab-panel wrappers that mount the per-tab panel hosts, keep tab selection in signal-backed shell state, and expose typed settings navigation APIs |
 | `app/views/esp_flash_panel.tsx` | Preact owner for the ESP flash settings shell, typed flash actions, and log-autoscroll lifecycle alongside the render bridge for port selection, readiness, journey, history, and logs |
 | `app/views/internet_panel.tsx` | Preact owner for the full internet settings surface that renders USB status, transport choices, Wi-Fi credentials, and readiness guidance through a typed bridge |
 | `app/views/update_panel.tsx` | Preact owner for the full update settings surface that renders the action row plus current status, health, journey, issues, latest attempt, and log cards through a typed bridge |

--- a/apps/ui/src/app/views/settings_shell.tsx
+++ b/apps/ui/src/app/views/settings_shell.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "preact";
 
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
 import { useUiTranslation } from "../ui_i18n";
+import { effect, type ReadonlySignal, signal } from "../ui_signals";
 import type { ViewDisposer } from "./dom_event_bindings";
 
 const SETTINGS_TABS = [
@@ -51,18 +52,13 @@ const SETTINGS_TABS = [
 
 type SettingsShellTabId = (typeof SETTINGS_TABS)[number]["id"];
 
-export interface SettingsShellDom {
-  settingsTabs: HTMLButtonElement[];
-}
-
 export interface SettingsShellView {
-  readonly dom: SettingsShellDom;
   activateTab(tabId: string): void;
   subscribeActiveTabChanges(listener: (tabId: string) => void): ViewDisposer;
 }
 
 type SettingsShellProps = {
-  activeTabId: SettingsShellTabId;
+  activeTabId: ReadonlySignal<SettingsShellTabId>;
   onActivateTab(tabId: SettingsShellTabId): void;
 };
 
@@ -87,7 +83,8 @@ function focusSettingsTab(
 }
 
 function SettingsShell(props: SettingsShellProps) {
-  const { activeTabId, onActivateTab } = props;
+  const activeTabId = props.activeTabId.value;
+  const { onActivateTab } = props;
   const t = useUiTranslation();
 
   function handleTabKeyDown(
@@ -170,59 +167,27 @@ function SettingsShell(props: SettingsShellProps) {
   );
 }
 
-function requireInHostAll<T extends HTMLElement>(
-  host: HTMLElement,
-  selector: string,
-): T[] {
-  const elements = Array.from(host.querySelectorAll<T>(selector));
-  if (elements.length === 0) {
-    throw new Error(`Settings shell requires ${selector}`);
-  }
-  return elements;
-}
-
-function createSettingsShellDom(host: HTMLElement): SettingsShellDom {
-  return {
-    settingsTabs: requireInHostAll<HTMLButtonElement>(host, ".settings-tab"),
-  };
-}
-
 export function mountSettingsShell(host: HTMLElement): SettingsShellView {
   const mount = createUiPreactMount(host);
-  let activeTabId: SettingsShellTabId = "carTab";
-  const activeTabListeners = new Set<(tabId: string) => void>();
-
-  function notifyActiveTabListeners(): void {
-    for (const listener of activeTabListeners) {
-      listener(activeTabId);
-    }
-  }
+  const activeTabId = signal<SettingsShellTabId>("carTab");
 
   function setActiveTab(tabId: SettingsShellTabId): void {
-    if (tabId === activeTabId) {
+    if (tabId === activeTabId.value) {
       return;
     }
-    activeTabId = tabId;
-    render();
-    notifyActiveTabListeners();
+    activeTabId.value = tabId;
   }
 
-  function render(): void {
-    mount.render(
-      <SettingsShell
-        activeTabId={activeTabId}
-        onActivateTab={(tabId) => {
-          setActiveTab(tabId);
-        }}
-      />,
-    );
-  }
-
-  render();
-  const dom = createSettingsShellDom(host);
+  mount.render(
+    <SettingsShell
+      activeTabId={activeTabId}
+      onActivateTab={(tabId) => {
+        setActiveTab(tabId);
+      }}
+    />,
+  );
 
   return {
-    dom,
     activateTab(tabId: string): void {
       if (!isSettingsShellTabId(tabId)) {
         return;
@@ -230,10 +195,15 @@ export function mountSettingsShell(host: HTMLElement): SettingsShellView {
       setActiveTab(tabId);
     },
     subscribeActiveTabChanges(listener: (tabId: string) => void): ViewDisposer {
-      activeTabListeners.add(listener);
-      return () => {
-        activeTabListeners.delete(listener);
-      };
+      let initialized = false;
+      return effect(() => {
+        const nextTabId = activeTabId.value;
+        if (!initialized) {
+          initialized = true;
+          return;
+        }
+        listener(nextTabId);
+      });
     },
   };
 }

--- a/apps/ui/tests/smoke.settings-shell.spec.ts
+++ b/apps/ui/tests/smoke.settings-shell.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  createSettingsHandlerFromMap,
+  gpsStatus,
+  installCommonRoutes,
+  installFakeWebSocket,
+} from "./smoke.helpers";
+
+async function openSettings(page: Page): Promise<void> {
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "/api/settings/language": { language: "en" },
+      "/api/settings/speed-unit": { speed_unit: "kmh" },
+      "/api/settings/speed-source/status": gpsStatus({}),
+    }),
+  });
+  await installFakeWebSocket(page);
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+}
+
+test("settings shell keeps selected tabs and panels in sync on click", async ({ page }) => {
+  await openSettings(page);
+
+  const carTabButton = page.locator('[data-settings-tab="carTab"]');
+  const analysisTabButton = page.locator('[data-settings-tab="analysisTab"]');
+  const speedSourceTabButton = page.locator('[data-settings-tab="speedSourceTab"]');
+
+  await expect(carTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#carTab")).toHaveJSProperty("hidden", false);
+
+  await analysisTabButton.click();
+  await expect(analysisTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(carTabButton).toHaveAttribute("aria-selected", "false");
+  await expect(page.locator("#analysisTab")).toHaveJSProperty("hidden", false);
+  await expect(page.locator("#carTab")).toHaveJSProperty("hidden", true);
+
+  await speedSourceTabButton.click();
+  await expect(speedSourceTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(analysisTabButton).toHaveAttribute("aria-selected", "false");
+  await expect(page.locator("#speedSourceTab")).toHaveJSProperty("hidden", false);
+  await expect(page.locator("#analysisTab")).toHaveJSProperty("hidden", true);
+});
+
+test("settings shell supports keyboard tab navigation", async ({ page }) => {
+  await openSettings(page);
+
+  const carTabButton = page.locator('[data-settings-tab="carTab"]');
+  const analysisTabButton = page.locator('[data-settings-tab="analysisTab"]');
+  const espFlashTabButton = page.locator('[data-settings-tab="espFlashTab"]');
+
+  await carTabButton.focus();
+  await carTabButton.press("ArrowRight");
+  await expect(analysisTabButton).toBeFocused();
+  await expect(analysisTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#analysisTab")).toHaveJSProperty("hidden", false);
+
+  await analysisTabButton.press("ArrowLeft");
+  await expect(carTabButton).toBeFocused();
+  await expect(carTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#carTab")).toHaveJSProperty("hidden", false);
+
+  await carTabButton.press("End");
+  await expect(espFlashTabButton).toBeFocused();
+  await expect(espFlashTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#espFlashTab")).toHaveJSProperty("hidden", false);
+
+  await espFlashTabButton.press("Home");
+  await expect(carTabButton).toBeFocused();
+  await expect(carTabButton).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#carTab")).toHaveJSProperty("hidden", false);
+});


### PR DESCRIPTION
## Summary

This PR fixes #2311 by making the settings shell own its tab state directly and by removing the last public `settingsTabs` DOM array from the shell view contract.

When this issue was filed, `settings_shell.tsx` still had two kinds of migration residue:

1. the mounted shell kept `activeTabId` in a mutable local variable and used a manual listener `Set` to fan tab changes out to consumers, and
2. the public view contract still exposed `dom.settingsTabs`, which encouraged downstream code to treat settings navigation as a DOM surface instead of a typed shell API.

Part of the original issue context is already outdated by the time of this PR: #2310 removed the last live downstream consumer that actually needed the raw tab-button array. That made this issue cleaner, not smaller in importance. The shell itself was still carrying the obsolete public DOM seam and the manual listener plumbing, so this PR finishes that cleanup directly in the shell owner.

Closes #2311.

## Problem

The settings shell was already rendered in Preact, but its state ownership still did not match the architecture the rest of the frontend migration is moving toward.

The specific problems were:

1. tab selection lived in a mount-local mutable variable,
2. change notification depended on a manual `Set` of listeners,
3. `SettingsShellView` still exported `dom.settingsTabs`,
4. downstream callers could still think of the shell as a bundle of DOM references rather than a typed navigation owner.

That design worked, but it kept the settings shell in the same half-migrated state that earlier issues removed from speed source, update, and ESP flash. The issue’s intent was to finish that ownership line: keep programmatic tab activation available, keep typed change notifications available where needed, but stop exposing the raw tab elements and stop hand-rolling state/listener plumbing outside the component model.

## Implementation approach

I kept the implementation centered on `settings_shell.tsx` itself and deliberately avoided widening scope into unrelated settings modules.

By the time this PR started, `settings_feature.ts` and the speed-source path were already consuming typed navigation APIs rather than `settingsTabs` arrays, so the cleanest remaining cut was:

1. move the active tab into signal-backed shell state,
2. render the shell once and let signal reads drive rerenders,
3. replace the manual listener `Set` with signal-backed `effect()` subscriptions,
4. remove `SettingsShellView.dom` from the public contract,
5. add focused browser coverage for click and keyboard tab navigation.

That gives the shell a single typed public surface:

- `activateTab(tabId)`
- `subscribeActiveTabChanges(listener)`

and removes the leftover DOM export entirely.

## Main code changes

### `apps/ui/src/app/views/settings_shell.tsx`

This is the core change.

The shell now stores `activeTabId` in a signal instead of a mutable mount-local variable. The mounted view renders once through `createUiPreactMount()`, and the `SettingsShell` component reads the signal value directly so Preact can react to state changes without an explicit rerender call after every tab switch.

The public `SettingsShellDom` type and `SettingsShellView.dom` export are gone. The shell no longer exposes `settingsTabs` as raw buttons to downstream code.

The old listener `Set` has also been removed. `subscribeActiveTabChanges()` now returns a signal `effect()` disposer and emits typed tab-id changes without keeping a separate mutable subscriber collection in the view layer.

Importantly, the shell’s behavioral contract stays intact:

- click activation still works,
- keyboard navigation still works,
- `activateTab()` still handles programmatic selection,
- invalid programmatic tab ids are still ignored,
- downstream modules still have a typed subscription API when they need to react to tab changes.

### `apps/ui/tests/smoke.settings-shell.spec.ts`

This PR adds focused browser coverage specifically for the settings shell.

The first test verifies click-driven tab switching by asserting that:

- the selected tab’s `aria-selected` state changes correctly,
- the previously active tab is deselected,
- the matching tab panel becomes visible,
- the previously active panel becomes hidden.

The second test verifies keyboard navigation directly on the settings tabs. It exercises:

- `ArrowRight`
- `ArrowLeft`
- `End`
- `Home`

and checks both focus movement and active panel selection, which is the behavior the issue explicitly called out.

### `apps/ui/README.md`

The frontend architecture table now describes `settings_shell.tsx` as the owner of signal-backed tab state plus typed navigation APIs, which matches the live code after this refactor.

## Validation

Because this change touches the shared tab owner for every settings surface, I validated it more broadly than a single focused shell spec.

I ran:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/smoke.settings-shell.spec.ts tests/smoke.settings.spec.ts tests/smoke.cars.spec.ts tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts tests/settings_car_feedback_reset.spec.ts tests/settings_obd_scan_timeout.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

That browser slice intentionally spans multiple settings tabs because the shell is shared infrastructure for:

- cars,
- analysis/settings,
- speed source,
- sensors,
- internet/update,
- ESP flash.

The new shell-specific smoke tests passed, and the broader settings-related flows continued to pass after the shell state change.

The isolated preview run still emitted the same Vite proxy `ECONNREFUSED 127.0.0.1:8000` noise for unstubbed `/api/update/status`, `/api/health`, and occasional websocket proxy paths. That noise is expected in this local preview harness and did not fail any of the relevant tests.

## Risks, tradeoffs, and out of scope

The main risk here was not visual rendering; it was behavior around tab selection and focus movement. Replacing a mutable variable plus listener `Set` with signal-backed state changes the ownership model, so the meaningful regression risk was keyboard navigation, click selection, or cross-tab visibility going subtly stale. That is why the new shell-specific browser tests assert both ARIA state and panel visibility, and why the broader validation re-ran real settings flows across multiple tabs instead of only testing the shell in isolation.

I did not broaden this PR into a rewrite of downstream settings modules. They were already using typed shell APIs by the time this issue was executed, especially after #2310 removed the last live `settingsTabs` array dependency. I also did not change the shell’s tab list, tab ids, host panel ids, or keyboard behavior contract. This PR is about ownership and public surface cleanup, not about changing how settings navigation works for users.
