### PR TITLE
Use functional shell view hosts

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -1,4 +1,4 @@
-import { Component, render, type ComponentChildren, type JSX } from "preact";
+import { render, type ComponentChildren, type JSX } from "preact";
 
 import { requiredById } from "../dom/dom_query";
 import {
@@ -183,40 +183,22 @@ function SettingsFeedbackSlot(props: {
   );
 }
 
-class DashboardViewHosts extends Component {
-  override shouldComponentUpdate(): boolean {
-    return false;
-  }
-
-  override render() {
-    return (
-      <div class="dashboard-grid">
-        <div id="liveOverviewRoot" class="panel card dashboard-grid__overview"></div>
-        <div id="spectrumPanelRoot" class="panel card dashboard-grid__main"></div>
-        <div id="loggingPanelRoot" class="panel card dashboard-grid__controls"></div>
-      </div>
-    );
-  }
+function DashboardViewHosts() {
+  return (
+    <div class="dashboard-grid">
+      <div id="liveOverviewRoot" class="panel card dashboard-grid__overview"></div>
+      <div id="spectrumPanelRoot" class="panel card dashboard-grid__main"></div>
+      <div id="loggingPanelRoot" class="panel card dashboard-grid__controls"></div>
+    </div>
+  );
 }
 
-class HistoryViewHosts extends Component {
-  override shouldComponentUpdate(): boolean {
-    return false;
-  }
-
-  override render() {
-    return <div id="historyPanelRoot" class="panel card"></div>;
-  }
+function HistoryViewHosts() {
+  return <div id="historyPanelRoot" class="panel card"></div>;
 }
 
-class SettingsViewHosts extends Component {
-  override shouldComponentUpdate(): boolean {
-    return false;
-  }
-
-  override render() {
-    return <div id="settingsShellRoot"></div>;
-  }
+function SettingsViewHosts() {
+  return <div id="settingsShellRoot"></div>;
 }
 
 function ShellViewSection(props: ShellViewSectionProps) {


### PR DESCRIPTION
## Summary

Closes #2384.

This PR converts the three static shell host wrappers in `apps/ui/src/app/runtime/ui_shell_chrome.tsx` from class components into plain function components:

- `DashboardViewHosts`
- `HistoryViewHosts`
- `SettingsViewHosts`

These wrappers only render static mount-host markup and previously existed as `Component` subclasses solely so `shouldComponentUpdate()` could return `false`. The functional rewrite removes that class-only scaffolding and also deletes the now-unused `Component` import from the shell runtime module.

## Problem

After the earlier shell/container work, `ui_shell_chrome.tsx` still carried three small class components whose only special behavior was opting out of rerendering. Each class returned fixed markup for the shell-owned panel host containers, and none of them accepted props, managed local lifecycle, or owned state. That made them a poor fit for the rest of the file, which is otherwise written in straightforward JSX and signal-backed function components.

Leaving those wrappers as classes had two drawbacks. First, it preserved an older Preact pattern that no longer matched the surrounding architecture. Second, it kept `Component` in the shell runtime import surface purely for the sake of three static wrappers, which made the file look more class-oriented than it really is. The issue correctly identified this residue and suggested replacing it with a more idiomatic functional shape.

## Scope and approach

The first step was to verify that the issue was still accurate after the recent frontend changes. A code search confirmed that all three `*ViewHosts` types still live together in `ui_shell_chrome.tsx`, and the file inspection showed that the issue description remained current: the classes only override `shouldComponentUpdate()` to return `false`, then return static host markup from `render()`.

The question was not whether they should remain classes; it was which functional replacement made the most sense in this repo. The issue suggested either `memo()`-wrapped functions or simple function components. I tested the `memo()` path first because it is the closest semantic match to the old “never rerender” intent. That immediately exposed a real compatibility constraint in this codebase: the current `preact` entrypoint used here does not export `memo`, so the build failed when I followed that suggestion literally.

At that point, the right move was not to pull in `preact/compat` just to preserve one optimization hint around static markup. The issue already allowed the simpler fallback, and this repository does not otherwise use `preact/compat` in the frontend app. So the final implementation uses plain function components, which keeps the change aligned with the existing dependency surface and still removes the class-only scaffolding the issue is targeting.

## Main code changes

All code changes are contained to one file:

- `apps/ui/src/app/runtime/ui_shell_chrome.tsx`

Within that file, the three class wrappers were rewritten as plain function components:

- `DashboardViewHosts()` now returns the dashboard grid host structure directly
- `HistoryViewHosts()` now returns the history panel host directly
- `SettingsViewHosts()` now returns the settings shell host directly

The functions preserve the exact same host ids and class names as before:

- `liveOverviewRoot`
- `spectrumPanelRoot`
- `loggingPanelRoot`
- `historyPanelRoot`
- `settingsShellRoot`

No caller changes were needed because the JSX usage sites already render these wrappers like ordinary components. After the rewrite, the stale `Component` import became dead and was removed from the file header.

## Why this shape is better

The improvement here is mostly structural clarity. `ui_shell_chrome.tsx` is the shell runtime’s Preact-owned rendering module, and the rest of the file already expresses its UI through simple JSX functions and signal-derived values. These three class wrappers were no longer carrying their own weight in that environment. Converting them to functions makes the file read more consistently and removes a legacy class-based seam that did not provide business logic, lifecycle management, or shared abstraction value.

Using plain functions instead of adding `preact/compat` is also intentional. Pulling in compat machinery for one static-host case would widen the runtime surface more than the issue warrants. The current solution keeps the dependency model flat: use the repo’s existing Preact entrypoint, express static markup as plain functions, and avoid adding new compatibility imports for a cleanup that does not need them.

## Validation and the implementation adjustment

This PR had one notable iteration during validation. The first implementation used `memo()`, which mirrored the issue’s primary suggestion. That did not survive the build:

- Vite/Rolldown reported that `"memo" is not exported by "node_modules/preact/dist/preact.module.js"`

That was a real build failure, not a theoretical concern, and it is the reason the final change set uses simple function components instead. After switching to plain functions, the same validation slice passed cleanly.

Validation for the final diff covered both the shell logic slice and the rendered bootstrap path:

1. `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts --workers=1`
2. `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
3. `cd apps/ui && npm run typecheck`
4. `cd apps/ui && npm run build`
5. `cd apps/ui && npm run lint`

That mix was intentional. The targeted shell module suite covers the runtime wiring around shell state, while the bootstrap smoke confirms the shell-owned view container structure still mounts and behaves correctly in the browser. The type/build/lint pass then verifies the repository-wide frontend integration for the touched file. Lint still reports only the same pre-existing Biome schema-version info message and no new issues from this PR.

## Risks, tradeoffs, and edge cases

Risk is low because the host markup itself did not change. The ids and classes that downstream panel mounting depends on are preserved exactly, and the usage sites remain the same.

The main tradeoff is performance semantics versus dependency simplicity. The old class components explicitly blocked rerenders, while the new plain functions may be re-invoked when the parent shell rerenders. In this specific case that is acceptable: the wrappers return tiny static host markup, and preserving the exact old “never rerender” behavior would have required either unsupported imports or additional compatibility surface that is not otherwise used in the app. The issue itself allowed the simple function fallback, and that is the more maintainable choice for this repository as it stands today.

## Out of scope

This PR does not alter shell navigation behavior, panel mounting order, shell signals, or view visibility rules. It does not rename any host ids, move the host markup to another module, or convert unrelated shell helpers in the same file. It also does not introduce `preact/compat` or other memoization utilities. The change stays tightly scoped to replacing the three legacy class host wrappers with simpler function components that fit the current shell rendering style.
