### PR TITLE
Consolidate frontend timestamp formatters

### DIFF
--- a/apps/ui/src/app/views/dom_helpers.ts
+++ b/apps/ui/src/app/views/dom_helpers.ts
@@ -21,10 +21,3 @@ export function inlineStateActionClass(variant: InlineStateActionVariant | undef
       return "btn btn--primary";
   }
 }
-
-export function formatEpochTimestamp(epoch: number | null | undefined): string {
-  if (epoch === null || epoch === undefined || !Number.isFinite(epoch)) {
-    return "—";
-  }
-  return new Date(epoch * 1000).toLocaleString();
-}

--- a/apps/ui/src/app/views/esp_flash_feature_presenter.ts
+++ b/apps/ui/src/app/views/esp_flash_feature_presenter.ts
@@ -3,8 +3,8 @@ import type {
   EspFlashStatusPayload,
   EspSerialPortPayload,
 } from "../../transport/http_models";
+import { formatEpochTimestamp } from "../../format";
 import type { VisualVariant } from "../view_style_types";
-import { formatEpochTimestamp } from "./dom_helpers";
 import type { MaintenanceReadinessPanelModel } from "./maintenance_readiness_view";
 import type {
   EspFlashHistoryAttemptModel,

--- a/apps/ui/src/app/views/update_status_builders.ts
+++ b/apps/ui/src/app/views/update_status_builders.ts
@@ -2,7 +2,7 @@ import type {
   HealthStatusPayload,
   UpdateStatusPayload,
 } from "../../transport/http_models";
-import { formatEpochTimestamp } from "./dom_helpers";
+import { formatEpochTimestamp } from "../../format";
 import {
   buildUpdateJourneySectionModel,
   formatUpdatePhase,

--- a/apps/ui/src/format.ts
+++ b/apps/ui/src/format.ts
@@ -3,11 +3,23 @@ export function fmt(n: number, digits = 2): string {
   return n.toFixed(digits);
 }
 
+function formatDateTime(date: Date, invalidText: string): string {
+  if (Number.isNaN(date.getTime())) {
+    return invalidText;
+  }
+  return date.toLocaleString();
+}
+
 export function fmtTs(iso: string): string {
   if (!iso) return "--";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleString();
+  return formatDateTime(new Date(iso), iso);
+}
+
+export function formatEpochTimestamp(epoch: number | null | undefined): string {
+  if (epoch === null || epoch === undefined || !Number.isFinite(epoch)) {
+    return "—";
+  }
+  return formatDateTime(new Date(epoch * 1000), "—");
 }
 
 const _defaultNumberFormat = new Intl.NumberFormat();

--- a/apps/ui/tests/format.spec.ts
+++ b/apps/ui/tests/format.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+import { fmtTs, formatEpochTimestamp } from "../src/format";
+
+test.describe("timestamp formatting helpers", () => {
+  test("formats ISO strings and epoch seconds through the same locale path", () => {
+    const iso = "2024-01-02T03:04:05Z";
+    const expected = new Date(iso).toLocaleString();
+
+    expect(fmtTs(iso)).toBe(expected);
+    expect(formatEpochTimestamp(Date.parse(iso) / 1000)).toBe(expected);
+  });
+
+  test("preserves existing empty and invalid fallback text", () => {
+    expect(fmtTs("")).toBe("--");
+    expect(fmtTs("not-a-date")).toBe("not-a-date");
+    expect(formatEpochTimestamp(null)).toBe("—");
+    expect(formatEpochTimestamp(Number.NaN)).toBe("—");
+  });
+});


### PR DESCRIPTION
## Summary

This PR consolidates the frontend timestamp-formatting logic so `fmtTs()` and `formatEpochTimestamp()` share one canonical date-formatting core in `apps/ui/src/format.ts` instead of maintaining two separate `toLocaleString()` implementations in different modules. Before this change, `fmtTs()` in `format.ts` handled ISO strings for the history presenters, while `formatEpochTimestamp()` lived in `apps/ui/src/app/views/dom_helpers.ts` and handled epoch-second values for the update-status and ESP-flash presenters. The two helpers produced the same localized display format, but they duplicated the actual `Date` parsing and `toLocaleString()` call path. They also had slightly different invalid-input behavior because the surrounding surfaces want different fallback text.

The key point of this change is that the duplication is removed without flattening those surface-level semantics. `fmtTs()` still treats an empty string as `"--"` and still returns the original input string when parsing fails. `formatEpochTimestamp()` still treats missing or non-finite epoch values as an em dash. What changes is where the shared “valid `Date` becomes localized text” step lives: both wrappers now call one internal `formatDateTime()` helper in `format.ts`, so there is only one formatting core to maintain.

## Problem being solved

Issue #2392 called out a small but real cleanup opportunity. The UI already has a general-purpose formatting module in `apps/ui/src/format.ts`, but one timestamp formatter had drifted into `app/views/dom_helpers.ts`, which is otherwise a view-side helper module for inline-state action classes. That split meant timestamp behavior could slowly diverge over time even though both helpers were clearly trying to do the same last-mile formatting work.

There was one nuance that mattered during the scope read: these functions are not interchangeable at the API boundary. `fmtTs()` takes ISO strings and is threaded through the history presenter dependency surface, while `formatEpochTimestamp()` takes epoch seconds and is used directly by update-status and ESP-flash presenters. Their invalid and empty fallback text is also intentionally different today. So the clean fix is not “delete one wrapper and force every caller onto the other.” The clean fix is a shared core plus thin wrappers that preserve the existing contracts each surface already depends on.

## Implementation approach

The implementation keeps that distinction explicit.

In `apps/ui/src/format.ts`, I added a small internal `formatDateTime(date, invalidText)` helper. It handles the common logic both wrappers need: check whether the `Date` is valid and, if so, return `date.toLocaleString()`. If the parsed date is invalid, it returns the caller-supplied fallback text. That becomes the single canonical place where localized timestamp rendering happens.

`fmtTs()` now delegates to that helper instead of carrying its own parsing/validity branch inline. Its behavior remains the same as before:

- empty ISO input still returns `"--"`
- invalid ISO input still returns the original string
- valid ISO input still returns `toLocaleString()`

`formatEpochTimestamp()` moved out of `apps/ui/src/app/views/dom_helpers.ts` and into `apps/ui/src/format.ts`, where it belongs alongside the other general formatting helpers. Its behavior also remains intentionally unchanged:

- `null`, `undefined`, or non-finite epoch input still returns `"—"`
- valid epoch-second input still converts through `new Date(epoch * 1000).toLocaleString()`

With that canonical helper in place, the old duplicated implementation was deleted from `dom_helpers.ts`.

The presenter call sites were updated directly instead of leaving behind an internal re-export layer. `apps/ui/src/app/views/update_status_builders.ts` and `apps/ui/src/app/views/esp_flash_feature_presenter.ts` now import `formatEpochTimestamp()` from `../../format`, which makes the ownership boundary clearer: timestamp formatting lives in the shared formatting module, not in a view helper file.

## Test coverage and validation

Because the main risk here is semantic drift rather than compile-time breakage, I added focused regression coverage in `apps/ui/tests/format.spec.ts`.

That new test file covers the two essential expectations:

1. ISO-string and epoch-second wrappers both flow through the same localized date-rendering path for valid timestamps.
2. Their existing fallback semantics remain distinct for empty or invalid input.

That direct test matters because the issue is about subtle behavioral divergence. A dedicated formatter spec makes that contract obvious and stable.

I also ran the presenter and browser slices that actually render these timestamp values in user-facing UI:

- `cd apps/ui && npx playwright test tests/format.spec.ts tests/update_status_view_models.spec.ts tests/esp_flash_feature_presenter.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

Those checks cover the new shared formatter directly, the update-status builder surface, the ESP-flash presenter surface, and the browser-level update/flash UI flows that consume those rendered values. Type-check and production build stayed green. Lint stayed clean apart from the same pre-existing Biome schema-version info message already present on `main`.

## Main code changes by area

### `apps/ui/src/format.ts`

- adds the shared internal `formatDateTime()` helper
- keeps `fmtTs()` public, but routes it through the shared core
- moves `formatEpochTimestamp()` into the canonical formatting module

### `apps/ui/src/app/views/dom_helpers.ts`

- deletes the duplicated `formatEpochTimestamp()` implementation
- leaves the remaining inline-state view helper behavior untouched

### Presenter call sites

- `update_status_builders.ts` now imports `formatEpochTimestamp()` from `../../format`
- `esp_flash_feature_presenter.ts` now imports `formatEpochTimestamp()` from `../../format`

### Tests

- adds `apps/ui/tests/format.spec.ts` to pin the shared core plus wrapper-specific fallback behavior

## Risks, tradeoffs, and out-of-scope notes

The main tradeoff here is that the API surface stays as two wrapper functions rather than one “universal timestamp formatter.” That is deliberate. Forcing history, update, and ESP-flash views onto one user-visible empty/invalid placeholder would be a larger product decision than this cleanup issue called for. The wrappers still reflect their input domains and current UX semantics; only the duplicated formatting core is consolidated.

I also intentionally did not thread `formatEpochTimestamp()` through the `feature_deps_base.ts` formatting dependency bag or rewrite history presenter contracts. That would widen the blast radius without solving a real problem for this issue. The current cut keeps the dependency surface stable where it already exists and updates only the direct call sites that owned the duplicate helper.

There are no schema, config, or documentation changes in this PR because the cleanup is internal to the frontend code path.

Closes #2392
