### PR TITLE
Make polling lifecycle reactive to view context

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -95,14 +95,14 @@ source-of-truth export commands remain the only writers for those files.
 | `app/runtime/ui_shell_controller.ts` | Menu/view shell, language and preference hydration, and the reactive shell-chrome model that feeds header pills, feedback, and app-level banners |
 | `app/runtime/ui_live_transport_controller.ts` | Demo/WebSocket transport coordinator that queues payloads through AppState, throttles live-session adaptation, and lets realtime, shell, and spectrum surfaces react from signal-backed state |
 | `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that wires overlay updates plus the extracted canvas, interaction, and panel modules |
-| `app/runtime/ui_startup_coordinator.ts` | Declarative startup-task runner that lets the shell own its initial bind/language/view boot while startup loads, polling, and transport start from a named sync/async plan |
-| `app/runtime/ui_startup_feature_ports.ts` | Narrow startup-only feature contract for initial refresh/load work and long-lived polling starts |
+| `app/runtime/ui_startup_coordinator.ts` | Declarative startup-task runner that lets the shell own its initial bind/language/view boot while startup loads and transport start from a named sync/async plan |
+| `app/runtime/ui_startup_feature_ports.ts` | Narrow startup-only feature contract for initial refresh/load work |
 | `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, tweening, and canvas draw plugin orchestration |
 | `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports |
 | `app/runtime/spectrum_panel_view.ts` | Typed spectrum panel contract for the signal-backed legend, band legend, inspector, band-toggle, and chart-host refs |
 | `app/app_feature_bundle.ts` | Creates concrete feature instances, then exposes explicit shell, transport, and startup port bundles back to the runtime |
 | `app/features/` | Feature owners for state changes, API calls, shared polling control, and typed actions emitted from local view surfaces |
-| `app/features/esp_flash_feature.ts` | Thin ESP flash facade that wires the workflow, presenter, and typed island action bridge together |
+| `app/features/esp_flash_feature.ts` | Thin ESP flash facade that wires the workflow, presenter, typed island action bridge, and settings-view polling context together |
 | `app/features/esp_flash_feature_workflow.ts` | DOM-free ESP flash workflow/controller for port refreshes, flash status polling, log/history hydration, and start/cancel orchestration |
 | `app/features/cars_feature.ts` | Thin car-wizard facade that wires the DOM-free workflow plus island-owned wizard DOM adapter into typed wizard actions |
 | `app/features/cars_feature_transport.ts` | Car-library transport wrapper for loading wizard brands, types, and models through the UI API facade |
@@ -125,7 +125,7 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/cars_panel.tsx` | Signal-backed Preact owner for the full car-management surface; it renders saved-car guidance/list rows plus the full add-car wizard in JSX, owns wizard focus/return-focus/scroll lifecycle locally, and exposes typed list and wizard bridges |
 | `app/views/cars_feature_presenter.ts` | Thin car-wizard presenter that turns workflow state into typed wizard render models and delegates focus/manual-input access through the island bridge |
 | `app/views/car_wizard_view.ts` | Typed add-car wizard render-model builders for progress, option sections, selected specs, and summary rows reused by the Preact car-management island |
-| `app/features/update_feature.ts` | Thin update facade that binds typed island actions, delegates island render-model updates to the presenter, and delegates update commands to the workflow |
+| `app/features/update_feature.ts` | Thin update facade that binds typed island actions, delegates island render-model updates to the presenter, and derives update/internet polling context from the shell and settings tab state |
 | `app/features/update_feature_workflow.ts` | DOM-free update workflow/controller for update polling, internet-status normalization, and start/cancel command orchestration |
 | `app/features/history_feature.ts` | Single owner for history refresh, expanded-run/detail state, download/delete actions, collapsed-preview prefetch, and the typed panel render model |
 | `app/features/history_download.ts` | Focused blob-download helper for the history PDF/report flow |
@@ -185,8 +185,9 @@ cross-feature ports, and returns only the shell, transport, and startup
 contracts the runtime needs, while `ui_app_runtime.ts` uses local helper
 factories and constructor-time callbacks instead of late `attach*` calls.
 `ui_startup_coordinator.ts` then runs those
-startup-only ports from a small declarative sync/async plan instead of a
-handwritten boot call chain.
+startup-only load/refresh ports from a small declarative sync/async plan
+instead of a handwritten boot call chain, while long-lived update, ESP flash,
+and GPS-status polling now start and stop from feature-owned reactive context.
 
 The live UI architecture is now fully Preact for every page, tab, and
 feature surface.

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -32,6 +32,7 @@ export interface AppFeatureBundleRuntimePorts {
   panels: UiMountedPanels;
   navigation: {
     activatePrimaryView(viewId: string): void;
+    getActiveViewId(): string;
     subscribeActiveViewChanges(listener: (viewId: string) => void): () => void;
   };
   realtimeChrome: Pick<RealtimeFeatureChromePorts, "setShellLiveStatus">;
@@ -112,6 +113,7 @@ export function createAppFeatureBundle(
       openCarWizard: () => {
         carsFeature?.openWizard();
       },
+      getActiveViewId: runtime.navigation.getActiveViewId,
       subscribePrimaryViewChanges: runtime.navigation.subscribeActiveViewChanges,
       view: runtime.view,
     },
@@ -149,10 +151,22 @@ export function createAppFeatureBundle(
       update: panels.settings.update,
       internet: panels.settings.internet,
     },
+    ports: {
+      getActiveSettingsTabId: () => panels.settingsShell.getActiveTabId(),
+      getActiveViewId: runtime.navigation.getActiveViewId,
+      subscribePrimaryViewChanges: runtime.navigation.subscribeActiveViewChanges,
+      subscribeSettingsTabChanges: panels.settingsShell.subscribeActiveTabChanges,
+    },
     services,
   });
   const espFlash = createEspFlashFeature({
     panel: panels.settings.espFlash,
+    ports: {
+      getActiveSettingsTabId: () => panels.settingsShell.getActiveTabId(),
+      getActiveViewId: runtime.navigation.getActiveViewId,
+      subscribePrimaryViewChanges: runtime.navigation.subscribeActiveViewChanges,
+      subscribeSettingsTabChanges: panels.settingsShell.subscribeActiveTabChanges,
+    },
     services,
   });
 

--- a/apps/ui/src/app/app_feature_bundle_ports.ts
+++ b/apps/ui/src/app/app_feature_bundle_ports.ts
@@ -31,11 +31,10 @@ interface AppFeatureBundlePortSources {
     | "loadSpeedSourceFromServer"
     | "loadAnalysisSettingsFromServer"
     | "loadCarsFromServer"
-    | "startGpsStatusPolling"
   >;
   cars: Pick<CarsFeature, "bindWizardHandlers">;
-  update: Pick<UpdateFeature, "bindUpdateHandlers" | "startPolling">;
-  espFlash: Pick<EspFlashFeature, "bindHandlers" | "startPolling">;
+  update: Pick<UpdateFeature, "bindUpdateHandlers">;
+  espFlash: Pick<EspFlashFeature, "bindHandlers">;
 }
 
 export function createRealtimeFeatureRecordingPorts(
@@ -84,13 +83,6 @@ export function createAppFeatureBundlePorts(
         loadAnalysisSettingsFromServer: () =>
           features.settings.loadAnalysisSettingsFromServer(),
         loadCarsFromServer: () => features.settings.loadCarsFromServer(),
-        startGpsStatusPolling: () => features.settings.startGpsStatusPolling(),
-      },
-      update: {
-        startPolling: () => features.update.startPolling(),
-      },
-      espFlash: {
-        startPolling: () => features.espFlash.startPolling(),
       },
     },
   };

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -1,10 +1,19 @@
+import { computed, effect, signal } from "../ui_signals";
 import type { FeatureServices } from "../feature_deps_base";
 import { createEspFlashFeatureWorkflow } from "./esp_flash_feature_workflow";
 import { createEspFlashFeaturePresenter } from "../views/esp_flash_feature_presenter";
 import type { EspFlashPanelView } from "../views/esp_flash_panel";
 
+interface EspFlashFeaturePorts {
+  getActiveSettingsTabId: () => string;
+  getActiveViewId: () => string;
+  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
+  subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
+}
+
 export interface EspFlashFeatureDeps {
   panel: EspFlashPanelView;
+  ports: EspFlashFeaturePorts;
   services: FeatureServices;
 }
 
@@ -14,10 +23,21 @@ export interface EspFlashFeature {
   stopPolling(): void;
 }
 
+function isEspFlashPollingContext(viewId: string, tabId: string): boolean {
+  return viewId === "settingsView" && tabId === "espFlashTab";
+}
+
 export function createEspFlashFeature(
   ctx: EspFlashFeatureDeps,
 ): EspFlashFeature {
-  const { panel, services } = ctx;
+  const { panel, ports, services } = ctx;
+  const handlersBound = signal(false);
+  const activeViewId = signal(ports.getActiveViewId());
+  const activeSettingsTabId = signal(ports.getActiveSettingsTabId());
+  const pollingEnabled = computed(() =>
+    handlersBound.value
+    && isEspFlashPollingContext(activeViewId.value, activeSettingsTabId.value)
+  );
   const presenter = createEspFlashFeaturePresenter({
     panel,
     t: services.t,
@@ -26,14 +46,30 @@ export function createEspFlashFeature(
     t: services.t,
     showError: services.showError,
     view: presenter,
+    pollingEnabled,
   });
-  let handlersBound = false;
+
+  ports.subscribePrimaryViewChanges((viewId) => {
+    activeViewId.value = viewId;
+  });
+  ports.subscribeSettingsTabChanges((tabId) => {
+    activeSettingsTabId.value = tabId;
+  });
+
+  let wasPollingEnabled = false;
+  effect(() => {
+    const enabled = pollingEnabled.value;
+    if (enabled && !wasPollingEnabled) {
+      void workflow.refreshPorts();
+    }
+    wasPollingEnabled = enabled;
+  });
 
   function bindHandlers(): void {
-    if (handlersBound) {
+    if (handlersBound.value) {
       return;
     }
-    handlersBound = true;
+    handlersBound.value = true;
     panel.bindActions({
       onStart: () => {
         void workflow.startFlash();

--- a/apps/ui/src/app/features/esp_flash_feature_workflow.ts
+++ b/apps/ui/src/app/features/esp_flash_feature_workflow.ts
@@ -18,6 +18,7 @@ import type {
   EspSerialPortPayload,
 } from "../../transport/http_models";
 import type { EspFlashFeatureRenderState } from "../views/esp_flash_feature_presenter";
+import type { ReadonlySignal } from "../ui_signals";
 import {
   createPollingController,
   type PollingController,
@@ -43,6 +44,7 @@ export interface EspFlashFeatureWorkflowDeps {
   view: EspFlashFeatureWorkflowViewPorts;
   api?: Partial<EspFlashFeatureWorkflowApi>;
   createPollingController?: (options: PollingControllerOptions) => PollingController;
+  pollingEnabled?: ReadonlySignal<boolean>;
 }
 
 export interface EspFlashFeatureWorkflow {
@@ -183,6 +185,7 @@ export function createEspFlashFeatureWorkflow(
   }
 
   const polling = createPolling({
+    enabled: deps.pollingEnabled,
     poll: async () => {
       await refreshStatus();
       return safeEspFlashState(latestStatus.state) === "running"

--- a/apps/ui/src/app/features/polling_controller.ts
+++ b/apps/ui/src/app/features/polling_controller.ts
@@ -1,3 +1,5 @@
+import { effect, type ReadonlySignal } from "../ui_signals";
+
 export interface PollingController {
   start(): void;
   stop(): void;
@@ -5,6 +7,7 @@ export interface PollingController {
 }
 
 export interface PollingControllerOptions {
+  enabled?: ReadonlySignal<boolean>;
   poll: () => Promise<number>;
   onErrorDelayMs: number;
 }
@@ -12,7 +15,7 @@ export interface PollingControllerOptions {
 export function createPollingController(
   options: PollingControllerOptions,
 ): PollingController {
-  const { poll, onErrorDelayMs } = options;
+  const { enabled, poll, onErrorDelayMs } = options;
 
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
   let pollGeneration = 0;
@@ -57,6 +60,16 @@ export function createPollingController(
     pollingActive = false;
     pollGeneration += 1;
     clearPollTimer();
+  }
+
+  if (enabled) {
+    effect(() => {
+      if (enabled.value) {
+        start();
+        return;
+      }
+      stop();
+    });
   }
 
   return {

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -37,6 +37,7 @@ interface SettingsFeaturePanelDeps {
 
 interface SettingsFeaturePortDeps {
   openCarWizard: () => void;
+  getActiveViewId: () => string;
   subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
   view: SettingsFeatureViewPorts;
 }
@@ -66,8 +67,6 @@ export interface SettingsFeature {
   showCarCreationSuccess(carId: string, carName: string): void;
   saveAnalysisFromInputs(): void;
   saveSpeedSourceFromInputs(): void;
-  startGpsStatusPolling(): void;
-  stopGpsStatusPolling(): void;
 }
 
 export function createSettingsFeature(
@@ -122,8 +121,13 @@ export function createSettingsFeature(
       formatting,
       getSpeedUnit: () => ctx.state.shell.speedUnit,
       ports: {
+        getActiveSettingsTabId: () => ctx.panels.settingsShell.getActiveTabId(),
+        getActiveViewId: ctx.ports.getActiveViewId,
         syncSpeedSourceSelectionUi: speedSourceModule.syncSpeedSourceSelectionUi,
         renderSpeedReadout: ctx.ports.view.renderSpeedReadout,
+        subscribePrimaryViewChanges: ctx.ports.subscribePrimaryViewChanges,
+        subscribeSettingsTabChanges:
+          ctx.panels.settingsShell.subscribeActiveTabChanges,
       },
     });
   carsModule = createSettingsCarsModule({
@@ -153,12 +157,21 @@ export function createSettingsFeature(
     carsModule.bindHandlers();
     analysisModule.bindHandlers();
     speedSourceModule.bindHandlers();
+    gpsStatusModule.bindHandlers();
+  }
+
+  async function loadSpeedSourceFromServer(): Promise<void> {
+    try {
+      await speedSourceModule.loadSpeedSourceFromServer();
+    } finally {
+      gpsStatusModule.markStartupReady();
+    }
   }
 
   return {
     bindHandlers,
     syncSettingsInputs: analysisModule.syncSettingsInputs,
-    loadSpeedSourceFromServer: speedSourceModule.loadSpeedSourceFromServer,
+    loadSpeedSourceFromServer,
     loadAnalysisSettingsFromServer:
       analysisModule.loadAnalysisSettingsFromServer,
     loadCarsFromServer: carsModule.loadCarsFromServer,
@@ -172,7 +185,5 @@ export function createSettingsFeature(
     },
     saveAnalysisFromInputs: analysisModule.saveAnalysisFromInputs,
     saveSpeedSourceFromInputs: speedSourceModule.saveSpeedSourceFromInputs,
-    startGpsStatusPolling: gpsStatusModule.startGpsStatusPolling,
-    stopGpsStatusPolling: gpsStatusModule.stopGpsStatusPolling,
   };
 }

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -2,6 +2,7 @@ import { getSettingsObdStatus, getSpeedSourceStatus } from "../../api";
 import { GPS_POLL_FAST_MS, GPS_POLL_SLOW_MS } from "../../config";
 import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import type { SettingsState } from "../ui_app_state";
+import { computed, signal } from "../ui_signals";
 import type { SpeedSourcePanelView } from "../views/speed_source_panel";
 import {
   buildSpeedSourceDiagnosticsRenderModel,
@@ -10,8 +11,12 @@ import {
 import { createPollingController } from "./polling_controller";
 
 interface SettingsGpsStatusModulePorts {
+  getActiveSettingsTabId: () => string;
+  getActiveViewId: () => string;
   syncSpeedSourceSelectionUi: () => void;
   renderSpeedReadout: () => void;
+  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
+  subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
 }
 
 export interface SettingsGpsStatusModuleDeps {
@@ -24,21 +29,44 @@ export interface SettingsGpsStatusModuleDeps {
 }
 
 export interface SettingsGpsStatusModule {
-  startGpsStatusPolling(): void;
-  stopGpsStatusPolling(): void;
+  bindHandlers(): void;
+  markStartupReady(): void;
 }
 
 export function createSettingsGpsStatusModule(
   ctx: SettingsGpsStatusModuleDeps,
 ): SettingsGpsStatusModule {
   const { panel, settings } = ctx;
+  const handlersBound = signal(false);
+  const startupReady = signal(false);
+  const activeViewId = signal(ctx.ports.getActiveViewId());
+  const activeSettingsTabId = signal(ctx.ports.getActiveSettingsTabId());
   const presenterDeps: SettingsSpeedSourcePresenterDeps = {
     fmt: ctx.formatting.fmt,
     getSpeedUnit: ctx.getSpeedUnit,
     t: ctx.services.t,
   };
+  const pollingEnabled = computed(() =>
+    handlersBound.value
+    && startupReady.value
+    && (
+      activeViewId.value === "dashboardView"
+      || (
+        activeViewId.value === "settingsView"
+        && activeSettingsTabId.value === "speedSourceTab"
+      )
+    )
+  );
 
-  const polling = createPollingController({
+  ctx.ports.subscribePrimaryViewChanges((viewId) => {
+    activeViewId.value = viewId;
+  });
+  ctx.ports.subscribeSettingsTabChanges((tabId) => {
+    activeSettingsTabId.value = tabId;
+  });
+
+  createPollingController({
+    enabled: pollingEnabled,
     poll: async () => {
       const shouldLoadObdStatus =
         settings.speedSource === "obd2" || settings.obdDeviceMac != null;
@@ -61,16 +89,12 @@ export function createSettingsGpsStatusModule(
     onErrorDelayMs: GPS_POLL_SLOW_MS,
   });
 
-  function startGpsStatusPolling(): void {
-    polling.start();
-  }
-
-  function stopGpsStatusPolling(): void {
-    polling.stop();
-  }
-
   return {
-    startGpsStatusPolling,
-    stopGpsStatusPolling,
+    bindHandlers(): void {
+      handlersBound.value = true;
+    },
+    markStartupReady(): void {
+      startupReady.value = true;
+    },
   };
 }

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -1,3 +1,4 @@
+import { computed, signal } from "../ui_signals";
 import type { FeatureServices } from "../feature_deps_base";
 import { createUpdateFeatureWorkflow } from "./update_feature_workflow";
 import { createUpdateFeaturePresenter } from "../views/update_feature_presenter";
@@ -9,8 +10,16 @@ interface UpdateFeaturePanels {
   internet: InternetPanelView;
 }
 
+interface UpdateFeaturePorts {
+  getActiveSettingsTabId: () => string;
+  getActiveViewId: () => string;
+  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
+  subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
+}
+
 export interface UpdateFeatureDeps {
   panels: UpdateFeaturePanels;
+  ports: UpdateFeaturePorts;
   services: FeatureServices;
 }
 
@@ -20,8 +29,19 @@ export interface UpdateFeature {
   stopPolling(): void;
 }
 
+function isUpdatePollingContext(viewId: string, tabId: string): boolean {
+  return viewId === "settingsView" && (tabId === "internetTab" || tabId === "updateTab");
+}
+
 export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
-  const { panels, services } = ctx;
+  const { panels, ports, services } = ctx;
+  const handlersBound = signal(false);
+  const activeViewId = signal(ports.getActiveViewId());
+  const activeSettingsTabId = signal(ports.getActiveSettingsTabId());
+  const pollingEnabled = computed(() =>
+    handlersBound.value
+    && isUpdatePollingContext(activeViewId.value, activeSettingsTabId.value)
+  );
   const presenter = createUpdateFeaturePresenter({
     panel: panels.update,
     internetPanel: panels.internet,
@@ -31,14 +51,21 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
     t: services.t,
     showError: services.showError,
     view: presenter,
+    pollingEnabled,
   });
-  let handlersBound = false;
+
+  ports.subscribePrimaryViewChanges((viewId) => {
+    activeViewId.value = viewId;
+  });
+  ports.subscribeSettingsTabChanges((tabId) => {
+    activeSettingsTabId.value = tabId;
+  });
 
   function bindUpdateHandlers(): void {
-    if (handlersBound) {
+    if (handlersBound.value) {
       return;
     }
-    handlersBound = true;
+    handlersBound.value = true;
     panels.update.bindActions({
       onStart: () => {
         workflow.renderCurrentState();

--- a/apps/ui/src/app/features/update_feature_workflow.ts
+++ b/apps/ui/src/app/features/update_feature_workflow.ts
@@ -19,6 +19,7 @@ import type {
   UpdateFeatureRenderState,
   UpdateFeatureStartIntent,
 } from "../views/update_feature_presenter";
+import type { ReadonlySignal } from "../ui_signals";
 import {
   createPollingController,
   type PollingController,
@@ -45,6 +46,7 @@ export interface UpdateFeatureWorkflowDeps {
   view: UpdateFeatureWorkflowViewPorts;
   api?: Partial<UpdateFeatureWorkflowApi>;
   createPollingController?: (options: PollingControllerOptions) => PollingController;
+  pollingEnabled?: ReadonlySignal<boolean>;
 }
 
 export interface UpdateFeatureWorkflow {
@@ -169,6 +171,7 @@ export function createUpdateFeatureWorkflow(
   }
 
   const polling = createPolling({
+    enabled: deps.pollingEnabled,
     poll: async () => {
       const snapshot = await fetchStatusSnapshot();
       applyStatusSnapshot(snapshot);

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -180,6 +180,10 @@ export class UiShellController {
     };
   }
 
+  getActiveViewId(): string {
+    return this.state.shell.activeViewId;
+  }
+
   setActiveView(viewId: string): void {
     const previousViewId = this.state.shell.activeViewId;
     this.navigation.setActiveView(viewId);

--- a/apps/ui/src/app/runtime/ui_startup_coordinator.ts
+++ b/apps/ui/src/app/runtime/ui_startup_coordinator.ts
@@ -74,9 +74,6 @@ export class UiStartupCoordinator {
         () => this.shell.start(this.defaultViewId),
       ],
       finalSyncTasks: [
-        () => this.features.update.startPolling(),
-        () => this.features.espFlash.startPolling(),
-        () => this.features.settings.startGpsStatusPolling(),
         () => this.transport.startTransportMode(),
       ],
       asyncTasks: [

--- a/apps/ui/src/app/runtime/ui_startup_feature_ports.ts
+++ b/apps/ui/src/app/runtime/ui_startup_feature_ports.ts
@@ -1,8 +1,6 @@
-import type { EspFlashFeature } from "../features/esp_flash_feature";
 import type { HistoryFeature } from "../features/history_feature";
 import type { RealtimeFeature } from "../features/realtime_feature";
 import type { SettingsFeature } from "../features/settings_feature";
-import type { UpdateFeature } from "../features/update_feature";
 
 export interface UiStartupFeaturePorts {
   history: Pick<HistoryFeature, "refreshHistory">;
@@ -12,8 +10,5 @@ export interface UiStartupFeaturePorts {
     | "loadSpeedSourceFromServer"
     | "loadAnalysisSettingsFromServer"
     | "loadCarsFromServer"
-    | "startGpsStatusPolling"
   >;
-  update: Pick<UpdateFeature, "startPolling">;
-  espFlash: Pick<EspFlashFeature, "startPolling">;
 }

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -65,6 +65,7 @@ function createUiAppFeatureRuntimePorts(deps: {
     panels,
     navigation: {
       activatePrimaryView: (viewId) => shell.setActiveView(viewId),
+      getActiveViewId: () => shell.getActiveViewId(),
       subscribeActiveViewChanges: (listener) =>
         shell.subscribeActiveViewChanges(listener),
     },

--- a/apps/ui/src/app/views/settings_shell.tsx
+++ b/apps/ui/src/app/views/settings_shell.tsx
@@ -54,6 +54,7 @@ type SettingsShellTabId = (typeof SETTINGS_TABS)[number]["id"];
 
 export interface SettingsShellView {
   activateTab(tabId: string): void;
+  getActiveTabId(): string;
   subscribeActiveTabChanges(listener: (tabId: string) => void): ViewDisposer;
 }
 
@@ -193,6 +194,9 @@ export function mountSettingsShell(host: HTMLElement): SettingsShellView {
         return;
       }
       setActiveTab(tabId);
+    },
+    getActiveTabId(): string {
+      return activeTabId.value;
     },
     subscribeActiveTabChanges(listener: (tabId: string) => void): ViewDisposer {
       let initialized = false;

--- a/apps/ui/tests/app_feature_ports.spec.ts
+++ b/apps/ui/tests/app_feature_ports.spec.ts
@@ -61,9 +61,6 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
     renderCarList() {
       calls.push("settings.renderCarList");
     },
-    startGpsStatusPolling() {
-      calls.push("settings.startGpsStatusPolling");
-    },
   };
   const cars = {
     bindWizardHandlers() {
@@ -74,16 +71,10 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
     bindUpdateHandlers() {
       calls.push("update.bindUpdateHandlers");
     },
-    startPolling() {
-      calls.push("update.startPolling");
-    },
   };
   const espFlash = {
     bindHandlers() {
       calls.push("espFlash.bindHandlers");
-    },
-    startPolling() {
-      calls.push("espFlash.startPolling");
     },
   };
 
@@ -117,9 +108,6 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
   await bundle.startup.settings.loadSpeedSourceFromServer();
   await bundle.startup.settings.loadAnalysisSettingsFromServer();
   await bundle.startup.settings.loadCarsFromServer();
-  bundle.startup.settings.startGpsStatusPolling();
-  bundle.startup.update.startPolling();
-  bundle.startup.espFlash.startPolling();
 
   expect(calls).toEqual([
     "history.refreshHistory",
@@ -138,8 +126,5 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
     "settings.loadSpeedSourceFromServer",
     "settings.loadAnalysisSettingsFromServer",
     "settings.loadCarsFromServer",
-    "settings.startGpsStatusPolling",
-    "update.startPolling",
-    "espFlash.startPolling",
   ]);
 });

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -512,7 +512,46 @@ function renderEspFlashPanelDom(
   }
 }
 
+function createFeatureNavigationHarness(defaultTabId: string) {
+  let activeViewId = "settingsView";
+  let activeSettingsTabId = defaultTabId;
+  const primaryViewListeners = new Set<(viewId: string) => void>();
+  const settingsTabListeners = new Set<(tabId: string) => void>();
+
+  return {
+    ports: {
+      getActiveSettingsTabId: () => activeSettingsTabId,
+      getActiveViewId: () => activeViewId,
+      subscribePrimaryViewChanges(listener: (viewId: string) => void) {
+        primaryViewListeners.add(listener);
+        return () => {
+          primaryViewListeners.delete(listener);
+        };
+      },
+      subscribeSettingsTabChanges(listener: (tabId: string) => void) {
+        settingsTabListeners.add(listener);
+        return () => {
+          settingsTabListeners.delete(listener);
+        };
+      },
+    },
+    setActiveSettingsTabId(nextTabId: string) {
+      activeSettingsTabId = nextTabId;
+      for (const listener of settingsTabListeners) {
+        listener(nextTabId);
+      }
+    },
+    setActiveViewId(nextViewId: string) {
+      activeViewId = nextViewId;
+      for (const listener of primaryViewListeners) {
+        listener(nextViewId);
+      }
+    },
+  };
+}
+
 function createDeps() {
+  const navigation = createFeatureNavigationHarness("espFlashTab");
   const espFlashPortSelect = createSelect("__auto__");
   const espFlashRefreshPortsBtn = createButton();
   const espFlashStartBtn = createButton();
@@ -561,6 +600,7 @@ function createDeps() {
         renderEspFlashPanelDom(dom, model);
       },
     },
+    ports: navigation.ports,
     els: dom,
     espFlashPortSelect,
     espFlashRefreshPortsBtn,
@@ -573,6 +613,8 @@ function createDeps() {
       t: (key: string) => key,
       showError: () => {},
     },
+    setActiveSettingsTabId: navigation.setActiveSettingsTabId,
+    setActiveViewId: navigation.setActiveViewId,
   };
 }
 
@@ -674,6 +716,7 @@ function createHealthyUpdateStatus() {
 }
 
 function createUpdateDeps() {
+  const navigation = createFeatureNavigationHarness("updateTab");
   const internetStatusPanel = createPanel();
   const updateTransportOptions = createPanel();
   const updateTransportChoiceWifi = createPanel();
@@ -759,6 +802,7 @@ function createUpdateDeps() {
         },
       },
     },
+    ports: navigation.ports,
     els: dom,
     internetStatusPanel,
     updateTransportOptions,
@@ -779,6 +823,8 @@ function createUpdateDeps() {
       t: (key: string) => key,
       showError: () => {},
     },
+    setActiveSettingsTabId: navigation.setActiveSettingsTabId,
+    setActiveViewId: navigation.setActiveViewId,
   };
 }
 

--- a/apps/ui/tests/esp_flash_feature_bindings.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_bindings.spec.ts
@@ -12,6 +12,12 @@ test("bindHandlers uses panel action surfaces instead of raw DOM bindings", () =
       },
       setModel() {},
     },
+    ports: {
+      getActiveSettingsTabId: () => "espFlashTab",
+      getActiveViewId: () => "settingsView",
+      subscribePrimaryViewChanges: () => () => undefined,
+      subscribeSettingsTabChanges: () => () => undefined,
+    },
     services: {
       t: (key) => key,
       showError() {},

--- a/apps/ui/tests/polling_controller.spec.ts
+++ b/apps/ui/tests/polling_controller.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { createPollingController } from "../src/app/features/polling_controller";
+import { signal } from "../src/app/ui_signals";
 import { createDeferred, flushAsyncWork, installTimerHarness } from "./async_test_helpers";
 
 test.describe("createPollingController", () => {
@@ -73,6 +74,38 @@ test.describe("createPollingController", () => {
       controller.start();
       await flushAsyncWork();
       expect(timers.pendingDelays()).toEqual([3_000]);
+    } finally {
+      timers.restore();
+    }
+  });
+
+  test("enabled signals start and stop the poll loop without manual lifecycle calls", async () => {
+    const timers = installTimerHarness();
+    const enabled = signal(false);
+    let pollCalls = 0;
+
+    createPollingController({
+      enabled,
+      poll: async () => {
+        pollCalls += 1;
+        return 500;
+      },
+      onErrorDelayMs: 2_000,
+    });
+
+    try {
+      await flushAsyncWork();
+      expect(pollCalls).toBe(0);
+      expect(timers.pendingDelays()).toEqual([]);
+
+      enabled.value = true;
+      await flushAsyncWork();
+      expect(pollCalls).toBe(1);
+      expect(timers.pendingDelays()).toEqual([500]);
+
+      enabled.value = false;
+      await flushAsyncWork();
+      expect(timers.pendingDelays()).toEqual([]);
     } finally {
       timers.restore();
     }

--- a/apps/ui/tests/ui_startup_coordinator.spec.ts
+++ b/apps/ui/tests/ui_startup_coordinator.spec.ts
@@ -70,19 +70,6 @@ function createCoordinatorHarness() {
           calls.push("settings.loadCarsFromServer");
           return loadCars.promise;
         },
-        startGpsStatusPolling(): void {
-          calls.push("settings.startGpsStatusPolling");
-        },
-      },
-      update: {
-        startPolling(): void {
-          calls.push("update.startPolling");
-        },
-      },
-      espFlash: {
-        startPolling(): void {
-          calls.push("espFlash.startPolling");
-        },
       },
     },
     transport: {
@@ -125,9 +112,6 @@ test.describe("UiStartupCoordinator", () => {
       "settings.loadCarsFromServer",
       "realtime.refreshLoggingStatus",
       "history.refreshHistory",
-      "update.startPolling",
-      "espFlash.startPolling",
-      "settings.startGpsStatusPolling",
       "transport.startTransportMode",
     ]);
   });

--- a/apps/ui/tests/update_feature_bindings.spec.ts
+++ b/apps/ui/tests/update_feature_bindings.spec.ts
@@ -30,6 +30,12 @@ test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners
       t: (key) => key,
       showError: () => undefined,
     },
+    ports: {
+      getActiveSettingsTabId: () => "updateTab",
+      getActiveViewId: () => "settingsView",
+      subscribePrimaryViewChanges: () => () => undefined,
+      subscribeSettingsTabChanges: () => () => undefined,
+    },
     panels: {
       update: {
         dom: {


### PR DESCRIPTION
## Summary

This PR completes #2334 by making the frontend polling primitive signal-aware and moving the remaining startup-driven polling lifecycles onto reactive feature-owned context. Before this change, `polling_controller.ts` was still an imperative timer helper: callers created a controller, then some outer runtime owner had to remember when to call `.start()`, `.stop()`, or `.restart()`. That pattern had already become a migration leftover after the broader Preact/signals work. The startup coordinator still kicked update polling, ESP flash polling, and GPS-status polling explicitly, even though the shell and settings surfaces already had enough reactive state to describe when those pollers should actually be active.

The goal was to remove the old “startup owns every polling lifecycle” assumption and let each feature describe its own active polling context from signal-backed view state instead.

## Implementation approach

I kept the refactor centered on three linked changes:

1. teach `PollingController` to react to a signal-backed enabled condition,
2. move the relevant feature polling lifecycles onto active shell/settings context, and
3. delete the now-dead startup kickoffs while preserving the startup ordering that earlier work in #2330 established.

That last point mattered. During validation, the first browser smoke pass exposed a real regression: GPS polling started early enough to fetch fallback state, then the later `loadSpeedSourceFromServer()` bootstrap task reset `resolvedSpeedSource` back to `null`, which changed the dashboard speed label from “Manual” back to “GPS”. The final cut fixes that explicitly instead of hand-waving around timing. GPS polling is now reactive, but it still waits for the initial speed-source load to finish before it becomes eligible to run.

## Main code changes

### `polling_controller.ts`

`apps/ui/src/app/features/polling_controller.ts` now accepts an optional `enabled` signal in `PollingControllerOptions`.

The controller still preserves the existing delay scheduling, error backoff, generation-based cancellation, and manual `start()` / `stop()` / `restart()` methods. The difference is that it can now also start and stop itself from an `effect()` watching `enabled.value`.

### Update and ESP flash feature polling context

`apps/ui/src/app/features/update_feature.ts` and `apps/ui/src/app/features/esp_flash_feature.ts` now derive polling enablement from the shell’s active primary view and the settings shell’s active tab.

For update, polling is active only while the settings view is open and either the internet tab or update tab is selected. For ESP flash, polling is active only while the settings view is open and the ESP flash tab is selected. Those features now receive small typed ports for:

- current active primary view,
- current active settings tab,
- primary-view subscription, and
- settings-tab subscription.

They convert those ports into local signals, compute `pollingEnabled`, and pass that signal into their workflows. ESP flash also refreshes serial ports when the polling context becomes active so the first render on tab entry still has fresh port options, which preserves the old `startPolling()` behavior without keeping startup responsible for it.

The feature-level manual `startPolling()` / `stopPolling()` methods remain in place for focused tests, but production startup no longer depends on them.

### GPS status module and startup ordering

`apps/ui/src/app/features/settings_gps_status_module.ts` got the most careful logic change because it affects both the speed-source diagnostics panel and the dashboard speed-source readout.

The module now derives its polling context from:

- dashboard visibility, or
- the settings view with the speed-source tab active.

The module also has a separate `startupReady` gate. `settings_feature.ts` flips that gate only after `loadSpeedSourceFromServer()` finishes its initial startup load. This is the key fix for the smoke regression mentioned above: the initial settings payload lands first, then GPS status polling can layer resolved source and fallback state on top of it instead of getting overwritten by the bootstrap load.

`settings_feature.ts` now binds the GPS-status module during normal feature binding and wraps the existing startup speed-source load so it marks GPS polling ready in a `finally` block.

### Shell and settings context getters

To support feature-owned polling context without inventing a new global store, two existing owners now expose their current context explicitly:

- `settings_shell.tsx` now exposes `getActiveTabId()`
- `ui_shell_controller.ts` now exposes `getActiveViewId()`

`ui_app_runtime.ts` and `app_feature_bundle.ts` thread those getters through existing runtime and feature ports so update, ESP flash, and settings GPS status can initialize their local signals from the real current state instead of waiting for a future subscription event.

### Startup and port cleanup

Because the features now own their own polling context, startup no longer needs to trigger those pollers directly.

This PR removes the long-lived polling kickoff seams from:

- `ui_startup_coordinator.ts`
- `ui_startup_feature_ports.ts`
- `app_feature_bundle_ports.ts`

The startup plan now only handles the startup-only loads/refreshes plus transport start.

### Documentation and tests

`apps/ui/README.md` now reflects the new architecture by describing startup as load/refresh oriented and by noting that update, ESP flash, and GPS-status polling come from feature-owned reactive context instead of startup kickoffs.

The focused test updates cover both the primitive and the orchestration seams:

- `tests/polling_controller.spec.ts` now covers signal-driven enable/disable
- startup and feature port tests no longer expect startup polling kickoffs
- update and ESP flash binding tests were updated for the new ports
- the existing large `esp_flash_feature.spec.ts` harness now provides active-view and active-tab context
- `tests/smoke.settings.spec.ts` caught the real GPS ordering regression and stays green on the final cut

## Validation performed

Local validation is green via:

- `cd apps/ui && npx playwright test tests/polling_controller.spec.ts tests/update_feature_bindings.spec.ts tests/esp_flash_feature_bindings.spec.ts tests/app_feature_ports.spec.ts tests/ui_startup_coordinator.spec.ts tests/esp_flash_feature.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/smoke.settings.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

Lint still reports the same pre-existing Biome schema-version info and the unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`; this PR does not change that baseline.

I also ran a focused code-review pass over the final diff, and it did not surface any material issues.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is that visibility-driven polling is intentionally narrower than the old startup-wide always-on behavior. That is desirable for update, ESP flash, and GPS status because their meaningful consumers are view-specific, but it does mean those pollers now refresh on re-entry instead of running continuously while hidden. That is acceptable for this UI because the workflow state is still sourced from the backend, and the pollers run immediately when their context becomes active again.

I intentionally did not rewrite the remaining manual `restart()` usage inside workflows like realtime logging or background OBD rescans. Those flows already have richer local lifecycle rules and were not the startup-owned polling residue this issue targeted. The controller change is broad enough to support future conversions without forcing all existing polling sites through one PR.

Closes #2334
