### PR TITLE
Delete stale JSX i18n markers

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -221,6 +221,8 @@ instead of controller-side variant class interpolation.
   mutable state bags or manual render-model caches.
 - Use `effect()` only for narrow imperative integrations such as timers,
   persistence, canvas/uPlot bridges, or other external-library coordination.
+- Preact-rendered copy comes from `useUiTranslation()`. Do not leave
+  `data-i18n` attributes in JSX unless a non-Preact consumer still reads them.
 - Existing mutable app-state objects and manual bridge rerenders are follow-up
   migration residue, not the default pattern for new frontend work.
 

--- a/apps/ui/src/app/views/analysis_panel.tsx
+++ b/apps/ui/src/app/views/analysis_panel.tsx
@@ -272,7 +272,7 @@ function AnalysisField(props: {
   const t = useUiTranslation();
   return (
     <div class="field">
-      <label htmlFor={spec.inputId} data-i18n={spec.labelKey}>
+      <label htmlFor={spec.inputId}>
         {t(spec.labelKey, spec.fallbackLabel)}
       </label>
       <input
@@ -340,13 +340,13 @@ function AnalysisPanel(props: {
           <span class="settings-help-disclosure__heading">
             <strong
               class="settings-help-disclosure__title"
-              data-i18n="settings.analysis.guidance_title"
+
             >
               {t("settings.analysis.guidance_title", "Safe starting point")}
             </strong>
             <span
               class="settings-help-disclosure__caption"
-              data-i18n="settings.analysis.guidance_summary"
+
             >
               {t(
                 "settings.analysis.guidance_summary",
@@ -358,7 +358,7 @@ function AnalysisPanel(props: {
         <div class="settings-help-disclosure__body">
           <div
             class="subtle"
-            data-i18n="settings.analysis.guidance_intro"
+
           >
             {t(
               "settings.analysis.guidance_intro",
@@ -367,7 +367,7 @@ function AnalysisPanel(props: {
           </div>
           <div
             class="subtle"
-            data-i18n="settings.analysis.guidance_guardrail"
+
           >
             {t(
               "settings.analysis.guidance_guardrail",
@@ -380,7 +380,7 @@ function AnalysisPanel(props: {
         id="analysisNoCarMessage"
         class="empty-state empty-state--inline"
         hidden={!noCarSelected}
-        data-i18n="settings.analysis.no_car_selected"
+
       >
         {t(
           "settings.analysis.no_car_selected",
@@ -389,7 +389,7 @@ function AnalysisPanel(props: {
       </div>
       <div class="settings-groups">
         <section class="settings-group">
-          <h3 data-i18n="settings.group.order_band_widths">
+          <h3>
             {t("settings.group.order_band_widths", "Order Band Widths")}
           </h3>
           <details
@@ -399,7 +399,7 @@ function AnalysisPanel(props: {
             <summary class="settings-help-disclosure__summary">
               <span
                 class="settings-help-disclosure__title"
-                data-i18n="settings.analysis.more_guidance"
+
               >
                 {t("settings.analysis.more_guidance", "Why this matters")}
               </span>
@@ -407,7 +407,7 @@ function AnalysisPanel(props: {
             <div class="settings-help-disclosure__body">
               <div
                 class="subtle"
-                data-i18n="settings.analysis.group.order_band_widths_help"
+
               >
                 {t(
                   "settings.analysis.group.order_band_widths_help",
@@ -432,7 +432,7 @@ function AnalysisPanel(props: {
         </section>
 
         <section class="settings-group">
-          <h3 data-i18n="settings.group.uncertainty_model">
+          <h3>
             {t("settings.group.uncertainty_model", "Uncertainty Model")}
           </h3>
           <details
@@ -442,14 +442,14 @@ function AnalysisPanel(props: {
             <summary class="settings-help-disclosure__summary">
               <span
                 class="settings-help-disclosure__title"
-                data-i18n="settings.analysis.more_guidance"
+
               >
                 {t("settings.analysis.more_guidance", "Why this matters")}
               </span>
             </summary>
             <div class="settings-help-disclosure__body">
               <div class="subtle">
-                <span data-i18n="settings.uncertainty_defaults">
+                <span>
                   {t(
                     "settings.uncertainty_defaults",
                     "Defaults use tire wear from 10/32 in to 2/32 in plus safety margin.",
@@ -458,7 +458,7 @@ function AnalysisPanel(props: {
               </div>
               <div
                 class="subtle"
-                data-i18n="settings.analysis.group.uncertainty_model_help"
+
               >
                 {t(
                   "settings.analysis.group.uncertainty_model_help",
@@ -496,7 +496,7 @@ function AnalysisPanel(props: {
           id="resetAnalysisBtn"
           type="button"
           class="btn"
-          data-i18n="settings.analysis.reset"
+
           disabled={!state.availability.hasActiveCar}
           onClick={() => state.actions?.onReset()}
         >
@@ -506,7 +506,7 @@ function AnalysisPanel(props: {
           id="saveAnalysisBtn"
           type="button"
           class="btn btn--primary"
-          data-i18n="settings.analysis.save"
+
           disabled={!state.availability.hasActiveCar}
           onClick={() => state.actions?.onSave()}
         >

--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -309,7 +309,7 @@ function CarsTableBody(props: {
   if (table === null) {
     return (
       <tr>
-        <td colSpan={3} data-i18n="settings.car.no_cars">
+        <td colSpan={3}>
           {t("settings.car.no_cars", "No cars added yet.")}
         </td>
       </tr>
@@ -528,20 +528,20 @@ function CarsPanel(props: {
     <>
       <div class="panel card">
         <div class="car-tab-header">
-          <strong data-i18n="settings.car.manage">
+          <strong>
             {t("settings.car.manage", "Manage Cars")}
           </strong>
           <button
             id="addCarBtn"
             class="btn btn--success"
-            data-i18n="settings.car.add_new"
+
             onClick={() => state.wizardActions?.onAction({ type: "open" })}
             ref={addCarBtnRef}
           >
             {t("settings.car.add_new", "+ Add Car")}
           </button>
         </div>
-        <div class="subtle" data-i18n="settings.car.hint">
+        <div class="subtle">
           {t(
             "settings.car.hint",
             "Add cars from the library or enter specs manually. Activate a car to use it for analysis.",
@@ -556,13 +556,13 @@ function CarsPanel(props: {
           <table class="car-list-table settings-entity-table settings-entity-table--cars">
             <thead>
               <tr>
-                <th data-i18n="settings.car.col_name">
+                <th>
                   {t("settings.car.col_name", "Name")}
                 </th>
-                <th data-i18n="settings.car.col_setup">
+                <th>
                   {t("settings.car.col_setup", "Setup")}
                 </th>
-                <th data-i18n="settings.car.col_actions">
+                <th>
                   {t("settings.car.col_actions", "Actions")}
                 </th>
               </tr>
@@ -593,10 +593,10 @@ function CarsPanel(props: {
         >
           <div class="wizard-header">
             <div class="wizard-header__text">
-              <strong id="wizardTitle" data-i18n="settings.car.add_title">
+              <strong id="wizardTitle">
                 {t("settings.car.add_title", "Add a Car")}
               </strong>
-              <div class="subtle" data-i18n="settings.car.wizard_intro">
+              <div class="subtle">
                 {t(
                   "settings.car.wizard_intro",
                   "Use the library when it fits, or branch into manual specs without losing your place.",
@@ -629,7 +629,7 @@ function CarsPanel(props: {
                       aria-current={index === wizardModel.step ? "step" : undefined}
                     >
                       <span class="wizard-step-dot__number">{index + 1}</span>
-                      <span class="wizard-step-dot__label" data-i18n={label.key}>
+                      <span class="wizard-step-dot__label">
                         {t(label.key, label.fallback)}
                       </span>
                     </span>
@@ -637,7 +637,7 @@ function CarsPanel(props: {
                 </div>
 
                 <div id="wizardStep0" class="wizard-step" hidden={wizardModel.step !== 0}>
-                  <h3 data-i18n="settings.car.step_brand">
+                  <h3>
                     {t("settings.car.step_brand", "Select Brand")}
                   </h3>
                   <WizardOptions
@@ -654,7 +654,7 @@ function CarsPanel(props: {
                     }}
                   />
                   <div class="wizard-custom">
-                    <label data-i18n="settings.car.or_custom_brand">
+                    <label>
                       {t("settings.car.or_custom_brand", "Or type a custom brand:")}
                     </label>
                     <input
@@ -667,7 +667,7 @@ function CarsPanel(props: {
                     <button
                       id="wizardCustomBrandBtn"
                       class="btn btn--primary"
-                      data-i18n="settings.car.use_custom"
+
                       onClick={() =>
                         state.wizardActions?.onAction({
                           type: "submit-custom-brand",
@@ -680,7 +680,7 @@ function CarsPanel(props: {
                 </div>
 
                 <div id="wizardStep1" class="wizard-step" hidden={wizardModel.step !== 1}>
-                  <h3 data-i18n="settings.car.step_type">
+                  <h3>
                     {t("settings.car.step_type", "Select Type")}
                   </h3>
                   <WizardOptions
@@ -697,7 +697,7 @@ function CarsPanel(props: {
                     }}
                   />
                   <div class="wizard-custom">
-                    <label data-i18n="settings.car.or_custom_type">
+                    <label>
                       {t("settings.car.or_custom_type", "Or type a custom type:")}
                     </label>
                     <input
@@ -710,7 +710,7 @@ function CarsPanel(props: {
                     <button
                       id="wizardCustomTypeBtn"
                       class="btn btn--primary"
-                      data-i18n="settings.car.use_custom"
+
                       onClick={() =>
                         state.wizardActions?.onAction({
                           type: "submit-custom-type",
@@ -723,7 +723,7 @@ function CarsPanel(props: {
                 </div>
 
                 <div id="wizardStep2" class="wizard-step" hidden={wizardModel.step !== 2}>
-                  <h3 data-i18n="settings.car.step_model">
+                  <h3>
                     {t("settings.car.step_model", "Select Model")}
                   </h3>
                   <WizardOptions
@@ -744,16 +744,16 @@ function CarsPanel(props: {
                     }}
                   />
                   <div class="wizard-custom wizard-custom--branch">
-                    <strong class="wizard-branch-label" data-i18n="settings.car.manual_branch_title">
+                    <strong class="wizard-branch-label">
                       {t("settings.car.manual_branch_title", "Manual specs branch")}
                     </strong>
-                    <div class="subtle wizard-branch-note" data-i18n="settings.car.manual_model_note">
+                    <div class="subtle wizard-branch-note">
                       {t(
                         "settings.car.manual_model_note",
                         "Skip library variants and finish with your own wheel and gearbox values.",
                       )}
                     </div>
-                    <label data-i18n="settings.car.or_custom_model">
+                    <label>
                       {t("settings.car.or_custom_model", "Or type a custom model:")}
                     </label>
                     <input
@@ -766,7 +766,7 @@ function CarsPanel(props: {
                     <button
                       id="wizardCustomModelBtn"
                       class="btn btn--primary"
-                      data-i18n="settings.car.use_custom"
+
                       onClick={() =>
                         state.wizardActions?.onAction({
                           type: "submit-custom-model",
@@ -779,7 +779,7 @@ function CarsPanel(props: {
                 </div>
 
                 <div id="wizardStep3" class="wizard-step" hidden={wizardModel.step !== 3}>
-                  <h3 data-i18n="settings.car.step_variant">
+                  <h3>
                     {t("settings.car.step_variant", "Select Variant")}
                   </h3>
                   <WizardOptions
@@ -804,17 +804,17 @@ function CarsPanel(props: {
                 <div id="wizardStep4" class="wizard-step" hidden={wizardModel.step !== 4}>
                   <div class="wizard-branch-card wizard-branch-card--library">
                     <div class="wizard-branch-card__header">
-                      <strong class="wizard-branch-label" data-i18n="settings.car.library_branch_title">
+                      <strong class="wizard-branch-label">
                         {t("settings.car.library_branch_title", "Library-matched specs")}
                       </strong>
-                      <div class="subtle wizard-branch-note" data-i18n="settings.car.library_branch_note">
+                      <div class="subtle wizard-branch-note">
                         {t(
                           "settings.car.library_branch_note",
                           "Choose the tire and gearbox that match this car. Finish stays pinned below.",
                         )}
                       </div>
                     </div>
-                    <h3 data-i18n="settings.car.step_wheels">
+                    <h3>
                       {t("settings.car.step_wheels", "Select Wheels")}
                     </h3>
                     <WizardOptions
@@ -834,7 +834,7 @@ function CarsPanel(props: {
                         optionRefs.current.tireOption = element;
                       }}
                     />
-                    <h3 data-i18n="settings.car.step_gearbox" class="wizard-section-title">
+                    <h3 class="wizard-section-title">
                       {t("settings.car.step_gearbox", "Select Gearbox")}
                     </h3>
                     <WizardOptions
@@ -856,18 +856,18 @@ function CarsPanel(props: {
                     />
                   </div>
                   <div class="wizard-branch-divider">
-                    <span data-i18n="settings.car.branch_divider">
+                    <span>
                       {t("settings.car.branch_divider", "Or switch to the manual branch")}
                     </span>
                   </div>
                   <div class="wizard-branch-card wizard-branch-card--manual wizard-custom-specs">
                     <div class="wizard-branch-card__header">
-                      <strong class="wizard-branch-label" data-i18n="settings.car.manual_branch_title">
+                      <strong class="wizard-branch-label">
                         {t("settings.car.manual_branch_title", "Manual specs branch")}
                       </strong>
                       <div
                         class="subtle wizard-custom-specs__note"
-                        data-i18n="settings.car.manual_specs_note"
+
                       >
                         {t(
                           "settings.car.manual_specs_note",
@@ -877,7 +877,7 @@ function CarsPanel(props: {
                     </div>
                     <div class="settings-subgrid">
                       <div class="field">
-                        <label htmlFor="wizTireWidth" data-i18n="settings.tire_width">
+                        <label htmlFor="wizTireWidth">
                           {t("settings.tire_width", "Tire Width (mm)")}
                         </label>
                         <input
@@ -891,7 +891,7 @@ function CarsPanel(props: {
                         />
                       </div>
                       <div class="field">
-                        <label htmlFor="wizTireAspect" data-i18n="settings.tire_aspect">
+                        <label htmlFor="wizTireAspect">
                           {t("settings.tire_aspect", "Tire Aspect (%)")}
                         </label>
                         <input
@@ -905,7 +905,7 @@ function CarsPanel(props: {
                         />
                       </div>
                       <div class="field">
-                        <label htmlFor="wizRim" data-i18n="settings.rim_size">
+                        <label htmlFor="wizRim">
                           {t("settings.rim_size", "Rim Size (in)")}
                         </label>
                         <input
@@ -919,7 +919,7 @@ function CarsPanel(props: {
                         />
                       </div>
                       <div class="field">
-                        <label htmlFor="wizFinalDrive" data-i18n="settings.final_drive_ratio">
+                        <label htmlFor="wizFinalDrive">
                           {t("settings.final_drive_ratio", "Final Drive Ratio")}
                         </label>
                         <input
@@ -933,7 +933,7 @@ function CarsPanel(props: {
                         />
                       </div>
                       <div class="field">
-                        <label htmlFor="wizGearRatio" data-i18n="settings.top_gear_ratio">
+                        <label htmlFor="wizGearRatio">
                           {t("settings.top_gear_ratio", "Top Gear Ratio")}
                         </label>
                         <input
@@ -960,7 +960,7 @@ function CarsPanel(props: {
                     id="wizardBackBtn"
                     class="btn btn--muted"
                     hidden={!wizardModel.backVisible}
-                    data-i18n="settings.car.back"
+
                     onClick={() => state.wizardActions?.onAction({ type: "back" })}
                   >
                     {t("settings.car.back", "Back")}
@@ -970,7 +970,7 @@ function CarsPanel(props: {
                     class="btn btn--success"
                     hidden={!wizardModel.finishVisible}
                     disabled={!wizardModel.finishEnabled}
-                    data-i18n="settings.car.finish_add"
+
                     onClick={() => state.wizardActions?.onAction({ type: "finish" })}
                     ref={wizardManualAddBtnRef}
                   >
@@ -982,20 +982,20 @@ function CarsPanel(props: {
 
             <aside class="wizard-summary-card" aria-live="polite">
               <div class="wizard-task-callout">
-                <strong data-i18n="settings.car.wizard_task_title">
+                <strong>
                   {t("settings.car.wizard_task_title", "Guided setup")}
                 </strong>
-                <div class="subtle" data-i18n="settings.car.wizard_task_intro">
+                <div class="subtle">
                   {t(
                     "settings.car.wizard_task_intro",
                     "This flow pauses the rest of Settings so you can build the next analysis profile step by step without losing your place.",
                   )}
                 </div>
               </div>
-              <div class="wizard-summary-card__title" data-i18n="settings.car.wizard_summary_title">
+              <div class="wizard-summary-card__title">
                 {t("settings.car.wizard_summary_title", "Current selection")}
               </div>
-              <div class="subtle" data-i18n="settings.car.wizard_summary_intro">
+              <div class="subtle">
                 {t(
                   "settings.car.wizard_summary_intro",
                   "Your choices stay visible here while the profile comes together.",

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -329,13 +329,13 @@ function EspFlashPanel(props: {
               <div>
                 <div
                   class="maintenance-card__title"
-                  data-i18n="settings.esp_flash.title"
+
                 >
                   {t("settings.esp_flash.title", "ESP Flash")}
                 </div>
                 <div
                   class="subtle"
-                  data-i18n="settings.esp_flash.hint"
+
                 >
                   {t(
                     "settings.esp_flash.hint",
@@ -355,7 +355,7 @@ function EspFlashPanel(props: {
               <div class="manual-speed-row">
                 <label
                   htmlFor="espFlashPortSelect"
-                  data-i18n="settings.esp_flash.port"
+
                 >
                   {t("settings.esp_flash.port", "Serial Port")}
                 </label>
@@ -376,7 +376,7 @@ function EspFlashPanel(props: {
                   type="button"
                   id="espFlashRefreshPortsBtn"
                   class="btn btn--muted"
-                  data-i18n="settings.esp_flash.refresh_ports"
+
                   disabled={model.refreshPortsDisabled}
                   onClick={() => state.actions?.onRefreshPorts()}
                 >
@@ -402,13 +402,13 @@ function EspFlashPanel(props: {
                   <span class="settings-help-disclosure__heading">
                     <span
                       class="settings-help-disclosure__title"
-                      data-i18n="settings.esp_flash.details_title"
+
                     >
                       {t("settings.esp_flash.details_title", "What happens next")}
                     </span>
                     <span
                       class="settings-help-disclosure__caption"
-                      data-i18n="settings.esp_flash.details_caption"
+
                     >
                       {t(
                         "settings.esp_flash.details_caption",
@@ -420,7 +420,7 @@ function EspFlashPanel(props: {
                 <div class="settings-help-disclosure__body">
                   <div
                     class="maintenance-note"
-                    data-i18n="settings.esp_flash.preflight_note"
+
                   >
                     {t(
                       "settings.esp_flash.preflight_note",
@@ -444,7 +444,7 @@ function EspFlashPanel(props: {
                   type="button"
                   id="espFlashCancelBtn"
                   class="btn btn--danger"
-                  data-i18n="settings.esp_flash.cancel"
+
                   hidden={model.cancelButtonHidden}
                   disabled={model.cancelButtonDisabled}
                   onClick={() => state.actions?.onCancel()}
@@ -461,7 +461,7 @@ function EspFlashPanel(props: {
                 <div>
                   <div
                     class="maintenance-card__title"
-                    data-i18n="settings.esp_flash.journey_title"
+
                   >
                     {t("settings.esp_flash.journey_title", "Expected stages")}
                   </div>
@@ -480,13 +480,13 @@ function EspFlashPanel(props: {
                 <div>
                   <div
                     class="maintenance-card__title"
-                    data-i18n="settings.esp_flash.logs_title"
+
                   >
                     {t("settings.esp_flash.logs_title", "Live flash output")}
                   </div>
                   <div
                     class="subtle"
-                    data-i18n="settings.esp_flash.logs_intro"
+
                   >
                     {t(
                       "settings.esp_flash.logs_intro",
@@ -515,13 +515,13 @@ function EspFlashPanel(props: {
               <div>
                 <div
                   class="maintenance-card__title"
-                  data-i18n="settings.esp_flash.history"
+
                   >
                     {t("settings.esp_flash.history", "Recent attempts")}
                   </div>
                 <div
                   class="subtle"
-                  data-i18n="settings.esp_flash.history_intro"
+
                   >
                     {t(
                       "settings.esp_flash.history_intro",

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -35,7 +35,7 @@ function HistoryPanel(props: { state: HistoryPanelBridgeState }) {
             id="refreshHistoryBtn"
             class="btn btn--muted"
             type="button"
-            data-i18n="history.refresh"
+
             onClick={() => state.actions?.onRefreshHistory()}
           >
             {t("history.refresh", "Refresh History")}
@@ -44,7 +44,7 @@ function HistoryPanel(props: { state: HistoryPanelBridgeState }) {
             id="deleteAllRunsBtn"
             class="btn btn--danger-quiet"
             type="button"
-            data-i18n="history.delete_all"
+
             disabled={state.deleteAllRunsDisabled}
             onClick={() => state.actions?.onDeleteAllRuns()}
           >
@@ -55,12 +55,12 @@ function HistoryPanel(props: { state: HistoryPanelBridgeState }) {
       <table class="history-table">
         <thead>
           <tr>
-            <th data-i18n="history.table.file">{t("history.table.file", "Run")}</th>
-            <th data-i18n="history.table.updated">{t("history.table.updated", "Started")}</th>
-            <th class="numeric" data-i18n="history.table.size">
+            <th>{t("history.table.file", "Run")}</th>
+            <th>{t("history.table.updated", "Started")}</th>
+            <th class="numeric">
               {t("history.table.size", "Samples")}
             </th>
-            <th data-i18n="history.table.actions">{t("history.table.actions", "Actions")}</th>
+            <th>{t("history.table.actions", "Actions")}</th>
           </tr>
         </thead>
         <tbody id="historyTableBody">

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -257,7 +257,7 @@ function UpdateTransportChoiceCard(props: {
         disabled={model.inputDisabled}
         onChange={() => onSelect?.(value)}
       />
-      <span class="speed-source-choice__title" data-i18n={titleKey}>
+      <span class="speed-source-choice__title">
         {titleText}
       </span>
       <span id={captionId} class="speed-source-choice__caption">
@@ -276,10 +276,10 @@ function InternetPanel(props: {
   return (
     <div class="maintenance-stack">
       <div class="panel card">
-        <strong data-i18n="settings.internet.title">
+        <strong>
           {t("settings.internet.title", "Internet")}
         </strong>
-        <div class="subtle" data-i18n="settings.internet.hint">
+        <div class="subtle">
           {t(
             "settings.internet.hint",
             "USB internet is optional. When a compatible phone or USB network device is detected, the Pi can keep its hotspot active while using USB as the upstream connection.",
@@ -302,13 +302,13 @@ function InternetPanel(props: {
           <div>
             <div
               class="maintenance-card__title"
-              data-i18n="settings.update.controls_title"
+
             >
               {t("settings.update.controls_title", "Update connection")}
             </div>
             <div
               class="subtle"
-              data-i18n="settings.update.controls_intro"
+
             >
               {t(
                 "settings.update.controls_intro",
@@ -324,7 +324,7 @@ function InternetPanel(props: {
           >
             <div
               class="subtle"
-              data-i18n="settings.update.transport_label"
+
             >
               {t("settings.update.transport_label", "Internet source")}
             </div>
@@ -355,7 +355,7 @@ function InternetPanel(props: {
           </div>
           <div id="updateWifiFields" hidden={model.wifiFieldsHidden}>
             <div class="form-group">
-              <label htmlFor="updateSsidInput" data-i18n="settings.update.ssid">
+              <label htmlFor="updateSsidInput">
                 {t("settings.update.ssid", "Wi-Fi SSID")}
               </label>
               <input
@@ -373,7 +373,7 @@ function InternetPanel(props: {
             <div class="form-group">
               <label
                 htmlFor="updatePasswordInput"
-                data-i18n="settings.update.password"
+
               >
                 {t("settings.update.password", "Wi-Fi Password")}
               </label>
@@ -413,7 +413,7 @@ function InternetPanel(props: {
               <span class="settings-help-disclosure__heading">
                 <span
                   class="settings-help-disclosure__title"
-                  data-i18n="settings.update.details_title"
+
                 >
                   {t("settings.update.details_title", "What happens next")}
                 </span>

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -66,10 +66,10 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
     <>
       <div class="card__header card__header--stack">
         <div>
-          <div class="card__title" data-i18n="dashboard.live_overview">
+          <div class="card__title">
             {t("dashboard.live_overview", "Live overview")}
           </div>
-          <div class="card__subtle" data-i18n="dashboard.live_overview_hint">
+          <div class="card__subtle">
             {t(
               "dashboard.live_overview_hint",
               "Check readiness, current run state, and the strongest sensor level before reading the chart.",
@@ -88,7 +88,7 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
       </div>
       <div class="stat-grid live-overview__stats">
         <div id="liveConnectedSensors" class="stat">
-          <div class="stat__label" data-i18n="dashboard.connected_sensors">
+          <div class="stat__label">
             {t("dashboard.connected_sensors", "Sensors online")}
           </div>
           <div class="stat__value" data-value>
@@ -100,7 +100,7 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
           class="stat"
           data-variant={state.activeCar.warning ? "warn" : undefined}
         >
-          <div class="stat__label" data-i18n="dashboard.active_car">
+          <div class="stat__label">
             {t("dashboard.active_car", "Active car")}
           </div>
           <div
@@ -122,7 +122,7 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
           </div>
         </div>
         <div id="liveRecordingState" class="stat">
-          <div class="stat__label" data-i18n="dashboard.recording_state">
+          <div class="stat__label">
             {t("dashboard.recording_state", "Run state")}
           </div>
           <div class="stat__value" data-value>
@@ -130,7 +130,7 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
           </div>
         </div>
         <div id="liveDataFreshness" class="stat">
-          <div class="stat__label" data-i18n="dashboard.data_freshness">
+          <div class="stat__label">
             {t("dashboard.data_freshness", "Feed freshness")}
           </div>
           <div class="stat__value" data-value>
@@ -138,7 +138,7 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
           </div>
         </div>
         <div id="liveStrongestSignal" class="stat">
-          <div class="stat__label" data-i18n="dashboard.strongest_signal">
+          <div class="stat__label">
             {t("dashboard.strongest_signal", "Strongest signal")}
           </div>
           <div class="stat__value" data-value>
@@ -146,7 +146,7 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
           </div>
         </div>
         <div class="stat">
-          <div class="stat__label" data-i18n="dashboard.current_speed">
+          <div class="stat__label">
             {t("dashboard.current_speed", "Current speed")}
           </div>
           <div id="speed" class="stat__value speed" aria-live="polite">
@@ -155,7 +155,7 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
         </div>
       </div>
       <div class="live-sensor-roster__header">
-        <div class="mini-label" data-i18n="dashboard.sensor_coverage">
+        <div class="mini-label">
           {t("dashboard.sensor_coverage", "Sensor coverage")}
         </div>
       </div>
@@ -181,7 +181,7 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
             );
           })
           : (
-            <div class="subtle" data-i18n="settings.sensors.no_sensors">
+            <div class="subtle">
               {t("settings.sensors.no_sensors", "No sensors yet.")}
             </div>
           )}

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -149,7 +149,7 @@ function RealtimeLoggingPanel(props: {
     <div class="realtime-logging-shell" data-layout={state.setupMode ? "setup" : undefined}>
       <div class="card__header card__header--stack">
         <div>
-          <div class="card__title" data-i18n="dashboard.run_recording">
+          <div class="card__title">
             {t("dashboard.run_recording", "Run Recording")}
           </div>
           <RealtimeLoggingSummary
@@ -176,12 +176,12 @@ function RealtimeLoggingPanel(props: {
       {showProgressSection
         ? (
           <>
-            <div class="mini-label" data-i18n="dashboard.recording_progress">
+            <div class="mini-label">
               {t("dashboard.recording_progress", "Run progress")}
             </div>
             <div class="stat-grid stat-grid--compact">
               <div id="loggingPhase" class="stat stat--compact" hidden>
-                <div class="stat__label" data-i18n="dashboard.recording_phase">
+                <div class="stat__label">
                   {t("dashboard.recording_phase", "Run phase")}
                 </div>
                 <div class="stat__value" data-value>
@@ -189,7 +189,7 @@ function RealtimeLoggingPanel(props: {
                 </div>
               </div>
               <div id="loggingElapsed" class="stat stat--compact">
-                <div class="stat__label" data-i18n="dashboard.recording_elapsed">
+                <div class="stat__label">
                   {t("dashboard.recording_elapsed", "Elapsed")}
                 </div>
                 <div class="stat__value" data-value>
@@ -197,7 +197,7 @@ function RealtimeLoggingPanel(props: {
                 </div>
               </div>
               <div id="loggingSamples" class="stat stat--compact">
-                <div class="stat__label" data-i18n="dashboard.recording_samples">
+                <div class="stat__label">
                   {t("dashboard.recording_samples", "Samples recorded")}
                 </div>
                 <div class="stat__value" data-value>
@@ -214,7 +214,7 @@ function RealtimeLoggingPanel(props: {
           id="startLoggingBtn"
           class="btn btn--primary"
           type="button"
-          data-i18n="dashboard.start_recording"
+
           hidden={!state.showStart}
           disabled={state.startDisabled}
           onClick={() => state.actions?.onStartLogging()}
@@ -225,7 +225,7 @@ function RealtimeLoggingPanel(props: {
           id="stopLoggingBtn"
           class="btn btn--danger-quiet"
           type="button"
-          data-i18n="dashboard.stop_recording"
+
           hidden={!state.showStop}
           disabled={state.stopDisabled}
           onClick={() => state.actions?.onStopLogging()}

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -126,10 +126,10 @@ function SensorsPanel(props: { state: ReadonlySignal<SensorsPanelBridgeState> })
   const t = useUiTranslation();
   return (
     <div class="panel card">
-      <strong data-i18n="settings.sensors.title">
+      <strong>
         {t("settings.sensors.title", "Sensors")}
       </strong>
-      <div class="subtle" data-i18n="settings.sensors.hint">
+      <div class="subtle">
         {t(
           "settings.sensors.hint",
           "Manage sensor names and locations. Default name is the MAC address.",
@@ -139,13 +139,13 @@ function SensorsPanel(props: { state: ReadonlySignal<SensorsPanelBridgeState> })
         <table class="clients-table settings-entity-table settings-entity-table--sensors">
           <thead>
             <tr>
-              <th data-i18n="settings.sensors.name">
+              <th>
                 {t("settings.sensors.name", "Name")}
               </th>
-              <th data-i18n="settings.sensors.location">
+              <th>
                 {t("settings.sensors.location", "Location")}
               </th>
-              <th data-i18n="settings.sensors.actions">
+              <th>
                 {t("settings.sensors.actions", "Actions")}
               </th>
             </tr>

--- a/apps/ui/src/app/views/settings_shell.tsx
+++ b/apps/ui/src/app/views/settings_shell.tsx
@@ -142,7 +142,7 @@ function SettingsShell(props: SettingsShellProps) {
               onClick={() => onActivateTab(tab.id)}
               onKeyDown={(event) => handleTabKeyDown(index, event)}
             >
-              <span data-i18n={tab.labelKey}>
+              <span>
                 {t(tab.labelKey, tab.fallbackLabel)}
               </span>
             </button>

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -90,7 +90,7 @@ function SpectrumPanel(props: {
   return (
     <>
       <div class="card__header">
-        <div class="card__title" data-i18n="chart.spectrum_title">
+        <div class="card__title">
           {t("chart.spectrum_title", state.header.titleText)}
         </div>
       </div>
@@ -113,7 +113,7 @@ function SpectrumPanel(props: {
       </div>
       <div class="spectrum-controls-panel">
         <div class="spectrum-toolbar">
-          <div class="card__subtle spectrum-toolbar__hint" data-i18n="spectrum.controls_hint">
+          <div class="card__subtle spectrum-toolbar__hint">
             {t("spectrum.controls_hint", state.header.hintText)}
           </div>
           <div class="spectrum-toolbar__bands">

--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -432,10 +432,10 @@ function SpeedSourceChoiceCard(props: {
           choice.mode === "obd2" && model.obdSelectionInvalid ? "true" : undefined
         }
       />
-      <span class="speed-source-choice__title" data-i18n={choice.titleKey}>
+      <span class="speed-source-choice__title">
         {choice.titleText}
       </span>
-      <span class="speed-source-choice__caption" data-i18n={choice.captionKey}>
+      <span class="speed-source-choice__caption">
         {choice.captionText}
       </span>
     </label>
@@ -503,19 +503,19 @@ function SpeedSourcePanel(props: {
   return (
     <>
       <div class="panel card">
-        <strong data-i18n="settings.speed.title">
+        <strong>
           {t("settings.speed.title", "Speed Source")}
         </strong>
         <div class="speed-source-summary">
           <div
             class="speed-source-summary__eyebrow"
-            data-i18n="settings.speed.summary_title"
+
           >
             {t("settings.speed.summary_title", "Active right now")}
           </div>
           <div
             class="subtle speed-source-summary__caption"
-            data-i18n="settings.speed.summary_caption"
+
           >
             {t(
               "settings.speed.summary_caption",
@@ -526,7 +526,7 @@ function SpeedSourcePanel(props: {
             <div class="speed-source-summary__stat">
               <div
                 class="speed-source-summary__label"
-                data-i18n="settings.speed.current_source"
+
               >
                 {t("settings.speed.current_source", "Current source")}
               </div>
@@ -540,7 +540,7 @@ function SpeedSourcePanel(props: {
             <div class="speed-source-summary__stat">
               <div
                 class="speed-source-summary__label"
-                data-i18n="settings.speed.effective_speed"
+
               >
                 {t("settings.speed.effective_speed", "Effective speed")}
               </div>
@@ -554,7 +554,7 @@ function SpeedSourcePanel(props: {
             <div class="speed-source-summary__stat">
               <div
                 class="speed-source-summary__label"
-                data-i18n="settings.speed.fallback_active"
+
               >
                 {t("settings.speed.fallback_active", "Fallback active")}
               </div>
@@ -584,7 +584,7 @@ function SpeedSourcePanel(props: {
           class="speed-source-config"
           hidden={!state.model.manualConfigVisible}
         >
-          <div class="subtle" data-i18n="settings.speed.manual_intro">
+          <div class="subtle">
             {t(
               "settings.speed.manual_intro",
               "Set a fixed speed for manual mode and as the live-source fallback when GPS or OBD-II data goes stale.",
@@ -593,7 +593,7 @@ function SpeedSourcePanel(props: {
           <div class="manual-speed-row">
             <label
               htmlFor="manualSpeedInput"
-              data-i18n="settings.speed.manual_label"
+
             >
               {t("settings.speed.manual_label", "Manual Speed (km/h)")}
             </label>
@@ -627,7 +627,7 @@ function SpeedSourcePanel(props: {
           class="speed-source-config"
           hidden={!state.model.obdConfigVisible}
         >
-          <div class="subtle" data-i18n="settings.speed.obd_intro">
+          <div class="subtle">
             {t(
               "settings.speed.obd_intro",
               "Pair a Bluetooth OBD adapter with the Pi, then save OBD-II as the selected live source.",
@@ -637,7 +637,7 @@ function SpeedSourcePanel(props: {
             <div class="speed-source-obd-toolbar__summary">
               <div
                 class="speed-source-summary__label"
-                data-i18n="settings.speed.obd_configured_device"
+
               >
                 {t("settings.speed.obd_configured_device", "Configured adapter")}
               </div>
@@ -651,7 +651,7 @@ function SpeedSourcePanel(props: {
               class="btn btn--secondary"
               type="button"
               disabled={state.model.scanObdDevicesDisabled}
-              data-i18n="settings.speed.obd_scan"
+
               onClick={() => {
                 state.actions?.onScanObdDevices();
               }}
@@ -679,7 +679,7 @@ function SpeedSourcePanel(props: {
           class="speed-source-config"
           hidden={!state.model.showGpsFallbackPanel}
         >
-          <div class="subtle" data-i18n="settings.speed.gps_intro">
+          <div class="subtle">
             {t(
               "settings.speed.gps_intro",
               "Choose how long stale live-source data can remain usable before the manual fallback takes over.",
@@ -688,7 +688,7 @@ function SpeedSourcePanel(props: {
           <div class="manual-speed-row">
             <label
               htmlFor="staleTimeoutInput"
-              data-i18n="settings.speed.stale_timeout_label"
+
             >
               {t("settings.speed.stale_timeout_label", "Stale timeout (s)")}
             </label>
@@ -729,7 +729,7 @@ function SpeedSourcePanel(props: {
             id="saveSpeedSourceBtn"
             class="btn btn--primary"
             type="button"
-            data-i18n="settings.speed.save"
+
             onClick={() => {
               state.actions?.onSave();
             }}
@@ -749,13 +749,13 @@ function SpeedSourcePanel(props: {
           <span class="settings-help-disclosure__heading">
             <span
               class="settings-help-disclosure__title"
-              data-i18n="settings.speed.status_title"
+
             >
               {t("settings.speed.status_title", "Live source status")}
             </span>
             <span
               class="settings-help-disclosure__caption"
-              data-i18n="settings.speed.status_caption"
+
             >
               {t(
                 "settings.speed.status_caption",
@@ -769,7 +769,7 @@ function SpeedSourcePanel(props: {
             <tbody>
               {GPS_STATUS_ROWS.map((row) => (
                 <tr key={row.id}>
-                  <td data-i18n={row.labelKey}>{t(row.labelKey, row.fallbackLabel)}</td>
+                  <td>{t(row.labelKey, row.fallbackLabel)}</td>
                   <td id={row.id}>{state.diagnostics.gps[row.valueKey]}</td>
                 </tr>
               ))}
@@ -783,7 +783,7 @@ function SpeedSourcePanel(props: {
             <tbody>
               {OBD_STATUS_ROWS.map((row) => (
                 <tr key={row.id}>
-                  <td data-i18n={row.labelKey}>{t(row.labelKey, row.fallbackLabel)}</td>
+                  <td>{t(row.labelKey, row.fallbackLabel)}</td>
                   <td id={row.id}>{state.diagnostics.obd[row.valueKey]}</td>
                 </tr>
               ))}

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -341,10 +341,10 @@ function UpdatePanel(props: {
         <section class="maintenance-card maintenance-card--hero">
           <div class="maintenance-card__header">
             <div>
-              <div class="maintenance-card__title" data-i18n="settings.update.title">
+              <div class="maintenance-card__title">
                 {t("settings.update.title", "System Update")}
               </div>
-              <div class="subtle" data-i18n="settings.update.hint">
+              <div class="subtle">
                 {t(
                   "settings.update.hint",
                   "Use either temporary Wi-Fi credentials or an already-connected USB internet uplink to update from GitHub. The hotspot only pauses for the Wi-Fi path.",
@@ -353,7 +353,7 @@ function UpdatePanel(props: {
             </div>
           </div>
           <div class="maintenance-card__body maintenance-card__body--hero">
-            <div class="maintenance-note" data-i18n="settings.update.reconnect_note">
+            <div class="maintenance-note">
               {t(
                 "settings.update.reconnect_note",
                 "Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.",

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -45,10 +45,11 @@ test("spectrum title updates when switching language", async ({ page }) => {
     },
   });
   await page.goto("/");
-  await expect(page.locator("#dashboardView [data-i18n='chart.spectrum_title']")).toHaveText("Multi-Sensor Blended Spectrum");
+  const spectrumTitle = page.locator("#spectrumPanelRoot .card__title");
+  await expect(spectrumTitle).toHaveText("Multi-Sensor Blended Spectrum");
   await expect(page.locator("#languageSelect")).toHaveValue("en");
   await page.locator("#languageSelect").selectOption("nl");
-  await expect(page.locator("#dashboardView [data-i18n='chart.spectrum_title']")).toHaveText("Gecombineerd spectrum van meerdere sensoren");
+  await expect(spectrumTitle).toHaveText("Gecombineerd spectrum van meerdere sensoren");
   await expect(page.locator("#languageSelect")).toHaveValue("nl");
 });
 


### PR DESCRIPTION
## Summary

This PR closes #2318 by removing stale `data-i18n` attributes from the Preact view layer and making `useUiTranslation()` the only live translation path inside JSX-rendered UI surfaces. During the incremental migration to Preact plus signals, many panels were updated to render translated copy directly in JSX but still kept the old DOM marker attributes on the same nodes. Those attributes no longer drove translation behavior, but they still looked like a second active localization mechanism. That made the migration status harder to reason about and encouraged new code to cargo-cult the obsolete marker pattern.

The goal here is intentionally narrow. This PR does not change translation dictionaries, language persistence, the shell language refresh flow, or any runtime controller logic. It only removes translation markers that had already become redundant inside Preact-owned views, updates the affected smoke selector, and documents the single-source-of-truth rule so future view work does not drift back toward a dual-path setup.

## Problem

The issue called out several concrete files, but the audit showed the residue was broader. `apps/ui/src/app/views/**` still had JSX-level `data-i18n` markers in the spectrum, settings, cars, realtime, history, analysis, sensors, update, internet, ESP flash, and speed-source surfaces. In all of those places, the visible text was already coming from `useUiTranslation()` and fallback strings, so the attribute no longer participated in rendering. The only remaining value was as ambiguous metadata.

Before deleting those markers, I checked whether anything in the current UI runtime still depended on them. That scan confirmed the opposite: `ui_shell_language_refresh_module.ts` already avoids sweeping `[data-i18n]` nodes and instead refreshes island-owned UI through focused feature and runtime render paths. A broader source search across `apps/ui/src/**` also found no remaining runtime consumer of `data-i18n`. The only direct dependency left after that audit was one Playwright smoke selector that located the spectrum title through the old attribute.

That evidence made the right fix straightforward: delete the stale marker attributes rather than preserve them as compatibility clutter.

## Implementation approach

I kept the change mechanical and reviewable. Instead of touching translation keys, presenter contracts, or component structure, I removed only the redundant JSX attributes from the affected Preact view files and left the existing translated text expressions intact. That preserves the same rendered copy, the same fallback behavior, and the same runtime ownership while making the DOM reflect the architecture more honestly.

The removal spans four main buckets of Preact UI:

1. Dashboard and realtime surfaces: `realtime_live_overview.tsx`, `realtime_logging_panel.tsx`, and `spectrum_panel.tsx`.
2. Settings and maintenance surfaces: `analysis_panel.tsx`, `sensors_panel.tsx`, `settings_shell.tsx`, `internet_panel.tsx`, `update_panel.tsx`, `esp_flash_panel.tsx`, and `speed_source_panel.tsx`.
3. Car-management flows: `cars_panel.tsx`, including the wizard steps and summary cards.
4. History surfaces: `history_panel.tsx`.

In each file, the visible strings still come from `t(...)` / `useUiTranslation()`. The diff is attribute deletion, not behavioral rewiring.

## Main code changes by area

Across the view layer, this PR removes the redundant `data-i18n` props from headings, labels, buttons, table headers, helper text, wizard step labels, and summary cards. That includes high-traffic UI such as the cars wizard flow, the speed-source settings panels, the update and internet surfaces, the history toolbar, the analysis help affordances, and the realtime dashboard cards. The important point is that none of those nodes lost their translated text source; they only lost the extra DOM metadata that was pretending to be a second translation path.

The one runtime-facing test change is in `apps/ui/tests/smoke.settings.spec.ts`. The spectrum title language-switch smoke previously asserted on `#dashboardView [data-i18n='chart.spectrum_title']`. That was precisely the kind of stale coupling the issue wanted removed. The test now targets `#spectrumPanelRoot .card__title`, which is the actual UI surface under test. This keeps the behavior assertion intact—switching the language still updates the rendered spectrum title—while avoiding dependence on removed marker metadata.

I also updated `apps/ui/README.md` under the shared reactive state contract. The new note says that Preact-rendered copy should come from `useUiTranslation()` and that JSX should not keep `data-i18n` attributes unless a non-Preact consumer still depends on them. That documentation matters because this cleanup is not just about deleting attributes once; it sets the rule for future incremental migration work so we do not reintroduce the same ambiguity in later panels.

## Validation

Local validation covered both the standard frontend quality gates and the specific behavior affected by the selector change:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/smoke.settings.spec.ts -g "spectrum title updates when switching language" --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

The standard frontend checks passed on the final tree. `npm run lint` still reports the same pre-existing Biome schema-version info and the unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`; those were not introduced by this change. The targeted Playwright smoke also passes after the selector update, confirming that the spectrum title still re-renders correctly when the language changes even though the old `data-i18n` attribute is gone.

I also ran a source scan after the cleanup to confirm there are no remaining `data-i18n` matches anywhere under `apps/ui/src`. That gives us a clean boundary: the live UI source no longer advertises a translation-marker path that the runtime no longer uses.

## Risks, tradeoffs, and edge cases

The main risk in a change like this is deleting an attribute that some hidden consumer still expects. I reduced that risk by auditing the runtime first instead of treating the markers as obviously dead. That audit showed no remaining in-repo UI source consumer, and the existing language refresh path already treats Preact islands as independently rendered surfaces rather than nodes to sweep by marker.

The tradeoff is deliberate: this PR prefers architectural clarity over preserving misleading metadata “just in case.” If an external script outside the UI source tree were somehow scraping these attributes from mounted islands, this change would break that script. There is no evidence of such a consumer in the repo.

It is also worth calling out what this PR does **not** change. It does not alter translation keys, translated strings, language persistence, language save behavior, or runtime language-refresh orchestration. It does not attempt to redesign remaining non-Preact localization seams because the audit did not find any in `apps/ui/src`. This is a cleanup PR, not a functional i18n rewrite.

## Out of scope

This PR does not address the larger live-transport/store migration work tracked elsewhere in the backlog, and it does not change non-translation DOM selectors beyond the one smoke assertion that was explicitly coupled to a removed marker. It also does not add a new hygiene test for `data-i18n` usage because this issue was best solved by cleaning the view layer directly, updating the affected smoke, and documenting the rule in the frontend README.
