### PR TITLE
Make realtime overview and logging panels reactive

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -103,7 +103,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/cars_feature.ts` | Thin car-wizard facade that wires the DOM-free workflow plus island-owned wizard DOM adapter into typed wizard actions |
 | `app/features/cars_feature_transport.ts` | Car-library transport wrapper for loading wizard brands, types, and models through the UI API facade |
 | `app/features/cars_feature_workflow.ts` | DOM-free car-wizard workflow/controller for step transitions, library loading, branch selection, and finish validation |
-| `app/features/realtime_feature.ts` | Thin realtime facade that wires the workflow, presenter, and delegated event bindings together |
+| `app/features/realtime_feature.ts` | Thin realtime facade that wires the workflow, presenter, and typed logging/sensor action bridges together |
 | `app/features/realtime_feature_workflow.ts` | DOM-free realtime workflow/controller for polling, logging actions, location updates, and client mutations |
 | `app/features/settings_cars_module.ts` | Settings-side car controller that owns list loading, activation/deletion flows, highlight feedback, and typed tab/view-driven feedback dismissal plus the explicit open-wizard port |
 | `app/features/settings_cars_transport.ts` | Settings-car transport wrapper over load/activate/delete API calls |
@@ -131,7 +131,8 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/history_table_content.tsx` | History island JSX renderer that turns typed row/detail models into empty state, table rows, expanded evidence cards, and action affordances |
 | `app/views/history_table_view.ts` | Thin history-panel bridge that defines the typed empty/table render contract consumed by the Preact history island |
 | `app/views/realtime_logging_view_models.ts` | Typed realtime logging and readiness view-model builders for summary, checklist, and control-state derivation |
-| `app/views/realtime_logging_panel.tsx` | Preact owner for the run-recording card that renders typed logging/readiness models and binds start/stop plus summary CTA actions through a bridge |
+| `app/views/realtime_live_overview.tsx` | Signal-backed Preact owner for the live overview card that consumes typed status/sensor models without manual island rerender loops |
+| `app/views/realtime_logging_panel.tsx` | Signal-backed Preact owner for the run-recording card that renders typed logging/readiness models, owns the setup-layout marker locally, and binds start/stop plus summary CTA actions through the shared bridge |
 | `app/views/settings_car_list_view.ts` | Typed saved-car list and guidance view-model builders reused by the car-management island for row, empty-state, and highlight rendering |
 | `app/views/settings_speed_source_presenter.ts` | Pure speed-source presenter that turns typed workflow state and live status payloads into panel and diagnostics render models |
 | `app/views/update_feature_presenter.ts` | Update presenter that derives typed update/internet panel models from workflow state plus draft form inputs and toggles |
@@ -191,11 +192,12 @@ contract below is available.
 Realtime follows that same split explicitly: `realtime_feature.ts` is the thin
 facade, `realtime_feature_workflow.ts` owns the controller-style polling and
 mutation flow, `realtime_feature_presenter.ts` owns realtime-specific panel
-state plus typed navigation actions, and `realtime_logging_view_models.ts`
-builds the logging/readiness models consumed by
-`app/views/realtime_logging_panel.tsx`. `app/views/` now owns typed view-model
-builders, event-target decoding, and disposable delegated listener binders for
-reusable multi-action panels.
+state plus typed navigation actions, `app/views/realtime_live_overview.tsx`
+and `app/views/realtime_logging_panel.tsx` keep the dashboard cards in
+signal-backed island state, and `realtime_logging_view_models.ts` builds the
+logging/readiness models consumed by the recording card. `app/views/` now owns
+typed view-model builders, event-target decoding, and disposable delegated
+listener binders for reusable multi-action panels.
 
 `src/transport/` owns the UI-local DTO and adapter layer between generated HTTP
 / WS contracts and `app/**`, so feature, runtime, and view modules no longer

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -1,5 +1,6 @@
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
 import { useUiTranslation } from "../ui_i18n";
+import { signal, type ReadonlySignal } from "../ui_signals";
 
 export interface RealtimeLiveOverviewActiveCarModel {
   text: string;
@@ -57,8 +58,8 @@ const DEFAULT_OVERVIEW_STATE: RealtimeLiveOverviewBridgeState = {
   speedText: "--",
 };
 
-function RealtimeLiveOverview(props: { state: RealtimeLiveOverviewBridgeState }) {
-  const { state } = props;
+function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOverviewBridgeState> }) {
+  const state = props.state.value;
   const t = useUiTranslation();
 
   return (
@@ -198,22 +199,15 @@ export function createNullRealtimeLiveOverviewBridge(): RealtimeLiveOverviewBrid
 
 export function mountRealtimeLiveOverview(host: HTMLElement): RealtimeLiveOverviewBridge {
   const mount = createUiPreactMount(host);
-  let state: RealtimeLiveOverviewBridgeState = { ...DEFAULT_OVERVIEW_STATE };
-
-  function render(): void {
-    mount.render(<RealtimeLiveOverview state={state} />);
-  }
-
-  render();
+  const state = signal<RealtimeLiveOverviewBridgeState>({ ...DEFAULT_OVERVIEW_STATE });
+  mount.render(<RealtimeLiveOverview state={state} />);
 
   return {
     render(model: RealtimeLiveOverviewRenderModel): void {
-      state = { ...state, ...model };
-      render();
+      state.value = { ...state.value, ...model };
     },
     setSpeedText(text: string): void {
-      state = { ...state, speedText: text };
-      render();
+      state.value = { ...state.value, speedText: text };
     },
   };
 }

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -1,5 +1,6 @@
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
 import { useUiTranslation } from "../ui_i18n";
+import { signal, type ReadonlySignal } from "../ui_signals";
 import { inlineStateActionClass } from "./dom_helpers";
 import type {
   RealtimeCaptureReadinessChecklistModel,
@@ -136,14 +137,16 @@ function RealtimeLoggingChecklist(props: {
   );
 }
 
-function RealtimeLoggingPanel(props: { state: RealtimeLoggingPanelBridgeState }) {
-  const { state } = props;
+function RealtimeLoggingPanel(props: {
+  state: ReadonlySignal<RealtimeLoggingPanelBridgeState>;
+}) {
+  const state = props.state.value;
   const t = useUiTranslation();
   const loggingRowHidden = !state.showPill && state.runIdText === "";
   const showProgressSection = !state.setupMode || state.checklist !== null;
 
   return (
-    <>
+    <div class="realtime-logging-shell" data-layout={state.setupMode ? "setup" : undefined}>
       <div class="card__header card__header--stack">
         <div>
           <div class="card__title" data-i18n="dashboard.run_recording">
@@ -230,20 +233,8 @@ function RealtimeLoggingPanel(props: { state: RealtimeLoggingPanelBridgeState })
           {t("dashboard.stop_recording", "Stop Recording")}
         </button>
       </div>
-    </>
+    </div>
   );
-}
-
-function syncDashboardLayout(host: HTMLElement, setupMode: boolean): void {
-  const dashboardGrid = host.closest<HTMLElement>(".dashboard-grid");
-  if (!dashboardGrid) {
-    return;
-  }
-  if (setupMode) {
-    dashboardGrid.setAttribute("data-layout", "setup");
-    return;
-  }
-  dashboardGrid.removeAttribute("data-layout");
 }
 
 export function createNullRealtimeLoggingPanelBridge(): RealtimeLoggingPanelBridge {
@@ -255,23 +246,15 @@ export function createNullRealtimeLoggingPanelBridge(): RealtimeLoggingPanelBrid
 
 export function mountRealtimeLoggingPanel(host: HTMLElement): RealtimeLoggingPanelBridge {
   const mount = createUiPreactMount(host);
-  let state: RealtimeLoggingPanelBridgeState = { ...DEFAULT_PANEL_STATE };
-
-  function render(): void {
-    syncDashboardLayout(host, state.setupMode);
-    mount.render(<RealtimeLoggingPanel state={state} />);
-  }
-
-  render();
+  const state = signal<RealtimeLoggingPanelBridgeState>({ ...DEFAULT_PANEL_STATE });
+  mount.render(<RealtimeLoggingPanel state={state} />);
 
   return {
     render(model: RealtimeLoggingPanelRenderModel): void {
-      state = { ...state, ...model };
-      render();
+      state.value = { ...state.value, ...model };
     },
     bindActions(handlers: RealtimeLoggingPanelActionHandlers): void {
-      state = { ...state, actions: handlers };
-      render();
+      state.value = { ...state.value, actions: handlers };
     },
   };
 }

--- a/apps/ui/src/styles/realtime.css
+++ b/apps/ui/src/styles/realtime.css
@@ -12,19 +12,19 @@
 .dashboard-grid__controls .card__header > :first-child { width: 100%; }
 .dashboard-grid__controls .card__subtle { text-align: left; }
 
-.dashboard-grid[data-layout="setup"] {
+.dashboard-grid:has(.realtime-logging-shell[data-layout="setup"]) {
   grid-template-columns: minmax(0, 1fr);
   grid-template-areas:
     "overview"
     "controls";
 }
 
-.dashboard-grid[data-layout="setup"] .dashboard-grid__main {
+.dashboard-grid:has(.realtime-logging-shell[data-layout="setup"]) .dashboard-grid__main {
   display: none;
 }
 
-.dashboard-grid[data-layout="setup"] .stat-grid--compact,
-.dashboard-grid[data-layout="setup"] .logging-actions {
+.realtime-logging-shell[data-layout="setup"] .stat-grid--compact,
+.realtime-logging-shell[data-layout="setup"] .logging-actions {
   display: none;
 }
 

--- a/apps/ui/tests/realtime_logging_summary.spec.ts
+++ b/apps/ui/tests/realtime_logging_summary.spec.ts
@@ -40,6 +40,8 @@ test("keeps the no-car Live CTA stable while repeated websocket payloads arrive"
   const liveSummary = page.locator("#loggingSummary");
   const addCarButton = liveSummary.getByRole("button", { name: "Add a car" });
   await expect(addCarButton).toBeVisible();
+  await expect(page.locator("#spectrumPanelRoot")).toBeHidden();
+  expect(await page.locator(".dashboard-grid").getAttribute("data-layout")).toBeNull();
 
   await page.evaluate(() => {
     const summary = document.querySelector<HTMLElement>("#loggingSummary");


### PR DESCRIPTION
## Summary

Closes #2312.

This change finishes the next realtime-island cleanup from the frontend
migration audit by converting the live overview card and the run-recording card
away from the old "mutable bridge state plus `mount.render()` on every update"
pattern. Both surfaces were already rendered with Preact JSX, but they still
behaved like imperative wrappers around `preact.render(...)`: each bridge method
mutated a mount-local object and then forced a full rerender of the island. The
logging panel also reached out of its own host and mutated the parent
`.dashboard-grid` with `closest()` plus `setAttribute("data-layout", "setup")`
to enter setup mode. That left the realtime dashboard in an awkward halfway
state where the HTML came from Preact, but the update flow still followed the
same manual rerender loop as the pre-migration code.

## Implementation approach

I kept the public bridge contract stable so the presenter, shell controller, and
runtime wiring do not need a coordinated API rewrite in this issue. The fix is
inside the two view owners themselves: render each island once, store the live
render state in signals, and let the JSX consume that reactive state directly.
That removes the repeated `mount.render()` loop while preserving the existing
typed render-model boundary that the realtime presenter already owns.

For the logging panel, I also removed the parent-DOM mutation seam instead of
just moving it into a hook. The issue explicitly called out that the setup-mode
layout should stop depending on `closest()` plus a parent `data-layout`
attribute mutation. The implementation now renders a local setup marker inside
the logging island and lets CSS `:has(...)` selectors drive the grid layout from
that owned marker. That preserves the setup-mode behavior without letting the
panel walk up the DOM tree and mutate its container imperatively.

## Main code changes

### `app/views/realtime_live_overview.tsx`

The live overview bridge now uses a signal-backed state object instead of a
plain mutable object plus a local `render()` helper. `mountRealtimeLiveOverview`
renders the component once, passes a `ReadonlySignal` into the JSX owner, and
updates that signal from the existing `render(model)` and `setSpeedText(text)`
bridge methods. The component reads `props.state.value`, so updates now flow
through the reactive island state instead of a manual rerender loop.

This is intentionally a narrow conversion. I did not widen the presenter
contract, merge speed text into a different presenter model, or introduce a new
runtime store just to satisfy the issue. The presenter still decides *what* to
render; the view now owns *how* those updates reach the island.

### `app/views/realtime_logging_panel.tsx`

The recording card follows the same mount-once reactive pattern. The bridge now
stores `RealtimeLoggingPanelBridgeState` in a signal and updates it from
`render(model)` / `bindActions(handlers)` without calling `mount.render()`
again. The island reads the signal value directly, so repeated logging-status
updates and action binding no longer take the "replace the bridge state object
and force a full render" path.

The setup-layout ownership moved at the same time. I removed the
`syncDashboardLayout()` helper that searched upward for `.dashboard-grid` and
mutated its `data-layout` attribute. The JSX owner now renders a local
`realtime-logging-shell` wrapper with `data-layout="setup"` when setup mode is
active.

### `styles/realtime.css`

The CSS now keys setup-mode layout from the logging island itself:

- `.dashboard-grid:has(.realtime-logging-shell[data-layout="setup"])` collapses
  the grid to the overview + controls stack
- the same `:has(...)` selector hides `.dashboard-grid__main`
- `.realtime-logging-shell[data-layout="setup"]` hides the compact progress
  stats and logging actions inside the recording card

This keeps the layout behavior that the smoke tests already expect while
deleting the parent attribute mutation path entirely.

### Tests and docs

`tests/realtime_logging_summary.spec.ts` now checks one more part of the
setup-mode contract: the no-car setup CTA still renders, the spectrum panel is
still hidden in setup mode, and the dashboard grid no longer receives a
`data-layout` attribute from the logging panel. The existing summary-stability
assertion remains in place, so repeated websocket payloads still prove that the
CTA button is not being recreated unnecessarily.

I also updated `apps/ui/README.md` so the architecture table and realtime
overview paragraph describe these surfaces as signal-backed islands instead of
plain bridge-driven renderers.

## Validation

I used the narrowest existing validation surface that exercises the changed
behavior:

- `cd apps/ui && npx playwright test tests/realtime_logging_summary.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.cars.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

The browser slice covers the two key user-visible flows affected here:

1. setup mode with no active car, where the logging card owns the CTA and hides
   the spectrum area
2. broader realtime bootstrap/status/logging behavior, including recording
   transitions and the car-guidance flow that exercises the setup layout and
   summary CTA path repeatedly

## Risks and tradeoffs

The main tradeoff is that the public bridge names still say "Bridge" even though
the implementation is now reactive under the hood. I kept that boundary stable
on purpose so this issue remains a surgical island-ownership cleanup instead of
turning into a presenter/runtime rename sweep. If a later cleanup wants to
rename these view contracts to `View` instead of `Bridge`, that can now happen
as a mechanical follow-up rather than being entangled with the reactive-state
conversion.

Using CSS `:has(...)` is also a deliberate tradeoff. It removes the imperative
parent mutation completely, but it does make the layout relationship more
explicit in CSS rather than in runtime DOM code. In this repo that is the
cleaner ownership split: the logging island exposes its own setup marker, and
the stylesheet decides how the dashboard grid should respond.

## Out of scope

This PR does not rewrite the realtime presenter, merge the overview and logging
state into a shared signal store, or touch unrelated realtime panels such as the
sensors table or spectrum panel. Those are separate backlog items. The scope
here is the two remaining realtime JSX owners that were still manually forcing
rerenders after every bridge call.
