### PR TITLE
Thin UiAppRuntime into a composition root

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -88,7 +88,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/ui_panel_host_registry.ts` | Centralized host registry for dashboard, history, and settings panel mount points so startup and tests stop depending on one host getter module per panel |
 | `app/ui_panel_bootstrap.ts` | Centralized host registry and panel-mount bootstrap for dashboard, history, and settings islands so startup/runtime stop wiring one host getter per panel |
 | `app/dom/` | Focused DOM lookup helpers that remain after the panel bootstrap cleanup, including `requiredById` and other non-panel runtime locators |
-| `app/ui_app_runtime.ts` | UI composition root that wires state, focused runtime controllers, explicit feature port bundles, and the startup coordinator |
+| `app/ui_app_runtime.ts` | Thin UI composition root that creates the shell, spectrum, transport, feature bundle, and startup coordinator from local helper wiring instead of deferred attachment seams |
 | `app/ui_app_state.ts` | Canonical AppState shape plus reactive slice helpers that keep object-style reads/writes working while shared shell/transport/realtime/history/settings/spectrum state becomes signal-observable |
 | `app/ui_signals.ts` | Canonical re-export surface for shared `signal`, `computed`, and `effect` usage across runtime, features, and views |
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, app-level error banner, and the top-level dashboard/history/settings view containers plus the typed shell bridge |
@@ -182,7 +182,9 @@ shell, and the per-settings-tab panel hosts. The spectrum island now owns the
 chart host refs internally and passes that typed bridge to the runtime.
 `app_feature_bundle.ts` creates the concrete features, wires explicit
 cross-feature ports, and returns only the shell, transport, and startup
-contracts the runtime needs. `ui_startup_coordinator.ts` then runs those
+contracts the runtime needs, while `ui_app_runtime.ts` uses local helper
+factories and constructor-time callbacks instead of late `attach*` calls.
+`ui_startup_coordinator.ts` then runs those
 startup-only ports from a small declarative sync/async plan instead of a
 handwritten boot call chain.
 

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -4,11 +4,10 @@ import {
   createSettingsFeatureRealtimePorts,
 } from "./app_feature_bundle_ports";
 import { createCarsFeature, type CarsFeature } from "./features/cars_feature";
-import { createEspFlashFeature, type EspFlashFeature } from "./features/esp_flash_feature";
-import { createHistoryFeature, type HistoryFeature } from "./features/history_feature";
+import { createEspFlashFeature } from "./features/esp_flash_feature";
+import { createHistoryFeature } from "./features/history_feature";
 import {
   createRealtimeFeature,
-  type RealtimeFeature,
   type RealtimeFeatureChromePorts,
   type RealtimeFeatureSelectionPorts,
 } from "./features/realtime_feature";
@@ -17,7 +16,7 @@ import {
   type SettingsFeature,
   type SettingsFeatureViewPorts,
 } from "./features/settings_feature";
-import { createUpdateFeature, type UpdateFeature } from "./features/update_feature";
+import { createUpdateFeature } from "./features/update_feature";
 import type { FeatureFormatting, FeatureServices } from "./feature_deps_base";
 import type { AppState } from "./ui_app_state";
 import { createUiCarCreationCommand } from "./runtime/ui_car_creation_command";

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -50,8 +50,11 @@ import type { VisualVariant } from "../view_style_types";
 type UiShellControllerDeps = {
   chrome: UiShellChromeView;
   chromeActions: UiShellChromeActionBridge;
+  featurePorts: () => UiShellFeaturePorts;
   liveOverview: RealtimeLiveOverviewBridge;
+  renderSpectrum: () => void;
   state: AppState;
+  updateSpectrumOverlay: () => void;
 };
 
 function normalizeBadgeVariant(variant: string): VisualVariant {
@@ -83,11 +86,7 @@ export class UiShellController {
 
   private readonly activeViewListeners = new Set<(viewId: string) => void>();
 
-  private ports: UiShellFeaturePorts | null = null;
-
-  private renderSpectrumChart: (() => void) | null = null;
-
-  private updateSpectrumOverlayState: (() => void) | null = null;
+  private readonly getFeaturePorts: () => UiShellFeaturePorts;
 
   private readonly liveStatusBadge = signal<UiShellBadgeModel>({
     text: "No live signal",
@@ -100,6 +99,7 @@ export class UiShellController {
     this.chrome = deps.chrome;
     this.appShellWrap = queryOne<HTMLElement>(".wrap");
     this.liveOverview = deps.liveOverview;
+    this.getFeaturePorts = deps.featurePorts;
     this.navigation = createUiShellNavigationModule({
       shell: this.state.shell,
       viewIds: SHELL_NAV_ITEMS.map((item) => item.viewId),
@@ -133,23 +133,11 @@ export class UiShellController {
       state: this.state,
       renderSpeedReadout: () => this.renderSpeedReadout(),
       renderWsState: () => this.renderWsState(),
-      renderSpectrum: () => this.renderSpectrumChart?.(),
-      updateSpectrumOverlay: () => this.updateSpectrumOverlayState?.(),
+      renderSpectrum: () => deps.renderSpectrum(),
+      updateSpectrumOverlay: () => deps.updateSpectrumOverlay(),
     });
     this.chromeRenderModel = this.createChromeRenderModel();
     this.bindReactiveStatusSync();
-  }
-
-  attachPorts(ports: UiShellFeaturePorts): void {
-    this.ports = ports;
-  }
-
-  attachSpectrumHooks(deps: {
-    renderSpectrum: () => void;
-    updateSpectrumOverlay: () => void;
-  }): void {
-    this.renderSpectrumChart = deps.renderSpectrum;
-    this.updateSpectrumOverlayState = deps.updateSpectrumOverlay;
   }
 
   t(key: string, vars?: Record<string, unknown>): string {
@@ -205,7 +193,7 @@ export class UiShellController {
   applyLanguage(forceReloadInsights = false): void {
     setUiLanguage(this.state.shell.lang);
     this.languageRefresh.applyLanguage(
-      this.requirePorts().languageRefresh,
+      this.getFeaturePorts().languageRefresh,
       forceReloadInsights,
     );
   }
@@ -221,7 +209,7 @@ export class UiShellController {
   }
 
   private bindFeatureEvents(): void {
-    bindUiShellFeatureEvents(this.requirePorts());
+    bindUiShellFeatureEvents(this.getFeaturePorts());
   }
 
   private bindReactiveStatusSync(): void {
@@ -271,12 +259,5 @@ export class UiShellController {
         wsLinkState: this.status.wsLinkState.value,
       };
     });
-  }
-
-  private requirePorts(): UiShellFeaturePorts {
-    if (this.ports === null) {
-      throw new Error("UiShellController ports used before initialization");
-    }
-    return this.ports;
   }
 }

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -1,7 +1,8 @@
 import { fmt, fmtTs } from "../format";
 import {
   createAppFeatureBundle,
-  type AppFeatureBundle,
+  type AppFeatureBundleRuntimePorts,
+  type AppFeatureBundleSharedDeps,
 } from "./app_feature_bundle";
 import type { AppState } from "./ui_app_state";
 import { createAppState } from "./ui_app_state";
@@ -16,6 +17,7 @@ import { UiShellController } from "./runtime/ui_shell_controller";
 import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
 import { UiStartupCoordinator } from "./runtime/ui_startup_coordinator";
 import type { UiMountedPanels } from "./ui_panel_bootstrap";
+import type { UiShellFeaturePorts } from "./runtime/ui_shell_feature_ports";
 
 export interface UiAppRuntimeDeps {
   shellChrome: UiShellChromeView;
@@ -24,80 +26,107 @@ export interface UiAppRuntimeDeps {
   shellChromeActions?: UiShellChromeActionBridge;
 }
 
+function requireUiRuntimeDependency<T>(value: T | null, name: string): T {
+  if (value === null) {
+    throw new Error(`UiAppRuntime ${name} used before initialization`);
+  }
+  return value;
+}
+
+function createUiAppSharedDeps(
+  shell: UiShellController,
+): AppFeatureBundleSharedDeps {
+  return {
+    services: {
+      t: (key, vars) => shell.t(key, vars),
+      showError: (message) => shell.showError(message),
+    },
+    formatting: {
+      fmt,
+      fmtTs,
+      formatInt: (value) => shell.localFormatInt(value),
+    },
+  };
+}
+
+function createUiAppFeatureRuntimePorts(deps: {
+  panels: UiMountedPanels;
+  shell: UiShellController;
+  spectrum: UiSpectrumController;
+  transport: UiLiveTransportController;
+}): AppFeatureBundleRuntimePorts {
+  const {
+    panels,
+    shell,
+    spectrum,
+    transport,
+  } = deps;
+  return {
+    panels,
+    navigation: {
+      activatePrimaryView: (viewId) => shell.setActiveView(viewId),
+      subscribeActiveViewChanges: (listener) =>
+        shell.subscribeActiveViewChanges(listener),
+    },
+    realtimeChrome: {
+      setShellLiveStatus: (variant, text) =>
+        shell.setLiveStatus(variant, text),
+    },
+    view: {
+      renderSpectrum: () => spectrum.renderSpectrum(),
+      renderSpeedReadout: () => shell.renderSpeedReadout(),
+    },
+    transport: {
+      sendSelection: () => transport.sendSelection(),
+    },
+  };
+}
+
 export class UiAppRuntime {
-  private readonly state: AppState;
-
-  private readonly featurePorts: AppFeatureBundle;
-
-  private readonly shell: UiShellController;
-
-  private readonly spectrum: UiSpectrumController;
-
-  private readonly transport: UiLiveTransportController;
-
   private readonly startup: UiStartupCoordinator;
 
   constructor(deps: UiAppRuntimeDeps) {
-    this.state = deps.state ?? createAppState();
+    const state = deps.state ?? createAppState();
     const shellChromeActions =
       deps.shellChromeActions ?? createUiShellChromeActionBridge();
-    this.shell = new UiShellController({
-      state: this.state,
+    let spectrum: UiSpectrumController | null = null;
+    let shellFeaturePorts: UiShellFeaturePorts | null = null;
+    const shell = new UiShellController({
+      state,
       chrome: deps.shellChrome,
       chromeActions: shellChromeActions,
       liveOverview: deps.panels.dashboard.liveOverview,
+      featurePorts: () =>
+        requireUiRuntimeDependency(shellFeaturePorts, "shell feature ports"),
+      renderSpectrum: () =>
+        requireUiRuntimeDependency(spectrum, "spectrum controller").renderSpectrum(),
+      updateSpectrumOverlay: () =>
+        requireUiRuntimeDependency(spectrum, "spectrum controller").updateSpectrumOverlay(),
     });
-    this.spectrum = new UiSpectrumController({
-      state: this.state,
+    spectrum = new UiSpectrumController({
+      state,
       panel: deps.panels.dashboard.spectrum,
-      t: (key, vars) => this.shell.t(key, vars),
+      t: (key, vars) => shell.t(key, vars),
     });
-    this.shell.attachSpectrumHooks({
-      renderSpectrum: () => this.spectrum.renderSpectrum(),
-      updateSpectrumOverlay: () => this.spectrum.updateSpectrumOverlay(),
+    const transport = new UiLiveTransportController({
+      state,
+      payloadErrorMessage: () => shell.t("ws.payload_error"),
     });
-    this.transport = new UiLiveTransportController({
-      state: this.state,
-      payloadErrorMessage: () => this.shell.t("ws.payload_error"),
-    });
-    this.featurePorts = createAppFeatureBundle({
-      state: this.state,
-      shared: {
-        services: {
-          t: (key, vars) => this.shell.t(key, vars),
-          showError: (message) => this.shell.showError(message),
-        },
-        formatting: {
-          fmt,
-          fmtTs,
-          formatInt: (value) => this.shell.localFormatInt(value),
-        },
-      },
-      runtime: {
+    const featurePorts = createAppFeatureBundle({
+      state,
+      shared: createUiAppSharedDeps(shell),
+      runtime: createUiAppFeatureRuntimePorts({
         panels: deps.panels,
-        navigation: {
-          activatePrimaryView: (viewId) => this.shell.setActiveView(viewId),
-          subscribeActiveViewChanges: (listener) =>
-            this.shell.subscribeActiveViewChanges(listener),
-        },
-        realtimeChrome: {
-          setShellLiveStatus: (variant, text) =>
-            this.shell.setLiveStatus(variant, text),
-        },
-        view: {
-          renderSpectrum: () => this.spectrum.renderSpectrum(),
-          renderSpeedReadout: () => this.shell.renderSpeedReadout(),
-        },
-        transport: {
-          sendSelection: () => this.transport.sendSelection(),
-        },
-      },
+        shell,
+        spectrum,
+        transport,
+      }),
     });
-    this.shell.attachPorts(this.featurePorts.shell);
+    shellFeaturePorts = featurePorts.shell;
     this.startup = new UiStartupCoordinator({
-      shell: this.shell,
-      transport: this.transport,
-      features: this.featurePorts.startup,
+      shell,
+      transport,
+      features: featurePorts.startup,
       defaultViewId: DEFAULT_SHELL_VIEW_ID,
     });
   }


### PR DESCRIPTION
## Summary

This PR completes #2332 by thinning `UiAppRuntime` down from a late-binding wiring hub into a clearer composition root. Before this change, the runtime constructed the shell, spectrum controller, transport controller, and feature bundle, but it also had to finish the shell setup afterward through two explicit attachment steps: `attachSpectrumHooks()` and `attachPorts()`. Those APIs were leftovers from an earlier phase when the runtime still needed to stitch controllers together after construction. With the signal-backed state work and the later feature/panel refactors now merged, those deferred attachment seams were no longer earning their complexity.

The key problem was not raw line count. The real issue was that `UiAppRuntime` still encoded construction order through late mutation. The shell controller could exist in a partially initialized state, with feature ports and spectrum hooks arriving later through imperative attachment calls. That made the startup path harder to reason about and kept `UiAppRuntime` feeling like a cross-wiring hub instead of a focused place that constructs the runtime graph once and then hands startup over to the coordinator.

## Implementation approach

I kept the refactor intentionally narrow. I did not try to redesign startup, remove the startup coordinator, or restructure the broader feature bundle created in #2331. The selected cut was:

1. delete the shell controller’s deferred attachment APIs,
2. replace them with constructor-time callbacks so the controller always receives its runtime dependencies through one consistent path,
3. shrink `UiAppRuntime` so it keeps only the startup coordinator as persistent state, and
4. extract the inline shared-deps and runtime-port assembly into local helper functions so the constructor reads like a composition sequence instead of a long block of ad hoc wiring.

That solves the actual issue without drifting into later cleanup work.

## Main code changes

### `UiShellController`

The largest behavior change is in `apps/ui/src/app/runtime/ui_shell_controller.ts`.

Previously, the shell controller carried three late-bound pieces of state:

- `ports`
- `renderSpectrumChart`
- `updateSpectrumOverlayState`

Those were populated after construction by `attachPorts()` and `attachSpectrumHooks()`, and the shell guarded some of that access through `requirePorts()`.

This PR removes that pattern entirely. The shell controller now receives constructor-time callbacks for:

- feature ports,
- spectrum rendering, and
- spectrum overlay refresh.

The language refresh module is built from those constructor callbacks directly, and the shell’s event binding and language refresh paths now call the provided feature-port accessor instead of consulting a mutable field that is populated later. As a result, `attachPorts()`, `attachSpectrumHooks()`, and `requirePorts()` are all deleted.

That is the main architectural win in this PR: the shell no longer has a special “constructed but not fully wired yet” state managed through ad hoc methods.

### `UiAppRuntime`

`apps/ui/src/app/ui_app_runtime.ts` now behaves more like a true composition root.

The class used to store the app state, feature bundle, shell controller, spectrum controller, transport controller, and startup coordinator as instance fields, even though only the startup coordinator was actually needed after construction. The refactor removes that unnecessary retained state. `UiAppRuntime` now keeps only the startup coordinator and uses local constructor variables for the rest.

I also extracted two local helper factories:

- `createUiAppSharedDeps()`
- `createUiAppFeatureRuntimePorts()`

These are small, but they matter because they pull the repetitive callback assembly out of the middle of the constructor. The constructor now reads as a straight sequence:

1. create state and shell chrome actions,
2. create the shell,
3. create the spectrum controller,
4. create the transport controller,
5. create the feature bundle from shared deps and runtime ports, and
6. create the startup coordinator.

That is still explicit wiring, but it is now composition-root wiring rather than “construct, attach, attach again, then continue.”

To preserve the clear initialization guarantees that the old `requirePorts()` path provided, the runtime uses a small local `requireUiRuntimeDependency()` helper when a closure might reference a dependency before assignment. In practice those callbacks are not exercised until startup begins, after the dependencies are initialized, but the guard keeps the ordering contract explicit instead of relying on silent `undefined` behavior.

### `app_feature_bundle.ts`

The only code change here is a follow-up cleanup caused by the runtime refactor and validation. The final lint pass surfaced a few stale type-only imports that were no longer used after the runtime helper extraction, so those were removed.

This file’s role stays the same: it creates the feature graph and exposes the runtime-facing shell/startup contracts. I intentionally kept the broader #2331 bundle shape intact rather than mixing both issues together.

### Documentation

`apps/ui/README.md` now describes `ui_app_runtime.ts` as a thin composition root built from local helper wiring rather than a place that still depends on deferred attachment seams. The runtime architecture section also now calls out that the runtime uses constructor-time callbacks instead of late `attach*` calls. That keeps the architecture notes aligned with the live code.

## Validation performed

Local validation is green with:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.settings.spec.ts tests/smoke.spectrum.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

Lint still reports the same pre-existing Biome schema-version info and the unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`; this PR does not change that baseline.

I also ran a focused code-review pass on the final runtime diff. It did not surface any material regressions. The main concern to check was startup ordering after removing the late attachment calls, and the final cut preserves that ordering by constructing the controllers in the same sequence and keeping the guarded callback access local to the composition root.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that `UiAppRuntime` is still an explicit composition root rather than becoming a factory-free shell around a single helper. That is intentional. The issue asked to make it a focused composition root, not to erase explicit runtime wiring entirely. The current result is easier to follow without hiding the important startup dependencies behind indirection.

I also did not broaden this PR into deeper runtime simplification beyond the late attachment seams. For example, I did not try to collapse the startup coordinator into the runtime, redesign the feature bundle, or revisit controller boundaries that are better handled by later issues. Those would have expanded the change well beyond the smallest complete fix.

The main correctness risk was accidentally changing when the shell first gains access to feature ports or spectrum refresh behavior. That is why the refactor keeps the same overall construction order and uses guarded constructor callbacks instead of mutable post-construction attachment. The callbacks are available when startup begins, but the shell no longer needs special APIs to receive them after the fact.

Closes #2332
