### PR TITLE
Collapse feature deps into grouped wiring

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -1,14 +1,14 @@
 import {
-  createAppFeaturePorts,
+  createAppFeatureBundlePorts,
   createRealtimeFeatureRecordingPorts,
   createSettingsFeatureRealtimePorts,
-  type AppFeatureBundle,
-} from "./app_feature_ports";
+} from "./app_feature_bundle_ports";
 import { createCarsFeature, type CarsFeature } from "./features/cars_feature";
-import { createEspFlashFeature } from "./features/esp_flash_feature";
-import { createHistoryFeature } from "./features/history_feature";
+import { createEspFlashFeature, type EspFlashFeature } from "./features/esp_flash_feature";
+import { createHistoryFeature, type HistoryFeature } from "./features/history_feature";
 import {
   createRealtimeFeature,
+  type RealtimeFeature,
   type RealtimeFeatureChromePorts,
   type RealtimeFeatureSelectionPorts,
 } from "./features/realtime_feature";
@@ -17,20 +17,17 @@ import {
   type SettingsFeature,
   type SettingsFeatureViewPorts,
 } from "./features/settings_feature";
-import { createUpdateFeature } from "./features/update_feature";
+import { createUpdateFeature, type UpdateFeature } from "./features/update_feature";
+import type { FeatureFormatting, FeatureServices } from "./feature_deps_base";
 import type { AppState } from "./ui_app_state";
 import { createUiCarCreationCommand } from "./runtime/ui_car_creation_command";
 import type { UiMountedPanels } from "./ui_panel_bootstrap";
-
-export type { AppFeatureBundle } from "./app_feature_ports";
+import type { AppFeatureBundle } from "./app_feature_bundle_ports";
+export type { AppFeatureBundle } from "./app_feature_bundle_ports";
 
 export interface AppFeatureBundleSharedDeps {
-  t: (key: string, vars?: Record<string, unknown>) => string;
-  escapeHtml: (value: unknown) => string;
-  showError: (message: string) => void;
-  fmt: (n: number, digits?: number) => string;
-  fmtTs: (iso: string) => string;
-  formatInt: (value: number) => string;
+  services: FeatureServices;
+  formatting: FeatureFormatting;
 }
 
 export interface AppFeatureBundleRuntimePorts {
@@ -55,68 +52,76 @@ export function createAppFeatureBundle(
 ): AppFeatureBundle {
   const {
     state,
-    shared: { t, escapeHtml, showError, fmt, fmtTs, formatInt },
+    shared: { services, formatting },
     runtime,
   } = deps;
   const { panels } = runtime;
 
   const history = createHistoryFeature({
     history: state.history,
-    getLanguage: () => state.shell.lang,
+    shell: state.shell,
     panel: panels.history,
     navigation: runtime.navigation,
-    t,
-    escapeHtml,
-    showError,
-    fmt,
-    fmtTs,
-    formatInt,
+    services,
+    formatting,
   });
 
   let carsFeature: CarsFeature | null = null;
   const realtime = createRealtimeFeature({
-    realtime: state.realtime,
-    spectrum: state.spectrum,
-    settings: state.settings,
-    shell: state.shell,
-    t,
-    escapeHtml,
-    showError,
-    formatInt,
-    chrome: {
-      ...runtime.realtimeChrome,
-      liveOverview: panels.dashboard.liveOverview,
-      loggingPanel: panels.dashboard.logging,
+    state: {
+      realtime: state.realtime,
+      settings: state.settings,
+      spectrum: state.spectrum,
+      shell: state.shell,
     },
-    sensorsPanel: panels.settings.sensors,
-    navigation: {
-      activatePrimaryView: runtime.navigation.activatePrimaryView,
-      activateSettingsTab: (tabId) => panels.settingsShell.activateTab(tabId),
-      openCarWizard: () => {
-        carsFeature?.openWizard();
+    panels: {
+      sensorsPanel: panels.settings.sensors,
+    },
+    ports: {
+      chrome: {
+        ...runtime.realtimeChrome,
+        liveOverview: panels.dashboard.liveOverview,
+        loggingPanel: panels.dashboard.logging,
       },
+      navigation: {
+        activatePrimaryView: runtime.navigation.activatePrimaryView,
+        activateSettingsTab: (tabId) => panels.settingsShell.activateTab(tabId),
+        openCarWizard: () => {
+          carsFeature?.openWizard();
+        },
+      },
+      selection: runtime.transport,
+      recording: createRealtimeFeatureRecordingPorts(history),
     },
-    selection: runtime.transport,
-    recording: createRealtimeFeatureRecordingPorts(history),
+    services,
+    formatting: {
+      formatInt: formatting.formatInt,
+    },
   });
 
   const settings: SettingsFeature = createSettingsFeature({
-    settings: state.settings,
-    getSpeedUnit: () => state.shell.speedUnit,
-    settingsShell: panels.settingsShell,
-    analysisPanel: panels.settings.analysis,
-    carsPanel: panels.settings.cars.list,
-    speedSourcePanel: panels.settings.speedSource,
-    openCarWizard: () => {
-      carsFeature?.openWizard();
+    state: {
+      settings: state.settings,
+      shell: state.shell,
     },
-    t,
-    escapeHtml,
-    showError,
-    fmt,
-    subscribePrimaryViewChanges: runtime.navigation.subscribeActiveViewChanges,
-    view: runtime.view,
-    realtime: createSettingsFeatureRealtimePorts(realtime),
+    panels: {
+      settingsShell: panels.settingsShell,
+      analysisPanel: panels.settings.analysis,
+      carsPanel: panels.settings.cars.list,
+      speedSourcePanel: panels.settings.speedSource,
+    },
+    ports: {
+      openCarWizard: () => {
+        carsFeature?.openWizard();
+      },
+      subscribePrimaryViewChanges: runtime.navigation.subscribeActiveViewChanges,
+      view: runtime.view,
+      realtime: createSettingsFeatureRealtimePorts(realtime),
+    },
+    services,
+    formatting: {
+      fmt: formatting.fmt,
+    },
   });
 
   const carCreation = createUiCarCreationCommand({
@@ -131,30 +136,30 @@ export function createAppFeatureBundle(
 
   const cars: CarsFeature = createCarsFeature({
     panel: panels.settings.cars.wizard,
-    t,
-    escapeHtml,
-    showError,
-    fmt,
+    services: {
+      t: services.t,
+    },
+    formatting: {
+      fmt: formatting.fmt,
+    },
     addCarFromWizard: (name, carType, aspects, variant) =>
       carCreation.addCarFromWizard(name, carType, aspects, variant),
   });
   carsFeature = cars;
 
   const update = createUpdateFeature({
-    panel: panels.settings.update,
-    internetPanel: panels.settings.internet,
-    t,
-    escapeHtml,
-    showError,
+    panels: {
+      update: panels.settings.update,
+      internet: panels.settings.internet,
+    },
+    services,
   });
   const espFlash = createEspFlashFeature({
     panel: panels.settings.espFlash,
-    t,
-    escapeHtml,
-    showError,
+    services,
   });
 
-  return createAppFeaturePorts({
+  return createAppFeatureBundlePorts({
     history,
     realtime,
     settings,

--- a/apps/ui/src/app/app_feature_bundle_ports.ts
+++ b/apps/ui/src/app/app_feature_bundle_ports.ts
@@ -1,3 +1,6 @@
+import { createUiRecordingHistoryRefresh } from "./runtime/ui_recording_history_refresh";
+import type { UiShellFeaturePorts } from "./runtime/ui_shell_feature_ports";
+import type { UiStartupFeaturePorts } from "./runtime/ui_startup_feature_ports";
 import type { CarsFeature } from "./features/cars_feature";
 import type { EspFlashFeature } from "./features/esp_flash_feature";
 import type { HistoryFeature } from "./features/history_feature";
@@ -10,16 +13,13 @@ import type {
   SettingsFeatureRealtimePorts,
 } from "./features/settings_feature";
 import type { UpdateFeature } from "./features/update_feature";
-import { createUiRecordingHistoryRefresh } from "./runtime/ui_recording_history_refresh";
-import type { UiShellFeaturePorts } from "./runtime/ui_shell_feature_ports";
-import type { UiStartupFeaturePorts } from "./runtime/ui_startup_feature_ports";
 
 export interface AppFeatureBundle {
   shell: UiShellFeaturePorts;
   startup: UiStartupFeaturePorts;
 }
 
-export interface AppFeaturesForPorts {
+interface AppFeatureBundlePortSources {
   history: Pick<
     HistoryFeature,
     "bindHandlers" | "renderHistoryTable" | "reloadExpandedRunOnLanguageChange" | "refreshHistory"
@@ -67,7 +67,9 @@ export function createRealtimeFeatureRecordingPorts(
   };
 }
 
-export function createAppFeaturePorts(features: AppFeaturesForPorts): AppFeatureBundle {
+export function createAppFeatureBundlePorts(
+  features: AppFeatureBundlePortSources,
+): AppFeatureBundle {
   return {
     shell: {
       bindSettingsHandlers: () => features.settings.bindHandlers(),
@@ -78,13 +80,15 @@ export function createAppFeaturePorts(features: AppFeaturesForPorts): AppFeature
       bindEspFlashHandlers: () => features.espFlash.bindHandlers(),
       languageRefresh: {
         realtime: {
-          maybeRenderSensorsSettingsList: (force) => features.realtime.maybeRenderSensorsSettingsList(force),
+          maybeRenderSensorsSettingsList: (force) =>
+            features.realtime.maybeRenderSensorsSettingsList(force),
           renderLoggingStatus: () => features.realtime.renderLoggingStatus(),
           renderStatus: () => features.realtime.renderStatus(),
         },
         history: {
           renderHistoryTable: () => features.history.renderHistoryTable(),
-          reloadExpandedRunOnLanguageChange: () => features.history.reloadExpandedRunOnLanguageChange(),
+          reloadExpandedRunOnLanguageChange: () =>
+            features.history.reloadExpandedRunOnLanguageChange(),
         },
         settings: {
           syncSettingsInputs: () => features.settings.syncSettingsInputs(),
@@ -101,7 +105,8 @@ export function createAppFeaturePorts(features: AppFeaturesForPorts): AppFeature
       },
       settings: {
         loadSpeedSourceFromServer: () => features.settings.loadSpeedSourceFromServer(),
-        loadAnalysisSettingsFromServer: () => features.settings.loadAnalysisSettingsFromServer(),
+        loadAnalysisSettingsFromServer: () =>
+          features.settings.loadAnalysisSettingsFromServer(),
         loadCarsFromServer: () => features.settings.loadCarsFromServer(),
         startGpsStatusPolling: () => features.settings.startGpsStatusPolling(),
       },

--- a/apps/ui/src/app/feature_deps_base.ts
+++ b/apps/ui/src/app/feature_deps_base.ts
@@ -1,12 +1,14 @@
 /**
- * Shared base interface for UI feature dependency injection.
- *
- * All feature Deps interfaces extend this base to avoid duplicating
- * the common non-DOM fields (i18n translation, HTML escaping)
- * across every feature module.
+ * Minimal shared utilities that feature factories still consume after the
+ * signal-backed state migration removed most of the older constructor plumbing.
  */
-export interface FeatureDepsBase {
+export interface FeatureServices {
   t: (key: string, vars?: Record<string, unknown>) => string;
-  escapeHtml: (value: unknown) => string;
   showError: (message: string) => void;
+}
+
+export interface FeatureFormatting {
+  fmt: (n: number, digits?: number) => string;
+  fmtTs: (iso: string) => string;
+  formatInt: (value: number) => string;
 }

--- a/apps/ui/src/app/features/cars_feature.ts
+++ b/apps/ui/src/app/features/cars_feature.ts
@@ -1,4 +1,4 @@
-import type { FeatureDepsBase } from "../feature_deps_base";
+import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import { createCarsFeaturePresenter } from "../views/cars_feature_presenter";
 import type {
   CarsFeatureInteraction,
@@ -6,7 +6,7 @@ import type {
 } from "../views/cars_panel";
 import { createCarsFeatureWorkflow } from "./cars_feature_workflow";
 
-export interface CarsFeatureDeps extends FeatureDepsBase {
+export interface CarsFeatureDeps {
   addCarFromWizard: (
     name: string,
     carType: string,
@@ -14,7 +14,8 @@ export interface CarsFeatureDeps extends FeatureDepsBase {
     variant?: string,
   ) => Promise<void>;
   panel: CarsWizardPanelBridge;
-  fmt: (n: number, digits?: number) => string;
+  services: Pick<FeatureServices, "t">;
+  formatting: Pick<FeatureFormatting, "fmt">;
 }
 
 export interface CarsFeature {
@@ -24,14 +25,14 @@ export interface CarsFeature {
 
 export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
   const presenter = createCarsFeaturePresenter({
-    fmt: ctx.fmt,
+    fmt: ctx.formatting.fmt,
     panel: ctx.panel,
-    t: ctx.t,
+    t: ctx.services.t,
   });
   const workflow = createCarsFeatureWorkflow({
     addCarFromWizard: ctx.addCarFromWizard,
-    fmt: ctx.fmt,
-    t: ctx.t,
+    fmt: ctx.formatting.fmt,
+    t: ctx.services.t,
     view: presenter,
   });
   let handlersBound = false;

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -1,10 +1,11 @@
-import type { FeatureDepsBase } from "../feature_deps_base";
+import type { FeatureServices } from "../feature_deps_base";
 import { createEspFlashFeatureWorkflow } from "./esp_flash_feature_workflow";
 import { createEspFlashFeaturePresenter } from "../views/esp_flash_feature_presenter";
 import type { EspFlashPanelView } from "../views/esp_flash_panel";
 
-export interface EspFlashFeatureDeps extends FeatureDepsBase {
+export interface EspFlashFeatureDeps {
   panel: EspFlashPanelView;
+  services: FeatureServices;
 }
 
 export interface EspFlashFeature {
@@ -16,13 +17,14 @@ export interface EspFlashFeature {
 export function createEspFlashFeature(
   ctx: EspFlashFeatureDeps,
 ): EspFlashFeature {
+  const { panel, services } = ctx;
   const presenter = createEspFlashFeaturePresenter({
-    panel: ctx.panel,
-    t: ctx.t,
+    panel,
+    t: services.t,
   });
   const workflow = createEspFlashFeatureWorkflow({
-    t: ctx.t,
-    showError: ctx.showError,
+    t: services.t,
+    showError: services.showError,
     view: presenter,
   });
   let handlersBound = false;
@@ -32,7 +34,7 @@ export function createEspFlashFeature(
       return;
     }
     handlersBound = true;
-    ctx.panel.bindActions({
+    panel.bindActions({
       onStart: () => {
         void workflow.startFlash();
       },

--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -5,8 +5,8 @@ import {
   historyExportUrl,
   historyReportPdfUrl,
 } from "../../api";
-import type { FeatureDepsBase } from "../feature_deps_base";
-import type { HistoryState, RunDetail } from "../ui_app_state";
+import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
+import type { HistoryState, RunDetail, ShellState } from "../ui_app_state";
 import type {
   HistoryPanelRenderModel,
   HistoryPanelView,
@@ -14,16 +14,15 @@ import type {
 } from "../views/history_table_view";
 import { downloadBlobFile } from "./history_download";
 
-export interface HistoryFeatureDeps extends FeatureDepsBase {
+export interface HistoryFeatureDeps {
   panel: HistoryPanelView;
   navigation: {
     activatePrimaryView(viewId: string): void;
   };
   history: HistoryState;
-  getLanguage: () => string;
-  fmt: (n: number, digits?: number) => string;
-  fmtTs: (iso: string) => string;
-  formatInt: (value: number) => string;
+  shell: Pick<ShellState, "lang">;
+  services: FeatureServices;
+  formatting: FeatureFormatting;
 }
 
 export interface HistoryFeature {
@@ -37,7 +36,7 @@ export interface HistoryFeature {
 }
 
 export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
-  const { history, panel } = ctx;
+  const { history, panel, shell, services, formatting } = ctx;
   let handlersBound = false;
   let previewPrefetchToken = 0;
 
@@ -74,22 +73,27 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     if (!history.runs.length) {
       collapseExpandedRun();
       return {
-        historySummaryText: ctx.t("history.none"),
+        historySummaryText: services.t("history.none"),
         deleteAllRunsDisabled,
         table: {
           kind: "empty",
-          t: ctx.t,
+          t: services.t,
         },
       };
     }
-    if (history.expandedRunId && !history.runs.some((row) => row.run_id === history.expandedRunId)) {
+    if (
+      history.expandedRunId &&
+      !history.runs.some((row) => row.run_id === history.expandedRunId)
+    ) {
       collapseExpandedRun();
     }
     for (const run of history.runs) {
       ensureRunDetail(run.run_id);
     }
     return {
-      historySummaryText: ctx.t("history.available_count", { count: history.runs.length }),
+      historySummaryText: services.t("history.available_count", {
+        count: history.runs.length,
+      }),
       deleteAllRunsDisabled,
       table: {
         kind: "rows",
@@ -97,10 +101,10 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
           runs: history.runs,
           expandedRunId: history.expandedRunId,
           runDetailsById: history.runDetailsById,
-          t: ctx.t,
-          fmt: ctx.fmt,
-          fmtTs: ctx.fmtTs,
-          formatInt: ctx.formatInt,
+          t: services.t,
+          fmt: formatting.fmt,
+          fmtTs: formatting.fmtTs,
+          formatInt: formatting.formatInt,
           historyExportUrl,
         },
       },
@@ -123,10 +127,12 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     detail.previewError = "";
     renderHistoryTable();
     try {
-      const response = await getHistoryInsights(runId, ctx.getLanguage());
+      const response = await getHistoryInsights(runId, shell.lang);
       detail.preview = response.status === "complete" ? response : null;
     } catch (err) {
-      detail.previewError = err instanceof Error ? err.message : ctx.t("report.unable_load_insights");
+      detail.previewError = err instanceof Error
+        ? err.message
+        : services.t("report.unable_load_insights");
     } finally {
       detail.previewLoading = false;
       renderHistoryTable();
@@ -145,10 +151,12 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     detail.insightsError = "";
     renderHistoryTable();
     try {
-      const response = await getHistoryInsights(runId, ctx.getLanguage());
+      const response = await getHistoryInsights(runId, shell.lang);
       detail.insights = response.status === "complete" ? response : null;
     } catch (err) {
-      detail.insightsError = err instanceof Error ? err.message : ctx.t("report.unable_load_insights");
+      detail.insightsError = err instanceof Error
+        ? err.message
+        : services.t("report.unable_load_insights");
     } finally {
       detail.insightsLoading = false;
       renderHistoryTable();
@@ -216,14 +224,16 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     if (!runId) {
       return;
     }
-    const ok = window.confirm(ctx.t("history.delete_confirm", { name: runId }));
+    const ok = window.confirm(services.t("history.delete_confirm", { name: runId }));
     if (!ok) {
       return;
     }
     try {
       await deleteHistoryRunApi(runId);
     } catch (err) {
-      ctx.showError(err instanceof Error ? err.message : ctx.t("history.delete_failed"));
+      services.showError(
+        err instanceof Error ? err.message : services.t("history.delete_failed"),
+      );
       return;
     }
     if (history.expandedRunId === runId) {
@@ -237,7 +247,9 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     if (!names.length) {
       return;
     }
-    const ok = window.confirm(ctx.t("history.delete_all_confirm", { count: names.length }));
+    const ok = window.confirm(
+      services.t("history.delete_all_confirm", { count: names.length }),
+    );
     if (!ok) {
       return;
     }
@@ -258,15 +270,21 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       } catch (err) {
         failed += 1;
         if (!firstError) {
-          firstError = err instanceof Error ? err.message : ctx.t("history.delete_failed");
+          firstError = err instanceof Error
+            ? err.message
+            : services.t("history.delete_failed");
         }
       }
     }
     history.deleteAllRunsInFlight = false;
     await refreshHistory();
     if (failed > 0) {
-      const summary = ctx.t("history.delete_all_partial", { deleted, total: names.length, failed });
-      ctx.showError(firstError ? `${summary}\n${firstError}` : summary);
+      const summary = services.t("history.delete_all_partial", {
+        deleted,
+        total: names.length,
+        failed,
+      });
+      services.showError(firstError ? `${summary}\n${firstError}` : summary);
     }
   }
 
@@ -279,16 +297,24 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     detail.pdfError = "";
     renderHistoryTable();
     try {
-      await downloadBlobFile(historyReportPdfUrl(runId, ctx.getLanguage()), `${runId}_report.pdf`);
+      await downloadBlobFile(
+        historyReportPdfUrl(runId, shell.lang),
+        `${runId}_report.pdf`,
+      );
     } catch (err) {
-      detail.pdfError = err instanceof Error ? err.message : ctx.t("history.pdf_failed");
+      detail.pdfError = err instanceof Error
+        ? err.message
+        : services.t("history.pdf_failed");
     } finally {
       detail.pdfLoading = false;
       renderHistoryTable();
     }
   }
 
-  async function onHistoryTableAction(action: HistoryRunAction, runId: string): Promise<void> {
+  async function onHistoryTableAction(
+    action: HistoryRunAction,
+    runId: string,
+  ): Promise<void> {
     if (!action || !runId) {
       return;
     }
@@ -323,7 +349,10 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
           return;
         }
         if (action.type === "run-action") {
-          void onHistoryTableAction(action.action, action.runId ?? history.expandedRunId ?? "");
+          void onHistoryTableAction(
+            action.action,
+            action.runId ?? history.expandedRunId ?? "",
+          );
           return;
         }
         toggleRunDetails(action.runId);

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -1,4 +1,4 @@
-import type { FeatureDepsBase } from "../feature_deps_base";
+import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import type {
   RealtimeState,
   SettingsState,
@@ -14,17 +14,30 @@ import { effect, untracked } from "../ui_signals";
 import { createRealtimeFeatureWorkflow } from "./realtime_feature_workflow";
 import { createRealtimeFeaturePresenter } from "../views/realtime_feature_presenter";
 
-export interface RealtimeFeatureDeps extends FeatureDepsBase {
+interface RealtimeFeatureStateDeps {
   realtime: RealtimeState;
   spectrum: SpectrumState;
   settings: SettingsState;
   shell: Pick<ShellState, "lang">;
-  formatInt: (value: number) => string;
-  chrome: RealtimeFeatureChromePorts;
+}
+
+interface RealtimeFeaturePanelDeps {
   sensorsPanel: SensorsPanelView;
+}
+
+interface RealtimeFeaturePortDeps {
+  chrome: RealtimeFeatureChromePorts;
   navigation: RealtimeFeatureNavigationPorts;
   selection: RealtimeFeatureSelectionPorts;
   recording: RealtimeFeatureRecordingPorts;
+}
+
+export interface RealtimeFeatureDeps {
+  state: RealtimeFeatureStateDeps;
+  panels: RealtimeFeaturePanelDeps;
+  ports: RealtimeFeaturePortDeps;
+  services: FeatureServices;
+  formatting: Pick<FeatureFormatting, "formatInt">;
 }
 
 export interface RealtimeFeatureChromePorts {
@@ -59,34 +72,35 @@ export interface RealtimeFeature {
 export function createRealtimeFeature(
   ctx: RealtimeFeatureDeps,
 ): RealtimeFeature {
+  const { state, panels, ports, services, formatting } = ctx;
   const isDemoMode = new URLSearchParams(window.location.search).has("demo");
   const presenter = createRealtimeFeaturePresenter({
-    realtime: ctx.realtime,
-    settings: ctx.settings,
-    shell: ctx.shell,
-    spectrum: ctx.spectrum,
-    sensorsPanel: ctx.sensorsPanel,
-    t: ctx.t,
-    formatInt: ctx.formatInt,
-    chrome: ctx.chrome,
-    navigation: ctx.navigation,
+    realtime: state.realtime,
+    settings: state.settings,
+    shell: state.shell,
+    spectrum: state.spectrum,
+    sensorsPanel: panels.sensorsPanel,
+    t: services.t,
+    formatInt: formatting.formatInt,
+    chrome: ports.chrome,
+    navigation: ports.navigation,
   });
   const workflow = createRealtimeFeatureWorkflow({
-    realtime: ctx.realtime,
-    t: ctx.t,
-    showError: ctx.showError,
+    realtime: state.realtime,
+    t: services.t,
+    showError: services.showError,
     isDemoMode,
     view: presenter,
-    selection: ctx.selection,
-    recording: ctx.recording,
+    selection: ports.selection,
+    recording: ports.recording,
     confirmRemoveClient: (message) => window.confirm(message),
   });
   let handlersBound = false;
 
   effect(() => {
-    trackAppStateSlice(ctx.realtime);
-    trackAppStateSlice(ctx.settings);
-    trackAppStateSlice(ctx.spectrum);
+    trackAppStateSlice(state.realtime);
+    trackAppStateSlice(state.settings);
+    trackAppStateSlice(state.spectrum);
     untracked(() => {
       presenter.maybeRenderSensorsSettingsList();
       workflow.renderLoggingStatus();
@@ -98,7 +112,7 @@ export function createRealtimeFeature(
       return;
     }
     handlersBound = true;
-    ctx.chrome.loggingPanel.bindActions({
+    ports.chrome.loggingPanel.bindActions({
       onStartLogging: () => {
         void workflow.startLogging();
       },
@@ -126,7 +140,7 @@ export function createRealtimeFeature(
       },
     });
     workflow.bindHandlers();
-    ctx.sensorsPanel.bindActions({
+    panels.sensorsPanel.bindActions({
       onSensorLocationChange: (change) => {
         void workflow.setClientLocation(change.clientId, change.locationCode);
       },

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -3,7 +3,7 @@ import type {
   AnalysisSettingsRequest,
 } from "../../transport/http_models";
 import { getAnalysisSettings, setAnalysisSettings } from "../../api";
-import type { FeatureDepsBase } from "../feature_deps_base";
+import type { FeatureServices } from "../feature_deps_base";
 import { defaultVehicleSettings, type SettingsState } from "../ui_app_state";
 import type {
   AnalysisPanelFieldKey,
@@ -33,9 +33,10 @@ export const ANALYSIS_SETTING_KEYS = [
   "tire_deflection_factor",
 ] as const satisfies readonly (keyof AnalysisSettingsPayload)[];
 
-export interface SettingsAnalysisModuleDeps extends FeatureDepsBase {
+export interface SettingsAnalysisModuleDeps {
   panel: AnalysisPanelView;
   settings: SettingsState;
+  services: FeatureServices;
   renderSpectrum: () => void;
   hasValidActiveCar: () => boolean;
   onMissingActiveCar: () => void;
@@ -209,7 +210,8 @@ function formatSettingValue(value: number): string {
 export function createSettingsAnalysisModule(
   ctx: SettingsAnalysisModuleDeps,
 ): SettingsAnalysisModule {
-  const { panel, settings, t } = ctx;
+  const { panel, settings, services } = ctx;
+  const { t } = services;
   let draftValues = buildDraftValues(settings);
   let saveFeedback: SettingsFeedbackMessage | null = null;
   const fieldErrorMessages = new Map<AnalysisPanelFieldKey, string>();

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -1,4 +1,4 @@
-import type { FeatureDepsBase } from "../feature_deps_base";
+import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import {
   createCarSelectionDerivedState,
   type CarSelectionState,
@@ -6,9 +6,7 @@ import {
 } from "../car_selection_state";
 import type { SettingsState } from "../ui_app_state";
 import type { CarRecord, CarsPayload } from "../../transport/http_models";
-import type {
-  CarsListPanelView,
-} from "../views/cars_panel";
+import type { CarsListPanelView } from "../views/cars_panel";
 import type { AnalysisPanelView } from "../views/analysis_panel";
 import {
   buildCarsGuidanceRenderModel,
@@ -20,20 +18,29 @@ import {
   type SettingsCarsTransport,
 } from "./settings_cars_transport";
 
-export interface SettingsCarsModuleDeps extends FeatureDepsBase {
-  confirmDelete?: (message: string) => boolean;
+interface SettingsCarsModulePanels {
   analysisPanel: Pick<AnalysisPanelView, "setCarAvailability">;
-  fmt: (value: number, digits?: number) => string;
+  panel: CarsListPanelView;
+}
+
+interface SettingsCarsModulePorts {
   openAnalysisTab: () => void;
   openCarWizard: () => void;
   renderRealtimeLoggingStatus: () => void;
   renderRealtimeStatus: () => void;
   renderSpectrum: () => void;
-  settings: SettingsState;
   subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
   subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
   syncAnalysisInputs: () => void;
-  panel: CarsListPanelView;
+}
+
+export interface SettingsCarsModuleDeps {
+  confirmDelete?: (message: string) => boolean;
+  settings: SettingsState;
+  panels: SettingsCarsModulePanels;
+  ports: SettingsCarsModulePorts;
+  services: FeatureServices;
+  formatting: Pick<FeatureFormatting, "fmt">;
   transport?: Partial<SettingsCarsTransport>;
 }
 
@@ -65,7 +72,8 @@ function copyActiveCarAspects(
 export function createSettingsCarsModule(
   ctx: SettingsCarsModuleDeps,
 ): SettingsCarsModule {
-  const { settings, t } = ctx;
+  const { settings, services, formatting } = ctx;
+  const { t } = services;
   const confirmDelete =
     ctx.confirmDelete ?? ((message: string) => window.confirm(message));
   const transport = createSettingsCarsTransport(ctx.transport);
@@ -96,14 +104,14 @@ export function createSettingsCarsModule(
           activeCarId: settings.activeCarId,
           cars: settings.cars,
           highlightedCarId: highlightedCarFeedback?.carId ?? null,
-          fmt: ctx.fmt,
+          fmt: formatting.fmt,
           t,
         }),
     };
   }
 
   function syncAnalysisControls(carSelectionState: CarSelectionState): void {
-    ctx.analysisPanel.setCarAvailability({
+    ctx.panels.analysisPanel.setCarAvailability({
       hasActiveCar: carSelectionState.kind === "active",
       isLoading: carSelectionState.kind === "loading",
     });
@@ -112,7 +120,7 @@ export function createSettingsCarsModule(
   function renderCarList(): void {
     const carSelectionState = getCarSelectionState();
     syncAnalysisControls(carSelectionState);
-    ctx.panel.setModel(createPanelModel(carSelectionState));
+    ctx.panels.panel.setModel(createPanelModel(carSelectionState));
   }
 
   function clearHighlightedCarFeedback(): void {
@@ -142,8 +150,8 @@ export function createSettingsCarsModule(
       highlightedCarFeedback = null;
     }
     renderCarList();
-    ctx.renderRealtimeStatus();
-    ctx.renderRealtimeLoggingStatus();
+    ctx.ports.renderRealtimeStatus();
+    ctx.ports.renderRealtimeLoggingStatus();
   }
 
   function findCar(carId: string): CarRecord | null {
@@ -153,7 +161,7 @@ export function createSettingsCarsModule(
   function syncActiveCarToInputs(): void {
     copyActiveCarAspects(carSelection.activeCar.value, settings);
     if (hasValidActiveCar()) {
-      ctx.syncAnalysisInputs();
+      ctx.ports.syncAnalysisInputs();
     }
     renderCarList();
   }
@@ -176,7 +184,7 @@ export function createSettingsCarsModule(
       return;
     }
     if (!getCarCompleteness(car).isComplete) {
-      ctx.showError(t("settings.car.activate_incomplete"));
+      services.showError(t("settings.car.activate_incomplete"));
       return;
     }
     try {
@@ -184,9 +192,9 @@ export function createSettingsCarsModule(
       syncActiveCarToInputs();
       clearHighlightedCarFeedback();
       renderCarList();
-      ctx.renderSpectrum();
+      ctx.ports.renderSpectrum();
     } catch (_err) {
-      ctx.showError(t("settings.car.activate_failed"));
+      services.showError(t("settings.car.activate_failed"));
     }
   }
 
@@ -203,16 +211,16 @@ export function createSettingsCarsModule(
       if (car.id !== settings.activeCarId) {
         syncCarsPayload(await transport.activateCar(carId));
         syncActiveCarToInputs();
-        ctx.renderSpectrum();
+        ctx.ports.renderSpectrum();
         shouldRefreshAfterSelection = true;
       }
       clearHighlightedCarFeedback();
       if (shouldRefreshAfterSelection) {
         renderCarList();
       }
-      ctx.openAnalysisTab();
+      ctx.ports.openAnalysisTab();
     } catch (_err) {
-      ctx.showError(t("settings.car.activate_failed"));
+      services.showError(t("settings.car.activate_failed"));
     }
   }
 
@@ -232,9 +240,9 @@ export function createSettingsCarsModule(
       syncActiveCarToInputs();
       clearHighlightedCarFeedback();
       renderCarList();
-      ctx.renderSpectrum();
+      ctx.ports.renderSpectrum();
     } catch (_err) {
-      ctx.showError(t("settings.car.delete_failed"));
+      services.showError(t("settings.car.delete_failed"));
     }
   }
 
@@ -243,20 +251,20 @@ export function createSettingsCarsModule(
       return;
     }
     handlersBound = true;
-    ctx.subscribeSettingsTabChanges((tabId) => {
+    ctx.ports.subscribeSettingsTabChanges((tabId) => {
       if (tabId !== "carTab") {
         dismissHighlightedCarFeedback();
       }
     });
-    ctx.subscribePrimaryViewChanges((viewId) => {
+    ctx.ports.subscribePrimaryViewChanges((viewId) => {
       if (viewId !== "settingsView") {
         dismissHighlightedCarFeedback();
       }
     });
-    ctx.panel.bindActions({
+    ctx.panels.panel.bindActions({
       onAction: (action) => {
         if (action.type === "add") {
-          ctx.openCarWizard();
+          ctx.ports.openCarWizard();
           return;
         }
         if (action.type === "activate") {

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -1,6 +1,6 @@
-import type { FeatureDepsBase } from "../feature_deps_base";
+import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import { createCarSelectionDerivedState } from "../car_selection_state";
-import type { SettingsState } from "../ui_app_state";
+import type { SettingsState, ShellState } from "../ui_app_state";
 import type { CarsPayload } from "../../transport/http_models";
 import {
   createSettingsAnalysisModule,
@@ -23,18 +23,31 @@ import type { AnalysisPanelView } from "../views/analysis_panel";
 import type { SettingsShellView } from "../views/settings_shell";
 import type { SpeedSourcePanelView } from "../views/speed_source_panel";
 
-export interface SettingsFeatureDeps extends FeatureDepsBase {
+interface SettingsFeatureStateDeps {
   settings: SettingsState;
-  getSpeedUnit: () => string;
-  fmt: (n: number, digits?: number) => string;
-  openCarWizard: () => void;
-  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
+  shell: Pick<ShellState, "speedUnit">;
+}
+
+interface SettingsFeaturePanelDeps {
   settingsShell: SettingsShellView;
   carsPanel: CarsListPanelView;
   analysisPanel: AnalysisPanelView;
   speedSourcePanel: SpeedSourcePanelView;
+}
+
+interface SettingsFeaturePortDeps {
+  openCarWizard: () => void;
+  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
   view: SettingsFeatureViewPorts;
   realtime: SettingsFeatureRealtimePorts;
+}
+
+export interface SettingsFeatureDeps {
+  state: SettingsFeatureStateDeps;
+  panels: SettingsFeaturePanelDeps;
+  ports: SettingsFeaturePortDeps;
+  services: FeatureServices;
+  formatting: Pick<FeatureFormatting, "fmt">;
 }
 
 export interface SettingsFeatureViewPorts {
@@ -66,73 +79,78 @@ export interface SettingsFeature {
 export function createSettingsFeature(
   ctx: SettingsFeatureDeps,
 ): SettingsFeature {
-  const { settings, t, escapeHtml, fmt } = ctx;
+  const { services, formatting } = ctx;
+  const settings = ctx.state.settings;
   const carSelection = createCarSelectionDerivedState(settings);
   let handlersBound = false;
   let carsModule!: SettingsCarsModule;
 
   function showSettingsSaveError(error: unknown): void {
-    ctx.showError(
-      error instanceof Error ? error.message : t("settings.save_failed"),
+    services.showError(
+      error instanceof Error ? error.message : services.t("settings.save_failed"),
     );
   }
 
   function openSettingsTab(tabId: string): void {
-    ctx.settingsShell.activateTab(tabId);
+    ctx.panels.settingsShell.activateTab(tabId);
   }
 
   const analysisModule: SettingsAnalysisModule = createSettingsAnalysisModule({
-    panel: ctx.analysisPanel,
-    t,
-    escapeHtml,
-    showError: ctx.showError,
+    panel: ctx.panels.analysisPanel,
     settings,
-    renderSpectrum: ctx.view.renderSpectrum,
+    services,
+    renderSpectrum: ctx.ports.view.renderSpectrum,
     hasValidActiveCar: () => carSelection.hasResolvedActiveCar.value,
     onMissingActiveCar: () => carsModule.renderCarList(),
     onSaveError: showSettingsSaveError,
   });
   const speedSourceModule: SettingsSpeedSourceModule =
     createSettingsSpeedSourceModule({
-      panel: ctx.speedSourcePanel,
-      t,
-      escapeHtml,
-      showError: ctx.showError,
+      panel: ctx.panels.speedSourcePanel,
       settings,
-      getSpeedUnit: ctx.getSpeedUnit,
-      fmt,
-      renderSpeedReadout: ctx.view.renderSpeedReadout,
-      subscribePrimaryViewChanges: ctx.subscribePrimaryViewChanges,
-      subscribeSettingsTabChanges: ctx.settingsShell.subscribeActiveTabChanges,
+      services,
+      formatting,
+      getSpeedUnit: () => ctx.state.shell.speedUnit,
+      ports: {
+        renderSpeedReadout: ctx.ports.view.renderSpeedReadout,
+        subscribePrimaryViewChanges: ctx.ports.subscribePrimaryViewChanges,
+        subscribeSettingsTabChanges:
+          ctx.panels.settingsShell.subscribeActiveTabChanges,
+      },
     });
   const gpsStatusModule: SettingsGpsStatusModule =
     createSettingsGpsStatusModule({
-      panel: ctx.speedSourcePanel,
-      t,
-      escapeHtml,
-      showError: ctx.showError,
+      panel: ctx.panels.speedSourcePanel,
       settings,
-      getSpeedUnit: ctx.getSpeedUnit,
-      fmt,
-      syncSpeedSourceSelectionUi: speedSourceModule.syncSpeedSourceSelectionUi,
-      renderSpeedReadout: ctx.view.renderSpeedReadout,
-  });
+      services: {
+        t: services.t,
+      },
+      formatting,
+      getSpeedUnit: () => ctx.state.shell.speedUnit,
+      ports: {
+        syncSpeedSourceSelectionUi: speedSourceModule.syncSpeedSourceSelectionUi,
+        renderSpeedReadout: ctx.ports.view.renderSpeedReadout,
+      },
+    });
   carsModule = createSettingsCarsModule({
-    analysisPanel: ctx.analysisPanel,
-    escapeHtml,
-    fmt,
-    openAnalysisTab: () => openSettingsTab("analysisTab"),
-    openCarWizard: ctx.openCarWizard,
-    renderRealtimeLoggingStatus: ctx.realtime.renderRealtimeLoggingStatus,
-    renderRealtimeStatus: ctx.realtime.renderRealtimeStatus,
-    renderSpectrum: ctx.view.renderSpectrum,
     settings,
-    subscribePrimaryViewChanges: ctx.subscribePrimaryViewChanges,
-    subscribeSettingsTabChanges: ctx.settingsShell.subscribeActiveTabChanges,
-    showError: ctx.showError,
-    syncAnalysisInputs: analysisModule.syncSettingsInputs,
-    panel: ctx.carsPanel,
-    t,
+    panels: {
+      analysisPanel: ctx.panels.analysisPanel,
+      panel: ctx.panels.carsPanel,
+    },
+    ports: {
+      openAnalysisTab: () => openSettingsTab("analysisTab"),
+      openCarWizard: ctx.ports.openCarWizard,
+      renderRealtimeLoggingStatus: ctx.ports.realtime.renderRealtimeLoggingStatus,
+      renderRealtimeStatus: ctx.ports.realtime.renderRealtimeStatus,
+      renderSpectrum: ctx.ports.view.renderSpectrum,
+      subscribePrimaryViewChanges: ctx.ports.subscribePrimaryViewChanges,
+      subscribeSettingsTabChanges:
+        ctx.panels.settingsShell.subscribeActiveTabChanges,
+      syncAnalysisInputs: analysisModule.syncSettingsInputs,
+    },
+    services,
+    formatting,
   });
 
   function bindHandlers(): void {

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -1,6 +1,6 @@
 import { getSettingsObdStatus, getSpeedSourceStatus } from "../../api";
 import { GPS_POLL_FAST_MS, GPS_POLL_SLOW_MS } from "../../config";
-import type { FeatureDepsBase } from "../feature_deps_base";
+import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import type { SettingsState } from "../ui_app_state";
 import type { SpeedSourcePanelView } from "../views/speed_source_panel";
 import {
@@ -9,13 +9,18 @@ import {
 } from "../views/settings_speed_source_presenter";
 import { createPollingController } from "./polling_controller";
 
-export interface SettingsGpsStatusModuleDeps extends FeatureDepsBase {
-  panel: SpeedSourcePanelView;
-  settings: SettingsState;
-  getSpeedUnit: () => string;
-  fmt: (n: number, digits?: number) => string;
+interface SettingsGpsStatusModulePorts {
   syncSpeedSourceSelectionUi: () => void;
   renderSpeedReadout: () => void;
+}
+
+export interface SettingsGpsStatusModuleDeps {
+  panel: SpeedSourcePanelView;
+  settings: SettingsState;
+  services: Pick<FeatureServices, "t">;
+  formatting: Pick<FeatureFormatting, "fmt">;
+  getSpeedUnit: () => string;
+  ports: SettingsGpsStatusModulePorts;
 }
 
 export interface SettingsGpsStatusModule {
@@ -28,9 +33,9 @@ export function createSettingsGpsStatusModule(
 ): SettingsGpsStatusModule {
   const { panel, settings } = ctx;
   const presenterDeps: SettingsSpeedSourcePresenterDeps = {
-    fmt: ctx.fmt,
+    fmt: ctx.formatting.fmt,
     getSpeedUnit: ctx.getSpeedUnit,
-    t: ctx.t,
+    t: ctx.services.t,
   };
 
   const polling = createPollingController({
@@ -47,8 +52,8 @@ export function createSettingsGpsStatusModule(
       panel.setDiagnostics(
         buildSpeedSourceDiagnosticsRenderModel(status, obdStatus, presenterDeps),
       );
-      ctx.syncSpeedSourceSelectionUi();
-      ctx.renderSpeedReadout();
+      ctx.ports.syncSpeedSourceSelectionUi();
+      ctx.ports.renderSpeedReadout();
       return status.connection_state === "connected"
         ? GPS_POLL_FAST_MS
         : GPS_POLL_SLOW_MS;

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -1,4 +1,4 @@
-import type { FeatureDepsBase } from "../feature_deps_base";
+import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import {
   buildSettingsSpeedSourcePanelModel,
   type SettingsSpeedSourcePresenterDeps,
@@ -7,14 +7,19 @@ import type { SpeedSourcePanelView } from "../views/speed_source_panel";
 import type { SettingsState } from "../ui_app_state";
 import { createSettingsSpeedSourceWorkflow } from "./settings_speed_source_workflow";
 
-export interface SettingsSpeedSourceModuleDeps extends FeatureDepsBase {
-  panel: SpeedSourcePanelView;
-  settings: SettingsState;
-  getSpeedUnit: () => string;
-  fmt: (n: number, digits?: number) => string;
+interface SettingsSpeedSourceModulePorts {
   renderSpeedReadout: () => void;
   subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
   subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
+}
+
+export interface SettingsSpeedSourceModuleDeps {
+  panel: SpeedSourcePanelView;
+  settings: SettingsState;
+  services: FeatureServices;
+  formatting: Pick<FeatureFormatting, "fmt">;
+  getSpeedUnit: () => string;
+  ports: SettingsSpeedSourceModulePorts;
 }
 
 export interface SettingsSpeedSourceModule {
@@ -28,17 +33,17 @@ export interface SettingsSpeedSourceModule {
 export function createSettingsSpeedSourceModule(
   ctx: SettingsSpeedSourceModuleDeps,
 ): SettingsSpeedSourceModule {
-  const { settings, t } = ctx;
+  const { settings, services } = ctx;
   const presenterDeps: SettingsSpeedSourcePresenterDeps = {
-    fmt: ctx.fmt,
+    fmt: ctx.formatting.fmt,
     getSpeedUnit: ctx.getSpeedUnit,
-    t,
+    t: services.t,
   };
   const workflow = createSettingsSpeedSourceWorkflow({
-    renderSpeedReadout: ctx.renderSpeedReadout,
+    renderSpeedReadout: ctx.ports.renderSpeedReadout,
     settings,
-    showError: ctx.showError,
-    t,
+    showError: services.showError,
+    t: services.t,
     view: {
       focusManualSpeedInput: ctx.panel.focusManualSpeedInput,
       focusScanObdDevices: ctx.panel.focusScanObdDevices,
@@ -56,10 +61,10 @@ export function createSettingsSpeedSourceModule(
       return;
     }
     handlersBound = true;
-    ctx.subscribeSettingsTabChanges(() => {
+    ctx.ports.subscribeSettingsTabChanges(() => {
       workflow.handleNavigateContext();
     });
-    ctx.subscribePrimaryViewChanges(() => {
+    ctx.ports.subscribePrimaryViewChanges(() => {
       workflow.handleNavigateContext();
     });
     ctx.panel.bindActions({

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -1,12 +1,17 @@
-import type { FeatureDepsBase } from "../feature_deps_base";
+import type { FeatureServices } from "../feature_deps_base";
 import { createUpdateFeatureWorkflow } from "./update_feature_workflow";
 import { createUpdateFeaturePresenter } from "../views/update_feature_presenter";
 import type { InternetPanelView } from "../views/internet_panel";
 import type { UpdatePanelView } from "../views/update_panel";
 
-export interface UpdateFeatureDeps extends FeatureDepsBase {
-  panel: UpdatePanelView;
-  internetPanel: InternetPanelView;
+interface UpdateFeaturePanels {
+  update: UpdatePanelView;
+  internet: InternetPanelView;
+}
+
+export interface UpdateFeatureDeps {
+  panels: UpdateFeaturePanels;
+  services: FeatureServices;
 }
 
 export interface UpdateFeature {
@@ -16,14 +21,15 @@ export interface UpdateFeature {
 }
 
 export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
+  const { panels, services } = ctx;
   const presenter = createUpdateFeaturePresenter({
-    panel: ctx.panel,
-    internetPanel: ctx.internetPanel,
-    t: ctx.t,
+    panel: panels.update,
+    internetPanel: panels.internet,
+    t: services.t,
   });
   const workflow = createUpdateFeatureWorkflow({
-    t: ctx.t,
-    showError: ctx.showError,
+    t: services.t,
+    showError: services.showError,
     view: presenter,
   });
   let handlersBound = false;
@@ -33,7 +39,7 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
       return;
     }
     handlersBound = true;
-    ctx.panel.bindActions({
+    panels.update.bindActions({
       onStart: () => {
         workflow.renderCurrentState();
         void workflow.startUpdate(
@@ -44,7 +50,7 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
         void workflow.cancelUpdate();
       },
     });
-    ctx.internetPanel.bindActions({
+    panels.internet.bindActions({
       onPasswordInput: (value) => {
         presenter.setPasswordInput(value);
       },

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -1,4 +1,4 @@
-import { escapeHtml, fmt, fmtTs } from "../format";
+import { fmt, fmtTs } from "../format";
 import {
   createAppFeatureBundle,
   type AppFeatureBundle,
@@ -63,12 +63,15 @@ export class UiAppRuntime {
     this.featurePorts = createAppFeatureBundle({
       state: this.state,
       shared: {
-        t: (key, vars) => this.shell.t(key, vars),
-        escapeHtml,
-        showError: (message) => this.shell.showError(message),
-        fmt,
-        fmtTs,
-        formatInt: (value) => this.shell.localFormatInt(value),
+        services: {
+          t: (key, vars) => this.shell.t(key, vars),
+          showError: (message) => this.shell.showError(message),
+        },
+        formatting: {
+          fmt,
+          fmtTs,
+          formatInt: (value) => this.shell.localFormatInt(value),
+        },
       },
       runtime: {
         panels: deps.panels,

--- a/apps/ui/tests/app_feature_ports.spec.ts
+++ b/apps/ui/tests/app_feature_ports.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@playwright/test";
 
 import {
-  createAppFeaturePorts,
+  createAppFeatureBundlePorts,
   createRealtimeFeatureRecordingPorts,
   createSettingsFeatureRealtimePorts,
-} from "../src/app/app_feature_ports";
+} from "../src/app/app_feature_bundle_ports";
 
 test("feature port helpers expose explicit shell and startup contracts without a full app shell", async () => {
   const calls: string[] = [];
@@ -99,7 +99,7 @@ test("feature port helpers expose explicit shell and startup contracts without a
 
   const settingsRealtime = createSettingsFeatureRealtimePorts(realtime);
   const recording = createRealtimeFeatureRecordingPorts(history);
-  const bundle = createAppFeaturePorts({
+  const bundle = createAppFeatureBundlePorts({
     history,
     realtime,
     settings,

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -569,9 +569,10 @@ function createDeps() {
     espFlashStartSummary,
     espFlashReadinessPanel,
     espFlashJourneyPanel,
-    t: (key: string) => key,
-    escapeHtml: (value: unknown) => String(value ?? ""),
-    showError: () => {},
+    services: {
+      t: (key: string) => key,
+      showError: () => {},
+    },
   };
 }
 
@@ -719,41 +720,43 @@ function createUpdateDeps() {
   } as UpdatePanelDom;
 
   return {
-    panel: {
-      dom,
-      bindActions(handlers: UpdatePanelActionHandlers) {
-        dom.updateStartBtn.addEventListener("click", () => {
-          handlers.onStart();
-        });
-        dom.updateCancelBtn.addEventListener("click", () => {
-          handlers.onCancel();
-        });
+    panels: {
+      update: {
+        dom,
+        bindActions(handlers: UpdatePanelActionHandlers) {
+          dom.updateStartBtn.addEventListener("click", () => {
+            handlers.onStart();
+          });
+          dom.updateCancelBtn.addEventListener("click", () => {
+            handlers.onCancel();
+          });
+        },
+        setModel(model: UpdatePanelRenderModel) {
+          renderUpdatePanelDom(dom, model);
+        },
       },
-      setModel(model: UpdatePanelRenderModel) {
-        renderUpdatePanelDom(dom, model);
-      },
-    },
-    internetPanel: {
-      dom: internetDom,
-      bindActions(handlers: InternetPanelActionHandlers) {
-        internetDom.updatePasswordInput?.addEventListener("input", () => {
-          handlers.onPasswordInput(internetDom.updatePasswordInput?.value ?? "");
-        });
-        internetDom.updateTogglePasswordBtn?.addEventListener("click", () => {
-          handlers.onTogglePassword();
-        });
-        internetDom.updateTransportWifiRadio?.addEventListener("change", () => {
-          handlers.onTransportChange("wifi");
-        });
-        internetDom.updateTransportUsbRadio?.addEventListener("change", () => {
-          handlers.onTransportChange("usb_internet");
-        });
-        internetDom.updateSsidInput?.addEventListener("input", () => {
-          handlers.onSsidInput(internetDom.updateSsidInput?.value ?? "");
-        });
-      },
-      setModel(model: InternetPanelRenderModel) {
-        renderInternetPanelDom(internetDom, model);
+      internet: {
+        dom: internetDom,
+        bindActions(handlers: InternetPanelActionHandlers) {
+          internetDom.updatePasswordInput?.addEventListener("input", () => {
+            handlers.onPasswordInput(internetDom.updatePasswordInput?.value ?? "");
+          });
+          internetDom.updateTogglePasswordBtn?.addEventListener("click", () => {
+            handlers.onTogglePassword();
+          });
+          internetDom.updateTransportWifiRadio?.addEventListener("change", () => {
+            handlers.onTransportChange("wifi");
+          });
+          internetDom.updateTransportUsbRadio?.addEventListener("change", () => {
+            handlers.onTransportChange("usb_internet");
+          });
+          internetDom.updateSsidInput?.addEventListener("input", () => {
+            handlers.onSsidInput(internetDom.updateSsidInput?.value ?? "");
+          });
+        },
+        setModel(model: InternetPanelRenderModel) {
+          renderInternetPanelDom(internetDom, model);
+        },
       },
     },
     els: dom,
@@ -772,9 +775,10 @@ function createUpdateDeps() {
     updatePasswordInput,
     updateStartBtn,
     updateCancelBtn,
-    t: (key: string) => key,
-    escapeHtml: (value: unknown) => String(value ?? ""),
-    showError: () => {},
+    services: {
+      t: (key: string) => key,
+      showError: () => {},
+    },
   };
 }
 
@@ -1440,13 +1444,13 @@ test.describe("createUpdateFeature polling", () => {
 
     try {
       const deps = createUpdateDeps();
-      deps.internetPanel.dom.updateSsidInput.value = "";
+      deps.panels.internet.dom.updateSsidInput.value = "";
       const feature = createUpdateFeature(deps);
 
       feature.startPolling();
       await flushAsyncWork();
 
-      expect(deps.internetPanel.dom.updateSsidInput.value).toBe("Workshop Wi-Fi");
+      expect(deps.panels.internet.dom.updateSsidInput.value).toBe("Workshop Wi-Fi");
       expect(deps.updateReadinessSummary.innerHTML).toContain(
         "settings.update.readiness.summary_ready",
       );
@@ -1485,7 +1489,7 @@ test.describe("createUpdateFeature polling", () => {
       feature.startPolling();
       await flushAsyncWork();
 
-      expect(deps.internetPanel.dom.updateSsidInput.value).toBe(
+      expect(deps.panels.internet.dom.updateSsidInput.value).toBe(
         "Driver-entered Wi-Fi",
       );
     } finally {

--- a/apps/ui/tests/esp_flash_feature_bindings.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_bindings.spec.ts
@@ -12,9 +12,10 @@ test("bindHandlers uses panel action surfaces instead of raw DOM bindings", () =
       },
       setModel() {},
     },
-    t: (key) => key,
-    escapeHtml: (value) => String(value ?? ""),
-    showError() {},
+    services: {
+      t: (key) => key,
+      showError() {},
+    },
   });
 
   expect(() => feature.bindHandlers()).not.toThrow();

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -215,15 +215,18 @@ function createFeatureHarness(
       },
     },
     history: state.history,
-    getLanguage: () => state.shell.lang,
-    t: testTranslation,
-    escapeHtml: (value) => String(value ?? ""),
-    showError: overrides.showError ?? ((message) => {
-      errors.push(message);
-    }),
-    fmt: (value, digits = 0) => Number(value).toFixed(digits),
-    fmtTs: (iso) => iso,
-    formatInt: (value) => String(value),
+    shell: state.shell,
+    services: {
+      t: testTranslation,
+      showError: overrides.showError ?? ((message) => {
+        errors.push(message);
+      }),
+    },
+    formatting: {
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      fmtTs: (iso) => iso,
+      formatInt: (value) => String(value),
+    },
   });
   return {
     feature,

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -65,14 +65,15 @@ test("settings analysis module renders guidance and surfaces invalid input throu
 
   const module = createSettingsAnalysisModule({
     panel,
-    escapeHtml: (value) => String(value ?? ""),
     hasValidActiveCar: () => true,
     onMissingActiveCar: () => undefined,
     onSaveError: () => undefined,
     renderSpectrum: () => undefined,
     settings: state,
-    showError: () => undefined,
-    t: translate,
+    services: {
+      t: translate,
+      showError: () => undefined,
+    },
   });
 
   module.bindHandlers();

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -27,43 +27,53 @@ test("settings cars module dismisses transient creation feedback through typed t
   };
 
   const module = createSettingsCarsModule({
-    analysisPanel: {
-      setCarAvailability() {
-        return;
-      },
-    },
-    escapeHtml: (value) => String(value ?? ""),
-    fmt: (value, digits = 0) => Number(value).toFixed(digits),
-    openAnalysisTab: () => undefined,
-    openCarWizard: () => undefined,
-    panel,
     renderRealtimeLoggingStatus: () => undefined,
     renderRealtimeStatus: () => undefined,
     renderSpectrum: () => undefined,
     settings: state,
-    showError: () => undefined,
-    subscribePrimaryViewChanges(listener) {
-      primaryViewListener = listener;
-      return () => {
-        if (primaryViewListener === listener) {
-          primaryViewListener = null;
-        }
-      };
+    panels: {
+      analysisPanel: {
+        setCarAvailability() {
+          return;
+        },
+      },
+      panel,
     },
-    subscribeSettingsTabChanges(listener) {
-      settingsTabListener = listener;
-      return () => {
-        if (settingsTabListener === listener) {
-          settingsTabListener = null;
-        }
-      };
+    ports: {
+      openAnalysisTab: () => undefined,
+      openCarWizard: () => undefined,
+      renderRealtimeLoggingStatus: () => undefined,
+      renderRealtimeStatus: () => undefined,
+      renderSpectrum: () => undefined,
+      subscribePrimaryViewChanges(listener) {
+        primaryViewListener = listener;
+        return () => {
+          if (primaryViewListener === listener) {
+            primaryViewListener = null;
+          }
+        };
+      },
+      subscribeSettingsTabChanges(listener) {
+        settingsTabListener = listener;
+        return () => {
+          if (settingsTabListener === listener) {
+            settingsTabListener = null;
+          }
+        };
+      },
+      syncAnalysisInputs: () => undefined,
     },
-    syncAnalysisInputs: () => undefined,
-    t: (key, vars) => {
-      if (key === "settings.car.created_body") {
-        return `${vars?.name ?? "Unknown"} was added and selected for this setup.`;
-      }
-      return key;
+    services: {
+      t: (key, vars) => {
+        if (key === "settings.car.created_body") {
+          return `${vars?.name ?? "Unknown"} was added and selected for this setup.`;
+        }
+        return key;
+      },
+      showError: () => undefined,
+    },
+    formatting: {
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
     },
   });
 

--- a/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
+++ b/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
@@ -24,19 +24,24 @@ test("bindHandlers uses typed panel actions and navigation subscriptions", () =>
       setModel() {},
       setDiagnostics() {},
     },
-    t: (key) => key,
-    escapeHtml: (value) => String(value ?? ""),
-    showError() {},
-    getSpeedUnit: () => "kmh",
-    fmt: (value) => String(value),
-    renderSpeedReadout() {},
-    subscribePrimaryViewChanges(listener) {
-      primaryViewListener = listener;
-      return () => undefined;
+    services: {
+      t: (key) => key,
+      showError() {},
     },
-    subscribeSettingsTabChanges(listener) {
-      settingsTabListener = listener;
-      return () => undefined;
+    formatting: {
+      fmt: (value) => String(value),
+    },
+    getSpeedUnit: () => "kmh",
+    ports: {
+      renderSpeedReadout() {},
+      subscribePrimaryViewChanges(listener) {
+        primaryViewListener = listener;
+        return () => undefined;
+      },
+      subscribeSettingsTabChanges(listener) {
+        settingsTabListener = listener;
+        return () => undefined;
+      },
     },
   });
 

--- a/apps/ui/tests/update_feature_bindings.spec.ts
+++ b/apps/ui/tests/update_feature_bindings.spec.ts
@@ -26,42 +26,45 @@ test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners
   let internetHandlers: InternetPanelActionHandlers | null = null;
 
   const feature = createUpdateFeature({
-    t: (key) => key,
-    escapeHtml: (value) => String(value ?? ""),
-    showError: () => undefined,
-    panel: {
-      dom: {
-        updateOverviewPanel: null,
-        updateStartBtn: {} as HTMLButtonElement,
-        updateCancelBtn: {} as HTMLButtonElement,
-        updateStatusPanel: {} as HTMLElement,
-      } as UpdatePanelDom,
-      bindActions(handlers: UpdatePanelActionHandlers) {
-        updateHandlers = handlers;
-      },
-      setModel(_model: UpdatePanelRenderModel) {},
+    services: {
+      t: (key) => key,
+      showError: () => undefined,
     },
-    internetPanel: {
-      dom: {
-        internetStatusPanel: null,
-        updateTransportOptions: null,
-        updateTransportChoiceWifi: null,
-        updateTransportChoiceUsb: null,
-        updateWifiFields: null,
-        updateReadinessSummary: null,
-        updateDetailsCaption: null,
-        updateTransportNote: null,
-        updateTransportWifiRadio: createInputStub("", "radio"),
-        updateTransportUsbRadio: createInputStub("", "radio"),
-        updateUsbTransportSummary: null,
-        updateSsidInput: createInputStub("MyWiFi"),
-        updatePasswordInput: createInputStub("secret", "password"),
-        updateTogglePasswordBtn: {} as HTMLButtonElement,
-      } as InternetPanelDom,
-      bindActions(handlers: InternetPanelActionHandlers) {
-        internetHandlers = handlers;
+    panels: {
+      update: {
+        dom: {
+          updateOverviewPanel: null,
+          updateStartBtn: {} as HTMLButtonElement,
+          updateCancelBtn: {} as HTMLButtonElement,
+          updateStatusPanel: {} as HTMLElement,
+        } as UpdatePanelDom,
+        bindActions(handlers: UpdatePanelActionHandlers) {
+          updateHandlers = handlers;
+        },
+        setModel(_model: UpdatePanelRenderModel) {},
       },
-      setModel(_model: InternetPanelRenderModel) {},
+      internet: {
+        dom: {
+          internetStatusPanel: null,
+          updateTransportOptions: null,
+          updateTransportChoiceWifi: null,
+          updateTransportChoiceUsb: null,
+          updateWifiFields: null,
+          updateReadinessSummary: null,
+          updateDetailsCaption: null,
+          updateTransportNote: null,
+          updateTransportWifiRadio: createInputStub("", "radio"),
+          updateTransportUsbRadio: createInputStub("", "radio"),
+          updateUsbTransportSummary: null,
+          updateSsidInput: createInputStub("MyWiFi"),
+          updatePasswordInput: createInputStub("secret", "password"),
+          updateTogglePasswordBtn: {} as HTMLButtonElement,
+        } as InternetPanelDom,
+        bindActions(handlers: InternetPanelActionHandlers) {
+          internetHandlers = handlers;
+        },
+        setModel(_model: InternetPanelRenderModel) {},
+      },
     },
   });
 


### PR DESCRIPTION
## Summary

This PR completes #2331 by collapsing the oversized frontend feature-constructor dependency surfaces that were left over from the earlier migration stages. Before this change, several feature factories still accepted long flat `*FeatureDeps` bags even though shared app state is now signal-backed and many panels already own their own reactive lifecycle. The result was that `app_feature_ports.ts` and `app_feature_bundle.ts` still spent a lot of code threading individual helpers, formatters, translation functions, and panel references into every feature, even when those values naturally belonged in a smaller shared bundle or in a more focused feature-specific group.

The goal here was not to remove dependency injection entirely. The goal was to keep the features independently testable while making the injected surface match the current architecture. After the signal-backed AppState and the panel ownership work, the remaining feature seams should mostly describe feature-local concerns: which state slices the feature reads, which panels it talks to, which outward ports it calls, and which shared services or formatters it still needs. This PR moves the codebase to that shape.

## Implementation approach

I kept the refactor deliberately scoped to dependency structure and port wiring. I did not try to take on the later `UiAppRuntime` simplification issue at the same time, and I did not broaden into unrelated presenter or workflow cleanup. The implementation was done in four coordinated parts:

1. reduce the old shared dependency base to the minimal cross-feature utilities that are still genuinely shared,
2. regroup feature constructor inputs into clearer buckets like `state`, `panels`, `ports`, `services`, and `formatting`,
3. simplify the app-level feature bundle so it mainly builds features and hands them the grouped inputs they need, and
4. update the direct-construction tests so they validate the new seam instead of pinning the old flat object shape.

That kept the refactor invasive enough to actually solve the issue, but bounded enough that it did not turn into a larger runtime-ownership rewrite.

## Main code changes

### Shared feature deps

`apps/ui/src/app/feature_deps_base.ts` is reduced to the small shared utility surface that still matters after the signal migration. The old broader base contract is replaced with `FeatureServices` and `FeatureFormatting`, which makes the remaining cross-feature dependencies explicit and reusable without pretending every feature needs the same giant flat bag.

As part of that cleanup, the dead `escapeHtml` dependency path is removed from the affected features and tests. At this point the touched surfaces render through Preact-owned views, so the old injected HTML-escaping helper was just leftover migration residue rather than a live business dependency.

### Bundle and port wiring

The old `app_feature_ports.ts` file is renamed and reduced into `app_feature_bundle_ports.ts`. The important change is not just the filename. The helper module is now the small pure port-assembly surface, while `app_feature_bundle.ts` becomes the place that actually constructs the feature graph. This keeps the port-helper tests from importing the entire runtime composition graph, and it makes the split between “build features” and “adapt feature methods into shell/startup ports” much clearer.

`app_feature_bundle.ts` now focuses on composing grouped inputs for each feature instead of repeating long flat constructor objects. The feature creation calls are still explicit, but they are materially less noisy because the shared services/formatting groups and grouped per-feature objects remove a lot of repetitive threading.

`ui_app_runtime.ts` was updated to pass the new grouped shared dependency shape into the bundle, but its external role remains the same. That is intentional: this PR simplifies the wiring without prematurely taking on the later runtime-thinning work tracked in #2332.

### Feature constructors

The touched feature factories now accept smaller, more meaningful dependency groups:

- `history_feature.ts` reads the shell state directly and consumes grouped `services` and `formatting`.
- `realtime_feature.ts` accepts grouped state, panels, ports, services, and formatting instead of one long mixed bag.
- `settings_feature.ts` and the related settings modules now separate panel ownership, outward ports, and shared helpers more cleanly.
- `cars_feature.ts`, `update_feature.ts`, and `esp_flash_feature.ts` follow the same direction so the surrounding bundle no longer has to thread a grab bag of unrelated values into each constructor.

The net result is that the feature deps are significantly smaller in the way the issue asked for, but the features are still independently constructible in tests.

## Test and validation updates

The direct-construction tests were the main blast radius because they intentionally instantiate features without the whole runtime. Those tests are exactly the right place to keep pressure on the constructor seam, so I updated them rather than weakening coverage.

The biggest test updates were in:

- `tests/app_feature_ports.spec.ts`
- `tests/history_feature_modules.spec.ts`
- `tests/settings_analysis_module.spec.ts`
- `tests/settings_cars_module.spec.ts`
- `tests/settings_speed_source_module_bindings.spec.ts`
- `tests/update_feature_bindings.spec.ts`
- `tests/esp_flash_feature_bindings.spec.ts`
- `tests/esp_flash_feature.spec.ts`

While doing that, one real testability issue showed up: once the pure helper exports lived in `app_feature_bundle.ts`, the helper spec started pulling in the full runtime graph and hit the JSON catalog import path from the Node-side Playwright environment. The fix was to keep the pure port helpers in the smaller `app_feature_bundle_ports.ts` module so the tests can import the seam they actually care about without dragging in the whole application graph. That change improved the code structure rather than just working around the test runner.

## Validation performed

Local validation is green with:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- targeted Playwright coverage for the feature-constructor and workflow surfaces touched by the refactor
- browser smoke coverage for bootstrap, history, settings, cars, update, and ESP flash using `.ai-temp/playwright.full.local.config.ts`

Lint still reports the same pre-existing Biome schema-version info and the unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`; this PR does not change that baseline.

I also ran a focused code-review pass over the final diff, and it did not surface any material bugs or missing follow-up work inside the chosen scope.

## Risks, tradeoffs, and out-of-scope items

The main risk in this PR was not logic correctness inside any one feature; it was wiring drift across many constructors and tests at once. That is why the validation mix intentionally covered both unit-style constructor tests and browser-level smoke across the affected surfaces. The tradeoff here is that `UiAppRuntime` still exists as a fairly explicit composition root, but that is the right stopping point for this issue. Shrinking the feature dependency seams first makes the later runtime simplification more mechanical and less risky.

I did not try to fold in later cleanup issues like deeper runtime thinning, presenter deletion, or more aggressive direct signal consumption in the views. Those remain better handled in their own follow-up issues now that the constructor and bundle seams are smaller and clearer.

Closes #2331
