### PR TITLE
Bind remaining panels to computed signals

### DIFF
--- a/apps/ui/src/app/features/cars_feature.ts
+++ b/apps/ui/src/app/features/cars_feature.ts
@@ -4,6 +4,7 @@ import type {
   CarsWizardPanelBridge,
 } from "../views/cars_panel";
 import { buildCarsWizardRenderModel } from "../views/car_wizard_view";
+import { computed } from "../ui_signals";
 import { createCarsFeatureWorkflow } from "./cars_feature_workflow";
 
 export interface CarsFeatureDeps {
@@ -32,16 +33,15 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
       focus(target): void {
         ctx.panel.focus(target);
       },
-      render(state): void {
-        ctx.panel.setModel(
-          buildCarsWizardRenderModel(state, {
-            fmt: ctx.formatting.fmt,
-            t: ctx.services.t,
-          }),
-        );
-      },
     },
   });
+  const wizardModel = computed(() =>
+    buildCarsWizardRenderModel(workflow.renderState.value, {
+      fmt: ctx.formatting.fmt,
+      t: ctx.services.t,
+    })
+  );
+  ctx.panel.bindModel(wizardModel);
   let handlersBound = false;
 
   function openWizard(): void {

--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -15,7 +15,6 @@ import {
   getWizardActionHint,
   readWizardManualGearboxValues,
   readWizardManualTireValues,
-  resetWizardState,
   resolveGearboxes,
   resolveTireOptions,
   type WizardSpecBranch,
@@ -25,6 +24,12 @@ import {
   createCarsFeatureTransport,
   type CarsFeatureTransport,
 } from "./cars_feature_transport";
+import {
+  batch,
+  computed,
+  signal,
+  type ReadonlySignal,
+} from "../ui_signals";
 
 export interface CarsFeatureManualInputState {
   finalDrive: string;
@@ -81,7 +86,6 @@ export interface CarsFeatureRenderState {
 
 export interface CarsFeatureWorkflowViewPorts {
   focus(target: CarsFeatureFocusTarget): void;
-  render(state: CarsFeatureRenderState): void;
 }
 
 export interface CarsFeatureWorkflowDeps {
@@ -101,6 +105,7 @@ export interface CarsFeatureWorkflow {
   closeWizard(): void;
   finishWizard(): Promise<boolean>;
   getRenderState(): CarsFeatureRenderState;
+  readonly renderState: ReadonlySignal<CarsFeatureRenderState>;
   goBack(): Promise<void>;
   handleManualInputsChanged(inputs: CarsFeatureManualInputState): void;
   openWizard(): Promise<void>;
@@ -193,39 +198,55 @@ export function createCarsFeatureWorkflow(
   deps: CarsFeatureWorkflowDeps,
 ): CarsFeatureWorkflow {
   const transport = createCarsFeatureTransport(deps.transport);
-  const wizardState: WizardState = createInitialWizardState();
-
-  let isOpen = false;
-  let manualInputs: CarsFeatureManualInputState = {
+  const wizardState = signal<WizardState>(createInitialWizardState());
+  const isOpen = signal(false);
+  const manualInputs = signal<CarsFeatureManualInputState>({
     ...DEFAULT_CARS_WIZARD_MANUAL_INPUTS,
-  };
-  let brandOptions = createIdleOptionsState<string>();
-  let typeOptions = createIdleOptionsState<string>();
-  let modelOptions = createIdleOptionsState<CarLibraryModel>();
-  let variantOptions: CarLibraryVariant[] = [];
-  let tireOptions: CarLibraryTireOption[] = [];
-  let gearboxOptions: CarLibraryGearbox[] = [];
-  let noGearboxesMessage: string | null = null;
+  });
+  const brandOptions = signal(createIdleOptionsState<string>());
+  const typeOptions = signal(createIdleOptionsState<string>());
+  const modelOptions = signal(createIdleOptionsState<CarLibraryModel>());
+  const variantOptions = signal<readonly CarLibraryVariant[]>([]);
+  const tireOptions = signal<readonly CarLibraryTireOption[]>([]);
+  const gearboxOptions = signal<readonly CarLibraryGearbox[]>([]);
+  const noGearboxesMessage = signal<string | null>(null);
+
+  function updateWizardState(mutator: (state: WizardState) => void): void {
+    const nextState = { ...wizardState.value };
+    mutator(nextState);
+    wizardState.value = nextState;
+  }
 
   function currentManualValues() {
+    const state = wizardState.value;
+    const inputs = manualInputs.value;
     return {
-      manualGearbox: readWizardManualGearboxValues(wizardState.step, {
-        finalDrive: manualInputs.finalDrive,
-        topGear: manualInputs.topGear,
+      manualGearbox: readWizardManualGearboxValues(state.step, {
+        finalDrive: inputs.finalDrive,
+        topGear: inputs.topGear,
       }),
-      manualTire: readWizardManualTireValues(wizardState.step, {
-        aspect: manualInputs.tireAspect,
-        rim: manualInputs.rim,
-        width: manualInputs.tireWidth,
+      manualTire: readWizardManualTireValues(state.step, {
+        aspect: inputs.tireAspect,
+        rim: inputs.rim,
+        width: inputs.tireWidth,
       }),
     };
   }
 
-  function getRenderState(): CarsFeatureRenderState {
+  const renderState = computed<CarsFeatureRenderState>(() => {
+    const state = wizardState.value;
+    const inputs = manualInputs.value;
+    const currentBrandOptions = brandOptions.value;
+    const currentTypeOptions = typeOptions.value;
+    const currentModelOptions = modelOptions.value;
+    const currentVariantOptions = variantOptions.value;
+    const currentTireOptions = tireOptions.value;
+    const currentGearboxOptions = gearboxOptions.value;
+    const currentNoGearboxesMessage = noGearboxesMessage.value;
     const { manualGearbox, manualTire } = currentManualValues();
     return {
-      actionHint: wizardState.step === 4
-        ? getWizardActionHint(wizardState, {
+      actionHint: state.step === 4
+        ? getWizardActionHint(state, {
           fmt: deps.fmt,
           manualGearbox,
           manualTire,
@@ -233,190 +254,210 @@ export function createCarsFeatureWorkflow(
         })
         : "",
       brandOptions: {
-        ...brandOptions,
-        options: [...brandOptions.options],
+        ...currentBrandOptions,
+        options: [...currentBrandOptions.options],
       },
-      canFinish: canFinishWizard(wizardState, manualTire, manualGearbox),
-      gearboxOptions: [...gearboxOptions],
-      isOpen,
-      manualInputs: cloneManualInputs(manualInputs),
+      canFinish: canFinishWizard(state, manualTire, manualGearbox),
+      gearboxOptions: [...currentGearboxOptions],
+      isOpen: isOpen.value,
+      manualInputs: cloneManualInputs(inputs),
       modelOptions: {
-        ...modelOptions,
-        options: [...modelOptions.options],
+        ...currentModelOptions,
+        options: [...currentModelOptions.options],
       },
-      noGearboxesMessage,
-      resolvedSpecBranch: getResolvedWizardSpecBranch(wizardState),
-      selectedGearbox: wizardState.selectedGearbox,
-      selectedTire: wizardState.selectedTire,
-      step: wizardState.step,
-      summaryData: buildWizardSummaryData(wizardState, {
+      noGearboxesMessage: currentNoGearboxesMessage,
+      resolvedSpecBranch: getResolvedWizardSpecBranch(state),
+      selectedGearbox: state.selectedGearbox,
+      selectedTire: state.selectedTire,
+      step: state.step,
+      summaryData: buildWizardSummaryData(state, {
         fmt: deps.fmt,
         manualGearbox,
         manualTire,
         t: deps.t,
       }),
-      tireOptions: [...tireOptions],
+      tireOptions: [...currentTireOptions],
       typeOptions: {
-        ...typeOptions,
-        options: [...typeOptions.options],
+        ...currentTypeOptions,
+        options: [...currentTypeOptions.options],
       },
-      variantOptions: [...variantOptions],
+      variantOptions: [...currentVariantOptions],
     };
-  }
+  });
 
-  function renderCurrentState(): void {
-    deps.view.render(getRenderState());
+  function getRenderState(): CarsFeatureRenderState {
+    return renderState.value;
   }
 
   function resetDownstreamAfterBrandChange(): void {
-    wizardState.carType = "";
-    wizardState.model = "";
-    wizardState.selectedModel = null;
-    wizardState.selectedVariant = null;
-    wizardState.selectedGearbox = null;
-    wizardState.selectedTire = null;
-    wizardState.specBranch = null;
-    typeOptions = createIdleOptionsState<string>();
-    modelOptions = createIdleOptionsState<CarLibraryModel>();
-    variantOptions = [];
-    tireOptions = [];
-    gearboxOptions = [];
-    noGearboxesMessage = null;
+    batch(() => {
+      updateWizardState((state) => {
+        state.carType = "";
+        state.model = "";
+        state.selectedModel = null;
+        state.selectedVariant = null;
+        state.selectedGearbox = null;
+        state.selectedTire = null;
+        state.specBranch = null;
+      });
+      typeOptions.value = createIdleOptionsState<string>();
+      modelOptions.value = createIdleOptionsState<CarLibraryModel>();
+      variantOptions.value = [];
+      tireOptions.value = [];
+      gearboxOptions.value = [];
+      noGearboxesMessage.value = null;
+    });
   }
 
   function resetDownstreamAfterTypeChange(): void {
-    wizardState.model = "";
-    wizardState.selectedModel = null;
-    wizardState.selectedVariant = null;
-    wizardState.selectedGearbox = null;
-    wizardState.selectedTire = null;
-    wizardState.specBranch = null;
-    modelOptions = createIdleOptionsState<CarLibraryModel>();
-    variantOptions = [];
-    tireOptions = [];
-    gearboxOptions = [];
-    noGearboxesMessage = null;
+    batch(() => {
+      updateWizardState((state) => {
+        state.model = "";
+        state.selectedModel = null;
+        state.selectedVariant = null;
+        state.selectedGearbox = null;
+        state.selectedTire = null;
+        state.specBranch = null;
+      });
+      modelOptions.value = createIdleOptionsState<CarLibraryModel>();
+      variantOptions.value = [];
+      tireOptions.value = [];
+      gearboxOptions.value = [];
+      noGearboxesMessage.value = null;
+    });
   }
 
   function resetDownstreamAfterModelChange(): void {
-    wizardState.selectedVariant = null;
-    wizardState.selectedGearbox = null;
-    wizardState.selectedTire = null;
-    wizardState.specBranch = null;
-    variantOptions = [];
-    tireOptions = [];
-    gearboxOptions = [];
-    noGearboxesMessage = null;
+    batch(() => {
+      updateWizardState((state) => {
+        state.selectedVariant = null;
+        state.selectedGearbox = null;
+        state.selectedTire = null;
+        state.specBranch = null;
+      });
+      variantOptions.value = [];
+      tireOptions.value = [];
+      gearboxOptions.value = [];
+      noGearboxesMessage.value = null;
+    });
   }
 
   function resetSpecSelections(): void {
-    wizardState.selectedGearbox = null;
-    wizardState.selectedTire = null;
-    wizardState.specBranch = null;
-    tireOptions = [];
-    gearboxOptions = [];
-    noGearboxesMessage = null;
+    batch(() => {
+      updateWizardState((state) => {
+        state.selectedGearbox = null;
+        state.selectedTire = null;
+        state.specBranch = null;
+      });
+      tireOptions.value = [];
+      gearboxOptions.value = [];
+      noGearboxesMessage.value = null;
+    });
   }
 
   async function loadBrandStep(): Promise<void> {
-    brandOptions = createLoadingOptionsState(deps.t("settings.wizard.loading"));
-    renderCurrentState();
+    brandOptions.value = createLoadingOptionsState(deps.t("settings.wizard.loading"));
     try {
-      brandOptions = createReadyOptionsState(await transport.loadBrands());
-      renderCurrentState();
+      brandOptions.value = createReadyOptionsState(await transport.loadBrands());
       deps.view.focus("brand-option");
     } catch (_err) {
-      brandOptions = createErrorOptionsState(deps.t("settings.wizard.load_failed_brands"));
-      renderCurrentState();
+      brandOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_brands"));
       deps.view.focus("custom-brand");
     }
   }
 
   async function loadTypeStep(): Promise<void> {
-    typeOptions = createLoadingOptionsState(deps.t("settings.wizard.loading"));
-    renderCurrentState();
+    typeOptions.value = createLoadingOptionsState(deps.t("settings.wizard.loading"));
     try {
-      typeOptions = createReadyOptionsState(await transport.loadTypes(wizardState.brand));
-      renderCurrentState();
+      typeOptions.value = createReadyOptionsState(await transport.loadTypes(wizardState.value.brand));
       deps.view.focus("type-option");
     } catch (_err) {
-      typeOptions = createErrorOptionsState(deps.t("settings.wizard.load_failed_types"));
-      renderCurrentState();
+      typeOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_types"));
       deps.view.focus("custom-type");
     }
   }
 
   async function loadModelStep(): Promise<void> {
-    modelOptions = createLoadingOptionsState(deps.t("settings.wizard.loading"));
-    renderCurrentState();
+    modelOptions.value = createLoadingOptionsState(deps.t("settings.wizard.loading"));
     try {
-      modelOptions = createReadyOptionsState(
-        await transport.loadModels(wizardState.brand, wizardState.carType),
+      modelOptions.value = createReadyOptionsState(
+        await transport.loadModels(wizardState.value.brand, wizardState.value.carType),
       );
-      renderCurrentState();
       deps.view.focus("model-option");
     } catch (_err) {
-      modelOptions = createErrorOptionsState(deps.t("settings.wizard.load_failed_models"));
-      renderCurrentState();
+      modelOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_models"));
       deps.view.focus("custom-model");
     }
   }
 
   function loadVariantStep(): void {
-    variantOptions = wizardState.selectedModel?.variants || [];
-    if (!variantOptions.length) {
-      wizardState.step = 4;
+    const nextVariantOptions = wizardState.value.selectedModel?.variants || [];
+    variantOptions.value = nextVariantOptions;
+    if (!nextVariantOptions.length) {
+      updateWizardState((state) => {
+        state.step = 4;
+      });
       loadSpecsStep();
       return;
     }
-    renderCurrentState();
     deps.view.focus("variant-option");
   }
 
   function loadSpecsStep(): void {
-    tireOptions = resolveTireOptions(wizardState.selectedModel, wizardState.selectedVariant);
-    gearboxOptions = resolveGearboxes(wizardState.selectedModel, wizardState.selectedVariant);
-    noGearboxesMessage = null;
+    const state = wizardState.value;
+    const currentManualInputs = manualInputs.value;
+    const nextTireOptions = resolveTireOptions(state.selectedModel, state.selectedVariant);
+    const nextGearboxOptions = resolveGearboxes(state.selectedModel, state.selectedVariant);
+    const nextSelectedTire = nextTireOptions.length > 0
+      ? (state.selectedTire && nextTireOptions.includes(state.selectedTire)
+        ? state.selectedTire
+        : nextTireOptions[0])
+      : null;
+    const nextManualInputs = nextSelectedTire
+      ? tireInputsFromOption(nextSelectedTire, currentManualInputs)
+      : currentManualInputs;
+    const nextNoGearboxesMessage = nextGearboxOptions.length > 0
+      ? null
+      : deps.t("settings.wizard.no_gearboxes");
 
-    if (tireOptions.length > 0) {
-      const selectedTire = wizardState.selectedTire && tireOptions.includes(wizardState.selectedTire)
-        ? wizardState.selectedTire
-        : tireOptions[0];
-      wizardState.selectedTire = selectedTire;
-      manualInputs = tireInputsFromOption(selectedTire, manualInputs);
-    } else {
-      wizardState.selectedTire = null;
-      wizardState.specBranch = "manual";
-    }
+    batch(() => {
+      tireOptions.value = nextTireOptions;
+      gearboxOptions.value = nextGearboxOptions;
+      noGearboxesMessage.value = nextNoGearboxesMessage;
+      manualInputs.value = nextManualInputs;
+      updateWizardState((nextState) => {
+        nextState.selectedTire = nextSelectedTire;
+        if (!nextTireOptions.length) {
+          nextState.specBranch = "manual";
+        }
+        if (!nextGearboxOptions.length) {
+          nextState.selectedGearbox = null;
+          nextState.specBranch = "manual";
+        }
+      });
+    });
 
-    if (!gearboxOptions.length) {
-      wizardState.selectedGearbox = null;
-      wizardState.specBranch = "manual";
-      noGearboxesMessage = deps.t("settings.wizard.no_gearboxes");
-      renderCurrentState();
-      deps.view.focus("manual-tire-width");
-      return;
-    }
-
-    renderCurrentState();
-    deps.view.focus(tireOptions.length > 0 ? "spec-selection" : "gearbox-option");
+    deps.view.focus(
+      nextGearboxOptions.length > 0
+        ? (nextTireOptions.length > 0 ? "spec-selection" : "gearbox-option")
+        : "manual-tire-width",
+    );
   }
 
   async function loadCurrentStep(): Promise<void> {
-    renderCurrentState();
-    if (wizardState.step === 0) {
+    if (wizardState.value.step === 0) {
       await loadBrandStep();
       return;
     }
-    if (wizardState.step === 1) {
+    if (wizardState.value.step === 1) {
       await loadTypeStep();
       return;
     }
-    if (wizardState.step === 2) {
+    if (wizardState.value.step === 2) {
       await loadModelStep();
       return;
     }
-    if (wizardState.step === 3) {
+    if (wizardState.value.step === 3) {
       loadVariantStep();
       return;
     }
@@ -425,15 +466,16 @@ export function createCarsFeatureWorkflow(
 
   return {
     closeWizard(): void {
-      isOpen = false;
-      renderCurrentState();
+      isOpen.value = false;
     },
 
     async finishWizard(): Promise<boolean> {
-      const resolvedBranch = getResolvedWizardSpecBranch(wizardState);
+      const state = wizardState.value;
+      const inputs = manualInputs.value;
+      const resolvedBranch = getResolvedWizardSpecBranch(state);
       if (resolvedBranch === "library") {
-        const tire = wizardState.selectedTire;
-        const gearbox = wizardState.selectedGearbox;
+        const tire = state.selectedTire;
+        const gearbox = state.selectedGearbox;
         if (!tire) {
           deps.view.focus("spec-selection");
           return false;
@@ -443,8 +485,8 @@ export function createCarsFeatureWorkflow(
           return false;
         }
         await deps.addCarFromWizard(
-          buildWizardCarName(wizardState.brand, wizardState.model, wizardState.selectedVariant),
-          wizardState.carType || "Custom",
+          buildWizardCarName(state.brand, state.model, state.selectedVariant),
+          state.carType || "Custom",
           {
             current_gear_ratio: gearbox.top_gear_ratio,
             final_drive_ratio: gearbox.final_drive_ratio,
@@ -452,69 +494,74 @@ export function createCarsFeatureWorkflow(
             tire_aspect_pct: tire.tire_aspect_pct,
             tire_width_mm: tire.tire_width_mm,
           },
-          wizardState.selectedVariant?.name,
+          state.selectedVariant?.name,
         );
-        isOpen = false;
-        renderCurrentState();
+        isOpen.value = false;
         return true;
       }
 
-      const missingFocusTarget = missingManualInputFocusTarget(manualInputs);
+      const missingFocusTarget = missingManualInputFocusTarget(inputs);
       if (missingFocusTarget) {
         deps.view.focus(missingFocusTarget);
         return false;
       }
 
       await deps.addCarFromWizard(
-        buildWizardCarName(wizardState.brand, wizardState.model, wizardState.selectedVariant),
-        wizardState.carType || "Custom",
+        buildWizardCarName(state.brand, state.model, state.selectedVariant),
+        state.carType || "Custom",
         {
-          current_gear_ratio: Number(manualInputs.topGear),
-          final_drive_ratio: Number(manualInputs.finalDrive),
-          rim_in: Number(manualInputs.rim),
-          tire_aspect_pct: Number(manualInputs.tireAspect),
-          tire_width_mm: Number(manualInputs.tireWidth),
+          current_gear_ratio: Number(inputs.topGear),
+          final_drive_ratio: Number(inputs.finalDrive),
+          rim_in: Number(inputs.rim),
+          tire_aspect_pct: Number(inputs.tireAspect),
+          tire_width_mm: Number(inputs.tireWidth),
         },
-        wizardState.selectedVariant?.name,
+        state.selectedVariant?.name,
       );
-      isOpen = false;
-      renderCurrentState();
+      isOpen.value = false;
       return true;
     },
 
     getRenderState,
+    renderState,
 
     async goBack(): Promise<void> {
-      if (wizardState.step === 0) {
+      if (wizardState.value.step === 0) {
         return;
       }
-      wizardState.step -= 1;
-      if (wizardState.step === 3 && !(wizardState.selectedModel?.variants?.length)) {
-        wizardState.step = 2;
-      }
+      updateWizardState((state) => {
+        state.step -= 1;
+        if (state.step === 3 && !(state.selectedModel?.variants?.length)) {
+          state.step = 2;
+        }
+      });
       await loadCurrentStep();
     },
 
     handleManualInputsChanged(inputs: CarsFeatureManualInputState): void {
-      manualInputs = cloneManualInputs(inputs);
-      if (isOpen && wizardState.step === 4) {
-        wizardState.specBranch = "manual";
-        renderCurrentState();
-      }
+      batch(() => {
+        manualInputs.value = cloneManualInputs(inputs);
+        if (isOpen.value && wizardState.value.step === 4) {
+          updateWizardState((state) => {
+            state.specBranch = "manual";
+          });
+        }
+      });
     },
 
     async openWizard(): Promise<void> {
-      resetWizardState(wizardState);
-      manualInputs = cloneManualInputs(manualInputs);
-      brandOptions = createIdleOptionsState<string>();
-      typeOptions = createIdleOptionsState<string>();
-      modelOptions = createIdleOptionsState<CarLibraryModel>();
-      variantOptions = [];
-      tireOptions = [];
-      gearboxOptions = [];
-      noGearboxesMessage = null;
-      isOpen = true;
-      renderCurrentState();
+      batch(() => {
+        wizardState.value = createInitialWizardState();
+        manualInputs.value = cloneManualInputs(manualInputs.value);
+        brandOptions.value = createIdleOptionsState<string>();
+        typeOptions.value = createIdleOptionsState<string>();
+        modelOptions.value = createIdleOptionsState<CarLibraryModel>();
+        variantOptions.value = [];
+        tireOptions.value = [];
+        gearboxOptions.value = [];
+        noGearboxesMessage.value = null;
+        isOpen.value = true;
+      });
       deps.view.focus("close");
       await loadCurrentStep();
     },
@@ -523,62 +570,74 @@ export function createCarsFeatureWorkflow(
       if (!value) {
         return;
       }
-      wizardState.brand = value;
-      wizardState.step = 1;
+      updateWizardState((state) => {
+        state.brand = value;
+        state.step = 1;
+      });
       resetDownstreamAfterBrandChange();
       await loadCurrentStep();
     },
 
     selectGearbox(index: number): void {
-      const gearbox = gearboxOptions[index];
+      const gearbox = gearboxOptions.value[index];
       if (!gearbox) {
         return;
       }
-      wizardState.selectedGearbox = gearbox;
-      wizardState.specBranch = "library";
-      renderCurrentState();
+      updateWizardState((state) => {
+        state.selectedGearbox = gearbox;
+        state.specBranch = "library";
+      });
       deps.view.focus("finish");
     },
 
     async selectModel(index: number): Promise<void> {
-      const selectedModel = modelOptions.options[index];
+      const selectedModel = modelOptions.value.options[index];
       if (!selectedModel) {
         return;
       }
-      wizardState.selectedModel = selectedModel;
-      wizardState.model = selectedModel.model;
-      wizardState.step = 3;
+      updateWizardState((state) => {
+        state.selectedModel = selectedModel;
+        state.model = selectedModel.model;
+        state.step = 3;
+      });
       resetDownstreamAfterModelChange();
       await loadCurrentStep();
     },
 
     selectTire(index: number): void {
-      const selectedTire = tireOptions[index];
+      const selectedTire = tireOptions.value[index];
       if (!selectedTire) {
         return;
       }
-      wizardState.selectedTire = selectedTire;
-      manualInputs = tireInputsFromOption(selectedTire, manualInputs);
-      renderCurrentState();
+      batch(() => {
+        updateWizardState((state) => {
+          state.selectedTire = selectedTire;
+        });
+        manualInputs.value = tireInputsFromOption(selectedTire, manualInputs.value);
+      });
     },
 
     async selectType(value: string): Promise<void> {
       if (!value) {
         return;
       }
-      wizardState.carType = value;
-      wizardState.step = 2;
+      updateWizardState((state) => {
+        state.carType = value;
+        state.step = 2;
+      });
       resetDownstreamAfterTypeChange();
       await loadCurrentStep();
     },
 
     async selectVariant(index: number): Promise<void> {
-      const selectedVariant = variantOptions[index];
+      const selectedVariant = variantOptions.value[index];
       if (!selectedVariant) {
         return;
       }
-      wizardState.selectedVariant = selectedVariant;
-      wizardState.step = 4;
+      updateWizardState((state) => {
+        state.selectedVariant = selectedVariant;
+        state.step = 4;
+      });
       resetSpecSelections();
       await loadCurrentStep();
     },
@@ -589,8 +648,10 @@ export function createCarsFeatureWorkflow(
         deps.view.focus("custom-brand");
         return;
       }
-      wizardState.brand = trimmedValue;
-      wizardState.step = 1;
+      updateWizardState((state) => {
+        state.brand = trimmedValue;
+        state.step = 1;
+      });
       resetDownstreamAfterBrandChange();
       await loadCurrentStep();
     },
@@ -601,17 +662,21 @@ export function createCarsFeatureWorkflow(
         deps.view.focus("custom-model");
         return;
       }
-      wizardState.model = trimmedValue;
-      wizardState.selectedModel = null;
-      wizardState.selectedVariant = null;
-      wizardState.selectedGearbox = null;
-      wizardState.selectedTire = null;
-      wizardState.specBranch = "manual";
-      wizardState.step = 4;
-      variantOptions = [];
-      tireOptions = [];
-      gearboxOptions = [];
-      noGearboxesMessage = null;
+      batch(() => {
+        updateWizardState((state) => {
+          state.model = trimmedValue;
+          state.selectedModel = null;
+          state.selectedVariant = null;
+          state.selectedGearbox = null;
+          state.selectedTire = null;
+          state.specBranch = "manual";
+          state.step = 4;
+        });
+        variantOptions.value = [];
+        tireOptions.value = [];
+        gearboxOptions.value = [];
+        noGearboxesMessage.value = null;
+      });
       await loadCurrentStep();
     },
 
@@ -621,8 +686,10 @@ export function createCarsFeatureWorkflow(
         deps.view.focus("custom-type");
         return;
       }
-      wizardState.carType = trimmedValue;
-      wizardState.step = 2;
+      updateWizardState((state) => {
+        state.carType = trimmedValue;
+        state.step = 2;
+      });
       resetDownstreamAfterTypeChange();
       await loadCurrentStep();
     },

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -41,16 +41,16 @@ export function createEspFlashFeature(
     handlersBound.value
     && isEspFlashPollingContext(ports.activeViewId.value, activeSettingsTabId.value)
   );
-  const presenter = createEspFlashFeaturePresenter({
-    panel,
-    t: services.t,
-  });
   const workflow = createEspFlashFeatureWorkflow({
     t: services.t,
     showError: services.showError,
-    view: presenter,
     pollingEnabled,
   });
+  const presenter = createEspFlashFeaturePresenter({
+    renderState: workflow.renderState,
+    t: services.t,
+  });
+  panel.bindModel(presenter.model);
 
   ports.subscribeSettingsTabChanges((tabId) => {
     activeSettingsTabId.value = tabId;
@@ -84,7 +84,6 @@ export function createEspFlashFeature(
         workflow.setSelectedPortValue(value);
       },
     });
-    workflow.renderCurrentState();
   }
 
   return {

--- a/apps/ui/src/app/features/esp_flash_feature_workflow.ts
+++ b/apps/ui/src/app/features/esp_flash_feature_workflow.ts
@@ -16,9 +16,14 @@ import type {
   EspFlashPortsPayload,
   EspFlashStatusPayload,
   EspSerialPortPayload,
-} from "../../transport/http_models";
+  } from "../../transport/http_models";
 import type { EspFlashFeatureRenderState } from "../views/esp_flash_feature_presenter";
-import type { ReadonlySignal } from "../ui_signals";
+import {
+  batch,
+  computed,
+  signal,
+  type ReadonlySignal,
+} from "../ui_signals";
 import {
   createPollingController,
   type PollingController,
@@ -34,14 +39,9 @@ export interface EspFlashFeatureWorkflowApi {
   startEspFlash(port: string | null, autoDetect: boolean): Promise<unknown>;
 }
 
-export interface EspFlashFeatureWorkflowViewPorts {
-  render(state: EspFlashFeatureRenderState): void;
-}
-
 export interface EspFlashFeatureWorkflowDeps {
   t: (key: string, vars?: Record<string, unknown>) => string;
   showError: (message: string) => void;
-  view: EspFlashFeatureWorkflowViewPorts;
   api?: Partial<EspFlashFeatureWorkflowApi>;
   createPollingController?: (options: PollingControllerOptions) => PollingController;
   pollingEnabled?: ReadonlySignal<boolean>;
@@ -50,9 +50,9 @@ export interface EspFlashFeatureWorkflowDeps {
 export interface EspFlashFeatureWorkflow {
   cancelFlash(): Promise<void>;
   getRenderState(): EspFlashFeatureRenderState;
+  readonly renderState: ReadonlySignal<EspFlashFeatureRenderState>;
   refreshPorts(): Promise<void>;
   refreshStatus(): Promise<void>;
-  renderCurrentState(): void;
   setSelectedPortValue(value: string): void;
   startFlash(): Promise<void>;
   startPolling(): void;
@@ -93,26 +93,23 @@ export function createEspFlashFeatureWorkflow(
   const createPolling = deps.createPollingController ?? createPollingController;
 
   let nextLogIndex = 0;
-  let latestStatus: EspFlashStatusPayload = createIdleStatus();
-  let lastJourneyPhase: string | null = null;
-  let availablePorts: EspSerialPortPayload[] = [];
-  let selectedPortValue = "__auto__";
-  let logText = "";
-  let latestAttempts: NonNullable<EspFlashHistoryPayload["attempts"]> = [];
+  const latestStatus = signal<EspFlashStatusPayload>(createIdleStatus());
+  const lastJourneyPhase = signal<string | null>(null);
+  const availablePorts = signal<readonly EspSerialPortPayload[]>([]);
+  const selectedPortValue = signal("__auto__");
+  const logText = signal("");
+  const latestAttempts = signal<readonly NonNullable<EspFlashHistoryPayload["attempts"]>[number][]>([]);
+  const renderState = computed<EspFlashFeatureRenderState>(() => ({
+    attempts: [...latestAttempts.value],
+    availablePorts: [...availablePorts.value],
+    lastJourneyPhase: lastJourneyPhase.value,
+    logText: logText.value,
+    selectedPortValue: selectedPortValue.value,
+    status: latestStatus.value,
+  }));
 
   function getRenderState(): EspFlashFeatureRenderState {
-    return {
-      attempts: latestAttempts,
-      availablePorts,
-      lastJourneyPhase,
-      logText,
-      selectedPortValue,
-      status: latestStatus,
-    };
-  }
-
-  function renderCurrentState(): void {
-    deps.view.render(getRenderState());
+    return renderState.value;
   }
 
   function updateJourneyPhase(status: EspFlashStatusPayload): void {
@@ -122,18 +119,18 @@ export function createEspFlashFeatureWorkflow(
       phase || "",
     );
     if (isJourneyPhase) {
-      lastJourneyPhase = phase;
+      lastJourneyPhase.value = phase;
       return;
     }
     if (safeState === "idle" || safeState === "success") {
-      lastJourneyPhase = null;
+      lastJourneyPhase.value = null;
     }
   }
 
   async function refreshHistory(): Promise<void> {
     try {
       const payload = await api.getEspFlashHistory();
-      latestAttempts = payload.attempts || [];
+      latestAttempts.value = payload.attempts || [];
     } catch {
       /* keep existing history on transient error */
     }
@@ -141,23 +138,23 @@ export function createEspFlashFeatureWorkflow(
 
   async function refreshLogs(status: EspFlashStatusPayload): Promise<void> {
     if ((status.log_count || 0) === 0) {
-      logText = "";
+      logText.value = "";
       nextLogIndex = 0;
       return;
     }
     if (nextLogIndex === 0) {
-      logText = "";
+      logText.value = "";
     }
     const logs = await api.getEspFlashLogs(nextLogIndex);
     if (logs.lines.length > 0) {
-      logText += `${logs.lines.join("\n")}\n`;
+      logText.value += `${logs.lines.join("\n")}\n`;
     }
     nextLogIndex = logs.next_index;
   }
 
   function applyStatus(status: EspFlashStatusPayload): void {
     updateJourneyPhase(status);
-    latestStatus = status;
+    latestStatus.value = status;
     if (safeEspFlashState(status.state) !== "running") {
       nextLogIndex = status.log_count || 0;
     }
@@ -165,20 +162,23 @@ export function createEspFlashFeatureWorkflow(
 
   async function refreshStatus(): Promise<void> {
     const status = await api.getEspFlashStatus();
-    applyStatus(status);
+    batch(() => {
+      applyStatus(status);
+    });
     await refreshLogs(status);
     await refreshHistory();
-    renderCurrentState();
   }
 
   async function refreshPorts(): Promise<void> {
     try {
       const payload = await api.getEspFlashPorts();
-      availablePorts = payload.ports || [];
-      if (!availablePorts.some((port) => port.port === selectedPortValue)) {
-        selectedPortValue = "__auto__";
-      }
-      renderCurrentState();
+      const ports = payload.ports || [];
+      batch(() => {
+        availablePorts.value = ports;
+        if (!ports.some((port) => port.port === selectedPortValue.value)) {
+          selectedPortValue.value = "__auto__";
+        }
+      });
     } catch {
       /* keep existing options on transient error */
     }
@@ -188,7 +188,7 @@ export function createEspFlashFeatureWorkflow(
     enabled: deps.pollingEnabled,
     poll: async () => {
       await refreshStatus();
-      return safeEspFlashState(latestStatus.state) === "running"
+      return safeEspFlashState(latestStatus.value.state) === "running"
         ? ESP_FLASH_POLL_ACTIVE_MS
         : ESP_FLASH_POLL_IDLE_MS;
     },
@@ -197,18 +197,17 @@ export function createEspFlashFeatureWorkflow(
 
   async function startFlash(): Promise<void> {
     if (
-      safeEspFlashState(latestStatus.state) === "running"
-      || availablePorts.length === 0
+      safeEspFlashState(latestStatus.value.state) === "running"
+      || availablePorts.value.length === 0
     ) {
       return;
     }
-    const autoDetect = selectedPortValue === "__auto__";
-    const port = autoDetect ? null : selectedPortValue;
+    const autoDetect = selectedPortValue.value === "__auto__";
+    const port = autoDetect ? null : selectedPortValue.value;
     try {
       await api.startEspFlash(port, autoDetect);
-      logText = "";
+      logText.value = "";
       nextLogIndex = 0;
-      renderCurrentState();
       polling.restart();
     } catch (err) {
       deps.showError(
@@ -229,12 +228,11 @@ export function createEspFlashFeatureWorkflow(
   return {
     cancelFlash,
     getRenderState,
+    renderState,
     refreshPorts,
     refreshStatus,
-    renderCurrentState,
     setSelectedPortValue(value: string) {
-      selectedPortValue = value || "__auto__";
-      renderCurrentState();
+      selectedPortValue.value = value || "__auto__";
     },
     startFlash,
     startPolling() {

--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -12,7 +12,7 @@ import {
   type RunDetail,
   type ShellState,
 } from "../ui_app_state";
-import { effect, untracked } from "../ui_signals";
+import { computed, effect, untracked } from "../ui_signals";
 import type {
   HistoryPanelRenderModel,
   HistoryPanelView,
@@ -74,8 +74,11 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
 
   function buildPanelRenderModel(): HistoryPanelRenderModel {
     const deleteAllRunsDisabled = history.deleteAllRunsInFlight || history.runs.length === 0;
+    const expandedRunId = history.expandedRunId
+      && history.runs.some((row) => row.run_id === history.expandedRunId)
+      ? history.expandedRunId
+      : null;
     if (!history.runs.length) {
-      collapseExpandedRun();
       return {
         historySummaryText: services.t("history.none"),
         deleteAllRunsDisabled,
@@ -85,39 +88,32 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
         },
       };
     }
-    if (
-      history.expandedRunId &&
-      !history.runs.some((row) => row.run_id === history.expandedRunId)
-    ) {
-      collapseExpandedRun();
-    }
-    for (const run of history.runs) {
-      ensureRunDetail(run.run_id);
-    }
     return {
       historySummaryText: services.t("history.available_count", {
         count: history.runs.length,
       }),
       deleteAllRunsDisabled,
-      table: {
-        kind: "rows",
-        params: {
-          runs: history.runs,
-          expandedRunId: history.expandedRunId,
-          runDetailsById: history.runDetailsById,
-          t: services.t,
-          fmt: formatting.fmt,
+        table: {
+          kind: "rows",
+          params: {
+            runs: history.runs,
+            expandedRunId,
+            runDetailsById: history.runDetailsById,
+            t: services.t,
+            fmt: formatting.fmt,
           fmtTs: formatting.fmtTs,
           formatInt: formatting.formatInt,
           historyExportUrl,
         },
       },
-    };
+      };
   }
-
-  function renderHistoryTable(): void {
-    panel.setModel(buildPanelRenderModel());
-  }
+  const panelModel = computed(() => {
+    trackAppStateSlice(history);
+    trackAppStateSlice(shell);
+    return buildPanelRenderModel();
+  });
+  panel.bindModel(panelModel);
 
   async function loadRunPreview(runId: string, force = false): Promise<void> {
     if (!runId) {
@@ -129,7 +125,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     }
     detail.previewLoading = true;
     detail.previewError = "";
-    renderHistoryTable();
     try {
       const response = await getHistoryInsights(runId, shell.lang);
       detail.preview = response.status === "complete" ? response : null;
@@ -139,7 +134,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
         : services.t("report.unable_load_insights");
     } finally {
       detail.previewLoading = false;
-      renderHistoryTable();
     }
   }
 
@@ -153,7 +147,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     }
     detail.insightsLoading = true;
     detail.insightsError = "";
-    renderHistoryTable();
     try {
       const response = await getHistoryInsights(runId, shell.lang);
       detail.insights = response.status === "complete" ? response : null;
@@ -163,7 +156,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
         : services.t("report.unable_load_insights");
     } finally {
       detail.insightsLoading = false;
-      renderHistoryTable();
     }
   }
 
@@ -173,12 +165,10 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     }
     if (history.expandedRunId === runId) {
       collapseExpandedRun();
-      renderHistoryTable();
       return;
     }
     collapseExpandedRun();
     history.expandedRunId = runId;
-    renderHistoryTable();
     void loadRunPreview(runId);
   }
 
@@ -206,9 +196,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       if (!initialized) {
         initialized = true;
         previousLanguage = currentLanguage;
-        untracked(() => {
-          renderHistoryTable();
-        });
         return;
       }
       if (currentLanguage === previousLanguage) {
@@ -216,7 +203,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       }
       previousLanguage = currentLanguage;
       untracked(() => {
-        renderHistoryTable();
         reloadExpandedRunOnLanguageChange();
       });
     });
@@ -242,10 +228,8 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       const payload = await getHistory();
       history.runs = payload.runs ?? [];
     } catch (_err) {
-      renderHistoryTable();
       return;
     }
-    renderHistoryTable();
     prefetchCollapsedRunContext();
   }
 
@@ -284,7 +268,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     }
 
     history.deleteAllRunsInFlight = true;
-    renderHistoryTable();
     let deleted = 0;
     let failed = 0;
     let firstError = "";
@@ -324,7 +307,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     }
     detail.pdfLoading = true;
     detail.pdfError = "";
-    renderHistoryTable();
     try {
       await downloadBlobFile(
         historyReportPdfUrl(runId, shell.lang),
@@ -336,7 +318,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
         : services.t("history.pdf_failed");
     } finally {
       detail.pdfLoading = false;
-      renderHistoryTable();
     }
   }
 

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -5,6 +5,7 @@ import type {
 import { getAnalysisSettings, setAnalysisSettings } from "../../api";
 import type { FeatureServices } from "../feature_deps_base";
 import { defaultVehicleSettings, type SettingsState } from "../ui_app_state";
+import { computed, signal } from "../ui_signals";
 import type {
   AnalysisPanelFieldKey,
   AnalysisPanelRenderModel,
@@ -210,9 +211,9 @@ export function createSettingsAnalysisModule(
 ): SettingsAnalysisModule {
   const { panel, settings, services } = ctx;
   const { t } = services;
-  let draftValues = buildDraftValues(settings);
-  let saveFeedback: SettingsFeedbackMessage | null = null;
-  const fieldErrorMessages = new Map<AnalysisPanelFieldKey, string>();
+  const draftValues = signal(buildDraftValues(settings));
+  const saveFeedback = signal<SettingsFeedbackMessage | null>(null);
+  const fieldErrorMessages = signal<Partial<Record<AnalysisPanelFieldKey, string>>>({});
 
   function formatRange(min: number, max: number, unit: UnitSuffix): string {
     return t("settings.analysis.range_value", {
@@ -239,13 +240,13 @@ export function createSettingsAnalysisModule(
         min_abs_band_hz: buildFieldRenderModel("min_abs_band_hz"),
         max_band_half_width_pct: buildFieldRenderModel("max_band_half_width_pct"),
       },
-      saveFeedback,
+      saveFeedback: saveFeedback.value,
     };
   }
 
   function buildFieldRenderModel(fieldKey: AnalysisPanelFieldKey) {
     const field = analysisFieldConfig(fieldKey);
-    const errorMessage = fieldErrorMessages.get(field.key);
+    const errorMessage = fieldErrorMessages.value[field.key];
     const guidance: SettingsAnalysisGuidanceRenderModel = {
       error: errorMessage
         ? {
@@ -268,16 +269,14 @@ export function createSettingsAnalysisModule(
     return {
       guidance,
       invalid: errorMessage !== undefined,
-      value: draftValues[field.key],
+      value: draftValues.value[field.key],
     };
   }
-
-  function syncPanelModel(): void {
-    panel.setModel(buildPanelModel());
-  }
+  const panelModel = computed(() => buildPanelModel());
+  panel.bindModel(panelModel);
 
   function clearFieldValidationState(): void {
-    fieldErrorMessages.clear();
+    fieldErrorMessages.value = {};
   }
 
   function openAnalysisGuidance(): void {
@@ -285,8 +284,10 @@ export function createSettingsAnalysisModule(
   }
 
   function markFieldInvalid(field: AnalysisFieldConfig, message: string): void {
-    fieldErrorMessages.set(field.key, message);
-    syncPanelModel();
+    fieldErrorMessages.value = {
+      ...fieldErrorMessages.value,
+      [field.key]: message,
+    };
     panel.focusField(field.key);
     openAnalysisGuidance();
   }
@@ -294,7 +295,7 @@ export function createSettingsAnalysisModule(
   function collectFieldStates(): AnalysisFieldState[] {
     return EDITABLE_ANALYSIS_KEYS.map((fieldKey) => {
       const config = analysisFieldConfig(fieldKey);
-      const rawValue = draftValues[fieldKey].trim();
+      const rawValue = draftValues.value[fieldKey].trim();
       return {
         config,
         rawValue,
@@ -322,8 +323,7 @@ export function createSettingsAnalysisModule(
       return;
     }
     clearFieldValidationState();
-    saveFeedback = null;
-    syncPanelModel();
+    saveFeedback.value = null;
     void syncAnalysisSettingsToServer({
       wheel_bandwidth_pct: defaultVehicleSettings.wheel_bandwidth_pct,
       driveshaft_bandwidth_pct: defaultVehicleSettings.driveshaft_bandwidth_pct,
@@ -340,10 +340,9 @@ export function createSettingsAnalysisModule(
   }
 
   function syncSettingsInputs(): void {
-    draftValues = buildDraftValues(settings);
+    draftValues.value = buildDraftValues(settings);
     clearFieldValidationState();
-    saveFeedback = null;
-    syncPanelModel();
+    saveFeedback.value = null;
   }
 
   function applyAnalysisSettingsPayload(
@@ -367,14 +366,13 @@ export function createSettingsAnalysisModule(
       applyAnalysisSettingsPayload(saved);
     } catch (error) {
       openAnalysisGuidance();
-      saveFeedback = {
+      saveFeedback.value = {
         tone: "error",
         title: t("settings.analysis.save_failed_title"),
         body:
           error instanceof Error ? error.message : t("settings.save_failed"),
         detail: t("settings.analysis.save_failed_detail"),
       };
-      syncPanelModel();
       ctx.onSaveError(error);
     }
   }
@@ -396,7 +394,7 @@ export function createSettingsAnalysisModule(
       return;
     }
     clearFieldValidationState();
-    saveFeedback = null;
+    saveFeedback.value = null;
     const fieldStates = collectFieldStates();
     const missingField = fieldStates.find(
       (field) =>
@@ -472,13 +470,14 @@ export function createSettingsAnalysisModule(
   function handleFieldInput(
     action: { field: AnalysisPanelFieldKey; value: string },
   ): void {
-    draftValues = {
-      ...draftValues,
+    draftValues.value = {
+      ...draftValues.value,
       [action.field]: action.value,
     };
-    fieldErrorMessages.delete(action.field);
-    saveFeedback = null;
-    syncPanelModel();
+    const nextErrors = { ...fieldErrorMessages.value };
+    delete nextErrors[action.field];
+    fieldErrorMessages.value = nextErrors;
+    saveFeedback.value = null;
   }
 
   function bindHandlers(): void {
@@ -487,7 +486,6 @@ export function createSettingsAnalysisModule(
       onReset: resetAnalysisToDefaults,
       onSave: saveAnalysisFromInputs,
     });
-    syncPanelModel();
   }
 
   return {

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -6,10 +6,15 @@ import {
 } from "../car_selection_state";
 import type { SettingsState } from "../ui_app_state";
 import type { CarRecord, CarsPayload } from "../../transport/http_models";
-import type { CarsListPanelView } from "../views/cars_panel";
+import type {
+  CarsListPanelView,
+  CarsListRenderModel,
+} from "../views/cars_panel";
 import type { AnalysisPanelView } from "../views/analysis_panel";
 import {
+  computed,
   effect,
+  signal,
   untracked,
   type ReadonlySignal,
 } from "../ui_signals";
@@ -24,7 +29,7 @@ import {
 } from "./settings_cars_transport";
 
 interface SettingsCarsModulePanels {
-  analysisPanel: Pick<AnalysisPanelView, "setCarAvailability">;
+  analysisPanel: Pick<AnalysisPanelView, "bindCarAvailability">;
   panel: CarsListPanelView;
 }
 
@@ -82,7 +87,7 @@ export function createSettingsCarsModule(
   const transport = createSettingsCarsTransport(ctx.transport);
   const carSelection = createCarSelectionDerivedState(settings);
   let handlersBound = false;
-  let highlightedCarFeedback: CarsListHighlightedFeedback | null = null;
+  const highlightedCarFeedback = signal<CarsListHighlightedFeedback | null>(null);
 
   function hasValidActiveCar(): boolean {
     return carSelection.hasResolvedActiveCar.value;
@@ -94,11 +99,11 @@ export function createSettingsCarsModule(
 
   function createPanelModel(
     carSelectionState: CarSelectionState,
-  ): Parameters<CarsListPanelView["setModel"]>[0] {
+  ): CarsListRenderModel {
     return {
       guidance: buildCarsGuidanceRenderModel({
         carSelectionState,
-        highlightedCarFeedback,
+        highlightedCarFeedback: highlightedCarFeedback.value,
         t,
       }),
       table: carSelectionState.kind === "loading"
@@ -106,36 +111,34 @@ export function createSettingsCarsModule(
         : buildSettingsCarListRenderModel({
           activeCarId: settings.activeCarId,
           cars: settings.cars,
-          highlightedCarId: highlightedCarFeedback?.carId ?? null,
+          highlightedCarId: highlightedCarFeedback.value?.carId ?? null,
           fmt: formatting.fmt,
           t,
         }),
     };
   }
-
-  function syncAnalysisControls(carSelectionState: CarSelectionState): void {
-    ctx.panels.analysisPanel.setCarAvailability({
+  const analysisAvailability = computed(() => {
+    const carSelectionState = carSelection.selection.value;
+    return {
       hasActiveCar: carSelectionState.kind === "active",
       isLoading: carSelectionState.kind === "loading",
-    });
-  }
+    };
+  });
+  const panelModel = computed(() => createPanelModel(getCarSelectionState()));
+  ctx.panels.analysisPanel.bindCarAvailability(analysisAvailability);
+  ctx.panels.panel.bindModel(panelModel);
 
-  function renderCarList(): void {
-    const carSelectionState = getCarSelectionState();
-    syncAnalysisControls(carSelectionState);
-    ctx.panels.panel.setModel(createPanelModel(carSelectionState));
-  }
+  function renderCarList(): void {}
 
   function clearHighlightedCarFeedback(): void {
-    highlightedCarFeedback = null;
+    highlightedCarFeedback.value = null;
   }
 
   function dismissHighlightedCarFeedback(): void {
-    if (!highlightedCarFeedback) {
+    if (!highlightedCarFeedback.value) {
       return;
     }
     clearHighlightedCarFeedback();
-    renderCarList();
   }
 
   function syncCarsPayload(payload: CarsPayload): void {
@@ -147,12 +150,11 @@ export function createSettingsCarsModule(
       : false;
     settings.activeCarId = hasRequestedActive ? requestedActiveCarId : null;
     if (
-      highlightedCarFeedback &&
-      !settings.cars.some((car) => car.id === highlightedCarFeedback?.carId)
+      highlightedCarFeedback.value &&
+      !settings.cars.some((car) => car.id === highlightedCarFeedback.value?.carId)
     ) {
-      highlightedCarFeedback = null;
+      highlightedCarFeedback.value = null;
     }
-    renderCarList();
   }
 
   function findCar(carId: string): CarRecord | null {
@@ -164,7 +166,6 @@ export function createSettingsCarsModule(
     if (hasValidActiveCar()) {
       ctx.ports.syncAnalysisInputs();
     }
-    renderCarList();
   }
 
   async function loadCarsFromServer(): Promise<void> {
@@ -192,7 +193,6 @@ export function createSettingsCarsModule(
       syncCarsPayload(await transport.activateCar(carId));
       syncActiveCarToInputs();
       clearHighlightedCarFeedback();
-      renderCarList();
       ctx.ports.renderSpectrum();
     } catch (_err) {
       services.showError(t("settings.car.activate_failed"));
@@ -208,17 +208,12 @@ export function createSettingsCarsModule(
       return;
     }
     try {
-      let shouldRefreshAfterSelection = highlightedCarFeedback !== null;
       if (car.id !== settings.activeCarId) {
         syncCarsPayload(await transport.activateCar(carId));
         syncActiveCarToInputs();
         ctx.ports.renderSpectrum();
-        shouldRefreshAfterSelection = true;
       }
       clearHighlightedCarFeedback();
-      if (shouldRefreshAfterSelection) {
-        renderCarList();
-      }
       ctx.ports.openAnalysisTab();
     } catch (_err) {
       services.showError(t("settings.car.activate_failed"));
@@ -240,7 +235,6 @@ export function createSettingsCarsModule(
       syncCarsPayload(await transport.deleteCar(carId));
       syncActiveCarToInputs();
       clearHighlightedCarFeedback();
-      renderCarList();
       ctx.ports.renderSpectrum();
     } catch (_err) {
       services.showError(t("settings.car.delete_failed"));
@@ -295,16 +289,13 @@ export function createSettingsCarsModule(
     });
   }
 
-  renderCarList();
-
   return {
     bindHandlers,
     hasValidActiveCar,
     loadCarsFromServer,
     renderCarList,
     showCarCreationSuccess(carId: string, carName: string): void {
-      highlightedCarFeedback = { carId, carName };
-      renderCarList();
+      highlightedCarFeedback.value = { carId, carName };
     },
     syncActiveCarToInputs,
     syncCarsPayload,

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -7,7 +7,10 @@ import {
   signal,
   type ReadonlySignal,
 } from "../ui_signals";
-import type { SpeedSourcePanelView } from "../views/speed_source_panel";
+import {
+  DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL,
+  type SpeedSourcePanelView,
+} from "../views/speed_source_panel";
 import {
   buildSpeedSourceDiagnosticsRenderModel,
   type SettingsSpeedSourcePresenterDeps,
@@ -48,6 +51,8 @@ export function createSettingsGpsStatusModule(
     getSpeedUnit: ctx.getSpeedUnit,
     t: ctx.services.t,
   };
+  const diagnosticsModel = signal(DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL);
+  panel.bindDiagnostics(diagnosticsModel);
   const pollingEnabled = computed(() =>
     handlersBound.value
     && startupReady.value
@@ -76,9 +81,7 @@ export function createSettingsGpsStatusModule(
       settings.gpsFallbackActive = status.fallback_active;
       settings.gpsEffectiveSpeedKph = status.effective_speed_kmh;
       settings.resolvedSpeedSource = status.speed_source;
-      panel.setDiagnostics(
-        buildSpeedSourceDiagnosticsRenderModel(status, obdStatus, presenterDeps),
-      );
+      diagnosticsModel.value = buildSpeedSourceDiagnosticsRenderModel(status, obdStatus, presenterDeps);
       ctx.ports.syncSpeedSourceSelectionUi();
       ctx.ports.renderSpeedReadout();
       return status.connection_state === "connected"

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -6,6 +6,7 @@ import {
 import type { SpeedSourcePanelView } from "../views/speed_source_panel";
 import type { SettingsState } from "../ui_app_state";
 import {
+  computed,
   effect,
   untracked,
   type ReadonlySignal,
@@ -54,11 +55,12 @@ export function createSettingsSpeedSourceModule(
       focusScanObdDevices: ctx.panel.focusScanObdDevices,
       focusStaleTimeoutInput: ctx.panel.focusStaleTimeoutInput,
       isObdConfigVisible: ctx.panel.isObdConfigVisible,
-      render(state): void {
-        ctx.panel.setModel(buildSettingsSpeedSourcePanelModel(state, presenterDeps));
-      },
     },
   });
+  const panelModel = computed(() =>
+    buildSettingsSpeedSourcePanelModel(workflow.renderState.value, presenterDeps)
+  );
+  ctx.panel.bindModel(panelModel);
   let handlersBound = false;
 
   function bindHandlers(): void {

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -9,7 +9,16 @@ import {
   resolveEffectiveSpeedSource,
   type DisplayedSpeedSourceMode,
 } from "../speed_source_state";
-import type { SettingsState } from "../ui_app_state";
+import {
+  trackAppStateSlice,
+  type SettingsState,
+} from "../ui_app_state";
+import {
+  batch,
+  computed,
+  signal,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type { SettingsSpeedSourceRenderState } from "../views/settings_speed_source_presenter";
 import type { SettingsFeedbackMessage } from "../views/settings_feedback";
 import {
@@ -29,7 +38,6 @@ export interface SettingsSpeedSourceWorkflowViewPorts {
   focusScanObdDevices(): void;
   focusStaleTimeoutInput(): void;
   isObdConfigVisible(): boolean;
-  render(state: SettingsSpeedSourceRenderState): void;
 }
 
 export interface SettingsSpeedSourceWorkflowDeps {
@@ -44,13 +52,13 @@ export interface SettingsSpeedSourceWorkflowDeps {
 
 export interface SettingsSpeedSourceWorkflow {
   getRenderState(): SettingsSpeedSourceRenderState;
+  readonly renderState: ReadonlySignal<SettingsSpeedSourceRenderState>;
   handleManualSpeedInput(value: string): void;
   handleNavigateContext(): void;
   handleSpeedSourceChanged(mode: DisplayedSpeedSourceMode): void;
   handleStaleTimeoutInput(value: string): void;
   loadSpeedSourceFromServer(): Promise<void>;
   pairObdDevice(macAddress: string): Promise<void>;
-  renderCurrentState(): void;
   saveSpeedSource(): Promise<void>;
   scanObdDevices(mode?: "manual" | "background"): Promise<void>;
   syncFromSettings(): void;
@@ -128,56 +136,61 @@ export function createSettingsSpeedSourceWorkflow(
   const transport = createSettingsSpeedSourceTransport(deps.transport);
   const createPolling = deps.createPollingController ?? createPollingController;
   const speedSourceState = createSpeedSourceDerivedState(deps.settings);
-
-  let speedSourceDraftDirty = false;
-  let selectedMode: DisplayedSpeedSourceMode = speedSourceState.displayedMode.value;
-  let manualSpeedInputValue = deps.settings.manualSpeedKph != null ? String(deps.settings.manualSpeedKph) : "";
-  let staleTimeoutInputValue = "";
+  const speedSourceDraftDirty = signal(false);
+  const selectedMode = signal<DisplayedSpeedSourceMode>(speedSourceState.displayedMode.value);
+  const manualSpeedInputValue = signal(
+    deps.settings.manualSpeedKph != null ? String(deps.settings.manualSpeedKph) : "",
+  );
+  const staleTimeoutInputValue = signal("");
   let speedSourceContextVisible = false;
   let backgroundRescanRequested = false;
-  let scannedDevices: ObdDevicePayload[] = [];
-  let scanInFlight = false;
-  let pairInFlightMac: string | null = null;
-  let obdScanStatusMessage: string | null = null;
-  let manualSpeedFeedback: SettingsFeedbackMessage | null = null;
-  let staleTimeoutFeedback: SettingsFeedbackMessage | null = null;
-  let saveFeedback: SettingsFeedbackMessage | null = null;
-  let obdSelectionError = false;
-  let diagnosticsOpen = false;
+  const scannedDevices = signal<readonly ObdDevicePayload[]>([]);
+  const scanInFlight = signal(false);
+  const pairInFlightMac = signal<string | null>(null);
+  const obdScanStatusMessage = signal<string | null>(null);
+  const manualSpeedFeedback = signal<SettingsFeedbackMessage | null>(null);
+  const staleTimeoutFeedback = signal<SettingsFeedbackMessage | null>(null);
+  const saveFeedback = signal<SettingsFeedbackMessage | null>(null);
+  const obdSelectionError = signal(false);
+  const diagnosticsOpen = signal(false);
+  const renderState = computed<SettingsSpeedSourceRenderState>(() => {
+    const trackedSettings = trackAppStateSlice(deps.settings);
+    return {
+      diagnosticsOpen: diagnosticsOpen.value,
+      draftDirty: speedSourceDraftDirty.value,
+      manualSpeedFeedback: cloneFeedback(manualSpeedFeedback.value),
+      manualSpeedInputValue: manualSpeedInputValue.value,
+      obdScanStatusMessage: obdScanStatusMessage.value,
+      obdSelectionError: obdSelectionError.value,
+      pairInFlightMac: pairInFlightMac.value,
+      saveFeedback: cloneFeedback(saveFeedback.value),
+      scannedDevices: [...scannedDevices.value],
+      scanInFlight: scanInFlight.value,
+      selectedMode: selectedMode.value,
+      settings: {
+        gpsFallbackActive: trackedSettings.gpsFallbackActive,
+        gpsEffectiveSpeedKph: trackedSettings.gpsEffectiveSpeedKph,
+        manualSpeedKph: trackedSettings.manualSpeedKph,
+        obdDeviceMac: trackedSettings.obdDeviceMac,
+        obdDeviceName: trackedSettings.obdDeviceName,
+        resolvedSpeedSource: trackedSettings.resolvedSpeedSource,
+        speedSource: trackedSettings.speedSource,
+      },
+      staleTimeoutFeedback: cloneFeedback(staleTimeoutFeedback.value),
+      staleTimeoutInputValue: staleTimeoutInputValue.value,
+    };
+  });
 
   function getRenderState(): SettingsSpeedSourceRenderState {
-    return {
-      diagnosticsOpen,
-      draftDirty: speedSourceDraftDirty,
-      manualSpeedFeedback: cloneFeedback(manualSpeedFeedback),
-      manualSpeedInputValue,
-      obdScanStatusMessage,
-      obdSelectionError,
-      pairInFlightMac,
-      saveFeedback: cloneFeedback(saveFeedback),
-      scannedDevices: [...scannedDevices],
-      scanInFlight,
-      selectedMode,
-      settings: {
-        gpsFallbackActive: deps.settings.gpsFallbackActive,
-        gpsEffectiveSpeedKph: deps.settings.gpsEffectiveSpeedKph,
-        manualSpeedKph: deps.settings.manualSpeedKph,
-        obdDeviceMac: deps.settings.obdDeviceMac,
-        obdDeviceName: deps.settings.obdDeviceName,
-        resolvedSpeedSource: deps.settings.resolvedSpeedSource,
-        speedSource: deps.settings.speedSource,
-      },
-      staleTimeoutFeedback: cloneFeedback(staleTimeoutFeedback),
-      staleTimeoutInputValue,
-    };
+    return renderState.value;
   }
 
   function shouldRunBackgroundRescan(): boolean {
     return backgroundRescanRequested
       && speedSourceContextVisible
-      && selectedMode === "obd2"
-      && !scanInFlight
-      && pairInFlightMac === null;
+      && selectedMode.value === "obd2"
+      && !scanInFlight.value
+      && pairInFlightMac.value === null;
   }
 
   function syncBackgroundRescan(): void {
@@ -193,49 +206,66 @@ export function createSettingsSpeedSourceWorkflow(
     syncBackgroundRescan();
   }
 
-  function renderCurrentState(): void {
-    deps.view.render(getRenderState());
-    syncContextVisibility();
+  let contextSyncScheduled = false;
+  function scheduleContextVisibilitySync(): void {
+    if (contextSyncScheduled) {
+      return;
+    }
+    contextSyncScheduled = true;
+    queueMicrotask(() => {
+      contextSyncScheduled = false;
+      syncContextVisibility();
+    });
   }
 
   function clearManualSpeedFeedback(): void {
-    manualSpeedFeedback = null;
-    saveFeedback = null;
+    batch(() => {
+      manualSpeedFeedback.value = null;
+      saveFeedback.value = null;
+    });
   }
 
   function clearStaleTimeoutFeedback(): void {
-    staleTimeoutFeedback = null;
-    saveFeedback = null;
+    batch(() => {
+      staleTimeoutFeedback.value = null;
+      saveFeedback.value = null;
+    });
   }
 
   function clearObdSelectionFeedback(): void {
-    obdSelectionError = false;
-    saveFeedback = null;
+    batch(() => {
+      obdSelectionError.value = false;
+      saveFeedback.value = null;
+    });
   }
 
   function clearAllFeedback(): void {
-    manualSpeedFeedback = null;
-    staleTimeoutFeedback = null;
-    saveFeedback = null;
-    obdSelectionError = false;
+    batch(() => {
+      manualSpeedFeedback.value = null;
+      staleTimeoutFeedback.value = null;
+      saveFeedback.value = null;
+      obdSelectionError.value = false;
+    });
   }
 
   function showSaveFeedback(message: string, detail: string): void {
-    saveFeedback = {
-      body: message,
-      detail,
-      title: deps.t("settings.speed.save_failed_title"),
-      tone: "error",
-    };
-    diagnosticsOpen = true;
+    batch(() => {
+      saveFeedback.value = {
+        body: message,
+        detail,
+        title: deps.t("settings.speed.save_failed_title"),
+        tone: "error",
+      };
+      diagnosticsOpen.value = true;
+    });
   }
 
   function setScannedDevices(devices: readonly ObdDevicePayload[]): void {
-    scannedDevices = [...devices].sort(compareScannedDevices);
+    scannedDevices.value = [...devices].sort(compareScannedDevices);
   }
 
   function mergeScannedDevices(devices: readonly ObdDevicePayload[]): void {
-    const merged = new Map(scannedDevices.map((device) => [device.mac_address, device]));
+    const merged = new Map(scannedDevices.value.map((device) => [device.mac_address, device]));
     devices.forEach((device) => {
       merged.set(device.mac_address, device);
     });
@@ -243,19 +273,30 @@ export function createSettingsSpeedSourceWorkflow(
   }
 
   function syncInputsFromSettings(): void {
-    speedSourceDraftDirty = false;
-    selectedMode = speedSourceState.displayedMode.value;
-    manualSpeedInputValue = deps.settings.manualSpeedKph != null ? String(deps.settings.manualSpeedKph) : "";
-    clearAllFeedback();
-    renderCurrentState();
+    batch(() => {
+      speedSourceDraftDirty.value = false;
+      selectedMode.value = speedSourceState.displayedMode.value;
+      manualSpeedInputValue.value = deps.settings.manualSpeedKph != null
+        ? String(deps.settings.manualSpeedKph)
+        : "";
+      manualSpeedFeedback.value = null;
+      staleTimeoutFeedback.value = null;
+      saveFeedback.value = null;
+      obdSelectionError.value = false;
+    });
+    scheduleContextVisibilitySync();
   }
 
   function syncFromSettings(): void {
-    if (!speedSourceDraftDirty) {
-      selectedMode = speedSourceState.displayedMode.value;
-      manualSpeedInputValue = deps.settings.manualSpeedKph != null ? String(deps.settings.manualSpeedKph) : "";
+    if (!speedSourceDraftDirty.value) {
+      batch(() => {
+        selectedMode.value = speedSourceState.displayedMode.value;
+        manualSpeedInputValue.value = deps.settings.manualSpeedKph != null
+          ? String(deps.settings.manualSpeedKph)
+          : "";
+      });
     }
-    renderCurrentState();
+    scheduleContextVisibilitySync();
   }
 
   function applyPayload(payload: SpeedSourcePayload): void {
@@ -264,7 +305,7 @@ export function createSettingsSpeedSourceWorkflow(
     deps.settings.obdDeviceMac = payload.obd_device_mac ?? null;
     deps.settings.obdDeviceName = payload.obd_device_name ?? null;
     deps.settings.resolvedSpeedSource = null;
-    staleTimeoutInputValue = String(payload.stale_timeout_s);
+    staleTimeoutInputValue.value = String(payload.stale_timeout_s);
     syncInputsFromSettings();
     deps.renderSpeedReadout();
   }
@@ -279,31 +320,33 @@ export function createSettingsSpeedSourceWorkflow(
   }
 
   function handleSpeedSourceChanged(mode: DisplayedSpeedSourceMode): void {
-    speedSourceDraftDirty = true;
-    selectedMode = mode;
-    clearAllFeedback();
-    renderCurrentState();
+    batch(() => {
+      speedSourceDraftDirty.value = true;
+      selectedMode.value = mode;
+      clearAllFeedback();
+    });
+    scheduleContextVisibilitySync();
   }
 
   function handleManualSpeedInput(value: string): void {
-    manualSpeedInputValue = value;
+    manualSpeedInputValue.value = value;
     clearManualSpeedFeedback();
-    renderCurrentState();
   }
 
   function handleStaleTimeoutInput(value: string): void {
-    staleTimeoutInputValue = value;
+    staleTimeoutInputValue.value = value;
     clearStaleTimeoutFeedback();
-    renderCurrentState();
   }
 
   async function saveSpeedSource(): Promise<void> {
     clearAllFeedback();
 
-    const source: SpeedSourceKind = speedSourceDraftDirty ? selectedMode : deps.settings.speedSource;
-    const manualInputValue = manualSpeedInputValue.trim();
+    const source: SpeedSourceKind = speedSourceDraftDirty.value
+      ? selectedMode.value
+      : deps.settings.speedSource;
+    const manualInputValue = manualSpeedInputValue.value.trim();
     const manualSpeedKph = parseManualSpeedKph(Number(manualInputValue));
-    const staleValueRaw = staleTimeoutInputValue.trim();
+    const staleValueRaw = staleTimeoutInputValue.value.trim();
     const staleValue = Number(staleValueRaw);
     const staleTimeoutInvalid = source !== "manual" && (
       staleValueRaw === ""
@@ -317,7 +360,7 @@ export function createSettingsSpeedSourceWorkflow(
     const activeSource = activeSourceLabel(deps.settings, deps.t);
 
     if (manualSpeedInvalid) {
-      manualSpeedFeedback = {
+      manualSpeedFeedback.value = {
         body: deps.t("settings.speed.manual_invalid"),
         compact: true,
         tone: "error",
@@ -326,13 +369,12 @@ export function createSettingsSpeedSourceWorkflow(
         deps.t("settings.speed.manual_invalid"),
         deps.t("settings.speed.validation_active_detail", { source: activeSource }),
       );
-      renderCurrentState();
       deps.view.focusManualSpeedInput();
       return;
     }
 
     if (staleTimeoutInvalid) {
-      staleTimeoutFeedback = {
+      staleTimeoutFeedback.value = {
         body: deps.t("settings.speed.stale_timeout_invalid"),
         compact: true,
         tone: "error",
@@ -341,18 +383,16 @@ export function createSettingsSpeedSourceWorkflow(
         deps.t("settings.speed.stale_timeout_invalid"),
         deps.t("settings.speed.validation_active_detail", { source: activeSource }),
       );
-      renderCurrentState();
       deps.view.focusStaleTimeoutInput();
       return;
     }
 
     if (source === "obd2" && !deps.settings.obdDeviceMac) {
-      obdSelectionError = true;
+      obdSelectionError.value = true;
       showSaveFeedback(
         deps.t("settings.speed.obd_missing_device_error"),
         deps.t("settings.speed.validation_active_detail", { source: activeSource }),
       );
-      renderCurrentState();
       deps.view.focusScanObdDevices();
       return;
     }
@@ -373,49 +413,47 @@ export function createSettingsSpeedSourceWorkflow(
         error instanceof Error ? error.message : deps.t("settings.save_failed"),
         deps.t("settings.speed.save_failed_detail", { source: activeSource }),
       );
-      renderCurrentState();
     }
   }
 
   async function scanObdDevices(mode: "manual" | "background" = "manual"): Promise<void> {
-    if (scanInFlight || pairInFlightMac !== null) {
+    if (scanInFlight.value || pairInFlightMac.value !== null) {
       return;
     }
-    scanInFlight = true;
+    scanInFlight.value = true;
     if (mode === "manual") {
       clearObdSelectionFeedback();
-      obdScanStatusMessage = deps.t("settings.speed.obd_scanning");
+      obdScanStatusMessage.value = deps.t("settings.speed.obd_scanning");
     }
-    renderCurrentState();
+    syncBackgroundRescan();
     try {
       const payload = await transport.scanObdDevices();
       if (mode === "manual") {
         setScannedDevices(payload.devices);
         backgroundRescanRequested = true;
-        obdScanStatusMessage = payload.devices.length > 0
+        obdScanStatusMessage.value = payload.devices.length > 0
           ? deps.t("settings.speed.obd_scan_found", { count: payload.devices.length })
           : deps.t("settings.speed.obd_scan_empty");
+        syncBackgroundRescan();
       } else {
         mergeScannedDevices(payload.devices);
       }
-      renderCurrentState();
     } catch (error) {
       if (mode === "manual") {
-        obdScanStatusMessage = deps.t("settings.speed.obd_scan_failed");
-        renderCurrentState();
+        obdScanStatusMessage.value = deps.t("settings.speed.obd_scan_failed");
         deps.showError(error instanceof Error ? error.message : deps.t("settings.speed.obd_scan_failed"));
       }
     } finally {
-      scanInFlight = false;
-      renderCurrentState();
+      scanInFlight.value = false;
+      syncBackgroundRescan();
     }
   }
 
   async function pairObdDevice(macAddress: string): Promise<void> {
     clearObdSelectionFeedback();
-    pairInFlightMac = macAddress;
-    obdScanStatusMessage = deps.t("settings.speed.obd_pairing");
-    renderCurrentState();
+    pairInFlightMac.value = macAddress;
+    obdScanStatusMessage.value = deps.t("settings.speed.obd_pairing");
+    syncBackgroundRescan();
     try {
       const payload = await transport.pairObdDevice(macAddress);
       deps.settings.obdDeviceMac = payload.configured_device_mac ?? null;
@@ -428,15 +466,13 @@ export function createSettingsSpeedSourceWorkflow(
         rfcomm_channel: payload.rfcomm_channel,
         trusted: payload.trusted,
       }]);
-      obdScanStatusMessage = deps.t("settings.speed.obd_pair_success");
-      renderCurrentState();
+      obdScanStatusMessage.value = deps.t("settings.speed.obd_pair_success");
     } catch (error) {
-      obdScanStatusMessage = deps.t("settings.speed.obd_pair_failed");
-      renderCurrentState();
+      obdScanStatusMessage.value = deps.t("settings.speed.obd_pair_failed");
       deps.showError(error instanceof Error ? error.message : deps.t("settings.speed.obd_pair_failed"));
     } finally {
-      pairInFlightMac = null;
-      renderCurrentState();
+      pairInFlightMac.value = null;
+      syncBackgroundRescan();
     }
   }
 
@@ -447,7 +483,7 @@ export function createSettingsSpeedSourceWorkflow(
   const obdBackgroundRescan = createPolling({
     onErrorDelayMs: OBD_BACKGROUND_RESCAN_DELAY_MS,
     poll: async () => {
-      if (!shouldRunBackgroundRescan() || scanInFlight || pairInFlightMac !== null) {
+      if (!shouldRunBackgroundRescan()) {
         return OBD_BACKGROUND_RESCAN_DELAY_MS;
       }
       await scanObdDevices("background");
@@ -457,13 +493,13 @@ export function createSettingsSpeedSourceWorkflow(
 
   return {
     getRenderState,
+    renderState,
     handleManualSpeedInput,
     handleNavigateContext,
     handleSpeedSourceChanged,
     handleStaleTimeoutInput,
     loadSpeedSourceFromServer,
     pairObdDevice,
-    renderCurrentState,
     saveSpeedSource,
     scanObdDevices,
     syncFromSettings,

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -5,7 +5,10 @@ import {
 } from "../ui_signals";
 import type { FeatureServices } from "../feature_deps_base";
 import { createUpdateFeatureWorkflow } from "./update_feature_workflow";
-import { createUpdateFeaturePresenter } from "../views/update_feature_presenter";
+import {
+  createUpdateFeaturePresenter,
+  type UpdateFeaturePresenter,
+} from "../views/update_feature_presenter";
 import type { InternetPanelView } from "../views/internet_panel";
 import type { UpdatePanelView } from "../views/update_panel";
 
@@ -44,17 +47,26 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
     handlersBound.value
     && isUpdatePollingContext(ports.activeViewId.value, activeSettingsTabId.value)
   );
-  const presenter = createUpdateFeaturePresenter({
-    panel: panels.update,
-    internetPanel: panels.internet,
-    t: services.t,
-  });
+  let presenter!: UpdateFeaturePresenter;
   const workflow = createUpdateFeatureWorkflow({
     t: services.t,
     showError: services.showError,
-    view: presenter,
+    view: {
+      clearPassword() {
+        presenter.clearPassword();
+      },
+      focusSsidInput() {
+        panels.internet.focusSsidInput();
+      },
+    },
     pollingEnabled,
   });
+  presenter = createUpdateFeaturePresenter({
+    renderState: workflow.renderState,
+    t: services.t,
+  });
+  panels.internet.bindModel(presenter.internetPanelModel);
+  panels.update.bindModel(presenter.updatePanelModel);
 
   ports.subscribeSettingsTabChanges((tabId) => {
     activeSettingsTabId.value = tabId;
@@ -67,10 +79,7 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
     handlersBound.value = true;
     panels.update.bindActions({
       onStart: () => {
-        workflow.renderCurrentState();
-        void workflow.startUpdate(
-          presenter.readStartIntent(workflow.getRenderState()),
-        );
+        void workflow.startUpdate(presenter.readStartIntent());
       },
       onCancel: () => {
         void workflow.cancelUpdate();
@@ -85,14 +94,11 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
       },
       onTransportChange: (transport) => {
         presenter.setSelectedTransport(transport);
-        workflow.renderCurrentState();
       },
       onSsidInput: (value) => {
         presenter.setSsidInput(value);
-        workflow.renderCurrentState();
       },
     });
-    workflow.renderCurrentState();
   }
 
   return {

--- a/apps/ui/src/app/features/update_feature_workflow.ts
+++ b/apps/ui/src/app/features/update_feature_workflow.ts
@@ -19,7 +19,12 @@ import type {
   UpdateFeatureRenderState,
   UpdateFeatureStartIntent,
 } from "../views/update_feature_presenter";
-import type { ReadonlySignal } from "../ui_signals";
+import {
+  batch,
+  computed,
+  signal,
+  type ReadonlySignal,
+} from "../ui_signals";
 import {
   createPollingController,
   type PollingController,
@@ -35,7 +40,6 @@ export interface UpdateFeatureWorkflowApi {
 }
 
 export interface UpdateFeatureWorkflowViewPorts {
-  render(state: UpdateFeatureRenderState): void;
   focusSsidInput(): void;
   clearPassword(): void;
 }
@@ -52,8 +56,8 @@ export interface UpdateFeatureWorkflowDeps {
 export interface UpdateFeatureWorkflow {
   cancelUpdate(): Promise<void>;
   getRenderState(): UpdateFeatureRenderState;
+  readonly renderState: ReadonlySignal<UpdateFeatureRenderState>;
   refreshStatus(): Promise<void>;
-  renderCurrentState(): void;
   startPolling(): void;
   startUpdate(intent: UpdateFeatureStartIntent): Promise<void>;
   stopPolling(): void;
@@ -118,24 +122,21 @@ export function createUpdateFeatureWorkflow(
   };
   const createPolling = deps.createPollingController ?? createPollingController;
 
-  let latestInternetStatus: UsbInternetStatusPayload = fallbackInternetStatus(deps.t);
-  let latestHealthStatus: HealthStatusPayload | null = null;
-  let latestUpdateStatus: UpdateStatusPayload | null = null;
-  let latestUpdateState: UpdateStatusPayload["state"] = "idle";
-  let latestUpdateTransport: UpdateStartRequestPayload["transport"] = "wifi";
+  const latestInternetStatus = signal<UsbInternetStatusPayload>(fallbackInternetStatus(deps.t));
+  const latestHealthStatus = signal<HealthStatusPayload | null>(null);
+  const latestUpdateStatus = signal<UpdateStatusPayload | null>(null);
+  const latestUpdateState = signal<UpdateStatusPayload["state"]>("idle");
+  const latestUpdateTransport = signal<UpdateStartRequestPayload["transport"]>("wifi");
+  const renderState = computed<UpdateFeatureRenderState>(() => ({
+    internetStatus: latestInternetStatus.value,
+    healthStatus: latestHealthStatus.value,
+    updateStatus: latestUpdateStatus.value,
+    updateState: latestUpdateState.value,
+    updateTransport: latestUpdateTransport.value,
+  }));
 
   function getRenderState(): UpdateFeatureRenderState {
-    return {
-      internetStatus: latestInternetStatus,
-      healthStatus: latestHealthStatus,
-      updateStatus: latestUpdateStatus,
-      updateState: latestUpdateState,
-      updateTransport: latestUpdateTransport,
-    };
-  }
-
-  function renderCurrentState(): void {
-    deps.view.render(getRenderState());
+    return renderState.value;
   }
 
   async function fetchStatusSnapshot(): Promise<{
@@ -162,12 +163,13 @@ export function createUpdateFeatureWorkflow(
     internet: UsbInternetStatusPayload;
     status: UpdateStatusPayload;
   }): void {
-    latestUpdateStatus = snapshot.status;
-    latestHealthStatus = snapshot.health;
-    latestInternetStatus = snapshot.internet;
-    latestUpdateState = snapshot.status.state;
-    latestUpdateTransport = safeUpdateTransport(snapshot.status.transport);
-    renderCurrentState();
+    batch(() => {
+      latestUpdateStatus.value = snapshot.status;
+      latestHealthStatus.value = snapshot.health;
+      latestInternetStatus.value = snapshot.internet;
+      latestUpdateState.value = snapshot.status.state;
+      latestUpdateTransport.value = safeUpdateTransport(snapshot.status.transport);
+    });
   }
 
   const polling = createPolling({
@@ -240,8 +242,8 @@ export function createUpdateFeatureWorkflow(
   return {
     cancelUpdate,
     getRenderState,
+    renderState,
     refreshStatus,
-    renderCurrentState,
     startPolling() {
       polling.start();
     },

--- a/apps/ui/src/app/views/analysis_panel.tsx
+++ b/apps/ui/src/app/views/analysis_panel.tsx
@@ -2,7 +2,12 @@ import { render, type JSX } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 
 import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import {
+  effect,
+  signal,
+  untracked,
+  type ReadonlySignal,
+} from "../ui_signals";
 import {
   settingsFeedbackClassName,
   type SettingsFeedbackMessage,
@@ -53,10 +58,10 @@ export interface AnalysisPanelActionHandlers {
 
 export interface AnalysisPanelView {
   bindActions(handlers: AnalysisPanelActionHandlers): void;
+  bindCarAvailability(state: ReadonlySignal<AnalysisPanelCarAvailability>): void;
+  bindModel(model: ReadonlySignal<AnalysisPanelRenderModel>): void;
   focusField(field: AnalysisPanelFieldKey): void;
   openGuidance(): void;
-  setModel(model: AnalysisPanelRenderModel): void;
-  setCarAvailability(state: AnalysisPanelCarAvailability): void;
 }
 
 type AnalysisFieldSpec = {
@@ -545,18 +550,30 @@ export function mountAnalysisPanel(host: HTMLElement): AnalysisPanelView {
     bindActions(handlers) {
       bridgeState.value = { ...bridgeState.value, actions: handlers };
     },
+    bindCarAvailability(state) {
+      effect(() => {
+        const currentBridgeState = untracked(() => bridgeState.value);
+        bridgeState.value = {
+          ...currentBridgeState,
+          availability: state.value,
+        };
+      });
+    },
+    bindModel(model) {
+      effect(() => {
+        const currentBridgeState = untracked(() => bridgeState.value);
+        bridgeState.value = {
+          ...currentBridgeState,
+          model: model.value,
+        };
+      });
+    },
     focusField(field) {
       focusRequestToken += 1;
       inputFocusRequest.value = { field, token: focusRequestToken };
     },
     openGuidance() {
       guidanceOpenRequest.value += 1;
-    },
-    setModel(model) {
-      bridgeState.value = { ...bridgeState.value, model };
-    },
-    setCarAvailability(state) {
-      bridgeState.value = { ...bridgeState.value, availability: state };
     },
   };
 }

--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -30,7 +30,7 @@ export interface CarsListRenderModel {
 
 export interface CarsListPanelView {
   bindActions(handlers: { onAction(action: CarsListAction): void }): void;
-  setModel(model: CarsListRenderModel): void;
+  bindModel(model: ReadonlySignal<CarsListRenderModel>): void;
 }
 
 export type CarsFeatureInteraction =
@@ -56,7 +56,7 @@ export interface CarsFeatureInteractionHandlers {
 export interface CarsWizardPanelBridge {
   bindActions(handlers: CarsFeatureInteractionHandlers): void;
   focus(target: CarsFeatureFocusTarget): void;
-  setModel(model: CarsWizardRenderModel): void;
+  bindModel(model: ReadonlySignal<CarsWizardRenderModel>): void;
 }
 
 export interface CarsPanelView {
@@ -79,9 +79,9 @@ type CarsWizardOptionRefs = {
 
 type CarsPanelBridgeState = {
   actions: CarsListPanelActionHandlers | null;
-  model: CarsListRenderModel;
+  model: ReadonlySignal<CarsListRenderModel> | null;
   wizardActions: CarsFeatureInteractionHandlers | null;
-  wizardModel: CarsWizardRenderModel;
+  wizardModel: ReadonlySignal<CarsWizardRenderModel> | null;
 };
 
 type CarsWizardFocusRequest = {
@@ -429,7 +429,8 @@ function CarsPanel(props: {
   const state = props.state.value;
   const wizardFocusRequest = props.wizardFocusRequest.value;
   const t = useUiTranslation();
-  const wizardModel = state.wizardModel;
+  const model = state.model?.value ?? DEFAULT_CARS_PANEL_MODEL;
+  const wizardModel = state.wizardModel?.value ?? createClosedCarsWizardRenderModel();
   const addCarBtnRef = useRef<HTMLButtonElement | null>(null);
   const addCarWizardRef = useRef<HTMLDivElement | null>(null);
   const wizardCloseBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -548,9 +549,9 @@ function CarsPanel(props: {
             "Add cars from the library or enter specs manually. Activate a car to use it for analysis.",
           )}
         </div>
-        <div id="carSelectionGuidance" hidden={state.model.guidance === null}>
-          {state.model.guidance ? (
-            <CarsInlineStatePanel actions={state.actions} state={state.model.guidance} />
+        <div id="carSelectionGuidance" hidden={model.guidance === null}>
+          {model.guidance ? (
+            <CarsInlineStatePanel actions={state.actions} state={model.guidance} />
           ) : null}
         </div>
         <div class="settings-table-wrap">
@@ -569,7 +570,7 @@ function CarsPanel(props: {
               </tr>
             </thead>
             <tbody id="carListBody">
-              <CarsTableBody actions={state.actions} table={state.model.table} />
+              <CarsTableBody actions={state.actions} table={model.table} />
             </tbody>
           </table>
         </div>
@@ -1014,9 +1015,9 @@ function CarsPanel(props: {
 export function mountCarsPanel(host: HTMLElement): CarsPanelView {
   const bridgeState = signal<CarsPanelBridgeState>({
     actions: null,
-    model: DEFAULT_CARS_PANEL_MODEL,
+    model: null,
     wizardActions: null,
-    wizardModel: createClosedCarsWizardRenderModel(),
+    wizardModel: null,
   });
   const wizardFocusRequest = signal<CarsWizardFocusRequest | null>(null);
   let focusRequestToken = 0;
@@ -1033,7 +1034,7 @@ export function mountCarsPanel(host: HTMLElement): CarsPanelView {
       bindActions(handlers): void {
         bridgeState.value = { ...bridgeState.value, actions: handlers };
       },
-      setModel(model): void {
+      bindModel(model): void {
         bridgeState.value = { ...bridgeState.value, model };
       },
     },
@@ -1045,7 +1046,7 @@ export function mountCarsPanel(host: HTMLElement): CarsPanelView {
         focusRequestToken += 1;
         wizardFocusRequest.value = { target, token: focusRequestToken };
       },
-      setModel(model): void {
+      bindModel(model): void {
         bridgeState.value = { ...bridgeState.value, wizardModel: model };
       },
     },

--- a/apps/ui/src/app/views/esp_flash_feature_presenter.ts
+++ b/apps/ui/src/app/views/esp_flash_feature_presenter.ts
@@ -14,11 +14,14 @@ import type {
   EspFlashJourneyStageState,
   EspFlashLogPanelModel,
   EspFlashPanelRenderModel,
-  EspFlashPanelView,
   EspFlashReadinessPanelModel,
   EspFlashStatusBadgeModel,
   EspFlashStatusGridRowModel,
 } from "./esp_flash_panel";
+import {
+  computed,
+  type ReadonlySignal,
+} from "../ui_signals";
 
 const STATE_TO_VARIANT: Readonly<Record<string, VisualVariant>> = {
   failed: "bad",
@@ -74,12 +77,12 @@ export interface EspFlashFeatureRenderState {
 }
 
 export interface EspFlashFeaturePresenterDeps {
-  panel: EspFlashPanelView;
+  renderState: ReadonlySignal<EspFlashFeatureRenderState>;
   t: (key: string, vars?: Record<string, unknown>) => string;
 }
 
 export interface EspFlashFeaturePresenter {
-  render(state: EspFlashFeatureRenderState): void;
+  readonly model: ReadonlySignal<EspFlashPanelRenderModel>;
 }
 
 function safeEspFlashState(state: string | null | undefined): string {
@@ -596,10 +599,10 @@ export function buildEspFlashPanelRenderModel(
 export function createEspFlashFeaturePresenter(
   ctx: EspFlashFeaturePresenterDeps,
 ): EspFlashFeaturePresenter {
+  const model = computed(() =>
+    buildEspFlashPanelRenderModel(ctx.renderState.value, { t: ctx.t })
+  );
   return {
-    render(state) {
-      const model = buildEspFlashPanelRenderModel(state, { t: ctx.t });
-      ctx.panel.setModel(model);
-    },
+    model,
   };
 }

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -113,12 +113,12 @@ export interface EspFlashPanelActionHandlers {
 
 export interface EspFlashPanelView {
   bindActions(handlers: EspFlashPanelActionHandlers): void;
-  setModel(model: EspFlashPanelRenderModel): void;
+  bindModel(model: ReadonlySignal<EspFlashPanelRenderModel>): void;
 }
 
 type EspFlashPanelBridgeState = {
   actions: EspFlashPanelActionHandlers | null;
-  model: EspFlashPanelRenderModel;
+  model: ReadonlySignal<EspFlashPanelRenderModel> | null;
 };
 
 const DEFAULT_ESP_FLASH_PANEL_MODEL: EspFlashPanelRenderModel = {
@@ -308,7 +308,7 @@ function EspFlashPanel(props: {
   state: ReadonlySignal<EspFlashPanelBridgeState>;
 }) {
   const state = props.state.value;
-  const { model } = state;
+  const model = state.model?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL;
   const t = useUiTranslation();
   const logPanelRef = useRef<HTMLDivElement | null>(null);
 
@@ -546,7 +546,7 @@ function EspFlashPanel(props: {
 export function mountEspFlashPanel(host: HTMLElement): EspFlashPanelView {
   const state = signal<EspFlashPanelBridgeState>({
     actions: null,
-    model: DEFAULT_ESP_FLASH_PANEL_MODEL,
+    model: null,
   });
   render(<EspFlashPanel state={state} />, host);
 
@@ -554,7 +554,7 @@ export function mountEspFlashPanel(host: HTMLElement): EspFlashPanelView {
     bindActions(handlers) {
       state.value = { ...state.value, actions: handlers };
     },
-    setModel(model) {
+    bindModel(model) {
       state.value = { ...state.value, model };
     },
   };

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -8,28 +8,32 @@ import type {
   HistoryPanelView,
 } from "./history_table_view";
 
-interface HistoryPanelBridgeState extends HistoryPanelRenderModel {
+interface HistoryPanelBridgeState {
   actions: HistoryPanelActionHandlers | null;
+  model: ReadonlySignal<HistoryPanelRenderModel> | null;
 }
 
 const DEFAULT_PANEL_STATE: HistoryPanelBridgeState = {
-  historySummaryText: "No runs yet.",
-  deleteAllRunsDisabled: true,
-  table: null,
   actions: null,
+  model: null,
 };
 
 function HistoryPanel(props: { state: ReadonlySignal<HistoryPanelBridgeState> }) {
   const state = props.state.value;
+  const model = state.model?.value ?? {
+    deleteAllRunsDisabled: true,
+    historySummaryText: "No runs yet.",
+    table: null,
+  };
   const t = useUiTranslation();
 
   return (
     <>
       <div class="history-toolbar">
         <div class="history-toolbar__copy">
-          <div id="historySummary" class="history-toolbar__summary subtle">
-            {state.historySummaryText}
-          </div>
+            <div id="historySummary" class="history-toolbar__summary subtle">
+            {model.historySummaryText}
+            </div>
         </div>
         <div class="history-toolbar__actions">
           <button
@@ -46,7 +50,7 @@ function HistoryPanel(props: { state: ReadonlySignal<HistoryPanelBridgeState> })
             class="btn btn--danger-quiet"
             type="button"
 
-            disabled={state.deleteAllRunsDisabled}
+            disabled={model.deleteAllRunsDisabled}
             onClick={() => state.actions?.onDeleteAllRuns()}
           >
             {t("history.delete_all", "Delete All Runs")}
@@ -65,7 +69,7 @@ function HistoryPanel(props: { state: ReadonlySignal<HistoryPanelBridgeState> })
           </tr>
         </thead>
         <tbody id="historyTableBody">
-          <HistoryTableBody handlers={state.actions} table={state.table} />
+          <HistoryTableBody handlers={state.actions} table={model.table} />
         </tbody>
       </table>
     </>
@@ -77,8 +81,8 @@ export function mountHistoryPanel(host: HTMLElement): HistoryPanelView {
   render(<HistoryPanel state={state} />, host);
 
   return {
-    setModel(model: HistoryPanelRenderModel): void {
-      state.value = { ...state.value, ...model };
+    bindModel(model: ReadonlySignal<HistoryPanelRenderModel>): void {
+      state.value = { ...state.value, model };
     },
     bindActions(handlers: HistoryPanelActionHandlers): void {
       state.value = { ...state.value, actions: handlers };

--- a/apps/ui/src/app/views/history_table_view.ts
+++ b/apps/ui/src/app/views/history_table_view.ts
@@ -1,5 +1,6 @@
 import type { HistoryEntry } from "../../transport/http_models";
 import type { RunDetail } from "../ui_app_state";
+import type { ReadonlySignal } from "../ui_signals";
 
 export interface HistoryTableViewParams {
   runs: HistoryEntry[];
@@ -49,6 +50,6 @@ export interface HistoryPanelActionHandlers {
 }
 
 export interface HistoryPanelView {
-  setModel(model: HistoryPanelRenderModel): void;
+  bindModel(model: ReadonlySignal<HistoryPanelRenderModel>): void;
   bindActions(handlers: HistoryPanelActionHandlers): void;
 }

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -52,13 +52,13 @@ export interface InternetPanelActionHandlers {
 
 export interface InternetPanelView {
   bindActions(handlers: InternetPanelActionHandlers): void;
+  bindModel(model: ReadonlySignal<InternetPanelRenderModel>): void;
   focusSsidInput(): void;
-  setModel(model: InternetPanelRenderModel): void;
 }
 
 type InternetPanelBridgeState = {
   actions: InternetPanelActionHandlers | null;
-  model: InternetPanelRenderModel;
+  model: ReadonlySignal<InternetPanelRenderModel> | null;
 };
 
 type InternetPanelFocusRequest = {
@@ -262,7 +262,7 @@ function InternetPanel(props: {
 }) {
   const focusRequest = props.focusRequest.value;
   const state = props.state.value;
-  const { model } = state;
+  const model = state.model?.value ?? DEFAULT_INTERNET_PANEL_MODEL;
   const t = useUiTranslation();
   const ssidInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -443,7 +443,7 @@ export function mountInternetPanel(host: HTMLElement): InternetPanelView {
   let focusRequestToken = 0;
   const state = signal<InternetPanelBridgeState>({
     actions: null,
-    model: DEFAULT_INTERNET_PANEL_MODEL,
+    model: null,
   });
   render(<InternetPanel focusRequest={focusRequest} state={state} />, host);
 
@@ -451,12 +451,12 @@ export function mountInternetPanel(host: HTMLElement): InternetPanelView {
     bindActions(handlers) {
       state.value = { ...state.value, actions: handlers };
     },
+    bindModel(model) {
+      state.value = { ...state.value, model };
+    },
     focusSsidInput() {
       focusRequestToken += 1;
       focusRequest.value = { field: "ssid", token: focusRequestToken };
-    },
-    setModel(model) {
-      state.value = { ...state.value, model };
     },
   };
 }

--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -3,7 +3,12 @@ import { h, render } from "preact";
 import type { DisplayedSpeedSourceMode } from "../speed_source_state";
 import type { ChoiceCardState } from "../view_style_types";
 import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import {
+  effect,
+  signal,
+  untracked,
+  type ReadonlySignal,
+} from "../ui_signals";
 import {
   settingsFeedbackClassName,
   type SettingsFeedbackMessage,
@@ -102,12 +107,12 @@ export interface SpeedSourcePanelActionHandlers {
 
 export interface SpeedSourcePanelView {
   bindActions(handlers: SpeedSourcePanelActionHandlers): void;
+  bindDiagnostics(model: ReadonlySignal<SpeedSourceDiagnosticsRenderModel>): void;
+  bindModel(model: ReadonlySignal<SpeedSourcePanelRenderModel>): void;
   focusManualSpeedInput(): void;
   focusScanObdDevices(): void;
   focusStaleTimeoutInput(): void;
   isObdConfigVisible(): boolean;
-  setModel(model: SpeedSourcePanelRenderModel): void;
-  setDiagnostics(model: SpeedSourceDiagnosticsRenderModel): void;
 }
 
 type SpeedSourcePanelBridgeState = {
@@ -340,7 +345,7 @@ const DEFAULT_SPEED_SOURCE_PANEL_MODEL: SpeedSourcePanelRenderModel = {
   },
 };
 
-const DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL: SpeedSourceDiagnosticsRenderModel = {
+export const DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL: SpeedSourceDiagnosticsRenderModel = {
   gps: {
     deviceText: "--",
     effectiveSpeedText: "--",
@@ -837,6 +842,26 @@ export function mountSpeedSourcePanel(host: HTMLElement): SpeedSourcePanelView {
     bindActions(handlers): void {
       bridgeState.value = { ...bridgeState.value, actions: handlers };
     },
+    bindDiagnostics(model): void {
+      effect(() => {
+        const currentBridgeState = untracked(() => bridgeState.value);
+        bridgeState.value = {
+          ...currentBridgeState,
+          diagnostics: model.value,
+        };
+      });
+    },
+    bindModel(model): void {
+      effect(() => {
+        const currentBridgeState = untracked(() => bridgeState.value);
+        bridgeState.value = {
+          ...currentBridgeState,
+          diagnosticsDisclosureOpen:
+            currentBridgeState.diagnosticsDisclosureOpen || model.value.diagnosticsShouldOpen,
+          model: model.value,
+        };
+      });
+    },
     focusManualSpeedInput(): void {
       manualSpeedInput?.focus();
     },
@@ -856,17 +881,6 @@ export function mountSpeedSourcePanel(host: HTMLElement): SpeedSourcePanelView {
       }
       const activeView = activePanel.closest<HTMLElement>(".view");
       return activeView == null || !activeView.hidden;
-    },
-    setModel(model): void {
-      bridgeState.value = {
-        ...bridgeState.value,
-        diagnosticsDisclosureOpen:
-          bridgeState.value.diagnosticsDisclosureOpen || model.diagnosticsShouldOpen,
-        model,
-      };
-    },
-    setDiagnostics(model): void {
-      bridgeState.value = { ...bridgeState.value, diagnostics: model };
     },
   };
 }

--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -6,7 +6,6 @@ import type {
 } from "../../transport/http_models";
 import type {
   InternetPanelRenderModel,
-  InternetPanelView,
   UpdateTransportChoiceCardRenderModel,
 } from "./internet_panel";
 import {
@@ -16,12 +15,18 @@ import {
 import type { MaintenanceReadinessPanelModel } from "./maintenance_readiness_view";
 import type {
   UpdatePanelRenderModel,
-  UpdatePanelView,
 } from "./update_panel";
 import {
   buildUpdateStatusPanelViewModel,
   getUpdateFailureSummary,
 } from "./update_status_view_models";
+import {
+  computed,
+  effect,
+  signal,
+  untracked,
+  type ReadonlySignal,
+} from "../ui_signals";
 
 export interface UpdateFeatureRenderState {
   internetStatus: UsbInternetStatusPayload;
@@ -61,19 +66,18 @@ export interface UpdateFeaturePanelModels {
 }
 
 export interface UpdateFeaturePresenterDeps {
-  internetPanel: InternetPanelView;
-  panel: UpdatePanelView;
+  renderState: ReadonlySignal<UpdateFeatureRenderState>;
   t: (key: string, vars?: Record<string, unknown>) => string;
 }
 
 export interface UpdateFeaturePresenter {
+  readonly internetPanelModel: ReadonlySignal<InternetPanelRenderModel>;
+  readonly updatePanelModel: ReadonlySignal<UpdatePanelRenderModel>;
   setPasswordInput(value: string): void;
   setSelectedTransport(transport: UpdateStartRequestPayload["transport"]): void;
   setSsidInput(value: string): void;
-  render(state: UpdateFeatureRenderState): void;
-  readStartIntent(state: UpdateFeatureRenderState): UpdateFeatureStartIntent;
+  readStartIntent(): UpdateFeatureStartIntent;
   togglePassword(): void;
-  focusSsidInput(): void;
   clearPassword(): void;
 }
 
@@ -342,94 +346,80 @@ export function buildUpdateFeaturePanelModels(
 export function createUpdateFeaturePresenter(
   ctx: UpdateFeaturePresenterDeps,
 ): UpdateFeaturePresenter {
-  const { internetPanel, panel, t } = ctx;
-
-  let formState: UpdateFeatureFormSnapshot = {
+  const { renderState, t } = ctx;
+  const formState = signal<UpdateFeatureFormSnapshot>({
     passwordInputValue: "",
     passwordVisible: false,
     selectedTransport: "wifi",
     ssidInputValue: "",
-  };
-  let lastPanelModels: UpdateFeaturePanelModels | null = null;
-  let lastRenderedState: UpdateFeatureRenderState | null = null;
+  });
   let hasHydratedPersistedWifiSettings = false;
 
-  function syncHydratedWifiSettings(state: UpdateFeatureRenderState): void {
-    if (hasHydratedPersistedWifiSettings || state.updateStatus == null) {
-      return;
-    }
-    hasHydratedPersistedWifiSettings = true;
-    if (
-      state.updateStatus.transport === "wifi" &&
-      state.updateStatus.ssid &&
-      formState.ssidInputValue.trim().length === 0
-    ) {
-      formState = { ...formState, ssidInputValue: state.updateStatus.ssid };
-    }
-  }
+  effect(() => {
+    const state = renderState.value;
+    const currentForm = untracked(() => formState.value);
+    let nextForm = currentForm;
 
-  function readFormSnapshot(
-    state: UpdateFeatureRenderState,
-  ): UpdateFeatureFormSnapshot {
-    syncHydratedWifiSettings(state);
-    if (state.updateState === "running" && formState.selectedTransport !== state.updateTransport) {
-      formState = { ...formState, selectedTransport: state.updateTransport };
+    if (!hasHydratedPersistedWifiSettings && state.updateStatus != null) {
+      hasHydratedPersistedWifiSettings = true;
+      if (
+        state.updateStatus.transport === "wifi"
+        && state.updateStatus.ssid
+        && currentForm.ssidInputValue.trim().length === 0
+      ) {
+        nextForm = { ...nextForm, ssidInputValue: state.updateStatus.ssid };
+      }
     }
-    return formState;
-  }
 
-  function render(state: UpdateFeatureRenderState): void {
-    lastRenderedState = state;
-    const panelModels = buildUpdateFeaturePanelModels(state, readFormSnapshot(state), {
-      t,
-    });
-    lastPanelModels = panelModels;
-    internetPanel.setModel(panelModels.internetPanel);
-    panel.setModel(panelModels.updatePanel);
-  }
+    if (state.updateState === "running" && nextForm.selectedTransport !== state.updateTransport) {
+      nextForm = { ...nextForm, selectedTransport: state.updateTransport };
+    }
 
-  function readStartIntent(
-    state: UpdateFeatureRenderState,
-  ): UpdateFeatureStartIntent {
-    const form = readFormSnapshot(state);
-    const panelModels = lastPanelModels ?? buildUpdateFeaturePanelModels(state, form, { t });
+    if (nextForm !== currentForm) {
+      formState.value = nextForm;
+    }
+  });
+
+  const panelModels = computed(() =>
+    buildUpdateFeaturePanelModels(renderState.value, formState.value, { t })
+  );
+  const internetPanelModel = computed(() => panelModels.value.internetPanel);
+  const updatePanelModel = computed(() => panelModels.value.updatePanel);
+
+  function readStartIntent(): UpdateFeatureStartIntent {
+    const form = formState.value;
+    const currentRenderState = renderState.value;
+    const currentPanelModels = panelModels.value;
     return {
-      canStart: panelModels.canStart,
+      canStart: currentPanelModels.canStart,
       password: form.passwordInputValue,
       ssid: form.ssidInputValue.trim(),
-      transport: panelModels.transport,
-      usbAvailable: state.internetStatus.usable,
+      transport: currentPanelModels.transport,
+      usbAvailable: currentRenderState.internetStatus.usable,
     };
   }
 
-  function rerenderLastState(): void {
-    if (lastRenderedState) {
-      render(lastRenderedState);
-    }
-  }
-
   return {
+    internetPanelModel,
+    updatePanelModel,
     setPasswordInput(value) {
-      formState = { ...formState, passwordInputValue: value };
+      formState.value = { ...formState.value, passwordInputValue: value };
     },
     setSelectedTransport(transport) {
-      formState = { ...formState, selectedTransport: transport };
+      formState.value = { ...formState.value, selectedTransport: transport };
     },
     setSsidInput(value) {
-      formState = { ...formState, ssidInputValue: value };
+      formState.value = { ...formState.value, ssidInputValue: value };
     },
-    render,
     readStartIntent,
     togglePassword() {
-      formState = { ...formState, passwordVisible: !formState.passwordVisible };
-      rerenderLastState();
-    },
-    focusSsidInput() {
-      internetPanel.focusSsidInput();
+      formState.value = {
+        ...formState.value,
+        passwordVisible: !formState.value.passwordVisible,
+      };
     },
     clearPassword() {
-      formState = { ...formState, passwordInputValue: "" };
-      rerenderLastState();
+      formState.value = { ...formState.value, passwordInputValue: "" };
     },
   };
 }

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -33,12 +33,12 @@ export interface UpdatePanelActionHandlers {
 
 export interface UpdatePanelView {
   bindActions(handlers: UpdatePanelActionHandlers): void;
-  setModel(model: UpdatePanelRenderModel): void;
+  bindModel(model: ReadonlySignal<UpdatePanelRenderModel>): void;
 }
 
 type UpdatePanelBridgeState = {
   actions: UpdatePanelActionHandlers | null;
-  model: UpdatePanelRenderModel;
+  model: ReadonlySignal<UpdatePanelRenderModel> | null;
 };
 
 const DEFAULT_UPDATE_PANEL_MODEL: UpdatePanelRenderModel = {
@@ -325,7 +325,7 @@ function UpdatePanel(props: {
   state: ReadonlySignal<UpdatePanelBridgeState>;
 }) {
   const state = props.state.value;
-  const { model } = state;
+  const model = state.model?.value ?? DEFAULT_UPDATE_PANEL_MODEL;
   const t = useUiTranslation();
   return (
     <div class="panel card">
@@ -398,7 +398,7 @@ function UpdatePanel(props: {
 export function mountUpdatePanel(host: HTMLElement): UpdatePanelView {
   const state = signal<UpdatePanelBridgeState>({
     actions: null,
-    model: DEFAULT_UPDATE_PANEL_MODEL,
+    model: null,
   });
   render(<UpdatePanel state={state} />, host);
 
@@ -406,7 +406,7 @@ export function mountUpdatePanel(host: HTMLElement): UpdatePanelView {
     bindActions(handlers) {
       state.value = { ...state.value, actions: handlers };
     },
-    setModel(model) {
+    bindModel(model) {
       state.value = { ...state.value, model };
     },
   };

--- a/apps/ui/tests/cars_feature_workflow.spec.ts
+++ b/apps/ui/tests/cars_feature_workflow.spec.ts
@@ -3,7 +3,6 @@ import { expect, test } from "@playwright/test";
 import {
   createCarsFeatureWorkflow,
   type CarsFeatureFocusTarget,
-  type CarsFeatureRenderState,
   type CarsFeatureWorkflowViewPorts,
 } from "../src/app/features/cars_feature_workflow";
 import type {
@@ -14,13 +13,11 @@ import type {
 
 type WorkflowHarness = {
   focuses: CarsFeatureFocusTarget[];
-  renderStates: CarsFeatureRenderState[];
 };
 
 function createHarness(): WorkflowHarness {
   return {
     focuses: [],
-    renderStates: [],
   };
 }
 
@@ -28,27 +25,6 @@ function createViewPorts(harness: WorkflowHarness): CarsFeatureWorkflowViewPorts
   return {
     focus(target): void {
       harness.focuses.push(target);
-    },
-    render(state): void {
-      harness.renderStates.push({
-        ...state,
-        brandOptions: {
-          ...state.brandOptions,
-          options: [...state.brandOptions.options],
-        },
-        gearboxOptions: [...state.gearboxOptions],
-        manualInputs: { ...state.manualInputs },
-        modelOptions: {
-          ...state.modelOptions,
-          options: [...state.modelOptions.options],
-        },
-        tireOptions: [...state.tireOptions],
-        typeOptions: {
-          ...state.typeOptions,
-          options: [...state.typeOptions.options],
-        },
-        variantOptions: [...state.variantOptions],
-      });
     },
   };
 }
@@ -122,7 +98,7 @@ test.describe("createCarsFeatureWorkflow", () => {
     await workflow.openWizard();
 
     expect(harness.focuses).toEqual(["close", "custom-brand"]);
-    expect(harness.renderStates.at(-1)?.brandOptions).toEqual({
+    expect(workflow.getRenderState().brandOptions).toEqual({
       message: "settings.wizard.load_failed_brands",
       options: [],
       status: "error",
@@ -183,7 +159,7 @@ test.describe("createCarsFeatureWorkflow", () => {
       variant: undefined,
     }]);
     expect(harness.focuses).toContain("manual-tire-width");
-    expect(harness.renderStates.at(-1)?.isOpen).toBe(false);
+    expect(workflow.getRenderState().isOpen).toBe(false);
   });
 
   test("keeps the library branch disabled until a gearbox is chosen and then submits the selected specs", async () => {
@@ -224,7 +200,7 @@ test.describe("createCarsFeatureWorkflow", () => {
     await workflow.selectType("SUV");
     await workflow.selectModel(0);
 
-    expect(harness.renderStates.at(-1)).toMatchObject({
+    expect(workflow.getRenderState()).toMatchObject({
       canFinish: false,
       resolvedSpecBranch: null,
       selectedTire: tire,
@@ -248,6 +224,6 @@ test.describe("createCarsFeatureWorkflow", () => {
       variant: undefined,
     }]);
     expect(harness.focuses).toContain("finish");
-    expect(harness.renderStates.at(-1)?.isOpen).toBe(false);
+    expect(workflow.getRenderState().isOpen).toBe(false);
   });
 });

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -24,9 +24,15 @@ import {
 } from "./async_test_helpers";
 import type { TimerHarness } from "./async_test_helpers";
 import { createPanel, installFakeDomGlobals } from "./dom_render_test_support";
-import { signal } from "../src/app/ui_signals";
+import { effect, signal, type ReadonlySignal } from "../src/app/ui_signals";
 
 type ClickListener = (() => void) | null;
+
+function bindReactiveModel<T>(model: ReadonlySignal<T>, renderModel: (value: T) => void): void {
+  effect(() => {
+    renderModel(model.value);
+  });
+}
 
 function pendingPollDelays(timers: TimerHarness): number[] {
   return timers.pendingDelays().filter((delay) => delay !== 10_000);
@@ -609,8 +615,10 @@ function createDeps() {
           handlers.onSelectPort(dom.espFlashPortSelect?.value || "__auto__");
         });
       },
-      setModel(model: EspFlashPanelRenderModel) {
-        renderEspFlashPanelDom(dom, model);
+      bindModel(model) {
+        bindReactiveModel(model, (nextModel) => {
+          renderEspFlashPanelDom(dom, nextModel);
+        });
       },
     },
     ports: navigation.ports,
@@ -786,8 +794,10 @@ function createUpdateDeps() {
             handlers.onCancel();
           });
         },
-        setModel(model: UpdatePanelRenderModel) {
-          renderUpdatePanelDom(dom, model);
+        bindModel(model) {
+          bindReactiveModel(model, (nextModel) => {
+            renderUpdatePanelDom(dom, nextModel);
+          });
         },
       },
       internet: {
@@ -811,8 +821,10 @@ function createUpdateDeps() {
         focusSsidInput() {
           internetDom.updateSsidInput?.focus();
         },
-        setModel(model: InternetPanelRenderModel) {
-          renderInternetPanelDom(internetDom, model);
+        bindModel(model) {
+          bindReactiveModel(model, (nextModel) => {
+            renderInternetPanelDom(internetDom, nextModel);
+          });
         },
       },
     },

--- a/apps/ui/tests/esp_flash_feature_bindings.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_bindings.spec.ts
@@ -11,7 +11,7 @@ test("bindHandlers uses panel action surfaces instead of raw DOM bindings", () =
       bindActions(nextHandlers) {
         handlers = nextHandlers;
       },
-      setModel() {},
+      bindModel() {},
     },
     ports: {
       getActiveSettingsTabId: () => "espFlashTab",

--- a/apps/ui/tests/esp_flash_feature_presenter.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_presenter.spec.ts
@@ -5,7 +5,7 @@ import {
   createEspFlashFeaturePresenter,
   type EspFlashFeatureRenderState,
 } from "../src/app/views/esp_flash_feature_presenter";
-import type { EspFlashPanelRenderModel } from "../src/app/views/esp_flash_panel";
+import { signal } from "../src/app/ui_signals";
 import type {
   EspFlashHistoryAttemptPayload,
   EspFlashStatusPayload,
@@ -227,28 +227,20 @@ test.describe("buildEspFlashPanelRenderModel", () => {
 
 test.describe("createEspFlashFeaturePresenter", () => {
   test("renders log output without a DOM-backed panel view", () => {
-    let latestModel: EspFlashPanelRenderModel | null = null;
+    const renderState = signal(makeState({
+      availablePorts: [makePort()],
+      logText: "build ok\nflash ok\n",
+      status: makeStatus({
+        log_count: 2,
+        phase: "flashing",
+        state: "running",
+      }),
+    }));
     const presenter = createEspFlashFeaturePresenter({
-      panel: {
-        bindActions() {},
-        setModel(model) {
-          latestModel = model;
-        },
-      },
+      renderState,
       t: (key) => key,
     });
-
-    presenter.render(
-      makeState({
-        availablePorts: [makePort()],
-        logText: "build ok\nflash ok\n",
-        status: makeStatus({
-          log_count: 2,
-          phase: "flashing",
-          state: "running",
-        }),
-      }),
-    );
+    const latestModel = presenter.model.value;
 
     expect(latestModel?.log.emptyState).toBeNull();
     expect(latestModel?.log.text).toContain("flash ok");

--- a/apps/ui/tests/esp_flash_feature_workflow.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_workflow.spec.ts
@@ -1,41 +1,21 @@
 import { expect, test } from "@playwright/test";
 
-import {
-  createEspFlashFeatureWorkflow,
-  type EspFlashFeatureWorkflowViewPorts,
-} from "../src/app/features/esp_flash_feature_workflow";
+import { createEspFlashFeatureWorkflow } from "../src/app/features/esp_flash_feature_workflow";
 import type {
   EspFlashHistoryAttemptPayload,
   EspFlashStatusPayload,
   EspSerialPortPayload,
 } from "../src/transport/http_models";
-import type { EspFlashFeatureRenderState } from "../src/app/views/esp_flash_feature_presenter";
 
 type WorkflowHarness = {
   errors: string[];
   pollerCalls: string[];
-  renderStates: EspFlashFeatureRenderState[];
 };
 
 function createHarness(): WorkflowHarness {
   return {
     errors: [],
     pollerCalls: [],
-    renderStates: [],
-  };
-}
-
-function createViewPorts(
-  harness: WorkflowHarness,
-): EspFlashFeatureWorkflowViewPorts {
-  return {
-    render(state): void {
-      harness.renderStates.push({
-        ...state,
-        attempts: [...state.attempts],
-        availablePorts: [...state.availablePorts],
-      });
-    },
   };
 }
 
@@ -101,7 +81,6 @@ test.describe("createEspFlashFeatureWorkflow", () => {
       showError: (message) => {
         harness.errors.push(message);
       },
-      view: createViewPorts(harness),
       api: {
         async getEspFlashStatus() {
           return status;
@@ -123,13 +102,13 @@ test.describe("createEspFlashFeatureWorkflow", () => {
 
     await workflow.refreshStatus();
 
-    expect(harness.renderStates).toHaveLength(1);
-    expect(harness.renderStates[0]).toMatchObject({
+    const renderState = workflow.getRenderState();
+    expect(renderState).toMatchObject({
       status,
       lastJourneyPhase: "flashing",
     });
-    expect(harness.renderStates[0].logText).toContain("erase ok");
-    expect(harness.renderStates[0].attempts).toHaveLength(1);
+    expect(renderState.logText).toContain("erase ok");
+    expect(renderState.attempts).toHaveLength(1);
   });
 
   test("keeps the last running journey phase when a later status only reports failure", async () => {
@@ -144,7 +123,6 @@ test.describe("createEspFlashFeatureWorkflow", () => {
       showError: (message) => {
         harness.errors.push(message);
       },
-      view: createViewPorts(harness),
       api: {
         async getEspFlashStatus() {
           return status;
@@ -173,7 +151,7 @@ test.describe("createEspFlashFeatureWorkflow", () => {
     });
     await workflow.refreshStatus();
 
-    expect(harness.renderStates.at(-1)?.lastJourneyPhase).toBe("flashing");
+    expect(workflow.getRenderState().lastJourneyPhase).toBe("flashing");
     expect(harness.errors).toEqual([]);
   });
 
@@ -185,7 +163,6 @@ test.describe("createEspFlashFeatureWorkflow", () => {
       showError: (message) => {
         harness.errors.push(message);
       },
-      view: createViewPorts(harness),
       api: {
         async getEspFlashPorts() {
           return {
@@ -235,7 +212,7 @@ test.describe("createEspFlashFeatureWorkflow", () => {
       port: "/dev/ttyUSB0",
       autoDetect: false,
     });
-    expect(harness.renderStates.at(-1)?.logText).toBe("");
+    expect(workflow.getRenderState().logText).toBe("");
     expect(harness.pollerCalls).toEqual(["restart"]);
     expect(harness.errors).toEqual([]);
   });

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { createHistoryFeature } from "../src/app/features/history_feature";
 import { downloadBlobFile } from "../src/app/features/history_download";
 import { createAppState, type RunDetail } from "../src/app/ui_app_state";
+import { effect } from "../src/app/ui_signals";
 import type {
   HistoryPanelActionHandlers,
   HistoryPanelRenderModel,
@@ -46,11 +47,14 @@ function createHistoryElements(): {
   let latestHandlers: HistoryPanelActionHandlers | null = null;
   let renderCount = 0;
   const panel: HistoryPanelView = {
-    setModel(model) {
-      renderCount += 1;
-      latestModel = model;
-      historySummary.textContent = model.historySummaryText;
-      deleteAllRunsBtn.disabled = model.deleteAllRunsDisabled;
+    bindModel(model) {
+      effect(() => {
+        const nextModel = model.value;
+        renderCount += 1;
+        latestModel = nextModel;
+        historySummary.textContent = nextModel.historySummaryText;
+        deleteAllRunsBtn.disabled = nextModel.deleteAllRunsDisabled;
+      });
     },
     bindActions(handlers) {
       latestHandlers = handlers;
@@ -447,7 +451,7 @@ test("history feature preloads collapsed row context for completed runs", async 
   expect(row.summaryChips.map((chip) => chip.text)).toContain("history.row_status.complete");
   expect(row.summaryHeadline).toBe("Front-right wheel imbalance");
   expect(row.summaryMeta?.includes("report.confidence")).toBe(true);
-  expect(requests).toEqual([
+  expect(requests.filter((url) => url.startsWith("/api/history"))).toEqual([
     "/api/history",
     "/api/history/run-001/insights?lang=en",
   ]);

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { createSettingsAnalysisModule } from "../src/app/features/settings_analysis_module";
 import { createAppState } from "../src/app/ui_app_state";
+import { effect } from "../src/app/ui_signals";
 import type {
   AnalysisPanelActionHandlers,
   AnalysisPanelFieldKey,
@@ -55,11 +56,13 @@ test("settings analysis module renders guidance and surfaces invalid input throu
     openGuidance() {
       guidanceOpened = true;
     },
-    setModel(model) {
-      renders.push(model);
-    },
-    setCarAvailability() {
+    bindCarAvailability() {
       return;
+    },
+    bindModel(model) {
+      effect(() => {
+        renders.push(model.value);
+      });
     },
   };
 

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { createSettingsCarsModule } from "../src/app/features/settings_cars_module";
-import { signal } from "../src/app/ui_signals";
+import { effect, signal } from "../src/app/ui_signals";
 import type { CarsListRenderModel, CarsListPanelView } from "../src/app/views/cars_panel";
 import { createAppState } from "../src/app/ui_app_state";
 import type { CarsPayload } from "../src/transport/http_models";
@@ -22,8 +22,10 @@ test("settings cars module dismisses transient creation feedback through typed t
 
   const panel: CarsListPanelView = {
     bindActions() {},
-    setModel(model) {
-      renders.push(model);
+    bindModel(model) {
+      effect(() => {
+        renders.push(model.value);
+      });
     },
   };
 
@@ -31,7 +33,7 @@ test("settings cars module dismisses transient creation feedback through typed t
     settings: state,
     panels: {
       analysisPanel: {
-        setCarAvailability() {
+        bindCarAvailability() {
           return;
         },
       },

--- a/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
+++ b/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
@@ -22,8 +22,8 @@ test("bindHandlers uses typed panel actions and navigation subscriptions", () =>
       isObdConfigVisible() {
         return false;
       },
-      setModel() {},
-      setDiagnostics() {},
+      bindModel() {},
+      bindDiagnostics() {},
     },
     services: {
       t: (key) => key,

--- a/apps/ui/tests/settings_speed_source_workflow.spec.ts
+++ b/apps/ui/tests/settings_speed_source_workflow.spec.ts
@@ -10,13 +10,11 @@ import type {
   SpeedSourceRequest,
 } from "../src/transport/http_models";
 import { createAppState } from "../src/app/ui_app_state";
-import type { SettingsSpeedSourceRenderState } from "../src/app/views/settings_speed_source_presenter";
 
 type WorkflowHarness = {
   contextVisible: boolean;
   errors: string[];
   focuses: string[];
-  renderStates: SettingsSpeedSourceRenderState[];
 };
 
 function createHarness(): WorkflowHarness {
@@ -24,7 +22,6 @@ function createHarness(): WorkflowHarness {
     contextVisible: false,
     errors: [],
     focuses: [],
-    renderStates: [],
   };
 }
 
@@ -43,16 +40,6 @@ function createViewPorts(
     },
     isObdConfigVisible(): boolean {
       return harness.contextVisible;
-    },
-    render(state): void {
-      harness.renderStates.push({
-        ...state,
-        manualSpeedFeedback: state.manualSpeedFeedback ? { ...state.manualSpeedFeedback } : null,
-        saveFeedback: state.saveFeedback ? { ...state.saveFeedback } : null,
-        scannedDevices: [...state.scannedDevices],
-        settings: { ...state.settings },
-        staleTimeoutFeedback: state.staleTimeoutFeedback ? { ...state.staleTimeoutFeedback } : null,
-      });
     },
   };
 }
@@ -136,7 +123,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
       speed_source: "gps",
       stale_timeout_s: 5,
     });
-    expect(harness.renderStates.at(-1)?.selectedMode).toBe("gps");
+    expect(workflow.getRenderState().selectedMode).toBe("gps");
     expect(appState.settings.speedSource).toBe("gps");
     expect(appState.settings.manualSpeedKph).toBe(90);
     expect(harness.focuses).toEqual([]);
@@ -161,7 +148,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     await workflow.saveSpeedSource();
 
     expect(harness.focuses).toEqual(["scan"]);
-    expect(harness.renderStates.at(-1)).toMatchObject({
+    expect(workflow.getRenderState()).toMatchObject({
       obdSelectionError: true,
       selectedMode: "obd2",
       saveFeedback: {
@@ -221,7 +208,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     await workflow.scanObdDevices();
     await workflow.pairObdDevice(scannedDevice.mac_address);
 
-    expect(harness.renderStates.at(-1)?.scannedDevices).toEqual([{
+    expect(workflow.getRenderState().scannedDevices).toEqual([{
       ...scannedDevice,
       connected: true,
       paired: true,
@@ -282,6 +269,32 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     workflow.handleNavigateContext();
 
     expect(pollingStarts).toBeGreaterThan(1);
+    expect(harness.errors).toEqual([]);
+  });
+
+  test("reflects polled effective speed updates in render state", () => {
+    const harness = createHarness();
+    const appState = createAppState();
+    const workflow = createSettingsSpeedSourceWorkflow({
+      createPollingController: () => ({
+        restart() {},
+        start() {},
+        stop() {},
+      }),
+      renderSpeedReadout: () => undefined,
+      settings: appState.settings,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      t: createTranslator(),
+      view: createViewPorts(harness),
+    });
+
+    appState.settings.speedSource = "obd2";
+    appState.settings.resolvedSpeedSource = "obd2";
+    appState.settings.gpsEffectiveSpeedKph = 81;
+
+    expect(workflow.getRenderState().settings.gpsEffectiveSpeedKph).toBe(81);
     expect(harness.errors).toEqual([]);
   });
 });

--- a/apps/ui/tests/update_feature_bindings.spec.ts
+++ b/apps/ui/tests/update_feature_bindings.spec.ts
@@ -2,13 +2,9 @@ import { expect, test } from "@playwright/test";
 
 import { createUpdateFeature } from "../src/app/features/update_feature";
 import { signal } from "../src/app/ui_signals";
-import type {
-  InternetPanelActionHandlers,
-  InternetPanelRenderModel,
-} from "../src/app/views/internet_panel";
+import type { InternetPanelActionHandlers } from "../src/app/views/internet_panel";
 import type {
   UpdatePanelActionHandlers,
-  UpdatePanelRenderModel,
 } from "../src/app/views/update_panel";
 
 test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners", () => {
@@ -30,14 +26,14 @@ test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners
         bindActions(handlers: UpdatePanelActionHandlers) {
           updateHandlers = handlers;
         },
-        setModel(_model: UpdatePanelRenderModel) {},
+        bindModel() {},
       },
       internet: {
         bindActions(handlers: InternetPanelActionHandlers) {
           internetHandlers = handlers;
         },
         focusSsidInput() {},
-        setModel(_model: InternetPanelRenderModel) {},
+        bindModel() {},
       },
     },
   });

--- a/apps/ui/tests/update_feature_presenter.spec.ts
+++ b/apps/ui/tests/update_feature_presenter.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import type { InternetPanelRenderModel } from "../src/app/views/internet_panel";
 import type { UpdatePanelRenderModel } from "../src/app/views/update_panel";
+import { signal } from "../src/app/ui_signals";
 import {
   buildUpdateFeaturePanelModels,
   createUpdateFeaturePresenter,
@@ -245,28 +246,7 @@ test.describe("buildUpdateFeaturePanelModels", () => {
 
 test.describe("createUpdateFeaturePresenter", () => {
   test("reads and clears presenter-owned form state instead of DOM values", () => {
-    let latestInternetPanel: InternetPanelRenderModel | null = null;
-    let latestUpdatePanel: UpdatePanelRenderModel | null = null;
-    let focusCalls = 0;
-    const presenter = createUpdateFeaturePresenter({
-      internetPanel: {
-        bindActions() {},
-        focusSsidInput() {
-          focusCalls += 1;
-        },
-        setModel(model) {
-          latestInternetPanel = model;
-        },
-      },
-      panel: {
-        bindActions() {},
-        setModel(model) {
-          latestUpdatePanel = model;
-        },
-      },
-      t,
-    });
-    const state = {
+    const renderState = signal({
       internetStatus: makeInternet({
         detected: true,
         usable: true,
@@ -276,31 +256,33 @@ test.describe("createUpdateFeaturePresenter", () => {
       updateStatus: makeStatus(),
       updateState: "idle" as const,
       updateTransport: "wifi" as const,
-    };
+    });
+    const presenter = createUpdateFeaturePresenter({
+      renderState,
+      t,
+    });
 
     presenter.setSelectedTransport("wifi");
     presenter.setSsidInput("presenter-ssid");
     presenter.setPasswordInput("presenter-password");
-    presenter.render(state);
+    const latestInternetPanel: InternetPanelRenderModel = presenter.internetPanelModel.value;
+    const latestUpdatePanel: UpdatePanelRenderModel = presenter.updatePanelModel.value;
 
     expect(latestInternetPanel?.ssidInputValue).toBe("presenter-ssid");
     expect(latestInternetPanel?.passwordInputValue).toBe("presenter-password");
     expect(latestUpdatePanel?.startButtonDisabled).toBe(false);
-    expect(presenter.readStartIntent(state)).toMatchObject({
+    expect(presenter.readStartIntent()).toMatchObject({
       password: "presenter-password",
       ssid: "presenter-ssid",
       transport: "wifi",
     });
 
     presenter.clearPassword();
-    expect(latestInternetPanel?.passwordInputValue).toBe("");
-    expect(presenter.readStartIntent(state)).toMatchObject({
+    expect(presenter.internetPanelModel.value.passwordInputValue).toBe("");
+    expect(presenter.readStartIntent()).toMatchObject({
       password: "",
       ssid: "presenter-ssid",
       transport: "wifi",
     });
-
-    presenter.focusSsidInput();
-    expect(focusCalls).toBe(1);
   });
 });

--- a/apps/ui/tests/update_feature_workflow.spec.ts
+++ b/apps/ui/tests/update_feature_workflow.spec.ts
@@ -9,12 +9,10 @@ import type {
   UpdateStatusPayload,
   UsbInternetStatusPayload,
 } from "../src/transport/http_models";
-import type { UpdateFeatureRenderState } from "../src/app/views/update_feature_presenter";
 
 type WorkflowHarness = {
   errors: string[];
   pollerCalls: string[];
-  renderStates: UpdateFeatureRenderState[];
   viewCalls: string[];
 };
 
@@ -22,7 +20,6 @@ function createHarness(): WorkflowHarness {
   return {
     errors: [],
     pollerCalls: [],
-    renderStates: [],
     viewCalls: [],
   };
 }
@@ -31,10 +28,6 @@ function createViewPorts(
   harness: WorkflowHarness,
 ): UpdateFeatureWorkflowViewPorts {
   return {
-    render(state): void {
-      harness.renderStates.push(state);
-      harness.viewCalls.push(`render:${state.updateState}`);
-    },
     focusSsidInput(): void {
       harness.viewCalls.push("focusSsidInput");
     },
@@ -158,14 +151,14 @@ test.describe("createUpdateFeatureWorkflow", () => {
 
     await workflow.refreshStatus();
 
-    expect(harness.renderStates).toHaveLength(1);
-    expect(harness.renderStates[0]).toMatchObject({
+    const renderState = workflow.getRenderState();
+    expect(renderState).toMatchObject({
       updateState: "running",
       updateTransport: "usb_internet",
       updateStatus: status,
       healthStatus: health,
     });
-    expect(harness.renderStates[0].internetStatus).toMatchObject({
+    expect(renderState.internetStatus).toMatchObject({
       usable: true,
       interface_name: "usb0",
     });


### PR DESCRIPTION
## Summary

Closes #2366.

This PR finishes the remaining panel-model migration from workflow/presenter setter pushes to signal-driven computed bindings. The issue description describes a broad bridge-state cleanup across many panels, but the current branch state was already further along than the original issue text: most panels already mounted once and kept local signal state. The real remaining work was to remove the last feature-owned render-model pushes, let the affected panels stay bound to computed signal models, and tighten the reactive seams where the migration had left stale behavior or signal-cycle hazards behind.

## What changed

The biggest functional change is in the settings speed-source and GPS status flow. `settings_speed_source_module.ts` no longer rebuilds a render model and pushes it into the panel with `setModel()`. Instead, it derives a `panelModel` from the workflow render-state signal, binds that signal once, and lets the panel react to changes without another imperative render step. `settings_gps_status_module.ts` follows the same pattern for diagnostics: the module now keeps a diagnostics signal model, binds it once through `bindDiagnostics()`, and then updates the shared settings slice plus the diagnostics signal as polling results arrive. This removes the last active feature-owned setter path from that surface while preserving the existing polling and save behavior.

The migration also removes the last leftover compatibility seam in `internet_panel.tsx`. That panel still exposed a temporary `setModel()` method even after the rest of the update/internet flow had moved to signal-backed bindings. With this change, the update/internet surface no longer advertises the old setter contract and only exposes the narrowed semantic view APIs that the feature layer still needs.

The broader computed-binding cleanup touched the remaining workflow/state-driven callers and their test contracts. `cars_feature.ts`, `cars_feature_workflow.ts`, `esp_flash_feature.ts`, `esp_flash_feature_workflow.ts`, `history_feature.ts`, `settings_analysis_module.ts`, `settings_cars_module.ts`, `update_feature.ts`, and `update_feature_workflow.ts` were updated so the affected panels consume bound model signals rather than repeated render pushes or stale presenter-style test doubles. On the view side, `analysis_panel.tsx`, `cars_panel.tsx`, `esp_flash_panel.tsx`, `history_panel.tsx`, `speed_source_panel.tsx`, `update_panel.tsx`, and the related presenter/view helpers now line up with the signal-binding contract instead of expecting the older setter/render sequence.

This PR also fixes two real reactive regressions that only showed up once the broader smoke coverage ran against the migrated code. First, `analysis_panel.tsx` and `speed_source_panel.tsx` both had binder effects that read `bridgeState.value` and then wrote back to the same signal in the same tracked effect. That made the effect depend on the signal it was mutating, which surfaced as browser-side `Cycle detected` failures. Both panels now snapshot the current bridge state with `untracked()` before writing the merged value back, which preserves the binder behavior without creating a self-dependent effect.

Second, the speed-source summary had one stale path left even after the setter migration looked complete. The OBD diagnostics poller updated `appState.settings.gpsEffectiveSpeedKph` and `resolvedSpeedSource`, and the diagnostics panel reflected that data correctly, but the speed-source summary kept showing `--`. The root cause was that `settings_speed_source_workflow.ts` built its render state from plain settings-field reads without first tracking the reactive settings slice. The computed state therefore did not re-run when external settings updates landed. The fix is explicit and narrow: the workflow now calls `trackAppStateSlice(deps.settings)` before reading the settings fields that feed the render state. That keeps the workflow aligned with the signal-backed AppState convention already used elsewhere in the UI runtime and makes the summary react correctly to polled OBD effective-speed updates.

## Test and documentation updates

The existing targeted tests around these surfaces were still shaped for the transitional API, so the test suite was updated alongside the production code rather than left to pin obsolete internals. The affected workflow, presenter, and binding specs now stub `bindModel()`, `bindDiagnostics()`, and the current signal-backed render-state APIs instead of expecting `setModel()`, `setDiagnostics()`, or repeated presenter render calls. That includes the cars, update, ESP flash, history, analysis, and speed-source specs touched by this migration.

I also added a focused regression in `settings_speed_source_workflow.spec.ts` that proves external settings-slice updates now propagate into the workflow render state. That test closes the exact gap the smoke suite uncovered and should keep future AppState-tracking regressions from slipping back in.

## Validation

I validated the migration in two passes. First, I ran focused checks around the migrated surfaces and the newly added speed-source regression:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/settings_speed_source_workflow.spec.ts tests/smoke.settings.spec.ts -g "reflects polled effective speed updates in render state|resolved OBD2 state stays coherent across header status, form, and device summary" --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

After that passed, I reran the broader frontend slice that had previously exposed the cycle and stale-summary failures:

- `cd apps/ui && npm run typecheck && npm run lint && npx playwright test tests/update_feature_presenter.spec.ts tests/update_feature_bindings.spec.ts tests/update_feature_workflow.spec.ts tests/esp_flash_feature_presenter.spec.ts tests/esp_flash_feature.spec.ts tests/esp_flash_feature_workflow.spec.ts tests/esp_flash_feature_bindings.spec.ts tests/cars_feature_workflow.spec.ts tests/settings_cars_module.spec.ts tests/settings_analysis_module.spec.ts tests/history_feature_modules.spec.ts tests/settings_speed_source_module_bindings.spec.ts tests/settings_speed_source_workflow.spec.ts --workers=1 && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.settings.spec.ts tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts tests/smoke.history.spec.ts tests/smoke.cars.spec.ts tests/smoke.analysis-sensors.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

`npm run lint` still reports the same pre-existing Biome schema-version information, but the issue-specific code and smoke suites are green.

## Risks, tradeoffs, and follow-ups

The main tradeoff here is that this PR finishes the feature/workflow-to-panel migration without trying to also do the next optimization step from #2367. The affected panels now consume signal-backed computed models through one-time bindings, which removes the old render-push chain and fixes the stale reactivity bugs that remained, but it does not yet rewrite those components to use direct signal children, `useComputed()`, or `useSignal()` per field. That follow-up is still valuable, but it is deliberately separated so this PR stays focused on completing the current contract cleanup safely.

The other important risk area was behavior drift in settings and diagnostics flows, especially OBD polling and speed-source summaries. The targeted regression coverage and broader browser smoke checks were chosen specifically to protect those paths, because the failure mode here was not a compile-time error — it was a stale summary view that only appeared once polling and shared-state updates interacted in the browser.
