### PR TITLE
Remove update and internet panel DOM leaks

### DIFF
--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -1,4 +1,5 @@
 import { h, render, type ComponentChildren } from "preact";
+import { useEffect, useRef } from "preact/hooks";
 
 import type { UpdateStartRequestPayload } from "../../transport/http_models";
 import type { ChoiceCardState } from "../view_style_types";
@@ -13,23 +14,6 @@ import type {
   UpdateStatusBadgeModel,
   UpdateStatusRowModel,
 } from "./update_status_view_models";
-
-export interface InternetPanelDom {
-  internetStatusPanel: HTMLElement | null;
-  updateTransportOptions: HTMLElement | null;
-  updateTransportChoiceWifi: HTMLElement | null;
-  updateTransportChoiceUsb: HTMLElement | null;
-  updateWifiFields: HTMLElement | null;
-  updateReadinessSummary: HTMLElement | null;
-  updateDetailsCaption: HTMLElement | null;
-  updateTransportNote: HTMLElement | null;
-  updateTransportWifiRadio: HTMLInputElement | null;
-  updateTransportUsbRadio: HTMLInputElement | null;
-  updateUsbTransportSummary: HTMLElement | null;
-  updateSsidInput: HTMLInputElement | null;
-  updatePasswordInput: HTMLInputElement | null;
-  updateTogglePasswordBtn: HTMLButtonElement | null;
-}
 
 export interface UpdateTransportChoiceCardRenderModel {
   badgeText: string | null;
@@ -67,14 +51,19 @@ export interface InternetPanelActionHandlers {
 }
 
 export interface InternetPanelView {
-  readonly dom: InternetPanelDom;
   bindActions(handlers: InternetPanelActionHandlers): void;
+  focusSsidInput(): void;
   setModel(model: InternetPanelRenderModel): void;
 }
 
 type InternetPanelBridgeState = {
   actions: InternetPanelActionHandlers | null;
   model: InternetPanelRenderModel;
+};
+
+type InternetPanelFocusRequest = {
+  field: "ssid";
+  token: number;
 };
 
 const DEFAULT_INTERNET_PANEL_MODEL: InternetPanelRenderModel = {
@@ -268,11 +257,22 @@ function UpdateTransportChoiceCard(props: {
 }
 
 function InternetPanel(props: {
+  focusRequest: ReadonlySignal<InternetPanelFocusRequest | null>;
   state: ReadonlySignal<InternetPanelBridgeState>;
 }) {
+  const focusRequest = props.focusRequest.value;
   const state = props.state.value;
   const { model } = state;
   const t = useUiTranslation();
+  const ssidInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!focusRequest) {
+      return;
+    }
+    ssidInputRef.current?.focus();
+  }, [focusRequest]);
+
   return (
     <div class="maintenance-stack">
       <div class="panel card">
@@ -361,6 +361,7 @@ function InternetPanel(props: {
               <input
                 type="text"
                 id="updateSsidInput"
+                ref={ssidInputRef}
                 autoComplete="off"
                 maxLength={64}
                 style="width:100%;max-width:20rem;"
@@ -437,54 +438,22 @@ function InternetPanel(props: {
   );
 }
 
-function createInternetPanelDom(host: HTMLElement): InternetPanelDom {
-  return {
-    internetStatusPanel: host.querySelector<HTMLElement>("#internetStatusPanel"),
-    updateTransportOptions: host.querySelector<HTMLElement>(
-      "#updateTransportOptions",
-    ),
-    updateTransportChoiceWifi: host.querySelector<HTMLElement>(
-      "#updateTransportChoiceWifi",
-    ),
-    updateTransportChoiceUsb: host.querySelector<HTMLElement>(
-      "#updateTransportChoiceUsb",
-    ),
-    updateWifiFields: host.querySelector<HTMLElement>("#updateWifiFields"),
-    updateReadinessSummary: host.querySelector<HTMLElement>(
-      "#updateReadinessSummary",
-    ),
-    updateDetailsCaption: host.querySelector<HTMLElement>("#updateDetailsCaption"),
-    updateTransportNote: host.querySelector<HTMLElement>("#updateTransportNote"),
-    updateTransportWifiRadio: host.querySelector<HTMLInputElement>(
-      "#updateTransportWifiRadio",
-    ),
-    updateTransportUsbRadio: host.querySelector<HTMLInputElement>(
-      "#updateTransportUsbRadio",
-    ),
-    updateUsbTransportSummary: host.querySelector<HTMLElement>(
-      "#updateUsbTransportSummary",
-    ),
-    updateSsidInput: host.querySelector<HTMLInputElement>("#updateSsidInput"),
-    updatePasswordInput: host.querySelector<HTMLInputElement>(
-      "#updatePasswordInput",
-    ),
-    updateTogglePasswordBtn: host.querySelector<HTMLButtonElement>(
-      "#updateTogglePasswordBtn",
-    ),
-  };
-}
-
 export function mountInternetPanel(host: HTMLElement): InternetPanelView {
+  const focusRequest = signal<InternetPanelFocusRequest | null>(null);
+  let focusRequestToken = 0;
   const state = signal<InternetPanelBridgeState>({
     actions: null,
     model: DEFAULT_INTERNET_PANEL_MODEL,
   });
-  render(<InternetPanel state={state} />, host);
+  render(<InternetPanel focusRequest={focusRequest} state={state} />, host);
 
   return {
-    dom: createInternetPanelDom(host),
     bindActions(handlers) {
       state.value = { ...state.value, actions: handlers };
+    },
+    focusSsidInput() {
+      focusRequestToken += 1;
+      focusRequest.value = { field: "ssid", token: focusRequestToken };
     },
     setModel(model) {
       state.value = { ...state.value, model };

--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -425,7 +425,7 @@ export function createUpdateFeaturePresenter(
       rerenderLastState();
     },
     focusSsidInput() {
-      internetPanel.dom.updateSsidInput?.focus();
+      internetPanel.focusSsidInput();
     },
     clearPassword() {
       formState = { ...formState, passwordInputValue: "" };

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -17,13 +17,6 @@ import type {
   UpdateStatusRowModel,
 } from "./update_status_view_models";
 
-export interface UpdatePanelDom {
-  updateOverviewPanel: HTMLElement | null;
-  updateStartBtn: HTMLButtonElement;
-  updateCancelBtn: HTMLButtonElement;
-  updateStatusPanel: HTMLElement;
-}
-
 export interface UpdatePanelRenderModel {
   cancelButtonDisabled: boolean;
   cancelButtonHidden: boolean;
@@ -39,7 +32,6 @@ export interface UpdatePanelActionHandlers {
 }
 
 export interface UpdatePanelView {
-  readonly dom: UpdatePanelDom;
   bindActions(handlers: UpdatePanelActionHandlers): void;
   setModel(model: UpdatePanelRenderModel): void;
 }
@@ -403,26 +395,6 @@ function UpdatePanel(props: {
   );
 }
 
-function requiredInHost<T extends Element>(
-  host: ParentNode,
-  selector: string,
-): T {
-  const element = host.querySelector<T>(selector);
-  if (!element) {
-    throw new Error(`Update feature requires ${selector}`);
-  }
-  return element;
-}
-
-function createUpdatePanelDom(host: HTMLElement): UpdatePanelDom {
-  return {
-    updateOverviewPanel: host.querySelector<HTMLElement>("#updateOverviewPanel"),
-    updateStartBtn: requiredInHost<HTMLButtonElement>(host, "#updateStartBtn"),
-    updateCancelBtn: requiredInHost<HTMLButtonElement>(host, "#updateCancelBtn"),
-    updateStatusPanel: requiredInHost<HTMLElement>(host, "#updateStatusPanel"),
-  };
-}
-
 export function mountUpdatePanel(host: HTMLElement): UpdatePanelView {
   const state = signal<UpdatePanelBridgeState>({
     actions: null,
@@ -431,7 +403,6 @@ export function mountUpdatePanel(host: HTMLElement): UpdatePanelView {
   render(<UpdatePanel state={state} />, host);
 
   return {
-    dom: createUpdatePanelDom(host),
     bindActions(handlers) {
       state.value = { ...state.value, actions: handlers };
     },

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -9,12 +9,10 @@ import type {
 } from "../src/app/views/esp_flash_panel";
 import type {
   InternetPanelActionHandlers,
-  InternetPanelDom,
   InternetPanelRenderModel,
 } from "../src/app/views/internet_panel";
 import type {
   UpdatePanelActionHandlers,
-  UpdatePanelDom,
   UpdatePanelRenderModel,
 } from "../src/app/views/update_panel";
 import {
@@ -293,8 +291,15 @@ function serializeUpdateStatus(
   return `<div class="maintenance-pair-grid maintenance-pair-grid--focus">${serializeJourneyCard(status.journey)}${serializeLogCard(status.log)}</div>${status.latestAttempt ? serializeLatestAttemptCard(status.latestAttempt) : ""}${status.issues ? serializeIssuesCard(status.issues) : ""}`;
 }
 
+type UpdatePanelDomHarness = {
+  updateOverviewPanel: HTMLElement | null;
+  updateStartBtn: HTMLButtonElement;
+  updateCancelBtn: HTMLButtonElement;
+  updateStatusPanel: HTMLElement;
+};
+
 function renderUpdatePanelDom(
-  dom: UpdatePanelDom,
+  dom: UpdatePanelDomHarness,
   model: UpdatePanelRenderModel,
 ): void {
   dom.updateStartBtn.textContent = model.startButtonLabelText;
@@ -332,8 +337,25 @@ function serializeInternetStatusPanel(
   });
 }
 
+type InternetPanelDomHarness = {
+  internetStatusPanel: HTMLElement | null;
+  updateTransportOptions: HTMLElement | null;
+  updateTransportChoiceWifi: HTMLElement | null;
+  updateTransportChoiceUsb: HTMLElement | null;
+  updateWifiFields: HTMLElement | null;
+  updateReadinessSummary: HTMLElement | null;
+  updateDetailsCaption: HTMLElement | null;
+  updateTransportNote: HTMLElement | null;
+  updateTransportWifiRadio: HTMLInputElement | null;
+  updateTransportUsbRadio: HTMLInputElement | null;
+  updateUsbTransportSummary: HTMLElement | null;
+  updateSsidInput: HTMLInputElement | null;
+  updatePasswordInput: HTMLInputElement | null;
+  updateTogglePasswordBtn: HTMLButtonElement | null;
+};
+
 function renderInternetPanelDom(
-  dom: InternetPanelDom,
+  dom: InternetPanelDomHarness,
   model: InternetPanelRenderModel,
 ): void {
   if (dom.internetStatusPanel) {
@@ -744,19 +766,18 @@ function createUpdateDeps() {
     updateSsidInput,
     updatePasswordInput,
     updateTogglePasswordBtn,
-  } as InternetPanelDom;
+  } satisfies InternetPanelDomHarness;
 
   const dom = {
     updateOverviewPanel,
     updateStartBtn,
     updateCancelBtn,
     updateStatusPanel,
-  } as UpdatePanelDom;
+  } satisfies UpdatePanelDomHarness;
 
   return {
     panels: {
       update: {
-        dom,
         bindActions(handlers: UpdatePanelActionHandlers) {
           dom.updateStartBtn.addEventListener("click", () => {
             handlers.onStart();
@@ -770,7 +791,6 @@ function createUpdateDeps() {
         },
       },
       internet: {
-        dom: internetDom,
         bindActions(handlers: InternetPanelActionHandlers) {
           internetDom.updatePasswordInput?.addEventListener("input", () => {
             handlers.onPasswordInput(internetDom.updatePasswordInput?.value ?? "");
@@ -787,6 +807,9 @@ function createUpdateDeps() {
           internetDom.updateSsidInput?.addEventListener("input", () => {
             handlers.onSsidInput(internetDom.updateSsidInput?.value ?? "");
           });
+        },
+        focusSsidInput() {
+          internetDom.updateSsidInput?.focus();
         },
         setModel(model: InternetPanelRenderModel) {
           renderInternetPanelDom(internetDom, model);
@@ -1481,13 +1504,13 @@ test.describe("createUpdateFeature polling", () => {
 
     try {
       const deps = createUpdateDeps();
-      deps.panels.internet.dom.updateSsidInput.value = "";
+      deps.updateSsidInput.value = "";
       const feature = createUpdateFeature(deps);
 
       feature.startPolling();
       await flushAsyncWork();
 
-      expect(deps.panels.internet.dom.updateSsidInput.value).toBe("Workshop Wi-Fi");
+      expect(deps.updateSsidInput.value).toBe("Workshop Wi-Fi");
       expect(deps.updateReadinessSummary.innerHTML).toContain(
         "settings.update.readiness.summary_ready",
       );
@@ -1526,7 +1549,7 @@ test.describe("createUpdateFeature polling", () => {
       feature.startPolling();
       await flushAsyncWork();
 
-      expect(deps.panels.internet.dom.updateSsidInput.value).toBe(
+      expect(deps.updateSsidInput.value).toBe(
         "Driver-entered Wi-Fi",
       );
     } finally {

--- a/apps/ui/tests/update_feature_bindings.spec.ts
+++ b/apps/ui/tests/update_feature_bindings.spec.ts
@@ -4,23 +4,12 @@ import { createUpdateFeature } from "../src/app/features/update_feature";
 import { signal } from "../src/app/ui_signals";
 import type {
   InternetPanelActionHandlers,
-  InternetPanelDom,
   InternetPanelRenderModel,
 } from "../src/app/views/internet_panel";
 import type {
   UpdatePanelActionHandlers,
-  UpdatePanelDom,
   UpdatePanelRenderModel,
 } from "../src/app/views/update_panel";
-
-function createInputStub(value = "", type = "text") {
-  return {
-    checked: false,
-    disabled: false,
-    type,
-    value,
-  } as HTMLInputElement;
-}
 
 test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners", () => {
   let updateHandlers: UpdatePanelActionHandlers | null = null;
@@ -38,37 +27,16 @@ test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners
     },
     panels: {
       update: {
-        dom: {
-          updateOverviewPanel: null,
-          updateStartBtn: {} as HTMLButtonElement,
-          updateCancelBtn: {} as HTMLButtonElement,
-          updateStatusPanel: {} as HTMLElement,
-        } as UpdatePanelDom,
         bindActions(handlers: UpdatePanelActionHandlers) {
           updateHandlers = handlers;
         },
         setModel(_model: UpdatePanelRenderModel) {},
       },
       internet: {
-        dom: {
-          internetStatusPanel: null,
-          updateTransportOptions: null,
-          updateTransportChoiceWifi: null,
-          updateTransportChoiceUsb: null,
-          updateWifiFields: null,
-          updateReadinessSummary: null,
-          updateDetailsCaption: null,
-          updateTransportNote: null,
-          updateTransportWifiRadio: createInputStub("", "radio"),
-          updateTransportUsbRadio: createInputStub("", "radio"),
-          updateUsbTransportSummary: null,
-          updateSsidInput: createInputStub("MyWiFi"),
-          updatePasswordInput: createInputStub("secret", "password"),
-          updateTogglePasswordBtn: {} as HTMLButtonElement,
-        } as InternetPanelDom,
         bindActions(handlers: InternetPanelActionHandlers) {
           internetHandlers = handlers;
         },
+        focusSsidInput() {},
         setModel(_model: InternetPanelRenderModel) {},
       },
     },

--- a/apps/ui/tests/update_feature_presenter.spec.ts
+++ b/apps/ui/tests/update_feature_presenter.spec.ts
@@ -250,41 +250,15 @@ test.describe("createUpdateFeaturePresenter", () => {
     let focusCalls = 0;
     const presenter = createUpdateFeaturePresenter({
       internetPanel: {
-        dom: {
-          internetStatusPanel: null,
-          updateTransportOptions: null,
-          updateTransportChoiceWifi: null,
-          updateTransportChoiceUsb: null,
-          updateWifiFields: null,
-          updateReadinessSummary: null,
-          updateDetailsCaption: null,
-          updateTransportNote: null,
-          updateTransportWifiRadio: { checked: false } as HTMLInputElement,
-          updateTransportUsbRadio: { checked: true } as HTMLInputElement,
-          updateUsbTransportSummary: null,
-          updateSsidInput: {
-            focus() {
-              focusCalls += 1;
-            },
-            value: "dom-ssid",
-          } as HTMLInputElement,
-          updatePasswordInput: {
-            value: "dom-password",
-          } as HTMLInputElement,
-          updateTogglePasswordBtn: null,
-        },
         bindActions() {},
+        focusSsidInput() {
+          focusCalls += 1;
+        },
         setModel(model) {
           latestInternetPanel = model;
         },
       },
       panel: {
-        dom: {
-          updateOverviewPanel: null,
-          updateStartBtn: {} as HTMLButtonElement,
-          updateCancelBtn: {} as HTMLButtonElement,
-          updateStatusPanel: {} as HTMLElement,
-        },
         bindActions() {},
         setModel(model) {
           latestUpdatePanel = model;


### PR DESCRIPTION
## Summary

This PR closes #2358 by finishing the last real piece of the panel bridge migration that was still left in the live codebase: the raw `.dom` escape hatch on the update and internet panels. The issue body was written before several later panel-migration refactors landed, so the first step here was re-scoping the work against the current repo instead of following the original description literally. That re-read showed the five panels named in the issue are already on the signal-backed bridge pattern today: `esp_flash_panel.tsx`, `update_panel.tsx`, `internet_panel.tsx`, `history_panel.tsx`, and `speed_source_panel.tsx` all mount once and update through signal-backed bridge state rather than the old repeated `mount.render()` loop.

What remained was narrower but still meaningful. `update_panel.tsx` and `internet_panel.tsx` still exposed raw `.dom` properties on their public view contracts, and `update_feature_presenter.ts` still reached through `internetPanel.dom.updateSsidInput?.focus()` when a Wi-Fi update start was blocked by a missing SSID. That direct DOM reach-through was exactly the kind of migration residue this issue was meant to remove. This PR deletes that leaked contract and moves SSID focus ownership back into the panel itself, which keeps the update feature on a semantic view API instead of a DOM bag.

## Why this is the right cut

Because most of the issue body had already been satisfied by later migration work, I intentionally did not reopen the broader panel conversion effort or churn already-correct files just to match the old issue text. The current code already satisfies the one-time render plus signal-backed bridge-state part of #2358. The remaining incomplete migration seam was the update/internet DOM exposure, so this PR focuses there and leaves the already-converted panels untouched.

That narrower cut also keeps the dependency chain clean for later signal work. Future panel follow-ups should build on semantic panel contracts and reactive state ownership, not on hidden DOM reach-throughs that survived only because one presenter still needed to call `.focus()` on a specific input. Removing the leaked DOM seam now makes the current panel layer more internally consistent and gives later signal work a cleaner surface to build on.

## Main code changes

### 1. Remove raw DOM exposure from the update and internet panel contracts

`apps/ui/src/app/views/update_panel.tsx` no longer exports `UpdatePanelDom`, no longer exposes a `dom` property on `UpdatePanelView`, and no longer builds that DOM bag during mount. The mounted view now exposes only the semantic surface the rest of the app actually uses: `bindActions()` and `setModel()`.

`apps/ui/src/app/views/internet_panel.tsx` gets the same cleanup. `InternetPanelDom` is gone from the production module, `InternetPanelView` no longer exposes `.dom`, and the old host-query helper is removed. The public panel contract is now intentionally narrow: bind actions, set the model, and request SSID focus.

This matters because it restores the intended ownership boundary. The panel owns how its DOM is structured and how focus is applied; callers should not need to know where the SSID input lives in that structure.

### 2. Move SSID focusing into the internet panel

To replace the old raw DOM access, `internet_panel.tsx` now owns a small signal-driven focus request path. The mounted panel keeps a focus-request signal with a monotonic token, passes that signal into the component, and the component uses `useRef` plus `useEffect` to focus the SSID input when a new request arrives.

This mirrors the pattern already used elsewhere in the migrated UI, especially the signal-owned focus request in `analysis_panel.tsx`. The semantic API exposed to callers is `focusSsidInput()`, but the actual focus behavior is handled inside the island, not by external code poking at a queried input node.

The token is important because repeated focus requests for the same field must still retrigger the effect even if the requested target does not change. Incrementing the token on each request makes that behavior explicit and reliable.

### 3. Update the presenter to consume the semantic panel seam

`apps/ui/src/app/views/update_feature_presenter.ts` now calls `internetPanel.focusSsidInput()` instead of reaching through `internetPanel.dom.updateSsidInput?.focus()`.

This is the only production caller that still depended on the leaked DOM bag, so once this call site was updated, the public `.dom` contract no longer had a reason to exist. The presenter continues to own update-form state and start-intent derivation exactly as before; the only behavioral shift is where the focus side effect lives.

### 4. Bring the focused test harnesses in line with the real contract

The update and ESP-focused tests had fake panel harnesses that mirrored the old `.dom`-shaped production surface. Those harnesses are now tightened to match the actual public contract.

`apps/ui/tests/update_feature_bindings.spec.ts` now stubs only the real view API rather than building unused DOM bags. `apps/ui/tests/update_feature_presenter.spec.ts` now verifies the presenter calls the semantic `focusSsidInput()` seam directly instead of depending on a fake DOM input. `apps/ui/tests/esp_flash_feature.spec.ts` keeps its local fake DOM helpers because that test still serializes panel output and drives input events through stub elements, but those DOM surfaces now stay private to the test harness instead of pretending to be part of the production panel API.

That distinction is important: the tests can still use DOM-shaped fixtures when they need them, but the production panel contract no longer has to expose those shapes just to keep the tests convenient.

## Validation

I validated the change at the focused feature level and at the standard frontend gates:

- `cd apps/ui && npx playwright test tests/update_feature_presenter.spec.ts tests/update_feature_bindings.spec.ts tests/update_feature_workflow.spec.ts tests/esp_flash_feature.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.update.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

That combination covers the presenter contract, the update feature binding seam, the workflow path that requests SSID focus when Wi-Fi start is blocked, the larger ESP/update harness that reuses the same surfaces, and the browser-level update smoke flow.

## Risks, tradeoffs, and out-of-scope items

The main risk here is behavioral drift around SSID focus, since the implementation moved from an immediate external DOM call to a panel-owned focus effect. The focused workflow/presenter tests and the browser smoke run are aimed directly at that risk. Functionally, the intent remains the same: if Wi-Fi start is blocked because SSID is missing, focus the SSID input. The difference is architectural, not product-facing.

I intentionally did not change the already-migrated panel bridge state for the other four panels named in the issue because that work has already landed. I also did not broaden this into the next stage of panel work from #2366; this PR stays on the narrower cleanup required to finish #2358 accurately against the current codebase.

No docs, schema, or contract-sync files needed updates for this change because the affected seam is internal to the frontend view layer and its focused tests.

Closes #2358
