### PR TITLE
Adopt signal hooks in hot UI islands

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -234,10 +234,14 @@ instead of controller-side variant class interpolation.
   single component render. Keep component-local transient state in hooks.
 - Use `computed()` for derived state instead of mirroring derived fields onto
   mutable state bags or manual render-model caches.
+- Inside Preact components, prefer `useComputed()`, `useSignal()`, and
+  `useSignalEffect()` over ad-hoc local refs or render-time signal reads when a
+  hook-scoped reactive owner is clearer.
 - Use `effect()` only for narrow imperative integrations such as timers,
   persistence, canvas/uPlot bridges, or other external-library coordination.
-- Preact-rendered copy comes from `useUiTranslation()`. Do not leave
-  `data-i18n` attributes in JSX unless a non-Preact consumer still reads them.
+- Preact-rendered copy should come from `useUiTranslation()` or `useUiText()`.
+  Do not leave `data-i18n` attributes in JSX unless a non-Preact consumer still
+  reads them.
 - Existing mutable app-state objects and manual bridge rerenders are follow-up
   migration residue, not the default pattern for new frontend work.
 
@@ -323,7 +327,8 @@ pages are seeded manually.
 - Drive island state with `signal()` and `computed()` inputs instead of
   rebuilding the old `render(model)` fixture pattern.
   `tests/signal_view_reference_tests.ts` contains the reference panel coverage
-  for computed-driven output assertions.
+  for direct signal JSX bindings, computed-driven output assertions, and
+  effect-backed subscription seams.
 - Run `npm run test:signals` to execute the reference signal-view coverage
   directly in Node with the same helper path used by future isolated island
   tests.

--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -1,7 +1,11 @@
 import { Component, h, render, type ComponentChildren, type JSX } from "preact";
 
 import { requiredById } from "../dom/dom_query";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import {
+  signal,
+  useComputed,
+  type ReadonlySignal,
+} from "../ui_signals";
 import {
   settingsFeedbackClassName,
   type SettingsFeedbackMessage,
@@ -232,7 +236,26 @@ function ShellViewSection(props: ShellViewSectionProps) {
 
 function UiShellChrome(props: UiShellChromeProps) {
   const { bridge } = props;
-  const model = props.model.value;
+  const activeViewId = useComputed(() => props.model.value.activeViewId);
+  const appErrorBanner = useComputed(() => props.model.value.appErrorBanner);
+  const languageFeedback = useComputed(() => props.model.value.languageFeedback);
+  const languageLabelText = useComputed(() => props.model.value.languageLabelText);
+  const navItems = useComputed(() => props.model.value.navItems);
+  const selectedLanguage = useComputed(() => props.model.value.selectedLanguage);
+  const selectedSpeedUnit = useComputed(() => props.model.value.selectedSpeedUnit);
+  const shellLiveStatus = useComputed(() => props.model.value.shellLiveStatus);
+  const speedUnitFeedback = useComputed(() => props.model.value.speedUnitFeedback);
+  const speedUnitLabelText = useComputed(() => props.model.value.speedUnitLabelText);
+  const speedUnitOptionLabels = useComputed(() => props.model.value.speedUnitOptionLabels);
+  const wsLinkState = useComputed(() => props.model.value.wsLinkState);
+  const statusHidden = useComputed(() => activeViewId.value === "dashboardView");
+  const appErrorHidden = useComputed(() => appErrorBanner.value.hidden);
+  const appErrorVariant = useComputed(() => appErrorBanner.value.variant ?? undefined);
+  const appErrorText = useComputed(() => appErrorBanner.value.text);
+  const wsLinkVariant = useComputed(() => wsLinkState.value.variant);
+  const wsLinkText = useComputed(() => wsLinkState.value.text);
+  const shellLiveVariant = useComputed(() => shellLiveStatus.value.variant);
+  const shellLiveText = useComputed(() => shellLiveStatus.value.text);
 
   function activateView(viewId: string): void {
     bridge.current.activateView(viewId);
@@ -244,33 +267,33 @@ function UiShellChrome(props: UiShellChromeProps) {
   ): void {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      activateView(model.navItems[index].viewId);
+      activateView(navItems.value[index].viewId);
       return;
     }
     if (event.key === "ArrowRight") {
       event.preventDefault();
       const nextIndex = normalizeMenuIndex(index + 1);
-      activateView(model.navItems[nextIndex].viewId);
+      activateView(navItems.value[nextIndex].viewId);
       focusMenuButton(event, nextIndex);
       return;
     }
     if (event.key === "ArrowLeft") {
       event.preventDefault();
       const nextIndex = normalizeMenuIndex(index - 1);
-      activateView(model.navItems[nextIndex].viewId);
+      activateView(navItems.value[nextIndex].viewId);
       focusMenuButton(event, nextIndex);
       return;
     }
     if (event.key === "Home") {
       event.preventDefault();
-      activateView(model.navItems[0].viewId);
+      activateView(navItems.value[0].viewId);
       focusMenuButton(event, 0);
       return;
     }
     if (event.key === "End") {
       event.preventDefault();
-      const nextIndex = model.navItems.length - 1;
-      activateView(model.navItems[nextIndex].viewId);
+      const nextIndex = navItems.value.length - 1;
+      activateView(navItems.value[nextIndex].viewId);
       focusMenuButton(event, nextIndex);
     }
   }
@@ -295,8 +318,8 @@ function UiShellChrome(props: UiShellChromeProps) {
               </picture>
             </h1>
             <nav class="menu" aria-label="Primary" role="tablist">
-              {model.navItems.map((item, index) => {
-                const isActive = item.viewId === model.activeViewId;
+              {navItems.value.map((item, index) => {
+                const isActive = item.viewId === activeViewId.value;
                 return (
                   <button
                     key={item.viewId}
@@ -319,38 +342,38 @@ function UiShellChrome(props: UiShellChromeProps) {
           </div>
           <div class="site-header__preferences">
             <label class="header-select" htmlFor="speedUnitSelect">
-              <span class="mini-label">{model.speedUnitLabelText}</span>
+              <span class="mini-label">{speedUnitLabelText}</span>
               <select
                 id="speedUnitSelect"
                 class="unit-picker"
-                aria-label={model.speedUnitLabelText}
-                aria-describedby={model.speedUnitFeedback ? "speedUnitFeedback" : undefined}
-                aria-invalid={model.speedUnitFeedback?.tone === "error" ? "true" : undefined}
-                value={model.selectedSpeedUnit}
+                aria-label={speedUnitLabelText}
+                aria-describedby={speedUnitFeedback.value ? "speedUnitFeedback" : undefined}
+                aria-invalid={speedUnitFeedback.value?.tone === "error" ? "true" : undefined}
+                value={selectedSpeedUnit}
                 onChange={(event) => {
                   void bridge.current.saveSpeedUnit(event.currentTarget.value);
                 }}
               >
                 {SPEED_UNIT_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value}>
-                    {model.speedUnitOptionLabels[option.value] ?? option.fallbackLabel}
+                    {speedUnitOptionLabels.value[option.value] ?? option.fallbackLabel}
                   </option>
                 ))}
               </select>
               <SettingsFeedbackSlot
                 id="speedUnitFeedback"
-                message={model.speedUnitFeedback}
+                message={speedUnitFeedback.value}
               />
             </label>
             <label class="header-select" htmlFor="languageSelect">
-              <span class="mini-label">{model.languageLabelText}</span>
+              <span class="mini-label">{languageLabelText}</span>
               <select
                 id="languageSelect"
                 class="lang-picker"
-                aria-label={model.languageLabelText}
-                aria-describedby={model.languageFeedback ? "languageFeedback" : undefined}
-                aria-invalid={model.languageFeedback?.tone === "error" ? "true" : undefined}
-                value={model.selectedLanguage}
+                aria-label={languageLabelText}
+                aria-describedby={languageFeedback.value ? "languageFeedback" : undefined}
+                aria-invalid={languageFeedback.value?.tone === "error" ? "true" : undefined}
+                value={selectedLanguage}
                 onChange={(event) => {
                   void bridge.current.saveLanguage(event.currentTarget.value);
                 }}
@@ -363,28 +386,28 @@ function UiShellChrome(props: UiShellChromeProps) {
               </select>
               <SettingsFeedbackSlot
                 id="languageFeedback"
-                message={model.languageFeedback}
+                message={languageFeedback.value}
               />
             </label>
           </div>
         </div>
-        <div class="site-header__status" hidden={model.activeViewId === "dashboardView"}>
+        <div class="site-header__status" hidden={statusHidden}>
           <div class="site-header__status-pills">
             <div
               id="linkState"
               class="pill"
-              data-variant={model.wsLinkState.variant}
+              data-variant={wsLinkVariant}
               aria-live="polite"
             >
-              {model.wsLinkState.text}
+              {wsLinkText}
             </div>
             <div
               id="shellLiveStatus"
               class="pill"
-              data-variant={model.shellLiveStatus.variant}
+              data-variant={shellLiveVariant}
               aria-live="polite"
             >
-              {model.shellLiveStatus.text}
+              {shellLiveText}
             </div>
           </div>
         </div>
@@ -393,16 +416,16 @@ function UiShellChrome(props: UiShellChromeProps) {
       <div
         id="appErrorBanner"
         class="connection-banner app-error-banner"
-        hidden={model.appErrorBanner.hidden}
-        data-variant={model.appErrorBanner.variant ?? undefined}
+        hidden={appErrorHidden}
+        data-variant={appErrorVariant}
         aria-live="assertive"
         role="alert"
       >
-        {model.appErrorBanner.text}
+        {appErrorText}
       </div>
 
       <ShellViewSection
-        activeViewId={model.activeViewId}
+        activeViewId={activeViewId.value}
         ariaLabelledBy="tab-dashboard"
         viewId="dashboardView"
       >
@@ -410,7 +433,7 @@ function UiShellChrome(props: UiShellChromeProps) {
       </ShellViewSection>
 
       <ShellViewSection
-        activeViewId={model.activeViewId}
+        activeViewId={activeViewId.value}
         ariaLabelledBy="tab-history"
         viewId="historyView"
       >
@@ -418,7 +441,7 @@ function UiShellChrome(props: UiShellChromeProps) {
       </ShellViewSection>
 
       <ShellViewSection
-        activeViewId={model.activeViewId}
+        activeViewId={activeViewId.value}
         ariaLabelledBy="tab-settings"
         viewId="settingsView"
       >

--- a/apps/ui/src/app/ui_i18n.ts
+++ b/apps/ui/src/app/ui_i18n.ts
@@ -1,5 +1,5 @@
 import { get as translate, normalizeLang } from "../i18n";
-import { signal } from "./ui_signals";
+import { signal, useComputed, type ReadonlySignal } from "./ui_signals";
 
 const currentLanguage = signal("en");
 
@@ -27,4 +27,12 @@ export function useUiTranslation() {
     fallback: string,
     vars?: Record<string, unknown>,
   ): string => translate(language, key, vars) || fallback;
+}
+
+export function useUiText(
+  key: string,
+  fallback: string,
+  vars?: Record<string, unknown>,
+): ReadonlySignal<string> {
+  return useComputed(() => translate(currentLanguage.value, key, vars) || fallback);
 }

--- a/apps/ui/src/app/ui_signals.ts
+++ b/apps/ui/src/app/ui_signals.ts
@@ -4,6 +4,9 @@ import {
   effect,
   signal,
   untracked,
+  useComputed,
+  useSignal,
+  useSignalEffect,
   type ReadonlySignal,
   type Signal,
 } from "@preact/signals";
@@ -16,5 +19,5 @@ import {
  * and keep effect() limited to narrow imperative integrations such as timers,
  * storage, or external library bridges.
  */
-export { batch, computed, effect, signal, untracked };
+export { batch, computed, effect, signal, untracked, useComputed, useSignal, useSignalEffect };
 export type { ReadonlySignal, Signal };

--- a/apps/ui/src/app/views/analysis_panel.tsx
+++ b/apps/ui/src/app/views/analysis_panel.tsx
@@ -1,11 +1,12 @@
 import { render, type JSX } from "preact";
-import { useEffect, useRef } from "preact/hooks";
+import { useRef } from "preact/hooks";
 
 import { useUiTranslation } from "../ui_i18n";
 import {
   effect,
   signal,
   untracked,
+  useSignalEffect,
   type ReadonlySignal,
 } from "../ui_signals";
 import {
@@ -307,8 +308,6 @@ function AnalysisPanel(props: {
   state: ReadonlySignal<AnalysisPanelBridgeState>;
 }) {
   const state = props.state.value;
-  const guidanceOpenRequest = props.guidanceOpenRequest.value;
-  const inputFocusRequest = props.inputFocusRequest.value;
   const t = useUiTranslation();
   const guidanceHelpRef = useRef<HTMLDetailsElement | null>(null);
   const inputRefs = useRef<Record<AnalysisPanelFieldKey, HTMLInputElement | null>>({
@@ -323,21 +322,23 @@ function AnalysisPanel(props: {
     max_band_half_width_pct: null,
   });
 
-  useEffect(() => {
+  useSignalEffect(() => {
+    const inputFocusRequest = props.inputFocusRequest.value;
     if (!inputFocusRequest) {
       return;
     }
     inputRefs.current[inputFocusRequest.field]?.focus();
-  }, [inputFocusRequest]);
+  });
 
-  useEffect(() => {
+  useSignalEffect(() => {
+    const guidanceOpenRequest = props.guidanceOpenRequest.value;
     if (guidanceOpenRequest <= 0) {
       return;
     }
     if (guidanceHelpRef.current) {
       guidanceHelpRef.current.open = true;
     }
-  }, [guidanceOpenRequest]);
+  });
 
   const noCarSelected = !state.availability.hasActiveCar && !state.availability.isLoading;
   return (

--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -6,7 +6,11 @@ import type {
   CarsFeatureManualInputState,
 } from "../features/cars_feature_workflow";
 import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import {
+  signal,
+  useSignal,
+  type ReadonlySignal,
+} from "../ui_signals";
 import {
   createClosedCarsWizardRenderModel,
   type CarsWizardOptionItem,
@@ -452,10 +456,10 @@ function CarsPanel(props: {
     variantOption: null,
   });
   const lastReturnFocusTargetRef = useRef<HTMLElement | null>(null);
-  const lastWizardOpenStateRef = useRef(wizardModel.isOpen);
+  const lastWizardOpenState = useSignal(wizardModel.isOpen);
 
   useEffect(() => {
-    const wasOpen = lastWizardOpenStateRef.current;
+    const wasOpen = lastWizardOpenState.value;
     if (wizardModel.isOpen && !wasOpen) {
       const activeElement = document.activeElement instanceof HTMLElement
         ? document.activeElement
@@ -472,7 +476,7 @@ function CarsPanel(props: {
       focusElement(safeTarget);
       lastReturnFocusTargetRef.current = null;
     }
-    lastWizardOpenStateRef.current = wizardModel.isOpen;
+    lastWizardOpenState.value = wizardModel.isOpen;
   }, [wizardModel.isOpen]);
 
   useEffect(() => {

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -1,8 +1,13 @@
 import { h, render } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 
-import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import { useUiText } from "../ui_i18n";
+import {
+  computed,
+  signal,
+  useComputed,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type { VisualVariant } from "../view_style_types";
 import {
   MaintenanceReadinessPanel,
@@ -115,11 +120,6 @@ export interface EspFlashPanelView {
   bindActions(handlers: EspFlashPanelActionHandlers): void;
   bindModel(model: ReadonlySignal<EspFlashPanelRenderModel>): void;
 }
-
-type EspFlashPanelBridgeState = {
-  actions: EspFlashPanelActionHandlers | null;
-  model: ReadonlySignal<EspFlashPanelRenderModel> | null;
-};
 
 const DEFAULT_ESP_FLASH_PANEL_MODEL: EspFlashPanelRenderModel = {
   cancelButtonDisabled: true,
@@ -305,20 +305,60 @@ function EspFlashHistoryContent(props: {
 }
 
 function EspFlashPanel(props: {
-  state: ReadonlySignal<EspFlashPanelBridgeState>;
+  actions: ReadonlySignal<EspFlashPanelActionHandlers | null>;
+  model: ReadonlySignal<EspFlashPanelRenderModel>;
 }) {
-  const state = props.state.value;
-  const model = state.model?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL;
-  const t = useUiTranslation();
+  const titleText = useUiText("settings.esp_flash.title", "ESP Flash");
+  const hintText = useUiText("settings.esp_flash.hint", "Flash ESP firmware from local source on this Pi.");
+  const portLabel = useUiText("settings.esp_flash.port", "Serial Port");
+  const refreshLabel = useUiText("settings.esp_flash.refresh_ports", "Refresh");
+  const detailsTitle = useUiText("settings.esp_flash.details_title", "What happens next");
+  const detailsCaption = useUiText(
+    "settings.esp_flash.details_caption",
+    "Build, erase, and write the current firmware over USB.",
+  );
+  const preflightNote = useUiText(
+    "settings.esp_flash.preflight_note",
+    "Starting a flash builds the latest firmware on this Pi, erases the selected board, and writes the new image over USB. Keep the board powered until the staged progress reaches Done.",
+  );
+  const cancelLabel = useUiText("settings.esp_flash.cancel", "Cancel");
+  const journeyTitle = useUiText("settings.esp_flash.journey_title", "Expected stages");
+  const logsTitle = useUiText("settings.esp_flash.logs_title", "Live flash output");
+  const logsIntro = useUiText(
+    "settings.esp_flash.logs_intro",
+    "Build, erase, and upload output appears here while the toolchain runs.",
+  );
+  const historyTitle = useUiText("settings.esp_flash.history", "Recent attempts");
+  const historyIntro = useUiText(
+    "settings.esp_flash.history_intro",
+    "Recent flashes stay here so the next operator can see what happened last.",
+  );
+  const statusBanner = useComputed(() => props.model.value.statusBanner);
+  const statusBannerVariant = useComputed(() => statusBanner.value.variant);
+  const statusBannerText = useComputed(() => statusBanner.value.text);
+  const portSelectDisabled = useComputed(() => props.model.value.portSelectDisabled);
+  const selectedPortValue = useComputed(() => props.model.value.selectedPortValue);
+  const portOptions = useComputed(() => props.model.value.portOptions);
+  const refreshPortsDisabled = useComputed(() => props.model.value.refreshPortsDisabled);
+  const startSummary = useComputed(() => props.model.value.startSummary);
+  const readiness = useComputed(() => props.model.value.readiness);
+  const journey = useComputed(() => props.model.value.journey);
+  const log = useComputed(() => props.model.value.log);
+  const history = useComputed(() => props.model.value.history);
+  const startButtonHidden = useComputed(() => props.model.value.startButtonHidden);
+  const startButtonDisabled = useComputed(() => props.model.value.startButtonDisabled);
+  const startButtonLabelText = useComputed(() => props.model.value.startButtonLabelText);
+  const cancelButtonHidden = useComputed(() => props.model.value.cancelButtonHidden);
+  const cancelButtonDisabled = useComputed(() => props.model.value.cancelButtonDisabled);
   const logPanelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const logPanel = logPanelRef.current;
-    if (!logPanel || model.log.emptyState !== null) {
+    if (!logPanel || log.value.emptyState !== null) {
       return;
     }
     logPanel.scrollTop = logPanel.scrollHeight;
-  }, [model.log.emptyState, model.log.text]);
+  }, [log.value.emptyState, log.value.text]);
 
   return (
     <div class="panel card">
@@ -331,24 +371,21 @@ function EspFlashPanel(props: {
                   class="maintenance-card__title"
 
                 >
-                  {t("settings.esp_flash.title", "ESP Flash")}
+                  {titleText}
                 </div>
                 <div
                   class="subtle"
 
                 >
-                  {t(
-                    "settings.esp_flash.hint",
-                    "Flash ESP firmware from local source on this Pi.",
-                  )}
+                  {hintText}
                 </div>
               </div>
               <span
                 id="espFlashStatusBanner"
                 class="pill"
-                data-variant={model.statusBanner.variant}
+                data-variant={statusBannerVariant}
               >
-                {model.statusBanner.text}
+                {statusBannerText}
               </span>
             </div>
             <div class="maintenance-card__body maintenance-card__body--hero">
@@ -357,45 +394,45 @@ function EspFlashPanel(props: {
                   htmlFor="espFlashPortSelect"
 
                 >
-                  {t("settings.esp_flash.port", "Serial Port")}
+                  {portLabel}
                 </label>
                 <select
                   id="espFlashPortSelect"
-                  disabled={model.portSelectDisabled}
-                  value={model.selectedPortValue}
+                  disabled={portSelectDisabled}
+                  value={selectedPortValue}
                   onChange={(event) =>
-                    state.actions?.onSelectPort(event.currentTarget.value)}
+                    props.actions.value?.onSelectPort(event.currentTarget.value)}
                 >
-                  {model.portOptions.map((option) => (
+                  {portOptions.value.map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.labelText}
                     </option>
                   ))}
                 </select>
                 <button
-                  type="button"
-                  id="espFlashRefreshPortsBtn"
-                  class="btn btn--muted"
+                   type="button"
+                   id="espFlashRefreshPortsBtn"
+                   class="btn btn--muted"
 
-                  disabled={model.refreshPortsDisabled}
-                  onClick={() => state.actions?.onRefreshPorts()}
-                >
-                  {t("settings.esp_flash.refresh_ports", "Refresh")}
-                </button>
-              </div>
+                   disabled={refreshPortsDisabled}
+                   onClick={() => props.actions.value?.onRefreshPorts()}
+                 >
+                   {refreshLabel}
+                 </button>
+               </div>
               <div
                 id="espFlashStartSummary"
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
               >
-                <MaintenanceReadinessPanel model={model.startSummary} />
+                <MaintenanceReadinessPanel model={startSummary.value} />
               </div>
               <div
                 id="espFlashReadinessPanel"
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
               >
-                <EspFlashReadinessSection model={model.readiness} />
+                <EspFlashReadinessSection model={readiness.value} />
               </div>
               <details class="settings-help-disclosure settings-help-disclosure--inline">
                 <summary class="settings-help-disclosure__summary">
@@ -404,16 +441,13 @@ function EspFlashPanel(props: {
                       class="settings-help-disclosure__title"
 
                     >
-                      {t("settings.esp_flash.details_title", "What happens next")}
+                      {detailsTitle}
                     </span>
                     <span
                       class="settings-help-disclosure__caption"
 
                     >
-                      {t(
-                        "settings.esp_flash.details_caption",
-                        "Build, erase, and write the current firmware over USB.",
-                      )}
+                      {detailsCaption}
                     </span>
                   </span>
                 </summary>
@@ -422,10 +456,7 @@ function EspFlashPanel(props: {
                     class="maintenance-note"
 
                   >
-                    {t(
-                      "settings.esp_flash.preflight_note",
-                      "Starting a flash builds the latest firmware on this Pi, erases the selected board, and writes the new image over USB. Keep the board powered until the staged progress reaches Done.",
-                    )}
+                    {preflightNote}
                   </div>
                 </div>
               </details>
@@ -434,22 +465,22 @@ function EspFlashPanel(props: {
                   type="button"
                   id="espFlashStartBtn"
                   class="btn btn--success"
-                  hidden={model.startButtonHidden}
-                  disabled={model.startButtonDisabled}
-                  onClick={() => state.actions?.onStart()}
+                  hidden={startButtonHidden}
+                  disabled={startButtonDisabled}
+                  onClick={() => props.actions.value?.onStart()}
                 >
-                  {model.startButtonLabelText}
+                  {startButtonLabelText}
                 </button>
                 <button
                   type="button"
                   id="espFlashCancelBtn"
                   class="btn btn--danger"
 
-                  hidden={model.cancelButtonHidden}
-                  disabled={model.cancelButtonDisabled}
-                  onClick={() => state.actions?.onCancel()}
+                  hidden={cancelButtonHidden}
+                  disabled={cancelButtonDisabled}
+                  onClick={() => props.actions.value?.onCancel()}
                 >
-                  {t("settings.esp_flash.cancel", "Cancel")}
+                  {cancelLabel}
                 </button>
               </div>
             </div>
@@ -463,7 +494,7 @@ function EspFlashPanel(props: {
                     class="maintenance-card__title"
 
                   >
-                    {t("settings.esp_flash.journey_title", "Expected stages")}
+                    {journeyTitle}
                   </div>
                 </div>
               </div>
@@ -472,7 +503,7 @@ function EspFlashPanel(props: {
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
               >
-                <EspFlashJourneySection model={model.journey} />
+                <EspFlashJourneySection model={journey.value} />
               </div>
             </section>
             <section class="maintenance-card">
@@ -482,16 +513,13 @@ function EspFlashPanel(props: {
                     class="maintenance-card__title"
 
                   >
-                    {t("settings.esp_flash.logs_title", "Live flash output")}
+                    {logsTitle}
                   </div>
                   <div
                     class="subtle"
 
                   >
-                    {t(
-                      "settings.esp_flash.logs_intro",
-                      "Build, erase, and upload output appears here while the toolchain runs.",
-                    )}
+                    {logsIntro}
                   </div>
                 </div>
               </div>
@@ -499,13 +527,13 @@ function EspFlashPanel(props: {
                 id="espFlashLogPanel"
                 ref={logPanelRef}
                 class={
-                  model.log.emptyState
+                  log.value.emptyState
                     ? "maintenance-log-slot"
                     : "maintenance-log-slot maintenance-log-panel"
                 }
                 aria-live="polite"
               >
-                <EspFlashLogContent model={model.log} />
+                <EspFlashLogContent model={log.value} />
               </div>
             </section>
           </div>
@@ -513,30 +541,27 @@ function EspFlashPanel(props: {
           <section class="maintenance-card">
             <div class="maintenance-card__header">
               <div>
-                <div
-                  class="maintenance-card__title"
+                  <div
+                    class="maintenance-card__title"
 
-                  >
-                    {t("settings.esp_flash.history", "Recent attempts")}
+                   >
+                    {historyTitle}
                   </div>
                 <div
-                  class="subtle"
+                   class="subtle"
 
-                  >
-                    {t(
-                      "settings.esp_flash.history_intro",
-                      "Recent flashes stay here so the next operator can see what happened last.",
-                    )}
+                   >
+                    {historyIntro}
                   </div>
-              </div>
-            </div>
+               </div>
+             </div>
             <div
               id="espFlashHistoryPanel"
               class="maintenance-stack maintenance-stack--tight"
-            >
-              <EspFlashHistoryContent model={model.history} />
-            </div>
-          </section>
+             >
+               <EspFlashHistoryContent model={history.value} />
+             </div>
+           </section>
         </div>
       </div>
     </div>
@@ -544,18 +569,17 @@ function EspFlashPanel(props: {
 }
 
 export function mountEspFlashPanel(host: HTMLElement): EspFlashPanelView {
-  const state = signal<EspFlashPanelBridgeState>({
-    actions: null,
-    model: null,
-  });
-  render(<EspFlashPanel state={state} />, host);
+  const actions = signal<EspFlashPanelActionHandlers | null>(null);
+  const modelSource = signal<ReadonlySignal<EspFlashPanelRenderModel> | null>(null);
+  const model = computed<EspFlashPanelRenderModel>(() => modelSource.value?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL);
+  render(<EspFlashPanel actions={actions} model={model} />, host);
 
   return {
     bindActions(handlers) {
-      state.value = { ...state.value, actions: handlers };
+      actions.value = handlers;
     },
     bindModel(model) {
-      state.value = { ...state.value, model };
+      modelSource.value = model;
     },
   };
 }

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -1,6 +1,11 @@
 import { render } from "preact";
-import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import { useUiText } from "../ui_i18n";
+import {
+  computed,
+  signal,
+  useComputed,
+  type ReadonlySignal,
+} from "../ui_signals";
 import { HistoryTableBody } from "./history_table_content";
 import type {
   HistoryPanelActionHandlers,
@@ -8,68 +13,65 @@ import type {
   HistoryPanelView,
 } from "./history_table_view";
 
-interface HistoryPanelBridgeState {
-  actions: HistoryPanelActionHandlers | null;
-  model: ReadonlySignal<HistoryPanelRenderModel> | null;
-}
-
-const DEFAULT_PANEL_STATE: HistoryPanelBridgeState = {
-  actions: null,
-  model: null,
+const DEFAULT_PANEL_MODEL: HistoryPanelRenderModel = {
+  deleteAllRunsDisabled: true,
+  historySummaryText: "No runs yet.",
+  table: null,
 };
 
-function HistoryPanel(props: { state: ReadonlySignal<HistoryPanelBridgeState> }) {
-  const state = props.state.value;
-  const model = state.model?.value ?? {
-    deleteAllRunsDisabled: true,
-    historySummaryText: "No runs yet.",
-    table: null,
-  };
-  const t = useUiTranslation();
+function HistoryPanel(props: {
+  actions: ReadonlySignal<HistoryPanelActionHandlers | null>;
+  model: ReadonlySignal<HistoryPanelRenderModel>;
+}) {
+  const refreshLabel = useUiText("history.refresh", "Refresh History");
+  const deleteAllLabel = useUiText("history.delete_all", "Delete All Runs");
+  const runLabel = useUiText("history.table.file", "Run");
+  const startedLabel = useUiText("history.table.updated", "Started");
+  const samplesLabel = useUiText("history.table.size", "Samples");
+  const actionsLabel = useUiText("history.table.actions", "Actions");
+  const deleteAllRunsDisabled = useComputed(() => props.model.value.deleteAllRunsDisabled);
+  const historySummaryText = useComputed(() => props.model.value.historySummaryText);
+  const table = useComputed(() => props.model.value.table);
 
   return (
     <>
       <div class="history-toolbar">
         <div class="history-toolbar__copy">
-            <div id="historySummary" class="history-toolbar__summary subtle">
-            {model.historySummaryText}
-            </div>
+          <div id="historySummary" class="history-toolbar__summary subtle">
+            {historySummaryText}
+          </div>
         </div>
         <div class="history-toolbar__actions">
           <button
             id="refreshHistoryBtn"
             class="btn btn--muted"
             type="button"
-
-            onClick={() => state.actions?.onRefreshHistory()}
+            onClick={() => props.actions.value?.onRefreshHistory()}
           >
-            {t("history.refresh", "Refresh History")}
+            {refreshLabel}
           </button>
           <button
             id="deleteAllRunsBtn"
             class="btn btn--danger-quiet"
             type="button"
-
-            disabled={model.deleteAllRunsDisabled}
-            onClick={() => state.actions?.onDeleteAllRuns()}
+            disabled={deleteAllRunsDisabled}
+            onClick={() => props.actions.value?.onDeleteAllRuns()}
           >
-            {t("history.delete_all", "Delete All Runs")}
+            {deleteAllLabel}
           </button>
         </div>
       </div>
       <table class="history-table">
         <thead>
           <tr>
-            <th>{t("history.table.file", "Run")}</th>
-            <th>{t("history.table.updated", "Started")}</th>
-            <th class="numeric">
-              {t("history.table.size", "Samples")}
-            </th>
-            <th>{t("history.table.actions", "Actions")}</th>
+            <th>{runLabel}</th>
+            <th>{startedLabel}</th>
+            <th class="numeric">{samplesLabel}</th>
+            <th>{actionsLabel}</th>
           </tr>
         </thead>
         <tbody id="historyTableBody">
-          <HistoryTableBody handlers={state.actions} table={model.table} />
+          <HistoryTableBody handlers={props.actions.value} table={table.value} />
         </tbody>
       </table>
     </>
@@ -77,15 +79,17 @@ function HistoryPanel(props: { state: ReadonlySignal<HistoryPanelBridgeState> })
 }
 
 export function mountHistoryPanel(host: HTMLElement): HistoryPanelView {
-  const state = signal<HistoryPanelBridgeState>({ ...DEFAULT_PANEL_STATE });
-  render(<HistoryPanel state={state} />, host);
+  const actions = signal<HistoryPanelActionHandlers | null>(null);
+  const modelSource = signal<ReadonlySignal<HistoryPanelRenderModel> | null>(null);
+  const model = computed<HistoryPanelRenderModel>(() => modelSource.value?.value ?? DEFAULT_PANEL_MODEL);
+  render(<HistoryPanel actions={actions} model={model} />, host);
 
   return {
     bindModel(model: ReadonlySignal<HistoryPanelRenderModel>): void {
-      state.value = { ...state.value, model };
+      modelSource.value = model;
     },
     bindActions(handlers: HistoryPanelActionHandlers): void {
-      state.value = { ...state.value, actions: handlers };
+      actions.value = handlers;
     },
   };
 }

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -1,10 +1,14 @@
 import { h, render, type ComponentChildren } from "preact";
-import { useEffect, useRef } from "preact/hooks";
+import { useRef } from "preact/hooks";
 
 import type { UpdateStartRequestPayload } from "../../transport/http_models";
 import type { ChoiceCardState } from "../view_style_types";
 import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import {
+  signal,
+  useSignalEffect,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type {
   MaintenanceReadinessItem,
   MaintenanceReadinessPanelModel,
@@ -260,18 +264,18 @@ function InternetPanel(props: {
   focusRequest: ReadonlySignal<InternetPanelFocusRequest | null>;
   state: ReadonlySignal<InternetPanelBridgeState>;
 }) {
-  const focusRequest = props.focusRequest.value;
   const state = props.state.value;
   const model = state.model?.value ?? DEFAULT_INTERNET_PANEL_MODEL;
   const t = useUiTranslation();
   const ssidInputRef = useRef<HTMLInputElement | null>(null);
 
-  useEffect(() => {
+  useSignalEffect(() => {
+    const focusRequest = props.focusRequest.value;
     if (!focusRequest) {
       return;
     }
     ssidInputRef.current?.focus();
-  }, [focusRequest]);
+  });
 
   return (
     <div class="maintenance-stack">

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -1,7 +1,12 @@
 import { render } from "preact";
 
-import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import { useUiText } from "../ui_i18n";
+import {
+  computed,
+  signal,
+  useComputed,
+  type ReadonlySignal,
+} from "../ui_signals";
 
 export interface RealtimeLiveOverviewActiveCarModel {
   text: string;
@@ -33,7 +38,6 @@ export interface RealtimeLiveOverviewRenderModel {
 }
 
 interface RealtimeLiveOverviewBridgeState {
-  model: ReadonlySignal<RealtimeLiveOverviewRenderModel> | null;
   speedText: string;
 }
 
@@ -60,115 +64,138 @@ const DEFAULT_OVERVIEW_MODEL: RealtimeLiveOverviewRenderModel = {
 };
 
 const DEFAULT_OVERVIEW_STATE: RealtimeLiveOverviewBridgeState = {
-  model: null,
   speedText: "--",
 };
 
-function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOverviewBridgeState> }) {
-  const state = props.state.value;
-  const model = state.model?.value ?? DEFAULT_OVERVIEW_MODEL;
-  const t = useUiTranslation();
+function RealtimeLiveOverview(props: {
+  model: ReadonlySignal<RealtimeLiveOverviewRenderModel>;
+  speedText: ReadonlySignal<string>;
+}) {
+  const titleText = useUiText("dashboard.live_overview", "Live overview");
+  const hintText = useUiText(
+    "dashboard.live_overview_hint",
+    "Check readiness, current run state, and the strongest sensor level before reading the chart.",
+  );
+  const connectedSensorsLabel = useUiText("dashboard.connected_sensors", "Sensors online");
+  const activeCarLabel = useUiText("dashboard.active_car", "Active car");
+  const recordingStateLabel = useUiText("dashboard.recording_state", "Run state");
+  const dataFreshnessLabel = useUiText("dashboard.data_freshness", "Feed freshness");
+  const strongestSignalLabel = useUiText("dashboard.strongest_signal", "Strongest signal");
+  const currentSpeedLabel = useUiText("dashboard.current_speed", "Current speed");
+  const sensorCoverageLabel = useUiText("dashboard.sensor_coverage", "Sensor coverage");
+  const noSensorsText = useUiText("settings.sensors.no_sensors", "No sensors yet.");
+  const connectedSensorsText = useComputed(() => props.model.value.connectedSensorsText);
+  const activeCar = useComputed(() => props.model.value.activeCar);
+  const activeCarText = useComputed(() => activeCar.value.text);
+  const activeCarWarning = useComputed(() => activeCar.value.warning);
+  const activeCarVariant = useComputed(() => activeCar.value.warning ? "warn" : undefined);
+  const activeCarHasIcon = useComputed(() => activeCar.value.warning ? "true" : undefined);
+  const recordingStateText = useComputed(() => props.model.value.recordingStateText);
+  const dataFreshnessText = useComputed(() => props.model.value.dataFreshnessText);
+  const strongestSignalText = useComputed(() => props.model.value.strongestSignalText);
+  const runHealth = useComputed(() => props.model.value.runHealth);
+  const runHealthHidden = useComputed(() => runHealth.value.hidden);
+  const runHealthText = useComputed(() => runHealth.value.text);
+  const runHealthVariant = useComputed(() => runHealth.value.variant);
+  const sensorCards = useComputed(() => props.model.value.sensorCards);
 
   return (
     <>
       <div class="card__header card__header--stack">
         <div>
           <div class="card__title">
-            {t("dashboard.live_overview", "Live overview")}
+            {titleText}
           </div>
           <div class="card__subtle">
-            {t(
-              "dashboard.live_overview_hint",
-              "Check readiness, current run state, and the strongest sensor level before reading the chart.",
-            )}
+            {hintText}
           </div>
         </div>
         <div
           id="liveRunHealth"
           class="pill"
-          data-variant={model.runHealth.variant}
-          hidden={model.runHealth.hidden}
+          data-variant={runHealthVariant}
+          hidden={runHealthHidden}
           aria-live="polite"
         >
-          {model.runHealth.text}
+          {runHealthText}
         </div>
       </div>
       <div class="stat-grid live-overview__stats">
         <div id="liveConnectedSensors" class="stat">
           <div class="stat__label">
-            {t("dashboard.connected_sensors", "Sensors online")}
+            {connectedSensorsLabel}
           </div>
           <div class="stat__value" data-value>
-            {model.connectedSensorsText}
+            {connectedSensorsText}
           </div>
         </div>
         <div
           id="liveActiveCar"
           class="stat"
-          data-variant={model.activeCar.warning ? "warn" : undefined}
+          data-variant={activeCarVariant}
         >
           <div class="stat__label">
-            {t("dashboard.active_car", "Active car")}
+            {activeCarLabel}
           </div>
           <div
             class="stat__value"
             data-value
-            data-variant={model.activeCar.warning ? "warn" : undefined}
-            data-has-icon={model.activeCar.warning ? "true" : undefined}
+            data-variant={activeCarVariant}
+            data-has-icon={activeCarHasIcon}
           >
-            {model.activeCar.warning
+            {activeCarWarning.value
               ? (
                 <>
                   <span class="stat__value-icon" data-variant="warn" aria-hidden="true">
                     !
                   </span>
-                  <span>{model.activeCar.text}</span>
+                  <span>{activeCarText}</span>
                 </>
               )
-              : model.activeCar.text}
+              : activeCarText}
           </div>
         </div>
         <div id="liveRecordingState" class="stat">
           <div class="stat__label">
-            {t("dashboard.recording_state", "Run state")}
+            {recordingStateLabel}
           </div>
           <div class="stat__value" data-value>
-            {model.recordingStateText}
+            {recordingStateText}
           </div>
         </div>
         <div id="liveDataFreshness" class="stat">
           <div class="stat__label">
-            {t("dashboard.data_freshness", "Feed freshness")}
+            {dataFreshnessLabel}
           </div>
           <div class="stat__value" data-value>
-            {model.dataFreshnessText}
+            {dataFreshnessText}
           </div>
         </div>
         <div id="liveStrongestSignal" class="stat">
           <div class="stat__label">
-            {t("dashboard.strongest_signal", "Strongest signal")}
+            {strongestSignalLabel}
           </div>
           <div class="stat__value" data-value>
-            {model.strongestSignalText}
+            {strongestSignalText}
           </div>
         </div>
         <div class="stat">
           <div class="stat__label">
-            {t("dashboard.current_speed", "Current speed")}
+            {currentSpeedLabel}
           </div>
           <div id="speed" class="stat__value speed" aria-live="polite">
-            {state.speedText}
+            {props.speedText}
           </div>
         </div>
       </div>
       <div class="live-sensor-roster__header">
         <div class="mini-label">
-          {t("dashboard.sensor_coverage", "Sensor coverage")}
+          {sensorCoverageLabel}
         </div>
       </div>
       <div id="liveSensorRoster" class="live-sensor-roster">
-        {model.sensorCards.length
-          ? model.sensorCards.map((card) => {
+        {sensorCards.value.length
+          ? sensorCards.value.map((card) => {
             const statusClass = card.connected ? "online" : "offline";
             return (
               <article
@@ -189,7 +216,7 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
           })
           : (
             <div class="subtle">
-              {t("settings.sensors.no_sensors", "No sensors yet.")}
+              {noSensorsText}
             </div>
           )}
       </div>
@@ -198,15 +225,17 @@ function RealtimeLiveOverview(props: { state: ReadonlySignal<RealtimeLiveOvervie
 }
 
 export function mountRealtimeLiveOverview(host: HTMLElement): RealtimeLiveOverviewBridge {
-  const state = signal<RealtimeLiveOverviewBridgeState>({ ...DEFAULT_OVERVIEW_STATE });
-  render(<RealtimeLiveOverview state={state} />, host);
+  const modelSource = signal<ReadonlySignal<RealtimeLiveOverviewRenderModel> | null>(null);
+  const model = computed<RealtimeLiveOverviewRenderModel>(() => modelSource.value?.value ?? DEFAULT_OVERVIEW_MODEL);
+  const speedText = signal(DEFAULT_OVERVIEW_STATE.speedText);
+  render(<RealtimeLiveOverview model={model} speedText={speedText} />, host);
 
   return {
     bindModel(model: ReadonlySignal<RealtimeLiveOverviewRenderModel>): void {
-      state.value = { ...state.value, model };
+      modelSource.value = model;
     },
     setSpeedText(text: string): void {
-      state.value = { ...state.value, speedText: text };
+      speedText.value = text;
     },
   };
 }

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -1,7 +1,12 @@
 import { render } from "preact";
 
-import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import { useUiText } from "../ui_i18n";
+import {
+  computed,
+  signal,
+  useComputed,
+  type ReadonlySignal,
+} from "../ui_signals";
 import { inlineStateActionClass } from "./dom_helpers";
 import type {
   RealtimeCaptureReadinessChecklistModel,
@@ -33,11 +38,6 @@ export interface RealtimeLoggingPanelActionHandlers {
   onSummaryAction: (action: RealtimeLoggingSummaryAction) => void;
 }
 
-interface RealtimeLoggingPanelBridgeState {
-  actions: RealtimeLoggingPanelActionHandlers | null;
-  model: ReadonlySignal<RealtimeLoggingPanelRenderModel> | null;
-}
-
 export interface RealtimeLoggingPanelBridge {
   bindModel(model: ReadonlySignal<RealtimeLoggingPanelRenderModel>): void;
   bindActions(handlers: RealtimeLoggingPanelActionHandlers): void;
@@ -59,11 +59,6 @@ const DEFAULT_PANEL_MODEL: RealtimeLoggingPanelRenderModel = {
   startDisabled: false,
   stopDisabled: true,
   setupMode: false,
-};
-
-const DEFAULT_PANEL_STATE: RealtimeLoggingPanelBridgeState = {
-  actions: null,
-  model: null,
 };
 
 function RealtimeLoggingSummary(props: {
@@ -144,25 +139,50 @@ function RealtimeLoggingChecklist(props: {
 }
 
 function RealtimeLoggingPanel(props: {
-  state: ReadonlySignal<RealtimeLoggingPanelBridgeState>;
+  actions: ReadonlySignal<RealtimeLoggingPanelActionHandlers | null>;
+  model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
 }) {
-  const state = props.state.value;
-  const model = state.model?.value ?? DEFAULT_PANEL_MODEL;
-  const t = useUiTranslation();
-  const loggingRowHidden = !model.showPill && model.runIdText === "";
-  const showProgressSection = !model.setupMode || model.checklist !== null;
+  const titleText = useUiText("dashboard.run_recording", "Run Recording");
+  const runProgressLabel = useUiText("dashboard.recording_progress", "Run progress");
+  const runPhaseLabel = useUiText("dashboard.recording_phase", "Run phase");
+  const elapsedLabel = useUiText("dashboard.recording_elapsed", "Elapsed");
+  const samplesLabel = useUiText("dashboard.recording_samples", "Samples recorded");
+  const startLabel = useUiText("dashboard.start_recording", "Start Recording");
+  const stopLabel = useUiText("dashboard.stop_recording", "Stop Recording");
+  const pillVariant = useComputed(() => props.model.value.pillVariant);
+  const pillText = useComputed(() => props.model.value.pillText);
+  const showPill = useComputed(() => props.model.value.showPill);
+  const summaryText = useComputed(() => props.model.value.summaryText);
+  const summaryPanel = useComputed(() => props.model.value.summaryPanel);
+  const runIdText = useComputed(() => props.model.value.runIdText);
+  const phaseText = useComputed(() => props.model.value.phaseText);
+  const elapsedText = useComputed(() => props.model.value.elapsedText);
+  const samplesText = useComputed(() => props.model.value.samplesText);
+  const checklist = useComputed(() => props.model.value.checklist);
+  const showStart = useComputed(() => props.model.value.showStart);
+  const showStop = useComputed(() => props.model.value.showStop);
+  const startDisabled = useComputed(() => props.model.value.startDisabled);
+  const stopDisabled = useComputed(() => props.model.value.stopDisabled);
+  const setupMode = useComputed(() => props.model.value.setupMode);
+  const shellLayout = useComputed(() => setupMode.value ? "setup" : undefined);
+  const loggingRowHidden = useComputed(() => !showPill.value && runIdText.value === "");
+  const showPillHidden = useComputed(() => !showPill.value);
+  const runIdHidden = useComputed(() => runIdText.value === "");
+  const showProgressSection = useComputed(() => !setupMode.value || checklist.value !== null);
+  const showStartHidden = useComputed(() => !showStart.value);
+  const showStopHidden = useComputed(() => !showStop.value);
 
   return (
-    <div class="realtime-logging-shell" data-layout={model.setupMode ? "setup" : undefined}>
+    <div class="realtime-logging-shell" data-layout={shellLayout}>
       <div class="card__header card__header--stack">
         <div>
           <div class="card__title">
-            {t("dashboard.run_recording", "Run Recording")}
+            {titleText}
           </div>
           <RealtimeLoggingSummary
-            summaryText={model.summaryText}
-            summaryPanel={model.summaryPanel}
-            onAction={state.actions?.onSummaryAction ?? null}
+            summaryText={summaryText.value}
+            summaryPanel={summaryPanel.value}
+            onAction={props.actions.value?.onSummaryAction ?? null}
           />
         </div>
       </div>
@@ -170,49 +190,49 @@ function RealtimeLoggingPanel(props: {
         <span
           id="loggingStatus"
           class="pill"
-          data-variant={model.pillVariant}
-          hidden={!model.showPill}
+          data-variant={pillVariant}
+          hidden={showPillHidden}
           aria-live="polite"
         >
-          {model.pillText}
+          {pillText}
         </span>
-        <span id="loggingRunId" class="subtle" hidden={model.runIdText === ""}>
-          {model.runIdText}
+        <span id="loggingRunId" class="subtle" hidden={runIdHidden}>
+          {runIdText}
         </span>
       </div>
-      {showProgressSection
+      {showProgressSection.value
         ? (
           <>
             <div class="mini-label">
-              {t("dashboard.recording_progress", "Run progress")}
+              {runProgressLabel}
             </div>
             <div class="stat-grid stat-grid--compact">
               <div id="loggingPhase" class="stat stat--compact" hidden>
                 <div class="stat__label">
-                  {t("dashboard.recording_phase", "Run phase")}
+                  {runPhaseLabel}
                 </div>
                 <div class="stat__value" data-value>
-                  {model.phaseText}
+                  {phaseText}
                 </div>
               </div>
               <div id="loggingElapsed" class="stat stat--compact">
                 <div class="stat__label">
-                  {t("dashboard.recording_elapsed", "Elapsed")}
+                  {elapsedLabel}
                 </div>
                 <div class="stat__value" data-value>
-                  {model.elapsedText}
+                  {elapsedText}
                 </div>
               </div>
               <div id="loggingSamples" class="stat stat--compact">
                 <div class="stat__label">
-                  {t("dashboard.recording_samples", "Samples recorded")}
+                  {samplesLabel}
                 </div>
                 <div class="stat__value" data-value>
-                  {model.samplesText}
+                  {samplesText}
                 </div>
               </div>
             </div>
-            <RealtimeLoggingChecklist checklist={model.checklist} />
+            <RealtimeLoggingChecklist checklist={checklist.value} />
           </>
         )
         : null}
@@ -222,22 +242,22 @@ function RealtimeLoggingPanel(props: {
           class="btn btn--primary"
           type="button"
 
-          hidden={!model.showStart}
-          disabled={model.startDisabled}
-          onClick={() => state.actions?.onStartLogging()}
+          hidden={showStartHidden}
+          disabled={startDisabled}
+          onClick={() => props.actions.value?.onStartLogging()}
         >
-          {t("dashboard.start_recording", "Start Recording")}
+          {startLabel}
         </button>
         <button
           id="stopLoggingBtn"
           class="btn btn--danger-quiet"
           type="button"
 
-          hidden={!model.showStop}
-          disabled={model.stopDisabled}
-          onClick={() => state.actions?.onStopLogging()}
+          hidden={showStopHidden}
+          disabled={stopDisabled}
+          onClick={() => props.actions.value?.onStopLogging()}
         >
-          {t("dashboard.stop_recording", "Stop Recording")}
+          {stopLabel}
         </button>
       </div>
     </div>
@@ -245,15 +265,17 @@ function RealtimeLoggingPanel(props: {
 }
 
 export function mountRealtimeLoggingPanel(host: HTMLElement): RealtimeLoggingPanelBridge {
-  const state = signal<RealtimeLoggingPanelBridgeState>({ ...DEFAULT_PANEL_STATE });
-  render(<RealtimeLoggingPanel state={state} />, host);
+  const actions = signal<RealtimeLoggingPanelActionHandlers | null>(null);
+  const modelSource = signal<ReadonlySignal<RealtimeLoggingPanelRenderModel> | null>(null);
+  const model = computed<RealtimeLoggingPanelRenderModel>(() => modelSource.value?.value ?? DEFAULT_PANEL_MODEL);
+  render(<RealtimeLoggingPanel actions={actions} model={model} />, host);
 
   return {
     bindModel(model: ReadonlySignal<RealtimeLoggingPanelRenderModel>): void {
-      state.value = { ...state.value, model };
+      modelSource.value = model;
     },
     bindActions(handlers: RealtimeLoggingPanelActionHandlers): void {
-      state.value = { ...state.value, actions: handlers };
+      actions.value = handlers;
     },
   };
 }

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -1,8 +1,13 @@
 import type { JSX } from "preact";
 
 import { render } from "preact";
-import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import { useUiText } from "../ui_i18n";
+import {
+  computed,
+  signal,
+  useComputed,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type {
   RealtimeSensorTableClickAction,
   RealtimeSensorTableLocationChange,
@@ -23,11 +28,6 @@ export interface SensorsPanelView {
   bindModel(model: ReadonlySignal<SensorsPanelRenderModel>): void;
   bindActions(handlers: SensorsPanelActionHandlers): void;
 }
-
-type SensorsPanelBridgeState = {
-  actions: SensorsPanelActionHandlers | null;
-  model: ReadonlySignal<SensorsPanelRenderModel> | null;
-};
 
 function handleSensorAction(
   event: JSX.TargetedMouseEvent<HTMLButtonElement>,
@@ -106,12 +106,12 @@ function SensorsTableBody(props: {
   table: RealtimeSensorTableRenderModel | null;
 }) {
   const { actions, table } = props;
-  const t = useUiTranslation();
+  const emptyText = useUiText("settings.sensors.no_sensors", "No sensors detected yet.");
   if (table === null || table.kind === "empty") {
     return (
       <tr>
         <td colSpan={3}>
-          {table?.emptyText ?? t("settings.sensors.no_sensors", "No sensors detected yet.")}
+          {table?.emptyText ?? emptyText}
         </td>
       </tr>
     );
@@ -121,38 +121,44 @@ function SensorsTableBody(props: {
   ));
 }
 
-function SensorsPanel(props: { state: ReadonlySignal<SensorsPanelBridgeState> }) {
-  const state = props.state.value;
-  const model = state.model?.value ?? { table: null };
-  const t = useUiTranslation();
+function SensorsPanel(props: {
+  actions: ReadonlySignal<SensorsPanelActionHandlers | null>;
+  model: ReadonlySignal<SensorsPanelRenderModel>;
+}) {
+  const titleText = useUiText("settings.sensors.title", "Sensors");
+  const hintText = useUiText(
+    "settings.sensors.hint",
+    "Manage sensor names and locations. Default name is the MAC address.",
+  );
+  const nameLabel = useUiText("settings.sensors.name", "Name");
+  const locationLabel = useUiText("settings.sensors.location", "Location");
+  const actionsLabel = useUiText("settings.sensors.actions", "Actions");
+  const table = useComputed(() => props.model.value.table);
   return (
     <div class="panel card">
       <strong>
-        {t("settings.sensors.title", "Sensors")}
+        {titleText}
       </strong>
       <div class="subtle">
-        {t(
-          "settings.sensors.hint",
-          "Manage sensor names and locations. Default name is the MAC address.",
-        )}
+        {hintText}
       </div>
       <div class="settings-table-wrap">
         <table class="clients-table settings-entity-table settings-entity-table--sensors">
           <thead>
             <tr>
               <th>
-                {t("settings.sensors.name", "Name")}
+                {nameLabel}
               </th>
               <th>
-                {t("settings.sensors.location", "Location")}
+                {locationLabel}
               </th>
               <th>
-                {t("settings.sensors.actions", "Actions")}
+                {actionsLabel}
               </th>
             </tr>
           </thead>
           <tbody id="sensorsSettingsBody">
-            <SensorsTableBody actions={state.actions} table={model.table} />
+            <SensorsTableBody actions={props.actions.value} table={table.value} />
           </tbody>
         </table>
       </div>
@@ -161,17 +167,16 @@ function SensorsPanel(props: { state: ReadonlySignal<SensorsPanelBridgeState> })
 }
 
 export function mountSensorsPanel(host: HTMLElement): SensorsPanelView {
-  const state = signal<SensorsPanelBridgeState>({
-    actions: null,
-    model: null,
-  });
-  render(<SensorsPanel state={state} />, host);
+  const actions = signal<SensorsPanelActionHandlers | null>(null);
+  const modelSource = signal<ReadonlySignal<SensorsPanelRenderModel> | null>(null);
+  const model = computed<SensorsPanelRenderModel>(() => modelSource.value?.value ?? { table: null });
+  render(<SensorsPanel actions={actions} model={model} />, host);
   return {
     bindModel(model) {
-      state.value = { ...state.value, model };
+      modelSource.value = model;
     },
     bindActions(handlers) {
-      state.value = { ...state.value, actions: handlers };
+      actions.value = handlers;
     },
   };
 }

--- a/apps/ui/src/app/views/settings_shell.tsx
+++ b/apps/ui/src/app/views/settings_shell.tsx
@@ -1,7 +1,12 @@
 import { render, type JSX } from "preact";
 
-import { useUiTranslation } from "../ui_i18n";
-import { effect, type ReadonlySignal, signal } from "../ui_signals";
+import { useUiText } from "../ui_i18n";
+import {
+  effect,
+  useComputed,
+  type ReadonlySignal,
+  signal,
+} from "../ui_signals";
 
 type ViewDisposer = () => void;
 
@@ -83,18 +88,25 @@ function focusSettingsTab(
   buttons[normalizeSettingsTabIndex(nextIndex)]?.focus();
 }
 
-function SettingsShell(props: SettingsShellProps) {
-  const activeTabId = props.activeTabId.value;
-  const { onActivateTab } = props;
-  const t = useUiTranslation();
+function SettingsShellTabButton(props: {
+  activeTabId: ReadonlySignal<SettingsShellTabId>;
+  index: number;
+  onActivateTab(tabId: SettingsShellTabId): void;
+  tab: (typeof SETTINGS_TABS)[number];
+}) {
+  const { index, onActivateTab, tab } = props;
+  const isActive = useComputed(() => tab.id === props.activeTabId.value);
+  const labelText = useUiText(tab.labelKey, tab.fallbackLabel);
+  const tabClass = useComputed(() => isActive.value ? "settings-tab active" : "settings-tab");
+  const ariaSelected = useComputed(() => isActive.value ? "true" : "false");
+  const tabIndex = useComputed(() => isActive.value ? 0 : -1);
 
   function handleTabKeyDown(
-    index: number,
     event: JSX.TargetedKeyboardEvent<HTMLButtonElement>,
   ): void {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      onActivateTab(SETTINGS_TABS[index].id);
+      onActivateTab(tab.id);
       return;
     }
     if (event.key === "ArrowRight") {
@@ -126,44 +138,63 @@ function SettingsShell(props: SettingsShellProps) {
   }
 
   return (
+    <button
+      type="button"
+      class={tabClass}
+      data-settings-tab={tab.id}
+      role="tab"
+      aria-controls={tab.id}
+      aria-selected={ariaSelected}
+      tabIndex={tabIndex}
+      onClick={() => onActivateTab(tab.id)}
+      onKeyDown={handleTabKeyDown}
+    >
+      <span>{labelText}</span>
+    </button>
+  );
+}
+
+function SettingsShellTabPanel(props: {
+  activeTabId: ReadonlySignal<SettingsShellTabId>;
+  tab: (typeof SETTINGS_TABS)[number];
+}) {
+  const isActive = useComputed(() => props.tab.id === props.activeTabId.value);
+  const panelClass = useComputed(() => isActive.value ? "settings-tab-panel active" : "settings-tab-panel");
+  const hidden = useComputed(() => !isActive.value);
+
+  return (
+    <div
+      id={props.tab.id}
+      class={panelClass}
+      role="tabpanel"
+      hidden={hidden}
+    >
+      <div id={props.tab.hostId} />
+    </div>
+  );
+}
+
+function SettingsShell(props: SettingsShellProps) {
+  const { onActivateTab } = props;
+
+  return (
     <>
       <nav class="settings-tabs" role="tablist">
         {SETTINGS_TABS.map((tab, index) => {
-          const isActive = tab.id === activeTabId;
           return (
-            <button
+            <SettingsShellTabButton
               key={tab.id}
-              type="button"
-              class={isActive ? "settings-tab active" : "settings-tab"}
-              data-settings-tab={tab.id}
-              role="tab"
-              aria-controls={tab.id}
-              aria-selected={isActive ? "true" : "false"}
-              tabIndex={isActive ? 0 : -1}
-              onClick={() => onActivateTab(tab.id)}
-              onKeyDown={(event) => handleTabKeyDown(index, event)}
-            >
-              <span>
-                {t(tab.labelKey, tab.fallbackLabel)}
-              </span>
-            </button>
+              activeTabId={props.activeTabId}
+              index={index}
+              onActivateTab={onActivateTab}
+              tab={tab}
+            />
           );
         })}
       </nav>
-      {SETTINGS_TABS.map((tab) => {
-        const isActive = tab.id === activeTabId;
-        return (
-          <div
-            key={tab.id}
-            id={tab.id}
-            class={isActive ? "settings-tab-panel active" : "settings-tab-panel"}
-            role="tabpanel"
-            hidden={!isActive}
-          >
-            <div id={tab.hostId} />
-          </div>
-        );
-      })}
+      {SETTINGS_TABS.map((tab) => (
+        <SettingsShellTabPanel key={tab.id} activeTabId={props.activeTabId} tab={tab} />
+      ))}
     </>
   );
 }

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -1,6 +1,10 @@
 import { render } from "preact";
-import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import { getUiText } from "../ui_i18n";
+import {
+  signal,
+  useComputed,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type {
   SpectrumBandLegendModel,
   SpectrumPanelChartDom,
@@ -80,18 +84,38 @@ function requireSpectrumElement<T extends HTMLElement>(
 }
 
 function SpectrumPanel(props: {
-  state: ReadonlySignal<SpectrumPanelBridgeState>;
+  bandLegend: ReadonlySignal<SpectrumBandLegendModel>;
+  bandToggle: ReadonlySignal<SpectrumPanelBridgeState["bandToggle"]>;
   chartDom: MutableSpectrumPanelChartDom;
+  header: ReadonlySignal<SpectrumPanelHeaderModel>;
+  inspectorText: ReadonlySignal<string>;
+  onBandToggle: ReadonlySignal<(() => void) | null>;
+  overlayMessage: ReadonlySignal<string | null>;
+  sensorLegend: ReadonlySignal<SpectrumSensorLegendModel | null>;
+  sensorLegendHandlers: ReadonlySignal<SpectrumLegendHandlers | null>;
 }) {
-  const state = props.state.value;
   const { chartDom } = props;
-  const t = useUiTranslation();
+  const titleText = useComputed(() => getUiText("chart.spectrum_title", props.header.value.titleText));
+  const hintText = useComputed(() => getUiText("spectrum.controls_hint", props.header.value.hintText));
+  const overlayHidden = useComputed(() => props.overlayMessage.value === null);
+  const overlayText = useComputed(() => props.overlayMessage.value ?? "Waiting for sensor data...");
+  const bandToggleHasBands = useComputed(() => props.bandToggle.value.hasBands);
+  const bandToggleBandsVisible = useComputed(() => props.bandToggle.value.bandsVisible);
+  const bandTogglePressed = useComputed(() =>
+    bandToggleHasBands.value && bandToggleBandsVisible.value ? "true" : "false"
+  );
+  const bandToggleText = useComputed(() => props.bandToggle.value.text);
+  const bandToggleHidden = useComputed(() => !bandToggleHasBands.value);
+  const bandLegendHidden = useComputed(() => !props.bandLegend.value.visible);
+  const bandLegend = props.bandLegend.value;
+  const sensorLegend = props.sensorLegend.value;
+  const sensorLegendHandlers = props.sensorLegendHandlers.value;
 
   return (
     <>
       <div class="card__header">
         <div class="card__title">
-          {t("chart.spectrum_title", state.header.titleText)}
+          {titleText}
         </div>
       </div>
       <div
@@ -107,14 +131,14 @@ function SpectrumPanel(props: {
             chartDom.specChart = element;
           }}
         />
-        <div id="spectrumOverlay" class="empty-state" hidden={state.overlayMessage === null}>
-          {state.overlayMessage ?? "Waiting for sensor data..."}
+        <div id="spectrumOverlay" class="empty-state" hidden={overlayHidden}>
+          {overlayText}
         </div>
       </div>
       <div class="spectrum-controls-panel">
         <div class="spectrum-toolbar">
           <div class="card__subtle spectrum-toolbar__hint">
-            {t("spectrum.controls_hint", state.header.hintText)}
+            {hintText}
           </div>
           <div class="spectrum-toolbar__bands">
             <button
@@ -122,18 +146,18 @@ function SpectrumPanel(props: {
               class="btn spectrum-toolbar__toggle"
               type="button"
               aria-controls="bandLegend"
-              aria-pressed={state.bandToggle.hasBands && state.bandToggle.bandsVisible ? "true" : "false"}
-              aria-expanded={state.bandToggle.hasBands && state.bandToggle.bandsVisible ? "true" : "false"}
-              hidden={!state.bandToggle.hasBands}
-              disabled={!state.bandToggle.hasBands}
-              onClick={() => state.onBandToggle?.()}
+              aria-pressed={bandTogglePressed}
+              aria-expanded={bandTogglePressed}
+              hidden={bandToggleHidden}
+              disabled={bandToggleHidden}
+              onClick={() => props.onBandToggle.value?.()}
             >
-              {state.bandToggle.text}
+              {bandToggleText}
             </button>
-            <div id="bandLegend" class="legend band-legend" hidden={!state.bandLegend.visible}>
-              {state.bandLegend.visible
-                ? state.bandLegend.items.length
-                  ? state.bandLegend.items.map((item) => (
+            <div id="bandLegend" class="legend band-legend" hidden={bandLegendHidden}>
+              {bandLegend.visible
+                ? bandLegend.items.length
+                  ? bandLegend.items.map((item) => (
                     <div
                       key={item.labelText}
                       class="legend-item legend-item--band"
@@ -146,7 +170,7 @@ function SpectrumPanel(props: {
                   ))
                   : (
                     <div class="legend-item legend-item--band" data-band-state="empty">
-                      {state.bandLegend.emptyText}
+                      {bandLegend.emptyText}
                     </div>
                   )
                 : null}
@@ -154,24 +178,24 @@ function SpectrumPanel(props: {
           </div>
         </div>
         <div id="spectrumInspector" class="spectrum-inspector" aria-live="polite">
-          {state.inspectorText}
+          {props.inspectorText}
         </div>
         <div id="legend" class="legend">
-          {state.sensorLegend && state.sensorLegend.items.length > 0 && state.sensorLegendHandlers
+          {sensorLegend && sensorLegend.items.length > 0 && sensorLegendHandlers
             ? (
               <>
                 <button
                   type="button"
                   class="legend-item legend-item--interactive legend-item--reset"
-                  aria-pressed={state.sensorLegend.reset.ariaPressed ? "true" : "false"}
-                  title={state.sensorLegend.reset.titleText}
-                  aria-label={state.sensorLegend.reset.ariaLabel}
-                  data-legend-state={state.sensorLegend.reset.active ? "active" : undefined}
-                  onClick={() => state.sensorLegendHandlers?.onReset()}
+                  aria-pressed={sensorLegend.reset.ariaPressed ? "true" : "false"}
+                  title={sensorLegend.reset.titleText}
+                  aria-label={sensorLegend.reset.ariaLabel}
+                  data-legend-state={sensorLegend.reset.active ? "active" : undefined}
+                  onClick={() => sensorLegendHandlers?.onReset()}
                 >
-                  <span class="legend-item__label">{state.sensorLegend.reset.labelText}</span>
+                  <span class="legend-item__label">{sensorLegend.reset.labelText}</span>
                 </button>
-                {state.sensorLegend.items.map((item) => (
+                {sensorLegend.items.map((item) => (
                   <button
                     key={item.id}
                     type="button"
@@ -180,7 +204,7 @@ function SpectrumPanel(props: {
                     title={item.titleText}
                     aria-label={item.ariaLabel}
                     data-legend-state={item.active ? "active" : item.muted ? "muted" : undefined}
-                    onClick={() => state.sensorLegendHandlers?.onSelect(item.id)}
+                    onClick={() => sensorLegendHandlers?.onSelect(item.id)}
                   >
                     <span class="swatch" style={`--swatch-color: ${item.color}`} />
                     <span class="legend-item__text-group">
@@ -201,12 +225,33 @@ function SpectrumPanel(props: {
 }
 
 export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
-  const state = signal<SpectrumPanelBridgeState>(createDefaultPanelState());
+  const defaultState = createDefaultPanelState();
+  const header = signal<SpectrumPanelHeaderModel>(defaultState.header);
+  const overlayMessage = signal<string | null>(defaultState.overlayMessage);
+  const bandToggle = signal(defaultState.bandToggle);
+  const sensorLegend = signal<SpectrumSensorLegendModel | null>(defaultState.sensorLegend);
+  const sensorLegendHandlers = signal<SpectrumLegendHandlers | null>(defaultState.sensorLegendHandlers);
+  const bandLegend = signal(defaultState.bandLegend);
+  const inspectorText = signal(defaultState.inspectorText);
+  const onBandToggle = signal<(() => void) | null>(defaultState.onBandToggle);
   const chartDom: MutableSpectrumPanelChartDom = {
     specChartWrap: null,
     specChart: null,
   };
-  render(<SpectrumPanel state={state} chartDom={chartDom} />, host);
+  render(
+    <SpectrumPanel
+      bandLegend={bandLegend}
+      bandToggle={bandToggle}
+      chartDom={chartDom}
+      header={header}
+      inspectorText={inspectorText}
+      onBandToggle={onBandToggle}
+      overlayMessage={overlayMessage}
+      sensorLegend={sensorLegend}
+      sensorLegendHandlers={sensorLegendHandlers}
+    />,
+    host,
+  );
 
   return {
     chartDom: {
@@ -218,32 +263,29 @@ export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
       },
     } satisfies SpectrumPanelChartDom,
     bindBandToggle(onToggle: () => void): void {
-      state.value = { ...state.value, onBandToggle: onToggle };
+      onBandToggle.value = onToggle;
     },
     renderHeader(model: SpectrumPanelHeaderModel): void {
-      state.value = { ...state.value, header: model };
+      header.value = model;
     },
     renderOverlay(message: string | null): void {
-      state.value = { ...state.value, overlayMessage: message };
+      overlayMessage.value = message;
     },
     renderBandToggle(model: { hasBands: boolean; bandsVisible: boolean; text: string }): void {
-      state.value = { ...state.value, bandToggle: model };
+      bandToggle.value = model;
     },
     renderSensorLegend(
       model: SpectrumSensorLegendModel | null,
       handlers?: SpectrumLegendHandlers,
     ): void {
-      state.value = {
-        ...state.value,
-        sensorLegend: model,
-        sensorLegendHandlers: model && handlers ? handlers : null,
-      };
+      sensorLegend.value = model;
+      sensorLegendHandlers.value = model && handlers ? handlers : null;
     },
     renderBandLegend(model: SpectrumBandLegendModel): void {
-      state.value = { ...state.value, bandLegend: model };
+      bandLegend.value = model;
     },
     renderInspectorText(text: string): void {
-      state.value = { ...state.value, inspectorText: text };
+      inspectorText.value = text;
     },
   };
 }

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -1,7 +1,12 @@
 import { h, render, type ComponentChildren } from "preact";
 
-import { useUiTranslation } from "../ui_i18n";
-import { signal, type ReadonlySignal } from "../ui_signals";
+import { useUiText } from "../ui_i18n";
+import {
+  computed,
+  signal,
+  useComputed,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type {
   UpdateCurrentStatusSectionModel,
   UpdateHealthSectionModel,
@@ -35,11 +40,6 @@ export interface UpdatePanelView {
   bindActions(handlers: UpdatePanelActionHandlers): void;
   bindModel(model: ReadonlySignal<UpdatePanelRenderModel>): void;
 }
-
-type UpdatePanelBridgeState = {
-  actions: UpdatePanelActionHandlers | null;
-  model: ReadonlySignal<UpdatePanelRenderModel> | null;
-};
 
 const DEFAULT_UPDATE_PANEL_MODEL: UpdatePanelRenderModel = {
   cancelButtonDisabled: true,
@@ -322,11 +322,25 @@ function UpdateStatusContent(props: {
 }
 
 function UpdatePanel(props: {
-  state: ReadonlySignal<UpdatePanelBridgeState>;
+  actions: ReadonlySignal<UpdatePanelActionHandlers | null>;
+  model: ReadonlySignal<UpdatePanelRenderModel>;
 }) {
-  const state = props.state.value;
-  const model = state.model?.value ?? DEFAULT_UPDATE_PANEL_MODEL;
-  const t = useUiTranslation();
+  const titleText = useUiText("settings.update.title", "System Update");
+  const hintText = useUiText(
+    "settings.update.hint",
+    "Use either temporary Wi-Fi credentials or an already-connected USB internet uplink to update from GitHub. The hotspot only pauses for the Wi-Fi path.",
+  );
+  const reconnectNote = useUiText(
+    "settings.update.reconnect_note",
+    "Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.",
+  );
+  const cancelLabel = useUiText("settings.update.cancel", "Cancel Update");
+  const status = useComputed(() => props.model.value.status);
+  const startButtonHidden = useComputed(() => props.model.value.startButtonHidden);
+  const startButtonDisabled = useComputed(() => props.model.value.startButtonDisabled);
+  const startButtonLabelText = useComputed(() => props.model.value.startButtonLabelText);
+  const cancelButtonHidden = useComputed(() => props.model.value.cancelButtonHidden);
+  const cancelButtonDisabled = useComputed(() => props.model.value.cancelButtonDisabled);
   return (
     <div class="panel card">
       <div class="maintenance-layout maintenance-layout--compact">
@@ -334,50 +348,44 @@ function UpdatePanel(props: {
           <div class="maintenance-card__header">
             <div>
               <div class="maintenance-card__title">
-                {t("settings.update.title", "System Update")}
+                {titleText}
               </div>
               <div class="subtle">
-                {t(
-                  "settings.update.hint",
-                  "Use either temporary Wi-Fi credentials or an already-connected USB internet uplink to update from GitHub. The hotspot only pauses for the Wi-Fi path.",
-                )}
+                {hintText}
               </div>
             </div>
           </div>
           <div class="maintenance-card__body maintenance-card__body--hero">
             <div class="maintenance-note">
-              {t(
-                "settings.update.reconnect_note",
-                "Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.",
-              )}
+              {reconnectNote}
             </div>
             <div
               id="updateOverviewPanel"
               class="maintenance-stack maintenance-stack--tight"
               aria-live="polite"
             >
-              <UpdateOverviewContent status={model.status} />
+              <UpdateOverviewContent status={status.value} />
             </div>
             <div class="maintenance-action-row">
               <button
                 type="button"
                 id="updateStartBtn"
                 class="btn btn--success"
-                hidden={model.startButtonHidden}
-                disabled={model.startButtonDisabled}
-                onClick={() => state.actions?.onStart()}
+                hidden={startButtonHidden}
+                disabled={startButtonDisabled}
+                onClick={() => props.actions.value?.onStart()}
               >
-                {model.startButtonLabelText}
+                {startButtonLabelText}
               </button>
               <button
                 type="button"
                 id="updateCancelBtn"
                 class="btn btn--danger"
-                hidden={model.cancelButtonHidden}
-                disabled={model.cancelButtonDisabled}
-                onClick={() => state.actions?.onCancel()}
+                hidden={cancelButtonHidden}
+                disabled={cancelButtonDisabled}
+                onClick={() => props.actions.value?.onCancel()}
               >
-                {t("settings.update.cancel", "Cancel Update")}
+                {cancelLabel}
               </button>
             </div>
           </div>
@@ -388,7 +396,7 @@ function UpdatePanel(props: {
           class="maintenance-stack maintenance-stack--tight"
           aria-live="polite"
         >
-          <UpdateStatusContent status={model.status} />
+          <UpdateStatusContent status={status.value} />
         </div>
       </div>
     </div>
@@ -396,18 +404,17 @@ function UpdatePanel(props: {
 }
 
 export function mountUpdatePanel(host: HTMLElement): UpdatePanelView {
-  const state = signal<UpdatePanelBridgeState>({
-    actions: null,
-    model: null,
-  });
-  render(<UpdatePanel state={state} />, host);
+  const actions = signal<UpdatePanelActionHandlers | null>(null);
+  const modelSource = signal<ReadonlySignal<UpdatePanelRenderModel> | null>(null);
+  const model = computed<UpdatePanelRenderModel>(() => modelSource.value?.value ?? DEFAULT_UPDATE_PANEL_MODEL);
+  render(<UpdatePanel actions={actions} model={model} />, host);
 
   return {
     bindActions(handlers) {
-      state.value = { ...state.value, actions: handlers };
+      actions.value = handlers;
     },
     bindModel(model) {
-      state.value = { ...state.value, model };
+      modelSource.value = model;
     },
   };
 }

--- a/apps/ui/tests/signal_view_reference_tests.ts
+++ b/apps/ui/tests/signal_view_reference_tests.ts
@@ -13,6 +13,57 @@ function requireElement<T extends Element = HTMLElement>(root: ParentNode, selec
   return element;
 }
 
+async function runDirectSignalBindingReferenceTest(): Promise<void> {
+  const buttonText = signal("Idle");
+  const variant = signal("muted");
+  const disabled = signal(true);
+  let renderCount = 0;
+
+  const harness = await mountSignalView(async () => {
+    const { h, render } = await import("preact");
+    return (host) => {
+      function SignalButton() {
+        renderCount += 1;
+        return h(
+          "button",
+          {
+            "data-variant": variant,
+            disabled,
+            id: "signalBindingButton",
+            type: "button",
+          },
+          buttonText,
+        );
+      }
+
+      render(h(SignalButton, {}), host);
+      return {};
+    };
+  });
+
+  try {
+    await harness.flush();
+
+    const button = requireElement<HTMLButtonElement>(harness.host, "#signalBindingButton");
+    assert.equal(renderCount, 1);
+    assert.equal(button.textContent, "Idle");
+    assert.equal(button.getAttribute("data-variant"), "muted");
+    assert.equal(button.disabled, true);
+
+    buttonText.value = "Running";
+    variant.value = "warn";
+    disabled.value = false;
+    await harness.flush();
+
+    assert.equal(renderCount, 1);
+    assert.equal(button.textContent, "Running");
+    assert.equal(button.getAttribute("data-variant"), "warn");
+    assert.equal(button.disabled, false);
+  } finally {
+    harness.cleanup();
+  }
+}
+
 async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
   const connectedSensorsText = signal("2 / 4");
   const activeCarText = signal("Roadster");
@@ -140,6 +191,10 @@ async function runSettingsShellReferenceTest(): Promise<void> {
 }
 
 const referenceTests = [
+  {
+    name: "direct signal jsx bindings update without rerender",
+    run: runDirectSignalBindingReferenceTest,
+  },
   {
     name: "realtime live overview computed-driven output",
     run: runRealtimeLiveOverviewReferenceTest,


### PR DESCRIPTION
## Summary

This PR pushes the post-#2366 frontend further into idiomatic `@preact/signals` usage by adopting the hook surface and direct JSX signal binding where it materially reduces broad island rerenders. The goal was not to mechanically rewrite every remaining panel, but to target the hot runtime surfaces and the simpler mounted islands that still read `.value` at the component root even after the earlier signal-backed bridge work landed.

The main result is that the shell chrome, the realtime overview/logging surfaces, and several lower-complexity settings/history/maintenance panels now derive field-level values through `useComputed()` and bind those signals directly into JSX text nodes, attributes, and boolean props. That keeps the fast-changing DOM locations reactive without rebuilding large render models in the component body on every update. The PR also introduces the missing hook exports and a small signal-text helper in the shared i18n layer so these patterns are available from the repo’s canonical frontend entrypoints.

## Problem

Issue #2367 called out an awkward middle state in the migration: the app already used signal-backed bridge state and shared computed state, but many TSX components still followed the old “read the whole model signal, then render from plain values” shape. That still works, but it misses the main Preact signals optimization path where direct signal children and signal-backed attributes update DOM nodes without re-running a whole component tree through the VDOM diff.

This was most noticeable on the frequently changing runtime surfaces. `ui_shell_chrome.tsx`, `realtime_live_overview.tsx`, and `realtime_logging_panel.tsx` were already fed from reactive model signals, but they still had broad root-level reads that made the entire component respond as one reactive unit. Several simpler mounted islands such as history, update, ESP flash, sensors, and the settings shell also still kept a “single state bag” bridge shape that made direct signal binding harder than it needed to be.

## Implementation approach

I kept the cut deliberately bounded. Instead of trying to flatten every remaining form-heavy panel in one pass, I focused on:

1. adding the missing shared hook surface,
2. introducing a shared signal-friendly text helper for translated copy,
3. converting the highest-impact live shell/realtime surfaces to hook-scoped computed signals,
4. converting the simpler mounted islands away from root state-bag reads, and
5. adding explicit reference coverage for direct JSX signal binding.

The heavier form-style panels still touched here (`analysis_panel.tsx`, `internet_panel.tsx`, and `cars_panel.tsx`) were limited to the lifecycle parts that clearly benefited from hooks now: `useSignalEffect()` for focus/open requests and `useSignal()` for the wizard-local open-state tracking. That kept the issue aligned with its signal-hook intent without turning the PR into a risky full panel architecture rewrite.

## Main code changes

### Shared signal and i18n surface

`apps/ui/src/app/ui_signals.ts` now re-exports `useComputed`, `useSignal`, and `useSignalEffect` from the repo’s canonical signal entrypoint. That keeps view/runtime code importing reactive primitives from one documented surface rather than reaching directly into `@preact/signals`.

`apps/ui/src/app/ui_i18n.ts` now adds `useUiText()`. This is a narrow helper for the common “single translated string as a signal” case, which lets components bind translated copy directly into JSX without having to manually read from `useUiTranslation()` in every render expression.

### Hot runtime and realtime surfaces

`apps/ui/src/app/runtime/ui_shell_chrome.tsx` now replaces the broad root model read with field-level `useComputed()` signals for the active view, error banner, nav metadata, language/speed-unit controls, and live status badges. The result is more fine-grained reactive ownership in the app shell.

`apps/ui/src/app/views/realtime_live_overview.tsx` and `apps/ui/src/app/views/realtime_logging_panel.tsx` now follow the same pattern for the frequently changing live dashboard fields: sensor counts, active-car warning state, health pill state, logging summary content, elapsed/sample text, and action visibility/disabled state. These values are now modeled as component-scoped computed signals and bound directly into JSX where possible.

`apps/ui/src/app/views/spectrum_panel.tsx` was also tightened further. The panel already mounted once, but this pass split more of its internal state into focused signals for the header copy, overlay text, band toggle state, and legend/inspector sections so the remaining reactive work is closer to the DOM sites that change.

### Simpler mounted islands

The settings shell, sensors, history, update, and ESP flash panels were all shifted away from a single root bridge-state read inside the component. Their mount helpers now keep separate action/model signals, and the components themselves consume field-level computed signals or signal-backed text labels instead of unpacking the whole render model up front.

This was especially useful for:

- `settings_shell.tsx`, where tab buttons and tab panels now have focused `useComputed()` ownership for active state and label binding,
- `history_panel.tsx`, which now binds the summary text and destructive-action disabled state through direct signals,
- `update_panel.tsx` and `esp_flash_panel.tsx`, which now drive status, action visibility, and translated copy through computed signals rather than a root `state.value` snapshot,
- `sensors_panel.tsx`, which now treats the table model as a direct computed input instead of a component-wide state read.

### Hook-based lifecycle cleanup

`analysis_panel.tsx` and `internet_panel.tsx` now use `useSignalEffect()` for focus/open request side effects, which removes render-time signal subscriptions that only existed to trigger imperative DOM work.

`cars_panel.tsx` now uses `useSignal()` for the local wizard open-state tracking that was previously held in a mutable ref-backed boolean. The DOM refs remain as refs, which preserves the intended “signals for reactive values, refs for DOM handles” split from the issue scope.

### Test and docs updates

`apps/ui/tests/signal_view_reference_tests.ts` now adds a direct-signal JSX reference test that proves signal-backed children/attributes update without causing a component rerender. That complements the earlier computed-driven island reference coverage and gives this issue a focused regression guard for the optimization it was explicitly targeting.

`apps/ui/README.md` was updated to document the new preferred patterns: hook-scoped computed/signal ownership inside Preact components, `useUiText()` for direct signal-backed copy, and the widened signal-view reference coverage.

## Validation

I validated this change with:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run test:signals`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/realtime_logging_summary.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.settings-shell.spec.ts tests/smoke.settings.spec.ts tests/smoke.history.spec.ts tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts tests/smoke.analysis-sensors.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

One interim failure in `realtime_logging_summary.spec.ts` was not a product regression: I initially ran that browser test on the default Playwright server, which pointed at an unrelated localhost app in this environment. Re-running the browser slice under `.ai-temp/playwright.full.local.config.ts` passed cleanly.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff here is scope discipline. There are still heavier form-oriented panels that read broader state at the component root, but I kept those out of this PR unless a hook-based lifecycle fix was clearly beneficial. That avoids mixing the signal optimization pass with a much larger UI-architecture rewrite.

The risk area was mostly around boolean attrs, translated copy, and action binding in the migrated islands. The targeted browser coverage above exercises exactly those surfaces so the PR does not rely only on typecheck-level confidence.
