### PR TITLE
Move shell chrome state off render fan-out

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -93,7 +93,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/ui_signals.ts` | Canonical re-export surface for shared `signal`, `computed`, and `effect` usage across runtime, features, and views |
 | `app/runtime/ui_preact_mount.ts` | Canonical helper for mounting and disposing incremental Preact islands inside existing DOM hosts |
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, and app-level error banner plus the typed shell chrome bridge |
-| `app/runtime/ui_shell_controller.ts` | Menu/view shell, language and preference hydration, connection pill/banner, and other chrome state |
+| `app/runtime/ui_shell_controller.ts` | Menu/view shell, language and preference hydration, and the reactive shell-chrome model that feeds header pills, feedback, and app-level banners |
 | `app/runtime/ui_live_transport_controller.ts` | Demo/WebSocket transport coordinator that queues payloads through AppState, throttles live-session adaptation, and lets shell/spectrum react from signal-backed state |
 | `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that wires overlay updates plus the extracted canvas, interaction, and panel modules |
 | `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, tweening, and canvas draw plugin orchestration |

--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -1,6 +1,7 @@
 import { h, type JSX } from "preact";
 
 import { requiredById } from "../dom/dom_query";
+import { signal, type ReadonlySignal } from "../ui_signals";
 import {
   settingsFeedbackClassName,
   type SettingsFeedbackMessage,
@@ -96,11 +97,7 @@ export interface UiShellChromeView {
 
 type UiShellChromeProps = {
   bridge: UiShellChromeActionBridge;
-  model: UiShellChromeRenderModel;
-};
-
-type UiShellChromeBridgeState = {
-  model: UiShellChromeRenderModel;
+  model: ReadonlySignal<UiShellChromeRenderModel>;
 };
 
 const DEFAULT_SHELL_CHROME_MODEL: UiShellChromeRenderModel = {
@@ -183,7 +180,8 @@ function SettingsFeedbackSlot(props: {
 }
 
 function UiShellChrome(props: UiShellChromeProps) {
-  const { bridge, model } = props;
+  const { bridge } = props;
+  const model = props.model.value;
 
   function activateView(viewId: string): void {
     bridge.current.activateView(viewId);
@@ -385,22 +383,14 @@ export function mountUiShellChrome(
   host: HTMLElement,
   bridge: UiShellChromeActionBridge,
 ): UiShellChromeView {
-  const bridgeState: UiShellChromeBridgeState = {
-    model: DEFAULT_SHELL_CHROME_MODEL,
-  };
+  const model = signal<UiShellChromeRenderModel>(DEFAULT_SHELL_CHROME_MODEL);
   const mount = createUiPreactMount(host);
-
-  function render(): void {
-    mount.render(<UiShellChrome bridge={bridge} model={bridgeState.model} />);
-  }
-
-  render();
+  mount.render(<UiShellChrome bridge={bridge} model={model} />);
 
   return {
     dom: createUiShellChromeDom(host),
-    render(model) {
-      bridgeState.model = model;
-      render();
+    render(nextModel) {
+      model.value = nextModel;
     },
   };
 }

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -3,7 +3,13 @@ import { formatIntLocale } from "../../format";
 import { queryOne, queryRequiredAll } from "../dom/dom_query";
 import { setUiLanguage } from "../ui_i18n";
 import { trackAppStateSlice, type AppState } from "../ui_app_state";
-import { effect, untracked } from "../ui_signals";
+import {
+  computed,
+  effect,
+  signal,
+  untracked,
+  type ReadonlySignal,
+} from "../ui_signals";
 import {
   bindUiShellFeatureEvents,
   type UiShellFeaturePorts,
@@ -60,6 +66,10 @@ export class UiShellController {
 
   private readonly chrome: UiShellChromeView;
 
+  private readonly appShellWrap: HTMLElement | null;
+
+  private readonly liveOverview: RealtimeLiveOverviewBridge;
+
   private readonly navigation: UiShellNavigationModule;
 
   private readonly notifications: UiShellNotificationModule;
@@ -70,6 +80,8 @@ export class UiShellController {
 
   private readonly languageRefresh: UiShellLanguageRefreshModule;
 
+  private readonly chromeRenderModel: ReadonlySignal<UiShellChromeRenderModel>;
+
   private readonly activeViewListeners = new Set<(viewId: string) => void>();
 
   private ports: UiShellFeaturePorts | null = null;
@@ -78,16 +90,17 @@ export class UiShellController {
 
   private updateSpectrumOverlayState: (() => void) | null = null;
 
-  private liveStatusBadge: UiShellBadgeModel = {
+  private readonly liveStatusBadge = signal<UiShellBadgeModel>({
     text: "No live signal",
     variant: "muted",
-  };
+  });
 
   constructor(deps: UiShellControllerDeps) {
     this.state = deps.state;
     setUiLanguage(this.state.shell.lang);
     this.chrome = deps.chrome;
-    const appShellWrap = queryOne<HTMLElement>(".wrap");
+    this.appShellWrap = queryOne<HTMLElement>(".wrap");
+    this.liveOverview = deps.liveOverview;
     const views = queryRequiredAll<HTMLElement>(".view", "UI shell views");
     this.navigation = createUiShellNavigationModule({
       shell: this.state.shell,
@@ -101,13 +114,10 @@ export class UiShellController {
       views,
     });
     this.notifications = createUiShellNotificationModule({
-      onChanged: () => this.renderChrome(),
       window,
     });
     this.status = createUiShellStatusModule({
-      appShellWrap,
       realtime: this.state.realtime,
-      renderLiveOverviewSpeed: (text) => deps.liveOverview.setSpeedText(text),
       settings: this.state.settings,
       shell: this.state.shell,
       t: (key, vars) => this.t(key, vars),
@@ -119,7 +129,6 @@ export class UiShellController {
       normalizeLanguage: (lang) => I18N.normalizeLang(lang ?? ""),
       applyLanguage: (forceReloadInsights = false) => this.applyLanguage(forceReloadInsights),
       renderSpeedReadout: () => this.renderSpeedReadout(),
-      onChanged: () => this.renderChrome(),
     });
     deps.chromeActions.attach({
       activateView: (viewId) => this.setActiveView(viewId),
@@ -133,7 +142,7 @@ export class UiShellController {
       renderSpectrum: () => this.renderSpectrumChart?.(),
       updateSpectrumOverlay: () => this.updateSpectrumOverlayState?.(),
     });
-    this.renderChrome();
+    this.chromeRenderModel = this.createChromeRenderModel();
     this.bindReactiveStatusSync();
   }
 
@@ -162,21 +171,24 @@ export class UiShellController {
   }
 
   renderSpeedReadout(): void {
-    this.status.renderSpeedReadout();
-    this.renderChrome();
+    untracked(() => {
+      this.liveOverview.setSpeedText(this.status.speedReadoutText.value);
+    });
   }
 
   renderWsState(): void {
-    this.status.syncConnectionState();
-    this.renderChrome();
+    untracked(() => {
+      if (this.appShellWrap) {
+        this.appShellWrap.dataset.connectionState = this.status.connectionState.value;
+      }
+    });
   }
 
   setLiveStatus(variant: string, text: string): void {
-    this.liveStatusBadge = {
+    this.liveStatusBadge.value = {
       text,
       variant: normalizeBadgeVariant(variant),
     };
-    this.renderChrome();
   }
 
   subscribeActiveViewChanges(listener: (viewId: string) => void): () => void {
@@ -189,7 +201,6 @@ export class UiShellController {
   setActiveView(viewId: string): void {
     const previousViewId = this.state.shell.activeViewId;
     this.navigation.setActiveView(viewId);
-    this.renderChrome();
     if (this.state.shell.activeViewId !== previousViewId) {
       for (const listener of this.activeViewListeners) {
         listener(this.state.shell.activeViewId);
@@ -203,7 +214,6 @@ export class UiShellController {
       this.requirePorts().languageRefresh,
       forceReloadInsights,
     );
-    this.renderChrome();
   }
 
   bindUiEvents(): void {
@@ -212,7 +222,6 @@ export class UiShellController {
 
   async hydratePersistedPreferences(): Promise<void> {
     await this.preferences.hydratePersistedPreferences();
-    this.renderChrome();
   }
 
   private bindFeatureEvents(): void {
@@ -220,66 +229,52 @@ export class UiShellController {
   }
 
   private bindReactiveStatusSync(): void {
-    let previousWsState = this.state.transport.wsState;
-    let previousPayloadError = this.state.transport.payloadError;
-    let transportInitialized = false;
     effect(() => {
-      trackAppStateSlice(this.state.transport);
-      const nextWsState = this.state.transport.wsState;
-      const nextPayloadError = this.state.transport.payloadError;
-      if (!transportInitialized) {
-        transportInitialized = true;
-        previousWsState = nextWsState;
-        previousPayloadError = nextPayloadError;
-        return;
-      }
-      if (nextWsState === previousWsState && nextPayloadError === previousPayloadError) {
-        return;
-      }
-      previousWsState = nextWsState;
-      previousPayloadError = nextPayloadError;
-      untracked(() => this.renderWsState());
+      const model = this.chromeRenderModel.value;
+      const connectionState = this.status.connectionState.value;
+      untracked(() => {
+        if (this.appShellWrap) {
+          this.appShellWrap.dataset.connectionState = connectionState;
+        }
+        this.chrome.render(model);
+      });
     });
 
-    let speedInitialized = false;
     effect(() => {
-      trackAppStateSlice(this.state.realtime);
-      trackAppStateSlice(this.state.settings);
+      const speedText = this.status.speedReadoutText.value;
+      untracked(() => {
+        this.liveOverview.setSpeedText(speedText);
+      });
+    });
+  }
+
+  private createChromeRenderModel(): ReadonlySignal<UiShellChromeRenderModel> {
+    return computed(() => {
       trackAppStateSlice(this.state.shell);
-      if (!speedInitialized) {
-        speedInitialized = true;
-        return;
-      }
-      untracked(() => this.renderSpeedReadout());
+      return {
+        activeViewId: this.state.shell.activeViewId,
+        appErrorBanner: this.notifications.bannerModel.value,
+        languageFeedback: this.preferences.languageFeedback.value,
+        languageLabelText: this.t("settings.language"),
+        navItems: SHELL_NAV_ITEMS.map((item) => ({
+          labelText: this.t(item.labelKey) || item.fallbackLabel,
+          tabId: item.tabId,
+          viewId: item.viewId,
+        })),
+        selectedLanguage: this.preferences.selectedLanguage.value,
+        selectedSpeedUnit: this.preferences.selectedSpeedUnit.value,
+        shellLiveStatus: this.liveStatusBadge.value,
+        speedUnitFeedback: this.preferences.speedUnitFeedback.value,
+        speedUnitLabelText: this.t("speed.unit"),
+        speedUnitOptionLabels: Object.fromEntries(
+          SPEED_UNIT_OPTIONS.map((option) => [
+            option.value,
+            this.t(option.labelKey) || option.fallbackLabel,
+          ]),
+        ),
+        wsLinkState: this.status.wsLinkState.value,
+      };
     });
-  }
-
-  private buildRenderModel(): UiShellChromeRenderModel {
-    return {
-      activeViewId: this.state.shell.activeViewId,
-      appErrorBanner: this.notifications.getBannerModel(),
-      languageFeedback: this.preferences.getLanguageFeedback(),
-      languageLabelText: this.t("settings.language"),
-      navItems: SHELL_NAV_ITEMS.map((item) => ({
-        labelText: this.t(item.labelKey) || item.fallbackLabel,
-        tabId: item.tabId,
-        viewId: item.viewId,
-      })),
-      selectedLanguage: this.preferences.getSelectedLanguage(),
-      selectedSpeedUnit: this.preferences.getSelectedSpeedUnit(),
-      shellLiveStatus: this.liveStatusBadge,
-      speedUnitFeedback: this.preferences.getSpeedUnitFeedback(),
-      speedUnitLabelText: this.t("speed.unit"),
-      speedUnitOptionLabels: Object.fromEntries(
-        SPEED_UNIT_OPTIONS.map((option) => [option.value, this.t(option.labelKey) || option.fallbackLabel]),
-      ),
-      wsLinkState: this.status.getWsLinkState(),
-    };
-  }
-
-  private renderChrome(): void {
-    this.status.syncConnectionState();
-    this.chrome.render(this.buildRenderModel());
   }
 
   private requirePorts(): UiShellFeaturePorts {

--- a/apps/ui/src/app/runtime/ui_shell_notification_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_notification_module.ts
@@ -1,26 +1,27 @@
 import type { UiShellErrorBannerModel } from "./ui_shell_chrome";
+import { signal, type ReadonlySignal } from "../ui_signals";
 
 type UiShellNotificationDeps = {
-  onChanged?: () => void;
   window: Pick<Window, "clearTimeout" | "setTimeout">;
 };
 
 export interface UiShellNotificationModule {
+  readonly bannerModel: ReadonlySignal<UiShellErrorBannerModel>;
   clearError(): void;
-  getBannerModel(): UiShellErrorBannerModel;
   showError(message: string): void;
 }
+
+const HIDDEN_BANNER_MODEL: UiShellErrorBannerModel = {
+  hidden: true,
+  text: "",
+  variant: null,
+};
 
 export function createUiShellNotificationModule(
   deps: UiShellNotificationDeps,
 ): UiShellNotificationModule {
   let hideBannerTimer: ReturnType<typeof setTimeout> | null = null;
-  let bannerText = "";
-  let bannerVisible = false;
-
-  function notifyChanged(): void {
-    deps.onChanged?.();
-  }
+  const bannerModel = signal<UiShellErrorBannerModel>(HIDDEN_BANNER_MODEL);
 
   function clearScheduledHide(): void {
     if (hideBannerTimer !== null) {
@@ -31,30 +32,22 @@ export function createUiShellNotificationModule(
 
   function clearError(): void {
     clearScheduledHide();
-    bannerVisible = false;
-    bannerText = "";
-    notifyChanged();
+    bannerModel.value = HIDDEN_BANNER_MODEL;
   }
 
   return {
+    bannerModel,
     clearError,
-    getBannerModel() {
-      return {
-        hidden: !bannerVisible,
-        text: bannerText,
-        variant: bannerVisible ? "bad" : null,
-      };
-    },
     showError(message) {
       clearScheduledHide();
-      bannerText = message;
-      bannerVisible = true;
-      notifyChanged();
+      bannerModel.value = {
+        hidden: false,
+        text: message,
+        variant: "bad",
+      };
       hideBannerTimer = deps.window.setTimeout(() => {
-        bannerVisible = false;
-        bannerText = "";
+        bannerModel.value = HIDDEN_BANNER_MODEL;
         hideBannerTimer = null;
-        notifyChanged();
       }, 5000);
     },
   };

--- a/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
@@ -6,13 +6,14 @@ import {
 } from "../../api/settings";
 import type { SettingsFeedbackMessage } from "../views/settings_feedback";
 import type { ShellState } from "../ui_app_state";
+import { signal, type ReadonlySignal } from "../ui_signals";
 
 export interface UiShellPreferencesModule {
+  readonly languageFeedback: ReadonlySignal<SettingsFeedbackMessage | null>;
+  readonly selectedLanguage: ReadonlySignal<string>;
+  readonly selectedSpeedUnit: ReadonlySignal<string>;
+  readonly speedUnitFeedback: ReadonlySignal<SettingsFeedbackMessage | null>;
   clearPreferenceFeedback(): void;
-  getLanguageFeedback(): SettingsFeedbackMessage | null;
-  getSelectedLanguage(): string;
-  getSelectedSpeedUnit(): string;
-  getSpeedUnitFeedback(): SettingsFeedbackMessage | null;
   hydratePersistedPreferences(): Promise<void>;
   saveLanguage(lang: string): Promise<void>;
   saveSpeedUnit(unit: string): Promise<void>;
@@ -21,7 +22,6 @@ export interface UiShellPreferencesModule {
 type UiShellPreferencesDeps = {
   applyLanguage: (forceReloadInsights?: boolean) => void;
   normalizeLanguage: (value: string | null | undefined) => string;
-  onChanged?: () => void;
   renderSpeedReadout: () => void;
   shell: ShellState;
   t: (key: string, vars?: Record<string, unknown>) => string;
@@ -30,14 +30,10 @@ type UiShellPreferencesDeps = {
 export function createUiShellPreferencesModule(
   deps: UiShellPreferencesDeps,
 ): UiShellPreferencesModule {
-  let languageFeedback: SettingsFeedbackMessage | null = null;
-  let speedUnitFeedback: SettingsFeedbackMessage | null = null;
-  let selectedLanguage = deps.shell.lang;
-  let selectedSpeedUnit = deps.shell.speedUnit;
-
-  function notifyChanged(): void {
-    deps.onChanged?.();
-  }
+  const languageFeedback = signal<SettingsFeedbackMessage | null>(null);
+  const speedUnitFeedback = signal<SettingsFeedbackMessage | null>(null);
+  const selectedLanguage = signal(deps.shell.lang);
+  const selectedSpeedUnit = signal(deps.shell.speedUnit);
 
   function speedUnitLabel(value: string): string {
     return deps.t(value === "mps" ? "speed.unit.mps" : "speed.unit.kmh");
@@ -53,12 +49,12 @@ export function createUiShellPreferencesModule(
 
   function applyLanguageValue(rawLanguage: string): void {
     deps.shell.lang = deps.normalizeLanguage(rawLanguage);
-    selectedLanguage = deps.shell.lang;
+    selectedLanguage.value = deps.shell.lang;
   }
 
   function applySpeedUnitValue(rawUnit: string): void {
     deps.shell.speedUnit = normalizeSpeedUnit(rawUnit);
-    selectedSpeedUnit = deps.shell.speedUnit;
+    selectedSpeedUnit.value = deps.shell.speedUnit;
   }
 
   function buildSaveFailureFeedback(
@@ -78,22 +74,13 @@ export function createUiShellPreferencesModule(
   }
 
   return {
+    languageFeedback,
+    selectedLanguage,
+    selectedSpeedUnit,
+    speedUnitFeedback,
     clearPreferenceFeedback() {
-      languageFeedback = null;
-      speedUnitFeedback = null;
-      notifyChanged();
-    },
-    getLanguageFeedback() {
-      return languageFeedback;
-    },
-    getSelectedLanguage() {
-      return selectedLanguage;
-    },
-    getSelectedSpeedUnit() {
-      return selectedSpeedUnit;
-    },
-    getSpeedUnitFeedback() {
-      return speedUnitFeedback;
+      languageFeedback.value = null;
+      speedUnitFeedback.value = null;
     },
     async hydratePersistedPreferences() {
       try {
@@ -118,41 +105,37 @@ export function createUiShellPreferencesModule(
     async saveLanguage(lang) {
       const nextLanguage = deps.normalizeLanguage(lang);
       const previousLanguage = deps.shell.lang;
-      languageFeedback = null;
-      selectedLanguage = nextLanguage;
-      notifyChanged();
+      languageFeedback.value = null;
+      selectedLanguage.value = nextLanguage;
       try {
         const payload = await setSettingsLanguage(nextLanguage);
         applyLanguageValue(payload?.language || nextLanguage);
         deps.applyLanguage(true);
       } catch (error) {
-        selectedLanguage = previousLanguage;
-        languageFeedback = buildSaveFailureFeedback(
+        selectedLanguage.value = previousLanguage;
+        languageFeedback.value = buildSaveFailureFeedback(
           deps.t("settings.language"),
           languageLabel(previousLanguage),
           error,
         );
-        notifyChanged();
       }
     },
     async saveSpeedUnit(unit) {
       const nextUnit = normalizeSpeedUnit(unit);
       const previousUnit = deps.shell.speedUnit;
-      speedUnitFeedback = null;
-      selectedSpeedUnit = nextUnit;
-      notifyChanged();
+      speedUnitFeedback.value = null;
+      selectedSpeedUnit.value = nextUnit;
       try {
         const payload = await setSettingsSpeedUnit(nextUnit);
         applySpeedUnitValue(payload?.speed_unit || nextUnit);
         deps.renderSpeedReadout();
       } catch (error) {
-        selectedSpeedUnit = previousUnit;
-        speedUnitFeedback = buildSaveFailureFeedback(
+        selectedSpeedUnit.value = previousUnit;
+        speedUnitFeedback.value = buildSaveFailureFeedback(
           deps.t("speed.unit"),
           speedUnitLabel(previousUnit),
           error,
         );
-        notifyChanged();
       }
     },
   };

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -8,7 +8,7 @@ import type {
 } from "../ui_app_state";
 import { trackAppStateSlice } from "../ui_app_state";
 import type { VisualVariant } from "../style_state";
-import { computed } from "../ui_signals";
+import { computed, type ReadonlySignal } from "../ui_signals";
 import type { UiShellBadgeModel } from "./ui_shell_chrome";
 
 const WS_KEY_BY_STATE: Record<string, string> = {
@@ -28,9 +28,7 @@ const WS_VARIANT_BY_STATE: Record<string, VisualVariant> = {
 };
 
 type UiShellStatusDeps = {
-  appShellWrap: HTMLElement | null;
   realtime: RealtimeState;
-  renderLiveOverviewSpeed: (text: string) => void;
   settings: SettingsState;
   shell: ShellState;
   t: (key: string, vars?: Record<string, unknown>) => string;
@@ -38,9 +36,9 @@ type UiShellStatusDeps = {
 };
 
 export interface UiShellStatusModule {
-  getWsLinkState(): UiShellBadgeModel;
-  renderSpeedReadout(): void;
-  syncConnectionState(): void;
+  readonly connectionState: ReadonlySignal<"degraded" | "live">;
+  readonly speedReadoutText: ReadonlySignal<string>;
+  readonly wsLinkState: ReadonlySignal<UiShellBadgeModel>;
 }
 
 export function createUiShellStatusModule(
@@ -103,16 +101,8 @@ export function createUiShellStatusModule(
   });
 
   return {
-    getWsLinkState() {
-      return wsLinkState.value;
-    },
-    renderSpeedReadout() {
-      deps.renderLiveOverviewSpeed(speedReadoutText.value);
-    },
-    syncConnectionState() {
-      if (deps.appShellWrap) {
-        deps.appShellWrap.dataset.connectionState = connectionState.value;
-      }
-    },
+    connectionState,
+    speedReadoutText,
+    wsLinkState,
   };
 }

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -26,12 +26,6 @@ function createView(id: string): HTMLElement {
   } as unknown as HTMLElement;
 }
 
-function createWrap(): HTMLElement {
-  return {
-    dataset: {},
-  } as unknown as HTMLElement;
-}
-
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     headers: { "content-type": "application/json" },
@@ -176,8 +170,8 @@ test.describe("createUiShellPreferencesModule", () => {
     ]);
     expect(state.shell.lang).toBe("nl");
     expect(state.shell.speedUnit).toBe("mps");
-    expect(module.getSelectedLanguage()).toBe("nl");
-    expect(module.getSelectedSpeedUnit()).toBe("mps");
+    expect(module.selectedLanguage.value).toBe("nl");
+    expect(module.selectedSpeedUnit.value).toBe("mps");
     expect(applyLanguageCalls).toEqual([true]);
     expect(renderSpeedReadoutCalls).toBe(1);
   });
@@ -204,7 +198,7 @@ test.describe("createUiShellPreferencesModule", () => {
         })) as typeof fetch,
       async () => {
         const savePromise = module.saveLanguage("nl");
-        expect(module.getSelectedLanguage()).toBe("nl");
+        expect(module.selectedLanguage.value).toBe("nl");
         expect(state.shell.lang).toBe("en");
         resolveResponse?.(jsonResponse({ language: "nl" }));
         await savePromise;
@@ -212,7 +206,7 @@ test.describe("createUiShellPreferencesModule", () => {
     );
 
     expect(state.shell.lang).toBe("nl");
-    expect(module.getSelectedLanguage()).toBe("nl");
+    expect(module.selectedLanguage.value).toBe("nl");
     expect(applyLanguageCalls).toEqual([true]);
   });
 
@@ -237,20 +231,16 @@ test.describe("createUiShellPreferencesModule", () => {
     );
 
     expect(state.shell.speedUnit).toBe("kmh");
-    expect(module.getSelectedSpeedUnit()).toBe("kmh");
-    expect(module.getSpeedUnitFeedback()?.detail).toBe("save failed");
+    expect(module.selectedSpeedUnit.value).toBe("kmh");
+    expect(module.speedUnitFeedback.value?.detail).toBe("save failed");
   });
 });
 
 test.describe("createUiShellNotificationModule", () => {
-  test("shows and clears the shared error banner model", () => {
-    let onChangedCalls = 0;
+  test("shows and clears the shared error banner model signal", () => {
     let pendingHide: (() => void) | null = null;
 
     const module = createUiShellNotificationModule({
-      onChanged: () => {
-        onChangedCalls += 1;
-      },
       window: {
         clearTimeout: () => undefined,
         setTimeout: ((callback: TimerHandler) => {
@@ -261,71 +251,64 @@ test.describe("createUiShellNotificationModule", () => {
     });
 
     module.showError("save failed");
-    expect(module.getBannerModel()).toEqual({
+    expect(module.bannerModel.value).toEqual({
       hidden: false,
       text: "save failed",
       variant: "bad",
     });
 
     pendingHide?.();
-    expect(module.getBannerModel()).toEqual({
+    expect(module.bannerModel.value).toEqual({
       hidden: true,
       text: "",
       variant: null,
     });
-    expect(onChangedCalls).toBe(2);
   });
 });
 
 test.describe("createUiShellStatusModule", () => {
-  test("builds websocket badge state and degraded shell status without bootstrap wiring", () => {
+  test("builds websocket badge state and degraded shell status signals without bootstrap wiring", () => {
     const state = createAppState();
     state.transport.wsState = "stale";
-    const appShellWrap = createWrap();
 
     const module = createUiShellStatusModule({
-      appShellWrap,
       realtime: state.realtime,
-      renderLiveOverviewSpeed: () => undefined,
       settings: state.settings,
       shell: state.shell,
       t: testTranslation,
       transport: state.transport,
     });
 
-    expect(module.getWsLinkState()).toEqual({
+    expect(module.wsLinkState.value).toEqual({
       text: "ws.stale",
       variant: "bad",
     });
-    module.syncConnectionState();
-    expect(appShellWrap.dataset.connectionState).toBe("degraded");
+    expect(module.connectionState.value).toBe("degraded");
   });
 
   test("derives updated websocket badge state after transport mutations", () => {
     const state = createAppState();
     const module = createUiShellStatusModule({
-      appShellWrap: createWrap(),
       realtime: state.realtime,
-      renderLiveOverviewSpeed: () => undefined,
       settings: state.settings,
       shell: state.shell,
       t: testTranslation,
       transport: state.transport,
     });
 
-    expect(module.getWsLinkState()).toEqual({
+    expect(module.wsLinkState.value).toEqual({
       text: "ws.connecting",
       variant: "muted",
     });
 
     state.transport.wsState = "stale";
-    expect(module.getWsLinkState()).toEqual({
+    expect(module.wsLinkState.value).toEqual({
       text: "ws.stale",
       variant: "bad",
     });
 
     state.transport.payloadError = "bad frame";
-    expect(module.getWsLinkState()).toEqual({
+    expect(module.wsLinkState.value).toEqual({
       text: "ws.payload_error_pill",
       variant: "bad",
     });
@@ -340,24 +323,17 @@ test.describe("createUiShellStatusModule", () => {
     state.settings.carsLoaded = true;
     state.settings.cars = [];
     state.settings.activeCarId = null;
-    let renderedSpeedText = "";
 
     const module = createUiShellStatusModule({
-      appShellWrap: createWrap(),
       realtime: state.realtime,
-      renderLiveOverviewSpeed: (text) => {
-        renderedSpeedText = text;
-      },
       settings: state.settings,
       shell: state.shell,
       t: testTranslation,
       transport: state.transport,
     });
 
-    module.renderSpeedReadout();
-
-    expect(renderedSpeedText).toContain("speed.override");
-    expect(renderedSpeedText).toContain('"unit":"speed.unit.kmh"');
+    expect(module.speedReadoutText.value).toContain("speed.override");
+    expect(module.speedReadoutText.value).toContain('"unit":"speed.unit.kmh"');
   });
 
   test("renders OBD2 when OBD2 is the resolved speed source", () => {
@@ -366,24 +342,17 @@ test.describe("createUiShellStatusModule", () => {
     state.settings.speedSource = "obd2";
     state.settings.resolvedSpeedSource = "obd2";
     state.shell.speedUnit = "kmh";
-    let renderedSpeedText = "";
 
     const module = createUiShellStatusModule({
-      appShellWrap: createWrap(),
       realtime: state.realtime,
-      renderLiveOverviewSpeed: (text) => {
-        renderedSpeedText = text;
-      },
       settings: state.settings,
       shell: state.shell,
       t: testTranslation,
       transport: state.transport,
     });
 
-    module.renderSpeedReadout();
-
-    expect(renderedSpeedText).toContain("speed.obd2");
-    expect(renderedSpeedText).toContain('"unit":"speed.unit.kmh"');
+    expect(module.speedReadoutText.value).toContain("speed.obd2");
+    expect(module.speedReadoutText.value).toContain('"unit":"speed.unit.kmh"');
   });
 });
 


### PR DESCRIPTION
## Summary

This PR resolves #2305 by removing the remaining `UiShellController.renderChrome()` fan-out and replacing it with one reactive shell-chrome render path. Before this change, small shell updates still bounced through callback-style plumbing: the notification module, preferences module, and live-status path all pushed `onChanged` or imperative render calls back into `UiShellController`, which then rebuilt the full shell chrome model and re-rendered the header island. That architecture no longer matched the rest of the Preact/signals migration. The shell header was still behaving like a legacy mutable bridge even though the surrounding runtime had already moved toward signal-backed state.

The goal here was not to redesign the shell UI. The visible header, nav, pills, and inline feedback all stay the same. The change is purely about ownership: shell sub-state is now held in reactive state close to the modules that own it, `UiShellController` computes one render model from those signals, and the chrome island consumes that model reactively instead of being explicitly told to rebuild from many call sites.

## Problem

Issue #2305 called out one of the last shell-specific migration leftovers after the AppState and websocket signal work landed. `UiShellController` still coordinated shell updates with a callback chain:

- notification changes called back into `renderChrome()`
- preference saves and failures called back into `renderChrome()`
- live-status changes called back into `renderChrome()`
- the controller kept rebuilding a full chrome render model even when only one small banner or badge changed

That left the controller doing too much view-model fan-out and made the shell chrome harder to reason about than the other reactive islands. It also meant the header island was effectively being rerendered as a mutable bridge target instead of behaving like a mounted reactive owner.

## Implementation approach

I kept the change centered on the exact seam named in the issue:

1. make shell sub-state directly reactive
2. remove callback-driven `renderChrome()` fan-out
3. keep `UiShellController` focused on orchestration
4. let the shell chrome island update from reactive model changes

I did not broaden the issue into a larger shell-controller rewrite. The navigation API, public shell actions, language refresh orchestration, and visible UI stayed intact. The main cut is that the controller no longer acts as a render callback hub.

## Main code changes

### 1. Signal-backed shell sub-state in the runtime modules

`ui_shell_notification_module.ts` now owns a signal-backed `bannerModel` instead of keeping mutable local fields plus a controller callback. Showing or clearing the shared app-error banner updates that signal directly, including the delayed auto-hide path.

`ui_shell_preferences_module.ts` now exposes signal-backed `selectedLanguage`, `selectedSpeedUnit`, `languageFeedback`, and `speedUnitFeedback` values. That means optimistic selection changes and inline save failures update local reactive state directly rather than depending on getters plus `onChanged` callbacks into the controller.

`ui_shell_status_module.ts` was simplified into a pure derived-state module. It no longer receives DOM or bridge callbacks. Instead it exposes computed `wsLinkState`, `connectionState`, and `speedReadoutText` signals derived from AppState. That change is important because it removes the remaining “status module computes data and controller immediately renders it” coupling.

### 2. One computed chrome model in `UiShellController`

`ui_shell_controller.ts` now creates one computed shell-chrome render model from the shell sub-state signals and the existing translated nav metadata. The controller still owns orchestration responsibilities such as navigation, language refresh, and feature-port binding, but it no longer has a dedicated `renderChrome()` method that every module calls.

Instead, the controller now has targeted effects:

- one effect renders the shell chrome from the computed model and synchronizes the wrap connection-state dataset
- one effect pushes the derived speed text into the live overview bridge

That reduces the controller to coordination and side-effect application rather than manual view-model rebuild fan-out.

### 3. The shell chrome island mounts once and updates from a signal

`ui_shell_chrome.tsx` was also part of the issue. Previously the mounted island still behaved like a rerender target: `render(model)` replaced local bridge state and called `mount.render(...)` again. The header now mounts once and reads from a signal-backed render model. The bridge method still exists as the controller-facing seam, but it simply updates the model signal instead of remounting the island on every chrome change.

That keeps the public view contract stable while making the island itself behave like the reactive owner the migration was aiming for.

## Tests and validation

I updated the shell runtime module tests to match the new ownership model instead of pinning the old callback/getter API. `apps/ui/tests/ui_shell_runtime_modules.spec.ts` now asserts signal-backed notification, preference, and shell-status state directly.

Targeted validation for this issue was:

- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.settings.spec.ts tests/smoke.settings-shell.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

The lint run still reports only the pre-existing Biome schema-version info and the unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`. No new lint failures were introduced by this change.

## Docs and contract changes

There are no backend, schema, or API contract changes in this PR. The only documentation update is in `apps/ui/README.md`, where the shell controller description now reflects the reactive shell-chrome ownership model instead of the older “controller rebuilds chrome state” framing.

## Risks and tradeoffs

The main risk in this area is accidental reactive cycles, because the shell controller still has to bridge from shared reactive state into imperative DOM or island APIs. The earlier websocket-input issue already exposed that class of bug, so this change keeps the effect boundaries narrow and applies imperative work from effects rather than rebuilding many ad hoc render paths. I also kept the language-refresh orchestration imperative on purpose; that issue is about cross-feature refresh sequencing, not shell-chrome fan-out.

Another tradeoff is that I preserved the existing `chrome.render(model)` bridge method instead of deleting it outright. I kept it because the runtime seam between controller and mounted shell view is still useful, and the problem here was not the existence of a view bridge by itself. The problem was the callback chain and repeated full-model rebuild fan-out. The new implementation keeps the seam but changes it into a single reactive update path.

## Out of scope

This PR does not attempt to solve the broader “replace manual listener sets and `onChanged` callbacks everywhere” follow-up mentioned in #2336. It only addresses the shell-chrome fan-out named in #2305. The rest of the shell runtime APIs and higher-level feature orchestration remain intentionally stable.

Closes #2305
