### PR TITLE
Wire websocket transport input into AppState signals

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -94,7 +94,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/runtime/ui_preact_mount.ts` | Canonical helper for mounting and disposing incremental Preact islands inside existing DOM hosts |
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, and app-level error banner plus the typed shell chrome bridge |
 | `app/runtime/ui_shell_controller.ts` | Menu/view shell, language and preference hydration, connection pill/banner, and other chrome state |
-| `app/runtime/ui_live_transport_controller.ts` | Demo/WebSocket transport, payload adaptation, and throttled live-session rendering |
+| `app/runtime/ui_live_transport_controller.ts` | Demo/WebSocket transport coordinator that queues payloads through AppState, throttles live-session adaptation, and lets shell/spectrum react from signal-backed state |
 | `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that wires overlay updates plus the extracted canvas, interaction, and panel modules |
 | `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, tweening, and canvas draw plugin orchestration |
 | `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports |
@@ -147,7 +147,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/realtime_feature_presenter.ts` | Realtime presenter that owns derived live/logging panel state, elapsed-timer sync, and cross-view navigation clicks |
 | `transport/` | UI-local HTTP / WS DTOs plus adapter helpers that isolate generated contract files from app state and feature code |
 | `api.ts` | REST API facade that returns local transport DTOs while `api/types.ts` stays the generated HTTP boundary |
-| `ws.ts` | WebSocket client with auto-reconnect and stale detection |
+| `ws.ts` | WebSocket client with auto-reconnect, stale detection, and direct writes into the signal-backed transport slice |
 | `config.ts` | Centralized UI tuning constants for polling intervals, spectrum ranges, and history heatmap positions |
 | `i18n.ts` | Internationalization dictionary (English, Dutch) |
 | `spectrum.ts` | uPlot chart wrapper for interactive spectrum visualization |

--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -4,7 +4,6 @@ import type { AppState } from "./ui_app_state";
 
 type DemoDeps = {
   state: Pick<AppState, "transport" | "settings">;
-  renderWsState: () => void;
   applyPayload: (payload: unknown) => void;
 };
 
@@ -15,12 +14,11 @@ declare global {
 }
 
 export function runDemoMode(deps: DemoDeps): void {
-  const { state, renderWsState, applyPayload } = deps;
+  const { state, applyPayload } = deps;
 
   batchAppStateUpdates(() => {
     state.transport.wsState = "connected";
   });
-  renderWsState();
 
   const demoClients = [
     {

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -5,17 +5,15 @@ import { WsClient } from "../../ws";
 import {
   applyLivePayloadUpdate,
   batchAppStateUpdates,
+  trackAppStateSlice,
   type AppState,
   unwrapAppStateValue,
 } from "../ui_app_state";
+import { effect, untracked } from "../ui_signals";
 
 type UiLiveTransportControllerDeps = {
   state: AppState;
   payloadErrorMessage: () => string;
-  renderWsState: () => void;
-  renderSpeedReadout: () => void;
-  renderSpectrum: () => void;
-  updateSpectrumOverlay: () => void;
 };
 
 export interface UiTransportFeaturePorts {
@@ -32,21 +30,10 @@ export class UiLiveTransportController {
 
   private readonly payloadErrorMessage: () => string;
 
-  private readonly renderWsState: () => void;
-
-  private readonly renderSpeedReadout: () => void;
-
-  private readonly renderSpectrum: () => void;
-
-  private readonly updateSpectrumOverlay: () => void;
-
   constructor(deps: UiLiveTransportControllerDeps) {
     this.state = deps.state;
     this.payloadErrorMessage = deps.payloadErrorMessage;
-    this.renderWsState = deps.renderWsState;
-    this.renderSpeedReadout = deps.renderSpeedReadout;
-    this.renderSpectrum = deps.renderSpectrum;
-    this.updateSpectrumOverlay = deps.updateSpectrumOverlay;
+    this.bindTransportSignalSync();
   }
 
   attachPorts(ports: UiTransportFeaturePorts): void {
@@ -59,9 +46,44 @@ export class UiLiveTransportController {
     }
   }
 
-  private refreshWsChrome(): void {
-    this.renderWsState();
-    this.updateSpectrumOverlay();
+  private bindTransportSignalSync(): void {
+    let previousPendingPayload = unwrapAppStateValue(this.state.transport.pendingPayload);
+    let pendingPayloadInitialized = false;
+    effect(() => {
+      trackAppStateSlice(this.state.transport);
+      const nextPendingPayload = unwrapAppStateValue(this.state.transport.pendingPayload);
+      if (!pendingPayloadInitialized) {
+        pendingPayloadInitialized = true;
+        previousPendingPayload = nextPendingPayload;
+        return;
+      }
+      if (nextPendingPayload === previousPendingPayload) {
+        return;
+      }
+      previousPendingPayload = nextPendingPayload;
+      if (nextPendingPayload !== null) {
+        untracked(() => this.queueRender());
+      }
+    });
+
+    let previousWsState = this.state.transport.wsState;
+    let wsStateInitialized = false;
+    effect(() => {
+      trackAppStateSlice(this.state.transport);
+      const nextWsState = this.state.transport.wsState;
+      if (!wsStateInitialized) {
+        wsStateInitialized = true;
+        previousWsState = nextWsState;
+        return;
+      }
+      if (nextWsState === previousWsState) {
+        return;
+      }
+      previousWsState = nextWsState;
+      if (nextWsState === "connected" || nextWsState === "no_data") {
+        untracked(() => this.sendSelection());
+      }
+    });
   }
 
   startTransportMode(): void {
@@ -69,7 +91,6 @@ export class UiLiveTransportController {
     if (isDemoMode) {
       runDemoMode({
         state: this.state,
-        renderWsState: this.renderWsState,
         applyPayload: (payload) => this.applyPayload(payload),
       });
       return;
@@ -108,7 +129,6 @@ export class UiLiveTransportController {
           error instanceof Error ? error.message : this.payloadErrorMessage();
         this.state.spectrum.hasSpectrumData = false;
       });
-      this.refreshWsChrome();
       return;
     }
 
@@ -121,17 +141,10 @@ export class UiLiveTransportController {
         updateClientSelection: () => ports.updateClientSelection(),
       });
     });
-    this.renderWsState();
     ports.maybeRenderSensorsSettingsList();
     ports.renderLoggingStatus();
     if (update.hasSelectedClientChanged) {
       this.sendSelection();
-    }
-    this.renderSpeedReadout();
-    if (update.hasNewSpectrumFrame) {
-      this.renderSpectrum();
-    } else {
-      this.updateSpectrumOverlay();
     }
     ports.renderStatus(update.selectedClient);
   }
@@ -140,20 +153,7 @@ export class UiLiveTransportController {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     this.state.transport.ws = new WsClient({
       url: `${protocol}//${window.location.host}/ws`,
-      onPayload: (payload) => {
-        batchAppStateUpdates(() => {
-          this.state.transport.hasReceivedPayload = true;
-          this.state.transport.pendingPayload = payload;
-        });
-        this.queueRender();
-      },
-      onStateChange: (nextState) => {
-        this.state.transport.wsState = nextState;
-        this.refreshWsChrome();
-        if (nextState === "connected" || nextState === "no_data") {
-          this.sendSelection();
-        }
-      },
+      transport: this.state.transport,
     });
     this.state.transport.ws.connect();
   }

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -2,7 +2,8 @@ import * as I18N from "../../i18n";
 import { formatIntLocale } from "../../format";
 import { queryOne, queryRequiredAll } from "../dom/dom_query";
 import { setUiLanguage } from "../ui_i18n";
-import type { AppState } from "../ui_app_state";
+import { trackAppStateSlice, type AppState } from "../ui_app_state";
+import { effect, untracked } from "../ui_signals";
 import {
   bindUiShellFeatureEvents,
   type UiShellFeaturePorts,
@@ -133,6 +134,7 @@ export class UiShellController {
       updateSpectrumOverlay: () => this.updateSpectrumOverlayState?.(),
     });
     this.renderChrome();
+    this.bindReactiveStatusSync();
   }
 
   attachPorts(ports: UiShellFeaturePorts): void {
@@ -215,6 +217,41 @@ export class UiShellController {
 
   private bindFeatureEvents(): void {
     bindUiShellFeatureEvents(this.requirePorts());
+  }
+
+  private bindReactiveStatusSync(): void {
+    let previousWsState = this.state.transport.wsState;
+    let previousPayloadError = this.state.transport.payloadError;
+    let transportInitialized = false;
+    effect(() => {
+      trackAppStateSlice(this.state.transport);
+      const nextWsState = this.state.transport.wsState;
+      const nextPayloadError = this.state.transport.payloadError;
+      if (!transportInitialized) {
+        transportInitialized = true;
+        previousWsState = nextWsState;
+        previousPayloadError = nextPayloadError;
+        return;
+      }
+      if (nextWsState === previousWsState && nextPayloadError === previousPayloadError) {
+        return;
+      }
+      previousWsState = nextWsState;
+      previousPayloadError = nextPayloadError;
+      untracked(() => this.renderWsState());
+    });
+
+    let speedInitialized = false;
+    effect(() => {
+      trackAppStateSlice(this.state.realtime);
+      trackAppStateSlice(this.state.settings);
+      trackAppStateSlice(this.state.shell);
+      if (!speedInitialized) {
+        speedInitialized = true;
+        return;
+      }
+      untracked(() => this.renderSpeedReadout());
+    });
   }
 
   private buildRenderModel(): UiShellChromeRenderModel {

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -1,4 +1,5 @@
-import type { AppState } from "../ui_app_state";
+import { trackAppStateSlice, type AppState } from "../ui_app_state";
+import { effect, untracked } from "../ui_signals";
 import { SpectrumCanvasRenderer } from "./spectrum_canvas_renderer";
 import { SpectrumInteractionController } from "./spectrum_interaction_controller";
 import type { SpectrumPanelView } from "./spectrum_panel_view";
@@ -41,6 +42,8 @@ export class UiSpectrumController {
       setSeriesIsolation: (seriesIndex) => this.canvas.setSeriesIsolation(seriesIndex),
       requestPlotRefresh: () => this.canvas.refreshDecorations(),
     });
+    this.updateSpectrumOverlay();
+    this.bindReactiveTransportSync();
   }
 
   private get state(): AppState {
@@ -97,5 +100,45 @@ export class UiSpectrumController {
 
   private setSpectrumOverlay(message: string | null): void {
     this.panel.renderOverlay(message);
+  }
+
+  private bindReactiveTransportSync(): void {
+    let previousSpectra = this.state.spectrum.spectra;
+    let previousWsState = this.state.transport.wsState;
+    let previousPayloadError = this.state.transport.payloadError;
+    let previousHasReceivedPayload = this.state.transport.hasReceivedPayload;
+    let initialized = false;
+    effect(() => {
+      trackAppStateSlice(this.state.spectrum);
+      trackAppStateSlice(this.state.transport);
+      const nextSpectra = this.state.spectrum.spectra;
+      const nextWsState = this.state.transport.wsState;
+      const nextPayloadError = this.state.transport.payloadError;
+      const nextHasReceivedPayload = this.state.transport.hasReceivedPayload;
+      if (!initialized) {
+        initialized = true;
+        previousSpectra = nextSpectra;
+        previousWsState = nextWsState;
+        previousPayloadError = nextPayloadError;
+        previousHasReceivedPayload = nextHasReceivedPayload;
+        return;
+      }
+      const spectraChanged = nextSpectra !== previousSpectra;
+      const transportChanged =
+        nextWsState !== previousWsState
+        || nextPayloadError !== previousPayloadError
+        || nextHasReceivedPayload !== previousHasReceivedPayload;
+      previousSpectra = nextSpectra;
+      previousWsState = nextWsState;
+      previousPayloadError = nextPayloadError;
+      previousHasReceivedPayload = nextHasReceivedPayload;
+      if (spectraChanged) {
+        untracked(() => this.renderSpectrum());
+        return;
+      }
+      if (transportChanged) {
+        untracked(() => this.updateSpectrumOverlay());
+      }
+    });
   }
 }

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -59,10 +59,6 @@ export class UiAppRuntime {
     this.transport = new UiLiveTransportController({
       state: this.state,
       payloadErrorMessage: () => this.shell.t("ws.payload_error"),
-      renderWsState: () => this.shell.renderWsState(),
-      renderSpeedReadout: () => this.shell.renderSpeedReadout(),
-      renderSpectrum: () => this.spectrum.renderSpectrum(),
-      updateSpectrumOverlay: () => this.spectrum.updateSpectrumOverlay(),
     });
     this.featurePorts = createAppFeatureBundle({
       state: this.state,

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -1,5 +1,5 @@
 import type { SpectrumChart } from "../spectrum";
-import type { WsClient } from "../ws";
+import type { WsClient, WsUiState } from "../ws";
 import type {
   AdaptedClient,
   AdaptedPayload,
@@ -250,7 +250,7 @@ export interface ShellState {
 
 export interface TransportState {
   ws: WsClient | null;
-  wsState: string;
+  wsState: WsUiState;
   pendingPayload: unknown | null;
   renderQueued: boolean;
   lastRenderTsMs: number;

--- a/apps/ui/src/app/ui_signals.ts
+++ b/apps/ui/src/app/ui_signals.ts
@@ -3,6 +3,7 @@ import {
   computed,
   effect,
   signal,
+  untracked,
   type ReadonlySignal,
   type Signal,
 } from "@preact/signals";
@@ -15,5 +16,5 @@ import {
  * and keep effect() limited to narrow imperative integrations such as timers,
  * storage, or external library bridges.
  */
-export { batch, computed, effect, signal };
+export { batch, computed, effect, signal, untracked };
 export type { ReadonlySignal, Signal };

--- a/apps/ui/src/ws.ts
+++ b/apps/ui/src/ws.ts
@@ -1,14 +1,20 @@
 import type { LiveWsPayload } from "./contracts/ws_payload_types";
+import { batchAppStateUpdates } from "./app/ui_app_state";
 
 export type WsUiState = "connecting" | "connected" | "reconnecting" | "stale" | "no_data";
+
+export interface WsTransportState {
+  wsState: WsUiState;
+  pendingPayload: unknown | null;
+  hasReceivedPayload: boolean;
+}
 
 export interface WsClientOptions {
   url: string;
   staleAfterMs?: number;
   reconnectDelayMs?: number;
   hasData?: (payload: unknown) => boolean;
-  onPayload: (payload: unknown) => void;
-  onStateChange: (state: WsUiState) => void;
+  transport: WsTransportState;
 }
 
 function hasSpectraClients(payload: unknown): boolean {
@@ -20,13 +26,12 @@ function hasSpectraClients(payload: unknown): boolean {
 }
 
 export class WsClient {
-  private readonly options: Required<Omit<WsClientOptions, "onPayload" | "onStateChange">> & {
-    onPayload: (payload: unknown) => void;
-    onStateChange: (state: WsUiState) => void;
+  private readonly options: Required<Omit<WsClientOptions, "transport">> & {
+    transport: WsTransportState;
   };
 
   private ws: WebSocket | null = null;
-  private state: WsUiState = "connecting";
+  private state: WsUiState;
   private reconnectTimer: number | null = null;
   private staleTimer: number | null = null;
   private lastMessageAtMs = 0;
@@ -42,6 +47,7 @@ export class WsClient {
       hasData: hasSpectraClients,
       ...options,
     };
+    this.state = this.options.transport.wsState;
   }
 
   connect(): void {
@@ -95,8 +101,11 @@ export class WsClient {
       this.lastMessageAtMs = receivedAt;
       this.hasData = this.hasData || this.options.hasData(payload);
       this.reconnectAttempt = 0;
-      this.setState(this.hasData ? "connected" : "no_data");
-      this.options.onPayload(payload);
+      batchAppStateUpdates(() => {
+        this.commitState(this.hasData ? "connected" : "no_data");
+        this.options.transport.hasReceivedPayload = true;
+        this.options.transport.pendingPayload = payload;
+      });
     };
 
     this.ws.onclose = () => {
@@ -142,8 +151,14 @@ export class WsClient {
   }
 
   private setState(next: WsUiState): void {
+    batchAppStateUpdates(() => {
+      this.commitState(next);
+    });
+  }
+
+  private commitState(next: WsUiState): void {
     if (this.state === next) return;
     this.state = next;
-    this.options.onStateChange(next);
+    this.options.transport.wsState = next;
   }
 }

--- a/apps/ui/tests/demo_mode.spec.ts
+++ b/apps/ui/tests/demo_mode.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { runDemoMode } from "../src/app/demo_mode";
-import { defaultVehicleSettings } from "../src/app/ui_app_state";
+import { createAppState } from "../src/app/ui_app_state";
 import { adaptServerPayload } from "../src/server_payload";
 import { installWindowGlobal } from "./async_test_helpers";
 
@@ -12,41 +12,19 @@ test.describe("runDemoMode", () => {
 
   test("emits a schema-valid websocket payload", () => {
     const selectedClientId = "aabbcc001122";
-    const state = {
-      transport: {
-        wsState: "disconnected",
-        hasReceivedPayload: false,
-      },
-      settings: {
-        vehicleSettings: { ...defaultVehicleSettings },
-        cars: [],
-        carsLoaded: false,
-        activeCarId: null,
-        speedSource: "gps",
-        manualSpeedKph: null,
-        obdDeviceMac: null,
-        obdDeviceName: null,
-        resolvedSpeedSource: null,
-        gpsFallbackActive: false,
-        gpsEffectiveSpeedKph: null,
-      },
-    };
-    let renderWsStateCalls = 0;
+    const state = createAppState();
+    state.transport.wsState = "reconnecting";
     let adaptedPayload:
       | ReturnType<typeof adaptServerPayload>
       | undefined;
 
     runDemoMode({
       state,
-      renderWsState: () => {
-        renderWsStateCalls += 1;
-      },
       applyPayload: (payload) => {
         adaptedPayload = adaptServerPayload(payload);
       },
     });
 
-    expect(renderWsStateCalls).toBe(1);
     expect(state.transport.wsState).toBe("connected");
     expect(state.transport.hasReceivedPayload).toBe(true);
     expect(adaptedPayload).toBeDefined();

--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { EXPECTED_SCHEMA_VERSION, type LiveWsPayload } from "../src/contracts/ws_payload_types";
 import { UiLiveTransportController, type UiTransportFeaturePorts } from "../src/app/runtime/ui_live_transport_controller";
 import { createAppState } from "../src/app/ui_app_state";
+import { flushAsyncWork, installWindowGlobal } from "./async_test_helpers";
 
 function makeLivePayload(overrides: Partial<LiveWsPayload> = {}): LiveWsPayload {
   return {
@@ -35,8 +36,33 @@ function applyPayload(controller: UiLiveTransportController, payload: LiveWsPayl
   (controller as unknown as { applyPayload(nextPayload: LiveWsPayload): void }).applyPayload(payload);
 }
 
+function installRafHarness() {
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const callbacks: FrameRequestCallback[] = [];
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    callbacks.push(callback);
+    return callbacks.length as unknown as number;
+  }) as typeof requestAnimationFrame;
+  return {
+    flushNext(): void {
+      const callback = callbacks.shift();
+      if (!callback) {
+        throw new Error("No pending animation frame");
+      }
+      callback(Date.now());
+    },
+    restore(): void {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    },
+  };
+}
+
 test.describe("UiLiveTransportController", () => {
-  test("applies payloads through narrow transport ports without an AppFeatureBundle", () => {
+  test.beforeEach(() => {
+    installWindowGlobal();
+  });
+
+  test("applies queued transport payloads through narrow transport ports without an AppFeatureBundle", async () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
     state.transport.ws = {
@@ -45,26 +71,9 @@ test.describe("UiLiveTransportController", () => {
       },
     } as unknown as typeof state.transport.ws;
 
-    let renderWsStateCalls = 0;
-    let renderSpeedReadoutCalls = 0;
-    let renderSpectrumCalls = 0;
-    let updateSpectrumOverlayCalls = 0;
-
     const controller = new UiLiveTransportController({
       state,
       payloadErrorMessage: () => "payload error",
-      renderWsState: () => {
-        renderWsStateCalls += 1;
-      },
-      renderSpeedReadout: () => {
-        renderSpeedReadoutCalls += 1;
-      },
-      renderSpectrum: () => {
-        renderSpectrumCalls += 1;
-      },
-      updateSpectrumOverlay: () => {
-        updateSpectrumOverlayCalls += 1;
-      },
     });
 
     const portCalls: string[] = [];
@@ -86,37 +95,65 @@ test.describe("UiLiveTransportController", () => {
       },
     } satisfies UiTransportFeaturePorts;
 
-    controller.attachPorts(ports);
-    applyPayload(controller, makeLivePayload({
-      clients: [makeClient("client-1")],
-      speed_mps: 12,
-    }));
+    const raf = installRafHarness();
+    try {
+      controller.attachPorts(ports);
+      state.transport.pendingPayload = makeLivePayload({
+        clients: [makeClient("client-1")],
+        speed_mps: 12,
+      });
+      await flushAsyncWork();
+      raf.flushNext();
 
-    expect(state.realtime.clients.map((client) => client.id)).toEqual(["client-1"]);
-    expect(state.realtime.selectedClientId).toBe("client-1");
-    expect(state.realtime.speedMps).toBe(12);
-    expect(portCalls).toEqual([
-      "updateClientSelection",
-      "maybeRenderSensorsSettingsList",
-      "renderLoggingStatus",
-      "renderStatus",
+      expect(state.transport.pendingPayload).toBeNull();
+      expect(state.realtime.clients.map((client) => client.id)).toEqual(["client-1"]);
+      expect(state.realtime.selectedClientId).toBe("client-1");
+      expect(state.realtime.speedMps).toBe(12);
+      expect(portCalls).toEqual([
+        "updateClientSelection",
+        "maybeRenderSensorsSettingsList",
+        "renderLoggingStatus",
+        "renderStatus",
+      ]);
+      expect(renderedStatusIds).toEqual(["client-1"]);
+      expect(sentSelections).toEqual([{ client_id: "client-1" }]);
+    } finally {
+      raf.restore();
+    }
+  });
+
+  test("sends the current client selection when websocket state becomes ready", async () => {
+    const state = createAppState();
+    const sentSelections: Array<{ client_id: string | null }> = [];
+    state.transport.ws = {
+      send(selection: { client_id: string | null }) {
+        sentSelections.push(selection);
+      },
+    } as unknown as typeof state.transport.ws;
+    state.realtime.selectedClientId = "client-7";
+
+    new UiLiveTransportController({
+      state,
+      payloadErrorMessage: () => "payload error",
+    });
+
+    state.transport.wsState = "no_data";
+    await flushAsyncWork();
+    state.transport.wsState = "connected";
+    await flushAsyncWork();
+    state.transport.wsState = "stale";
+    await flushAsyncWork();
+
+    expect(sentSelections).toEqual([
+      { client_id: "client-7" },
+      { client_id: "client-7" },
     ]);
-    expect(renderedStatusIds).toEqual(["client-1"]);
-    expect(renderWsStateCalls).toBe(1);
-    expect(renderSpeedReadoutCalls).toBe(1);
-    expect(renderSpectrumCalls).toBe(0);
-    expect(updateSpectrumOverlayCalls).toBe(1);
-    expect(sentSelections).toEqual([{ client_id: "client-1" }]);
   });
 
   test("throws a clear error when payloads arrive before ports are attached", () => {
     const controller = new UiLiveTransportController({
       state: createAppState(),
       payloadErrorMessage: () => "payload error",
-      renderWsState: () => undefined,
-      renderSpeedReadout: () => undefined,
-      renderSpectrum: () => undefined,
-      updateSpectrumOverlay: () => undefined,
     });
 
     expect(() => applyPayload(controller, makeLivePayload())).toThrow(

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -51,15 +51,36 @@ test.describe("UiSpectrumController", () => {
       state.transport.hasReceivedPayload = false;
       const panel = createPanelStub();
 
-      const controller = new UiSpectrumController({
+      new UiSpectrumController({
         state,
         panel: panel.panel,
         t: (key) => key,
       });
 
-      controller.updateSpectrumOverlay();
-
       expect(panel.lastOverlayMessage).toBe("spectrum.loading");
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("reacts to transport state changes without explicit overlay callbacks", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const UiSpectrumController = await importUiSpectrumController();
+      const state = createAppState();
+      state.transport.wsState = "connecting";
+      state.transport.hasReceivedPayload = false;
+      const panel = createPanelStub();
+
+      new UiSpectrumController({
+        state,
+        panel: panel.panel,
+        t: (key) => key,
+      });
+
+      state.transport.wsState = "stale";
+
+      expect(panel.lastOverlayMessage).toBe("spectrum.stale");
     } finally {
       restoreDocument();
     }

--- a/apps/ui/tests/ws.spec.ts
+++ b/apps/ui/tests/ws.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "@playwright/test";
+
+import { createAppState, unwrapAppStateValue } from "../src/app/ui_app_state";
+import { WsClient } from "../src/ws";
+import { installWindowGlobal } from "./async_test_helpers";
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+
+  readyState = FakeWebSocket.CONNECTING;
+
+  onopen: WebSocket["onopen"] = null;
+
+  onmessage: WebSocket["onmessage"] = null;
+
+  onclose: WebSocket["onclose"] = null;
+
+  onerror: WebSocket["onerror"] = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  static reset(): void {
+    FakeWebSocket.instances = [];
+  }
+
+  send(): void {}
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.(new Event("close") as CloseEvent);
+  }
+
+  emitOpen(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  emitMessage(payload: unknown): void {
+    this.onmessage?.({
+      data: JSON.stringify(payload),
+    } as MessageEvent);
+  }
+}
+
+test.describe("WsClient", () => {
+  test.beforeEach(() => {
+    installWindowGlobal();
+    FakeWebSocket.reset();
+  });
+
+  test("writes websocket state and queued payloads into the transport slice", () => {
+    const originalWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    try {
+      const state = createAppState();
+      const client = new WsClient({
+        url: "ws://example.test/ws",
+        transport: state.transport,
+      });
+
+      client.connect();
+
+      const socket = FakeWebSocket.instances[0];
+      expect(socket?.url).toBe("ws://example.test/ws");
+
+      socket?.emitOpen();
+      expect(state.transport.wsState).toBe("no_data");
+
+      const payload = {
+        spectra: {
+          clients: {
+            "client-1": {},
+          },
+        },
+      };
+      socket?.emitMessage(payload);
+
+      expect(state.transport.wsState).toBe("connected");
+      expect(state.transport.hasReceivedPayload).toBe(true);
+      expect(unwrapAppStateValue(state.transport.pendingPayload)).toEqual(payload);
+
+      client.close();
+    } finally {
+      globalThis.WebSocket = originalWebSocket;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes #2323 by moving the WebSocket input path onto the shared signal-backed transport state introduced in #2324, instead of continuing to fan raw payloads and connection state through callback props. Before this change, `WsClient` in `apps/ui/src/ws.ts` still exposed `onPayload` and `onStateChange` callbacks, and `UiLiveTransportController` had to receive those events and then imperatively fan the results out again through callback dependencies like `renderWsState`, `renderSpeedReadout`, `renderSpectrum`, and `updateSpectrumOverlay`. That structure meant the new AppState signal store was only being used after the transport layer had already passed through a callback bottleneck.

The goal here was to move the **transport input** side of the runtime onto the shared reactive path without breaking reconnect behavior, the queued `requestAnimationFrame` render throttle, or demo mode. This issue intentionally complements the broader render-fan-out cleanup tracked elsewhere: the focus here is that the WebSocket layer should write into shared signal-backed state, and downstream runtime consumers should react from that state instead of depending on explicit transport callbacks.

## Implementation approach

The main design choice in this PR is that `WsClient` now writes directly into a small transport-state shape (`wsState`, `pendingPayload`, and `hasReceivedPayload`) rather than invoking consumer-owned callback props. I kept the existing `WsClient` class rather than introducing a second wrapper abstraction because the repo already has one canonical WebSocket client and the cleaner architecture here is to make that client talk to the shared state it already serves.

On the runtime side, `UiLiveTransportController` now reacts to the signal-backed transport slice by watching for queued payload changes and ready-state transitions. That preserves the existing `requestAnimationFrame` throttling behavior for payload adaptation while removing the transport-specific callback dependency list from the controller constructor. Shell and spectrum updates are no longer driven from the transport controller either; instead, they react from AppState-backed effects closer to their actual ownership boundaries.

One important implementation detail is that AppState still uses proxy-backed slice signals rather than a parallel store, so I kept the object-style state reads and writes in place. I only tightened the typing where the transport seam now benefits from a stronger contract: `TransportState.wsState` is now typed as the shared `WsUiState` union instead of a generic string.

## Main code changes by area

### `apps/ui/src/ws.ts`

- Removed `onPayload` and `onStateChange` from `WsClientOptions`
- Added a focused `WsTransportState` interface for the state that the client owns
- Updated `WsClient` to batch writes into the transport slice when messages arrive
- Kept reconnect and stale detection behavior intact

The message path now parses JSON, computes whether the connection has real data, updates the current websocket state, marks that at least one payload has been received, and stores the latest payload in `pendingPayload` for the runtime throttle to consume. That keeps transport input on the shared reactive path instead of reintroducing new callback plumbing.

### `apps/ui/src/app/runtime/ui_live_transport_controller.ts`

- Removed the explicit render callback dependencies from the constructor
- Added signal-tracking effects for queued transport payloads and ready-state selection sync
- Kept the existing `requestAnimationFrame` throttling behavior for payload adaptation
- Simplified the live and demo transport paths so both rely on shared state rather than transport callback props

This keeps the controller focused on adapting payloads and coordinating the existing realtime feature ports, while AppState owns transport input delivery.

### `apps/ui/src/app/runtime/ui_shell_controller.ts` and `ui_spectrum_controller.ts`

- Added AppState-driven effects so shell and spectrum runtime behavior reacts from shared state rather than transport callbacks
- Preserved the existing imperative bridge methods (`renderWsState`, `renderSpeedReadout`, `renderSpectrum`, `updateSpectrumOverlay`) where other flows still use them

This was the cleanest way to finish the issue without inventing a second state path or forcing a larger render-architecture rewrite into the same PR.

### `apps/ui/src/app/ui_signals.ts`

- Re-exported `untracked()` from the canonical signals surface

This turned out to be necessary during validation. The first browser cut used AppState-tracking effects to call imperative bridge methods like `liveOverview.setSpeedText()`. Those bridge methods read and write local island signals, so calling them directly from an AppState-tracking effect caused Preact `Cycle detected` failures and left the UI stuck at startup defaults. The final version wraps those imperative bridge calls in `untracked()` so the effect depends on the shared AppState slice, but does not accidentally subscribe to island-local bridge signals.

### Tests and docs

- Added `apps/ui/tests/ws.spec.ts` to directly cover the new `WsClient` signal-backed transport writes
- Updated `ui_live_transport_controller.spec.ts` to prove queued payloads now flow through the transport slice and RAF queue
- Updated `ui_spectrum_controller.spec.ts` to cover reactive overlay updates without manual transport callbacks
- Updated `demo_mode.spec.ts` for the simplified demo-mode transport API
- Updated `apps/ui/README.md` so the runtime descriptions match the new transport/signal ownership

## Validation

I ran the following local validation against the final cut:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ws.spec.ts tests/ui_live_transport_controller.spec.ts tests/ui_spectrum_controller.spec.ts tests/demo_mode.spec.ts tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.spectrum.spec.ts tests/smoke.settings.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1 -g "ui bootstrap smoke: tabs, ws state, recording, history|spectrum controls stay interactive while repeated websocket updates arrive|spectrum band toggle stays hidden when no spectrum data is available|gps status polling does not override websocket speed readout"`
- `cd apps/ui && npm run lint`

The lint run still reports the same pre-existing optional-chain warning in `tests/history_feature_modules.spec.ts` plus the existing Biome schema-version info, but there are no new lint warnings from this PR.

## Risks, tradeoffs, and edge cases

The main risk here was accidentally creating either a second store or an effect loop. I intentionally avoided the first by reusing the existing AppState transport slice, and I addressed the second with the `untracked()` fix once the initial browser validation exposed the cycle. That regression was useful because it proved the new wiring was genuinely reactive rather than merely looking reactive in unit tests.

I also deliberately preserved the existing `requestAnimationFrame` throttling path in `UiLiveTransportController`, since removing it as part of the callback cleanup would have mixed performance and ownership concerns into the same change. Likewise, the broader removal of remaining render fan-out on the realtime-output side is still better handled as separate follow-up work; this PR is specifically about making **WS input → shared signals** the canonical transport path.

Closes #2323
