### PR TITLE
Drop dead escapeHtml export from format.ts

### DIFF
--- a/apps/ui/src/format.ts
+++ b/apps/ui/src/format.ts
@@ -28,16 +28,3 @@ export function formatIntLocale(value: number, lang: string): string {
   }
   return fmt.format(Math.round(value));
 }
-
-const _HTML_ESCAPE_RE = /[&<>"']/g;
-const _HTML_ESCAPE_MAP: Record<string, string> = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  '"': "&quot;",
-  "'": "&#39;",
-};
-
-export function escapeHtml(value: unknown): string {
-  return String(value).replace(_HTML_ESCAPE_RE, (ch) => _HTML_ESCAPE_MAP[ch]);
-}


### PR DESCRIPTION
## Summary

This PR removes the dead `escapeHtml()` export from `apps/ui/src/format.ts` along with its two supporting constants, `_HTML_ESCAPE_RE` and `_HTML_ESCAPE_MAP`. The function was still exported from the shared UI formatting module, but it was no longer imported anywhere in production or test code. With the frontend now rendered through Preact and JSX rather than manual string-to-HTML assembly, the helper had become leftover pre-Preact utility code rather than an active dependency.

The change is intentionally small. I did not broaden it into a general formatting cleanup or touch the similarly named `escapeHtml()` helper inside `apps/ui/tests/dom_render_test_support.ts`, because that second function is a local test-only serializer used by the fake DOM harness and is unrelated to the dead export in `format.ts`. The goal here is simply to delete one confirmed-unused export cleanly and validate that the UI package still builds and lints without it.

## Problem

Issue #2381 called out a narrow but worthwhile cleanup target: `apps/ui/src/format.ts` still exported an HTML escaping helper that no live code consumed. That sort of stale export is small, but it still has real maintenance cost. It suggests a supported formatting API that does not actually belong to the current architecture, makes the module look more complex than it is, and can confuse future cleanup work by implying that some legacy string-HTML path still needs to be preserved.

In this repo, that confusion matters because the frontend has already been migrating toward Preact ownership, typed view models, and signal-driven JSX rendering. In that model, UI text is rendered through JSX where escaping is already handled by the framework. Keeping a dead escape helper in the shared UI formatting module would preserve a legacy seam that no longer represents how the application should render content.

## Implementation approach

I took the narrowest possible path:

1. confirm the helper was truly unused,
2. confirm that no adjacent production utility still depended on the constants,
3. confirm that any same-named helpers elsewhere were not shared imports, and
4. remove only the dead export and its local support data.

The scope read showed exactly that. A repo search found `_HTML_ESCAPE_RE`, `_HTML_ESCAPE_MAP`, and the exported `escapeHtml()` only in `apps/ui/src/format.ts`. The only other `escapeHtml()` symbol in the UI tree lives in `apps/ui/tests/dom_render_test_support.ts`, where it is defined locally and used internally by the fake DOM serializer. Because that test helper is independent, this issue did not justify touching tests or the fake DOM harness at all.

That bounded approach keeps the diff honest. This PR is not a “format utilities cleanup” umbrella change and does not claim to modernize every naming or escaping path in the repo. It just removes one dead export whose lack of usage was confirmed before editing.

## Main code changes

The production diff is contained entirely in `apps/ui/src/format.ts`.

The following were deleted:

- `_HTML_ESCAPE_RE`
- `_HTML_ESCAPE_MAP`
- `escapeHtml(value: unknown): string`

No other functions in the file changed. `fmt()`, `fmtTs()`, `formatInt()`, and `formatIntLocale()` remain as-is. No imports or call sites had to be updated, because there were no consumers to update.

This is also why the PR intentionally avoids introducing compatibility shims or deprecation comments. A dead internal export should just be removed. The repo owns both producers and consumers here, and the search confirmed there were no consumers in the current codebase.

## Validation

Because the removal is structural rather than behavior-changing, validation focused on proving two things:

1. the symbol really was dead before deletion, and
2. the frontend package still typechecks, builds, and lints after the deletion.

I validated the change with:

- `cd /workspace/VibeSensor && rg -n "\\bescapeHtml\\b|_HTML_ESCAPE_RE|_HTML_ESCAPE_MAP" apps/ui`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

The search after the edit showed no remaining references to the removed production helper or its constants inside `apps/ui/src`. The only surviving `escapeHtml()` match in repo-owned frontend code is the unrelated local helper in `apps/ui/tests/dom_render_test_support.ts`, which is expected and unchanged. The other matches came from vendored code under `apps/ui/node_modules`, which is not part of the application source.

`npm run typecheck`, `npm run build`, and `npm run lint` all completed successfully. The lint run still emits the same pre-existing Biome schema-version info message already present on `main`; no new lint failures were introduced by this change.

## Risks and tradeoffs

The main risk with a dead-export cleanup is misclassifying “unused” as “not imported in obvious places” when some indirect caller still relies on it. That is why I verified usage with a repo search before touching the file and kept the deletion scoped to the exact local symbols that search proved dead.

Another possible risk would have been overreaching into the test helper because it shares the same function name. I explicitly did not do that. The test helper is a local serializer for the fake DOM harness and has different ownership, different call sites, and a real current purpose. Folding that into this PR would have expanded a simple dead-code removal into a broader and less certain cleanup.

The tradeoff here is that the diff is intentionally very small. There are broader utility-consolidation and frontend-cleanup issues in the backlog, but those belong to their own scoped tickets. For #2381, the cleanest result is a one-file deletion, not a larger refactor justified only by adjacency.

## Out of scope

The following were deliberately left untouched:

- the local `escapeHtml()` helper in `apps/ui/tests/dom_render_test_support.ts`
- any broader formatting utility consolidation
- any legacy helper cleanup outside the specific dead export named in the issue
- any frontend behavior, rendering, or styling changes

Those can be handled under their own issues if they are still useful follow-up work. This PR resolves only the confirmed dead export in `apps/ui/src/format.ts`.
