### PR TITLE
Replace shell view callbacks with signals

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -18,6 +18,7 @@ import {
 import { createUpdateFeature } from "./features/update_feature";
 import type { FeatureFormatting, FeatureServices } from "./feature_deps_base";
 import type { AppState } from "./ui_app_state";
+import type { ReadonlySignal } from "./ui_signals";
 import { createUiCarCreationCommand } from "./runtime/ui_car_creation_command";
 import type { UiMountedPanels } from "./ui_panel_bootstrap";
 import type { AppFeatureBundle } from "./app_feature_bundle_ports";
@@ -32,8 +33,7 @@ export interface AppFeatureBundleRuntimePorts {
   panels: UiMountedPanels;
   navigation: {
     activatePrimaryView(viewId: string): void;
-    getActiveViewId(): string;
-    subscribeActiveViewChanges(listener: (viewId: string) => void): () => void;
+    activeViewId: ReadonlySignal<string>;
   };
   realtimeChrome: Pick<RealtimeFeatureChromePorts, "setShellLiveStatus">;
   transport: RealtimeFeatureSelectionPorts;
@@ -113,8 +113,7 @@ export function createAppFeatureBundle(
       openCarWizard: () => {
         carsFeature?.openWizard();
       },
-      getActiveViewId: runtime.navigation.getActiveViewId,
-      subscribePrimaryViewChanges: runtime.navigation.subscribeActiveViewChanges,
+      activeViewId: runtime.navigation.activeViewId,
       view: runtime.view,
     },
     services,
@@ -153,8 +152,7 @@ export function createAppFeatureBundle(
     },
     ports: {
       getActiveSettingsTabId: () => panels.settingsShell.getActiveTabId(),
-      getActiveViewId: runtime.navigation.getActiveViewId,
-      subscribePrimaryViewChanges: runtime.navigation.subscribeActiveViewChanges,
+      activeViewId: runtime.navigation.activeViewId,
       subscribeSettingsTabChanges: panels.settingsShell.subscribeActiveTabChanges,
     },
     services,
@@ -163,8 +161,7 @@ export function createAppFeatureBundle(
     panel: panels.settings.espFlash,
     ports: {
       getActiveSettingsTabId: () => panels.settingsShell.getActiveTabId(),
-      getActiveViewId: runtime.navigation.getActiveViewId,
-      subscribePrimaryViewChanges: runtime.navigation.subscribeActiveViewChanges,
+      activeViewId: runtime.navigation.activeViewId,
       subscribeSettingsTabChanges: panels.settingsShell.subscribeActiveTabChanges,
     },
     services,

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -1,4 +1,9 @@
-import { computed, effect, signal } from "../ui_signals";
+import {
+  computed,
+  effect,
+  signal,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type { FeatureServices } from "../feature_deps_base";
 import { createEspFlashFeatureWorkflow } from "./esp_flash_feature_workflow";
 import { createEspFlashFeaturePresenter } from "../views/esp_flash_feature_presenter";
@@ -6,8 +11,7 @@ import type { EspFlashPanelView } from "../views/esp_flash_panel";
 
 interface EspFlashFeaturePorts {
   getActiveSettingsTabId: () => string;
-  getActiveViewId: () => string;
-  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
+  activeViewId: ReadonlySignal<string>;
   subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
 }
 
@@ -32,11 +36,10 @@ export function createEspFlashFeature(
 ): EspFlashFeature {
   const { panel, ports, services } = ctx;
   const handlersBound = signal(false);
-  const activeViewId = signal(ports.getActiveViewId());
   const activeSettingsTabId = signal(ports.getActiveSettingsTabId());
   const pollingEnabled = computed(() =>
     handlersBound.value
-    && isEspFlashPollingContext(activeViewId.value, activeSettingsTabId.value)
+    && isEspFlashPollingContext(ports.activeViewId.value, activeSettingsTabId.value)
   );
   const presenter = createEspFlashFeaturePresenter({
     panel,
@@ -49,9 +52,6 @@ export function createEspFlashFeature(
     pollingEnabled,
   });
 
-  ports.subscribePrimaryViewChanges((viewId) => {
-    activeViewId.value = viewId;
-  });
   ports.subscribeSettingsTabChanges((tabId) => {
     activeSettingsTabId.value = tabId;
   });

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -9,6 +9,11 @@ import type { CarRecord, CarsPayload } from "../../transport/http_models";
 import type { CarsListPanelView } from "../views/cars_panel";
 import type { AnalysisPanelView } from "../views/analysis_panel";
 import {
+  effect,
+  untracked,
+  type ReadonlySignal,
+} from "../ui_signals";
+import {
   buildCarsGuidanceRenderModel,
   buildSettingsCarListRenderModel,
   type CarsListHighlightedFeedback,
@@ -24,10 +29,10 @@ interface SettingsCarsModulePanels {
 }
 
 interface SettingsCarsModulePorts {
+  activeViewId: ReadonlySignal<string>;
   openAnalysisTab: () => void;
   openCarWizard: () => void;
   renderSpectrum: () => void;
-  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
   subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
   syncAnalysisInputs: () => void;
 }
@@ -247,13 +252,21 @@ export function createSettingsCarsModule(
       return;
     }
     handlersBound = true;
-    ctx.ports.subscribeSettingsTabChanges((tabId) => {
-      if (tabId !== "carTab") {
-        dismissHighlightedCarFeedback();
+    let hasSeenInitialView = false;
+    effect(() => {
+      const activeViewId = ctx.ports.activeViewId.value;
+      if (!hasSeenInitialView) {
+        hasSeenInitialView = true;
+        return;
+      }
+      if (activeViewId !== "settingsView") {
+        untracked(() => {
+          dismissHighlightedCarFeedback();
+        });
       }
     });
-    ctx.ports.subscribePrimaryViewChanges((viewId) => {
-      if (viewId !== "settingsView") {
+    ctx.ports.subscribeSettingsTabChanges((tabId) => {
+      if (tabId !== "carTab") {
         dismissHighlightedCarFeedback();
       }
     });

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -1,6 +1,7 @@
 import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import { createCarSelectionDerivedState } from "../car_selection_state";
 import type { SettingsState, ShellState } from "../ui_app_state";
+import type { ReadonlySignal } from "../ui_signals";
 import type { CarsPayload } from "../../transport/http_models";
 import {
   createSettingsAnalysisModule,
@@ -37,8 +38,7 @@ interface SettingsFeaturePanelDeps {
 
 interface SettingsFeaturePortDeps {
   openCarWizard: () => void;
-  getActiveViewId: () => string;
-  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
+  activeViewId: ReadonlySignal<string>;
   view: SettingsFeatureViewPorts;
 }
 
@@ -105,8 +105,8 @@ export function createSettingsFeature(
       formatting,
       getSpeedUnit: () => ctx.state.shell.speedUnit,
       ports: {
+        activeViewId: ctx.ports.activeViewId,
         renderSpeedReadout: ctx.ports.view.renderSpeedReadout,
-        subscribePrimaryViewChanges: ctx.ports.subscribePrimaryViewChanges,
         subscribeSettingsTabChanges:
           ctx.panels.settingsShell.subscribeActiveTabChanges,
       },
@@ -122,10 +122,9 @@ export function createSettingsFeature(
       getSpeedUnit: () => ctx.state.shell.speedUnit,
       ports: {
         getActiveSettingsTabId: () => ctx.panels.settingsShell.getActiveTabId(),
-        getActiveViewId: ctx.ports.getActiveViewId,
+        activeViewId: ctx.ports.activeViewId,
         syncSpeedSourceSelectionUi: speedSourceModule.syncSpeedSourceSelectionUi,
         renderSpeedReadout: ctx.ports.view.renderSpeedReadout,
-        subscribePrimaryViewChanges: ctx.ports.subscribePrimaryViewChanges,
         subscribeSettingsTabChanges:
           ctx.panels.settingsShell.subscribeActiveTabChanges,
       },
@@ -139,8 +138,8 @@ export function createSettingsFeature(
     ports: {
       openAnalysisTab: () => openSettingsTab("analysisTab"),
       openCarWizard: ctx.ports.openCarWizard,
+      activeViewId: ctx.ports.activeViewId,
       renderSpectrum: ctx.ports.view.renderSpectrum,
-      subscribePrimaryViewChanges: ctx.ports.subscribePrimaryViewChanges,
       subscribeSettingsTabChanges:
         ctx.panels.settingsShell.subscribeActiveTabChanges,
       syncAnalysisInputs: analysisModule.syncSettingsInputs,

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -2,7 +2,11 @@ import { getSettingsObdStatus, getSpeedSourceStatus } from "../../api";
 import { GPS_POLL_FAST_MS, GPS_POLL_SLOW_MS } from "../../config";
 import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import type { SettingsState } from "../ui_app_state";
-import { computed, signal } from "../ui_signals";
+import {
+  computed,
+  signal,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type { SpeedSourcePanelView } from "../views/speed_source_panel";
 import {
   buildSpeedSourceDiagnosticsRenderModel,
@@ -12,10 +16,9 @@ import { createPollingController } from "./polling_controller";
 
 interface SettingsGpsStatusModulePorts {
   getActiveSettingsTabId: () => string;
-  getActiveViewId: () => string;
+  activeViewId: ReadonlySignal<string>;
   syncSpeedSourceSelectionUi: () => void;
   renderSpeedReadout: () => void;
-  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
   subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
 }
 
@@ -39,7 +42,6 @@ export function createSettingsGpsStatusModule(
   const { panel, settings } = ctx;
   const handlersBound = signal(false);
   const startupReady = signal(false);
-  const activeViewId = signal(ctx.ports.getActiveViewId());
   const activeSettingsTabId = signal(ctx.ports.getActiveSettingsTabId());
   const presenterDeps: SettingsSpeedSourcePresenterDeps = {
     fmt: ctx.formatting.fmt,
@@ -50,17 +52,14 @@ export function createSettingsGpsStatusModule(
     handlersBound.value
     && startupReady.value
     && (
-      activeViewId.value === "dashboardView"
+      ctx.ports.activeViewId.value === "dashboardView"
       || (
-        activeViewId.value === "settingsView"
+        ctx.ports.activeViewId.value === "settingsView"
         && activeSettingsTabId.value === "speedSourceTab"
       )
     )
   );
 
-  ctx.ports.subscribePrimaryViewChanges((viewId) => {
-    activeViewId.value = viewId;
-  });
   ctx.ports.subscribeSettingsTabChanges((tabId) => {
     activeSettingsTabId.value = tabId;
   });

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -5,11 +5,16 @@ import {
 } from "../views/settings_speed_source_presenter";
 import type { SpeedSourcePanelView } from "../views/speed_source_panel";
 import type { SettingsState } from "../ui_app_state";
+import {
+  effect,
+  untracked,
+  type ReadonlySignal,
+} from "../ui_signals";
 import { createSettingsSpeedSourceWorkflow } from "./settings_speed_source_workflow";
 
 interface SettingsSpeedSourceModulePorts {
+  activeViewId: ReadonlySignal<string>;
   renderSpeedReadout: () => void;
-  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
   subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
 }
 
@@ -61,10 +66,18 @@ export function createSettingsSpeedSourceModule(
       return;
     }
     handlersBound = true;
-    ctx.ports.subscribeSettingsTabChanges(() => {
-      workflow.handleNavigateContext();
+    let hasSeenInitialView = false;
+    effect(() => {
+      ctx.ports.activeViewId.value;
+      if (!hasSeenInitialView) {
+        hasSeenInitialView = true;
+        return;
+      }
+      untracked(() => {
+        workflow.handleNavigateContext();
+      });
     });
-    ctx.ports.subscribePrimaryViewChanges(() => {
+    ctx.ports.subscribeSettingsTabChanges(() => {
       workflow.handleNavigateContext();
     });
     ctx.panel.bindActions({

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -1,4 +1,8 @@
-import { computed, signal } from "../ui_signals";
+import {
+  computed,
+  signal,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type { FeatureServices } from "../feature_deps_base";
 import { createUpdateFeatureWorkflow } from "./update_feature_workflow";
 import { createUpdateFeaturePresenter } from "../views/update_feature_presenter";
@@ -12,8 +16,7 @@ interface UpdateFeaturePanels {
 
 interface UpdateFeaturePorts {
   getActiveSettingsTabId: () => string;
-  getActiveViewId: () => string;
-  subscribePrimaryViewChanges(listener: (viewId: string) => void): () => void;
+  activeViewId: ReadonlySignal<string>;
   subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
 }
 
@@ -36,11 +39,10 @@ function isUpdatePollingContext(viewId: string, tabId: string): boolean {
 export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
   const { panels, ports, services } = ctx;
   const handlersBound = signal(false);
-  const activeViewId = signal(ports.getActiveViewId());
   const activeSettingsTabId = signal(ports.getActiveSettingsTabId());
   const pollingEnabled = computed(() =>
     handlersBound.value
-    && isUpdatePollingContext(activeViewId.value, activeSettingsTabId.value)
+    && isUpdatePollingContext(ports.activeViewId.value, activeSettingsTabId.value)
   );
   const presenter = createUpdateFeaturePresenter({
     panel: panels.update,
@@ -54,9 +56,6 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
     pollingEnabled,
   });
 
-  ports.subscribePrimaryViewChanges((viewId) => {
-    activeViewId.value = viewId;
-  });
   ports.subscribeSettingsTabChanges((tabId) => {
     activeSettingsTabId.value = tabId;
   });

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -82,8 +82,6 @@ export class UiShellController {
 
   private readonly chromeRenderModel: ReadonlySignal<UiShellChromeRenderModel>;
 
-  private readonly activeViewListeners = new Set<(viewId: string) => void>();
-
   private readonly bindFeatureHandlers: () => void;
 
   private readonly getLanguageRefreshPorts: () => UiShellLanguageRefreshFeaturePorts;
@@ -174,25 +172,12 @@ export class UiShellController {
     };
   }
 
-  subscribeActiveViewChanges(listener: (viewId: string) => void): () => void {
-    this.activeViewListeners.add(listener);
-    return () => {
-      this.activeViewListeners.delete(listener);
-    };
-  }
-
-  getActiveViewId(): string {
-    return this.state.shell.activeViewId;
+  get activeViewId(): ReadonlySignal<string> {
+    return this.navigation.activeViewId;
   }
 
   setActiveView(viewId: string): void {
-    const previousViewId = this.state.shell.activeViewId;
     this.navigation.setActiveView(viewId);
-    if (this.state.shell.activeViewId !== previousViewId) {
-      for (const listener of this.activeViewListeners) {
-        listener(this.state.shell.activeViewId);
-      }
-    }
   }
 
   applyLanguage(forceReloadInsights = false): void {

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -65,9 +65,7 @@ function createUiAppFeatureRuntimePorts(deps: {
     panels,
     navigation: {
       activatePrimaryView: (viewId) => shell.setActiveView(viewId),
-      getActiveViewId: () => shell.getActiveViewId(),
-      subscribeActiveViewChanges: (listener) =>
-        shell.subscribeActiveViewChanges(listener),
+      activeViewId: shell.activeViewId,
     },
     realtimeChrome: {
       setShellLiveStatus: (variant, text) =>

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -26,6 +26,7 @@ import {
 } from "./async_test_helpers";
 import type { TimerHarness } from "./async_test_helpers";
 import { createPanel, installFakeDomGlobals } from "./dom_render_test_support";
+import { signal } from "../src/app/ui_signals";
 
 type ClickListener = (() => void) | null;
 
@@ -513,21 +514,14 @@ function renderEspFlashPanelDom(
 }
 
 function createFeatureNavigationHarness(defaultTabId: string) {
-  let activeViewId = "settingsView";
+  const activeViewId = signal("settingsView");
   let activeSettingsTabId = defaultTabId;
-  const primaryViewListeners = new Set<(viewId: string) => void>();
   const settingsTabListeners = new Set<(tabId: string) => void>();
 
   return {
     ports: {
       getActiveSettingsTabId: () => activeSettingsTabId,
-      getActiveViewId: () => activeViewId,
-      subscribePrimaryViewChanges(listener: (viewId: string) => void) {
-        primaryViewListeners.add(listener);
-        return () => {
-          primaryViewListeners.delete(listener);
-        };
-      },
+      activeViewId,
       subscribeSettingsTabChanges(listener: (tabId: string) => void) {
         settingsTabListeners.add(listener);
         return () => {
@@ -542,10 +536,7 @@ function createFeatureNavigationHarness(defaultTabId: string) {
       }
     },
     setActiveViewId(nextViewId: string) {
-      activeViewId = nextViewId;
-      for (const listener of primaryViewListeners) {
-        listener(nextViewId);
-      }
+      activeViewId.value = nextViewId;
     },
   };
 }

--- a/apps/ui/tests/esp_flash_feature_bindings.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_bindings.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { createEspFlashFeature } from "../src/app/features/esp_flash_feature";
+import { signal } from "../src/app/ui_signals";
 import type { EspFlashPanelActionHandlers } from "../src/app/views/esp_flash_panel";
 
 test("bindHandlers uses panel action surfaces instead of raw DOM bindings", () => {
@@ -14,8 +15,7 @@ test("bindHandlers uses panel action surfaces instead of raw DOM bindings", () =
     },
     ports: {
       getActiveSettingsTabId: () => "espFlashTab",
-      getActiveViewId: () => "settingsView",
-      subscribePrimaryViewChanges: () => () => undefined,
+      activeViewId: signal("settingsView"),
       subscribeSettingsTabChanges: () => () => undefined,
     },
     services: {

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { createSettingsCarsModule } from "../src/app/features/settings_cars_module";
+import { signal } from "../src/app/ui_signals";
 import type { CarsListRenderModel, CarsListPanelView } from "../src/app/views/cars_panel";
 import { createAppState } from "../src/app/ui_app_state";
 import type { CarsPayload } from "../src/transport/http_models";
@@ -16,8 +17,8 @@ function lastRender(renders: CarsListRenderModel[]): CarsListRenderModel {
 test("settings cars module dismisses transient creation feedback through typed tab and view callbacks", () => {
   const state = createAppState().settings;
   const renders: CarsListRenderModel[] = [];
+  const activeViewId = signal("settingsView");
   let settingsTabListener: ((tabId: string) => void) | null = null;
-  let primaryViewListener: ((viewId: string) => void) | null = null;
 
   const panel: CarsListPanelView = {
     bindActions() {},
@@ -37,17 +38,10 @@ test("settings cars module dismisses transient creation feedback through typed t
       panel,
     },
     ports: {
+      activeViewId,
       openAnalysisTab: () => undefined,
       openCarWizard: () => undefined,
       renderSpectrum: () => undefined,
-      subscribePrimaryViewChanges(listener) {
-        primaryViewListener = listener;
-        return () => {
-          if (primaryViewListener === listener) {
-            primaryViewListener = null;
-          }
-        };
-      },
       subscribeSettingsTabChanges(listener) {
         settingsTabListener = listener;
         return () => {
@@ -117,7 +111,7 @@ test("settings cars module dismisses transient creation feedback through typed t
   expect(dismissedByTab.table.rows[0].highlightedStatusText).toBeNull();
 
   module.showCarCreationSuccess("car-1", "Track Demo");
-  primaryViewListener?.("dashboardView");
+  activeViewId.value = "dashboardView";
 
   const dismissedByView = lastRender(renders);
   expect(dismissedByView.guidance).toBeNull();

--- a/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
+++ b/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
@@ -2,12 +2,13 @@ import { expect, test } from "@playwright/test";
 
 import { createSettingsSpeedSourceModule } from "../src/app/features/settings_speed_source_module";
 import { createAppState } from "../src/app/ui_app_state";
+import { signal } from "../src/app/ui_signals";
 import type { SpeedSourcePanelActionHandlers } from "../src/app/views/speed_source_panel";
 
 test("bindHandlers uses typed panel actions and navigation subscriptions", () => {
   let handlers: SpeedSourcePanelActionHandlers | null = null;
+  const activeViewId = signal("settingsView");
   let settingsTabListener: ((tabId: string) => void) | null = null;
-  let primaryViewListener: ((viewId: string) => void) | null = null;
 
   const module = createSettingsSpeedSourceModule({
     settings: createAppState().settings,
@@ -33,11 +34,8 @@ test("bindHandlers uses typed panel actions and navigation subscriptions", () =>
     },
     getSpeedUnit: () => "kmh",
     ports: {
+      activeViewId,
       renderSpeedReadout() {},
-      subscribePrimaryViewChanges(listener) {
-        primaryViewListener = listener;
-        return () => undefined;
-      },
       subscribeSettingsTabChanges(listener) {
         settingsTabListener = listener;
         return () => undefined;
@@ -54,13 +52,12 @@ test("bindHandlers uses typed panel actions and navigation subscriptions", () =>
   expect(typeof handlers?.onScanObdDevices).toBe("function");
   expect(typeof handlers?.onPairObdDevice).toBe("function");
   expect(settingsTabListener).not.toBeNull();
-  expect(primaryViewListener).not.toBeNull();
 
   expect(() => {
     handlers?.onSpeedSourceChanged("manual");
     handlers?.onManualSpeedInput("80");
     handlers?.onStaleTimeoutInput("5");
     settingsTabListener?.("analysisTab");
-    primaryViewListener?.("dashboardView");
+    activeViewId.value = "dashboardView";
   }).not.toThrow();
 });

--- a/apps/ui/tests/update_feature_bindings.spec.ts
+++ b/apps/ui/tests/update_feature_bindings.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { createUpdateFeature } from "../src/app/features/update_feature";
+import { signal } from "../src/app/ui_signals";
 import type {
   InternetPanelActionHandlers,
   InternetPanelDom,
@@ -32,8 +33,7 @@ test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners
     },
     ports: {
       getActiveSettingsTabId: () => "updateTab",
-      getActiveViewId: () => "settingsView",
-      subscribePrimaryViewChanges: () => () => undefined,
+      activeViewId: signal("settingsView"),
       subscribeSettingsTabChanges: () => () => undefined,
     },
     panels: {


### PR DESCRIPTION
## Summary

This PR closes #2338 by removing the remaining manual shell-view listener chain and replacing it with direct signal consumption from the shared active-view state.

The issue body was partly stale by the time I picked it up. `UiShellNotificationModule` and `UiShellPreferencesModule` are already signal-backed, and there are no remaining `onChanged` callbacks in those modules. The real leftover was narrower:

- `UiShellController` still owned an `activeViewListeners` `Set`
- the runtime still exposed `subscribeActiveViewChanges()` and `getActiveViewId()`
- several feature modules still rebuilt their own local active-view signals from that getter-plus-callback API

This PR removes that residue and makes the active shell view a first-class shared signal all the way through the runtime wiring.

## Problem being solved

The shell-navigation state itself was already signal-backed in `ui_shell_navigation_module.ts`, but that reactive state was not the thing feature consumers actually received.

Instead, `UiShellController` wrapped the navigation signal in an older imperative API:

- it stored a manual `activeViewListeners` `Set`
- it exposed `subscribeActiveViewChanges()`
- and downstream features rebuilt their own local `signal(...)` from `getActiveViewId()` plus the subscription callback

That meant the codebase was still carrying a hand-rolled pub-sub seam alongside the existing signal state. It also duplicated state ownership in the feature layer: update, ESP flash, GPS status, and some settings modules each had to reconstruct “what is the active shell view?” even though the runtime already had that answer as a signal.

The result was not a user-facing bug, but it was exactly the kind of migration residue this issue was meant to remove.

## Implementation approach

I kept the fix aligned with the current architecture rather than inventing a new shell store.

The active shell view already exists as `ui_shell_navigation_module.ts` state, so the right move here was:

1. expose that existing signal directly from `UiShellController`,
2. thread it through `UiAppRuntime` and `app_feature_bundle.ts`,
3. update the affected feature modules to consume the shared `ReadonlySignal<string>` instead of manual subscriptions, and
4. leave the already-signal-backed notification and preference modules alone.

For consumers that only needed the view value as part of a computed polling gate, I switched them to read the shared signal directly.

For consumers that only needed a side effect when the view changed, I switched them from callback registration to `effect()` plus `untracked()` so the effect listens to the active-view signal without accidentally tracking unrelated reactive reads inside workflow or render helpers.

## Main code changes

### `apps/ui/src/app/runtime/ui_shell_controller.ts`

This is the core cleanup.

The controller no longer owns:

- `activeViewListeners`
- `subscribeActiveViewChanges()`
- `getActiveViewId()`

Instead, it exposes `activeViewId` as a getter that returns the already-existing `navigation.activeViewId` signal. `setActiveView()` now simply delegates to the navigation module without fanning out through a manual listener loop.

This leaves `UiShellController` closer to its real job: coordinating shell actions and shell render state, not acting as a second event bus on top of signal-backed navigation state.

### `apps/ui/src/app/ui_app_runtime.ts` and `apps/ui/src/app/app_feature_bundle.ts`

The runtime and feature-bundle contracts now pass the active shell view as `ReadonlySignal<string>`.

Before this change, the runtime surface exposed:

- `getActiveViewId()`
- `subscribeActiveViewChanges(...)`

Now it exposes:

- `activeViewId`

That change removes the old callback seam from the runtime composition root and makes the feature bundle consume the same shared navigation signal that the shell already owns.

### `apps/ui/src/app/features/update_feature.ts`

`createUpdateFeature()` no longer creates a local active-view signal from runtime callbacks.

Its polling gate now reads `ports.activeViewId.value` directly and combines that with the existing settings-tab signal. The settings-tab subscription remains because the settings shell already owns its tab state separately.

### `apps/ui/src/app/features/esp_flash_feature.ts`

`createEspFlashFeature()` follows the same pattern as update:

- remove the local active-view signal reconstruction
- read the shared `ports.activeViewId.value` directly in the polling `computed()`

That keeps the polling context logic the same while deleting the redundant listener-based wiring.

### `apps/ui/src/app/features/settings_gps_status_module.ts`

The GPS status polling gate now reads the shared active-view signal directly instead of maintaining its own view subscription mirror.

This is a good fit for the module because its polling enablement is already modeled as a computed expression over startup readiness, current shell view, and current settings tab.

### `apps/ui/src/app/features/settings_cars_module.ts` and `apps/ui/src/app/features/settings_speed_source_module.ts`

These two modules were slightly different because they do not just compute a boolean from the active view; they perform imperative work when navigation changes.

For those cases, I replaced the callback registration with `effect()` plus `untracked()`:

- the cars module now dismisses highlighted creation feedback when the active view leaves settings via a signal-driven effect
- the speed-source module now reruns its navigation-context handler from a signal-driven effect instead of a view-subscription callback

`untracked()` matters here because both code paths eventually call helpers that read other signals or render derived state. Using `untracked()` keeps the effect subscribed only to the active-view signal rather than accidentally widening the dependency set.

### Tests

The affected tests were updated to match the new runtime contract:

- runtime/feature fixtures now provide `signal("settingsView")` instead of callback-based primary-view subscriptions
- the larger ESP flash feature harness now mutates the signal directly when simulating a shell-view change
- the focused settings-cars and speed-source tests now exercise the signal path instead of capturing listener callbacks

This keeps the tests aligned with the live architecture instead of preserving the API being deleted.

## Contracts, config, and docs

There are no API schema changes, config changes, or user-facing documentation changes in this PR.

## Validation performed

Local validation is green via:

- `cd apps/ui && npx playwright test tests/update_feature_bindings.spec.ts tests/esp_flash_feature_bindings.spec.ts tests/settings_cars_module.spec.ts tests/settings_speed_source_module_bindings.spec.ts tests/esp_flash_feature.spec.ts tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.settings.spec.ts tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

`npm run lint` still reports the same pre-existing Biome schema-version info and the unrelated optional-chain warning in `tests/history_feature_modules.spec.ts`; this PR does not change that baseline.

I also ran a focused review pass over the final diff, and it did not surface any material issues.

## Risks, tradeoffs, and out-of-scope items

The main risk here is reactive overreach: replacing a callback with an `effect()` is only safe when the effect tracks the right signal and does not accidentally subscribe to unrelated derived state. That is why the side-effect-driven consumers use `untracked()` around their imperative handlers.

I intentionally did not broaden this into a larger shell-language-refresh rewrite or a settings-tab signal refactor. The issue is specifically about the remaining manual shell-view listener seam, and this PR removes that seam without pulling unrelated signal migrations into the same review.

Out of scope:

- deleting `ui_shell_language_refresh_module.ts`
- changing settings-tab subscriptions, which already route through signal-backed `effect()` in `settings_shell.tsx`
- touching notification/preference behavior beyond recognizing that those callbacks were already gone

Closes #2338
