### PR TITLE
Convert AppState slices into a signal-backed store

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -89,6 +89,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/ui_panel_bootstrap.ts` | Centralized host registry and panel-mount bootstrap for dashboard, history, and settings islands so startup/runtime stop wiring one host getter per panel |
 | `app/dom/` | Focused DOM lookup helpers that remain after the panel bootstrap cleanup, including `requiredById` and other non-panel runtime locators |
 | `app/ui_app_runtime.ts` | UI composition root that wires state, feature-scoped DOM locators, focused runtime controllers, and explicit feature port bundles |
+| `app/ui_app_state.ts` | Canonical AppState shape plus reactive slice helpers that keep object-style reads/writes working while shared shell/transport/realtime/history/settings/spectrum state becomes signal-observable |
 | `app/ui_signals.ts` | Canonical re-export surface for shared `signal`, `computed`, and `effect` usage across runtime, features, and views |
 | `app/runtime/ui_preact_mount.ts` | Canonical helper for mounting and disposing incremental Preact islands inside existing DOM hosts |
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, and app-level error banner plus the typed shell chrome bridge |
@@ -158,6 +159,8 @@ source-of-truth export commands remain the only writers for those files.
 | `theme.ts` | Chart color palette and order band fill colors |
 | `styles/app.css` | Thin stylesheet aggregator that imports the UI style modules in cascade order |
 | `styles/{tokens,shell,components,maintenance,realtime,history,settings,adaptive,theme}.css` | Shared tokens/primitives plus feature-scoped and cross-cutting style ownership for shell, updater, realtime, history, settings, responsive, and theme overrides |
+
+- AppState top-level slices returned by `createAppState()` are reactive proxy stores. Existing feature/runtime code can keep object-style reads and writes, but any `computed()`/`effect()` that depends on a slice should call `trackAppStateSlice(slice)` (or read `getAppStateSliceSignal(slice).value`) and bulk multi-field writes should use `batchAppStateUpdates()`.
 
 ## Features
 

--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -1,4 +1,5 @@
 import { EXPECTED_LIVE_PAYLOAD_SCHEMA_VERSION } from "../transport/live_models";
+import { batchAppStateUpdates } from "./ui_app_state";
 import type { AppState } from "./ui_app_state";
 
 type DemoDeps = {
@@ -16,7 +17,9 @@ declare global {
 export function runDemoMode(deps: DemoDeps): void {
   const { state, renderWsState, applyPayload } = deps;
 
-  state.transport.wsState = "connected";
+  batchAppStateUpdates(() => {
+    state.transport.wsState = "connected";
+  });
   renderWsState();
 
   const demoClients = [
@@ -165,18 +168,20 @@ export function runDemoMode(deps: DemoDeps): void {
     spectra: { clients: demoSpectra },
   };
 
-  state.settings.carsLoaded = true;
-  state.settings.cars = [
-    {
-      id: "demo-car-1",
-      name: "Demo Hatch",
-      type: "Simulated setup",
-      variant: "Audit baseline",
-      aspects: { ...state.settings.vehicleSettings },
-    },
-  ];
-  state.settings.activeCarId = "demo-car-1";
-  state.transport.hasReceivedPayload = true;
+  batchAppStateUpdates(() => {
+    state.settings.carsLoaded = true;
+    state.settings.cars = [
+      {
+        id: "demo-car-1",
+        name: "Demo Hatch",
+        type: "Simulated setup",
+        variant: "Audit baseline",
+        aspects: { ...state.settings.vehicleSettings },
+      },
+    ];
+    state.settings.activeCarId = "demo-car-1";
+    state.transport.hasReceivedPayload = true;
+  });
   applyPayload(demoPayload);
 
   window.__vibesensorDemoCleanup = undefined;

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -2,7 +2,12 @@ import { adaptServerPayload } from "../../server_payload";
 import type { AdaptedClient, AdaptedPayload } from "../../transport/live_models";
 import { runDemoMode } from "../demo_mode";
 import { WsClient } from "../../ws";
-import { applyLivePayloadUpdate, type AppState } from "../ui_app_state";
+import {
+  applyLivePayloadUpdate,
+  batchAppStateUpdates,
+  type AppState,
+  unwrapAppStateValue,
+} from "../ui_app_state";
 
 type UiLiveTransportControllerDeps = {
   state: AppState;
@@ -82,10 +87,12 @@ export class UiLiveTransportController {
         this.queueRender();
         return;
       }
-      const payload = this.state.transport.pendingPayload;
+      const payload = unwrapAppStateValue(this.state.transport.pendingPayload);
       if (!payload) return;
-      this.state.transport.pendingPayload = null;
-      this.state.transport.lastRenderTsMs = now;
+      batchAppStateUpdates(() => {
+        this.state.transport.pendingPayload = null;
+        this.state.transport.lastRenderTsMs = now;
+      });
       this.applyPayload(payload);
     });
   }
@@ -96,21 +103,25 @@ export class UiLiveTransportController {
     try {
       adapted = adaptServerPayload(payload);
     } catch (error) {
-      this.state.transport.payloadError = error instanceof Error ? error.message : this.payloadErrorMessage();
-      this.state.spectrum.hasSpectrumData = false;
+      batchAppStateUpdates(() => {
+        this.state.transport.payloadError =
+          error instanceof Error ? error.message : this.payloadErrorMessage();
+        this.state.spectrum.hasSpectrumData = false;
+      });
       this.refreshWsChrome();
       return;
     }
 
-    this.state.transport.payloadError = null;
-    this.renderWsState();
-
-    const update = applyLivePayloadUpdate({
-      realtime: this.state.realtime,
-      spectrum: this.state.spectrum,
-      adaptedPayload: adapted,
-      updateClientSelection: () => ports.updateClientSelection(),
+    const update = batchAppStateUpdates(() => {
+      this.state.transport.payloadError = null;
+      return applyLivePayloadUpdate({
+        realtime: this.state.realtime,
+        spectrum: this.state.spectrum,
+        adaptedPayload: adapted,
+        updateClientSelection: () => ports.updateClientSelection(),
+      });
     });
+    this.renderWsState();
     ports.maybeRenderSensorsSettingsList();
     ports.renderLoggingStatus();
     if (update.hasSelectedClientChanged) {
@@ -130,8 +141,10 @@ export class UiLiveTransportController {
     this.state.transport.ws = new WsClient({
       url: `${protocol}//${window.location.host}/ws`,
       onPayload: (payload) => {
-        this.state.transport.hasReceivedPayload = true;
-        this.state.transport.pendingPayload = payload;
+        batchAppStateUpdates(() => {
+          this.state.transport.hasReceivedPayload = true;
+          this.state.transport.pendingPayload = payload;
+        });
         this.queueRender();
       },
       onStateChange: (nextState) => {

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -6,7 +6,9 @@ import type {
   ShellState,
   TransportState,
 } from "../ui_app_state";
+import { trackAppStateSlice } from "../ui_app_state";
 import type { VisualVariant } from "../style_state";
+import { computed } from "../ui_signals";
 import type { UiShellBadgeModel } from "./ui_shell_chrome";
 
 const WS_KEY_BY_STATE: Record<string, string> = {
@@ -54,7 +56,8 @@ export function createUiShellStatusModule(
       : deps.t("speed.unit.kmh");
   }
 
-  function getWsLinkState(): UiShellBadgeModel {
+  const wsLinkState = computed<UiShellBadgeModel>(() => {
+    trackAppStateSlice(deps.transport);
     if (deps.transport.payloadError) {
       return {
         text: deps.t("ws.payload_error_pill"),
@@ -66,38 +69,49 @@ export function createUiShellStatusModule(
       text: deps.t(WS_KEY_BY_STATE[wsState] || "ws.connecting"),
       variant: WS_VARIANT_BY_STATE[wsState] || "muted",
     };
-  }
+  });
+
+  const speedReadoutText = computed(() => {
+    trackAppStateSlice(deps.realtime);
+    trackAppStateSlice(deps.settings);
+    trackAppStateSlice(deps.shell);
+    const unitLabel = selectedSpeedUnitLabel();
+    if (
+      typeof deps.realtime.speedMps === "number" &&
+      Number.isFinite(deps.realtime.speedMps)
+    ) {
+      const value = speedValueInSelectedUnit(deps.realtime.speedMps);
+      const labelKey = deriveSpeedReadoutLabelKey(
+        deps.settings,
+        deps.realtime.rotationalSpeeds?.basis_speed_source ?? null,
+      );
+      return deps.t(labelKey, {
+        unit: unitLabel,
+        value: fmt(value, 1),
+      });
+    }
+    return deps.t("speed.none", { unit: unitLabel });
+  });
+
+  const connectionState = computed(() => {
+    trackAppStateSlice(deps.transport);
+    const degraded =
+      deps.transport.payloadError !== null ||
+      deps.transport.wsState === "reconnecting" ||
+      deps.transport.wsState === "stale";
+    return degraded ? "degraded" : "live";
+  });
 
   return {
-    getWsLinkState,
+    getWsLinkState() {
+      return wsLinkState.value;
+    },
     renderSpeedReadout() {
-      const unitLabel = selectedSpeedUnitLabel();
-      if (
-        typeof deps.realtime.speedMps === "number" &&
-        Number.isFinite(deps.realtime.speedMps)
-      ) {
-        const value = speedValueInSelectedUnit(deps.realtime.speedMps);
-        const labelKey = deriveSpeedReadoutLabelKey(
-          deps.settings,
-          deps.realtime.rotationalSpeeds?.basis_speed_source ?? null,
-        );
-        deps.renderLiveOverviewSpeed(
-          deps.t(labelKey, {
-            unit: unitLabel,
-            value: fmt(value, 1),
-          }),
-        );
-        return;
-      }
-      deps.renderLiveOverviewSpeed(deps.t("speed.none", { unit: unitLabel }));
+      deps.renderLiveOverviewSpeed(speedReadoutText.value);
     },
     syncConnectionState() {
       if (deps.appShellWrap) {
-        const degraded =
-          deps.transport.payloadError !== null ||
-          deps.transport.wsState === "reconnecting" ||
-          deps.transport.wsState === "stale";
-        deps.appShellWrap.dataset.connectionState = degraded ? "degraded" : "live";
+        deps.appShellWrap.dataset.connectionState = connectionState.value;
       }
     },
   };

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -16,6 +16,111 @@ import type {
   SpeedSourceKind,
   SpeedSourceStatusPayload,
 } from "../transport/http_models";
+import { batch, signal, type ReadonlySignal, type Signal } from "./ui_signals";
+
+const reactiveTargetProxies = new WeakMap<object, WeakMap<Signal<number>, object>>();
+const reactiveProxyTargets = new WeakMap<object, object>();
+const reactiveSliceSignals = new WeakMap<object, Signal<number>>();
+
+function isProxyableObject(value: unknown): value is object {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return true;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function unwrapReactiveValue<T>(value: T): T {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  return (reactiveProxyTargets.get(value) as T | undefined) ?? value;
+}
+
+function createReactiveProxy<T extends object>(target: T, rootSignal: Signal<number>): T {
+  let proxiesBySignal = reactiveTargetProxies.get(target);
+  if (!proxiesBySignal) {
+    proxiesBySignal = new WeakMap<Signal<number>, object>();
+    reactiveTargetProxies.set(target, proxiesBySignal);
+  }
+  const existingProxy = proxiesBySignal.get(rootSignal);
+  if (existingProxy) {
+    return existingProxy as T;
+  }
+
+  const proxy = new Proxy(target, {
+    get(current, property) {
+      const value = Reflect.get(current, property);
+      if (isProxyableObject(value)) {
+        return createReactiveProxy(unwrapReactiveValue(value), rootSignal);
+      }
+      return value;
+    },
+    set(current, property, nextValue) {
+      const rawNextValue = unwrapReactiveValue(nextValue);
+      const previousValue = unwrapReactiveValue(Reflect.get(current, property));
+      if (Object.is(previousValue, rawNextValue)) {
+        return true;
+      }
+      const didSet = Reflect.set(current, property, rawNextValue);
+      if (didSet) {
+        rootSignal.value += 1;
+      }
+      return didSet;
+    },
+    deleteProperty(current, property) {
+      if (!Reflect.has(current, property)) {
+        return true;
+      }
+      const didDelete = Reflect.deleteProperty(current, property);
+      if (didDelete) {
+        rootSignal.value += 1;
+      }
+      return didDelete;
+    },
+  });
+
+  proxiesBySignal.set(rootSignal, proxy);
+  reactiveProxyTargets.set(proxy, target);
+  reactiveSliceSignals.set(proxy, rootSignal);
+  return proxy as T;
+}
+
+function createReactiveStateSlice<T extends object>(value: T): T {
+  return createReactiveProxy(value, signal(0));
+}
+
+function requireReactiveSliceSignal<T extends object>(slice: T): Signal<number> {
+  const sliceSignal = reactiveSliceSignals.get(slice as object);
+  if (!sliceSignal) {
+    throw new Error("AppState slice signal is unavailable outside createAppState()");
+  }
+  return sliceSignal;
+}
+
+export function getAppStateSliceSignal<T extends object>(slice: T): ReadonlySignal<number> {
+  return requireReactiveSliceSignal(slice);
+}
+
+export function trackAppStateSlice<T extends object>(slice: T): T {
+  requireReactiveSliceSignal(slice).value;
+  return slice;
+}
+
+export function batchAppStateUpdates<T>(callback: () => T): T {
+  let result!: T;
+  batch(() => {
+    result = callback();
+  });
+  return result;
+}
+
+export function unwrapAppStateValue<T>(value: T): T {
+  return unwrapReactiveValue(value);
+}
 
 export interface VehicleSettings {
   tire_width_mm: number;
@@ -115,20 +220,26 @@ export function applySpectrumTick(
 }
 
 export function applyLivePayloadUpdate(deps: LivePayloadUpdateDeps): LivePayloadUpdateResult {
-  const { realtime, spectrum, adaptedPayload, updateClientSelection } = deps;
-  const previousSelectedClientId = realtime.selectedClientId;
-  realtime.clients = adaptedPayload.clients;
-  const spectrumTick = applySpectrumTick(spectrum.spectra, spectrum.hasSpectrumData, adaptedPayload.spectra);
-  spectrum.spectra = spectrumTick.spectra;
-  updateClientSelection();
-  realtime.speedMps = adaptedPayload.speed_mps;
-  realtime.rotationalSpeeds = adaptedPayload.rotational_speeds;
-  spectrum.hasSpectrumData = spectrumTick.hasSpectrumData;
-  return {
-    hasSelectedClientChanged: previousSelectedClientId !== realtime.selectedClientId,
-    selectedClient: realtime.clients.find((client) => client.id === realtime.selectedClientId),
-    hasNewSpectrumFrame: spectrumTick.hasNewSpectrumFrame,
-  };
+  return batchAppStateUpdates(() => {
+    const { realtime, spectrum, adaptedPayload, updateClientSelection } = deps;
+    const previousSelectedClientId = realtime.selectedClientId;
+    realtime.clients = adaptedPayload.clients;
+    const spectrumTick = applySpectrumTick(
+      spectrum.spectra,
+      spectrum.hasSpectrumData,
+      adaptedPayload.spectra,
+    );
+    spectrum.spectra = spectrumTick.spectra;
+    updateClientSelection();
+    realtime.speedMps = adaptedPayload.speed_mps;
+    realtime.rotationalSpeeds = adaptedPayload.rotational_speeds;
+    spectrum.hasSpectrumData = spectrumTick.hasSpectrumData;
+    return {
+      hasSelectedClientChanged: previousSelectedClientId !== realtime.selectedClientId,
+      selectedClient: realtime.clients.find((client) => client.id === realtime.selectedClientId),
+      hasNewSpectrumFrame: spectrumTick.hasNewSpectrumFrame,
+    };
+  });
 }
 
 export interface ShellState {
@@ -198,12 +309,12 @@ export interface AppState {
 
 export function createAppState(): AppState {
   return {
-    shell: {
+    shell: createReactiveStateSlice({
       lang: "en",
       speedUnit: "kmh",
       activeViewId: "dashboardView",
-    },
-    transport: {
+    }),
+    transport: createReactiveStateSlice({
       ws: null,
       wsState: "connecting",
       pendingPayload: null,
@@ -212,8 +323,8 @@ export function createAppState(): AppState {
       minRenderIntervalMs: 100,
       hasReceivedPayload: false,
       payloadError: null,
-    },
-    realtime: {
+    }),
+    realtime: createReactiveStateSlice({
       clients: [],
       selectedClientId: null,
       speedMps: null,
@@ -233,14 +344,14 @@ export function createAppState(): AppState {
       locationOptions: [],
       locationCodes: defaultLocationCodes.slice(),
       sensorsSettingsSignature: "",
-    },
-    history: {
+    }),
+    history: createReactiveStateSlice({
       runs: [],
       deleteAllRunsInFlight: false,
       expandedRunId: null,
       runDetailsById: {},
-    },
-    settings: {
+    }),
+    settings: createReactiveStateSlice({
       vehicleSettings: { ...defaultVehicleSettings },
       cars: [],
       carsLoaded: false,
@@ -252,12 +363,12 @@ export function createAppState(): AppState {
       resolvedSpeedSource: null,
       gpsFallbackActive: false,
       gpsEffectiveSpeedKph: null,
-    },
-    spectrum: {
+    }),
+    spectrum: createReactiveStateSlice({
       spectrumPlot: null,
       spectra: { clients: {} },
       chartBands: [],
       hasSpectrumData: false,
-    },
+    }),
   };
 }

--- a/apps/ui/tests/ui_app_state.spec.ts
+++ b/apps/ui/tests/ui_app_state.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  batchAppStateUpdates,
+  createAppState,
+  getAppStateSliceSignal,
+  trackAppStateSlice,
+} from "../src/app/ui_app_state";
+import { effect } from "../src/app/ui_signals";
+
+test.describe("ui_app_state reactivity", () => {
+  test("tracks direct slice writes through a stable slice signal", () => {
+    const state = createAppState();
+    const seenStates: string[] = [];
+
+    const transportSignal = getAppStateSliceSignal(state.transport);
+    expect(getAppStateSliceSignal(state.transport)).toBe(transportSignal);
+
+    const dispose = effect(() => {
+      trackAppStateSlice(state.transport);
+      seenStates.push(`${state.transport.wsState}:${String(state.transport.payloadError)}`);
+    });
+
+    expect(seenStates).toEqual(["connecting:null"]);
+
+    state.transport.wsState = "connected";
+    state.transport.payloadError = "boom";
+
+    expect(seenStates).toEqual([
+      "connecting:null",
+      "connected:null",
+      "connected:boom",
+    ]);
+
+    dispose();
+  });
+
+  test("tracks nested object writes within a slice", () => {
+    const state = createAppState();
+    const seenRatios: number[] = [];
+
+    const dispose = effect(() => {
+      trackAppStateSlice(state.settings);
+      seenRatios.push(state.settings.vehicleSettings.current_gear_ratio);
+    });
+
+    expect(seenRatios).toEqual([0.64]);
+
+    state.settings.vehicleSettings.current_gear_ratio = 0.72;
+
+    expect(seenRatios).toEqual([0.64, 0.72]);
+
+    dispose();
+  });
+
+  test("keeps slice notifications isolated", () => {
+    const state = createAppState();
+    let transportRuns = 0;
+    let settingsRuns = 0;
+
+    const disposeTransport = effect(() => {
+      trackAppStateSlice(state.transport);
+      transportRuns += 1;
+    });
+    const disposeSettings = effect(() => {
+      trackAppStateSlice(state.settings);
+      settingsRuns += 1;
+    });
+
+    expect(transportRuns).toBe(1);
+    expect(settingsRuns).toBe(1);
+
+    state.transport.wsState = "stale";
+
+    expect(transportRuns).toBe(2);
+    expect(settingsRuns).toBe(1);
+
+    disposeTransport();
+    disposeSettings();
+  });
+
+  test("batches multi-field writes into one reactive invalidation", () => {
+    const state = createAppState();
+    const seenSnapshots: string[] = [];
+
+    const dispose = effect(() => {
+      trackAppStateSlice(state.transport);
+      seenSnapshots.push(
+        `${state.transport.wsState}:${String(state.transport.hasReceivedPayload)}:${String(state.transport.payloadError)}`,
+      );
+    });
+
+    expect(seenSnapshots).toEqual(["connecting:false:null"]);
+
+    batchAppStateUpdates(() => {
+      state.transport.wsState = "connected";
+      state.transport.hasReceivedPayload = true;
+      state.transport.payloadError = "frame-error";
+    });
+
+    expect(seenSnapshots).toEqual([
+      "connecting:false:null",
+      "connected:true:frame-error",
+    ]);
+
+    dispose();
+  });
+});

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -301,6 +301,36 @@ test.describe("createUiShellStatusModule", () => {
     expect(appShellWrap.dataset.connectionState).toBe("degraded");
   });
 
+  test("derives updated websocket badge state after transport mutations", () => {
+    const state = createAppState();
+    const module = createUiShellStatusModule({
+      appShellWrap: createWrap(),
+      realtime: state.realtime,
+      renderLiveOverviewSpeed: () => undefined,
+      settings: state.settings,
+      shell: state.shell,
+      t: testTranslation,
+      transport: state.transport,
+    });
+
+    expect(module.getWsLinkState()).toEqual({
+      text: "ws.connecting",
+      variant: "muted",
+    });
+
+    state.transport.wsState = "stale";
+    expect(module.getWsLinkState()).toEqual({
+      text: "ws.stale",
+      variant: "bad",
+    });
+
+    state.transport.payloadError = "bad frame";
+    expect(module.getWsLinkState()).toEqual({
+      text: "ws.payload_error_pill",
+      variant: "bad",
+    });
+  });
+
   test("renders speed override after car bootstrap resolves", () => {
     const state = createAppState();
     state.realtime.speedMps = 12;


### PR DESCRIPTION
## Summary

Closes #2324.

This PR converts the shared frontend `AppState` slices into signal-backed reactive stores while preserving the object-style reads and writes that the current runtime and feature code still depend on. Instead of introducing a second parallel store or a temporary DTO layer, `createAppState()` now returns reactive proxy slices for `shell`, `transport`, `realtime`, `history`, `settings`, and `spectrum`, and `ui_app_state.ts` exports explicit helpers for observing and batching those slice changes during the migration.

That gives the codebase a real shared reactive foundation under the existing imperative API. Downstream issues can now subscribe to AppState changes through signals instead of inventing new local stores, without forcing an all-at-once runtime rewrite.

## Problem being solved

Before this change, `AppState` in `apps/ui/src/app/ui_app_state.ts` was still just a nested mutable object. Panels and shell helpers already used `@preact/signals` in several places, but shared application state did not. Runtime and feature modules mutated `state.transport`, `state.realtime`, `state.settings`, and friends directly, and hot transport updates still depended on imperative fan-out because AppState provided no reactive substrate.

Leaving AppState plain would have pushed the remaining transport and shell issues toward either more bespoke local signal layers or a second shared store beside AppState. Neither is a durable architecture.

## Implementation approach

The key design choice is that I did **not** add a separate `AppStateStore` and keep the old `AppState` around as a synchronized mirror. That would have created two shared state systems during the migration.

Instead, the existing AppState slices are now the reactive boundary. `createAppState()` still returns the same logical shape, and callers still write code like `state.transport.wsState = "connected"` or `state.settings.vehicleSettings.current_gear_ratio = 0.72`. The difference is that each top-level slice is now a reactive proxy backed by a slice-specific signal. Plain object and array mutations inside that slice invalidate the slice signal, which makes those changes observable through `computed()` and `effect()` without forcing the rest of the runtime to stop using object-style access immediately.

## Main code changes by area

### Reactive AppState slices

`apps/ui/src/app/ui_app_state.ts` now owns the shared reactive AppState primitives.

The file still defines the canonical AppState interfaces and `createAppState()`, but it now also creates each top-level slice as a reactive proxy. These proxies intentionally only wrap plain objects and arrays. They do **not** proxy class instances such as `WsClient` or `SpectrumChart`, which avoids breaking runtime-owned objects.

The file also now exports three migration helpers:

- `getAppStateSliceSignal(slice)` for direct signal access when a caller wants the slice revision signal explicitly,
- `trackAppStateSlice(slice)` as the convenience helper for `computed()` / `effect()` dependencies,
- `batchAppStateUpdates()` for coalescing multi-field writes into one reactive invalidation.

This is the core of the issue: shared state is now signal-backed without forcing a big-bang rewrite of every consumer.

### Batched hot-path writes

Once AppState slices became reactive, the hot transport path needed to stop producing avoidable multi-write invalidations. `applyLivePayloadUpdate()` now performs its coordinated `realtime` and `spectrum` mutations inside `batchAppStateUpdates()`, and `apps/ui/src/app/runtime/ui_live_transport_controller.ts` now batches the other high-churn transport writes around payload queuing and application. I also updated `apps/ui/src/app/demo_mode.ts` so the demo bootstrap path follows the same mutation pattern.

One bug surfaced during validation: queued WebSocket payloads are stored in `state.transport.pendingPayload`, and because that field now lives inside a reactive proxy slice, reading it back through AppState would wrap the raw JSON object before `adaptServerPayload()` saw it. That broke bootstrap smoke by leaving the live overview at `0 / 0`. The fix was to explicitly unwrap the queued payload on the hot path before adapting it. This keeps external WS payloads raw while the AppState slice itself remains reactive.

### First production consumer of AppState slice signals

`apps/ui/src/app/runtime/ui_shell_status_module.ts` now derives its WebSocket badge, speed readout text, and shell connection state through `computed()` values that track the relevant AppState slices. This gives the PR a small production use of the new pattern without duplicating the later transport-output cleanup issues.

### Tests and docs

I added `apps/ui/tests/ui_app_state.spec.ts` to cover the new AppState behavior directly: direct slice writes trigger signal invalidation, nested object writes within a slice are observable, slices stay isolated from each other, and batched multi-field writes coalesce to one reactive invalidation. I also extended `apps/ui/tests/ui_shell_runtime_modules.spec.ts` with a runtime-facing regression that proves the shell status module sees transport-slice mutations after module creation instead of only reflecting construction-time state.

`apps/ui/README.md` now documents `ui_app_state.ts` as the owner of the reactive AppState helpers and explains the intended migration pattern: keep object-style access where needed, call `trackAppStateSlice()` or `getAppStateSliceSignal()` when subscribing reactively, and wrap bulk writes in `batchAppStateUpdates()`.

## Validation

I validated the change with a broader frontend slice than usual because this issue changes shared state infrastructure rather than one isolated panel:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/ui_app_state.spec.ts tests/ui_shell_runtime_modules.spec.ts tests/ui_live_transport_controller.spec.ts tests/ui_live_payload_application.spec.ts tests/settings_speed_source_workflow.spec.ts tests/realtime_feature_workflow.spec.ts tests/history_feature_modules.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

That suite caught the raw-payload proxy bug described above, and the final version passes after unwrapping the queued payload before adaptation. Lint still reports only the same pre-existing optional-chain warning in `tests/history_feature_modules.spec.ts` plus the existing Biome schema-version info. A code-review pass on the final diff found no remaining correctness issues in the proxy semantics, class-instance exclusions, batching behavior, or raw-payload handling.

## Risks, tradeoffs, and out of scope

The main tradeoff is that AppState slices now carry a small amount of proxy machinery. I chose that over a parallel store because one shared reactive state system is cleaner than maintaining both “old AppState” and “new AppStateStore” during the migration. I also intentionally limited proxying to plain objects and arrays; proxying runtime class instances would have been risky and unnecessary for objects like `WsClient` and `SpectrumChart`.

This PR does **not** remove the remaining explicit render callback fan-out from `UiLiveTransportController`, and it does **not** move WebSocket input directly into shared signals. Those are the follow-on issues that this AppState conversion now unblocks. The goal here is foundational: make shared AppState itself reactive and give the rest of the frontend one canonical pattern for subscribing to and batching shared state changes.
