### PR TITLE
Split update status view models by concern

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -142,7 +142,9 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/settings_speed_source_presenter.ts` | Pure speed-source presenter that turns typed workflow state and live status payloads into panel and diagnostics render models |
 | `app/views/update_feature_presenter.ts` | Update presenter that derives typed update/internet panel models from workflow state plus draft form inputs and toggles |
 | `app/views/internet_status_view.ts` | Pure USB-internet status model builder reused by the Preact internet panel |
-| `app/views/update_status_view_models.ts` | Typed update-status section builders for current status, journey, issues, attempt history, health, and log cards |
+| `app/views/update_status_models.ts` | Shared update-status badge, row, and section interfaces consumed by the update and internet panels |
+| `app/views/update_journey_builder.ts` | Update journey and recovery-summary builders for phase formatting, staged progress, and retry guidance |
+| `app/views/update_status_builders.ts` | Typed update-status section builders for current status, issues, latest attempt, health, log, and full panel assembly |
 | `app/views/maintenance_readiness_view.ts` | Shared maintenance-readiness model and Preact component contract reused by update and ESP flash readiness flows |
 | `app/views/` | Focused render-model builders, event-target decoding, and signal-backed Preact surfaces for settings, cars wizard, realtime, history, and updater flows |
 | `app/features/realtime_feature_view_state.ts` | Signal-backed realtime view-state owner that derives live overview, logging, and sensors models plus idle readiness signatures without presenter render fan-out |

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -17,7 +17,7 @@ import type { InternetStatusPanelModel } from "./internet_status_view";
 import type {
   UpdateStatusBadgeModel,
   UpdateStatusRowModel,
-} from "./update_status_view_models";
+} from "./update_status_models";
 
 export interface UpdateTransportChoiceCardRenderModel {
   badgeText: string | null;

--- a/apps/ui/src/app/views/internet_status_view.ts
+++ b/apps/ui/src/app/views/internet_status_view.ts
@@ -2,7 +2,7 @@ import type { UsbInternetStatusPayload } from "../../transport/http_models";
 import type {
   UpdateStatusBadgeModel,
   UpdateStatusRowModel,
-} from "./update_status_view_models";
+} from "./update_status_models";
 
 export interface InternetStatusViewDeps {
   t: (key: string, vars?: Record<string, unknown>) => string;

--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -18,8 +18,10 @@ import type {
 } from "./update_panel";
 import {
   buildUpdateStatusPanelViewModel,
+} from "./update_status_builders";
+import {
   getUpdateFailureSummary,
-} from "./update_status_view_models";
+} from "./update_journey_builder";
 import {
   computed,
   effect,

--- a/apps/ui/src/app/views/update_journey_builder.ts
+++ b/apps/ui/src/app/views/update_journey_builder.ts
@@ -1,0 +1,245 @@
+import type {
+  UpdateIssue,
+  UpdateStatusPayload,
+} from "../../transport/http_models";
+import type {
+  JourneyStageState,
+  UpdateFailureSummary,
+  UpdateJourneyFailureNoteModel,
+  UpdateJourneySectionModel,
+  UpdateJourneyTransport,
+  UpdateStatusViewDeps,
+} from "./update_status_models";
+
+type UpdateJourneyStage = {
+  phase: string;
+  titleKey: string;
+  detailKey: string;
+};
+
+const WIFI_JOURNEY_STAGES: readonly UpdateJourneyStage[] = [
+  {
+    phase: "validating",
+    titleKey: "settings.update.phase.validating",
+    detailKey: "settings.update.journey.detail.validating",
+  },
+  {
+    phase: "stopping_hotspot",
+    titleKey: "settings.update.phase.stopping_hotspot",
+    detailKey: "settings.update.journey.detail.stopping_hotspot",
+  },
+  {
+    phase: "connecting_wifi",
+    titleKey: "settings.update.phase.connecting_wifi",
+    detailKey: "settings.update.journey.detail.connecting_wifi",
+  },
+  {
+    phase: "checking",
+    titleKey: "settings.update.phase.checking",
+    detailKey: "settings.update.journey.detail.checking",
+  },
+  {
+    phase: "downloading",
+    titleKey: "settings.update.phase.downloading",
+    detailKey: "settings.update.journey.detail.downloading",
+  },
+  {
+    phase: "installing",
+    titleKey: "settings.update.phase.installing",
+    detailKey: "settings.update.journey.detail.installing",
+  },
+  {
+    phase: "restoring_hotspot",
+    titleKey: "settings.update.phase.restoring_hotspot",
+    detailKey: "settings.update.journey.detail.restoring_hotspot",
+  },
+  {
+    phase: "done",
+    titleKey: "settings.update.phase.done",
+    detailKey: "settings.update.journey.detail.done",
+  },
+] as const;
+
+const USB_JOURNEY_STAGES: readonly UpdateJourneyStage[] = [
+  {
+    phase: "validating",
+    titleKey: "settings.update.phase.validating",
+    detailKey: "settings.update.journey.detail.validating",
+  },
+  {
+    phase: "connecting_usb_internet",
+    titleKey: "settings.update.phase.connecting_usb_internet",
+    detailKey: "settings.update.journey.detail.connecting_usb_internet",
+  },
+  {
+    phase: "checking",
+    titleKey: "settings.update.phase.checking",
+    detailKey: "settings.update.journey.detail.checking",
+  },
+  {
+    phase: "downloading",
+    titleKey: "settings.update.phase.downloading",
+    detailKey: "settings.update.journey.detail.downloading",
+  },
+  {
+    phase: "installing",
+    titleKey: "settings.update.phase.installing",
+    detailKey: "settings.update.journey.detail.installing",
+  },
+  {
+    phase: "done",
+    titleKey: "settings.update.phase.done",
+    detailKey: "settings.update.journey.detail.done",
+  },
+] as const;
+
+function translateKeyOrFallback(
+  key: string,
+  fallback: string,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): string {
+  const translated = t(key);
+  return translated === key ? fallback : translated;
+}
+
+function normalizeUpdatePhase(phase: string | null | undefined): string {
+  if (!phase) return "idle";
+  if (phase === "restore") return "restoring_hotspot";
+  return phase;
+}
+
+function journeyStages(transport: UpdateJourneyTransport): readonly UpdateJourneyStage[] {
+  return transport === "usb_internet" ? USB_JOURNEY_STAGES : WIFI_JOURNEY_STAGES;
+}
+
+function resolvedJourneyTransport(
+  status: UpdateStatusPayload,
+  selectedTransport: UpdateJourneyTransport,
+): UpdateJourneyTransport {
+  if (status.state === "idle") {
+    return selectedTransport;
+  }
+  return status.transport === "usb_internet" ? "usb_internet" : "wifi";
+}
+
+function journeyStageIndex(
+  phase: string | null | undefined,
+  stages: readonly UpdateJourneyStage[],
+): number {
+  const normalized = normalizeUpdatePhase(phase);
+  return stages.findIndex((stage) => stage.phase === normalized);
+}
+
+function resolveJourneyStageState(
+  status: UpdateStatusPayload,
+  stages: readonly UpdateJourneyStage[],
+  stageIndex: number,
+): JourneyStageState {
+  if (status.state === "success") return "done";
+  if (status.state === "idle") return "upcoming";
+  const currentIndex = journeyStageIndex(status.phase, stages);
+  if (currentIndex === -1) {
+    return "upcoming";
+  }
+  if (stageIndex < currentIndex) return "done";
+  if (stageIndex === currentIndex) {
+    return status.state === "failed" ? "attention" : "active";
+  }
+  return "upcoming";
+}
+
+function primaryJourneyIssue(status: UpdateStatusPayload): UpdateIssue | null {
+  const currentPhase = normalizeUpdatePhase(status.phase);
+  for (let index = status.issues.length - 1; index >= 0; index -= 1) {
+    const issue = status.issues[index];
+    if (normalizeUpdatePhase(issue.phase) === currentPhase) {
+      return issue;
+    }
+  }
+  return status.issues.length > 0 ? status.issues[status.issues.length - 1] : null;
+}
+
+function recoveryGuidanceKey(phase: string): string {
+  switch (normalizeUpdatePhase(phase)) {
+    case "stopping_hotspot":
+    case "connecting_wifi":
+    case "restoring_hotspot":
+      return "settings.update.recovery.wifi";
+    case "connecting_usb_internet":
+      return "settings.update.recovery.usb";
+    case "checking":
+    case "downloading":
+      return "settings.update.recovery.network";
+    case "installing":
+      return "settings.update.recovery.install";
+    default:
+      return "settings.update.recovery.generic";
+  }
+}
+
+function buildJourneyFailureNoteModel(
+  status: UpdateStatusPayload,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): UpdateJourneyFailureNoteModel | null {
+  const failure = getUpdateFailureSummary(status, t);
+  if (!failure) {
+    return null;
+  }
+  return {
+    summaryText: failure.message ? `${failure.phaseLabel} — ${failure.message}` : failure.phaseLabel,
+    detailText: failure.detail,
+    recoveryTitleText: failure.recoveryTitle,
+    recoveryDetailText: failure.recoveryDetail,
+  };
+}
+
+export function formatUpdatePhase(
+  phase: string | null | undefined,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): string {
+  const normalized = normalizeUpdatePhase(phase);
+  return translateKeyOrFallback(`settings.update.phase.${normalized}`, normalized, t);
+}
+
+export function getUpdateFailureSummary(
+  status: UpdateStatusPayload,
+  t: (key: string, vars?: Record<string, unknown>) => string,
+): UpdateFailureSummary | null {
+  if (status.state !== "failed") {
+    return null;
+  }
+  const issue = primaryJourneyIssue(status);
+  const phase = issue?.phase ?? status.phase;
+  const keyBase = recoveryGuidanceKey(phase);
+  return {
+    detail: issue?.detail ?? null,
+    message: issue?.message ?? null,
+    phaseLabel: formatUpdatePhase(phase, t),
+    recoveryTitle: t(`${keyBase}.title`),
+    recoveryDetail: t(`${keyBase}.detail`),
+  };
+}
+
+export function buildUpdateJourneySectionModel(
+  status: UpdateStatusPayload,
+  deps: UpdateStatusViewDeps,
+): UpdateJourneySectionModel {
+  const stages = journeyStages(resolvedJourneyTransport(status, deps.selectedTransport));
+  return {
+    titleText: deps.t("settings.update.journey_title"),
+    subtitleText: deps.t("settings.update.journey_intro"),
+    failureNote: buildJourneyFailureNoteModel(status, deps.t),
+    stages: stages.map((stage, index) => {
+      const state = resolveJourneyStageState(status, stages, index);
+      return {
+        phase: stage.phase,
+        titleText: deps.t(stage.titleKey),
+        detailText: deps.t(stage.detailKey),
+        markerText: state === "done" ? "✓" : `${index + 1}`,
+        state,
+        stateText: deps.t(`maintenance.stage_state.${state}`),
+        current: state === "active",
+      };
+    }),
+  };
+}

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -20,7 +20,7 @@ import type {
   UpdateStatusBadgeModel,
   UpdateStatusPanelViewModel,
   UpdateStatusRowModel,
-} from "./update_status_view_models";
+} from "./update_status_models";
 
 export interface UpdatePanelRenderModel {
   cancelButtonDisabled: boolean;

--- a/apps/ui/src/app/views/update_status_builders.ts
+++ b/apps/ui/src/app/views/update_status_builders.ts
@@ -1,10 +1,25 @@
 import type {
   HealthStatusPayload,
-  UpdateIssue,
-  UpdateStartRequestPayload,
   UpdateStatusPayload,
 } from "../../transport/http_models";
 import { formatEpochTimestamp } from "./dom_helpers";
+import {
+  buildUpdateJourneySectionModel,
+  formatUpdatePhase,
+  getUpdateFailureSummary,
+} from "./update_journey_builder";
+import type {
+  UpdateCurrentStatusSectionModel,
+  UpdateHealthSectionModel,
+  UpdateIssuesSectionModel,
+  UpdateLatestAttemptSectionModel,
+  UpdateLogSectionModel,
+  UpdateStatusBadgeModel,
+  UpdateStatusBadgeVariant,
+  UpdateStatusPanelViewModel,
+  UpdateStatusRowModel,
+  UpdateStatusViewDeps,
+} from "./update_status_models";
 
 const STATE_VARIANT: Readonly<Record<UpdateStatusPayload["state"], UpdateStatusBadgeVariant>> = {
   idle: "muted",
@@ -29,202 +44,6 @@ const HEALTH_REASON_KEYS: Readonly<Record<string, string>> = {
 };
 
 const ASSET_ISSUE_RE = /asset|artifacts|stale|hash|missing/i;
-
-type JourneyStageState = "upcoming" | "active" | "done" | "attention";
-type UpdateJourneyTransport = UpdateStartRequestPayload["transport"];
-
-export interface UpdateFailureSummary {
-  detail: string | null;
-  message: string | null;
-  phaseLabel: string;
-  recoveryDetail: string;
-  recoveryTitle: string;
-}
-
-type UpdateJourneyStage = {
-  phase: string;
-  titleKey: string;
-  detailKey: string;
-};
-
-const WIFI_JOURNEY_STAGES: readonly UpdateJourneyStage[] = [
-  {
-    phase: "validating",
-    titleKey: "settings.update.phase.validating",
-    detailKey: "settings.update.journey.detail.validating",
-  },
-  {
-    phase: "stopping_hotspot",
-    titleKey: "settings.update.phase.stopping_hotspot",
-    detailKey: "settings.update.journey.detail.stopping_hotspot",
-  },
-  {
-    phase: "connecting_wifi",
-    titleKey: "settings.update.phase.connecting_wifi",
-    detailKey: "settings.update.journey.detail.connecting_wifi",
-  },
-  {
-    phase: "checking",
-    titleKey: "settings.update.phase.checking",
-    detailKey: "settings.update.journey.detail.checking",
-  },
-  {
-    phase: "downloading",
-    titleKey: "settings.update.phase.downloading",
-    detailKey: "settings.update.journey.detail.downloading",
-  },
-  {
-    phase: "installing",
-    titleKey: "settings.update.phase.installing",
-    detailKey: "settings.update.journey.detail.installing",
-  },
-  {
-    phase: "restoring_hotspot",
-    titleKey: "settings.update.phase.restoring_hotspot",
-    detailKey: "settings.update.journey.detail.restoring_hotspot",
-  },
-  {
-    phase: "done",
-    titleKey: "settings.update.phase.done",
-    detailKey: "settings.update.journey.detail.done",
-  },
-] as const;
-
-const USB_JOURNEY_STAGES: readonly UpdateJourneyStage[] = [
-  {
-    phase: "validating",
-    titleKey: "settings.update.phase.validating",
-    detailKey: "settings.update.journey.detail.validating",
-  },
-  {
-    phase: "connecting_usb_internet",
-    titleKey: "settings.update.phase.connecting_usb_internet",
-    detailKey: "settings.update.journey.detail.connecting_usb_internet",
-  },
-  {
-    phase: "checking",
-    titleKey: "settings.update.phase.checking",
-    detailKey: "settings.update.journey.detail.checking",
-  },
-  {
-    phase: "downloading",
-    titleKey: "settings.update.phase.downloading",
-    detailKey: "settings.update.journey.detail.downloading",
-  },
-  {
-    phase: "installing",
-    titleKey: "settings.update.phase.installing",
-    detailKey: "settings.update.journey.detail.installing",
-  },
-  {
-    phase: "done",
-    titleKey: "settings.update.phase.done",
-    detailKey: "settings.update.journey.detail.done",
-  },
-] as const;
-
-export interface UpdateStatusViewDeps {
-  t: (key: string, vars?: Record<string, unknown>) => string;
-  selectedTransport: UpdateJourneyTransport;
-}
-
-export type UpdateStatusBadgeVariant = "muted" | "warn" | "ok" | "bad";
-
-export interface UpdateStatusBadgeModel {
-  variant: UpdateStatusBadgeVariant;
-  text: string;
-}
-
-export interface UpdateStatusRowModel {
-  labelText: string;
-  valueText: string;
-}
-
-export interface UpdateCurrentStatusSectionModel {
-  titleText: string;
-  summaryText: string;
-  badge: UpdateStatusBadgeModel;
-  rows: readonly UpdateStatusRowModel[];
-  emptyText: string | null;
-}
-
-export interface UpdateJourneyFailureNoteModel {
-  summaryText: string;
-  detailText: string | null;
-  recoveryTitleText: string;
-  recoveryDetailText: string;
-}
-
-export interface UpdateJourneyStageModel {
-  phase: string;
-  titleText: string;
-  detailText: string;
-  markerText: string;
-  state: JourneyStageState;
-  stateText: string;
-  current: boolean;
-}
-
-export interface UpdateJourneySectionModel {
-  titleText: string;
-  subtitleText: string;
-  failureNote: UpdateJourneyFailureNoteModel | null;
-  stages: readonly UpdateJourneyStageModel[];
-}
-
-export interface UpdateIssueSectionItemModel {
-  phaseText: string;
-  messageText: string;
-  detailText: string | null;
-}
-
-export interface UpdateIssuesSectionModel {
-  titleText: string;
-  subtitleText: string;
-  items: readonly UpdateIssueSectionItemModel[];
-}
-
-export interface UpdateLatestAttemptFailureNoteModel {
-  summaryText: string;
-  detailText: string | null;
-}
-
-export interface UpdateLatestAttemptSectionModel {
-  titleText: string;
-  subtitleText: string;
-  badge: UpdateStatusBadgeModel;
-  rows: readonly UpdateStatusRowModel[];
-  failureNote: UpdateLatestAttemptFailureNoteModel | null;
-}
-
-export interface UpdateHealthSectionModel {
-  titleText: string;
-  summaryText: string;
-  badge: UpdateStatusBadgeModel;
-  rows: readonly UpdateStatusRowModel[];
-}
-
-export interface UpdateLogEmptyStateModel {
-  titleText: string;
-  bodyText: string;
-}
-
-export interface UpdateLogSectionModel {
-  titleText: string;
-  subtitleText: string;
-  noteText: string | null;
-  lines: readonly string[];
-  emptyState: UpdateLogEmptyStateModel | null;
-}
-
-export interface UpdateStatusPanelViewModel {
-  currentStatus: UpdateCurrentStatusSectionModel;
-  journey: UpdateJourneySectionModel;
-  issues: UpdateIssuesSectionModel | null;
-  latestAttempt: UpdateLatestAttemptSectionModel | null;
-  health: UpdateHealthSectionModel;
-  log: UpdateLogSectionModel;
-}
 
 function formatDuration(seconds: number | null | undefined): string {
   if (seconds === null || seconds === undefined || !Number.isFinite(seconds)) return "—";
@@ -251,29 +70,6 @@ function formatHealthReason(
   }
   const key = HEALTH_REASON_KEYS[reason];
   return key ? t(key) : reason;
-}
-
-function translateKeyOrFallback(
-  key: string,
-  fallback: string,
-  t: (key: string, vars?: Record<string, unknown>) => string,
-): string {
-  const translated = t(key);
-  return translated === key ? fallback : translated;
-}
-
-function normalizeUpdatePhase(phase: string | null | undefined): string {
-  if (!phase) return "idle";
-  if (phase === "restore") return "restoring_hotspot";
-  return phase;
-}
-
-export function formatUpdatePhase(
-  phase: string | null | undefined,
-  t: (key: string, vars?: Record<string, unknown>) => string,
-): string {
-  const normalized = normalizeUpdatePhase(phase);
-  return translateKeyOrFallback(`settings.update.phase.${normalized}`, normalized, t);
 }
 
 function buildStateBadge(
@@ -433,224 +229,6 @@ function hasAssetRelatedIssue(status: UpdateStatusPayload): boolean {
   return status.issues.some((issue) => ASSET_ISSUE_RE.test(`${issue.message} ${issue.detail}`));
 }
 
-export function buildUpdateCurrentStatusSectionModel(
-  status: UpdateStatusPayload,
-  health: HealthStatusPayload,
-  deps: UpdateStatusViewDeps,
-): UpdateCurrentStatusSectionModel {
-  const showRuntimeAssetsCheck = status.state !== "failed" || hasAssetRelatedIssue(status);
-  const rows = [
-    ...buildLifecycleRows(status, deps.t),
-    ...buildRuntimeRows(status, showRuntimeAssetsCheck, deps.t),
-  ];
-  return {
-    titleText: deps.t("settings.update.current_status_title"),
-    summaryText: buildCurrentStatusSummaryText(status, health, deps.t),
-    badge: buildStateBadge(status, deps.t),
-    rows,
-    emptyText: rows.length > 0 ? null : deps.t("settings.update.current_status_empty"),
-  };
-}
-
-function journeyStages(transport: UpdateJourneyTransport): readonly UpdateJourneyStage[] {
-  return transport === "usb_internet" ? USB_JOURNEY_STAGES : WIFI_JOURNEY_STAGES;
-}
-
-function resolvedJourneyTransport(
-  status: UpdateStatusPayload,
-  selectedTransport: UpdateJourneyTransport,
-): UpdateJourneyTransport {
-  if (status.state === "idle") {
-    return selectedTransport;
-  }
-  return status.transport === "usb_internet" ? "usb_internet" : "wifi";
-}
-
-function journeyStageIndex(
-  phase: string | null | undefined,
-  stages: readonly UpdateJourneyStage[],
-): number {
-  const normalized = normalizeUpdatePhase(phase);
-  return stages.findIndex((stage) => stage.phase === normalized);
-}
-
-function resolveJourneyStageState(
-  status: UpdateStatusPayload,
-  stages: readonly UpdateJourneyStage[],
-  stageIndex: number,
-): JourneyStageState {
-  if (status.state === "success") return "done";
-  if (status.state === "idle") return "upcoming";
-  const currentIndex = journeyStageIndex(status.phase, stages);
-  if (currentIndex === -1) {
-    return "upcoming";
-  }
-  if (stageIndex < currentIndex) return "done";
-  if (stageIndex === currentIndex) {
-    return status.state === "failed" ? "attention" : "active";
-  }
-  return "upcoming";
-}
-
-function primaryJourneyIssue(status: UpdateStatusPayload): UpdateIssue | null {
-  const currentPhase = normalizeUpdatePhase(status.phase);
-  for (let index = status.issues.length - 1; index >= 0; index -= 1) {
-    const issue = status.issues[index];
-    if (normalizeUpdatePhase(issue.phase) === currentPhase) {
-      return issue;
-    }
-  }
-  return status.issues.length > 0 ? status.issues[status.issues.length - 1] : null;
-}
-
-function recoveryGuidanceKey(phase: string): string {
-  switch (normalizeUpdatePhase(phase)) {
-    case "stopping_hotspot":
-    case "connecting_wifi":
-    case "restoring_hotspot":
-      return "settings.update.recovery.wifi";
-    case "connecting_usb_internet":
-      return "settings.update.recovery.usb";
-    case "checking":
-    case "downloading":
-      return "settings.update.recovery.network";
-    case "installing":
-      return "settings.update.recovery.install";
-    default:
-      return "settings.update.recovery.generic";
-  }
-}
-
-export function getUpdateFailureSummary(
-  status: UpdateStatusPayload,
-  t: (key: string, vars?: Record<string, unknown>) => string,
-): UpdateFailureSummary | null {
-  if (status.state !== "failed") {
-    return null;
-  }
-  const issue = primaryJourneyIssue(status);
-  const phase = issue?.phase ?? status.phase;
-  const keyBase = recoveryGuidanceKey(phase);
-  return {
-    detail: issue?.detail ?? null,
-    message: issue?.message ?? null,
-    phaseLabel: formatUpdatePhase(phase, t),
-    recoveryTitle: t(`${keyBase}.title`),
-    recoveryDetail: t(`${keyBase}.detail`),
-  };
-}
-
-function buildJourneyFailureNoteModel(
-  status: UpdateStatusPayload,
-  t: (key: string, vars?: Record<string, unknown>) => string,
-): UpdateJourneyFailureNoteModel | null {
-  const failure = getUpdateFailureSummary(status, t);
-  if (!failure) {
-    return null;
-  }
-  return {
-    summaryText: failure.message ? `${failure.phaseLabel} — ${failure.message}` : failure.phaseLabel,
-    detailText: failure.detail,
-    recoveryTitleText: failure.recoveryTitle,
-    recoveryDetailText: failure.recoveryDetail,
-  };
-}
-
-export function buildUpdateJourneySectionModel(
-  status: UpdateStatusPayload,
-  deps: UpdateStatusViewDeps,
-): UpdateJourneySectionModel {
-  const stages = journeyStages(resolvedJourneyTransport(status, deps.selectedTransport));
-  return {
-    titleText: deps.t("settings.update.journey_title"),
-    subtitleText: deps.t("settings.update.journey_intro"),
-    failureNote: buildJourneyFailureNoteModel(status, deps.t),
-    stages: stages.map((stage, index) => {
-      const state = resolveJourneyStageState(status, stages, index);
-      return {
-        phase: stage.phase,
-        titleText: deps.t(stage.titleKey),
-        detailText: deps.t(stage.detailKey),
-        markerText: state === "done" ? "✓" : `${index + 1}`,
-        state,
-        stateText: deps.t(`maintenance.stage_state.${state}`),
-        current: state === "active",
-      };
-    }),
-  };
-}
-
-export function buildUpdateIssuesSectionModel(
-  status: UpdateStatusPayload,
-  deps: UpdateStatusViewDeps,
-): UpdateIssuesSectionModel | null {
-  if (status.issues.length === 0) {
-    return null;
-  }
-  return {
-    titleText: deps.t("settings.update.issues"),
-    subtitleText: deps.t("settings.update.issues_intro"),
-    items: status.issues.map((issue) => ({
-      phaseText: formatUpdatePhase(issue.phase, deps.t),
-      messageText: issue.message,
-      detailText: issue.detail ?? null,
-    })),
-  };
-}
-
-export function buildUpdateLatestAttemptSectionModel(
-  status: UpdateStatusPayload,
-  deps: UpdateStatusViewDeps,
-): UpdateLatestAttemptSectionModel | null {
-  if (status.state === "idle" || status.state === "running") {
-    return null;
-  }
-  const rows: UpdateStatusRowModel[] = [];
-  if (status.started_at != null) {
-    rows.push(
-      buildStatusRow(
-        deps.t("settings.update.started_at"),
-        formatEpochTimestamp(status.started_at),
-      ),
-    );
-  }
-  if (status.finished_at != null) {
-    rows.push(
-      buildStatusRow(
-        deps.t("settings.update.finished_at"),
-        formatEpochTimestamp(status.finished_at),
-      ),
-    );
-  }
-  rows.push(
-    buildStatusRow(
-      deps.t("settings.update.transport_label"),
-      buildTransportValueText(status, deps.t),
-    ),
-  );
-  if (status.exit_code != null) {
-    rows.push(
-      buildStatusRow(
-        deps.t("settings.update.exit_code"),
-        String(status.exit_code),
-      ),
-    );
-  }
-  const failure = getUpdateFailureSummary(status, deps.t);
-  return {
-    titleText: deps.t("settings.update.attempt_title"),
-    subtitleText: deps.t("settings.update.attempt_intro"),
-    badge: buildStateBadge(status, deps.t),
-    rows,
-    failureNote: failure
-      ? {
-          summaryText: failure.message ?? failure.phaseLabel,
-          detailText: failure.detail,
-        }
-      : null,
-  };
-}
-
 function buildHealthSummaryRows(
   health: HealthStatusPayload,
   t: (key: string, vars?: Record<string, unknown>) => string,
@@ -787,6 +365,96 @@ function buildHealthSummaryText(
       ? "settings.update.health_card_summary.warn"
       : "settings.update.health_card_summary.ok";
   return t(key);
+}
+
+export function buildUpdateCurrentStatusSectionModel(
+  status: UpdateStatusPayload,
+  health: HealthStatusPayload,
+  deps: UpdateStatusViewDeps,
+): UpdateCurrentStatusSectionModel {
+  const showRuntimeAssetsCheck = status.state !== "failed" || hasAssetRelatedIssue(status);
+  const rows = [
+    ...buildLifecycleRows(status, deps.t),
+    ...buildRuntimeRows(status, showRuntimeAssetsCheck, deps.t),
+  ];
+  return {
+    titleText: deps.t("settings.update.current_status_title"),
+    summaryText: buildCurrentStatusSummaryText(status, health, deps.t),
+    badge: buildStateBadge(status, deps.t),
+    rows,
+    emptyText: rows.length > 0 ? null : deps.t("settings.update.current_status_empty"),
+  };
+}
+
+export function buildUpdateIssuesSectionModel(
+  status: UpdateStatusPayload,
+  deps: UpdateStatusViewDeps,
+): UpdateIssuesSectionModel | null {
+  if (status.issues.length === 0) {
+    return null;
+  }
+  return {
+    titleText: deps.t("settings.update.issues"),
+    subtitleText: deps.t("settings.update.issues_intro"),
+    items: status.issues.map((issue) => ({
+      phaseText: formatUpdatePhase(issue.phase, deps.t),
+      messageText: issue.message,
+      detailText: issue.detail ?? null,
+    })),
+  };
+}
+
+export function buildUpdateLatestAttemptSectionModel(
+  status: UpdateStatusPayload,
+  deps: UpdateStatusViewDeps,
+): UpdateLatestAttemptSectionModel | null {
+  if (status.state === "idle" || status.state === "running") {
+    return null;
+  }
+  const rows: UpdateStatusRowModel[] = [];
+  if (status.started_at != null) {
+    rows.push(
+      buildStatusRow(
+        deps.t("settings.update.started_at"),
+        formatEpochTimestamp(status.started_at),
+      ),
+    );
+  }
+  if (status.finished_at != null) {
+    rows.push(
+      buildStatusRow(
+        deps.t("settings.update.finished_at"),
+        formatEpochTimestamp(status.finished_at),
+      ),
+    );
+  }
+  rows.push(
+    buildStatusRow(
+      deps.t("settings.update.transport_label"),
+      buildTransportValueText(status, deps.t),
+    ),
+  );
+  if (status.exit_code != null) {
+    rows.push(
+      buildStatusRow(
+        deps.t("settings.update.exit_code"),
+        String(status.exit_code),
+      ),
+    );
+  }
+  const failure = getUpdateFailureSummary(status, deps.t);
+  return {
+    titleText: deps.t("settings.update.attempt_title"),
+    subtitleText: deps.t("settings.update.attempt_intro"),
+    badge: buildStateBadge(status, deps.t),
+    rows,
+    failureNote: failure
+      ? {
+          summaryText: failure.message ?? failure.phaseLabel,
+          detailText: failure.detail,
+        }
+      : null,
+  };
 }
 
 export function buildUpdateHealthSectionModel(

--- a/apps/ui/src/app/views/update_status_models.ts
+++ b/apps/ui/src/app/views/update_status_models.ts
@@ -1,0 +1,114 @@
+import type { UpdateStartRequestPayload } from "../../transport/http_models";
+
+export type JourneyStageState = "upcoming" | "active" | "done" | "attention";
+export type UpdateJourneyTransport = UpdateStartRequestPayload["transport"];
+export type UpdateStatusBadgeVariant = "muted" | "warn" | "ok" | "bad";
+
+export interface UpdateStatusViewDeps {
+  t: (key: string, vars?: Record<string, unknown>) => string;
+  selectedTransport: UpdateJourneyTransport;
+}
+
+export interface UpdateFailureSummary {
+  detail: string | null;
+  message: string | null;
+  phaseLabel: string;
+  recoveryDetail: string;
+  recoveryTitle: string;
+}
+
+export interface UpdateStatusBadgeModel {
+  variant: UpdateStatusBadgeVariant;
+  text: string;
+}
+
+export interface UpdateStatusRowModel {
+  labelText: string;
+  valueText: string;
+}
+
+export interface UpdateCurrentStatusSectionModel {
+  titleText: string;
+  summaryText: string;
+  badge: UpdateStatusBadgeModel;
+  rows: readonly UpdateStatusRowModel[];
+  emptyText: string | null;
+}
+
+export interface UpdateJourneyFailureNoteModel {
+  summaryText: string;
+  detailText: string | null;
+  recoveryTitleText: string;
+  recoveryDetailText: string;
+}
+
+export interface UpdateJourneyStageModel {
+  phase: string;
+  titleText: string;
+  detailText: string;
+  markerText: string;
+  state: JourneyStageState;
+  stateText: string;
+  current: boolean;
+}
+
+export interface UpdateJourneySectionModel {
+  titleText: string;
+  subtitleText: string;
+  failureNote: UpdateJourneyFailureNoteModel | null;
+  stages: readonly UpdateJourneyStageModel[];
+}
+
+export interface UpdateIssueSectionItemModel {
+  phaseText: string;
+  messageText: string;
+  detailText: string | null;
+}
+
+export interface UpdateIssuesSectionModel {
+  titleText: string;
+  subtitleText: string;
+  items: readonly UpdateIssueSectionItemModel[];
+}
+
+export interface UpdateLatestAttemptFailureNoteModel {
+  summaryText: string;
+  detailText: string | null;
+}
+
+export interface UpdateLatestAttemptSectionModel {
+  titleText: string;
+  subtitleText: string;
+  badge: UpdateStatusBadgeModel;
+  rows: readonly UpdateStatusRowModel[];
+  failureNote: UpdateLatestAttemptFailureNoteModel | null;
+}
+
+export interface UpdateHealthSectionModel {
+  titleText: string;
+  summaryText: string;
+  badge: UpdateStatusBadgeModel;
+  rows: readonly UpdateStatusRowModel[];
+}
+
+export interface UpdateLogEmptyStateModel {
+  titleText: string;
+  bodyText: string;
+}
+
+export interface UpdateLogSectionModel {
+  titleText: string;
+  subtitleText: string;
+  noteText: string | null;
+  lines: readonly string[];
+  emptyState: UpdateLogEmptyStateModel | null;
+}
+
+export interface UpdateStatusPanelViewModel {
+  currentStatus: UpdateCurrentStatusSectionModel;
+  journey: UpdateJourneySectionModel;
+  issues: UpdateIssuesSectionModel | null;
+  latestAttempt: UpdateLatestAttemptSectionModel | null;
+  health: UpdateHealthSectionModel;
+  log: UpdateLogSectionModel;
+}

--- a/apps/ui/tests/update_status_view_models.spec.ts
+++ b/apps/ui/tests/update_status_view_models.spec.ts
@@ -2,9 +2,11 @@ import { expect, test } from "@playwright/test";
 
 import {
   buildUpdateCurrentStatusSectionModel,
-  buildUpdateJourneySectionModel,
   buildUpdateLogSectionModel,
-} from "../src/app/views/update_status_view_models";
+} from "../src/app/views/update_status_builders";
+import {
+  buildUpdateJourneySectionModel,
+} from "../src/app/views/update_journey_builder";
 import type {
   HealthStatusPayload,
   UpdateStatusPayload,


### PR DESCRIPTION
Closes #2390

## Summary

This PR splits the old `apps/ui/src/app/views/update_status_view_models.ts` monolith by concern without changing the update feature’s runtime behavior or the panel contracts that the surrounding presenter and views consume. The issue description called out an 859-line file that mixed model types, formatting utilities, builder functions, and journey-stage logic. That is exactly what the file had become in practice. It defined the shared badge and row types consumed by both the update and internet surfaces, the full update-panel section interfaces, generic builders for current status, issues, latest attempt, health, and log cards, and also the update-journey phase formatting plus recovery guidance logic.

The main problem was not just file length. The file mixed pure type definitions used by other view modules, journey/recovery logic tied to phase normalization and transport-dependent stage progression, and generic section builders that assemble the current-status, issues, latest-attempt, health, log, and full panel view models. This PR separates those concerns so the shared types, journey logic, and general section builders each live in their own focused module.

## Implementation approach

I kept the split narrow and behavior-preserving. Instead of redesigning the presenter or changing how the update panel renders, I used the old monolith as the base and split it into the three module boundaries suggested by the issue, but with the current codebase’s real responsibilities in mind:

1. `update_status_models.ts` now owns the shared update-status interfaces and aliases.
2. `update_journey_builder.ts` now owns phase normalization, phase formatting, journey-stage definitions, transport-aware journey assembly, and failure/recovery summary logic.
3. `update_status_builders.ts` now owns the non-journey section builders plus the top-level panel-assembly helper.

That means the old `update_status_view_models.ts` path disappears entirely. The former file effectively becomes `update_status_builders.ts`, while the pure models and journey/recovery logic are extracted into companion modules.

I deliberately did **not** change the render-model shapes returned to `update_panel.tsx`, the internet panel contracts, or the presenter workflow. This keeps the refactor reviewable and ensures the issue stays about file ownership rather than feature behavior.

## Main code changes by area

### `apps/ui/src/app/views/update_status_models.ts`

This new file is the shared type authority for the update-status surface. It now owns:

- `JourneyStageState`
- `UpdateJourneyTransport`
- `UpdateStatusBadgeVariant`
- the shared badge/row models
- all update-panel section interfaces
- `UpdateStatusPanelViewModel`
- the shared `UpdateStatusViewDeps`
- the `UpdateFailureSummary` shape used by the journey/recovery path

This matters because `internet_status_view.ts`, `internet_panel.tsx`, and `update_panel.tsx` only need those shared models.

### `apps/ui/src/app/views/update_journey_builder.ts`

This new file owns the parts of the old module that are specifically about update phase semantics and journey rendering:

- phase normalization
- translated phase formatting
- Wi-Fi and USB journey-stage definitions
- transport resolution for idle vs. active update state
- stage-state calculation
- primary-issue selection for failure context
- recovery-guidance selection
- `getUpdateFailureSummary()`
- `buildUpdateJourneySectionModel()`

This is the cleanest place for that logic because it is specifically about how the update journey progresses, how failures map back to the active phase, and what retry guidance the user should see.

### `apps/ui/src/app/views/update_status_builders.ts`

This file becomes the home for the remaining section builders:

- current status
- issues
- latest attempt
- health
- log
- full panel assembly

It still owns the shared row/badge helper functions and the small status/health formatting helpers those builders need, but it now imports journey-specific logic from `update_journey_builder.ts` instead of carrying all of that logic inline.

That makes the file read much more directly as “build the non-journey update status cards and assemble the full panel model” instead of “own every update-status concern in the app.”

### Caller updates

The blast radius stayed narrow and explicit:

- `update_feature_presenter.ts` now imports `buildUpdateStatusPanelViewModel()` from `update_status_builders.ts` and `getUpdateFailureSummary()` from `update_journey_builder.ts`
- `internet_status_view.ts`, `internet_panel.tsx`, and `update_panel.tsx` now import their shared types from `update_status_models.ts`
- `tests/update_status_view_models.spec.ts` now imports the current-status/log builders from `update_status_builders.ts` and the journey builder from `update_journey_builder.ts`
- `apps/ui/README.md` now documents the three new files instead of the deleted monolith

The old `update_status_view_models.ts` import path is gone completely, so there is no compatibility alias left behind.

## Contract and behavior notes

This PR intentionally does **not** change the update feature behavior, API payloads, server contracts, or the render-model shapes consumed by the update and internet panels. The presenter still builds the same higher-level panel models. The update panel still receives the same section structures. The tests continue asserting the same behaviors around runtime asset verification, journey failure guidance, running-stage state, and empty-log rendering.

The only meaningful change is module ownership: shared interfaces now come from `update_status_models.ts`, journey and recovery logic lives in `update_journey_builder.ts`, and the general status-card builders live in `update_status_builders.ts`. That is the whole point of the issue, and it is why the change stays safe: the module graph is clearer, but the data flowing through it is intentionally unchanged.

## Validation

Because this is a structural split with a small caller blast radius, I validated the parts most likely to catch accidental import drift or behavior changes:

- `cd /workspace/VibeSensor/apps/ui && npx playwright test tests/update_status_view_models.spec.ts tests/update_feature_presenter.spec.ts tests/update_feature_workflow.spec.ts --workers=1`
- `cd /workspace/VibeSensor/apps/ui && npx playwright test tests/smoke.update.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd /workspace/VibeSensor/apps/ui && npm run typecheck`
- `cd /workspace/VibeSensor/apps/ui && npm run build`
- `cd /workspace/VibeSensor/apps/ui && npm run lint`

That coverage exercises the focused section-builder expectations, the presenter path that consumes both the full panel builder and failure summary helper, the workflow path that refreshes update status through the no-DOM seam, and the browser-level updater surface that renders readiness, internet transport state, persisted Wi-Fi state, password toggling, and retry guidance.

The only lint output remains the existing Biome schema-version info message already present in this checkout. There were no new lint or type errors introduced by the module split itself.

## Risks and tradeoffs

The main tradeoff is that update-status logic now spans three files instead of one. I chose that because the previous file was not “one coherent implementation that happened to be long.” It was genuinely mixing different ownership concerns, and that made the import surface noisier for downstream modules.

I also deliberately avoided introducing a new barrel or compatibility wrapper for the old path. The repo owns all consumers, and the issue is specifically about splitting the monolith by concern. Updating the real callers directly produces a cleaner final state than leaving a transitional alias in place.

I did not use this PR to change naming beyond the ownership split, to add new presenter abstractions, or to redesign the update-panel models. Those could be separate refactors if they ever become necessary, but they are out of scope here. The goal of this issue is narrower: split the oversized update-status builder file into focused modules while preserving the existing behavior and keeping the downstream call sites straightforward.
