### PR TITLE
Simplify startup coordinator into a declarative boot plan

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -88,13 +88,15 @@ source-of-truth export commands remain the only writers for those files.
 | `app/ui_panel_host_registry.ts` | Centralized host registry for dashboard, history, and settings panel mount points so startup and tests stop depending on one host getter module per panel |
 | `app/ui_panel_bootstrap.ts` | Centralized host registry and panel-mount bootstrap for dashboard, history, and settings islands so startup/runtime stop wiring one host getter per panel |
 | `app/dom/` | Focused DOM lookup helpers that remain after the panel bootstrap cleanup, including `requiredById` and other non-panel runtime locators |
-| `app/ui_app_runtime.ts` | UI composition root that wires state, feature-scoped DOM locators, focused runtime controllers, and explicit feature port bundles |
+| `app/ui_app_runtime.ts` | UI composition root that wires state, focused runtime controllers, explicit feature port bundles, and the startup coordinator |
 | `app/ui_app_state.ts` | Canonical AppState shape plus reactive slice helpers that keep object-style reads/writes working while shared shell/transport/realtime/history/settings/spectrum state becomes signal-observable |
 | `app/ui_signals.ts` | Canonical re-export surface for shared `signal`, `computed`, and `effect` usage across runtime, features, and views |
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, app-level error banner, and the top-level dashboard/history/settings view containers plus the typed shell bridge |
 | `app/runtime/ui_shell_controller.ts` | Menu/view shell, language and preference hydration, and the reactive shell-chrome model that feeds header pills, feedback, and app-level banners |
 | `app/runtime/ui_live_transport_controller.ts` | Demo/WebSocket transport coordinator that queues payloads through AppState, throttles live-session adaptation, and lets realtime, shell, and spectrum surfaces react from signal-backed state |
 | `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that wires overlay updates plus the extracted canvas, interaction, and panel modules |
+| `app/runtime/ui_startup_coordinator.ts` | Declarative startup-task runner that lets the shell own its initial bind/language/view boot while startup loads, polling, and transport start from a named sync/async plan |
+| `app/runtime/ui_startup_feature_ports.ts` | Narrow startup-only feature contract for initial refresh/load work and long-lived polling starts |
 | `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, tweening, and canvas draw plugin orchestration |
 | `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports |
 | `app/runtime/spectrum_panel_view.ts` | Typed spectrum panel contract for the signal-backed legend, band legend, inspector, band-toggle, and chart-host refs |
@@ -180,7 +182,9 @@ shell, and the per-settings-tab panel hosts. The spectrum island now owns the
 chart host refs internally and passes that typed bridge to the runtime.
 `app_feature_bundle.ts` creates the concrete features, wires explicit
 cross-feature ports, and returns only the shell, transport, and startup
-contracts the runtime needs.
+contracts the runtime needs. `ui_startup_coordinator.ts` then runs those
+startup-only ports from a small declarative sync/async plan instead of a
+handwritten boot call chain.
 
 The live UI architecture is now fully Preact for every page, tab, and
 feature surface.

--- a/apps/ui/src/app/app_feature_ports.ts
+++ b/apps/ui/src/app/app_feature_ports.ts
@@ -100,7 +100,6 @@ export function createAppFeaturePorts(features: AppFeaturesForPorts): AppFeature
         refreshLoggingStatus: () => features.realtime.refreshLoggingStatus(),
       },
       settings: {
-        syncSettingsInputs: () => features.settings.syncSettingsInputs(),
         loadSpeedSourceFromServer: () => features.settings.loadSpeedSourceFromServer(),
         loadAnalysisSettingsFromServer: () => features.settings.loadAnalysisSettingsFromServer(),
         loadCarsFromServer: () => features.settings.loadCarsFromServer(),

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -210,8 +210,10 @@ export class UiShellController {
     );
   }
 
-  bindUiEvents(): void {
+  start(defaultViewId: string): void {
     this.bindFeatureEvents();
+    this.applyLanguage(false);
+    this.setActiveView(defaultViewId);
   }
 
   async hydratePersistedPreferences(): Promise<void> {

--- a/apps/ui/src/app/runtime/ui_startup_coordinator.ts
+++ b/apps/ui/src/app/runtime/ui_startup_coordinator.ts
@@ -1,10 +1,8 @@
 import type { UiStartupFeaturePorts } from "./ui_startup_feature_ports";
 
 type StartupShell = {
-  bindUiEvents(): void;
+  start(defaultViewId: string): void;
   hydratePersistedPreferences(): Promise<void>;
-  applyLanguage(forceReloadInsights?: boolean): void;
-  setActiveView(viewId: string): void;
 };
 
 type StartupTransport = {
@@ -19,6 +17,17 @@ type UiStartupCoordinatorDeps = {
   features: UiStartupFeaturePorts;
   defaultViewId: string;
   warn?: StartupWarn;
+};
+
+type UiStartupAsyncTask = {
+  name: string;
+  run: () => Promise<void>;
+};
+
+type UiStartupPlan = {
+  asyncTasks: readonly UiStartupAsyncTask[];
+  finalSyncTasks: ReadonlyArray<() => void>;
+  initialSyncTasks: ReadonlyArray<() => void>;
 };
 
 export class UiStartupCoordinator {
@@ -41,13 +50,16 @@ export class UiStartupCoordinator {
   }
 
   start(): void {
-    this.shell.bindUiEvents();
-    this.features.settings.syncSettingsInputs();
-    this.runAsyncTask("hydrate persisted preferences", () => this.shell.hydratePersistedPreferences());
-    this.shell.applyLanguage(false);
-    this.shell.setActiveView(this.defaultViewId);
-    this.startBackgroundActivity();
-    this.transport.startTransportMode();
+    const plan = this.createStartupPlan();
+    for (const task of plan.initialSyncTasks) {
+      task();
+    }
+    for (const task of plan.asyncTasks) {
+      this.runAsyncTask(task.name, task.run);
+    }
+    for (const task of plan.finalSyncTasks) {
+      task();
+    }
   }
 
   private runAsyncTask(taskName: string, task: () => Promise<void>): void {
@@ -56,17 +68,47 @@ export class UiStartupCoordinator {
     });
   }
 
-  private startBackgroundActivity(): void {
-    this.runAsyncTask("refresh location options", () => this.features.realtime.refreshLocationOptions());
-    this.runAsyncTask("load speed source", () => this.features.settings.loadSpeedSourceFromServer());
-    this.runAsyncTask("load analysis settings", () =>
-      this.features.settings.loadAnalysisSettingsFromServer(),
-    );
-    this.runAsyncTask("load cars", () => this.features.settings.loadCarsFromServer());
-    this.runAsyncTask("refresh logging status", () => this.features.realtime.refreshLoggingStatus());
-    this.runAsyncTask("refresh history", () => this.features.history.refreshHistory());
-    this.features.update.startPolling();
-    this.features.espFlash.startPolling();
-    this.features.settings.startGpsStatusPolling();
+  private createStartupPlan(): UiStartupPlan {
+    return {
+      initialSyncTasks: [
+        () => this.shell.start(this.defaultViewId),
+      ],
+      finalSyncTasks: [
+        () => this.features.update.startPolling(),
+        () => this.features.espFlash.startPolling(),
+        () => this.features.settings.startGpsStatusPolling(),
+        () => this.transport.startTransportMode(),
+      ],
+      asyncTasks: [
+        {
+          name: "hydrate persisted preferences",
+          run: () => this.shell.hydratePersistedPreferences(),
+        },
+        {
+          name: "refresh location options",
+          run: () => this.features.realtime.refreshLocationOptions(),
+        },
+        {
+          name: "load speed source",
+          run: () => this.features.settings.loadSpeedSourceFromServer(),
+        },
+        {
+          name: "load analysis settings",
+          run: () => this.features.settings.loadAnalysisSettingsFromServer(),
+        },
+        {
+          name: "load cars",
+          run: () => this.features.settings.loadCarsFromServer(),
+        },
+        {
+          name: "refresh logging status",
+          run: () => this.features.realtime.refreshLoggingStatus(),
+        },
+        {
+          name: "refresh history",
+          run: () => this.features.history.refreshHistory(),
+        },
+      ],
+    };
   }
 }

--- a/apps/ui/src/app/runtime/ui_startup_feature_ports.ts
+++ b/apps/ui/src/app/runtime/ui_startup_feature_ports.ts
@@ -9,7 +9,6 @@ export interface UiStartupFeaturePorts {
   realtime: Pick<RealtimeFeature, "refreshLocationOptions" | "refreshLoggingStatus">;
   settings: Pick<
     SettingsFeature,
-    | "syncSettingsInputs"
     | "loadSpeedSourceFromServer"
     | "loadAnalysisSettingsFromServer"
     | "loadCarsFromServer"

--- a/apps/ui/tests/app_feature_ports.spec.ts
+++ b/apps/ui/tests/app_feature_ports.spec.ts
@@ -130,7 +130,6 @@ test("feature port helpers expose explicit shell and startup contracts without a
   await bundle.startup.history.refreshHistory();
   await bundle.startup.realtime.refreshLocationOptions();
   await bundle.startup.realtime.refreshLoggingStatus();
-  bundle.startup.settings.syncSettingsInputs();
   await bundle.startup.settings.loadSpeedSourceFromServer();
   await bundle.startup.settings.loadAnalysisSettingsFromServer();
   await bundle.startup.settings.loadCarsFromServer();
@@ -157,7 +156,6 @@ test("feature port helpers expose explicit shell and startup contracts without a
     "history.refreshHistory",
     "realtime.refreshLocationOptions",
     "realtime.refreshLoggingStatus",
-    "settings.syncSettingsInputs",
     "settings.loadSpeedSourceFromServer",
     "settings.loadAnalysisSettingsFromServer",
     "settings.loadCarsFromServer",

--- a/apps/ui/tests/ui_startup_coordinator.spec.ts
+++ b/apps/ui/tests/ui_startup_coordinator.spec.ts
@@ -32,18 +32,12 @@ function createCoordinatorHarness() {
 
   const coordinator = new UiStartupCoordinator({
     shell: {
-      bindUiEvents(): void {
-        calls.push("shell.bindUiEvents");
+      start(defaultViewId: string): void {
+        calls.push(`shell.start:${defaultViewId}`);
       },
       hydratePersistedPreferences(): Promise<void> {
         calls.push("shell.hydratePersistedPreferences");
         return hydrate.promise;
-      },
-      applyLanguage(forceReloadInsights = false): void {
-        calls.push(`shell.applyLanguage:${String(forceReloadInsights)}`);
-      },
-      setActiveView(viewId: string): void {
-        calls.push(`shell.setActiveView:${viewId}`);
       },
     },
     features: {
@@ -64,9 +58,6 @@ function createCoordinatorHarness() {
         },
       },
       settings: {
-        syncSettingsInputs(): void {
-          calls.push("settings.syncSettingsInputs");
-        },
         loadSpeedSourceFromServer(): Promise<void> {
           calls.push("settings.loadSpeedSourceFromServer");
           return loadSpeedSource.promise;
@@ -126,11 +117,8 @@ test.describe("UiStartupCoordinator", () => {
     harness.coordinator.start();
 
     expect(harness.calls).toEqual([
-      "shell.bindUiEvents",
-      "settings.syncSettingsInputs",
+      "shell.start:dashboardView",
       "shell.hydratePersistedPreferences",
-      "shell.applyLanguage:false",
-      "shell.setActiveView:dashboardView",
       "realtime.refreshLocationOptions",
       "settings.loadSpeedSourceFromServer",
       "settings.loadAnalysisSettingsFromServer",


### PR DESCRIPTION
## Summary

This PR addresses #2330 by simplifying the frontend startup path around
`UiStartupCoordinator` without broadening into the later wiring-cleanup
issues. Before this change, startup was still expressed as one imperative
call chain inside the coordinator: bind shell events, force a settings-input
sync, hydrate persisted preferences, apply language, set the initial view,
start background startup work, and then start transport. That sequence still
worked, but it had become a poor fit for the rest of the migration. The shell
now owns the top-level view containers, shared state is signal-backed, and the
remaining startup contract should read as “what kinds of work happen at boot”
instead of “which exact method is called next.”

The change here keeps the issue narrow and behavior-safe. Rather than trying to
fully dissolve startup into a web of implicit effects, the coordinator now
builds an explicit declarative startup plan and runs that plan in named phases.
That preserves the parts of the current boot path that still benefit from
central sequencing, while removing the hand-written one-off chain that had been
accumulating shell-specific details.

## Implementation approach

The key decision was to make startup more declarative without pretending that
ordering no longer matters. Some startup work really is order-sensitive:
initial shell setup should happen before the rest of the UI begins reacting to
state, async hydration and one-shot refreshes should be kicked off before the
long-lived polling and transport machinery starts, and async failures should
continue to warn without blocking later work. Because of that, this PR does not
replace the coordinator with a pile of disconnected effects. Instead, it gives
the coordinator one small job: assemble a startup plan and run it.

The plan is intentionally simple:

- `initialSyncTasks` for synchronous boot work that must happen first
- `asyncTasks` for one-shot async loads and refreshes that should be kicked off
  during startup
- `finalSyncTasks` for long-lived polling and transport starts that should only
  happen after the earlier startup work has been launched

That structure makes the sequencing legible in one place and reduces the amount
of shell- and feature-specific choreography embedded directly in `start()`.

## Main code changes

In `apps/ui/src/app/runtime/ui_startup_coordinator.ts`, `start()` no longer
hardcodes the full boot chain inline. It now asks `createStartupPlan()` for the
named phases above, runs the initial sync work, kicks off each async task
through the existing warning wrapper, and then runs the final sync work. This
keeps the existing async error-handling behavior intact while making the boot
flow read as data instead of as a manually threaded sequence.

In `apps/ui/src/app/runtime/ui_shell_controller.ts`, the shell now owns its
initial startup trio through a new `start(defaultViewId)` method. That method
encapsulates `bindFeatureEvents()`, `applyLanguage(false)`, and
`setActiveView(defaultViewId)`. Pulling those calls behind a shell-owned entry
point matters for two reasons. First, it removes shell-specific boot knowledge
from the coordinator. Second, it keeps the shell responsible for the same
cross-cutting concerns it already owns elsewhere: event wiring, language
application, and active-view state.

In `apps/ui/src/app/runtime/ui_startup_feature_ports.ts` and
`apps/ui/src/app/app_feature_ports.ts`, the startup-only
`settings.syncSettingsInputs` port has been removed. That extra startup hook no
longer needs to be threaded through the runtime contract now that the shell’s
startup path is narrower and the remaining startup work is clearly separated
from long-lived feature ownership. This keeps the startup feature contract
tighter and removes one more bit of boot-only plumbing from the port surface.

## Tests and docs

`apps/ui/tests/ui_startup_coordinator.spec.ts` was updated to prove the new
behavior directly. The test harness now records `shell.start:dashboardView`
instead of the old separate shell calls, and the expected call order asserts
the named-phase behavior rather than the former step-by-step chain. The async
warning coverage still verifies that one failing startup task does not prevent
later startup work from being launched.

`apps/ui/tests/app_feature_ports.spec.ts` was updated to match the contract
change, removing the expectation that callers can reach
`bundle.startup.settings.syncSettingsInputs()`. This is the relevant guard for
making sure the startup bundle exposed by `createAppFeaturePorts()` still lines
up with the real runtime wiring.

`apps/ui/README.md` now documents the current startup ownership more accurately.
The source-module map calls out `ui_startup_coordinator.ts` and
`ui_startup_feature_ports.ts` explicitly, and the runtime architecture section
now describes startup as a small declarative sync/async plan instead of a
handwritten boot chain.

## Regressions found during the work

This refactor surfaced two real problems during validation, and both are fixed
in the final diff.

The first was a straightforward TypeScript issue: the initial version of the
startup-plan type used `readonly Array<...>`, which is not valid syntax in that
position. That has been corrected to `ReadonlyArray<...>`.

The second problem was more important. My first pass at the declarative plan
moved polling and transport startup too early relative to the async hydration
and load tasks. The old imperative chain had effectively launched those later,
and the reordered version caused the real startup smoke to time out against the
native server. The fix was not to abandon the declarative approach, but to
restore the original relative sequencing inside the new structure by separating
`initialSyncTasks`, `asyncTasks`, and `finalSyncTasks`. That gives the
coordinator a declarative shape while preserving the old startup semantics.

## Validation

The final change set was validated with the focused startup/runtime slice plus a
real integration fallback:

- `cd apps/ui && npx playwright test tests/ui_startup_coordinator.spec.ts tests/app_feature_ports.spec.ts tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

Because Docker is unavailable in this environment, I reran the runtime check
through the repo’s native-server path after the final ordering fix:

- `python3 tools/build_ui_static.py --skip-npm-ci`
- `vibesensor-server --config apps/server/config.dev.yaml`
- `vibesensor-sim --count 2 --duration 20 --server-host 127.0.0.1 --server-http-port 8000 --speed-kmh 0 --no-interactive --no-auto-server`
- Live Playwright probe against `http://127.0.0.1:8000`

That live probe confirmed the app still boots to Dashboard by default, tab
navigation between Dashboard / History / Settings still works, and the connected
sensors readout transitions from `2 / 2` to `0 / 2` after the simulator stops.

## Risks, tradeoffs, and out of scope

The main tradeoff is that startup is now more declarative, but not fully
effect-owned. That is intentional. This issue is about simplifying the startup
coordinator, not about hiding all ordering behind indirect reactive behavior or
collapsing the broader runtime composition layers. Later issues in this backlog
still cover bigger cleanup around runtime and port wiring.

So the end state here is deliberately modest: the coordinator is simpler, the
shell owns more of its own boot behavior, the startup feature contract is
narrower, and the runtime behavior is still proven against both targeted tests
and a live native integration smoke.

Closes #2330
