### PR TITLE
Convert state derivation modules to computed signals

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -78,7 +78,7 @@ export function createAppFeatureBundle(
     realtime: state.realtime,
     spectrum: state.spectrum,
     settings: state.settings,
-    getLanguage: () => state.shell.lang,
+    shell: state.shell,
     t,
     escapeHtml,
     showError,

--- a/apps/ui/src/app/app_feature_ports.ts
+++ b/apps/ui/src/app/app_feature_ports.ts
@@ -27,7 +27,6 @@ export interface AppFeaturesForPorts {
   realtime: Pick<
     RealtimeFeature,
     | "bindHandlers"
-    | "buildLocationOptions"
     | "maybeRenderSensorsSettingsList"
     | "renderLoggingStatus"
     | "renderStatus"
@@ -79,7 +78,6 @@ export function createAppFeaturePorts(features: AppFeaturesForPorts): AppFeature
       bindEspFlashHandlers: () => features.espFlash.bindHandlers(),
       languageRefresh: {
         realtime: {
-          buildLocationOptions: (codes) => features.realtime.buildLocationOptions(codes),
           maybeRenderSensorsSettingsList: (force) => features.realtime.maybeRenderSensorsSettingsList(force),
           renderLoggingStatus: () => features.realtime.renderLoggingStatus(),
           renderStatus: () => features.realtime.renderStatus(),

--- a/apps/ui/src/app/car_selection_state.ts
+++ b/apps/ui/src/app/car_selection_state.ts
@@ -1,5 +1,7 @@
 import type { CarRecord } from "../transport/http_models";
 import type { SettingsState } from "./ui_app_state";
+import { trackAppStateSlice } from "./ui_app_state";
+import { computed, type ReadonlySignal } from "./ui_signals";
 
 const REQUIRED_CAR_ASPECT_KEYS = [
   "tire_width_mm",
@@ -22,6 +24,12 @@ export type CarSelectionState =
   | { kind: "no_cars" }
   | { kind: "no_active_car" }
   | { kind: "active"; car: CarRecord };
+
+export interface CarSelectionDerivedState {
+  activeCar: ReadonlySignal<CarRecord | null>;
+  hasResolvedActiveCar: ReadonlySignal<boolean>;
+  selection: ReadonlySignal<CarSelectionState>;
+}
 
 export interface CarCompleteness {
   isComplete: boolean;
@@ -55,6 +63,38 @@ export function deriveCarSelectionState(settings: CarSelectionStateSource): CarS
 
 export function hasResolvedActiveCar(settings: CarSelectionStateSource): boolean {
   return deriveCarSelectionState(settings).kind === "active";
+}
+
+export function createCarSelectionDerivedState(
+  settings: CarSelectionStateSource,
+): CarSelectionDerivedState {
+  const activeCar = computed(() => {
+    trackAppStateSlice(settings);
+    return resolveActiveCar(settings);
+  });
+  const selection = computed<CarSelectionState>(() => {
+    trackAppStateSlice(settings);
+    if (!settings.carsLoaded) {
+      return { kind: "loading" };
+    }
+    if (!settings.cars.length) {
+      return { kind: "no_cars" };
+    }
+    const resolvedCar = activeCar.value;
+    if (resolvedCar) {
+      return { kind: "active", car: resolvedCar };
+    }
+    return { kind: "no_active_car" };
+  });
+  const hasResolvedActiveCarSignal = computed(
+    () => selection.value.kind === "active",
+  );
+
+  return {
+    activeCar,
+    hasResolvedActiveCar: hasResolvedActiveCarSignal,
+    selection,
+  };
 }
 
 export function getCarCompleteness(car: CarRecord): CarCompleteness {

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -2,10 +2,10 @@ import type { FeatureDepsBase } from "../feature_deps_base";
 import type {
   RealtimeState,
   SettingsState,
+  ShellState,
   SpectrumState,
 } from "../ui_app_state";
 import { trackAppStateSlice } from "../ui_app_state";
-import type { LocationOption } from "../../transport/http_models";
 import type { AdaptedClient } from "../../transport/live_models";
 import type { RealtimeLoggingPanelBridge } from "../views/realtime_logging_panel";
 import type { RealtimeLiveOverviewBridge } from "../views/realtime_live_overview";
@@ -18,7 +18,7 @@ export interface RealtimeFeatureDeps extends FeatureDepsBase {
   realtime: RealtimeState;
   spectrum: SpectrumState;
   settings: SettingsState;
-  getLanguage: () => string;
+  shell: Pick<ShellState, "lang">;
   formatInt: (value: number) => string;
   chrome: RealtimeFeatureChromePorts;
   sensorsPanel: SensorsPanelView;
@@ -49,7 +49,6 @@ export interface RealtimeFeatureRecordingPorts {
 
 export interface RealtimeFeature {
   bindHandlers(): void;
-  buildLocationOptions(codes: readonly string[]): LocationOption[];
   maybeRenderSensorsSettingsList(force?: boolean): void;
   renderStatus(clientRow?: AdaptedClient): void;
   renderLoggingStatus(): void;
@@ -64,8 +63,8 @@ export function createRealtimeFeature(
   const presenter = createRealtimeFeaturePresenter({
     realtime: ctx.realtime,
     settings: ctx.settings,
+    shell: ctx.shell,
     spectrum: ctx.spectrum,
-    getLanguage: ctx.getLanguage,
     sensorsPanel: ctx.sensorsPanel,
     t: ctx.t,
     formatInt: ctx.formatInt,
@@ -143,7 +142,6 @@ export function createRealtimeFeature(
 
   return {
     bindHandlers,
-    buildLocationOptions: (codes) => presenter.buildLocationOptions(codes),
     maybeRenderSensorsSettingsList: (force) =>
       presenter.maybeRenderSensorsSettingsList(force),
     renderStatus: (clientRow) => presenter.renderStatus(clientRow),

--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -10,7 +10,6 @@ import {
 import { defaultLocationCodes } from "../../constants";
 import type {
   ClientLocationsResponse,
-  LocationOption,
   LoggingStatusPayload,
 } from "../../transport/http_models";
 import type { AdaptedClient } from "../../transport/live_models";
@@ -39,7 +38,6 @@ export interface RealtimeFeatureWorkflowApi {
 }
 
 export interface RealtimeFeatureWorkflowViewPorts {
-  buildLocationOptions(codes: readonly string[]): LocationOption[];
   maybeRenderSensorsSettingsList(force?: boolean): void;
   renderStatus(clientRow?: AdaptedClient): void;
   renderLoggingStatus(state: RealtimeFeatureRenderState): void;
@@ -131,7 +129,6 @@ export function createRealtimeFeatureWorkflow(
 
   function applyLocationCodes(codes: string[]): void {
     realtime.locationCodes = codes.length ? codes : defaultLocationCodes.slice();
-    realtime.locationOptions = view.buildLocationOptions(realtime.locationCodes);
   }
 
   function requestIdleCaptureReadinessRefresh(): void {

--- a/apps/ui/src/app/features/realtime_sensor_state.ts
+++ b/apps/ui/src/app/features/realtime_sensor_state.ts
@@ -1,8 +1,18 @@
 import type { LocationOption, LoggingStatusPayload } from "../../transport/http_models";
 import type { AdaptedClient } from "../../transport/live_models";
 import * as I18N from "../../i18n";
-import { deriveCarSelectionState } from "../car_selection_state";
-import type { RealtimeState, SettingsState, SpectrumState } from "../ui_app_state";
+import {
+  createCarSelectionDerivedState,
+  type CarSelectionState,
+} from "../car_selection_state";
+import type {
+  RealtimeState,
+  SettingsState,
+  ShellState,
+  SpectrumState,
+} from "../ui_app_state";
+import { trackAppStateSlice } from "../ui_app_state";
+import { computed, type ReadonlySignal } from "../ui_signals";
 
 export type ActiveCarDisplayState = {
   text: string;
@@ -21,22 +31,26 @@ type CaptureReadinessPayload = NonNullable<LoggingStatusPayload["capture_readine
 export interface RealtimeSensorStateDeps {
   realtime: RealtimeState;
   settings: SettingsState;
+  shell: Pick<ShellState, "lang">;
   spectrum: SpectrumState;
-  getLanguage: () => string;
+  captureReadinessSummaryText: (
+    readiness: CaptureReadinessPayload | null,
+  ) => string;
   t: (key: string, vars?: Record<string, unknown>) => string;
   formatInt: (value: number) => string;
 }
 
 export interface RealtimeSensorState {
-  buildLocationOptions(codes: readonly string[]): LocationOption[];
+  activeCarSelection: ReadonlySignal<CarSelectionState>;
+  activeCarDisplayState: ReadonlySignal<ActiveCarDisplayState>;
+  assignedClientCount: ReadonlySignal<number>;
+  connectedClients: ReadonlySignal<AdaptedClient[]>;
+  hasActiveCarSelection: ReadonlySignal<boolean>;
+  liveHealth: ReadonlySignal<LiveHealth>;
   locationCodeForClient(client: AdaptedClient): string;
-  connectedClients(): AdaptedClient[];
-  assignedClientCount(): number;
-  strongestSignal(): { client: AdaptedClient; db: number } | null;
-  strongestSignalText(signal?: { client: AdaptedClient; db: number } | null): string;
-  activeCarDisplayState(): ActiveCarDisplayState;
-  hasActiveCarSelection(): boolean;
-  computeLiveHealth(captureReadinessSummaryText: (readiness: CaptureReadinessPayload | null) => string): LiveHealth;
+  locationOptions: ReadonlySignal<LocationOption[]>;
+  strongestSignal: ReadonlySignal<{ client: AdaptedClient; db: number } | null>;
+  strongestSignalText: ReadonlySignal<string>;
 }
 
 const SHORTHAND_LOCATION_MAP: Record<string, string> = {
@@ -48,19 +62,26 @@ const SHORTHAND_LOCATION_MAP: Record<string, string> = {
 };
 
 export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): RealtimeSensorState {
-  const { realtime, settings, spectrum, getLanguage, t, formatInt } = ctx;
+  const { realtime, settings, shell, spectrum, t, formatInt } = ctx;
+  const carSelection = createCarSelectionDerivedState(settings);
 
   function locationLabelForLang(lang: string, code: string): string {
     return I18N.get(lang, `location.${code}`, { code });
   }
 
   function locationLabel(code: string): string {
-    return locationLabelForLang(getLanguage(), code);
+    return locationLabelForLang(shell.lang, code);
   }
 
   function buildLocationOptions(codes: readonly string[]): LocationOption[] {
     return codes.map((code) => ({ code, label: locationLabel(code) }));
   }
+
+  const locationOptions = computed<LocationOption[]>(() => {
+    trackAppStateSlice(realtime);
+    trackAppStateSlice(shell);
+    return buildLocationOptions(realtime.locationCodes);
+  });
 
   function locationCodeForClient(client: AdaptedClient): string {
     const explicitCode = String(client.location_code || "").trim();
@@ -75,7 +96,7 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
       const labels = I18N.getForAllLangs(`location.${code}`);
       if (labels.some((label) => label === name)) return code;
     }
-    const match = realtime.locationOptions.find((loc) => loc.label === name);
+    const match = locationOptions.value.find((loc) => loc.label === name);
     return match ? match.code : "";
   }
 
@@ -88,22 +109,26 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
     if (!code) {
       return t("dashboard.sensor_unassigned");
     }
-    const option = realtime.locationOptions.find((location) => location.code === code);
+    const option = locationOptions.value.find((location) => location.code === code);
     return option?.label ?? locationLabel(code);
   }
 
-  function connectedClients(): AdaptedClient[] {
+  const connectedClients = computed<AdaptedClient[]>(() => {
+    trackAppStateSlice(realtime);
     return realtime.clients.filter((client) => Boolean(client.connected));
-  }
+  });
 
-  function assignedClientCount(): number {
+  const assignedClientCount = computed(() => {
+    trackAppStateSlice(realtime);
     return realtime.clients.filter((client) => locationCodeForClient(client)).length;
-  }
+  });
 
-  function strongestSignal(): { client: AdaptedClient; db: number } | null {
+  const strongestSignal = computed<{ client: AdaptedClient; db: number } | null>(() => {
+    trackAppStateSlice(realtime);
+    trackAppStateSlice(spectrum);
     let bestClient: AdaptedClient | null = null;
     let bestDb = Number.NEGATIVE_INFINITY;
-    for (const client of connectedClients()) {
+    for (const client of connectedClients.value) {
       const db = spectrum.spectra.clients[client.id]?.strength_metrics?.vibration_strength_db;
       if (typeof db !== "number" || !Number.isFinite(db)) continue;
       if (db > bestDb) {
@@ -118,9 +143,12 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
       client: bestClient,
       db: bestDb,
     };
-  }
+  });
 
-  function strongestSignalText(signal = strongestSignal()): string {
+  const strongestSignalText = computed(() => {
+    trackAppStateSlice(realtime);
+    trackAppStateSlice(shell);
+    const signal = strongestSignal.value;
     if (!signal) {
       return t("dashboard.strongest_signal_none");
     }
@@ -128,10 +156,11 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
       ? clientLocationText(signal.client)
       : clientDisplayName(signal.client);
     return `${primary} · ${formatInt(signal.db)} dB`;
-  }
+  });
 
-  function activeCarDisplayState(): ActiveCarDisplayState {
-    const selection = deriveCarSelectionState(settings);
+  const activeCarDisplayState = computed<ActiveCarDisplayState>(() => {
+    trackAppStateSlice(shell);
+    const selection = carSelection.selection.value;
     if (selection.kind === "loading") {
       return {
         text: t("dashboard.active_car_loading"),
@@ -150,15 +179,15 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
       text: selection.car.name,
       isWarning: false,
     };
-  }
+  });
 
-  function hasActiveCarSelection(): boolean {
-    return deriveCarSelectionState(settings).kind === "active";
-  }
+  const hasActiveCarSelection = computed(
+    () => carSelection.hasResolvedActiveCar.value,
+  );
 
-  function computeLiveHealth(
-    captureReadinessSummaryText: (readiness: CaptureReadinessPayload | null) => string,
-  ): LiveHealth {
+  const liveHealth = computed<LiveHealth>(() => {
+    trackAppStateSlice(realtime);
+    trackAppStateSlice(shell);
     if (realtime.loggingStatus.write_error) {
       return {
         variant: "bad",
@@ -167,7 +196,7 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
         showOverviewPill: true,
       };
     }
-    const connected = connectedClients();
+    const connected = connectedClients.value;
     if (!connected.length) {
       return {
         variant: "muted",
@@ -176,7 +205,7 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
         showOverviewPill: true,
       };
     }
-    if (!hasActiveCarSelection()) {
+    if (!hasActiveCarSelection.value) {
       return {
         variant: "warn",
         text: t("dashboard.health.attention"),
@@ -212,7 +241,7 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
       };
     }
     const connectedCount = formatInt(connected.length);
-    const assignedCount = formatInt(assignedClientCount());
+    const assignedCount = formatInt(assignedClientCount.value);
     if (realtime.loggingStatus.enabled) {
       return {
         variant: "ok",
@@ -226,7 +255,7 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
       return {
         variant: "warn",
         text: t("dashboard.health.attention"),
-        summary: captureReadinessSummaryText(captureReadiness),
+        summary: ctx.captureReadinessSummaryText(captureReadiness),
         showOverviewPill: true,
       };
     }
@@ -236,17 +265,18 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
       summary: "",
       showOverviewPill: false,
     };
-  }
+  });
 
   return {
-    buildLocationOptions,
-    locationCodeForClient,
-    connectedClients,
+    activeCarDisplayState,
+    activeCarSelection: carSelection.selection,
     assignedClientCount,
+    connectedClients,
+    hasActiveCarSelection,
+    liveHealth,
+    locationCodeForClient,
+    locationOptions,
     strongestSignal,
     strongestSignalText,
-    activeCarDisplayState,
-    hasActiveCarSelection,
-    computeLiveHealth,
   };
 }

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -1,10 +1,8 @@
 import type { FeatureDepsBase } from "../feature_deps_base";
 import {
+  createCarSelectionDerivedState,
   type CarSelectionState,
-  deriveCarSelectionState,
   getCarCompleteness,
-  hasResolvedActiveCar,
-  resolveActiveCar,
 } from "../car_selection_state";
 import type { SettingsState } from "../ui_app_state";
 import type { CarRecord, CarsPayload } from "../../transport/http_models";
@@ -71,15 +69,16 @@ export function createSettingsCarsModule(
   const confirmDelete =
     ctx.confirmDelete ?? ((message: string) => window.confirm(message));
   const transport = createSettingsCarsTransport(ctx.transport);
+  const carSelection = createCarSelectionDerivedState(settings);
   let handlersBound = false;
   let highlightedCarFeedback: CarsListHighlightedFeedback | null = null;
 
   function hasValidActiveCar(): boolean {
-    return hasResolvedActiveCar(settings);
+    return carSelection.hasResolvedActiveCar.value;
   }
 
   function getCarSelectionState(): CarSelectionState {
-    return deriveCarSelectionState(settings);
+    return carSelection.selection.value;
   }
 
   function createPanelModel(
@@ -152,7 +151,7 @@ export function createSettingsCarsModule(
   }
 
   function syncActiveCarToInputs(): void {
-    copyActiveCarAspects(resolveActiveCar(settings), settings);
+    copyActiveCarAspects(carSelection.activeCar.value, settings);
     if (hasValidActiveCar()) {
       ctx.syncAnalysisInputs();
     }

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -1,5 +1,5 @@
 import type { FeatureDepsBase } from "../feature_deps_base";
-import { hasResolvedActiveCar } from "../car_selection_state";
+import { createCarSelectionDerivedState } from "../car_selection_state";
 import type { SettingsState } from "../ui_app_state";
 import type { CarsPayload } from "../../transport/http_models";
 import {
@@ -67,6 +67,7 @@ export function createSettingsFeature(
   ctx: SettingsFeatureDeps,
 ): SettingsFeature {
   const { settings, t, escapeHtml, fmt } = ctx;
+  const carSelection = createCarSelectionDerivedState(settings);
   let handlersBound = false;
   let carsModule!: SettingsCarsModule;
 
@@ -87,7 +88,7 @@ export function createSettingsFeature(
     showError: ctx.showError,
     settings,
     renderSpectrum: ctx.view.renderSpectrum,
-    hasValidActiveCar: () => hasResolvedActiveCar(settings),
+    hasValidActiveCar: () => carSelection.hasResolvedActiveCar.value,
     onMissingActiveCar: () => carsModule.renderCarList(),
     onSaveError: showSettingsSaveError,
   });

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -5,7 +5,7 @@ import type {
   SpeedSourceRequest,
 } from "../../transport/http_models";
 import {
-  deriveDisplayedSpeedSourceMode,
+  createSpeedSourceDerivedState,
   resolveEffectiveSpeedSource,
   type DisplayedSpeedSourceMode,
 } from "../speed_source_state";
@@ -127,9 +127,10 @@ export function createSettingsSpeedSourceWorkflow(
 ): SettingsSpeedSourceWorkflow {
   const transport = createSettingsSpeedSourceTransport(deps.transport);
   const createPolling = deps.createPollingController ?? createPollingController;
+  const speedSourceState = createSpeedSourceDerivedState(deps.settings);
 
   let speedSourceDraftDirty = false;
-  let selectedMode: DisplayedSpeedSourceMode = deriveDisplayedSpeedSourceMode(deps.settings);
+  let selectedMode: DisplayedSpeedSourceMode = speedSourceState.displayedMode.value;
   let manualSpeedInputValue = deps.settings.manualSpeedKph != null ? String(deps.settings.manualSpeedKph) : "";
   let staleTimeoutInputValue = "";
   let speedSourceContextVisible = false;
@@ -243,7 +244,7 @@ export function createSettingsSpeedSourceWorkflow(
 
   function syncInputsFromSettings(): void {
     speedSourceDraftDirty = false;
-    selectedMode = deriveDisplayedSpeedSourceMode(deps.settings);
+    selectedMode = speedSourceState.displayedMode.value;
     manualSpeedInputValue = deps.settings.manualSpeedKph != null ? String(deps.settings.manualSpeedKph) : "";
     clearAllFeedback();
     renderCurrentState();
@@ -251,7 +252,7 @@ export function createSettingsSpeedSourceWorkflow(
 
   function syncFromSettings(): void {
     if (!speedSourceDraftDirty) {
-      selectedMode = deriveDisplayedSpeedSourceMode(deps.settings);
+      selectedMode = speedSourceState.displayedMode.value;
       manualSpeedInputValue = deps.settings.manualSpeedKph != null ? String(deps.settings.manualSpeedKph) : "";
     }
     renderCurrentState();

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -3,8 +3,12 @@ import type uPlot from "uplot";
 import { SPECTRUM_TWEEN_DURATION_MS } from "../../config";
 import { convertSpectrumAmplitudesToDbInPlace, SpectrumChart } from "../../spectrum";
 import { chartSeriesPalette, orderBandFills } from "../../theme";
-import { areHeavyFramesCompatible, interpolateHeavyFrame, type SpectrumHeavyFrame } from "../spectrum_animation";
+import {
+  createSpectrumTweenDerivedState,
+  type SpectrumHeavyFrame,
+} from "../spectrum_animation";
 import type { AppState, ChartBand } from "../ui_app_state";
+import { signal } from "../ui_signals";
 import type { SpectrumPanelChartDom } from "./spectrum_panel_view";
 import { closestFrequencyIndex, freqGridsMatch, type SpectrumFocusMarker, type SpectrumSeriesEntry } from "./spectrum_shared";
 
@@ -46,6 +50,18 @@ export class SpectrumCanvasRenderer {
   private spectrumTweenRaf: number | null = null;
 
   private spectrumLastFrame: SpectrumHeavyFrame | null = null;
+
+  private readonly tweenAlpha = signal(1);
+
+  private readonly tweenFromFrame = signal<SpectrumHeavyFrame | null>(null);
+
+  private readonly tweenToFrame = signal<SpectrumHeavyFrame | null>(null);
+
+  private readonly tweenState = createSpectrumTweenDerivedState(
+    this.tweenFromFrame,
+    this.tweenToFrame,
+    this.tweenAlpha,
+  );
 
   private currentEntries: readonly SpectrumSeriesEntry[] = [];
 
@@ -163,20 +179,24 @@ export class SpectrumCanvasRenderer {
     }
 
     const nextFrame = prepared.frame;
-    const canTween = this.deps.state.transport.wsState === "connected"
-      && areHeavyFramesCompatible(this.spectrumLastFrame, nextFrame);
+    this.tweenFromFrame.value = this.spectrumLastFrame;
+    this.tweenToFrame.value = nextFrame;
     this.stopSpectrumTween();
+    const canTween = this.deps.state.transport.wsState === "connected"
+      && this.tweenState.canTween.value;
     if (!canTween || !this.spectrumLastFrame) {
       this.setSpectrumDataFromFrame(nextFrame);
       return;
     }
 
-    const tweenFrom = this.spectrumLastFrame;
     const startedAt = performance.now();
     const animate = (now: number): void => {
-      const alpha = Math.min(1, Math.max(0, (now - startedAt) / SPECTRUM_TWEEN_DURATION_MS));
-      this.setSpectrumDataFromFrame(interpolateHeavyFrame(tweenFrom, nextFrame, alpha));
-      if (alpha >= 1) {
+      this.tweenAlpha.value = Math.min(1, Math.max(0, (now - startedAt) / SPECTRUM_TWEEN_DURATION_MS));
+      const frame = this.tweenState.frame.value;
+      if (frame) {
+        this.setSpectrumDataFromFrame(frame);
+      }
+      if (this.tweenAlpha.value >= 1) {
         this.spectrumTweenRaf = null;
         this.setSpectrumDataFromFrame(nextFrame);
         return;

--- a/apps/ui/src/app/runtime/ui_shell_language_refresh_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_language_refresh_module.ts
@@ -10,7 +10,6 @@ export interface UiShellLanguageRefreshFeaturePorts {
   >;
   realtime: Pick<
     RealtimeFeature,
-    | "buildLocationOptions"
     | "maybeRenderSensorsSettingsList"
     | "renderLoggingStatus"
     | "renderStatus"
@@ -39,9 +38,6 @@ export function createUiShellLanguageRefreshModule(
   return {
     applyLanguage(features, forceReloadInsights = false) {
       document.documentElement.lang = deps.state.shell.lang;
-      deps.state.realtime.locationOptions = features.realtime.buildLocationOptions(
-        deps.state.realtime.locationCodes,
-      );
       features.settings.syncSettingsInputs();
       features.realtime.maybeRenderSensorsSettingsList(true);
       deps.renderSpeedReadout();

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -1,5 +1,5 @@
 import { fmt } from "../../format";
-import { deriveSpeedReadoutLabelKey } from "../speed_source_state";
+import { createSpeedSourceDerivedState } from "../speed_source_state";
 import type {
   RealtimeState,
   SettingsState,
@@ -54,6 +54,15 @@ export function createUiShellStatusModule(
       : deps.t("speed.unit.kmh");
   }
 
+  const runtimeSpeedSource = computed(() => {
+    trackAppStateSlice(deps.realtime);
+    return deps.realtime.rotationalSpeeds?.basis_speed_source ?? null;
+  });
+  const speedSourceState = createSpeedSourceDerivedState(
+    deps.settings,
+    runtimeSpeedSource,
+  );
+
   const wsLinkState = computed<UiShellBadgeModel>(() => {
     trackAppStateSlice(deps.transport);
     if (deps.transport.payloadError) {
@@ -71,7 +80,6 @@ export function createUiShellStatusModule(
 
   const speedReadoutText = computed(() => {
     trackAppStateSlice(deps.realtime);
-    trackAppStateSlice(deps.settings);
     trackAppStateSlice(deps.shell);
     const unitLabel = selectedSpeedUnitLabel();
     if (
@@ -79,10 +87,7 @@ export function createUiShellStatusModule(
       Number.isFinite(deps.realtime.speedMps)
     ) {
       const value = speedValueInSelectedUnit(deps.realtime.speedMps);
-      const labelKey = deriveSpeedReadoutLabelKey(
-        deps.settings,
-        deps.realtime.rotationalSpeeds?.basis_speed_source ?? null,
-      );
+      const labelKey = speedSourceState.speedReadoutLabelKey.value;
       return deps.t(labelKey, {
         unit: unitLabel,
         value: fmt(value, 1),

--- a/apps/ui/src/app/spectrum_animation.ts
+++ b/apps/ui/src/app/spectrum_animation.ts
@@ -1,3 +1,5 @@
+import { computed, type ReadonlySignal } from "./ui_signals";
+
 export interface SpectrumHeavyFrame {
   seriesIds: string[];
   freq: number[];
@@ -74,5 +76,37 @@ export function interpolateHeavyFrame(previous: SpectrumHeavyFrame, next: Spectr
     freq: next.freq,
     values: outValues,
     _freqFingerprint: next._freqFingerprint,
+  };
+}
+
+export interface SpectrumTweenDerivedState {
+  canTween: ReadonlySignal<boolean>;
+  frame: ReadonlySignal<SpectrumHeavyFrame | null>;
+}
+
+export function createSpectrumTweenDerivedState(
+  previousFrame: ReadonlySignal<SpectrumHeavyFrame | null>,
+  nextFrame: ReadonlySignal<SpectrumHeavyFrame | null>,
+  alpha: ReadonlySignal<number>,
+): SpectrumTweenDerivedState {
+  const canTween = computed(() => {
+    const next = nextFrame.value;
+    return next !== null && areHeavyFramesCompatible(previousFrame.value, next);
+  });
+  const frame = computed(() => {
+    const next = nextFrame.value;
+    if (!next) {
+      return null;
+    }
+    const previous = previousFrame.value;
+    if (!previous || !canTween.value) {
+      return next;
+    }
+    return interpolateHeavyFrame(previous, next, alpha.value);
+  });
+
+  return {
+    canTween,
+    frame,
   };
 }

--- a/apps/ui/src/app/speed_source_state.ts
+++ b/apps/ui/src/app/speed_source_state.ts
@@ -1,4 +1,6 @@
 import type { SettingsState } from "./ui_app_state";
+import { trackAppStateSlice } from "./ui_app_state";
+import { computed, type ReadonlySignal } from "./ui_signals";
 
 export interface SpeedSourceStateSource {
   speedSource: SettingsState["speedSource"];
@@ -8,6 +10,13 @@ export interface SpeedSourceStateSource {
 
 export type DisplayedSpeedSourceMode = "gps" | "manual" | "obd2";
 export type SpeedReadoutLabelKey = "speed.gps" | "speed.override" | "speed.obd2";
+
+export interface SpeedSourceDerivedState {
+  displayedMode: ReadonlySignal<DisplayedSpeedSourceMode>;
+  effectiveSource: ReadonlySignal<string | null>;
+  isManualEffective: ReadonlySignal<boolean>;
+  speedReadoutLabelKey: ReadonlySignal<SpeedReadoutLabelKey>;
+}
 
 export function isManualLikeSpeedSource(source: string | null | undefined): boolean {
   return source === "manual" || source === "fallback_manual";
@@ -55,4 +64,44 @@ export function deriveSpeedReadoutLabelKey(
     return "speed.obd2";
   }
   return isManualLikeSpeedSource(effectiveSource) ? "speed.override" : "speed.gps";
+}
+
+export function createSpeedSourceDerivedState(
+  settings: SpeedSourceStateSource,
+  runtimeSpeedSource?: ReadonlySignal<string | null>,
+): SpeedSourceDerivedState {
+  const effectiveSource = computed(() => {
+    trackAppStateSlice(settings);
+    return resolveEffectiveSpeedSource(settings, runtimeSpeedSource?.value);
+  });
+  const displayedMode = computed<DisplayedSpeedSourceMode>(() => {
+    trackAppStateSlice(settings);
+    const resolvedSource = effectiveSource.value;
+    if (resolvedSource === "obd2") {
+      return "obd2";
+    }
+    if (isManualLikeSpeedSource(resolvedSource)) {
+      return "manual";
+    }
+    return settings.speedSource;
+  });
+  const isManualEffective = computed(() =>
+    isManualLikeSpeedSource(effectiveSource.value),
+  );
+  const speedReadoutLabelKey = computed<SpeedReadoutLabelKey>(() => {
+    const resolvedSource = effectiveSource.value;
+    if (resolvedSource === "obd2") {
+      return "speed.obd2";
+    }
+    return isManualLikeSpeedSource(resolvedSource)
+      ? "speed.override"
+      : "speed.gps";
+  });
+
+  return {
+    displayedMode,
+    effectiveSource,
+    isManualEffective,
+    speedReadoutLabelKey,
+  };
 }

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -11,7 +11,6 @@ import type {
   CarRecord,
   HistoryEntry,
   HistoryInsightsPayload,
-  LocationOption,
   LoggingStatusPayload,
   SpeedSourceKind,
   SpeedSourceStatusPayload,
@@ -281,7 +280,6 @@ export interface RealtimeState {
   speedMps: number | null;
   rotationalSpeeds: RotationalSpeeds | null;
   loggingStatus: LoggingStatusPayload;
-  locationOptions: LocationOption[];
   locationCodes: string[];
 }
 
@@ -356,7 +354,6 @@ export function createAppState(): AppState {
         last_completed_run_error: null,
         capture_readiness: null,
       },
-      locationOptions: [],
       locationCodes: defaultLocationCodes.slice(),
     }),
     history: createReactiveStateSlice({

--- a/apps/ui/src/app/views/realtime_feature_presenter.ts
+++ b/apps/ui/src/app/views/realtime_feature_presenter.ts
@@ -1,13 +1,12 @@
-import { deriveCarSelectionState } from "../car_selection_state";
 import { classifyDataFreshness } from "../features/data_freshness";
 import { createRealtimeSensorState } from "../features/realtime_sensor_state";
 import type { RealtimeFeatureNavigationPorts } from "../features/realtime_feature";
 import type {
   RealtimeState,
   SettingsState,
+  ShellState,
   SpectrumState,
 } from "../ui_app_state";
-import type { LocationOption } from "../../transport/http_models";
 import type { AdaptedClient } from "../../transport/live_models";
 import {
   buildRealtimeLoggingPanelViewModel,
@@ -39,7 +38,7 @@ export interface RealtimeFeaturePresenterDeps {
   realtime: RealtimeState;
   spectrum: SpectrumState;
   settings: SettingsState;
-  getLanguage: () => string;
+  shell: Pick<ShellState, "lang">;
   t: (key: string, vars?: Record<string, unknown>) => string;
   formatInt: (value: number) => string;
   chrome: {
@@ -51,7 +50,6 @@ export interface RealtimeFeaturePresenterDeps {
 }
 
 export interface RealtimeFeaturePresenter {
-  buildLocationOptions(codes: readonly string[]): LocationOption[];
   locationCodeForClient(client: AdaptedClient): string;
   maybeRenderSensorsSettingsList(force?: boolean): void;
   renderStatus(clientRow?: AdaptedClient): void;
@@ -72,6 +70,7 @@ export function createRealtimeFeaturePresenter(
     sensorsPanel,
     realtime,
     settings,
+    shell,
     spectrum,
     t,
     formatInt,
@@ -86,25 +85,31 @@ export function createRealtimeFeaturePresenter(
   const sensorState = createRealtimeSensorState({
     realtime,
     settings,
+    shell,
     spectrum,
-    getLanguage: ctx.getLanguage,
+    captureReadinessSummaryText: (readiness) =>
+      captureReadinessSummaryText(readiness, {
+        t,
+        formatInt,
+      }),
     t,
     formatInt,
   });
   const {
+    activeCarSelection,
     activeCarDisplayState,
     assignedClientCount,
-    buildLocationOptions,
-    computeLiveHealth,
     connectedClients,
+    liveHealth,
     locationCodeForClient,
+    locationOptions,
     strongestSignal,
     strongestSignalText,
   } = sensorState;
   let renderedSensorsSettingsSignature = "";
 
   function dataFreshnessText(): string {
-    const connected = connectedClients();
+    const connected = connectedClients.value;
     const ages = connected
       .map((client) => client.last_seen_age_ms)
       .filter(
@@ -145,12 +150,7 @@ export function createRealtimeFeaturePresenter(
   }
 
   function computeCurrentLiveHealth() {
-    return computeLiveHealth((readiness) =>
-      captureReadinessSummaryText(readiness, {
-        t,
-        formatInt,
-      }),
-    );
+    return liveHealth.value;
   }
 
   function liveSensorOverviewLabel(client: AdaptedClient): string {
@@ -160,7 +160,7 @@ export function createRealtimeFeaturePresenter(
         client.name || client.id || t("dashboard.sensor_unassigned"),
       ).trim();
     }
-    const option = realtime.locationOptions.find(
+    const option = locationOptions.value.find(
       (location) => location.code === code,
     );
     return option?.label ?? code;
@@ -169,20 +169,20 @@ export function createRealtimeFeaturePresenter(
   function buildLiveOverviewModel(
     phaseText: string,
   ): RealtimeLiveOverviewRenderModel {
-    const signal = strongestSignal();
+    const signal = strongestSignal.value;
     const health = computeCurrentLiveHealth();
     const totalClients = realtime.clients.length;
-    const activeCar = activeCarDisplayState();
+    const activeCar = activeCarDisplayState.value;
     const setupBlockReason = selectionBlockReason();
     return {
-      connectedSensorsText: `${formatInt(connectedClients().length)} / ${formatInt(totalClients)}`,
+      connectedSensorsText: `${formatInt(connectedClients.value.length)} / ${formatInt(totalClients)}`,
       activeCar: {
         text: activeCar.text,
         warning: setupBlockReason === null && activeCar.isWarning,
       },
       recordingStateText: phaseText,
       dataFreshnessText: dataFreshnessText(),
-      strongestSignalText: strongestSignalText(signal),
+      strongestSignalText: strongestSignalText.value,
       runHealth: {
         hidden: !health.showOverviewPill,
         text: health.text,
@@ -199,7 +199,7 @@ export function createRealtimeFeaturePresenter(
   }
 
   function selectionBlockReason(): "no_cars" | "no_active" | null {
-    const selection = deriveCarSelectionState(settings);
+    const selection = activeCarSelection.value;
     if (selection.kind === "active") {
       return null;
     }
@@ -214,8 +214,8 @@ export function createRealtimeFeaturePresenter(
       pendingLoggingAction,
       selectionBlockReason: selectionBlockReason(),
       liveHealth: computeCurrentLiveHealth(),
-      connectedCountText: formatInt(connectedClients().length),
-      assignedCountText: formatInt(assignedClientCount()),
+      connectedCountText: formatInt(connectedClients.value.length),
+      assignedCountText: formatInt(assignedClientCount.value),
       runIdText: recordingRunIdText(realtime.loggingStatus),
       elapsedText: realtime.loggingStatus.enabled
         ? formatElapsed(realtime.loggingStatus.start_time_utc)
@@ -267,7 +267,7 @@ export function createRealtimeFeaturePresenter(
         return `${client.id}|${client.name || ""}|${client.mac_address || ""}|${connected}|${client.location_code || ""}`;
       })
       .join("||");
-    const locationPart = realtime.locationOptions
+    const locationPart = locationOptions.value
       .map((loc) => `${loc.code}|${loc.label}`)
       .join("||");
     return `${clientPart}##${locationPart}`;
@@ -284,7 +284,7 @@ export function createRealtimeFeaturePresenter(
     sensorsPanel.setModel({
       table: buildRealtimeSensorTableRenderModel({
         clients: realtime.clients,
-        locationOptions: realtime.locationOptions,
+        locationOptions: locationOptions.value,
         t,
       }),
     });
@@ -458,7 +458,6 @@ export function createRealtimeFeaturePresenter(
   }
 
   return {
-    buildLocationOptions,
     locationCodeForClient,
     maybeRenderSensorsSettingsList,
     renderStatus,

--- a/apps/ui/tests/app_feature_ports.spec.ts
+++ b/apps/ui/tests/app_feature_ports.spec.ts
@@ -27,10 +27,6 @@ test("feature port helpers expose explicit shell and startup contracts without a
     bindHandlers() {
       calls.push("realtime.bindHandlers");
     },
-    buildLocationOptions(codes: readonly string[]) {
-      calls.push(`realtime.buildLocationOptions:${codes.join(",")}`);
-      return codes.map((code) => ({ code, label: code }));
-    },
     maybeRenderSensorsSettingsList(force?: boolean) {
       calls.push(`realtime.maybeRenderSensorsSettingsList:${String(force)}`);
     },
@@ -124,7 +120,6 @@ test("feature port helpers expose explicit shell and startup contracts without a
   bundle.shell.bindHistoryHandlers();
   bundle.shell.bindUpdateHandlers();
   bundle.shell.bindEspFlashHandlers();
-  bundle.shell.languageRefresh.realtime.buildLocationOptions(["front-left", "front-right"]);
   bundle.shell.languageRefresh.realtime.maybeRenderSensorsSettingsList(true);
   bundle.shell.languageRefresh.realtime.renderLoggingStatus();
   bundle.shell.languageRefresh.realtime.renderStatus();
@@ -153,7 +148,6 @@ test("feature port helpers expose explicit shell and startup contracts without a
     "history.bindHandlers",
     "update.bindUpdateHandlers",
     "espFlash.bindHandlers",
-    "realtime.buildLocationOptions:front-left,front-right",
     "realtime.maybeRenderSensorsSettingsList:true",
     "realtime.renderLoggingStatus",
     "realtime.renderStatus",

--- a/apps/ui/tests/car_selection_state.spec.ts
+++ b/apps/ui/tests/car_selection_state.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  createCarSelectionDerivedState,
+} from "../src/app/car_selection_state";
+import { createAppState } from "../src/app/ui_app_state";
+import type { CarRecord } from "../src/transport/http_models";
+
+function makeCar(overrides: Partial<CarRecord> = {}): CarRecord {
+  return {
+    id: "car-1",
+    name: "Demo Car",
+    type: "Coupe",
+    variant: null,
+    aspects: {},
+    ...overrides,
+  };
+}
+
+test.describe("car selection derived state", () => {
+  test("tracks loading, empty, missing-active, and active states reactively", () => {
+    const state = createAppState();
+    const derived = createCarSelectionDerivedState(state.settings);
+
+    expect(derived.selection.value).toEqual({ kind: "loading" });
+    expect(derived.activeCar.value).toBeNull();
+    expect(derived.hasResolvedActiveCar.value).toBe(false);
+
+    state.settings.carsLoaded = true;
+    expect(derived.selection.value).toEqual({ kind: "no_cars" });
+
+    state.settings.cars = [makeCar()];
+    expect(derived.selection.value).toEqual({ kind: "no_active_car" });
+
+    state.settings.activeCarId = "car-1";
+    expect(derived.selection.value).toEqual({
+      kind: "active",
+      car: makeCar(),
+    });
+    expect(derived.activeCar.value?.id).toBe("car-1");
+    expect(derived.hasResolvedActiveCar.value).toBe(true);
+
+    state.settings.activeCarId = "missing";
+    expect(derived.selection.value).toEqual({ kind: "no_active_car" });
+    expect(derived.activeCar.value).toBeNull();
+    expect(derived.hasResolvedActiveCar.value).toBe(false);
+  });
+});

--- a/apps/ui/tests/realtime_feature_workflow.spec.ts
+++ b/apps/ui/tests/realtime_feature_workflow.spec.ts
@@ -8,7 +8,6 @@ import { createAppState } from "../src/app/ui_app_state";
 import { defaultLocationCodes } from "../src/constants";
 import type {
   ClientLocationsResponse,
-  LocationOption,
   LoggingStatusPayload,
 } from "../src/transport/http_models";
 import type { AdaptedClient } from "../src/transport/live_models";
@@ -22,7 +21,6 @@ type WorkflowHarness = {
   state: ReturnType<typeof createAppState>;
   viewCalls: string[];
   renderStates: RenderLoggingState[];
-  buildLocationOptionsCalls: readonly string[][];
   selectionCalls: string[];
   recordingCalls: string[];
   confirmMessages: string[];
@@ -48,7 +46,6 @@ function createHarness(): WorkflowHarness {
     state: createAppState(),
     viewCalls: [],
     renderStates: [],
-    buildLocationOptionsCalls: [],
     selectionCalls: [],
     recordingCalls: [],
     confirmMessages: [],
@@ -58,10 +55,6 @@ function createHarness(): WorkflowHarness {
 
 function createViewPorts(harness: WorkflowHarness): RealtimeFeatureWorkflowViewPorts {
   return {
-    buildLocationOptions(codes: readonly string[]): LocationOption[] {
-      harness.buildLocationOptionsCalls.push([...codes]);
-      return codes.map((code) => ({ code, label: code }));
-    },
     maybeRenderSensorsSettingsList(force?: boolean): void {
       harness.viewCalls.push(`maybeRenderSensorsSettingsList:${String(force)}`);
     },
@@ -181,11 +174,6 @@ test.describe("createRealtimeFeatureWorkflow", () => {
     await workflow.refreshLocationOptions();
 
     expect(harness.state.realtime.locationCodes).toEqual(defaultLocationCodes);
-    expect(harness.state.realtime.locationOptions).toEqual(defaultLocationCodes.map((code) => ({
-      code,
-      label: code,
-    })));
-    expect(harness.buildLocationOptionsCalls).toEqual([defaultLocationCodes]);
     expect(harness.viewCalls).toEqual([
       "maybeRenderSensorsSettingsList:true",
       "renderStatus:none",

--- a/apps/ui/tests/spectrum_animation.spec.ts
+++ b/apps/ui/tests/spectrum_animation.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  createSpectrumTweenDerivedState,
+  type SpectrumHeavyFrame,
+} from "../src/app/spectrum_animation";
+import { signal } from "../src/app/ui_signals";
+
+const baseFrame: SpectrumHeavyFrame = {
+  seriesIds: ["sensor-1", "sensor-2"],
+  freq: [10, 20, 30],
+  values: [[1, 2, 3], [4, 5, 6]],
+};
+
+test.describe("spectrum tween derived state", () => {
+  test("tracks compatibility and interpolated frame from signal inputs", () => {
+    const previous = signal<SpectrumHeavyFrame | null>(baseFrame);
+    const next = signal<SpectrumHeavyFrame | null>({
+      seriesIds: ["sensor-1", "sensor-2"],
+      freq: [10, 20, 30],
+      values: [[3, 5, 7], [7, 9, 11]],
+    });
+    const alpha = signal(0.5);
+    const tween = createSpectrumTweenDerivedState(previous, next, alpha);
+
+    expect(tween.canTween.value).toBe(true);
+    expect(tween.frame.value?.values).toEqual([[2, 3.5, 5], [5.5, 7, 8.5]]);
+
+    next.value = {
+      seriesIds: ["sensor-2", "sensor-1"],
+      freq: [10, 20, 30],
+      values: [[3, 5, 7], [7, 9, 11]],
+    };
+
+    expect(tween.canTween.value).toBe(false);
+    expect(tween.frame.value).toBe(next.value);
+  });
+});

--- a/apps/ui/tests/speed_source_state.spec.ts
+++ b/apps/ui/tests/speed_source_state.spec.ts
@@ -1,11 +1,14 @@
 import { expect, test } from "@playwright/test";
 
 import {
+  createSpeedSourceDerivedState,
   deriveDisplayedSpeedSourceMode,
   deriveSpeedReadoutLabelKey,
   isManualEffectiveSpeedSource,
   resolveEffectiveSpeedSource,
 } from "../src/app/speed_source_state";
+import { createAppState } from "../src/app/ui_app_state";
+import { signal } from "../src/app/ui_signals";
 
 test.describe("speed source state helpers", () => {
   test("prefers the resolved fallback-manual source over gps configuration", () => {
@@ -71,5 +74,28 @@ test.describe("speed source state helpers", () => {
     expect(deriveSpeedReadoutLabelKey(settings)).toBe("speed.obd2");
     expect(resolveEffectiveSpeedSource(settings)).toBe("obd2");
     expect(isManualEffectiveSpeedSource(settings)).toBe(false);
+  });
+
+  test("reactively updates derived signals when settings and runtime source change", () => {
+    const state = createAppState();
+    const runtimeSpeedSource = signal<string | null>(null);
+    const derived = createSpeedSourceDerivedState(
+      state.settings,
+      runtimeSpeedSource,
+    );
+
+    expect(derived.displayedMode.value).toBe("gps");
+    expect(derived.speedReadoutLabelKey.value).toBe("speed.gps");
+    expect(derived.isManualEffective.value).toBe(false);
+
+    runtimeSpeedSource.value = "fallback_manual";
+    expect(derived.displayedMode.value).toBe("manual");
+    expect(derived.speedReadoutLabelKey.value).toBe("speed.override");
+    expect(derived.isManualEffective.value).toBe(true);
+
+    state.settings.resolvedSpeedSource = "obd2";
+    expect(derived.effectiveSource.value).toBe("obd2");
+    expect(derived.displayedMode.value).toBe("obd2");
+    expect(derived.speedReadoutLabelKey.value).toBe("speed.obd2");
   });
 });

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -401,10 +401,6 @@ test.describe("createUiShellLanguageRefreshModule", () => {
         },
       },
       realtime: {
-        buildLocationOptions(codes) {
-          portCalls.push("buildLocationOptions");
-          return codes.map((code) => ({ code, label: `${code}-label` }));
-        },
         maybeRenderSensorsSettingsList(force = false) {
           portCalls.push(`maybeRenderSensorsSettingsList:${String(force)}`);
         },
@@ -429,11 +425,7 @@ test.describe("createUiShellLanguageRefreshModule", () => {
     }
 
     expect(documentHarness.documentElement.lang).toBe("nl");
-    expect(state.realtime.locationOptions).toEqual([
-      { code: "front_left_wheel", label: "front_left_wheel-label" },
-    ]);
     expect(portCalls).toEqual([
-      "buildLocationOptions",
       "syncSettingsInputs",
       "maybeRenderSensorsSettingsList:true",
       "renderLoggingStatus",
@@ -480,10 +472,6 @@ test.describe("createUiShellLanguageRefreshModule", () => {
           },
         },
         realtime: {
-          buildLocationOptions(codes) {
-            portCalls.push("buildLocationOptions");
-            return codes.map((code) => ({ code, label: code }));
-          },
           maybeRenderSensorsSettingsList(force = false) {
             portCalls.push(`maybeRenderSensorsSettingsList:${String(force)}`);
           },
@@ -505,7 +493,6 @@ test.describe("createUiShellLanguageRefreshModule", () => {
     }
 
     expect(portCalls).toEqual([
-      "buildLocationOptions",
       "syncSettingsInputs",
       "maybeRenderSensorsSettingsList:true",
       "renderLoggingStatus",
@@ -545,7 +532,6 @@ test.describe("bindUiShellFeatureEvents", () => {
           renderHistoryTable: () => undefined,
         },
         realtime: {
-          buildLocationOptions: () => [],
           maybeRenderSensorsSettingsList: () => undefined,
           renderLoggingStatus: () => undefined,
           renderStatus: () => undefined,


### PR DESCRIPTION
## Summary

This PR resolves #2325 by moving the remaining shared frontend derivation seams onto computed signals instead of manual helper calls. After the AppState signal-store migration, several parts of the UI were still reading plain state and re-deriving values on demand: active car selection, effective speed-source display, realtime sensor summaries, and spectrum tween interpolation. The state itself had become reactive, but these derivations still depended on callers knowing when to invoke the right helper. This change makes those derivations reactive owners too.

## Problem

Issue #2325 targeted the next layer above the AppState conversion. `car_selection_state.ts`, `speed_source_state.ts`, `features/realtime_sensor_state.ts`, and `spectrum_animation.ts` were still organized as plain helper modules. That meant consumers like `settings_cars_module.ts`, `settings_feature.ts`, `settings_speed_source_workflow.ts`, `ui_shell_status_module.ts`, `realtime_feature_presenter.ts`, and `spectrum_canvas_renderer.ts` had to remember to re-run derivation functions whenever upstream state changed.

That imperative pattern was now the exception rather than the rule. Shared state writes already flowed through signal-backed AppState slices, but these modules still forced their callers to do their own synchronization. The result was unnecessary repetition, lingering stale-state risk, and a few leftover duplicate paths such as `realtime.locationOptions`, which had become derived data pretending to be source state.

## Implementation approach

I kept the cut focused on derivation ownership rather than turning this into another broad view rewrite. The approach was:

1. keep pure snapshot helpers where non-reactive render-state code still benefits from them
2. add computed-signal derived-state owners for the live AppState-backed paths
3. update the handful of callers that were still re-deriving values manually
4. remove the redundant `realtime.locationOptions` AppState field so realtime location labels come from one reactive source of truth
5. extend focused tests around the new derived-state seams and rerun the existing runtime/browser coverage that exercises those paths

This preserves the current data shapes and UI behavior while making the derivation layer reactive instead of ad hoc.

## Main code changes

### 1. Car selection is now a computed derived-state owner

`apps/ui/src/app/car_selection_state.ts` still exposed only plain helper functions. I kept those pure helpers for simple snapshot use and added a computed-signal wrapper that owns the live derivations for:

- active car
- full car selection state
- resolved-active-car status

`settings_cars_module.ts` and `settings_feature.ts` now read that derived signal state instead of re-running `deriveCarSelectionState()` and `hasResolvedActiveCar()` directly on every path. That means car-availability decisions now react from one derived owner instead of repeating the same helper calls in multiple feature modules.

### 2. Speed-source display derivations now live in computed signals

`apps/ui/src/app/speed_source_state.ts` now exposes a signal-backed derived-state helper for:

- effective speed source
- displayed speed-source mode
- manual-effective-source status
- shell speed-readout label key

I intentionally kept the original pure helper functions too, because presenter render-state snapshots still use them in a narrow non-AppState context. The reactive runtime consumers changed to the computed path:

- `settings_speed_source_workflow.ts` now syncs its selected mode from the computed derived state
- `ui_shell_status_module.ts` now reads the computed speed-readout label key instead of re-deriving the label from settings and runtime source on every render path

This removes another caller-owned derivation seam without forcing a broader rewrite of the speed-source presenter layer.

### 3. Realtime sensor summaries now derive from one computed module

`apps/ui/src/app/features/realtime_sensor_state.ts` was the biggest part of the issue. It previously returned regular functions that re-filtered clients, re-ranked strongest signal, re-derived active-car display, and re-computed live health every time the presenter wanted those values.

It now owns computed signals for:

- connected clients
- assigned client count
- strongest signal
- strongest-signal text
- active car selection and display state
- live health
- location options

`apps/ui/src/app/views/realtime_feature_presenter.ts` now reads those derived signals instead of re-invoking the derivation helpers on demand. That keeps the presenter focused on assembling view models while the sensor-state module owns the actual shared derivations.

As part of that cut, I removed the redundant `realtime.locationOptions` AppState field and the leftover writes to it from `realtime_feature_workflow.ts` and `ui_shell_language_refresh_module.ts`. Location options are now properly derived from `realtime.locationCodes` and `shell.lang`, which makes them actual derived state rather than mutable state with two competing update paths.

### 4. Spectrum tween derivation moved into a computed signal seam

`apps/ui/src/app/spectrum_animation.ts` now exposes a computed tween-derived state built from previous frame, next frame, and tween alpha signals. The pure frame-compatibility and interpolation helpers remain in place, but `SpectrumCanvasRenderer` now consumes the computed tween state instead of recomputing compatibility and interpolated frames ad hoc inside the animation path.

That keeps the animation math independently testable while moving the live tween derivation onto the same reactive model as the rest of the issue.

## Tests and validation

Focused regression coverage now includes:

- new `apps/ui/tests/car_selection_state.spec.ts`
- new `apps/ui/tests/spectrum_animation.spec.ts`
- expanded `apps/ui/tests/speed_source_state.spec.ts`
- updated `apps/ui/tests/realtime_feature_workflow.spec.ts`
- updated `apps/ui/tests/app_feature_ports.spec.ts`
- updated `apps/ui/tests/ui_shell_runtime_modules.spec.ts`

I also re-ran the existing runtime/browser coverage that exercises the changed derivations indirectly:

- `tests/spectrum_canvas_renderer.spec.ts`
- `tests/settings_speed_source_workflow.spec.ts`
- `tests/smoke.bootstrap.spec.ts`
- `tests/smoke.spectrum.spec.ts`
- `tests/realtime_logging_summary.spec.ts`

Local validation for this PR was:

- `cd apps/ui && npx playwright test tests/car_selection_state.spec.ts tests/speed_source_state.spec.ts tests/spectrum_animation.spec.ts tests/spectrum_canvas_renderer.spec.ts tests/settings_speed_source_workflow.spec.ts tests/realtime_feature_workflow.spec.ts tests/app_feature_ports.spec.ts tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.spectrum.spec.ts tests/realtime_logging_summary.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

The lint run still reports only the pre-existing Biome schema-version info and the unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`.

## Risks and tradeoffs

The main risk here was accidentally creating a split source of truth by layering computed derivations on top of stale mutable state. That is why the final cut removes `realtime.locationOptions` instead of keeping it around as redundant mirrored state. The reactive derivation should be the source, not a parallel cache.

I also intentionally did not delete the pure helper functions in `car_selection_state.ts`, `speed_source_state.ts`, or `spectrum_animation.ts`. A few snapshot-oriented consumers and tests still benefit from those pure functions, and keeping them lets the live reactive paths and pure algorithm paths coexist cleanly without forcing unrelated presenter code into signals just for this issue.

## Out of scope

This PR does not rewrite the remaining imperative presenter render methods in realtime or settings. It also does not move every UI-local draft state into signals. The scope is the shared derivation layer called out in #2325: make the live derived state itself computed and remove the leftover caller-owned re-derivation paths.

Closes #2325
