### PR TITLE
Adopt a signal-backed live transport store

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -94,7 +94,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/runtime/ui_preact_mount.ts` | Canonical helper for mounting and disposing incremental Preact islands inside existing DOM hosts |
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, and app-level error banner plus the typed shell chrome bridge |
 | `app/runtime/ui_shell_controller.ts` | Menu/view shell, language and preference hydration, and the reactive shell-chrome model that feeds header pills, feedback, and app-level banners |
-| `app/runtime/ui_live_transport_controller.ts` | Demo/WebSocket transport coordinator that queues payloads through AppState, throttles live-session adaptation, and lets shell/spectrum react from signal-backed state |
+| `app/runtime/ui_live_transport_controller.ts` | Demo/WebSocket transport coordinator that queues payloads through AppState, throttles live-session adaptation, and lets realtime, shell, and spectrum surfaces react from signal-backed state |
 | `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that wires overlay updates plus the extracted canvas, interaction, and panel modules |
 | `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, tweening, and canvas draw plugin orchestration |
 | `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports |

--- a/apps/ui/src/app/app_feature_ports.ts
+++ b/apps/ui/src/app/app_feature_ports.ts
@@ -10,14 +10,12 @@ import type {
   SettingsFeatureRealtimePorts,
 } from "./features/settings_feature";
 import type { UpdateFeature } from "./features/update_feature";
-import type { UiTransportFeaturePorts } from "./runtime/ui_live_transport_controller";
 import { createUiRecordingHistoryRefresh } from "./runtime/ui_recording_history_refresh";
 import type { UiShellFeaturePorts } from "./runtime/ui_shell_feature_ports";
 import type { UiStartupFeaturePorts } from "./runtime/ui_startup_feature_ports";
 
 export interface AppFeatureBundle {
   shell: UiShellFeaturePorts;
-  transport: UiTransportFeaturePorts;
   startup: UiStartupFeaturePorts;
 }
 
@@ -33,7 +31,6 @@ export interface AppFeaturesForPorts {
     | "maybeRenderSensorsSettingsList"
     | "renderLoggingStatus"
     | "renderStatus"
-    | "updateClientSelection"
     | "refreshLocationOptions"
     | "refreshLoggingStatus"
   >;
@@ -95,12 +92,6 @@ export function createAppFeaturePorts(features: AppFeaturesForPorts): AppFeature
           syncSettingsInputs: () => features.settings.syncSettingsInputs(),
         },
       },
-    },
-    transport: {
-      updateClientSelection: () => features.realtime.updateClientSelection(),
-      maybeRenderSensorsSettingsList: (force) => features.realtime.maybeRenderSensorsSettingsList(force),
-      renderLoggingStatus: () => features.realtime.renderLoggingStatus(),
-      renderStatus: (clientRow) => features.realtime.renderStatus(clientRow),
     },
     startup: {
       history: {

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -4,11 +4,13 @@ import type {
   SettingsState,
   SpectrumState,
 } from "../ui_app_state";
+import { trackAppStateSlice } from "../ui_app_state";
 import type { LocationOption } from "../../transport/http_models";
 import type { AdaptedClient } from "../../transport/live_models";
 import type { RealtimeLoggingPanelBridge } from "../views/realtime_logging_panel";
 import type { RealtimeLiveOverviewBridge } from "../views/realtime_live_overview";
 import type { SensorsPanelView } from "../views/sensors_panel";
+import { effect, untracked } from "../ui_signals";
 import { createRealtimeFeatureWorkflow } from "./realtime_feature_workflow";
 import { createRealtimeFeaturePresenter } from "../views/realtime_feature_presenter";
 
@@ -49,7 +51,6 @@ export interface RealtimeFeature {
   bindHandlers(): void;
   buildLocationOptions(codes: readonly string[]): LocationOption[];
   maybeRenderSensorsSettingsList(force?: boolean): void;
-  updateClientSelection(): void;
   renderStatus(clientRow?: AdaptedClient): void;
   renderLoggingStatus(): void;
   refreshLoggingStatus(): Promise<void>;
@@ -82,6 +83,16 @@ export function createRealtimeFeature(
     confirmRemoveClient: (message) => window.confirm(message),
   });
   let handlersBound = false;
+
+  effect(() => {
+    trackAppStateSlice(ctx.realtime);
+    trackAppStateSlice(ctx.settings);
+    trackAppStateSlice(ctx.spectrum);
+    untracked(() => {
+      presenter.maybeRenderSensorsSettingsList();
+      workflow.renderLoggingStatus();
+    });
+  });
 
   function bindHandlers(): void {
     if (handlersBound) {
@@ -135,7 +146,6 @@ export function createRealtimeFeature(
     buildLocationOptions: (codes) => presenter.buildLocationOptions(codes),
     maybeRenderSensorsSettingsList: (force) =>
       presenter.maybeRenderSensorsSettingsList(force),
-    updateClientSelection: () => workflow.updateClientSelection(),
     renderStatus: (clientRow) => presenter.renderStatus(clientRow),
     renderLoggingStatus: () => workflow.renderLoggingStatus(),
     refreshLoggingStatus: () => workflow.refreshLoggingStatus(),

--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -14,7 +14,10 @@ import type {
   LoggingStatusPayload,
 } from "../../transport/http_models";
 import type { AdaptedClient } from "../../transport/live_models";
-import type { RealtimeState } from "../ui_app_state";
+import {
+  syncSelectedRealtimeClient,
+  type RealtimeState,
+} from "../ui_app_state";
 import {
   createPollingController,
   type PollingController,
@@ -64,7 +67,6 @@ export interface RealtimeFeatureWorkflowDeps {
 
 export interface RealtimeFeatureWorkflow {
   bindHandlers(): void;
-  updateClientSelection(): void;
   renderLoggingStatus(): void;
   refreshLoggingStatus(): Promise<void>;
   startLogging(): Promise<void>;
@@ -130,18 +132,6 @@ export function createRealtimeFeatureWorkflow(
   function applyLocationCodes(codes: string[]): void {
     realtime.locationCodes = codes.length ? codes : defaultLocationCodes.slice();
     realtime.locationOptions = view.buildLocationOptions(realtime.locationCodes);
-  }
-
-  function updateClientSelection(): void {
-    const firstConnected = realtime.clients.find((client) => Boolean(client.connected));
-    if (!realtime.selectedClientId && realtime.clients.length > 0) {
-      realtime.selectedClientId = firstConnected ? firstConnected.id : realtime.clients[0].id;
-    }
-    if (realtime.selectedClientId && !realtime.clients.some((client) => client.id === realtime.selectedClientId)) {
-      realtime.selectedClientId = firstConnected
-        ? firstConnected.id
-        : realtime.clients.length ? realtime.clients[0].id : null;
-    }
   }
 
   function requestIdleCaptureReadinessRefresh(): void {
@@ -310,7 +300,7 @@ export function createRealtimeFeatureWorkflow(
     if (realtime.selectedClientId === clientId) {
       realtime.selectedClientId = null;
     }
-    updateClientSelection();
+    syncSelectedRealtimeClient(realtime);
     view.maybeRenderSensorsSettingsList();
     renderLoggingStatus();
     view.renderStatus();
@@ -321,7 +311,6 @@ export function createRealtimeFeatureWorkflow(
 
   return {
     bindHandlers,
-    updateClientSelection,
     renderLoggingStatus,
     refreshLoggingStatus,
     startLogging,

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -1,5 +1,5 @@
 import { adaptServerPayload } from "../../server_payload";
-import type { AdaptedClient, AdaptedPayload } from "../../transport/live_models";
+import type { AdaptedPayload } from "../../transport/live_models";
 import { runDemoMode } from "../demo_mode";
 import { WsClient } from "../../ws";
 import {
@@ -16,17 +16,8 @@ type UiLiveTransportControllerDeps = {
   payloadErrorMessage: () => string;
 };
 
-export interface UiTransportFeaturePorts {
-  updateClientSelection(): void;
-  maybeRenderSensorsSettingsList(force?: boolean): void;
-  renderLoggingStatus(): void;
-  renderStatus(clientRow: AdaptedClient | undefined): void;
-}
-
 export class UiLiveTransportController {
   private readonly state: AppState;
-
-  private ports: UiTransportFeaturePorts | null = null;
 
   private readonly payloadErrorMessage: () => string;
 
@@ -34,10 +25,6 @@ export class UiLiveTransportController {
     this.state = deps.state;
     this.payloadErrorMessage = deps.payloadErrorMessage;
     this.bindTransportSignalSync();
-  }
-
-  attachPorts(ports: UiTransportFeaturePorts): void {
-    this.ports = ports;
   }
 
   sendSelection(): void {
@@ -119,7 +106,6 @@ export class UiLiveTransportController {
   }
 
   private applyPayload(payload: unknown): void {
-    const ports = this.requirePorts();
     let adapted: AdaptedPayload;
     try {
       adapted = adaptServerPayload(payload);
@@ -138,15 +124,11 @@ export class UiLiveTransportController {
         realtime: this.state.realtime,
         spectrum: this.state.spectrum,
         adaptedPayload: adapted,
-        updateClientSelection: () => ports.updateClientSelection(),
       });
     });
-    ports.maybeRenderSensorsSettingsList();
-    ports.renderLoggingStatus();
     if (update.hasSelectedClientChanged) {
       this.sendSelection();
     }
-    ports.renderStatus(update.selectedClient);
   }
 
   private connectWs(): void {
@@ -156,12 +138,5 @@ export class UiLiveTransportController {
       transport: this.state.transport,
     });
     this.state.transport.ws.connect();
-  }
-
-  private requirePorts(): UiTransportFeaturePorts {
-    if (this.ports === null) {
-      throw new Error("UiLiveTransportController ports used before initialization");
-    }
-    return this.ports;
   }
 }

--- a/apps/ui/src/app/runtime/ui_shell_language_refresh_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_language_refresh_module.ts
@@ -42,7 +42,6 @@ export function createUiShellLanguageRefreshModule(
       deps.state.realtime.locationOptions = features.realtime.buildLocationOptions(
         deps.state.realtime.locationCodes,
       );
-      deps.state.realtime.sensorsSettingsSignature = "";
       features.settings.syncSettingsInputs();
       features.realtime.maybeRenderSensorsSettingsList(true);
       deps.renderSpeedReadout();

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -91,7 +91,6 @@ export class UiAppRuntime {
       },
     });
     this.shell.attachPorts(this.featurePorts.shell);
-    this.transport.attachPorts(this.featurePorts.transport);
     this.startup = new UiStartupCoordinator({
       shell: this.shell,
       transport: this.transport,

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -187,7 +187,6 @@ export interface LivePayloadUpdateDeps {
   realtime: RealtimeState;
   spectrum: SpectrumState;
   adaptedPayload: AdaptedPayload;
-  updateClientSelection: () => void;
 }
 
 export interface LivePayloadUpdateResult {
@@ -219,9 +218,26 @@ export function applySpectrumTick(
   };
 }
 
+export function syncSelectedRealtimeClient(realtime: RealtimeState): void {
+  const firstConnected = realtime.clients.find((client) => Boolean(client.connected));
+  if (!realtime.selectedClientId && realtime.clients.length > 0) {
+    realtime.selectedClientId = firstConnected ? firstConnected.id : realtime.clients[0]?.id ?? null;
+  }
+  if (
+    realtime.selectedClientId
+    && !realtime.clients.some((client) => client.id === realtime.selectedClientId)
+  ) {
+    realtime.selectedClientId = firstConnected
+      ? firstConnected.id
+      : realtime.clients.length
+        ? realtime.clients[0]?.id ?? null
+        : null;
+  }
+}
+
 export function applyLivePayloadUpdate(deps: LivePayloadUpdateDeps): LivePayloadUpdateResult {
   return batchAppStateUpdates(() => {
-    const { realtime, spectrum, adaptedPayload, updateClientSelection } = deps;
+    const { realtime, spectrum, adaptedPayload } = deps;
     const previousSelectedClientId = realtime.selectedClientId;
     realtime.clients = adaptedPayload.clients;
     const spectrumTick = applySpectrumTick(
@@ -230,7 +246,7 @@ export function applyLivePayloadUpdate(deps: LivePayloadUpdateDeps): LivePayload
       adaptedPayload.spectra,
     );
     spectrum.spectra = spectrumTick.spectra;
-    updateClientSelection();
+    syncSelectedRealtimeClient(realtime);
     realtime.speedMps = adaptedPayload.speed_mps;
     realtime.rotationalSpeeds = adaptedPayload.rotational_speeds;
     spectrum.hasSpectrumData = spectrumTick.hasSpectrumData;
@@ -267,7 +283,6 @@ export interface RealtimeState {
   loggingStatus: LoggingStatusPayload;
   locationOptions: LocationOption[];
   locationCodes: string[];
-  sensorsSettingsSignature: string;
 }
 
 export interface HistoryState {
@@ -343,7 +358,6 @@ export function createAppState(): AppState {
       },
       locationOptions: [],
       locationCodes: defaultLocationCodes.slice(),
-      sensorsSettingsSignature: "",
     }),
     history: createReactiveStateSlice({
       runs: [],

--- a/apps/ui/src/app/views/realtime_feature_presenter.ts
+++ b/apps/ui/src/app/views/realtime_feature_presenter.ts
@@ -101,6 +101,7 @@ export function createRealtimeFeaturePresenter(
     strongestSignal,
     strongestSignalText,
   } = sensorState;
+  let renderedSensorsSettingsSignature = "";
 
   function dataFreshnessText(): string {
     const connected = connectedClients();
@@ -274,10 +275,9 @@ export function createRealtimeFeaturePresenter(
 
   function maybeRenderSensorsSettingsList(force = false): void {
     const nextSig = sensorsSettingsSignature();
-    if (!force && nextSig === realtime.sensorsSettingsSignature) return;
-    realtime.sensorsSettingsSignature = nextSig;
+    if (!force && nextSig === renderedSensorsSettingsSignature) return;
+    renderedSensorsSettingsSignature = nextSig;
     renderSensorsSettingsList();
-    renderLiveOverview(buildLoggingPanelViewModel(null).phaseText);
   }
 
   function renderSensorsSettingsList(): void {

--- a/apps/ui/tests/app_feature_ports.spec.ts
+++ b/apps/ui/tests/app_feature_ports.spec.ts
@@ -6,7 +6,7 @@ import {
   createSettingsFeatureRealtimePorts,
 } from "../src/app/app_feature_ports";
 
-test("feature port helpers expose explicit shell, transport, and startup contracts without a full app shell", async () => {
+test("feature port helpers expose explicit shell and startup contracts without a full app shell", async () => {
   const calls: string[] = [];
 
   const history = {
@@ -33,9 +33,6 @@ test("feature port helpers expose explicit shell, transport, and startup contrac
     },
     maybeRenderSensorsSettingsList(force?: boolean) {
       calls.push(`realtime.maybeRenderSensorsSettingsList:${String(force)}`);
-    },
-    updateClientSelection() {
-      calls.push("realtime.updateClientSelection");
     },
     renderStatus() {
       calls.push("realtime.renderStatus");
@@ -115,7 +112,7 @@ test("feature port helpers expose explicit shell, transport, and startup contrac
     espFlash,
   });
 
-  expect(Object.keys(bundle).sort()).toEqual(["shell", "startup", "transport"]);
+  expect(Object.keys(bundle).sort()).toEqual(["shell", "startup"]);
 
   settingsRealtime.renderRealtimeStatus();
   settingsRealtime.renderRealtimeLoggingStatus();
@@ -134,11 +131,6 @@ test("feature port helpers expose explicit shell, transport, and startup contrac
   bundle.shell.languageRefresh.history.renderHistoryTable();
   bundle.shell.languageRefresh.history.reloadExpandedRunOnLanguageChange();
   bundle.shell.languageRefresh.settings.syncSettingsInputs();
-
-  bundle.transport.updateClientSelection();
-  bundle.transport.maybeRenderSensorsSettingsList(false);
-  bundle.transport.renderLoggingStatus();
-  bundle.transport.renderStatus(undefined);
 
   await bundle.startup.history.refreshHistory();
   await bundle.startup.realtime.refreshLocationOptions();
@@ -168,10 +160,6 @@ test("feature port helpers expose explicit shell, transport, and startup contrac
     "history.renderHistoryTable",
     "history.reloadExpandedRunOnLanguageChange",
     "settings.syncSettingsInputs",
-    "realtime.updateClientSelection",
-    "realtime.maybeRenderSensorsSettingsList:false",
-    "realtime.renderLoggingStatus",
-    "realtime.renderStatus",
     "history.refreshHistory",
     "realtime.refreshLocationOptions",
     "realtime.refreshLoggingStatus",

--- a/apps/ui/tests/ui_live_payload_application.spec.ts
+++ b/apps/ui/tests/ui_live_payload_application.spec.ts
@@ -54,9 +54,6 @@ test.describe("applyLivePayloadUpdate", () => {
           },
         },
       }),
-      updateClientSelection: () => {
-        state.realtime.selectedClientId = state.realtime.clients[0]?.id ?? null;
-      },
     });
 
     expect(state.realtime.clients.map((client) => client.id)).toEqual(["client-1"]);
@@ -97,9 +94,6 @@ test.describe("applyLivePayloadUpdate", () => {
         speed_mps: 14,
         spectra: null,
       }),
-      updateClientSelection: () => {
-        state.realtime.selectedClientId = "client-1";
-      },
     });
 
     expect(state.spectrum.spectra.clients["client-1"]?.freq).toEqual([1, 2, 3]);

--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { EXPECTED_SCHEMA_VERSION, type LiveWsPayload } from "../src/contracts/ws_payload_types";
-import { UiLiveTransportController, type UiTransportFeaturePorts } from "../src/app/runtime/ui_live_transport_controller";
+import { UiLiveTransportController } from "../src/app/runtime/ui_live_transport_controller";
 import { createAppState } from "../src/app/ui_app_state";
 import { flushAsyncWork, installWindowGlobal } from "./async_test_helpers";
 
@@ -62,7 +62,7 @@ test.describe("UiLiveTransportController", () => {
     installWindowGlobal();
   });
 
-  test("applies queued transport payloads through narrow transport ports without an AppFeatureBundle", async () => {
+  test("applies queued transport payloads through shared state without transport ports", async () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
     state.transport.ws = {
@@ -71,51 +71,25 @@ test.describe("UiLiveTransportController", () => {
       },
     } as unknown as typeof state.transport.ws;
 
-    const controller = new UiLiveTransportController({
+    new UiLiveTransportController({
       state,
       payloadErrorMessage: () => "payload error",
     });
 
-    const portCalls: string[] = [];
-    const renderedStatusIds: Array<string | null> = [];
-    const ports = {
-      updateClientSelection(): void {
-        portCalls.push("updateClientSelection");
-        state.realtime.selectedClientId = state.realtime.clients[0]?.id ?? null;
-      },
-      maybeRenderSensorsSettingsList(): void {
-        portCalls.push("maybeRenderSensorsSettingsList");
-      },
-      renderLoggingStatus(): void {
-        portCalls.push("renderLoggingStatus");
-      },
-      renderStatus(clientRow): void {
-        portCalls.push("renderStatus");
-        renderedStatusIds.push(clientRow?.id ?? null);
-      },
-    } satisfies UiTransportFeaturePorts;
-
     const raf = installRafHarness();
     try {
-      controller.attachPorts(ports);
       state.transport.pendingPayload = makeLivePayload({
         clients: [makeClient("client-1")],
         speed_mps: 12,
       });
       await flushAsyncWork();
       raf.flushNext();
+      await flushAsyncWork();
 
       expect(state.transport.pendingPayload).toBeNull();
       expect(state.realtime.clients.map((client) => client.id)).toEqual(["client-1"]);
       expect(state.realtime.selectedClientId).toBe("client-1");
       expect(state.realtime.speedMps).toBe(12);
-      expect(portCalls).toEqual([
-        "updateClientSelection",
-        "maybeRenderSensorsSettingsList",
-        "renderLoggingStatus",
-        "renderStatus",
-      ]);
-      expect(renderedStatusIds).toEqual(["client-1"]);
       expect(sentSelections).toEqual([{ client_id: "client-1" }]);
     } finally {
       raf.restore();
@@ -150,14 +124,14 @@ test.describe("UiLiveTransportController", () => {
     ]);
   });
 
-  test("throws a clear error when payloads arrive before ports are attached", () => {
+  test("applies payloads without requiring feature-port attachment", () => {
+    const state = createAppState();
     const controller = new UiLiveTransportController({
-      state: createAppState(),
+      state,
       payloadErrorMessage: () => "payload error",
     });
 
-    expect(() => applyPayload(controller, makeLivePayload())).toThrow(
-      "UiLiveTransportController ports used before initialization",
-    );
+    expect(() => applyPayload(controller, makeLivePayload())).not.toThrow();
+    expect(state.realtime.speedMps).toBe(10);
   });
 });

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -432,7 +432,6 @@ test.describe("createUiShellLanguageRefreshModule", () => {
     expect(state.realtime.locationOptions).toEqual([
       { code: "front_left_wheel", label: "front_left_wheel-label" },
     ]);
-    expect(state.realtime.sensorsSettingsSignature).toBe("");
     expect(portCalls).toEqual([
       "buildLocationOptions",
       "syncSettingsInputs",


### PR DESCRIPTION
## Summary

This PR resolves #2317 by removing the remaining live-transport output fan-out from `UiLiveTransportController` and moving realtime UI refreshes onto shared reactive AppState instead of transport-specific render ports. Websocket input was already signal-backed after #2324 and #2323, but the output side still looked imperative: every payload triggered a chain of realtime render helpers for sensors, logging, and live overview. The goal here was to finish that split cleanly without turning the issue into a full realtime-workflow rewrite.

## Problem

Issue #2317 called out the strongest remaining imperative runtime seam in the frontend after the AppState signal migration. `UiLiveTransportController.applyPayload()` still adapted payloads, mutated shared realtime/spectrum state, and then immediately called `maybeRenderSensorsSettingsList()`, `renderLoggingStatus()`, and `renderStatus()`. That wiring lived behind `UiTransportFeaturePorts`, so the controller still had feature-level knowledge of which realtime surfaces needed updates and in what order.

## Implementation approach

I kept the change focused on the transport-output seam rather than trying to solve every remaining presenter/workflow render method in one PR. The approach was:

1. delete the transport-specific render port contract
2. move selected-client syncing into shared state logic
3. let the realtime feature observe shared AppState and refresh its own surfaces
4. preserve the existing payload batching and throttling behavior
5. keep higher-level logging/location workflows stable unless they were directly coupled to the removed transport path

That gives us the core issue outcome: incoming transport payloads no longer require manual render fan-out across multiple features.

## Main code changes

### 1. `UiLiveTransportController` no longer drives realtime renders

`apps/ui/src/app/runtime/ui_live_transport_controller.ts` is the center of the fix. The `UiTransportFeaturePorts` interface is gone, along with the stored ports reference, `attachPorts()`, and the “ports must be attached before payloads arrive” requirement.

`applyPayload()` now does only transport work:

- parse and validate the payload
- write batched shared realtime/spectrum state updates
- clear or set payload errors
- resend websocket selection if the selected client changed

The old explicit render calls after payload application are deleted. That is the core behavior change in this PR.

### 2. Shared state now owns selected-client syncing

`apps/ui/src/app/ui_app_state.ts` now exports `syncSelectedRealtimeClient()` and uses it inside `applyLivePayloadUpdate()`. Previously the transport controller still depended on a feature callback for selected-client reconciliation. That callback was small but important because it kept the controller coupled to realtime feature ports.

Moving that logic into shared state handling lets payload application stay self-contained and removes another reason for the transport runtime to know about feature wiring.

This also let me remove the last transport-only feature-port dependency from `app_feature_ports.ts`, `ui_app_runtime.ts`, and the surrounding app bundle wiring.

### 3. Realtime surfaces now react from AppState instead of transport fan-out

`apps/ui/src/app/features/realtime_feature.ts` now binds a reactive synchronization effect that tracks the shared realtime, settings, and spectrum AppState slices. When those slices change, the feature refreshes the realtime presenter surfaces from that shared state rather than waiting for the transport controller to tell it to render.

The transport controller now mutates shared state, and the realtime feature responds to those state changes. I intentionally kept the update path narrow:

- sensors panel updates still flow through `maybeRenderSensorsSettingsList()`
- logging and overview updates still flow through the existing logging render path
- requestAnimationFrame throttling stays in the transport controller

So the PR removes the fan-out source without replacing it with a second transport-specific synchronization layer.

### 4. Presenter render caching moved off AppState

`apps/ui/src/app/views/realtime_feature_presenter.ts` previously stored `sensorsSettingsSignature` inside AppState as a render memoization cache. That became a bad fit once the realtime feature itself started reacting to AppState, because the presenter would have been mutating the same reactive slice it was observing.

I moved that signature cache to presenter-local state instead. That keeps AppState focused on shared runtime data rather than view-cache bookkeeping and avoids self-triggering reactive loops.

The matching reset in `ui_shell_language_refresh_module.ts` and the corresponding test expectation were removed because the signature is no longer part of shared state.

## Test and runtime updates

The transport refactor removed one real contract, so the focused test updates matter: `ui_live_transport_controller.spec.ts` now verifies the controller works without any transport-port attachment, `ui_live_payload_application.spec.ts` now exercises the shared-state payload helper without the old selection callback, `app_feature_ports.spec.ts` now asserts that the bundle exposes only shell and startup contracts, and `ui_shell_runtime_modules.spec.ts` no longer depends on the removed `sensorsSettingsSignature` AppState field.

Local validation for this PR was:

- `cd apps/ui && npx playwright test tests/ui_live_transport_controller.spec.ts tests/ui_live_payload_application.spec.ts tests/app_feature_ports.spec.ts tests/realtime_feature_workflow.spec.ts tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/realtime_logging_summary.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.settings.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test tests/ui_live_transport_controller.spec.ts tests/app_feature_ports.spec.ts --workers=1`
- `cd apps/ui && npm run lint`

The lint run still reports only the pre-existing Biome schema-version info and the unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`.

## Docs and contract changes

There are no backend or API contract changes here. The only user-facing documentation update is in `apps/ui/README.md`, where the `ui_live_transport_controller.ts` entry now reflects that realtime surfaces react from shared state alongside shell and spectrum rather than staying on a transport-specific output fan-out path.

## Risks and tradeoffs

The biggest risk in this area is unintended render churn when moving from imperative update calls to reactive observation. I kept the existing requestAnimationFrame queue and minimum render interval in the transport controller specifically to preserve the current batching behavior for bursty websocket traffic. The refactor changes who decides to refresh the realtime surfaces, not when payloads enter the system.

Another tradeoff is that this PR does not eliminate every remaining imperative render call in the realtime workflow. Logging API transitions and some settings-side refresh flows still call realtime render helpers directly. I left those in place because #2317 is about the transport output fan-out, not a full presenter/workflow decomposition.

## Out of scope

This PR does not attempt to convert the full realtime workflow render state into AppState or remove every remaining presenter render helper. It also does not change the existing spectrum requestAnimationFrame throttling behavior. The scope is the live transport output seam named in #2317.

Closes #2317
