### PR TITLE
Add signal-driven island test helpers

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -315,6 +315,26 @@ data for Live, History, Cars, Analysis, and Speed Source. Release CI publishes
 only these screenshot assets into the existing GitHub wiki; the wiki markdown
 pages are seeded manually.
 
+## Signal-driven island tests
+
+- Prefer `tests/dom_render_test_support.ts::mountSignalView()` for isolated
+  island tests. It installs an isolated DOM, mounts the Preact view once, and
+  returns a typed bridge plus deterministic cleanup.
+- Drive island state with `signal()` and `computed()` inputs instead of
+  rebuilding the old `render(model)` fixture pattern.
+  `tests/signal_view_reference_tests.ts` contains the reference panel coverage
+  for computed-driven output assertions.
+- Run `npm run test:signals` to execute the reference signal-view coverage
+  directly in Node with the same helper path used by future isolated island
+  tests.
+- Use `tests/async_test_helpers.ts::flushSignalUpdates()` after mutating signals
+  or when waiting on effect-owned side effects.
+  The same reference file also covers an effect-backed subscription seam through
+  `mountSettingsShell()`.
+- `createPanel()` and the raw fake-element builders remain only for legacy
+  bridge-style feature fixtures such as `tests/esp_flash_feature.spec.ts`.
+  Do not start new island tests from that pattern.
+
 ## Design Language
 
 The UI follows the design system documented in

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -17,7 +17,9 @@
         "@biomejs/biome": "^2.4.11",
         "@playwright/test": "^1.59.1",
         "@preact/preset-vite": "^2.10.5",
+        "linkedom": "^0.18.12",
         "openapi-typescript": "^7.13.0",
+        "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "vite": "^8.0.8"
       }
@@ -532,6 +534,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1292,6 +1736,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1399,6 +1850,48 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1479,6 +1972,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -1487,6 +1993,46 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -1845,6 +2391,31 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkedom": {
+      "version": "0.18.12",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
+      "integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.0.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2098,6 +2669,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
@@ -2220,6 +2801,26 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -2246,6 +2847,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -18,6 +18,7 @@
     "typecheck": "npm run check:contracts && tsc --noEmit",
     "pretest:smoke": "npm run sync:generated-contracts",
     "test:smoke": "npx playwright test --config=playwright.smoke.config.ts --project=laptop-light --workers=1",
+    "test:signals": "tsx tests/signal_view_reference_tests.ts",
     "test:visual": "npx playwright test",
     "test:visual:update": "npx playwright test --update-snapshots",
     "wiki:screenshots": "npx playwright test --config=playwright.wiki.config.ts tests/wiki_screenshots.spec.ts --workers=1",
@@ -34,7 +35,9 @@
     "@biomejs/biome": "^2.4.11",
     "@playwright/test": "^1.59.1",
     "@preact/preset-vite": "^2.10.5",
+    "linkedom": "^0.18.12",
     "openapi-typescript": "^7.13.0",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vite": "^8.0.8"
   }

--- a/apps/ui/src/i18n.ts
+++ b/apps/ui/src/i18n.ts
@@ -1,5 +1,5 @@
-import enCatalog from "./i18n/catalogs/en.json";
-import nlCatalog from "./i18n/catalogs/nl.json";
+import enCatalog from "./i18n/catalogs/en.json" with { type: "json" };
+import nlCatalog from "./i18n/catalogs/nl.json" with { type: "json" };
 
 type Catalog = Record<string, string>;
 

--- a/apps/ui/tests/async_test_helpers.ts
+++ b/apps/ui/tests/async_test_helpers.ts
@@ -66,3 +66,7 @@ export async function flushAsyncWork(rounds = 12): Promise<void> {
     });
   }
 }
+
+export async function flushSignalUpdates(rounds = 12): Promise<void> {
+  await flushAsyncWork(rounds);
+}

--- a/apps/ui/tests/dom_render_test_support.ts
+++ b/apps/ui/tests/dom_render_test_support.ts
@@ -1,3 +1,7 @@
+import { parseHTML } from "linkedom";
+
+import { flushSignalUpdates } from "./async_test_helpers";
+
 type DomGlobals = {
   Node?: typeof Node;
   Element?: typeof Element;
@@ -10,17 +14,44 @@ export class FakeNode {
   parentNode: FakeNode | null = null;
   childNodes: FakeNode[] = [];
 
+  get firstChild(): FakeNode | null {
+    return this.childNodes[0] ?? null;
+  }
+
+  get nextSibling(): FakeNode | null {
+    if (!this.parentNode) {
+      return null;
+    }
+    const siblings = this.parentNode.childNodes;
+    const index = siblings.indexOf(this);
+    return index >= 0 ? siblings[index + 1] ?? null : null;
+  }
+
+  get nodeType(): number {
+    return 0;
+  }
+
   appendChild<T extends FakeNode>(child: T): T {
+    return this.insertBefore(child, null);
+  }
+
+  insertBefore<T extends FakeNode>(child: T, before: FakeNode | null): T {
     if (child instanceof FakeDocumentFragment) {
       const fragmentChildren = [...child.childNodes];
       child.childNodes = [];
       for (const fragmentChild of fragmentChildren) {
-        this.appendChild(fragmentChild);
+        this.insertBefore(fragmentChild, before);
       }
       return child;
     }
+    child.remove();
     child.parentNode = this;
-    this.childNodes.push(child);
+    const index = before ? this.childNodes.indexOf(before) : -1;
+    if (index >= 0) {
+      this.childNodes.splice(index, 0, child);
+    } else {
+      this.childNodes.push(child);
+    }
     return child;
   }
 
@@ -33,6 +64,19 @@ export class FakeNode {
       }
       this.appendChild(child);
     }
+  }
+
+  removeChild<T extends FakeNode>(child: T): T {
+    const index = this.childNodes.indexOf(child);
+    if (index >= 0) {
+      this.childNodes.splice(index, 1);
+      child.parentNode = null;
+    }
+    return child;
+  }
+
+  remove(): void {
+    this.parentNode?.removeChild(this);
   }
 
   get textContent(): string {
@@ -52,6 +96,18 @@ class FakeText extends FakeNode {
     super();
   }
 
+  get data(): string {
+    return this.value;
+  }
+
+  set data(value: string) {
+    this.value = value;
+  }
+
+  override get nodeType(): number {
+    return 3;
+  }
+
   override get textContent(): string {
     return this.value;
   }
@@ -61,10 +117,14 @@ class FakeText extends FakeNode {
   }
 }
 
-export class FakeDocumentFragment extends FakeNode {}
+export class FakeDocumentFragment extends FakeNode {
+  override get nodeType(): number {
+    return 11;
+  }
+}
 
 function escapeHtml(value: string): string {
-  return value
+  return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
@@ -138,14 +198,41 @@ export class FakeElement extends FakeNode {
   readonly classList = new FakeClassList();
   readonly dataset: Record<string, string> = {};
   readonly #attributes = new Map<string, string>();
+  readonly #listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+  readonly #styleValues = new Map<string, string>();
   #rawInnerHTML: string | null = null;
 
   hidden = false;
   scrollTop = 0;
   scrollHeight = 0;
+  readonly namespaceURI = "http://www.w3.org/1999/xhtml";
+  readonly style = {
+    cssText: "",
+    getPropertyValue: (name: string): string => this.#styleValues.get(name) ?? "",
+    removeProperty: (name: string): string => {
+      const currentValue = this.#styleValues.get(name) ?? "";
+      this.#styleValues.delete(name);
+      this.#syncStyleCssText();
+      return currentValue;
+    },
+    setProperty: (name: string, value: string): void => {
+      this.#styleValues.set(name, value);
+      this.#syncStyleCssText();
+    },
+  } as unknown as CSSStyleDeclaration;
 
   constructor(readonly tagName: string) {
     super();
+  }
+
+  #syncStyleCssText(): void {
+    this.style.cssText = Array.from(this.#styleValues.entries())
+      .map(([name, value]) => `${name}: ${value};`)
+      .join(" ");
+  }
+
+  get attributes(): Array<{ name: string; value: string }> {
+    return Array.from(this.#attributes.entries(), ([name, value]) => ({ name, value }));
   }
 
   get className(): string {
@@ -154,6 +241,18 @@ export class FakeElement extends FakeNode {
 
   set className(value: string) {
     this.classList.setFromString(value);
+  }
+
+  get localName(): string {
+    return this.tagName.toLowerCase();
+  }
+
+  override get nodeType(): number {
+    return 1;
+  }
+
+  get ownerDocument(): Document | undefined {
+    return globalThis.document;
   }
 
   get innerHTML(): string {
@@ -170,9 +269,19 @@ export class FakeElement extends FakeNode {
     return super.appendChild(child);
   }
 
+  override insertBefore<T extends FakeNode>(child: T, before: FakeNode | null): T {
+    this.#rawInnerHTML = null;
+    return super.insertBefore(child, before);
+  }
+
   override replaceChildren(...children: Array<FakeNode | string>): void {
     this.#rawInnerHTML = null;
     super.replaceChildren(...children);
+  }
+
+  override removeChild<T extends FakeNode>(child: T): T {
+    this.#rawInnerHTML = null;
+    return super.removeChild(child);
   }
 
   override get textContent(): string {
@@ -202,6 +311,33 @@ export class FakeElement extends FakeNode {
     }
   }
 
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    let listeners = this.#listeners.get(type);
+    if (!listeners) {
+      listeners = new Set<EventListenerOrEventListenerObject>();
+      this.#listeners.set(type, listeners);
+    }
+    listeners.add(listener);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    this.#listeners.get(type)?.delete(listener);
+  }
+
+  dispatchEvent(event: Event): boolean {
+    const listeners = Array.from(this.#listeners.get(event.type) ?? []);
+    for (const listener of listeners) {
+      if (typeof listener === "function") {
+        listener.call(this, event);
+      } else {
+        listener.handleEvent(event);
+      }
+    }
+    return !event.defaultPrevented;
+  }
+
+  focus(): void {}
+
   toOuterHtml(): string {
     const attrs: string[] = [];
     if (this.className) {
@@ -218,8 +354,15 @@ export class FakeElement extends FakeNode {
 export class FakeHTMLElement extends FakeElement {}
 
 class FakeDocument {
+  readonly body = new FakeHTMLElement("BODY") as unknown as HTMLElement;
+  readonly documentElement = new FakeHTMLElement("HTML") as unknown as HTMLElement;
+
   createElement(tagName: string): FakeHTMLElement {
     return new FakeHTMLElement(tagName.toUpperCase());
+  }
+
+  createElementNS(_namespaceURI: string, tagName: string): FakeHTMLElement {
+    return this.createElement(tagName);
   }
 
   createTextNode(value: string): FakeText {
@@ -254,6 +397,31 @@ export function installFakeDomGlobals(): () => void {
   };
 }
 
+export type MountedSignalView<TView> = {
+  cleanup(): void;
+  flush(rounds?: number): Promise<void>;
+  host: HTMLElement;
+  view: TView;
+};
+
+type MountedViewGlobals = {
+  CustomEvent?: typeof CustomEvent;
+  DocumentFragment?: typeof DocumentFragment;
+  Element?: typeof Element;
+  Event?: typeof Event;
+  HTMLElement?: typeof HTMLElement;
+  HTMLButtonElement?: typeof HTMLButtonElement;
+  HTMLInputElement?: typeof HTMLInputElement;
+  KeyboardEvent?: typeof KeyboardEvent;
+  MouseEvent?: typeof MouseEvent;
+  Node?: typeof Node;
+  cancelAnimationFrame?: typeof cancelAnimationFrame;
+  document?: Document;
+  getComputedStyle?: typeof getComputedStyle;
+  requestAnimationFrame?: typeof requestAnimationFrame;
+  window?: Window & typeof globalThis;
+};
+
 function restoreGlobal<K extends keyof DomGlobals>(
   globalRef: typeof globalThis & DomGlobals,
   key: K,
@@ -266,8 +434,119 @@ function restoreGlobal<K extends keyof DomGlobals>(
   delete globalRef[key];
 }
 
+export async function mountSignalView<TView>(
+  loadMount: () => Promise<(host: HTMLElement) => TView> | ((host: HTMLElement) => TView),
+): Promise<MountedSignalView<TView>> {
+  const restoreDom = installMountedViewDomGlobals();
+  const host = globalThis.document.createElement("div");
+  globalThis.document.body.appendChild(host);
+  let cleanedUp = false;
+
+  try {
+    const { render } = await import("preact");
+    const mount = await loadMount();
+    const view = mount(host);
+    return {
+      cleanup(): void {
+        if (cleanedUp) {
+          return;
+        }
+        cleanedUp = true;
+        render(null, host);
+        restoreDom();
+      },
+      flush(rounds = 12): Promise<void> {
+        return flushSignalUpdates(rounds);
+      },
+      host,
+      view,
+    };
+  } catch (error) {
+    restoreDom();
+    throw error;
+  }
+}
+
+// Legacy escape hatch for bridge-style feature fixtures. New signal-backed
+// island tests should prefer mountSignalView().
 export function createPanel(): HTMLElement {
   return new FakeHTMLElement("DIV") as unknown as HTMLElement;
+}
+
+function installMountedViewDomGlobals(): () => void {
+  const { window } = parseHTML("<!doctype html><html><body></body></html>");
+  const globalRef = globalThis as typeof globalThis & MountedViewGlobals;
+  const original: MountedViewGlobals = {
+    CustomEvent: globalRef.CustomEvent,
+    DocumentFragment: globalRef.DocumentFragment,
+    Element: globalRef.Element,
+    Event: globalRef.Event,
+    HTMLElement: globalRef.HTMLElement,
+    HTMLButtonElement: globalRef.HTMLButtonElement,
+    HTMLInputElement: globalRef.HTMLInputElement,
+    KeyboardEvent: globalRef.KeyboardEvent,
+    MouseEvent: globalRef.MouseEvent,
+    Node: globalRef.Node,
+    cancelAnimationFrame: globalRef.cancelAnimationFrame,
+    document: globalRef.document,
+    getComputedStyle: globalRef.getComputedStyle,
+    requestAnimationFrame: globalRef.requestAnimationFrame,
+    window: globalRef.window,
+  };
+
+  globalRef.window = window as Window & typeof globalThis;
+  globalRef.document = window.document as unknown as Document;
+  globalRef.Node = window.Node as unknown as typeof Node;
+  globalRef.Element = window.Element as unknown as typeof Element;
+  globalRef.HTMLElement = window.HTMLElement as unknown as typeof HTMLElement;
+  globalRef.HTMLButtonElement = window.HTMLButtonElement as unknown as typeof HTMLButtonElement;
+  globalRef.HTMLInputElement = window.HTMLInputElement as unknown as typeof HTMLInputElement;
+  globalRef.DocumentFragment = window.DocumentFragment as unknown as typeof DocumentFragment;
+  globalRef.Event = window.Event as unknown as typeof Event;
+  globalRef.CustomEvent = window.CustomEvent as unknown as typeof CustomEvent;
+  globalRef.KeyboardEvent = window.KeyboardEvent as unknown as typeof KeyboardEvent;
+  globalRef.MouseEvent = window.MouseEvent as unknown as typeof MouseEvent;
+  globalRef.getComputedStyle = (window.getComputedStyle
+    ? window.getComputedStyle.bind(window)
+    : (() =>
+      ({
+        getPropertyValue: () => "",
+      }) as CSSStyleDeclaration)) as typeof getComputedStyle;
+  globalRef.requestAnimationFrame = ((callback: FrameRequestCallback) =>
+    setTimeout(() => callback(Date.now()), 16) as unknown as number) as typeof requestAnimationFrame;
+  globalRef.cancelAnimationFrame = ((handle: number) => {
+    clearTimeout(handle);
+  }) as typeof cancelAnimationFrame;
+
+  return () => {
+    restoreMountedViewGlobal(globalRef, "window", original.window);
+    restoreMountedViewGlobal(globalRef, "document", original.document);
+    restoreMountedViewGlobal(globalRef, "Node", original.Node);
+    restoreMountedViewGlobal(globalRef, "Element", original.Element);
+    restoreMountedViewGlobal(globalRef, "HTMLElement", original.HTMLElement);
+    restoreMountedViewGlobal(globalRef, "HTMLButtonElement", original.HTMLButtonElement);
+    restoreMountedViewGlobal(globalRef, "HTMLInputElement", original.HTMLInputElement);
+    restoreMountedViewGlobal(globalRef, "DocumentFragment", original.DocumentFragment);
+    restoreMountedViewGlobal(globalRef, "Event", original.Event);
+    restoreMountedViewGlobal(globalRef, "CustomEvent", original.CustomEvent);
+    restoreMountedViewGlobal(globalRef, "KeyboardEvent", original.KeyboardEvent);
+    restoreMountedViewGlobal(globalRef, "MouseEvent", original.MouseEvent);
+    restoreMountedViewGlobal(globalRef, "getComputedStyle", original.getComputedStyle);
+    restoreMountedViewGlobal(globalRef, "requestAnimationFrame", original.requestAnimationFrame);
+    restoreMountedViewGlobal(globalRef, "cancelAnimationFrame", original.cancelAnimationFrame);
+  };
+}
+
+function restoreMountedViewGlobal<K extends keyof MountedViewGlobals>(
+  globalRef: typeof globalThis & MountedViewGlobals,
+  key: K,
+  value: MountedViewGlobals[K],
+): void {
+  if (value) {
+    globalRef[key] = value;
+    return;
+  }
+  delete globalRef[key];
 }
 
 export function elementChildren(node: FakeNode): FakeElement[] {

--- a/apps/ui/tests/signal_view_reference_tests.ts
+++ b/apps/ui/tests/signal_view_reference_tests.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+
+import { computed, signal } from "../src/app/ui_signals";
+import type {
+  RealtimeLiveOverviewRenderModel,
+  RealtimeLiveOverviewSensorCardModel,
+} from "../src/app/views/realtime_live_overview";
+import { mountSignalView } from "./dom_render_test_support";
+
+function requireElement<T extends Element = HTMLElement>(root: ParentNode, selector: string): T {
+  const element = root.querySelector<T>(selector);
+  assert.ok(element, `Expected element matching ${selector}`);
+  return element;
+}
+
+async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
+  const connectedSensorsText = signal("2 / 4");
+  const activeCarText = signal("Roadster");
+  const activeCarWarning = signal(false);
+  const recordingStateText = signal("Stopped");
+  const dataFreshnessText = signal("Fresh");
+  const strongestSignalText = signal("68 dB");
+  const runHealthText = signal("Ready");
+  const runHealthVariant = signal<RealtimeLiveOverviewRenderModel["runHealth"]["variant"]>("ok");
+  const sensorCards = signal<RealtimeLiveOverviewSensorCardModel[]>([]);
+
+  const model = computed<RealtimeLiveOverviewRenderModel>(() => ({
+    activeCar: {
+      text: activeCarText.value,
+      warning: activeCarWarning.value,
+    },
+    connectedSensorsText: connectedSensorsText.value,
+    dataFreshnessText: dataFreshnessText.value,
+    recordingStateText: recordingStateText.value,
+    runHealth: {
+      hidden: false,
+      text: runHealthText.value,
+      variant: runHealthVariant.value,
+    },
+    sensorCards: sensorCards.value,
+    strongestSignalText: strongestSignalText.value,
+  }));
+
+  const harness = await mountSignalView(async () => {
+    const { mountRealtimeLiveOverview } = await import("../src/app/views/realtime_live_overview");
+    return mountRealtimeLiveOverview;
+  });
+
+  try {
+    harness.view.bindModel(model);
+    harness.view.setSpeedText("43 km/h");
+    await harness.flush();
+
+    assert.equal(requireElement(harness.host, "#liveConnectedSensors [data-value]").textContent, "2 / 4");
+    assert.equal(requireElement(harness.host, "#liveStrongestSignal [data-value]").textContent, "68 dB");
+    assert.equal(requireElement(harness.host, "#speed").textContent, "43 km/h");
+    assert.equal(requireElement(harness.host, "#liveRunHealth").textContent, "Ready");
+    assert.match(harness.host.textContent ?? "", /No sensors/i);
+
+    connectedSensorsText.value = "4 / 4";
+    strongestSignalText.value = "82 dB";
+    activeCarText.value = "Choose a car";
+    activeCarWarning.value = true;
+    recordingStateText.value = "Recording";
+    dataFreshnessText.value = "Live";
+    runHealthText.value = "Recording";
+    runHealthVariant.value = "warn";
+    sensorCards.value = [
+      {
+        connected: true,
+        id: "front-left",
+        label: "Front Left",
+        statusText: "Online",
+        strongest: true,
+      },
+    ];
+
+    await harness.flush();
+
+    assert.equal(requireElement(harness.host, "#liveConnectedSensors [data-value]").textContent, "4 / 4");
+    assert.equal(requireElement(harness.host, "#liveRecordingState [data-value]").textContent, "Recording");
+    assert.equal(requireElement(harness.host, "#liveDataFreshness [data-value]").textContent, "Live");
+    assert.equal(requireElement(harness.host, "#liveStrongestSignal [data-value]").textContent, "82 dB");
+    assert.equal(requireElement(harness.host, "#liveRunHealth").textContent, "Recording");
+    assert.equal(requireElement(harness.host, "#liveRunHealth").getAttribute("data-variant"), "warn");
+    assert.match(
+      requireElement(harness.host, "#liveActiveCar [data-value]").textContent ?? "",
+      /Choose a car/,
+    );
+    assert.equal(
+      requireElement(harness.host, "#liveActiveCar [data-value]").getAttribute("data-variant"),
+      "warn",
+    );
+    assert.equal(harness.host.querySelectorAll(".live-sensor-card--strongest").length, 1);
+    assert.match(harness.host.textContent ?? "", /Front Left/);
+    assert.doesNotMatch(harness.host.textContent ?? "", /No sensors/i);
+  } finally {
+    harness.cleanup();
+  }
+}
+
+async function runSettingsShellReferenceTest(): Promise<void> {
+  const harness = await mountSignalView(async () => {
+    const { mountSettingsShell } = await import("../src/app/views/settings_shell");
+    return mountSettingsShell;
+  });
+
+  try {
+    const observedTabs: string[] = [];
+    const dispose = harness.view.subscribeActiveTabChanges((tabId) => {
+      observedTabs.push(tabId);
+    });
+
+    assert.equal(harness.view.getActiveTabId(), "carTab");
+    assert.deepEqual(observedTabs, []);
+
+    harness.view.activateTab("analysisTab");
+    await harness.flush();
+
+    assert.deepEqual(observedTabs, ["analysisTab"]);
+    assert.equal(harness.view.getActiveTabId(), "analysisTab");
+    assert.equal(
+      requireElement(harness.host, '[data-settings-tab="analysisTab"]').getAttribute("aria-selected"),
+      "true",
+    );
+    assert.equal(requireElement(harness.host, "#analysisTab").hidden, false);
+    assert.equal(requireElement(harness.host, "#carTab").hidden, true);
+
+    harness.view.activateTab("analysisTab");
+    await harness.flush();
+    assert.deepEqual(observedTabs, ["analysisTab"]);
+
+    dispose();
+    harness.view.activateTab("speedSourceTab");
+    await harness.flush();
+    assert.deepEqual(observedTabs, ["analysisTab"]);
+  } finally {
+    harness.cleanup();
+  }
+}
+
+const referenceTests = [
+  {
+    name: "realtime live overview computed-driven output",
+    run: runRealtimeLiveOverviewReferenceTest,
+  },
+  {
+    name: "settings shell effect-backed subscription seam",
+    run: runSettingsShellReferenceTest,
+  },
+];
+
+for (const referenceTest of referenceTests) {
+  await referenceTest.run();
+  console.log(`PASS ${referenceTest.name}`);
+}


### PR DESCRIPTION
## Summary

This PR finishes issue #2340 by establishing one clear signal-era testing path for isolated Preact islands, while keeping the older bridge-fixture helpers available for the large feature tests that still depend on them. The migration to Preact + `@preact/signals` changed the frontend’s main testing problem: many of the older tests were built around imperative `render(model)` seams or typed panel stubs, but they did not provide a stable, documented way to mount a signal-driven island, mutate signals directly, and assert on the rendered output or effect-backed behavior. The missing pattern was especially visible once the runtime and panel work moved deeper into signal-backed ownership.

The first part of the work was scoping the current test surface against the live issue. That scan showed the issue body had already drifted a bit from the repo. The helper files now live at `apps/ui/tests/dom_render_test_support.ts` and `apps/ui/tests/async_test_helpers.ts`, not under `tests/helpers/`. It also showed that the old fake-element helper path is no longer broadly shared: `esp_flash_feature.spec.ts` is now the main remaining consumer of the legacy `createPanel()` style fixtures, while newer signal-era feature tests usually stay at the typed bridge level. That meant the right fix was not to rewrite every older feature fixture right now, but to add a new reference path for direct signal-view tests and clearly mark the old path as legacy-only for new work.

## Implementation approach

The core decision here was to avoid forcing the new reference tests through the visual Playwright browser configuration. Those browser projects are good for live UI and snapshot validation, but they are not the right home for direct node-side signal-view mounting. Instead, this PR adds a focused signal-view runner path built around a dedicated helper and a lightweight DOM implementation, so isolated island tests can run deterministically in Node while the broader browser and feature suites keep doing what they already do well.

The new helper lives in `apps/ui/tests/dom_render_test_support.ts` as `mountSignalView()`. Rather than leaning on the older fake-element tree that was only deep enough for bridge-style fixtures, `mountSignalView()` now installs an isolated `linkedom` DOM, mounts the requested Preact view once, and returns the typed bridge plus cleanup and flush helpers. This gives new tests a real DOM surface for `querySelector()`, attributes, hidden state, and other view assertions without having to start a browser page or rebuild the whole app shell. The existing fake DOM classes and `createPanel()` remain in place because the large legacy feature fixtures still use them, but they are now explicitly documented as a migration residue, not the default pattern for new isolated island tests.

Alongside that, `apps/ui/tests/async_test_helpers.ts` now exports `flushSignalUpdates()`. This is intentionally small, but it makes the expected pattern discoverable: mutate a `signal()` or a source feeding a `computed()`, flush reactive work, then assert on DOM output or effect-owned behavior. Naming this helper matters because it turns an implementation detail (`flushAsyncWork`) into a testing convention that future panel tests can follow directly.

## Reference tests and docs

The new reference coverage lives in `apps/ui/tests/signal_view_reference_tests.ts`, and it deliberately covers two different signal-era seams.

The first reference test mounts `mountRealtimeLiveOverview()` and binds a `computed()` render model built from smaller source signals. It then mutates those source signals, flushes reactive work, and asserts directly on the rendered DOM output for connected sensors, strongest signal, active-car warning state, run health, and the strongest-sensor badge. This is the concrete example of “set signal values and assert on component output” that the issue asked for.

The second reference test mounts `mountSettingsShell()` and exercises its `effect()`-backed subscription seam. It confirms that `subscribeActiveTabChanges()` does not replay the initial tab, emits only on real changes, updates the tabpanel visibility state correctly, and stops emitting after disposal. That gives the repo a reference pattern for asserting effect-owned side effects without dropping down to the larger end-to-end smoke flows.

To make that reference path easy to run, `apps/ui/package.json` now adds `npm run test:signals`, and the new `tsx` dev dependency executes the signal-view reference script directly in Node. `apps/ui/README.md` now documents the preferred testing path, points future contributors at `mountSignalView()`, `flushSignalUpdates()`, and `npm run test:signals`, and explicitly says that new island tests should not start from `createPanel()`-style bridge fixtures.

## Related supporting change

One small production-facing change was necessary to make these node-side signal view imports reliable: `apps/ui/src/i18n.ts` now imports its JSON catalogs with explicit JSON import attributes. The new reference tests dynamically import actual view modules in Node, and those views reach `ui_i18n.ts`, which reaches `i18n.ts`. Without the import attributes, those node-side imports failed outside the Vite runtime. This change is small, standards-compliant, and directly coupled to the testing path introduced here.

## Validation

I validated this change at the same levels the issue called for:

- `cd apps/ui && npx playwright test tests/settings_analysis_module.spec.ts tests/update_feature_bindings.spec.ts tests/esp_flash_feature.spec.ts --workers=1`
- `cd apps/ui && npm run test:signals`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

This keeps the legacy helper consumer in the loop, proves the new reference signal path runs successfully, and confirms the normal frontend gates still pass. I did not run `npm run test:visual` because the visual helpers and snapshot surfaces were not changed by this PR.

## Risks, tradeoffs, and follow-ups

The main tradeoff is that the new reference tests live on a focused Node runner path instead of being forced into the default visual Playwright browser projects. I believe that is the right tradeoff here: it keeps signal-view tests fast and deterministic, avoids contorting the visual suite into a unit-test runner, and still leaves the browser smoke and snapshot layers intact for higher-level confidence.

I also intentionally did not rewrite the remaining legacy bridge-style feature fixtures in this PR. The issue asked for a clear pattern and at least one panel reference implementation, not a full migration of every older test. Keeping `createPanel()` available while documenting it as legacy keeps the current big feature tests stable and gives future panel work a cleaner target.

Closes #2340
