### PR TITLE
Remove null UI bridges and require real mounted panels

### DIFF
--- a/apps/ui/src/app/runtime/spectrum_panel_view.ts
+++ b/apps/ui/src/app/runtime/spectrum_panel_view.ts
@@ -66,29 +66,3 @@ export interface SpectrumPanelView {
   renderBandLegend(model: SpectrumBandLegendModel): void;
   renderInspectorText(text: string): void;
 }
-
-function createNullSpectrumChartDom(): SpectrumPanelChartDom {
-  if (typeof document !== "undefined" && typeof document.createElement === "function") {
-    return {
-      specChartWrap: document.createElement("div"),
-      specChart: document.createElement("div"),
-    };
-  }
-  return {
-    specChartWrap: {} as HTMLElement,
-    specChart: {} as HTMLElement,
-  };
-}
-
-export function createNullSpectrumPanelView(): SpectrumPanelView {
-  return {
-    chartDom: createNullSpectrumChartDom(),
-    bindBandToggle() {},
-    renderHeader() {},
-    renderOverlay() {},
-    renderBandToggle() {},
-    renderSensorLegend() {},
-    renderBandLegend() {},
-    renderInspectorText() {},
-  };
-}

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -1,11 +1,11 @@
 import type { AppState } from "../ui_app_state";
 import { SpectrumCanvasRenderer } from "./spectrum_canvas_renderer";
 import { SpectrumInteractionController } from "./spectrum_interaction_controller";
-import { createNullSpectrumPanelView, type SpectrumPanelView } from "./spectrum_panel_view";
+import type { SpectrumPanelView } from "./spectrum_panel_view";
 
 type UiSpectrumControllerDeps = {
   state: AppState;
-  panel?: SpectrumPanelView;
+  panel: SpectrumPanelView;
   t: (key: string, vars?: Record<string, unknown>) => string;
 };
 
@@ -19,7 +19,7 @@ export class UiSpectrumController {
   constructor(
     private readonly deps: UiSpectrumControllerDeps,
   ) {
-    this.panel = this.deps.panel ?? createNullSpectrumPanelView();
+    this.panel = this.deps.panel;
     this.canvas = new SpectrumCanvasRenderer({
       state: this.state,
       dom: this.panel.chartDom,

--- a/apps/ui/src/app/views/history_table_view.ts
+++ b/apps/ui/src/app/views/history_table_view.ts
@@ -52,10 +52,3 @@ export interface HistoryPanelView {
   render(model: HistoryPanelRenderModel): void;
   bindActions(handlers: HistoryPanelActionHandlers): void;
 }
-
-export function createNullHistoryPanelView(): HistoryPanelView {
-  return {
-    render() {},
-    bindActions() {},
-  };
-}

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -190,13 +190,6 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
   );
 }
 
-export function createNullRealtimeLiveOverviewBridge(): RealtimeLiveOverviewBridge {
-  return {
-    render() {},
-    setSpeedText() {},
-  };
-}
-
 export function mountRealtimeLiveOverview(host: HTMLElement): RealtimeLiveOverviewBridge {
   const mount = createUiPreactMount(host);
   const state = signal<RealtimeLiveOverviewBridgeState>({ ...DEFAULT_OVERVIEW_STATE });

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -237,13 +237,6 @@ function RealtimeLoggingPanel(props: {
   );
 }
 
-export function createNullRealtimeLoggingPanelBridge(): RealtimeLoggingPanelBridge {
-  return {
-    render() {},
-    bindActions() {},
-  };
-}
-
 export function mountRealtimeLoggingPanel(host: HTMLElement): RealtimeLoggingPanelBridge {
   const mount = createUiPreactMount(host);
   const state = signal<RealtimeLoggingPanelBridgeState>({ ...DEFAULT_PANEL_STATE });


### PR DESCRIPTION
## Summary

Closes #2320.

This change removes the remaining `createNull*` UI bridge helpers from the frontend and makes the last live null-backed dependency explicit. After the earlier Preact panel bootstrap cleanup, the null-object bridges were no longer serving as safe migration scaffolding; they were either unused leftovers or, in the spectrum case, still fabricating fake DOM to satisfy an interface that should only ever represent a real mounted panel.

The result is a smaller and clearer startup/runtime contract. Normal frontend startup no longer depends on placeholder view objects, and missing mounts continue to fail through the explicit registry/bootstrap path instead of being silently papered over by no-op bridges.

## Problem being solved

The issue called out a migration smell that was still hanging around after the larger panel ownership work: null-object view bridges such as `createNullSpectrumPanelView()`, `createNullRealtimeLiveOverviewBridge()`, and similar helpers were still defined even though the app now has a concrete mount path for its live panels.

Those helpers created two different problems:

1. They hid whether a surface was truly optional or whether the app simply had not finished deleting migration scaffolding.
2. In the spectrum case, the fallback was stronger than a no-op bridge: it created fake chart DOM elements solely to let the runtime continue without a real mounted spectrum panel.

That made the runtime contract harder to reason about. If a panel is required for normal startup, the type surface should say so directly. If a panel is genuinely optional, that should be modeled explicitly instead of routing through a fake view implementation that absorbs calls and fabricates placeholder DOM.

## Scope and approach

The code search narrowed this issue down to four remaining null-view helpers:

- `createNullSpectrumPanelView()` in `apps/ui/src/app/runtime/spectrum_panel_view.ts`
- `createNullRealtimeLiveOverviewBridge()` in `apps/ui/src/app/views/realtime_live_overview.tsx`
- `createNullRealtimeLoggingPanelBridge()` in `apps/ui/src/app/views/realtime_logging_panel.tsx`
- `createNullHistoryPanelView()` in `apps/ui/src/app/views/history_table_view.ts`

The important finding was that these four helpers were not all equivalent.

The realtime overview, realtime logging, and history null bridges were dead exports. After the panel bootstrap refactor, every real caller receives mounted panel bridges through `UiMountedPanels`, and there were no remaining imports or call sites for those null helpers anywhere in `apps/ui/src` or `apps/ui/tests`.

The spectrum helper was different. `UiSpectrumController` still declared its `panel` dependency as optional and fell back to `createNullSpectrumPanelView()` when no panel was supplied. That helper also created fake `specChartWrap` and `specChart` elements via `document.createElement(...)` purely so the controller could satisfy `SpectrumCanvasRenderer` without a real mounted surface.

Because of that split, the correct implementation was not “introduce a new generic abstraction” or “replace every null helper with another fallback.” The correct implementation was:

- delete the dead realtime/history null exports outright, and
- make the spectrum panel dependency explicit so the runtime contract matches the actual mounted app architecture.

## Main code changes by area

### Spectrum runtime contract

`apps/ui/src/app/runtime/ui_spectrum_controller.ts` now requires `panel: SpectrumPanelView` instead of accepting `panel?: SpectrumPanelView`. The controller no longer imports or uses `createNullSpectrumPanelView()`, and it now binds directly to the mounted panel passed in through the runtime bootstrap.

This is the most important functional change in the PR. It removes the last path where the runtime could continue by manufacturing a fake mounted spectrum surface instead of depending on the real one that startup already guarantees.

`apps/ui/src/app/runtime/spectrum_panel_view.ts` was simplified accordingly. The null chart DOM builder and `createNullSpectrumPanelView()` were deleted, leaving the file as the type contract for a real mounted spectrum panel rather than a mixed “real or fake” surface.

### Dead null bridge cleanup

Three dead exports were removed:

- `createNullRealtimeLiveOverviewBridge()` from `realtime_live_overview.tsx`
- `createNullRealtimeLoggingPanelBridge()` from `realtime_logging_panel.tsx`
- `createNullHistoryPanelView()` from `history_table_view.ts`

These helpers had no remaining callers. Removing them makes the view modules reflect reality more clearly: they export mounted bridge constructors and their real bridge types, not migration placeholders that no longer participate in startup or tests.

### What did not change

This PR intentionally does not alter how panels are mounted, how features bind handlers, or how the startup registry resolves hosts. Those explicit contracts were already cleaned up in the previous issue. This change builds on that work by removing leftover null-object compatibility code that no longer matches the actual bootstrap architecture.

It also does not add a new optional-port abstraction. There was no second legitimate optional consumer here that justified adding new indirection. The app already knows which panels are required during startup, and the registry/bootstrap layer already throws clearly when those mounts are missing.

## Validation

I validated the change with the frontend commands that cover the affected contract and startup seam:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/ui_spectrum_controller.spec.ts tests/ui_runtime_dom.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

This validation mix matters for different reasons:

- typecheck proves the runtime no longer has any call sites that rely on an optional spectrum panel,
- build catches any stale exports/imports after deleting the null helpers,
- the focused spectrum controller test proves the controller still renders through a real passed panel,
- `ui_runtime_dom.spec.ts` keeps the startup failure contract covered for missing required mounts,
- bootstrap smoke confirms the live app still comes up normally through the real panel registry and mount path.

Lint remained green for this slice aside from the same pre-existing Biome schema-version info and unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`.

I also ran a code-review pass over the final diff. That review found no remaining behavioral issues and confirmed that all callers already provide a real spectrum panel through the `UiMountedPanels` contract.

## Risks and tradeoffs

The main intentional tradeoff is that the runtime is now less forgiving if someone attempts to instantiate `UiSpectrumController` without a mounted panel. That is the right failure mode for this app. The mounted panel is not optional in normal startup, and silently continuing with fake DOM would hide an actual composition bug.

The risk with deleting dead exports is mostly around overlooked test or tooling imports. I specifically searched the source and test tree for remaining `createNull*` references before removing them, and the build/typecheck pass confirmed that no hidden callers remained.

## Out of scope

This PR does not convert new surfaces to signals, change feature ownership, or alter the registry/bootstrap layout introduced in the previous issue. It is a cleanup of runtime contracts, not another startup architecture rewrite. The purpose is to finish removing migration-era null-object view shims now that the app consistently mounts real Preact-owned panel surfaces.
