### PR TITLE
Remove unused DOM query helpers

### DIFF
--- a/apps/ui/src/app/dom/dom_query.ts
+++ b/apps/ui/src/app/dom/dom_query.ts
@@ -13,16 +13,3 @@ export function requiredById<T extends HTMLElement>(id: string, owner: string): 
 export function queryOne<T extends Element>(selector: string): T | null {
   return document.querySelector<T>(selector);
 }
-
-export function queryRequired<T extends Element>(selector: string, owner: string): T {
-  return queryOne<T>(selector) ?? missingElement(owner, selector);
-}
-
-export function queryAll<T extends Element>(selector: string): T[] {
-  return Array.from(document.querySelectorAll<T>(selector));
-}
-
-export function queryRequiredAll<T extends Element>(selector: string, owner: string): T[] {
-  const elements = queryAll<T>(selector);
-  return elements.length ? elements : missingElement(owner, selector);
-}


### PR DESCRIPTION
## Summary

Closes #2382.

This PR removes three dead DOM query helpers from `apps/ui/src/app/dom/dom_query.ts`: `queryAll`, `queryRequiredAll`, and `queryRequired`. The current UI codebase only imports `requiredById` and `queryOne` from that module, so these extra exports were adding unused surface area without serving any runtime path, test path, or composition boundary. The change is intentionally narrow: it deletes only the confirmed-dead helpers and leaves the still-used `getById`, `requiredById`, and `queryOne` APIs intact.

## Problem

Issue #2382 called out a small but real cleanup target in the shared DOM query helper module. `dom_query.ts` had grown to expose several convenience functions for querying single and multiple elements, but the live app no longer depended on the full set. Carrying dead exports has a few costs even when the code is tiny. It widens the apparent supported helper surface for future contributors, makes audits of shared infrastructure slightly noisier, and leaves behind extra paths that can drift from the project’s actual runtime patterns. In this case the issue body already suspected that only `getById`, `requiredById`, and `queryOne` were still alive, so the first step was to prove that claim against the current tree rather than deleting on assumption.

## Implementation approach

The approach here was deliberately conservative: confirm the blast radius first, then apply the smallest possible deletion. I searched the frontend source tree for all of the relevant symbols—`queryAll`, `queryRequiredAll`, `queryRequired`, `queryOne`, `requiredById`, and `getById`—and compared that result against the issue’s expectation. That search showed that `queryAll`, `queryRequiredAll`, and `queryRequired` were referenced only inside `dom_query.ts` itself. No runtime feature, shell module, panel bootstrap path, or test harness imported them. The live consumers were exactly the three call sites mentioned in the issue: `ui_panel_host_registry.ts` and `ui_shell_chrome.tsx` use `requiredById`, while `ui_shell_controller.ts` uses `queryOne`.

With that confirmed, the right fix was not a refactor or a replacement helper. It was simply to remove the dead exports and stop advertising them as part of the module’s public surface.

## Main code changes

The code change is intentionally contained to one file:

- `apps/ui/src/app/dom/dom_query.ts`

Inside that module, I deleted:

- `queryRequired()`
- `queryAll()`
- `queryRequiredAll()`

Nothing else in the module changed. The remaining helpers still do the same work they did before:

- `getById()` returns a nullable element lookup by id
- `requiredById()` throws through `missingElement()` when a required host is missing
- `queryOne()` returns a nullable `document.querySelector()` result

That means the module now matches the codebase’s real usage pattern: simple one-element queries for required mount roots and the occasional optional single-node query. There is no new helper abstraction, no renamed API, and no caller churn because there were no callers to update for the removed exports.

## Why this shape is better

The main benefit is clarity. `dom_query.ts` is a shared utility module in the app runtime area, so its exported surface sends a signal about what kinds of DOM access patterns are considered normal in the current frontend architecture. After the Preact island migration and the follow-up signal/state cleanup work, the codebase has been moving away from broad imperative DOM traversal and toward narrow, typed ownership seams. Leaving unused multi-element and required-selector helpers in place suggested that broader query patterns were still part of the intended toolkit when they no longer are.

By deleting only the dead exports, the module now better reflects current practice: find a known mount point or a single known optional wrapper, then let the owning runtime/view layer manage the rest. This keeps the utility surface easier to understand and reduces the chance that future work reaches for an obsolete helper just because it still exists.

## Contracts, docs, and tests

There are no schema, generated-contract, config, or user-facing documentation changes in this PR. The issue is an internal code-surface cleanup inside the frontend app runtime, so nothing in backend contracts, saved payloads, or device behavior changes.

I also did not add new tests for this change. The removed functions were dead exports with no callers, so there was no runtime behavior to preserve through new assertions. Instead, the meaningful verification was:

1. prove the helpers were truly unused before removal, and
2. rerun the existing frontend validation path after the deletion.

If a hidden live import had existed, TypeScript or the build would have failed immediately after the export removal.

## Validation performed

Local validation was focused on the actual risk profile of the change:

1. A repo search confirmed there were no remaining frontend source references to `queryAll`, `queryRequiredAll`, or `queryRequired` after the deletion.
2. `cd apps/ui && npm run typecheck`
3. `cd apps/ui && npm run build`
4. `cd apps/ui && npm run lint`

That sequence passed on the issue branch. The lint run still reports the same pre-existing Biome schema-version info message that has shown up in prior frontend-only changes, but there were no new lint errors or warnings introduced by this PR.

## Risks, tradeoffs, and edge cases

Risk is low because the diff only removes unused exports and does not change any behavior that is currently reachable from the application. The main failure mode would have been an overlooked import in a less obvious source file, test, or runtime edge path. That is why the symbol search came before the edit and why the build/typecheck path was rerun afterward.

There is a mild tradeoff in removing helpers that could be convenient in the future: if a later change truly needs multi-element query helpers again, someone will have to reintroduce them. That is an acceptable tradeoff here. The repo’s current cleanup direction is to keep one canonical path and delete dead utility surface rather than preserving speculative helpers “just in case.” If future code needs those capabilities, it can add them back in the shape that best matches the then-current architecture rather than inheriting stale leftovers.

## Out of scope

This PR does not attempt any broader DOM helper redesign. It does not rename the remaining exports, move the module, replace direct `document` access with another abstraction, or touch unrelated helper files. It also does not sweep for every possibly dead frontend utility in adjacent modules. The issue was specifically about three unused exports in `dom_query.ts`, and the implemented change stays tightly scoped to that problem.
