### PR TITLE
Drop dead SpectrumChart legend method

### DIFF
--- a/apps/ui/src/spectrum.ts
+++ b/apps/ui/src/spectrum.ts
@@ -129,22 +129,6 @@ export class SpectrumChart {
     return this.plot ? this.plot.series.length : 0;
   }
 
-  renderLegend(legendEl: HTMLElement, seriesMeta: SpectrumSeriesMeta[]): void {
-    legendEl.replaceChildren();
-    for (const item of seriesMeta) {
-      const row = document.createElement("div");
-      row.className = "legend-item";
-      const swatch = document.createElement("span");
-      swatch.className = "swatch";
-      swatch.style.setProperty("--swatch-color", item.color);
-      const labelSpan = document.createElement("span");
-      labelSpan.textContent = item.label;
-      row.appendChild(swatch);
-      row.appendChild(labelSpan);
-      legendEl.appendChild(row);
-    }
-  }
-
   destroy(): void {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();


### PR DESCRIPTION
## Summary

Closes #2385.

This PR removes the dead imperative `SpectrumChart.renderLegend()` method from `apps/ui/src/spectrum.ts`. The current UI already renders both the sensor legend and the band legend declaratively inside `apps/ui/src/app/views/spectrum_panel.tsx`, so the old DOM-building method was no longer part of any live path. Rather than introducing a second Preact legend layer, this change deletes the obsolete imperative helper and leaves the existing declarative spectrum legend as the single canonical rendering path.

## Problem

Issue #2385 correctly identified an architectural smell in isolation: `SpectrumChart.renderLegend()` imperatively created DOM nodes with `document.createElement`, `.appendChild`, `.replaceChildren`, `.textContent`, and inline style writes. That pattern does not match the direction of the rest of the frontend, which has been moving rendering ownership into Preact components and signal-backed state.

The important detail was whether that method still mattered. In the current codebase, the answer is no. The spectrum panel already owns legend rendering declaratively in `spectrum_panel.tsx`, where band legend and sensor legend content are rendered directly from signal-backed models. Leaving the old imperative method in `SpectrumChart` created the impression that there were still two competing legend rendering models in play when, in practice, only the Preact-owned one remained live.

That kind of stale rendering seam is worth deleting because it obscures the real architecture. Future contributors reading `spectrum.ts` could reasonably assume there is still a chart-owned legend path to maintain, even though the runtime no longer calls it.

## Scope and approach

The first step was to verify whether the issue body matched the current runtime. I searched the UI source tree for legend-related code and then specifically for `renderLegend()` call sites. That investigation showed three important facts:

1. `SpectrumChart.renderLegend()` still existed in `apps/ui/src/spectrum.ts`
2. the actual visible legend UI already lives in `apps/ui/src/app/views/spectrum_panel.tsx`
3. there were no callers for `renderLegend()` anywhere under `apps/ui/src/**`

That changed the implementation strategy immediately. The issue suggested replacing the imperative method with a Preact component, but the repo already has that Preact component path in place. Building another declarative legend wrapper on top of a dead method would have been redundant and would have preserved duplicate concepts instead of collapsing them. The smallest complete fix, and the one that best matches the repository’s “one canonical path” rule, was to delete the unused imperative method outright.

## Main code changes

All code changes are contained to one file:

- `apps/ui/src/spectrum.ts`

Inside `SpectrumChart`, the following method was removed:

- `renderLegend(legendEl: HTMLElement, seriesMeta: SpectrumSeriesMeta[]): void`

That method previously:

- cleared a legend container with `replaceChildren()`
- created legend row elements imperatively
- appended swatch and label children
- applied swatch color through inline DOM style mutation

None of the chart setup, data updates, isolation logic, resize handling, or destruction paths changed. The public chart behavior that is still exercised by the runtime remains the same:

- `ensurePlot()`
- `setData()`
- `setSeriesIsolation()`
- `resize()`
- `getSeriesCount()`
- `destroy()`

So the diff is intentionally a subtraction-only cleanup. It removes obsolete functionality without changing the live chart API that the renderer/controller still use.

## Why deleting is better than replacing

The key design choice in this PR is deletion instead of conversion. The issue’s broader goal—get legend rendering out of imperative DOM code and into Preact—has already been achieved elsewhere in the stack. `spectrum_panel.tsx` now owns both legend surfaces declaratively, and `spectrum_interaction_controller.ts` pushes legend models into that panel view. That is the architecture the runtime is actually using today.

Once that is true, keeping `SpectrumChart.renderLegend()` around does not provide a compatibility layer or a second active rendering mode. It only preserves dead code. Deleting it improves clarity by making the chart class responsible only for chart mechanics and leaving legend rendering to the existing view layer that already owns it.

This also keeps the code aligned with the rest of the recent cleanup work: when an internal fallback or legacy seam is no longer consumed, remove it instead of preserving a parallel path “just in case.”

## Validation performed

Validation focused on proving both halves of the change:

1. the method really was unused before removal, and
2. the spectrum runtime still behaves correctly after deleting it.

The validation sequence was:

1. a scoped source search proving there are no remaining `renderLegend()` references under `apps/ui/src`
2. `cd apps/ui && npx playwright test tests/spectrum_canvas_renderer.spec.ts --workers=1`
3. `cd apps/ui && npm run typecheck`
4. `cd apps/ui && npm run build`
5. `cd apps/ui && npm run lint`

That passed on the issue branch. The targeted spectrum renderer test is especially relevant here because it exercises the chart/renderer side of the spectrum stack that still consumes `SpectrumChart`. If removing the method had exposed a hidden dependency or a stale interface assumption, that slice would have been one of the first places to fail. The lint run still reports only the same pre-existing Biome schema-version info message and no new issues from this PR.

## Risks, tradeoffs, and edge cases

Risk is low because the removed method had no callers. The meaningful failure mode would have been an overlooked reference in a runtime or test path that the initial search missed. That is why the change paired the caller search with type/build/test validation afterward.

The main edge case here is conceptual rather than technical: the issue description reads like a replacement task, but the live code has already moved past that step. Treating the issue as written without checking current ownership boundaries could have led to needless new code or a duplicated Preact legend abstraction layered on top of a path that is already declarative. The final implementation avoids that trap by aligning the fix with current reality instead of with the older snapshot reflected in the issue body.

There is no meaningful tradeoff in keeping the dead method for future reuse. If legend rendering ever needed to move back into the chart class—which does not appear desirable given the current architecture—it would be cleaner to reintroduce a purpose-built implementation at that time than to preserve an uncalled DOM-mutation helper indefinitely.

## Out of scope

This PR does not change the live spectrum legend UI, the `spectrum_panel.tsx` component structure, the interaction controller’s legend models, the chart library integration, or the spectrum band plugin behavior. It does not add a new Preact legend component because the repo already has one. The change stays tightly scoped to removing the dead imperative `renderLegend()` leftover from `SpectrumChart` now that the declarative panel-owned legend path is the only one in use.
