### PR TITLE
Wire demo mode into shared transport state

### DIFF
--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -4,7 +4,6 @@ import type { AppState } from "./ui_app_state";
 
 type DemoDeps = {
   state: Pick<AppState, "transport" | "settings">;
-  applyPayload: (payload: unknown) => void;
 };
 
 declare global {
@@ -14,11 +13,7 @@ declare global {
 }
 
 export function runDemoMode(deps: DemoDeps): void {
-  const { state, applyPayload } = deps;
-
-  batchAppStateUpdates(() => {
-    state.transport.wsState = "connected";
-  });
+  const { state } = deps;
 
   const demoClients = [
     {
@@ -167,6 +162,7 @@ export function runDemoMode(deps: DemoDeps): void {
   };
 
   batchAppStateUpdates(() => {
+    state.transport.wsState = "connected";
     state.settings.carsLoaded = true;
     state.settings.cars = [
       {
@@ -179,8 +175,8 @@ export function runDemoMode(deps: DemoDeps): void {
     ];
     state.settings.activeCarId = "demo-car-1";
     state.transport.hasReceivedPayload = true;
+    state.transport.pendingPayload = demoPayload;
   });
-  applyPayload(demoPayload);
 
   window.__vibesensorDemoCleanup = undefined;
 }

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -78,7 +78,6 @@ export class UiLiveTransportController {
     if (isDemoMode) {
       runDemoMode({
         state: this.state,
-        applyPayload: (payload) => this.applyPayload(payload),
       });
       return;
     }

--- a/apps/ui/tests/demo_mode.spec.ts
+++ b/apps/ui/tests/demo_mode.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { runDemoMode } from "../src/app/demo_mode";
-import { createAppState } from "../src/app/ui_app_state";
+import { createAppState, unwrapAppStateValue } from "../src/app/ui_app_state";
 import { adaptServerPayload } from "../src/server_payload";
 import { installWindowGlobal } from "./async_test_helpers";
 
@@ -10,26 +10,24 @@ test.describe("runDemoMode", () => {
     installWindowGlobal();
   });
 
-  test("emits a schema-valid websocket payload", () => {
+  test("queues a schema-valid websocket payload into shared transport state", () => {
     const selectedClientId = "aabbcc001122";
     const state = createAppState();
     state.transport.wsState = "reconnecting";
-    let adaptedPayload:
-      | ReturnType<typeof adaptServerPayload>
-      | undefined;
 
     runDemoMode({
       state,
-      applyPayload: (payload) => {
-        adaptedPayload = adaptServerPayload(payload);
-      },
     });
+
+    const adaptedPayload = adaptServerPayload(
+      unwrapAppStateValue(state.transport.pendingPayload),
+    );
 
     expect(state.transport.wsState).toBe("connected");
     expect(state.transport.hasReceivedPayload).toBe(true);
-    expect(adaptedPayload).toBeDefined();
-    expect(adaptedPayload?.clients).toHaveLength(5);
-    expect(adaptedPayload?.spectra?.clients[selectedClientId]).toMatchObject({
+    expect(state.transport.pendingPayload).not.toBeNull();
+    expect(adaptedPayload.clients).toHaveLength(5);
+    expect(adaptedPayload.spectra?.clients[selectedClientId]).toMatchObject({
       freq: expect.any(Array),
       combined: expect.any(Array),
       strength_metrics: expect.objectContaining({

--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -57,6 +57,23 @@ function installRafHarness() {
   };
 }
 
+function installLocation(search: string): () => void {
+  const target = window as Window & typeof globalThis & { location?: Location };
+  const previousLocation = target.location;
+  target.location = {
+    search,
+    protocol: "http:",
+    host: "localhost",
+  } as Location;
+  return () => {
+    if (previousLocation === undefined) {
+      delete target.location;
+      return;
+    }
+    target.location = previousLocation;
+  };
+}
+
 test.describe("UiLiveTransportController", () => {
   test.beforeEach(() => {
     installWindowGlobal();
@@ -133,5 +150,35 @@ test.describe("UiLiveTransportController", () => {
 
     expect(() => applyPayload(controller, makeLivePayload())).not.toThrow();
     expect(state.realtime.speedMps).toBe(10);
+  });
+
+  test("routes demo mode through the shared queued transport pipeline", async () => {
+    const state = createAppState();
+    const controller = new UiLiveTransportController({
+      state,
+      payloadErrorMessage: () => "payload error",
+    });
+    const restoreLocation = installLocation("?demo=1");
+    const raf = installRafHarness();
+    try {
+      controller.startTransportMode();
+      await flushAsyncWork();
+
+      expect(state.transport.wsState).toBe("connected");
+      expect(state.transport.hasReceivedPayload).toBe(true);
+      expect(state.transport.pendingPayload).not.toBeNull();
+
+      raf.flushNext();
+      await flushAsyncWork();
+
+      expect(state.transport.pendingPayload).toBeNull();
+      expect(state.realtime.clients).toHaveLength(5);
+      expect(state.realtime.selectedClientId).toBe("aabbcc001122");
+      expect(state.realtime.speedMps).toBe(22.2);
+      expect(state.spectrum.hasSpectrumData).toBe(true);
+    } finally {
+      restoreLocation();
+      raf.restore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

This PR completes #2335 by removing the last demo-mode bypass around the frontend transport pipeline. Before this change, `apps/ui/src/app/demo_mode.ts` still behaved differently from the live websocket path in one important way: it mutated a few transport fields directly and then called an `applyPayload` callback supplied by `UiLiveTransportController`. That jumped straight into payload adaptation and state application, so demo mode was no longer exercising the same queued transport flow that production websocket traffic uses after the AppState and websocket signal migrations landed in #2324 and #2323.

The live path is now structured around the shared transport slice: websocket state changes and raw payloads land in `state.transport`, the controller observes that reactive state, and the existing queued requestAnimationFrame path decides when to adapt and apply payloads. Demo mode was the remaining exception, which could hide regressions in the real queueing path.

This change removes that exception and routes demo input through the same signal-backed transport state as live websocket input.

## Implementation approach

I kept the fix intentionally narrow. The issue is not asking for a new demo feature or a different simulation payload; it is asking for the transport entrypoint to converge on the reactive store that the rest of the frontend already uses. The cleanest way to do that was:

1. narrow `DemoDeps` so demo mode only receives shared state,
2. make `runDemoMode()` enqueue its synthetic websocket payload into `state.transport.pendingPayload` while updating the normal transport status fields,
3. let `UiLiveTransportController` process that queued payload through its existing pending-payload effect and requestAnimationFrame queue, and
4. update focused tests so they validate the raw queued-payload behavior as well as the full `?demo` controller path.

This preserves the existing demo data and synthetic spectrum generation while deleting the special callback seam that no longer belongs in the migrated architecture.

## Main code changes

### `apps/ui/src/app/demo_mode.ts`

`runDemoMode()` no longer accepts an `applyPayload` callback. `DemoDeps` now carries only the parts of AppState that demo mode actually needs: the shared `transport` and `settings` slices.

The synthetic demo payload generation is unchanged. The same five demo clients, rotational-speed payload, and generated spectra remain intact because the point here is to change the transport handoff, not the deterministic dataset used by existing demo-backed browser coverage.

The meaningful change is at the end of the function. Instead of calling back into the controller with a payload argument, demo mode now updates the shared transport slice directly:

- `state.transport.wsState = "connected"`
- `state.transport.hasReceivedPayload = true`
- `state.transport.pendingPayload = demoPayload`

Those writes happen in the same batched state update that already marks cars as loaded and seeds the active demo car. In other words, demo mode now behaves like a producer of transport input rather than a privileged caller that skips over the queue.

### `apps/ui/src/app/runtime/ui_live_transport_controller.ts`

`UiLiveTransportController.startTransportMode()` now calls `runDemoMode({ state: this.state })` and nothing more. The controller no longer injects a custom `applyPayload` callback for demo mode.

After this change, demo mode reaches the rest of the system through the same reactive transport path that live websocket payloads use:

- the transport slice changes,
- the pending-payload effect notices the queued raw payload,
- `queueRender()` schedules the existing requestAnimationFrame work,
- the controller unwraps, adapts, and applies the payload,
- and the queued payload is cleared once consumed.

The live websocket flow itself is unchanged. This PR only removes the demo-only fast path so both transport sources converge on the same controller behavior.

### `apps/ui/tests/demo_mode.spec.ts`

The demo-mode unit test has been rewritten around the new contract. Instead of passing a callback and asserting that it receives a schema-valid payload, the test now verifies that `runDemoMode()` leaves a raw payload in shared transport state.

Because AppState slices are reactive proxies, the test explicitly unwraps `state.transport.pendingPayload` before adapting it. That matches the real controller behavior, which already unwraps queued transport payloads before calling `adaptServerPayload()`.

The assertions still prove the important invariants:

- websocket state becomes connected,
- the app marks that it has received data,
- a payload is present in the shared queue,
- the adapted payload remains schema-valid,
- the expected five demo clients are present, and
- the expected per-client spectrum data still exists.

### `apps/ui/tests/ui_live_transport_controller.spec.ts`

I added a focused regression that exercises the full `?demo` path through `UiLiveTransportController`.

The test installs a simple `window.location.search = "?demo=1"` harness and a requestAnimationFrame harness, starts transport mode, and then verifies the end-to-end behavior:

- demo mode sets transport state to connected,
- demo mode marks the payload as received,
- the raw demo payload is queued in `state.transport.pendingPayload`,
- the controller consumes that queued payload on the next animation frame,
- the queue is cleared afterward,
- realtime state gets populated with the demo clients and speed,
- and spectrum state reports available spectrum data.

This is the most important regression guard in the PR because it proves the demo entrypoint now exercises the same queued controller pipeline as production transport.

## Contracts, config, and documentation

There are no schema changes, config changes, or user-facing documentation changes in this PR. This is an internal frontend ownership cleanup that removes a stale callback seam while keeping the external demo behavior the same.

## Validation performed

Local validation is green via:

- `cd apps/ui && npx playwright test tests/demo_mode.spec.ts tests/ui_live_transport_controller.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.spectrum.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1 -g "spectrum controls simplify the chart and update the inspector"`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

`npm run lint` still reports the same pre-existing Biome schema-version info and the unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`; this PR does not change that baseline.

I also ran a focused code-review pass over the final diff, and it did not surface any material issues.

## Risks, tradeoffs, and edge cases

The only meaningful behavior change is that demo payload application now goes through the same queued requestAnimationFrame transport path as live websocket payloads. In practice that means demo mode is no longer effectively synchronous from the controller's point of view; there is now one queued frame before realtime and spectrum state are populated. That tradeoff is intentional: the added frame delay is negligible for users, but it removes an architectural divergence that could otherwise hide regressions in queueing, adaptation, throttling, or transport-state observation.

I deliberately kept the change focused and did not refactor unrelated transport helpers or reshape the demo payload itself. The synthetic client list, payload schema, spectra generation, and seeded car data remain the same so existing demo-backed UI behavior stays stable while the internal ingress path becomes cleaner and closer to production.

Closes #2335
