### PR TITLE
Make the spectrum panel reactive

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -95,7 +95,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that wires overlay updates plus the extracted canvas, interaction, and panel modules |
 | `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, tweening, and canvas draw plugin orchestration |
 | `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports |
-| `app/runtime/spectrum_panel_view.ts` | Spectrum legend, band legend, inspector, and band-toggle DOM rendering with button reuse |
+| `app/runtime/spectrum_panel_view.ts` | Typed spectrum panel contract for the signal-backed legend, band legend, inspector, band-toggle, and chart-host refs |
 | `app/app_feature_bundle.ts` | Creates concrete feature instances, then exposes explicit shell, transport, and startup port bundles back to the runtime |
 | `app/features/` | Feature owners for state changes, API calls, shared polling control, and typed actions emitted from local view binders |
 | `app/features/esp_flash_feature.ts` | Thin ESP flash facade that wires the workflow, presenter, and typed island action bridge together |

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -1,5 +1,6 @@
 import { createUiPreactMount } from "../runtime/ui_preact_mount";
 import { useUiTranslation } from "../ui_i18n";
+import { signal, type ReadonlySignal } from "../ui_signals";
 import type {
   SpectrumBandLegendModel,
   SpectrumPanelChartDom,
@@ -55,6 +56,19 @@ const DEFAULT_PANEL_STATE: SpectrumPanelBridgeState = {
   onBandToggle: null,
 };
 
+function createDefaultPanelState(): SpectrumPanelBridgeState {
+  return {
+    header: { ...DEFAULT_PANEL_STATE.header },
+    overlayMessage: DEFAULT_PANEL_STATE.overlayMessage,
+    bandToggle: { ...DEFAULT_PANEL_STATE.bandToggle },
+    sensorLegend: DEFAULT_PANEL_STATE.sensorLegend,
+    sensorLegendHandlers: DEFAULT_PANEL_STATE.sensorLegendHandlers,
+    bandLegend: { ...DEFAULT_PANEL_STATE.bandLegend, items: [...DEFAULT_PANEL_STATE.bandLegend.items] },
+    inspectorText: DEFAULT_PANEL_STATE.inspectorText,
+    onBandToggle: DEFAULT_PANEL_STATE.onBandToggle,
+  };
+}
+
 function requireSpectrumElement<T extends HTMLElement>(
   element: T | null,
   target: string,
@@ -66,10 +80,11 @@ function requireSpectrumElement<T extends HTMLElement>(
 }
 
 function SpectrumPanel(props: {
-  state: SpectrumPanelBridgeState;
+  state: ReadonlySignal<SpectrumPanelBridgeState>;
   chartDom: MutableSpectrumPanelChartDom;
 }) {
-  const { state, chartDom } = props;
+  const state = props.state.value;
+  const { chartDom } = props;
   const t = useUiTranslation();
 
   return (
@@ -186,18 +201,13 @@ function SpectrumPanel(props: {
 }
 
 export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
+  const state = signal<SpectrumPanelBridgeState>(createDefaultPanelState());
   const mount = createUiPreactMount(host);
-  let state: SpectrumPanelBridgeState = { ...DEFAULT_PANEL_STATE };
   const chartDom: MutableSpectrumPanelChartDom = {
     specChartWrap: null,
     specChart: null,
   };
-
-  function render(): void {
-    mount.render(<SpectrumPanel state={state} chartDom={chartDom} />);
-  }
-
-  render();
+  mount.render(<SpectrumPanel state={state} chartDom={chartDom} />);
 
   return {
     chartDom: {
@@ -209,39 +219,32 @@ export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
       },
     } satisfies SpectrumPanelChartDom,
     bindBandToggle(onToggle: () => void): void {
-      state = { ...state, onBandToggle: onToggle };
-      render();
+      state.value = { ...state.value, onBandToggle: onToggle };
     },
     renderHeader(model: SpectrumPanelHeaderModel): void {
-      state = { ...state, header: model };
-      render();
+      state.value = { ...state.value, header: model };
     },
     renderOverlay(message: string | null): void {
-      state = { ...state, overlayMessage: message };
-      render();
+      state.value = { ...state.value, overlayMessage: message };
     },
     renderBandToggle(model: { hasBands: boolean; bandsVisible: boolean; text: string }): void {
-      state = { ...state, bandToggle: model };
-      render();
+      state.value = { ...state.value, bandToggle: model };
     },
     renderSensorLegend(
       model: SpectrumSensorLegendModel | null,
       handlers?: SpectrumLegendHandlers,
     ): void {
-      state = {
-        ...state,
+      state.value = {
+        ...state.value,
         sensorLegend: model,
         sensorLegendHandlers: model && handlers ? handlers : null,
       };
-      render();
     },
     renderBandLegend(model: SpectrumBandLegendModel): void {
-      state = { ...state, bandLegend: model };
-      render();
+      state.value = { ...state.value, bandLegend: model };
     },
     renderInspectorText(text: string): void {
-      state = { ...state, inspectorText: text };
-      render();
+      state.value = { ...state.value, inspectorText: text };
     },
   };
 }

--- a/apps/ui/tests/smoke.spectrum.spec.ts
+++ b/apps/ui/tests/smoke.spectrum.spec.ts
@@ -8,6 +8,14 @@ import {
   requestPath,
 } from "./smoke.helpers";
 
+const strengthMetrics = {
+  vibration_strength_db: 12,
+  peak_amp_g: 0.2,
+  noise_floor_amp_g: 0.01,
+  strength_bucket: null,
+  top_peaks: [{ hz: 1, amp: 0.3, vibration_strength_db: 12, strength_bucket: "l2" }],
+};
+
 test("spectrum controls simplify the chart and update the inspector", async ({ page }) => {
   await page.goto("/?demo=1");
 
@@ -51,6 +59,150 @@ test("spectrum controls simplify the chart and update the inspector", async ({ p
   await expect(sensorChip).not.toHaveAttribute("data-legend-state", "active");
   await expect(sensorChip).not.toHaveAttribute("data-legend-state", "muted");
   await expect(inspector).toContainText("Strongest:");
+});
+
+test("spectrum controls stay interactive while repeated websocket updates arrive", async ({ page }) => {
+  await installCommonRoutes(page, {
+    locations: [
+      { code: "front_left_wheel", label: "Front Left Wheel" },
+      { code: "front_right_wheel", label: "Front Right Wheel" },
+    ],
+    settingsHandler: async (route) => {
+      if (requestPath(route) === "/api/settings/cars") {
+        await fulfillJson(route, {
+          cars: [{
+            id: "car-1",
+            name: "Selected",
+            type: "sedan",
+            aspects: {
+              tire_width_mm: 245,
+              tire_aspect_pct: 40,
+              rim_in: 18,
+              final_drive_ratio: 3.91,
+              current_gear_ratio: 0.82,
+            },
+          }],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await page.route("**/api/recording/status", async (route) => {
+    await fulfillJson(route, {
+      enabled: false,
+      run_id: null,
+      write_error: null,
+      analysis_in_progress: false,
+      start_time_utc: null,
+      samples_written: 0,
+      samples_dropped: 0,
+      last_completed_run_id: null,
+      last_completed_run_error: null,
+      capture_readiness: buildCaptureReadiness({
+        isReady: true,
+        sensors: { state: "pass", reasonKey: "sensors_ready", details: { live_sensor_count: 2 } },
+        reference: { state: "pass", reasonKey: "reference_ready" },
+        speed: { state: "pass", reasonKey: "speed_stable", details: { dwell_elapsed_s: 8 } },
+      }),
+    });
+  });
+  await installFakeWebSocket(page, {
+    payload: {
+      server_time: new Date().toISOString(),
+      speed_mps: 22.2,
+      clients: [
+        {
+          id: "front-right",
+          name: "Front Right Wheel",
+          connected: true,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 10,
+          dropped_frames: 0,
+          frames_total: 100,
+          location_code: "front_right_wheel",
+          mac_address: "001122334455",
+          firmware_version: "fw-1.0.0",
+        },
+        {
+          id: "front-left",
+          name: "Front Left Wheel",
+          connected: true,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 10,
+          dropped_frames: 0,
+          frames_total: 100,
+          location_code: "front_left_wheel",
+          mac_address: "66778899aabb",
+          firmware_version: "fw-1.0.0",
+        },
+      ],
+      rotational_speeds: {
+        basis_speed_source: "gps",
+        wheel: { rpm: 738, mode: "calculated", reason: null },
+        driveshaft: { rpm: 1476, mode: "calculated", reason: null },
+        engine: { rpm: 2208, mode: "calculated", reason: null },
+        order_bands: [
+          { key: "wheel_1x", center_hz: 12.3, tolerance: 0.08 },
+          { key: "wheel_2x", center_hz: 24.6, tolerance: 0.08 },
+          { key: "driveshaft_1x", center_hz: 24.6, tolerance: 0.08 },
+          { key: "engine_1x", center_hz: 36.8, tolerance: 0.08 },
+        ],
+      },
+      spectra: {
+        clients: {
+          "front-right": {
+            freq: [1, 2, 3],
+            combined_spectrum_amp_g: [0.3, 0.2, 0.1],
+            strength_metrics: strengthMetrics,
+          },
+          "front-left": {
+            freq: [1, 2, 3],
+            combined_spectrum_amp_g: [0.2, 0.1, 0.05],
+            strength_metrics: {
+              ...strengthMetrics,
+              vibration_strength_db: 9,
+            },
+          },
+        },
+      },
+    },
+    repeatPayloadCount: 6,
+    repeatPayloadIntervalMs: 50,
+  });
+
+  await page.goto("/");
+
+  const inspector = page.locator("#spectrumInspector");
+  const bandToggle = page.locator("#spectrumBandToggle");
+  const bandLegend = page.locator("#bandLegend");
+  const sensorChip = page.getByRole("button", { name: /Front Right Wheel/i });
+  const allTracesChip = page.getByRole("button", { name: /All sensor traces/i });
+
+  await expect(sensorChip).toBeVisible();
+  await expect(bandToggle).toBeVisible();
+
+  await sensorChip.click();
+  await expect(sensorChip).toHaveAttribute("aria-pressed", "true");
+  await expect(sensorChip).toHaveAttribute("data-legend-state", "active");
+  await expect(allTracesChip).toHaveAttribute("aria-pressed", "false");
+  await expect(inspector).toContainText("Focused:");
+  await expect(inspector).toContainText("Front Right Wheel");
+
+  await bandToggle.click();
+  await expect(bandToggle).toHaveAttribute("aria-pressed", "true");
+  await expect(bandLegend).toBeVisible();
+
+  await page.waitForTimeout(350);
+
+  await expect(sensorChip).toHaveAttribute("aria-pressed", "true");
+  await expect(sensorChip).toHaveAttribute("data-legend-state", "active");
+  await expect(allTracesChip).toHaveAttribute("aria-pressed", "false");
+  await expect(bandToggle).toHaveAttribute("aria-pressed", "true");
+  await expect(bandLegend).toBeVisible();
+  await expect(inspector).toContainText("Focused:");
+  await expect(inspector).toContainText("Front Right Wheel");
 });
 
 test("spectrum band toggle stays hidden when no spectrum data is available", async ({ page }) => {


### PR DESCRIPTION
## Summary

This PR fixes #2316 by finishing the reactive ownership cut for the spectrum panel UI around the already-migrated chart host. The earlier spectrum work moved `specChart` and `specChartWrap` ownership into `spectrum_panel.tsx`, but the rest of the panel still used the older bridge pattern: header text, overlay text, band-toggle state, legend state, and inspector text lived in a mutable mount-local object, and every update respread that object back through `mount.render(...)`.

I kept the scope intentionally narrow. The renderer, interaction controller, and panel interface already form a clean separation for chart drawing and spectrum interaction logic. This PR does not redesign those runtime layers or change the public spectrum panel contract. Instead, it converts the panel internals to the same single-mount, signal-backed pattern already used in the other migrated islands while keeping the chart-host ref seam stable for `SpectrumCanvasRenderer` and `UiSpectrumController`.

## Problem

Before this change, `apps/ui/src/app/views/spectrum_panel.tsx` still behaved like a bridge-driven view even though it was already rendered as a Preact island. The mount helper kept a `state` object outside the component tree, mutated pieces of that object in methods like `renderHeader()`, `renderOverlay()`, `renderBandToggle()`, `renderSensorLegend()`, `renderBandLegend()`, and `renderInspectorText()`, then called `mount.render(...)` again after each update.

That pattern was the exact migration residue the issue was calling out. The DOM host seam was already solved, but the visible panel state was still managed as if the island were a thin wrapper around imperative DOM rendering. It also made the file harder to reason about than necessary because the actual UI state lived outside the JSX component even though the component already owned the markup.

The important nuance here is that not all mutable spectrum state is bad. The `chartDom` seam is still required because the canvas renderer needs stable element refs for the chart container and chart node. The issue was to remove the unnecessary rerender loop for the surrounding UI while preserving that one intentional integration point.

## Implementation approach

I treated the current `SpectrumPanelView` interface as the stable outer contract for this PR. The runtime and controller code are already clean consumers of that contract, and changing them would have broadened the issue beyond its actual goal. The implementation therefore focused on three coordinated steps:

1. Keep `SpectrumPanelView` and `chartDom` stable so the runtime/controller/chart code does not need a follow-on refactor.
2. Replace the mutable bridge object in `spectrum_panel.tsx` with signal-backed component state.
3. Add browser coverage for the most likely regression: spectrum legend and band-toggle interactivity while repeated live payloads keep updating the panel.

That gives the issue its requested “reactive state” outcome without mixing it together with later backlog items such as broader contract cleanup or controller simplification.

## Main code changes

In `apps/ui/src/app/views/spectrum_panel.tsx`, the mount helper now renders the panel exactly once. It creates a signal-backed bridge state that holds the current header model, overlay message, band-toggle model, sensor legend model and handlers, band legend model, inspector text, and bound band-toggle callback. The component reads that signal directly, so updates now flow through signal assignment rather than repeated `mount.render(...)` calls.

The chart host integration is intentionally preserved. `specChartWrap` and `specChart` still flow through the existing `chartDom` getters, and the component still assigns those refs through the existing callback-ref path. That means `SpectrumCanvasRenderer` and `UiSpectrumController` continue to receive stable chart DOM references without any contract change in `spectrum_panel_view.ts`.

The resulting cut is deliberately asymmetric in the right way: the chart DOM seam stays mutable because the renderer needs it, while the panel UI state becomes reactive because the component should own it.

I also added a small helper, `createDefaultPanelState()`, so the initial signal-backed state is created as a fresh object instead of reusing the nested default structure directly. That keeps the initialization explicit and avoids accidental dependence on shared nested references as more of the UI moves toward signals.

On the documentation side, I updated `apps/ui/README.md` so `app/runtime/spectrum_panel_view.ts` is described as the typed contract for the signal-backed spectrum panel rather than as a DOM-rendering helper. That better matches the current architecture after this change.

## Tests and validation

Because the public spectrum contract stays stable, most of the existing focused runtime tests remain directly relevant. I kept those in the validation slice:

- `tests/ui_spectrum_controller.spec.ts` for coordinator-driven overlay behavior
- `tests/spectrum_interaction_controller.spec.ts` for legend, selection, and band-toggle interaction state
- `tests/spectrum_canvas_renderer.spec.ts` for chart preparation and chart DOM usage

I also extended `tests/smoke.spectrum.spec.ts` with a new regression that exercises the actual refactor risk in the browser. The new scenario uses a fake websocket that keeps replaying live payloads with spectra and rotational order bands, then verifies that:

- selecting a spectrum series still marks it active
- the band toggle still opens the reference-band legend
- both selections stay interactive and intact while repeated live payloads continue to arrive

That test matters because the old bridge pattern could hide bugs where repeated live rerenders disturbed panel-local interaction state. The new signal-backed panel should keep those interactions stable even as the runtime keeps calling the same render/update methods.

I also kept the broader browser slice around the panel in place:

- `tests/smoke.spectrum.spec.ts`
- `tests/smoke.bootstrap.spec.ts`
- `tests/smoke.settings.spec.ts` filtered to the spectrum-title language path

The title-language smoke is particularly relevant because the spectrum header now flows through the reactive state path rather than a fresh full mount render.

Validation for this PR was:

- `cd apps/ui && npx playwright test tests/ui_spectrum_controller.spec.ts tests/spectrum_interaction_controller.spec.ts tests/spectrum_canvas_renderer.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.spectrum.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.settings.spec.ts -g "spectrum title updates when switching language|spectrum controls|spectrum band toggle stays hidden|bootstrap" --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

The lint run still reports the same pre-existing repo-level Biome schema-version info plus the unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`, but nothing new from this spectrum diff.

## Tradeoffs and follow-ups

The main tradeoff is that this PR does not rename or collapse the `render*()` methods on `SpectrumPanelView` yet. I kept that out of scope on purpose. The issue was about removing manual rerender churn inside the panel implementation, not about redesigning the runtime-facing contract. Keeping the contract stable lets this PR stay small and safe while still eliminating the old bridge behavior that was actually causing the architectural smell.

That leaves later backlog items free to simplify panel contracts more aggressively once more of the UI is signal-backed. For this issue, the important result is that the spectrum panel now behaves like a normal mounted island: the chart refs stay stable, the surrounding UI updates reactively, and the live browser interactions remain intact under repeated websocket updates.

Closes #2316
