### PR TITLE
Make analysis and sensors panels reactive

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -111,12 +111,12 @@ source-of-truth export commands remain the only writers for those files.
 | `app/features/settings_speed_source_module.ts` | Thin speed-source settings facade that wires the transport seam, DOM-free workflow, pure presenter, typed panel actions, and typed navigation subscriptions into the shared panel bridge |
 | `app/features/settings_speed_source_transport.ts` | Speed-source settings transport wrapper over the UI-local settings and OBD APIs |
 | `app/features/settings_speed_source_workflow.ts` | DOM-free speed-source workflow/controller for draft state, validation, save/load orchestration, and background OBD rescans |
-| `app/views/analysis_panel.tsx` | Preact owner for the analysis-settings shell that mounts the full tab surface and exposes the typed bridge consumed by analysis and car-selection modules |
+| `app/views/analysis_panel.tsx` | Signal-backed Preact owner for the analysis-settings shell; local refs/effects handle guidance and field focus while analysis and car-selection modules feed typed model and availability updates |
 | `app/views/settings_shell.tsx` | Preact owner for the shared settings tab chrome and tab-panel wrappers that mount the per-tab panel hosts, keep tab selection in signal-backed shell state, and expose typed settings navigation APIs |
 | `app/views/esp_flash_panel.tsx` | Preact owner for the ESP flash settings shell, typed flash actions, and log-autoscroll lifecycle alongside the render bridge for port selection, readiness, journey, history, and logs |
 | `app/views/internet_panel.tsx` | Preact owner for the full internet settings surface that renders USB status, transport choices, Wi-Fi credentials, and readiness guidance through a typed bridge |
 | `app/views/update_panel.tsx` | Preact owner for the full update settings surface that renders the action row plus current status, health, journey, issues, latest attempt, and log cards through a typed bridge |
-| `app/views/sensors_panel.tsx` | Preact owner for the sensors settings shell that renders the full sensor table and exposes typed identify/remove/location callbacks to the realtime feature |
+| `app/views/sensors_panel.tsx` | Signal-backed Preact owner for the sensors settings shell that keeps the sensor table reactive while exposing typed identify/remove/location callbacks to the realtime feature |
 | `app/views/speed_source_panel.tsx` | Preact owner for the speed-source shell that renders the full tab plus live diagnostics in JSX, owns typed save/scan/select/input callbacks, and exposes the shared bridge consumed by the speed-source and GPS-status modules |
 | `app/views/cars_panel.tsx` | Preact owner for the full car-management surface that renders saved-car guidance/list rows plus the full add-car wizard internals in JSX and exposes typed list and wizard bridges |
 | `app/views/cars_feature_bindings.ts` | Typed car-wizard bindings reused as the thin wizard interaction adapter behind the car-management island |

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -265,8 +265,8 @@ export function createSettingsAnalysisModule(
     };
   }
 
-  function renderPanel(): void {
-    panel.render(buildPanelModel());
+  function syncPanelModel(): void {
+    panel.setModel(buildPanelModel());
   }
 
   function clearFieldValidationState(): void {
@@ -279,7 +279,7 @@ export function createSettingsAnalysisModule(
 
   function markFieldInvalid(field: AnalysisFieldConfig, message: string): void {
     fieldErrorMessages.set(field.key, message);
-    renderPanel();
+    syncPanelModel();
     panel.focusField(field.key);
     openAnalysisGuidance();
   }
@@ -316,7 +316,7 @@ export function createSettingsAnalysisModule(
     }
     clearFieldValidationState();
     saveFeedback = null;
-    renderPanel();
+    syncPanelModel();
     void syncAnalysisSettingsToServer({
       wheel_bandwidth_pct: defaultVehicleSettings.wheel_bandwidth_pct,
       driveshaft_bandwidth_pct: defaultVehicleSettings.driveshaft_bandwidth_pct,
@@ -336,7 +336,7 @@ export function createSettingsAnalysisModule(
     draftValues = buildDraftValues(settings);
     clearFieldValidationState();
     saveFeedback = null;
-    renderPanel();
+    syncPanelModel();
   }
 
   function applyAnalysisSettingsPayload(
@@ -367,7 +367,7 @@ export function createSettingsAnalysisModule(
           error instanceof Error ? error.message : t("settings.save_failed"),
         detail: t("settings.analysis.save_failed_detail"),
       };
-      renderPanel();
+      syncPanelModel();
       ctx.onSaveError(error);
     }
   }
@@ -471,7 +471,7 @@ export function createSettingsAnalysisModule(
     };
     fieldErrorMessages.delete(action.field);
     saveFeedback = null;
-    renderPanel();
+    syncPanelModel();
   }
 
   function bindHandlers(): void {
@@ -480,7 +480,7 @@ export function createSettingsAnalysisModule(
       onReset: resetAnalysisToDefaults,
       onSave: saveAnalysisFromInputs,
     });
-    renderPanel();
+    syncPanelModel();
   }
 
   return {

--- a/apps/ui/src/app/views/analysis_panel.tsx
+++ b/apps/ui/src/app/views/analysis_panel.tsx
@@ -1,7 +1,9 @@
 import type { JSX } from "preact";
+import { useEffect, useRef } from "preact/hooks";
 
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
 import { useUiTranslation } from "../ui_i18n";
+import { signal, type ReadonlySignal } from "../ui_signals";
 import type {
   SettingsAnalysisGuidanceRenderModel,
 } from "./settings_analysis_guidance";
@@ -47,7 +49,7 @@ export interface AnalysisPanelView {
   bindActions(handlers: AnalysisPanelActionHandlers): void;
   focusField(field: AnalysisPanelFieldKey): void;
   openGuidance(): void;
-  render(model: AnalysisPanelRenderModel): void;
+  setModel(model: AnalysisPanelRenderModel): void;
   setCarAvailability(state: AnalysisPanelCarAvailability): void;
 }
 
@@ -64,6 +66,11 @@ type AnalysisPanelBridgeState = {
   actions: AnalysisPanelActionHandlers | null;
   availability: AnalysisPanelCarAvailability;
   model: AnalysisPanelRenderModel;
+};
+
+type AnalysisFieldFocusRequest = {
+  field: AnalysisPanelFieldKey;
+  token: number;
 };
 
 const EMPTY_GUIDANCE_MODEL: SettingsAnalysisGuidanceRenderModel = {
@@ -284,15 +291,43 @@ function AnalysisField(props: {
 }
 
 function AnalysisPanel(props: {
-  guidanceHelpRef: (element: HTMLDetailsElement | null) => void;
-  inputRef: (
-    field: AnalysisPanelFieldKey,
-    element: HTMLInputElement | null,
-  ) => void;
-  state: AnalysisPanelBridgeState;
+  guidanceOpenRequest: ReadonlySignal<number>;
+  inputFocusRequest: ReadonlySignal<AnalysisFieldFocusRequest | null>;
+  state: ReadonlySignal<AnalysisPanelBridgeState>;
 }) {
-  const { guidanceHelpRef, inputRef, state } = props;
+  const state = props.state.value;
+  const guidanceOpenRequest = props.guidanceOpenRequest.value;
+  const inputFocusRequest = props.inputFocusRequest.value;
   const t = useUiTranslation();
+  const guidanceHelpRef = useRef<HTMLDetailsElement | null>(null);
+  const inputRefs = useRef<Record<AnalysisPanelFieldKey, HTMLInputElement | null>>({
+    wheel_bandwidth_pct: null,
+    driveshaft_bandwidth_pct: null,
+    engine_bandwidth_pct: null,
+    speed_uncertainty_pct: null,
+    tire_diameter_uncertainty_pct: null,
+    final_drive_uncertainty_pct: null,
+    gear_uncertainty_pct: null,
+    min_abs_band_hz: null,
+    max_band_half_width_pct: null,
+  });
+
+  useEffect(() => {
+    if (!inputFocusRequest) {
+      return;
+    }
+    inputRefs.current[inputFocusRequest.field]?.focus();
+  }, [inputFocusRequest]);
+
+  useEffect(() => {
+    if (guidanceOpenRequest <= 0) {
+      return;
+    }
+    if (guidanceHelpRef.current) {
+      guidanceHelpRef.current.open = true;
+    }
+  }, [guidanceOpenRequest]);
+
   const noCarSelected = !state.availability.hasActiveCar && !state.availability.isLoading;
   return (
     <div class="panel card settings-layout">
@@ -387,7 +422,9 @@ function AnalysisPanel(props: {
                 key={field.key}
                 actions={state.actions}
                 model={state.model.fields[field.key]}
-                onInputRef={(element) => inputRef(field.key, element)}
+                onInputRef={(element) => {
+                  inputRefs.current[field.key] = element;
+                }}
                 spec={field}
               />
             ))}
@@ -436,7 +473,9 @@ function AnalysisPanel(props: {
                 key={field.key}
                 actions={state.actions}
                 model={state.model.fields[field.key]}
-                onInputRef={(element) => inputRef(field.key, element)}
+                onInputRef={(element) => {
+                  inputRefs.current[field.key] = element;
+                }}
                 spec={field}
               />
             ))}
@@ -478,62 +517,40 @@ function AnalysisPanel(props: {
   );
 }
 
-function createInputRefs(): Record<AnalysisPanelFieldKey, HTMLInputElement | null> {
-  return {
-    wheel_bandwidth_pct: null,
-    driveshaft_bandwidth_pct: null,
-    engine_bandwidth_pct: null,
-    speed_uncertainty_pct: null,
-    tire_diameter_uncertainty_pct: null,
-    final_drive_uncertainty_pct: null,
-    gear_uncertainty_pct: null,
-    min_abs_band_hz: null,
-    max_band_half_width_pct: null,
-  };
-}
-
 export function mountAnalysisPanel(host: HTMLElement): AnalysisPanelView {
-  const bridgeState: AnalysisPanelBridgeState = {
+  const bridgeState = signal<AnalysisPanelBridgeState>({
     actions: null,
     availability: DEFAULT_ANALYSIS_CAR_AVAILABILITY,
     model: DEFAULT_ANALYSIS_PANEL_MODEL,
-  };
-  const inputRefs = createInputRefs();
-  let guidanceHelp: HTMLDetailsElement | null = null;
+  });
+  const inputFocusRequest = signal<AnalysisFieldFocusRequest | null>(null);
+  const guidanceOpenRequest = signal(0);
+  let focusRequestToken = 0;
   const mount = createUiPreactMount(host);
-  const render = () => mount.render(
+  mount.render(
     <AnalysisPanel
-      guidanceHelpRef={(element) => {
-        guidanceHelp = element;
-      }}
-      inputRef={(field, element) => {
-        inputRefs[field] = element;
-      }}
+      guidanceOpenRequest={guidanceOpenRequest}
+      inputFocusRequest={inputFocusRequest}
       state={bridgeState}
     />,
   );
-  render();
 
   return {
     bindActions(handlers) {
-      bridgeState.actions = handlers;
-      render();
+      bridgeState.value = { ...bridgeState.value, actions: handlers };
     },
     focusField(field) {
-      inputRefs[field]?.focus();
+      focusRequestToken += 1;
+      inputFocusRequest.value = { field, token: focusRequestToken };
     },
     openGuidance() {
-      if (guidanceHelp) {
-        guidanceHelp.open = true;
-      }
+      guidanceOpenRequest.value += 1;
     },
-    render(model) {
-      bridgeState.model = model;
-      render();
+    setModel(model) {
+      bridgeState.value = { ...bridgeState.value, model };
     },
     setCarAvailability(state) {
-      bridgeState.availability = state;
-      render();
+      bridgeState.value = { ...bridgeState.value, availability: state };
     },
   };
 }

--- a/apps/ui/src/app/views/realtime_feature_presenter.ts
+++ b/apps/ui/src/app/views/realtime_feature_presenter.ts
@@ -281,7 +281,7 @@ export function createRealtimeFeaturePresenter(
   }
 
   function renderSensorsSettingsList(): void {
-    sensorsPanel.render({
+    sensorsPanel.setModel({
       table: buildRealtimeSensorTableRenderModel({
         clients: realtime.clients,
         locationOptions: realtime.locationOptions,

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -1,7 +1,8 @@
-import { h } from "preact";
+import type { JSX } from "preact";
 
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
 import { useUiTranslation } from "../ui_i18n";
+import { signal, type ReadonlySignal } from "../ui_signals";
 import type {
   RealtimeSensorTableClickAction,
   RealtimeSensorTableLocationChange,
@@ -19,7 +20,7 @@ export interface SensorsPanelActionHandlers {
 }
 
 export interface SensorsPanelView {
-  render(model: SensorsPanelRenderModel): void;
+  setModel(model: SensorsPanelRenderModel): void;
   bindActions(handlers: SensorsPanelActionHandlers): void;
 }
 
@@ -29,7 +30,7 @@ type SensorsPanelBridgeState = {
 };
 
 function handleSensorAction(
-  event: h.JSX.TargetedMouseEvent<HTMLButtonElement>,
+  event: JSX.TargetedMouseEvent<HTMLButtonElement>,
   actions: SensorsPanelActionHandlers | null,
   action: RealtimeSensorTableClickAction["type"],
   clientId: string,
@@ -120,8 +121,8 @@ function SensorsTableBody(props: {
   ));
 }
 
-function SensorsPanel(props: { state: SensorsPanelBridgeState }) {
-  const { state } = props;
+function SensorsPanel(props: { state: ReadonlySignal<SensorsPanelBridgeState> }) {
+  const state = props.state.value;
   const t = useUiTranslation();
   return (
     <div class="panel card">
@@ -159,21 +160,18 @@ function SensorsPanel(props: { state: SensorsPanelBridgeState }) {
 }
 
 export function mountSensorsPanel(host: HTMLElement): SensorsPanelView {
-  let state: SensorsPanelBridgeState = {
+  const state = signal<SensorsPanelBridgeState>({
     actions: null,
     model: { table: null },
-  };
+  });
   const mount = createUiPreactMount(host);
-  const render = () => mount.render(<SensorsPanel state={state} />);
-  render();
+  mount.render(<SensorsPanel state={state} />);
   return {
-    render(model) {
-      state = { ...state, model };
-      render();
+    setModel(model) {
+      state.value = { ...state.value, model };
     },
     bindActions(handlers) {
-      state = { ...state, actions: handlers };
-      render();
+      state.value = { ...state.value, actions: handlers };
     },
   };
 }

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -55,7 +55,7 @@ test("settings analysis module renders guidance and surfaces invalid input throu
     openGuidance() {
       guidanceOpened = true;
     },
-    render(model) {
+    setModel(model) {
       renders.push(model);
     },
     setCarAvailability() {

--- a/apps/ui/tests/smoke.analysis-sensors.spec.ts
+++ b/apps/ui/tests/smoke.analysis-sensors.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  fulfillJson,
+  installCommonRoutes,
+  installFakeWebSocket,
+  requestPath,
+} from "./smoke.helpers";
+
+test("analysis guidance can reopen and refocus after repeated invalid saves", async ({ page }) => {
+  let analysisPutCalls = 0;
+
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      if (requestPath(route).startsWith("/api/settings/cars")) {
+        await fulfillJson(route, {
+          cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await page.route("**/api/settings/analysis", async (route) => {
+    if (route.request().method() === "PUT") {
+      analysisPutCalls += 1;
+    }
+    await fulfillJson(route, {});
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="analysisTab"]').click();
+
+  const guidanceHelp = page.locator("#analysisGuidanceHelp");
+  const bandwidthInput = page.locator("#wheelBandwidthInput");
+
+  await bandwidthInput.fill("120");
+  await page.locator("#saveAnalysisBtn").click();
+
+  await expect.poll(() => analysisPutCalls).toBe(0);
+  await expect(guidanceHelp).toHaveAttribute("open", "");
+  await expect(bandwidthInput).toHaveAttribute("aria-invalid", "true");
+  await expect(bandwidthInput).toBeFocused();
+
+  await guidanceHelp.evaluate((element) => {
+    if (!(element instanceof HTMLDetailsElement)) {
+      throw new Error("analysisGuidanceHelp must be a details element");
+    }
+    element.open = false;
+  });
+  await expect(guidanceHelp).not.toHaveAttribute("open", "");
+
+  await bandwidthInput.fill("130");
+  await page.locator("#saveAnalysisBtn").click();
+
+  await expect.poll(() => analysisPutCalls).toBe(0);
+  await expect(guidanceHelp).toHaveAttribute("open", "");
+  await expect(bandwidthInput).toHaveAttribute("aria-invalid", "true");
+  await expect(bandwidthInput).toBeFocused();
+});
+
+test("sensor row actions stay wired while live updates keep arriving", async ({ page }) => {
+  let identifyCalls = 0;
+  let locationUpdateCalls = 0;
+
+  await installCommonRoutes(page, {
+    locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
+  });
+  await page.route("**/api/clients/**/location", async (route) => {
+    locationUpdateCalls += 1;
+    await fulfillJson(route, {});
+  });
+  await page.route("**/api/clients/**/identify", async (route) => {
+    identifyCalls += 1;
+    await fulfillJson(route, {});
+  });
+  await installFakeWebSocket(page, {
+    payload: {
+      server_time: new Date().toISOString(),
+      clients: [
+        {
+          id: "sensor-1",
+          name: "Chassis Sensor A",
+          connected: true,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 10,
+          dropped_frames: 0,
+          frames_total: 100,
+          location_code: "",
+          mac_address: "sensor-1",
+          firmware_version: "fw-1.0.0",
+        },
+      ],
+      spectra: { clients: {} },
+    },
+    repeatPayloadCount: 6,
+    repeatPayloadIntervalMs: 40,
+  });
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="sensorsTab"]').click();
+
+  const row = page.locator('#sensorsSettingsBody tr[data-client-id="sensor-1"]');
+  const locationSelect = row.locator("select.row-location-select");
+
+  await expect(row.locator("strong")).toHaveText("Chassis Sensor A");
+  await locationSelect.selectOption("front_left_wheel");
+  await expect.poll(() => locationUpdateCalls).toBe(1);
+  await expect(row.locator("strong")).toHaveText("Chassis Sensor A");
+
+  await row.locator(".row-identify").click();
+  await expect.poll(() => identifyCalls).toBe(1);
+  await expect(row.locator("strong")).toHaveText("Chassis Sensor A");
+});


### PR DESCRIPTION
## Summary

This PR fixes #2314 by finishing the reactive ownership cut for the analysis and sensors settings panels. Both surfaces were already mounted as Preact islands, but they were still driven through the older bridge pattern: mount-local mutable state lived outside the component tree, callers pushed new models through `render(model)`, and each update forced another `mount.render(...)`.

The change keeps the surrounding feature logic intentionally narrow. I did not redesign the analysis validation flow, sensor table model builder, or upstream app state for this PR. Instead, I moved the state that belongs with these islands into the islands themselves, removed the manual rerender loops for normal updates, and renamed the remaining bridge seam from `render()` to `setModel()` so callers stop talking to these panels like generic render sinks.

## Problem

`apps/ui/src/app/views/analysis_panel.tsx` still kept three kinds of state outside the island: the current panel model, the active-car availability flag, and the focus/guidance refs used when validation needed to reopen the help disclosure and return focus to the invalid field. Every call to `bindActions()`, `render(model)`, or `setCarAvailability()` mutated that shared object and then manually invoked `mount.render(...)` again.

`apps/ui/src/app/views/sensors_panel.tsx` had the simpler version of the same smell. Its current table model and action handlers lived in a mutable object outside the component, and every update rerendered the whole mount.

The feature-side naming also reinforced the old mental model. `settings_analysis_module.ts` and `realtime_feature_presenter.ts` still called `render()` on these islands, which made them read as generic imperative render targets rather than components that own reactive state and accept model updates.

## Implementation approach

I kept the existing feature owners and render-model builders in place, because they are already the right scope for validation rules and sensor table assembly. The implementation therefore focused on three coordinated changes:

1. Move the mount-local bridge state into signals owned by the mounted island.
2. Localize analysis focus/help behavior to component refs and effects instead of storing DOM references in the mount wrapper.
3. Rename the public update seam from `render()` to `setModel()` for these two panels so the callers express “state sync” instead of “perform a render”.

That addressed the issue’s “done when” criteria without touching unrelated view contracts across the rest of the UI.

## Main code changes

In `analysis_panel.tsx`, the mount helper now renders the island exactly once. It creates a signal-backed bridge state holding the current model, active-car availability, and bound action handlers. It also creates signal-backed request channels for “focus this field” and “open the guidance disclosure”. Inside the component, `useRef()` owns the guidance `<details>` element and the input map, while `useEffect()` reacts to those request signals by focusing the right input or reopening the guidance help.

I used tokenized focus requests instead of a plain field name so repeated invalid saves against the same field still trigger the effect after the user dismisses the guidance. That matters for the analysis flow because the same field can fail validation more than once in a single session, and a simple “set the same value again” signal would otherwise be easy to no-op accidentally.

In the same file, the public contract changed from `render(model)` to `setModel(model)`. That is a small rename, but it matters semantically: callers are no longer commanding the panel to render, they are updating the model that the already-mounted island reacts to.

In `settings_analysis_module.ts`, I updated the analysis module to use the renamed `setModel()` seam through a new `syncPanelModel()` helper. The underlying validation flow is unchanged: invalid fields still mark the corresponding guidance block, focus the field, and reopen the guidance disclosure; successful saves still round-trip through the existing settings transport; and active-car availability still flows through `setCarAvailability()`.

In `sensors_panel.tsx`, the mount helper now follows the same single-render, signal-backed pattern. The sensor table model and action handlers live in a signal, `bindActions()` updates that signal, and `setModel()` updates the table model without rerendering the entire mount imperatively. The component itself reads the signal-backed state directly. This keeps the sensors settings surface aligned with the rest of the reactive migration without changing the actual row rendering behavior or action payloads.

In `realtime_feature_presenter.ts`, I updated the presenter to call `sensorsPanel.setModel(...)` so the runtime side also stops treating the sensors settings island as an imperative render sink. I made the corresponding test-stub rename in `settings_analysis_module.spec.ts`.

## Tests and docs

I added a new focused browser regression file, `apps/ui/tests/smoke.analysis-sensors.spec.ts`, because the existing omnibus settings smoke already covered these surfaces broadly but not the exact refactor risks introduced here.

The first new test exercises the repeated invalid-analysis-save path. It verifies that an out-of-range save does not hit the API, reopens the guidance disclosure, marks the field invalid, and returns focus to the invalid field. It then closes the disclosure and repeats the invalid save to prove the guidance/focus request path still fires when the same field fails again.

The second new test exercises the sensors panel while repeated websocket updates keep arriving. It verifies that the location-change action and identify action remain wired even while the live sensor row is being refreshed repeatedly.

I also kept the existing relevant coverage in place by running `tests/settings_analysis_module.spec.ts` and the broader `tests/smoke.settings.spec.ts` suite. On the documentation side, I updated the `apps/ui/README.md` architecture table so the analysis and sensors entries now describe these panels as signal-backed owners.

## Validation and tradeoffs

Validation for this PR was:

- `cd apps/ui && npx playwright test tests/settings_analysis_module.spec.ts tests/smoke.analysis-sensors.spec.ts tests/smoke.settings.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

The lint run still reports the same pre-existing Biome warnings outside this diff (`car_wizard_view.ts` unused import, one optional-chain suggestion in `history_feature_modules.spec.ts`, plus the known schema-version info), but nothing new from this change set.

The main tradeoff is that this PR stops short of a larger rewrite where the feature layer would stop producing panel models entirely. I kept that out of scope deliberately. The important improvement here is that these two islands no longer rely on manual mount rerender loops for normal updates, their local DOM lifecycle lives with the component where practical, and the remaining contract now reads as model synchronization rather than imperative rendering.

Closes #2314
