### PR TITLE
Add effect cleanup for realtime elapsed timer

### DIFF
--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -46,6 +46,12 @@ export interface RealtimeFeatureViewState {
   readonly sensorsPanelModel: ReadonlySignal<SensorsPanelRenderModel>;
 }
 
+interface LoggingElapsedTickInputs {
+  handlersBound: boolean;
+  loggingEnabled: boolean;
+  loggingStartTimeUtc: string | null;
+}
+
 function formatElapsed(
   startTimeUtc: string | null | undefined,
   nowMs: number,
@@ -148,6 +154,11 @@ export function createRealtimeFeatureViewState(
   });
   const elapsedNowMs = signal(Date.now());
   const lastCompletedElapsedText = signal("--");
+  const loggingElapsedTickInputs = signal<LoggingElapsedTickInputs>({
+    handlersBound: workflow.handlersBound.value,
+    loggingEnabled: realtime.loggingStatus.enabled,
+    loggingStartTimeUtc: realtime.loggingStatus.start_time_utc ?? null,
+  });
   let loggingElapsedTimer: ReturnType<typeof setInterval> | null = null;
 
   function clearLoggingElapsedTimer(): void {
@@ -159,23 +170,44 @@ export function createRealtimeFeatureViewState(
   }
 
   effect(() => {
+    const handlersBound = workflow.handlersBound.value;
     trackAppStateSlice(realtime);
+    const nextTickInputs = {
+      handlersBound,
+      loggingEnabled: realtime.loggingStatus.enabled,
+      loggingStartTimeUtc: realtime.loggingStatus.start_time_utc ?? null,
+    } satisfies LoggingElapsedTickInputs;
+    const currentTickInputs = loggingElapsedTickInputs.value;
+    if (
+      currentTickInputs.handlersBound === nextTickInputs.handlersBound
+      && currentTickInputs.loggingEnabled === nextTickInputs.loggingEnabled
+      && currentTickInputs.loggingStartTimeUtc === nextTickInputs.loggingStartTimeUtc
+    ) {
+      return;
+    }
+    loggingElapsedTickInputs.value = nextTickInputs;
+  });
+
+  effect(() => {
+    const {
+      handlersBound,
+      loggingEnabled,
+      loggingStartTimeUtc,
+    } = loggingElapsedTickInputs.value;
     const shouldTick =
-      workflow.handlersBound.value
-      && Boolean(
-        realtime.loggingStatus.enabled && realtime.loggingStatus.start_time_utc,
-      );
+      handlersBound && Boolean(loggingEnabled && loggingStartTimeUtc);
     if (!shouldTick) {
       clearLoggingElapsedTimer();
       return;
     }
     elapsedNowMs.value = Date.now();
-    if (loggingElapsedTimer !== null) {
-      return;
-    }
+    clearLoggingElapsedTimer();
     loggingElapsedTimer = setInterval(() => {
       elapsedNowMs.value = Date.now();
     }, 1_000);
+    return () => {
+      clearLoggingElapsedTimer();
+    };
   });
 
   effect(() => {

--- a/apps/ui/tests/realtime_feature_view_state.spec.ts
+++ b/apps/ui/tests/realtime_feature_view_state.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "@playwright/test";
+
+import { createRealtimeFeatureViewState } from "../src/app/features/realtime_feature_view_state";
+import { createRealtimeFeatureWorkflowState } from "../src/app/features/realtime_feature_workflow";
+import { createAppState } from "../src/app/ui_app_state";
+
+test("realtime view state only re-arms its elapsed timer when logging tick inputs change", () => {
+  const state = createAppState();
+  const workflow = createRealtimeFeatureWorkflowState();
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+  const createdTimerIds: Array<ReturnType<typeof setInterval>> = [];
+  const activeTimerIds = new Set<ReturnType<typeof setInterval>>();
+  const clearedTimerIds: Array<ReturnType<typeof setInterval>> = [];
+
+  globalThis.setInterval = ((handler: TimerHandler, timeout?: number) => {
+    void handler;
+    void timeout;
+    const timerId = originalSetInterval(() => undefined, 60_000);
+    originalClearInterval(timerId);
+    createdTimerIds.push(timerId);
+    activeTimerIds.add(timerId);
+    return timerId;
+  }) as typeof setInterval;
+  globalThis.clearInterval = ((intervalId?: ReturnType<typeof setInterval>) => {
+    if (intervalId === undefined) {
+      return;
+    }
+    clearedTimerIds.push(intervalId);
+    activeTimerIds.delete(intervalId);
+  }) as typeof clearInterval;
+
+  try {
+    createRealtimeFeatureViewState({
+      state: {
+        realtime: state.realtime,
+        settings: state.settings,
+        shell: state.shell,
+        spectrum: state.spectrum,
+      },
+      services: {
+        t: (key) => key,
+      },
+      formatting: {
+        formatInt: (value) => String(value),
+      },
+      workflow,
+    });
+
+    expect(activeTimerIds.size).toBe(0);
+
+    workflow.handlersBound.value = true;
+    state.realtime.loggingStatus.enabled = true;
+    state.realtime.loggingStatus.start_time_utc = "2026-04-16T00:00:00Z";
+
+    expect(createdTimerIds).toHaveLength(1);
+    expect(Array.from(activeTimerIds)).toEqual([createdTimerIds[0]]);
+    expect(clearedTimerIds).toEqual([]);
+
+    state.realtime.selectedClientId = "sensor-1";
+
+    expect(createdTimerIds).toHaveLength(1);
+    expect(Array.from(activeTimerIds)).toEqual([createdTimerIds[0]]);
+    expect(clearedTimerIds).toEqual([]);
+
+    state.realtime.loggingStatus.start_time_utc = "2026-04-16T00:00:05Z";
+
+    expect(createdTimerIds).toHaveLength(2);
+    expect(Array.from(activeTimerIds)).toEqual([createdTimerIds[1]]);
+    expect(clearedTimerIds).toEqual([createdTimerIds[0]]);
+
+    state.realtime.loggingStatus.enabled = false;
+
+    expect(activeTimerIds.size).toBe(0);
+    expect(clearedTimerIds).toEqual([createdTimerIds[0], createdTimerIds[1]]);
+  } finally {
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+  }
+});


### PR DESCRIPTION
Closes #2387

## Summary

This PR fixes the realtime logging elapsed-timer effect in `apps/ui/src/app/features/realtime_feature_view_state.ts`. The previous implementation started a `setInterval()` while logging was active, but it never returned an effect cleanup callback. That meant the timer was only cleared when the effect itself noticed that logging had stopped. If the effect was torn down while logging was still active, the timer reference could outlive the effect and continue running unnecessarily. The issue report suggested adding a cleanup return directly to the existing effect, but this code path sits on top of the repo’s coarse AppState slice tracking, so a straight “return cleanup” patch would also have caused the interval to be recreated on unrelated realtime state writes.

The change here keeps the fix narrow while avoiding that churn. Instead of letting the timer-owning effect depend on the full realtime slice, the code now splits the concern into two steps. One effect still watches the coarse realtime slice and the `handlersBound` signal, but it only publishes a small derived input object when one of the three timer-driving values actually changes: whether handlers are bound, whether logging is enabled, and the current logging start timestamp. A second effect owns the timer lifecycle itself, reads only that derived input, updates `elapsedNowMs`, and returns `clearLoggingElapsedTimer()` as cleanup. That preserves the cleanup guarantee the issue asked for, while avoiding interval resets from unrelated realtime mutations such as client selection changes.

## Implementation details

The main production change is in `createRealtimeFeatureViewState()`. I added a small internal `LoggingElapsedTickInputs` shape plus a `loggingElapsedTickInputs` signal. That signal is initialized from the existing workflow and logging state, with `start_time_utc` normalized to `null` so the local helper state stays narrow and explicit even though the transport payload type allows `undefined`.

The first effect now keeps the existing `trackAppStateSlice(realtime)` call. That part is important in this codebase because AppState slices are reactive proxies with coarse invalidation at the slice level rather than automatic fine-grained subscriptions on nested properties. Simply reading `realtime.loggingStatus.enabled` and `realtime.loggingStatus.start_time_utc` directly would not have been enough to reliably resubscribe the effect. Instead, the effect tracks the slice, snapshots the three timer inputs, compares them against the current `loggingElapsedTickInputs.value`, and only writes a new signal value when one of those inputs actually changed.

The second effect is the timer owner. It reads `loggingElapsedTickInputs.value`, decides whether ticking should be active, and either clears the timer or starts it. The effect now returns cleanup through `clearLoggingElapsedTimer()` so the timer is torn down both when the inputs change and when the effect is disposed. I also left an explicit `clearLoggingElapsedTimer()` call immediately before creating the new interval. In practice the effect cleanup should already run before re-execution, but the extra clear makes the lifecycle obvious and prevents accidental orphaning if this logic is ever reshaped again.

Nothing else in the realtime view-model pipeline changed. The later effect that derives `lastCompletedElapsedText` still uses `trackAppStateSlice(realtime)` and still formats elapsed time from the same sources. There are no API, schema, or contract changes in this PR, and no UI copy or styling changes.

## Tests and validation

I added a focused regression test in `apps/ui/tests/realtime_feature_view_state.spec.ts`. That test creates a real `AppState`, real workflow signals, and the realtime view state, then temporarily stubs `setInterval()` and `clearInterval()` so it can observe timer ownership directly. The test covers four cases that matter for this fix:

1. No timer is created before logging becomes active.
2. Enabling logging with a start time arms exactly one timer.
3. An unrelated realtime update (`selectedClientId`) does not create or restart the timer.
4. Changing the logging start time re-arms the timer, and disabling logging clears it.

That last pair is important because it proves both halves of the intended behavior: the timer still responds when the real inputs change, but it no longer churns when the coarse realtime slice changes for unrelated reasons.

I also reran the browser-level realtime logging check in `tests/realtime_logging_summary.spec.ts` under the repo’s working local Playwright config. That covers the no-car realtime CTA and repeated websocket payload behavior around the same view state. Finally, I reran `tests/smoke.bootstrap.spec.ts` under the same config because that smoke flow exercises the logging summary and elapsed display in the full UI startup path.

Local validation performed for this PR:

- `cd apps/ui && npx playwright test tests/realtime_feature_view_state.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test tests/realtime_logging_summary.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

The only lint output remains the existing Biome schema-version info message already present in this checkout; there were no new lint errors from the change itself.

## Risks, tradeoffs, and scope

The main tradeoff here is that the fix introduces one extra local signal purely to isolate timer-driving inputs from the rest of the realtime slice. I chose that over the minimal one-effect patch because the repo’s AppState model is intentionally coarse. A single-effect cleanup return would technically satisfy the leak concern, but it would also make the timer effect recreate the interval whenever any realtime field changed during an active logging session. That is still functionally acceptable, but it is noisier than necessary on a hot path that receives frequent transport updates.

This PR does not attempt a broader rethink of realtime elapsed rendering, timer abstraction, or AppState granularity. It stays scoped to the issue: ensure the interval has a proper cleanup path and keep the realtime logging timer stable under the current reactive architecture.
