### PR TITLE
Share spectrum CSS vars across chart classes

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -154,6 +154,7 @@ source-of-truth export commands remain the only writers for those files.
 | `config.ts` | Centralized UI tuning constants for polling intervals, spectrum ranges, and history heatmap positions |
 | `i18n.ts` | Internationalization dictionary (English, Dutch) |
 | `spectrum.ts` | uPlot chart wrapper for interactive spectrum visualization |
+| `spectrum_css_vars.ts` | Shared cached spectrum CSS-variable snapshot for chart and canvas renderer colors |
 | `server_payload.ts` | Transport-boundary WebSocket payload adaptation and schema-version guardrails around the generated WS types |
 | `diagnostics.ts` | Strength band normalization and vibration matrix helpers |
 | `vehicle_math.ts` | Tire diameter, order tolerance, and uncertainty calculations |

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -2,6 +2,7 @@ import type uPlot from "uplot";
 
 import { SPECTRUM_TWEEN_DURATION_MS } from "../../config";
 import { convertSpectrumAmplitudesToDbInPlace, SpectrumChart } from "../../spectrum";
+import { getSpectrumCssVars } from "../../spectrum_css_vars";
 import { chartSeriesPalette, orderBandFills } from "../../theme";
 import {
   createSpectrumTweenDerivedState,
@@ -43,8 +44,6 @@ export interface SpectrumCanvasRendererDeps {
 }
 
 export class SpectrumCanvasRenderer {
-  private readonly rootStyle: CSSStyleDeclaration;
-
   private readonly spectrumBandPlugin: uPlot.Plugin;
 
   private spectrumTweenRaf: number | null = null;
@@ -70,7 +69,6 @@ export class SpectrumCanvasRenderer {
   constructor(
     private readonly deps: SpectrumCanvasRendererDeps,
   ) {
-    this.rootStyle = getComputedStyle(document.documentElement);
     this.spectrumBandPlugin = this.createBandPlugin();
   }
 
@@ -314,6 +312,7 @@ export class SpectrumCanvasRenderer {
             const labelPaddingX = 6;
             const labelHeight = 20;
             const labelTop = top + 8;
+            const cssVars = getSpectrumCssVars();
             plot.ctx.save();
             plot.ctx.setLineDash([5, 4]);
             plot.ctx.strokeStyle = focusMarker.color;
@@ -333,9 +332,9 @@ export class SpectrumCanvasRenderer {
               plot.bbox.left,
               Math.min(x - (labelWidth / 2), plot.bbox.left + plot.bbox.width - labelWidth),
             );
-            plot.ctx.fillStyle = this.cssVar("--tooltip-bg", "rgba(15, 23, 42, 0.88)");
+            plot.ctx.fillStyle = cssVars.tooltipBg;
             plot.ctx.fillRect(labelLeft, labelTop, labelWidth, labelHeight);
-            plot.ctx.fillStyle = this.cssVar("--tooltip-fg", "#f8f9fb");
+            plot.ctx.fillStyle = cssVars.tooltipFg;
             plot.ctx.textBaseline = "middle";
             plot.ctx.fillText(label, labelLeft + labelPaddingX, labelTop + (labelHeight / 2));
             plot.ctx.restore();
@@ -366,10 +365,6 @@ export class SpectrumCanvasRenderer {
       },
       [this.spectrumBandPlugin],
     );
-  }
-
-  private cssVar(name: string, fallback: string): string {
-    return this.rootStyle.getPropertyValue(name).trim() || fallback;
   }
 
   private formatHz(value: number): string {

--- a/apps/ui/src/spectrum.ts
+++ b/apps/ui/src/spectrum.ts
@@ -6,6 +6,7 @@ import {
   SPECTRUM_DB_REFERENCE_AMP_G,
   SPECTRUM_MIN_RENDER_AMP_G,
 } from "./config";
+import { getSpectrumCssVars } from "./spectrum_css_vars";
 
 export interface SpectrumSeriesMeta {
   label: string;
@@ -38,7 +39,6 @@ export class SpectrumChart {
   private readonly hostEl: HTMLElement;
   private readonly measureEl: HTMLElement;
   private readonly height: number;
-  private readonly rootStyle: CSSStyleDeclaration;
   private resizeObserver: ResizeObserver | null = null;
   private resizeRaf: number | null = null;
 
@@ -46,7 +46,6 @@ export class SpectrumChart {
     this.hostEl = hostEl;
     this.measureEl = measureEl || hostEl;
     this.height = height;
-    this.rootStyle = getComputedStyle(document.documentElement);
     this.startResizeObserver();
   }
 
@@ -54,6 +53,7 @@ export class SpectrumChart {
     if (this.plot && this.plot.series.length === seriesMeta.length + 1) {
       return;
     }
+    const cssVars = getSpectrumCssVars();
 
     this.destroyPlot();
     const series: uPlot.Series[] = [{ label: "Hz" }];
@@ -76,7 +76,7 @@ export class SpectrumChart {
             one: true,
             size: 7,
             width: 2,
-            fill: this.cssVar("--surface", "#f8f9fb"),
+            fill: cssVars.surface,
           },
         },
         scales: {
@@ -88,13 +88,13 @@ export class SpectrumChart {
         axes: [
           {
             label: text.axisHz,
-            stroke: this.cssVar("--muted", "#5a6b82"),
-            grid: { stroke: this.cssVar("--border", "#d7e1ee"), width: 1 },
+            stroke: cssVars.muted,
+            grid: { stroke: cssVars.border, width: 1 },
           },
           {
             label: text.axisAmplitude,
-            stroke: this.cssVar("--muted", "#5a6b82"),
-            grid: { stroke: this.cssVar("--border", "#d7e1ee"), width: 1 },
+            stroke: cssVars.muted,
+            grid: { stroke: cssVars.border, width: 1 },
           },
         ],
         series,
@@ -159,11 +159,6 @@ export class SpectrumChart {
       });
     });
     this.resizeObserver.observe(this.measureEl);
-  }
-
-
-  private cssVar(name: string, fallback: string): string {
-    return this.rootStyle.getPropertyValue(name).trim() || fallback;
   }
 
   private computeWidth(): number {

--- a/apps/ui/src/spectrum_css_vars.ts
+++ b/apps/ui/src/spectrum_css_vars.ts
@@ -1,0 +1,42 @@
+export interface SpectrumCssVars {
+  surface: string;
+  muted: string;
+  border: string;
+  tooltipBg: string;
+  tooltipFg: string;
+}
+
+const DEFAULT_SPECTRUM_CSS_VARS: Readonly<SpectrumCssVars> = Object.freeze({
+  surface: "#f8f9fb",
+  muted: "#5a6b82",
+  border: "#d7e1ee",
+  tooltipBg: "rgba(15, 23, 42, 0.88)",
+  tooltipFg: "#f8f9fb",
+});
+
+let cachedSpectrumCssVars: Readonly<SpectrumCssVars> | null = null;
+
+function readSpectrumCssVars(): Readonly<SpectrumCssVars> {
+  const rootStyle = getComputedStyle(document.documentElement);
+  return Object.freeze({
+    surface: rootStyle.getPropertyValue("--surface").trim() || DEFAULT_SPECTRUM_CSS_VARS.surface,
+    muted: rootStyle.getPropertyValue("--muted").trim() || DEFAULT_SPECTRUM_CSS_VARS.muted,
+    border: rootStyle.getPropertyValue("--border").trim() || DEFAULT_SPECTRUM_CSS_VARS.border,
+    tooltipBg: rootStyle.getPropertyValue("--tooltip-bg").trim()
+      || DEFAULT_SPECTRUM_CSS_VARS.tooltipBg,
+    tooltipFg: rootStyle.getPropertyValue("--tooltip-fg").trim()
+      || DEFAULT_SPECTRUM_CSS_VARS.tooltipFg,
+  });
+}
+
+export function getSpectrumCssVars(): Readonly<SpectrumCssVars> {
+  if (cachedSpectrumCssVars === null) {
+    cachedSpectrumCssVars = readSpectrumCssVars();
+  }
+  return cachedSpectrumCssVars;
+}
+
+export function refreshSpectrumCssVars(): Readonly<SpectrumCssVars> {
+  cachedSpectrumCssVars = readSpectrumCssVars();
+  return cachedSpectrumCssVars;
+}

--- a/apps/ui/tests/spectrum_css_vars.spec.ts
+++ b/apps/ui/tests/spectrum_css_vars.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+import { installDocumentStub } from "./spectrum_test_support";
+
+test.describe("spectrum_css_vars", () => {
+  test("caches a plain spectrum css snapshot until refreshed", async () => {
+    const restoreDocument = installDocumentStub();
+    const styleValues: Record<string, string> = {
+      "--surface": "#101820",
+      "--muted": "#556677",
+      "--border": "#c0ffee",
+      "--tooltip-bg": "rgba(1, 2, 3, 0.9)",
+      "--tooltip-fg": "#fefefe",
+    };
+    let readCount = 0;
+    globalThis.getComputedStyle = (() => {
+      readCount += 1;
+      return {
+        getPropertyValue(name: string): string {
+          return styleValues[name] ?? "";
+        },
+      } as CSSStyleDeclaration;
+    }) as typeof getComputedStyle;
+
+    try {
+      const { getSpectrumCssVars, refreshSpectrumCssVars } = await import(
+        "../src/spectrum_css_vars"
+      );
+
+      const first = refreshSpectrumCssVars();
+      expect(first).toEqual({
+        surface: "#101820",
+        muted: "#556677",
+        border: "#c0ffee",
+        tooltipBg: "rgba(1, 2, 3, 0.9)",
+        tooltipFg: "#fefefe",
+      });
+      expect(readCount).toBe(1);
+
+      styleValues["--surface"] = "#222222";
+      expect(getSpectrumCssVars()).toBe(first);
+      expect(getSpectrumCssVars().surface).toBe("#101820");
+      expect(readCount).toBe(1);
+
+      const refreshed = refreshSpectrumCssVars();
+      expect(refreshed.surface).toBe("#222222");
+      expect(refreshed).not.toBe(first);
+      expect(getSpectrumCssVars()).toBe(refreshed);
+      expect(readCount).toBe(2);
+    } finally {
+      restoreDocument();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR removes the duplicated root computed-style caching from the two spectrum rendering classes and replaces it with one small shared utility that owns the spectrum color tokens. Before this change, `SpectrumChart` in `apps/ui/src/spectrum.ts` and `SpectrumCanvasRenderer` in `apps/ui/src/app/runtime/spectrum_canvas_renderer.ts` each called `getComputedStyle(document.documentElement)` and stored the returned `CSSStyleDeclaration` on the class instance. That meant the spectrum stack held two separate long-lived references to the root computed style even though it only needed a handful of CSS custom properties: the chart surface, muted axis text, border color, and the tooltip foreground/background colors used by the canvas overlay.

The implementation keeps the fix narrow and local to the spectrum surface. Rather than broadening the issue into a larger theme or signal refactor, this PR introduces `apps/ui/src/spectrum_css_vars.ts` as a small shared owner for those CSS variables. The module reads the current root custom properties into a plain frozen snapshot, caches that snapshot behind `getSpectrumCssVars()`, and exposes `refreshSpectrumCssVars()` as the explicit seam for any future theme-reactive refresh path. That removes the duplicated per-class `getComputedStyle()` storage, avoids holding live `CSSStyleDeclaration` objects in spectrum runtime classes, and gives the codebase a single place to adjust if the spectrum color tokens ever need to become actively reactive later.

## What changed

The new `spectrum_css_vars.ts` module is the main structural change. It defines the small `SpectrumCssVars` contract, keeps the existing fallback color values in one place, reads the spectrum-related CSS custom properties from `document.documentElement`, and freezes the returned snapshot so downstream code works with plain immutable color data instead of a live DOM style object. The helper is lazy, so nothing reads from the DOM at import time. The first real spectrum caller populates the cache, and any later caller reuses the same snapshot. The separate `refreshSpectrumCssVars()` export intentionally makes the “refresh the cached snapshot from the live DOM” step explicit instead of hiding it behind per-class state.

`SpectrumChart` now uses that shared snapshot when it builds the uPlot instance. The class no longer stores a `rootStyle` field or carries its own `cssVar()` helper. Instead, `ensurePlot()` pulls the shared snapshot once and uses `surface`, `muted`, and `border` directly for the cursor point fill and the axis/grid styling. That keeps the chart wrapper focused on uPlot lifecycle and sizing instead of acting as another root-style cache owner.

`SpectrumCanvasRenderer` received the same cleanup. The renderer no longer stores its own `rootStyle` field or a duplicate helper for looking up CSS variables. Inside the band/focus draw plugin, the tooltip label rendering path now reads the shared spectrum CSS snapshot and uses the `tooltipBg` and `tooltipFg` properties for the floating frequency label. This means the only remaining production `getComputedStyle(document.documentElement)` call in `apps/ui/src` now lives in the new shared utility instead of being spread across two different classes.

The change also adds focused regression coverage in `apps/ui/tests/spectrum_css_vars.spec.ts`. That test installs the existing spectrum document stub, overrides `getComputedStyle()`, and verifies two important behaviors from the new utility: repeated reads reuse the cached plain snapshot without re-running the DOM lookup, and `refreshSpectrumCssVars()` picks up changed values when a caller explicitly asks for a refresh. That gives the new cache/refresh seam its own direct test rather than relying only on broader spectrum behavior tests to catch a regression indirectly.

Finally, `apps/ui/README.md` now documents `spectrum_css_vars.ts` in the module map so the shared color-token owner is visible to future contributors. That keeps the human-facing module inventory aligned with the code change instead of leaving the new file as undocumented structure.

## Why this approach

The issue description suggested either a shared utility or a signal. I chose the utility route because it solves the real problem without expanding the blast radius. There is no existing runtime theme-toggle flow in this UI that currently pushes live theme updates into the spectrum stack, so a new signal-based theme subsystem would have been a much larger architectural change than the issue actually required. At the same time, simply moving the `getComputedStyle()` call into a shared module while still caching a live `CSSStyleDeclaration` would not have addressed the more important concern around long-lived live style objects.

Using a cached plain snapshot is the clean middle ground for the current codebase. It removes the duplicated lookups and duplicate ownership, keeps the fallback values centralized, and makes the “refresh from the DOM again” behavior explicit instead of implicit. The dedicated `refreshSpectrumCssVars()` function also leaves a clear future extension point if a later issue wants to react to `prefers-color-scheme` changes or another theme input. That future work can refresh one shared spectrum snapshot instead of teaching multiple classes how to manage root-style state independently.

## Validation

I validated the change against the spectrum-focused slices that actually exercise the touched code paths:

- `cd apps/ui && npx playwright test tests/spectrum_css_vars.spec.ts tests/spectrum_canvas_renderer.spec.ts tests/ui_spectrum_controller.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.spectrum.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

The targeted tests cover the new cache helper directly, the spectrum frame-preparation path, the controller surface, and the browser-level spectrum interactions. Build and type-check stayed green. Lint remained clean apart from the same pre-existing Biome schema-version info message that already exists on `main`.

## Risks and tradeoffs

The main tradeoff is that the new utility caches a plain snapshot instead of holding a live `CSSStyleDeclaration`. That is intentional. It means the spectrum classes no longer observe root CSS changes automatically through a live object reference. In the current app, that is a better fit for the real behavior: there is no dedicated runtime theme-refresh pipeline here today, and the previous “maybe live, maybe stale, long-lived DOM object” approach was more ambiguous than helpful. If a later change needs live theme updates, the code now has one explicit refresh seam to wire up instead of two independent class caches to unwind.

This PR does not change chart data, tween behavior, focus marker logic, or the overall spectrum controller contract. It stays narrowly scoped to CSS variable ownership and the small amount of documentation and testing needed to support that ownership change.

Closes #2391
