### PR TITLE
Remove dead h imports from JSX files

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -1,4 +1,4 @@
-import { Component, h, render, type ComponentChildren, type JSX } from "preact";
+import { Component, render, type ComponentChildren, type JSX } from "preact";
 
 import { requiredById } from "../dom/dom_query";
 import {

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -1,4 +1,4 @@
-import { h, render } from "preact";
+import { render } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 
 import { useUiText } from "../ui_i18n";

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -1,4 +1,4 @@
-import { h, render, type ComponentChildren } from "preact";
+import { render, type ComponentChildren } from "preact";
 import { useRef } from "preact/hooks";
 
 import type { UpdateStartRequestPayload } from "../../transport/http_models";

--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -1,4 +1,4 @@
-import { h, render } from "preact";
+import { render } from "preact";
 
 import type { DisplayedSpeedSourceMode } from "../speed_source_state";
 import type { ChoiceCardState } from "../view_style_types";

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -1,4 +1,4 @@
-import { h, render, type ComponentChildren } from "preact";
+import { render, type ComponentChildren } from "preact";
 
 import { useUiText } from "../ui_i18n";
 import {


### PR DESCRIPTION
## Summary

Closes #2383.

This PR removes unnecessary explicit `h` imports from files that use JSX under the automatic Preact JSX runtime. The cleanup touches five modules:

- `apps/ui/src/app/views/esp_flash_panel.tsx`
- `apps/ui/src/app/views/speed_source_panel.tsx`
- `apps/ui/src/app/views/update_panel.tsx`
- `apps/ui/src/app/views/internet_panel.tsx`
- `apps/ui/src/app/runtime/ui_shell_chrome.tsx`

The change is intentionally narrow. One file listed in the issue, `apps/ui/src/app/views/maintenance_readiness_view.ts`, still uses direct `h(...)` factory calls inside a plain `.ts` module, so its import remains in place. This PR removes only the imports that are actually dead today.

## Problem

The current UI build is already configured for the automatic JSX transform. `apps/ui/tsconfig.json` sets `jsx` to `react-jsx` and `jsxImportSource` to `preact`, while `apps/ui/vite.config.ts` uses `@preact/preset-vite`. In that configuration, JSX expressions do not require a manually imported `h` symbol in scope. Even so, several Preact view modules still carried `h` in their import lists from older transform conventions.

That is a small issue, but it is still worth cleaning up. Dead imports widen the apparent dependencies of a module, create noise when scanning the live architecture, and make it harder to tell whether a file is using JSX, direct vnode factory calls, or both. Since this repository has been steadily simplifying post-migration frontend seams, leaving obsolete JSX-era imports behind would keep the code looking more coupled to the old transform model than it really is.

## Scope and approach

The important part of this issue was not the edit itself; it was confirming which imports were truly dead and which ones were not. I started by checking the current runtime configuration rather than assuming the automatic transform was still enabled. That meant reading both `apps/ui/tsconfig.json` and `apps/ui/vite.config.ts` to confirm the `react-jsx` + `jsxImportSource: preact` path is still the active build model for this app.

From there I searched the frontend source tree for `import { ... h ... } from "preact"` and then checked whether those files actually reference `h` anywhere outside the import. That confirmed the five `.tsx` files above had dead `h` imports, but it also surfaced one important exception: `maintenance_readiness_view.ts` is not a JSX file at all. It still constructs its DOM through explicit `h(...)` calls, so its import is live. That made the issue body partly stale, and the smallest complete fix was to remove only the dead imports rather than broadening the task into a JSX conversion for that separate module.

## Main code changes

All code changes are single-line import edits. In each of the five JSX files, the `h` binding was removed from the `preact` import while leaving the still-used symbols in place:

- `render` remains in the panel and shell modules that still mount their islands directly
- `Component`, `ComponentChildren`, and `JSX` remain where they are still needed for types or class-based shell structure

There are no changes to render logic, props, event handling, signals, DOM ownership, or runtime behavior. This is not a panel/view refactor. It is a cleanup of import lists so they match the code that actually runs.

Just as importantly, there is one deliberate non-change:

- `apps/ui/src/app/views/maintenance_readiness_view.ts` still imports `h`

That file continues to use direct `h(...)` calls throughout its render helpers, so removing the import there would be incorrect. Converting that module to JSX could be reasonable in a different issue, but it is outside the narrow cleanup requested here.

## Why this version is correct

The value in this PR is precision. A naive implementation of the issue could have removed every listed `h` import mechanically, including the one in `maintenance_readiness_view.ts`, and then either broken the build or forced a broader rewrite than the issue actually called for. Instead, this change keeps the repository aligned with its “smallest complete fix” rule.

The resulting state is also clearer for future contributors. After this PR, the remaining `h` import in app code communicates something real: that the file is using direct factory calls rather than relying on JSX transformation. The JSX files, by contrast, now look the way the current toolchain expects them to look. That makes the distinction between automatic-transform JSX modules and explicit vnode-factory modules visible directly from the imports, which is useful when navigating a codebase that still contains a mix of both patterns.

## Contracts, docs, and tests

There are no backend contracts, transport payloads, configuration defaults, generated files, or user-facing behavior changes in this PR. This is an internal frontend code-surface cleanup only.

I also did not add new tests. The affected files only lost unused imports; none of their runtime logic changed. In a case like this, the meaningful proof is not a new behavioral assertion but a combination of targeted source inspection plus the existing type/build/lint pipeline. If any touched file still depended on `h`, TypeScript and the build would fail immediately once the import disappeared.

No documentation updates were needed either. The automatic JSX runtime is already represented in the live config, and this PR simply makes a handful of files consistent with that existing setup.

## Validation performed

Validation focused on proving the intended end state rather than inflating the test surface:

1. A scoped frontend search for `import { ... h ... } from "preact"` now reports only `apps/ui/src/app/views/maintenance_readiness_view.ts`, which is the expected remaining live import.
2. `cd apps/ui && npm run typecheck`
3. `cd apps/ui && npm run build`
4. `cd apps/ui && npm run lint`

That validation passed on the issue branch. The lint output still includes the same pre-existing Biome schema-version info message that has appeared on the other recent frontend-only issues, but there were no new lint problems introduced by this cleanup.

## Risks, tradeoffs, and edge cases

Risk is very low because the diff only removes imports that were proven unused in the touched JSX files. The only meaningful edge case was the stale issue-file list: one listed module was not actually a dead-import case. Treating that carefully was the main correctness concern in this change.

The tradeoff here is that the codebase still contains one direct `h(...)`-based rendering module afterward. That is acceptable. The goal of this issue is not to force uniform JSX syntax everywhere; it is to remove unnecessary explicit `h` imports where the automatic runtime already makes them redundant. Leaving the still-live `maintenance_readiness_view.ts` import in place preserves correctness and avoids turning a cleanup issue into an unrelated view rewrite.

## Out of scope

This PR does not convert `maintenance_readiness_view.ts` to JSX, rename files, alter panel ownership, or perform a larger sweep for every Preact import style choice in the repository. It also does not touch files outside the five confirmed dead-import cases. The change stays tightly scoped to the redundant `h` imports that are actually unnecessary under the current frontend runtime.
