### PR TITLE
Split cars workflow manual input signals

### DIFF
--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -200,9 +200,11 @@ export function createCarsFeatureWorkflow(
   const transport = createCarsFeatureTransport(deps.transport);
   const wizardState = signal<WizardState>(createInitialWizardState());
   const isOpen = signal(false);
-  const manualInputs = signal<CarsFeatureManualInputState>({
-    ...DEFAULT_CARS_WIZARD_MANUAL_INPUTS,
-  });
+  const manualFinalDrive = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.finalDrive);
+  const manualRim = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.rim);
+  const manualTireAspect = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.tireAspect);
+  const manualTireWidth = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.tireWidth);
+  const manualTopGear = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.topGear);
   const brandOptions = signal(createIdleOptionsState<string>());
   const typeOptions = signal(createIdleOptionsState<string>());
   const modelOptions = signal(createIdleOptionsState<CarLibraryModel>());
@@ -211,31 +213,48 @@ export function createCarsFeatureWorkflow(
   const gearboxOptions = signal<readonly CarLibraryGearbox[]>([]);
   const noGearboxesMessage = signal<string | null>(null);
 
+  function readManualInputs(): CarsFeatureManualInputState {
+    return {
+      finalDrive: manualFinalDrive.value,
+      rim: manualRim.value,
+      tireAspect: manualTireAspect.value,
+      tireWidth: manualTireWidth.value,
+      topGear: manualTopGear.value,
+    };
+  }
+
+  function writeManualInputs(inputs: CarsFeatureManualInputState): void {
+    manualFinalDrive.value = inputs.finalDrive;
+    manualRim.value = inputs.rim;
+    manualTireAspect.value = inputs.tireAspect;
+    manualTireWidth.value = inputs.tireWidth;
+    manualTopGear.value = inputs.topGear;
+  }
+
   function updateWizardState(mutator: (state: WizardState) => void): void {
     const nextState = { ...wizardState.value };
     mutator(nextState);
     wizardState.value = nextState;
   }
 
-  function currentManualValues() {
-    const state = wizardState.value;
-    const inputs = manualInputs.value;
-    return {
-      manualGearbox: readWizardManualGearboxValues(state.step, {
-        finalDrive: inputs.finalDrive,
-        topGear: inputs.topGear,
-      }),
-      manualTire: readWizardManualTireValues(state.step, {
-        aspect: inputs.tireAspect,
-        rim: inputs.rim,
-        width: inputs.tireWidth,
-      }),
-    };
-  }
+  const manualGearbox = computed(() =>
+    readWizardManualGearboxValues(wizardState.value.step, {
+      finalDrive: manualFinalDrive.value,
+      topGear: manualTopGear.value,
+    })
+  );
+
+  const manualTire = computed(() =>
+    readWizardManualTireValues(wizardState.value.step, {
+      aspect: manualTireAspect.value,
+      rim: manualRim.value,
+      width: manualTireWidth.value,
+    })
+  );
 
   const renderState = computed<CarsFeatureRenderState>(() => {
     const state = wizardState.value;
-    const inputs = manualInputs.value;
+    const inputs = readManualInputs();
     const currentBrandOptions = brandOptions.value;
     const currentTypeOptions = typeOptions.value;
     const currentModelOptions = modelOptions.value;
@@ -243,13 +262,14 @@ export function createCarsFeatureWorkflow(
     const currentTireOptions = tireOptions.value;
     const currentGearboxOptions = gearboxOptions.value;
     const currentNoGearboxesMessage = noGearboxesMessage.value;
-    const { manualGearbox, manualTire } = currentManualValues();
+    const currentManualGearbox = manualGearbox.value;
+    const currentManualTire = manualTire.value;
     return {
       actionHint: state.step === 4
         ? getWizardActionHint(state, {
           fmt: deps.fmt,
-          manualGearbox,
-          manualTire,
+          manualGearbox: currentManualGearbox,
+          manualTire: currentManualTire,
           t: deps.t,
         })
         : "",
@@ -257,7 +277,7 @@ export function createCarsFeatureWorkflow(
         ...currentBrandOptions,
         options: [...currentBrandOptions.options],
       },
-      canFinish: canFinishWizard(state, manualTire, manualGearbox),
+      canFinish: canFinishWizard(state, currentManualTire, currentManualGearbox),
       gearboxOptions: [...currentGearboxOptions],
       isOpen: isOpen.value,
       manualInputs: cloneManualInputs(inputs),
@@ -272,8 +292,8 @@ export function createCarsFeatureWorkflow(
       step: state.step,
       summaryData: buildWizardSummaryData(state, {
         fmt: deps.fmt,
-        manualGearbox,
-        manualTire,
+        manualGearbox: currentManualGearbox,
+        manualTire: currentManualTire,
         t: deps.t,
       }),
       tireOptions: [...currentTireOptions],
@@ -405,7 +425,7 @@ export function createCarsFeatureWorkflow(
 
   function loadSpecsStep(): void {
     const state = wizardState.value;
-    const currentManualInputs = manualInputs.value;
+    const currentManualInputs = readManualInputs();
     const nextTireOptions = resolveTireOptions(state.selectedModel, state.selectedVariant);
     const nextGearboxOptions = resolveGearboxes(state.selectedModel, state.selectedVariant);
     const nextSelectedTire = nextTireOptions.length > 0
@@ -424,7 +444,7 @@ export function createCarsFeatureWorkflow(
       tireOptions.value = nextTireOptions;
       gearboxOptions.value = nextGearboxOptions;
       noGearboxesMessage.value = nextNoGearboxesMessage;
-      manualInputs.value = nextManualInputs;
+      writeManualInputs(nextManualInputs);
       updateWizardState((nextState) => {
         nextState.selectedTire = nextSelectedTire;
         if (!nextTireOptions.length) {
@@ -471,7 +491,7 @@ export function createCarsFeatureWorkflow(
 
     async finishWizard(): Promise<boolean> {
       const state = wizardState.value;
-      const inputs = manualInputs.value;
+      const inputs = readManualInputs();
       const resolvedBranch = getResolvedWizardSpecBranch(state);
       if (resolvedBranch === "library") {
         const tire = state.selectedTire;
@@ -540,7 +560,7 @@ export function createCarsFeatureWorkflow(
 
     handleManualInputsChanged(inputs: CarsFeatureManualInputState): void {
       batch(() => {
-        manualInputs.value = cloneManualInputs(inputs);
+        writeManualInputs(inputs);
         if (isOpen.value && wizardState.value.step === 4) {
           updateWizardState((state) => {
             state.specBranch = "manual";
@@ -552,7 +572,6 @@ export function createCarsFeatureWorkflow(
     async openWizard(): Promise<void> {
       batch(() => {
         wizardState.value = createInitialWizardState();
-        manualInputs.value = cloneManualInputs(manualInputs.value);
         brandOptions.value = createIdleOptionsState<string>();
         typeOptions.value = createIdleOptionsState<string>();
         modelOptions.value = createIdleOptionsState<CarLibraryModel>();
@@ -613,7 +632,7 @@ export function createCarsFeatureWorkflow(
         updateWizardState((state) => {
           state.selectedTire = selectedTire;
         });
-        manualInputs.value = tireInputsFromOption(selectedTire, manualInputs.value);
+        writeManualInputs(tireInputsFromOption(selectedTire, readManualInputs()));
       });
     },
 

--- a/apps/ui/tests/cars_feature_workflow.spec.ts
+++ b/apps/ui/tests/cars_feature_workflow.spec.ts
@@ -162,6 +162,83 @@ test.describe("createCarsFeatureWorkflow", () => {
     expect(workflow.getRenderState().isOpen).toBe(false);
   });
 
+  test("preserves manual draft values across wizard reopen", async () => {
+    const harness = createHarness();
+    const workflow = createCarsFeatureWorkflow({
+      addCarFromWizard: async () => undefined,
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      t: createTranslator(),
+      transport: {
+        async loadBrands() {
+          return ["BMW"];
+        },
+      },
+      view: createViewPorts(harness),
+    });
+
+    await workflow.openWizard();
+    workflow.handleManualInputsChanged({
+      ...createDefaultManualInputs(),
+      finalDrive: "4.10",
+      topGear: "0.71",
+    });
+    workflow.closeWizard();
+
+    await workflow.openWizard();
+
+    expect(workflow.getRenderState().manualInputs).toEqual({
+      ...createDefaultManualInputs(),
+      finalDrive: "4.10",
+      topGear: "0.71",
+    });
+  });
+
+  test("keeps manual gearbox inputs when tire autofill updates only tire fields", async () => {
+    const harness = createHarness();
+    const tire = makeTireOption({
+      rim_in: 20,
+      tire_aspect_pct: 35,
+      tire_width_mm: 285,
+    });
+    const workflow = createCarsFeatureWorkflow({
+      addCarFromWizard: async () => undefined,
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      t: createTranslator(),
+      transport: {
+        async loadBrands() {
+          return ["BMW"];
+        },
+        async loadModels() {
+          return [makeModel({
+            tire_options: [tire],
+          })];
+        },
+        async loadTypes() {
+          return ["SUV"];
+        },
+      },
+      view: createViewPorts(harness),
+    });
+
+    await workflow.openWizard();
+    await workflow.selectBrand("BMW");
+    await workflow.selectType("SUV");
+    workflow.handleManualInputsChanged({
+      ...createDefaultManualInputs(),
+      finalDrive: "4.10",
+      topGear: "0.71",
+    });
+    await workflow.selectModel(0);
+
+    expect(workflow.getRenderState().manualInputs).toEqual({
+      finalDrive: "4.10",
+      rim: "20",
+      tireAspect: "35",
+      tireWidth: "285",
+      topGear: "0.71",
+    });
+  });
+
   test("keeps the library branch disabled until a gearbox is chosen and then submits the selected specs", async () => {
     const harness = createHarness();
     const addCalls: Array<{


### PR DESCRIPTION
## Summary

Closes #2393.

This change narrows the reactive ownership of the cars wizard's manual spec inputs without changing the public workflow or panel contracts. Before this patch, `createCarsFeatureWorkflow()` stored the entire `CarsFeatureManualInputState` in one signal object. That meant a single keystroke in any manual field replaced the whole object and invalidated every downstream reader, including branches that only cared about one subset of the data. The issue called out that pattern directly, and the fix here is to split the internal storage into field-level signals while keeping the aggregate object available anywhere the full draft still makes sense.

## Implementation approach

The goal was to make the reactive graph more precise without broadening the scope into a larger cars-wizard rewrite. I kept the external `CarsFeatureManualInputState` shape intact, kept `handleManualInputsChanged()` on the same whole-object action contract that `cars_wizard_panel.tsx` already emits, and kept `renderState.manualInputs` returning the same aggregate object that existing consumers expect. The refactor is strictly about how the workflow stores and derives that state internally.

Inside `apps/ui/src/app/features/cars_feature_workflow.ts`, the single `manualInputs` signal is replaced by five field signals: `manualFinalDrive`, `manualRim`, `manualTireAspect`, `manualTireWidth`, and `manualTopGear`. Two small helpers, `readManualInputs()` and `writeManualInputs()`, now bridge between that granular storage and the existing aggregate object contract. That gives the workflow a cheap path to reassemble the full draft when it needs to return view state or submit the finished car, but it stops forcing every manual-input dependency to subscribe to an unrelated five-field object.

The more important part of the change is how the derived manual-spec state now reads from those signals. `manualGearbox` is now its own `computed()` depending only on the wizard step plus `finalDrive` and `topGear`. `manualTire` is a separate `computed()` depending only on the wizard step plus `rim`, `tireAspect`, and `tireWidth`. That is the actual granularity win for this issue: changing a tire dimension no longer makes the gearbox-derived manual spec read through the same coarse object signal, and changing a gearbox field no longer pulls the tire branch through the same invalidation path.

## Main code changes by area

In `cars_feature_workflow.ts`, the render-state assembly still returns the same shape, but it now consumes the new derived values through `currentManualGearbox` and `currentManualTire` rather than recomputing both from one aggregate signal read. The workflow methods that need the full draft, such as `finishWizard()`, call `readManualInputs()` and continue to work with the same full object shape they used before. That keeps the implementation narrow and avoids touching downstream consumers that are not part of this issue.

The manual-write paths were updated carefully so the behavior stays consistent:

- `handleManualInputsChanged()` writes through the field-level helper instead of replacing one object signal.
- `loadSpecsStep()` still auto-fills tire data from the selected library tire option, but now does so through the granular helper.
- `selectTire()` also writes through the granular helper, which preserves the current gearbox draft values while replacing only the tire-related fields.
- `openWizard()` no longer performs the old clone-to-self write on the aggregate signal because there is no longer a single object signal to refresh.

That last point is worth calling out because it is an intentional cleanup, not a behavior change. The wizard still preserves the user's manual draft across close/reopen until they actually change it; the implementation just no longer needs a no-op clone assignment to do that.

## Tests and validation

I added focused workflow coverage in `apps/ui/tests/cars_feature_workflow.spec.ts` for the two behavior seams most directly affected by this refactor.

The first new test proves that manual draft values survive a close/reopen cycle. That guards the removal of the old aggregate-signal clone in `openWizard()` and makes sure the split storage still behaves like the previous implementation from the user's perspective.

The second new test proves that tire autofill only updates the tire-related portion of the manual draft while preserving the current gearbox inputs. That specifically covers the new `writeManualInputs()` usage inside `loadSpecsStep()` and `selectTire()`, which are the two places where the workflow intentionally rewrites only part of the aggregate draft.

Beyond those new focused assertions, I reran the relevant cars workflow, cars module, and browser smoke slices plus the standard frontend gates:

- `cd /workspace/VibeSensor/apps/ui && npx playwright test tests/cars_feature_workflow.spec.ts tests/settings_cars_module.spec.ts --workers=1`
- `cd /workspace/VibeSensor/apps/ui && npx playwright test tests/smoke.car-wizard.spec.ts tests/smoke.cars.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd /workspace/VibeSensor/apps/ui && npm run typecheck`
- `cd /workspace/VibeSensor/apps/ui && npm run build`
- `cd /workspace/VibeSensor/apps/ui && npm run lint`

Those runs stayed green. The only lint output remains the pre-existing Biome schema-version info message, which is unchanged by this branch.

## Risks, tradeoffs, and scope boundaries

The deliberate tradeoff here is that I did **not** widen the change into a broader render-state decomposition. `renderState` still assembles a full workflow view model, still returns cloned option arrays, and still computes other derived wizard fields in one owner. That larger hot-path cleanup is already being tracked separately by later follow-up issues in this backlog. For `#2393`, the narrow and maintainable fix is to stop storing the manual draft as one coarse signal and to stop forcing the tire and gearbox manual derivations through the same aggregate invalidation path.

I also kept the panel action contract whole-object on purpose. `cars_wizard_panel.tsx` already emits `manual-inputs-changed` with the complete manual draft, and there was no need to change that API to get the reactive granularity benefit inside the workflow. That keeps the public surface stable while still improving the internal signal graph.

There are no schema, backend, or documentation changes in this PR because the issue is purely an internal frontend workflow refactor. The user-visible wizard behavior remains the same; the improvement is in how the workflow stores and derives manual input state.
