### PR TITLE
Flatten ESP flash model signal reads

### DIFF
--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -333,32 +333,17 @@ function EspFlashPanel(props: {
     "settings.esp_flash.history_intro",
     "Recent flashes stay here so the next operator can see what happened last.",
   );
-  const statusBanner = useComputed(() => props.model.value.statusBanner);
-  const statusBannerVariant = useComputed(() => statusBanner.value.variant);
-  const statusBannerText = useComputed(() => statusBanner.value.text);
-  const portSelectDisabled = useComputed(() => props.model.value.portSelectDisabled);
-  const selectedPortValue = useComputed(() => props.model.value.selectedPortValue);
-  const portOptions = useComputed(() => props.model.value.portOptions);
-  const refreshPortsDisabled = useComputed(() => props.model.value.refreshPortsDisabled);
-  const startSummary = useComputed(() => props.model.value.startSummary);
-  const readiness = useComputed(() => props.model.value.readiness);
-  const journey = useComputed(() => props.model.value.journey);
-  const log = useComputed(() => props.model.value.log);
-  const history = useComputed(() => props.model.value.history);
-  const startButtonHidden = useComputed(() => props.model.value.startButtonHidden);
-  const startButtonDisabled = useComputed(() => props.model.value.startButtonDisabled);
-  const startButtonLabelText = useComputed(() => props.model.value.startButtonLabelText);
-  const cancelButtonHidden = useComputed(() => props.model.value.cancelButtonHidden);
-  const cancelButtonDisabled = useComputed(() => props.model.value.cancelButtonDisabled);
+  const model = useComputed(() => props.model.value);
   const logPanelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const logPanel = logPanelRef.current;
-    if (!logPanel || log.value.emptyState !== null) {
+    const log = model.value.log;
+    if (!logPanel || log.emptyState !== null) {
       return;
     }
     logPanel.scrollTop = logPanel.scrollHeight;
-  }, [log.value.emptyState, log.value.text]);
+  }, [model.value.log.emptyState, model.value.log.text]);
 
   return (
     <div class="panel card">
@@ -383,9 +368,9 @@ function EspFlashPanel(props: {
               <span
                 id="espFlashStatusBanner"
                 class="pill"
-                data-variant={statusBannerVariant}
+                data-variant={model.value.statusBanner.variant}
               >
-                {statusBannerText}
+                {model.value.statusBanner.text}
               </span>
             </div>
             <div class="maintenance-card__body maintenance-card__body--hero">
@@ -398,41 +383,40 @@ function EspFlashPanel(props: {
                 </label>
                 <select
                   id="espFlashPortSelect"
-                  disabled={portSelectDisabled}
-                  value={selectedPortValue}
+                  disabled={model.value.portSelectDisabled}
+                  value={model.value.selectedPortValue}
                   onChange={(event) =>
                     props.actions.value?.onSelectPort(event.currentTarget.value)}
                 >
-                  {portOptions.value.map((option) => (
+                  {model.value.portOptions.map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.labelText}
                     </option>
                   ))}
                 </select>
                 <button
-                   type="button"
-                   id="espFlashRefreshPortsBtn"
-                   class="btn btn--muted"
-
-                   disabled={refreshPortsDisabled}
-                   onClick={() => props.actions.value?.onRefreshPorts()}
-                 >
-                   {refreshLabel}
-                 </button>
-               </div>
+                  type="button"
+                  id="espFlashRefreshPortsBtn"
+                  class="btn btn--muted"
+                  disabled={model.value.refreshPortsDisabled}
+                  onClick={() => props.actions.value?.onRefreshPorts()}
+                >
+                  {refreshLabel}
+                </button>
+              </div>
               <div
                 id="espFlashStartSummary"
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
               >
-                <MaintenanceReadinessPanel model={startSummary.value} />
+                <MaintenanceReadinessPanel model={model.value.startSummary} />
               </div>
               <div
                 id="espFlashReadinessPanel"
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
               >
-                <EspFlashReadinessSection model={readiness.value} />
+                <EspFlashReadinessSection model={model.value.readiness} />
               </div>
               <details class="settings-help-disclosure settings-help-disclosure--inline">
                 <summary class="settings-help-disclosure__summary">
@@ -465,19 +449,18 @@ function EspFlashPanel(props: {
                   type="button"
                   id="espFlashStartBtn"
                   class="btn btn--success"
-                  hidden={startButtonHidden}
-                  disabled={startButtonDisabled}
+                  hidden={model.value.startButtonHidden}
+                  disabled={model.value.startButtonDisabled}
                   onClick={() => props.actions.value?.onStart()}
                 >
-                  {startButtonLabelText}
+                  {model.value.startButtonLabelText}
                 </button>
                 <button
                   type="button"
                   id="espFlashCancelBtn"
                   class="btn btn--danger"
-
-                  hidden={cancelButtonHidden}
-                  disabled={cancelButtonDisabled}
+                  hidden={model.value.cancelButtonHidden}
+                  disabled={model.value.cancelButtonDisabled}
                   onClick={() => props.actions.value?.onCancel()}
                 >
                   {cancelLabel}
@@ -503,7 +486,7 @@ function EspFlashPanel(props: {
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
               >
-                <EspFlashJourneySection model={journey.value} />
+                <EspFlashJourneySection model={model.value.journey} />
               </div>
             </section>
             <section class="maintenance-card">
@@ -527,13 +510,13 @@ function EspFlashPanel(props: {
                 id="espFlashLogPanel"
                 ref={logPanelRef}
                 class={
-                  log.value.emptyState
+                  model.value.log.emptyState
                     ? "maintenance-log-slot"
                     : "maintenance-log-slot maintenance-log-panel"
                 }
                 aria-live="polite"
               >
-                <EspFlashLogContent model={log.value} />
+                <EspFlashLogContent model={model.value.log} />
               </div>
             </section>
           </div>
@@ -541,27 +524,25 @@ function EspFlashPanel(props: {
           <section class="maintenance-card">
             <div class="maintenance-card__header">
               <div>
-                  <div
-                    class="maintenance-card__title"
-
-                   >
-                    {historyTitle}
-                  </div>
                 <div
-                   class="subtle"
-
-                   >
-                    {historyIntro}
-                  </div>
-               </div>
-             </div>
+                  class="maintenance-card__title"
+                >
+                  {historyTitle}
+                </div>
+                <div
+                  class="subtle"
+                >
+                  {historyIntro}
+                </div>
+              </div>
+            </div>
             <div
               id="espFlashHistoryPanel"
               class="maintenance-stack maintenance-stack--tight"
-             >
-               <EspFlashHistoryContent model={history.value} />
-             </div>
-           </section>
+            >
+              <EspFlashHistoryContent model={model.value.history} />
+            </div>
+          </section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Closes #2395.

This PR removes the property-by-property `useComputed()` chain from `apps/ui/src/app/views/esp_flash_panel.tsx` and flattens the panel onto a single top-level `useComputed(() => props.model.value)` read. The behavior of the ESP flash surface is intentionally unchanged. The goal is to reduce signal-graph overhead in a component that already receives one render-model signal, where the extra per-property computed nodes no longer provide meaningful isolation after the recent reactive-panel migration.

## Problem being solved

Before this change, `EspFlashPanel` built a long list of small computed nodes from one source signal:

- status banner
- selected port state
- port options
- refresh button disabled state
- start summary model
- readiness model
- journey model
- log model
- history model
- start/cancel button visibility and disabled state
- start button label text

That pattern was mechanically correct, but it no longer matched the current architecture of the component. The panel already accepts one `ReadonlySignal<EspFlashPanelRenderModel>`, so all of those intermediate `useComputed()` calls still depended on the same root source. When `props.model.value` changed, the component did not gain real per-field invalidation benefits from having eighteen separate signal nodes that simply peeled off nested properties. The issue called this out directly, and the current file confirmed it: this view is already a presentational island whose data comes from one upstream render-model owner.

There was also an adjacent cleanup sitting nearby in the same file: several inline JSX handlers still call `props.actions.value?.on...()` directly. I deliberately did **not** fold that into this PR, because that concern is already split into the next issue in the queue (`#2396`). Keeping this change scoped to the model-derived `useComputed()` chain makes the review smaller and preserves a clean issue boundary.

## Implementation approach

The chosen fix follows the narrowest version of the issue’s suggested direction: accept the render model as one computed value and read from it directly in the component body.

Inside `EspFlashPanel`, the old chain of per-property computed declarations is replaced with:

```ts
const model = useComputed(() => props.model.value);
```

From there, JSX reads the current values directly from `model.value.*`. That includes the hero status pill, port-select state, refresh/start/cancel button state, readiness summary, journey content, flash log content, and history content.

The log autoscroll effect was also updated to read from the flattened model path. Instead of depending on a separate `log` computed, the effect now snapshots `model.value.log` locally and uses `model.value.log.emptyState` plus `model.value.log.text` in its dependency list. That keeps the current behavior intact: when the log is non-empty and its text changes, the panel still scrolls to the bottom; when the log is empty, it still avoids forcing scroll position changes.

I did not touch:

- the mount contract in `mountEspFlashPanel()`
- the `EspFlashPanelRenderModel` type
- feature/presenter/workflow code upstream of the view
- the inline `props.actions.value` handler pattern that belongs to `#2396`

So this is a structural cleanup of the view’s reactive read path, not a broader redesign of ESP flash state ownership.

## Main code changes by area

The full diff is intentionally contained to one file: `apps/ui/src/app/views/esp_flash_panel.tsx`.

1. **Flattened model extraction**
   - Removed the long run of one-property `useComputed()` declarations.
   - Added one top-level `model` computed sourced from `props.model.value`.

2. **Updated JSX bindings**
   - The status pill now reads `model.value.statusBanner.variant` and `.text`.
   - The port select and refresh button now read `model.value.portSelectDisabled`, `selectedPortValue`, `portOptions`, and `refreshPortsDisabled`.
   - The start summary, readiness section, journey section, log content, and history content now receive their models directly from `model.value.*`.
   - The start/cancel buttons now read hidden/disabled state and label text directly from `model.value`.

3. **Preserved log autoscroll behavior**
   - The effect still scrolls the log panel after log text updates.
   - The only change is where the effect reads its source values from.

No schema, API, config, or documentation changes were needed for this issue. No tests needed rewriting because the existing ESP flash feature and binding suites already cover the panel behavior through the public view/feature seam instead of pinning the internal `useComputed()` shape.

## Validation and tests

I kept validation focused on the surfaces that can regress from this refactor: the ESP flash view bindings, the ESP flash feature wiring, and the browser smoke that exercises the mounted panel through the live UI shell.

The following commands passed locally:

- `cd /workspace/VibeSensor/apps/ui && npx playwright test tests/esp_flash_feature.spec.ts tests/esp_flash_feature_bindings.spec.ts --workers=1`
- `cd /workspace/VibeSensor/apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.esp-flash.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd /workspace/VibeSensor/apps/ui && npm run typecheck`
- `cd /workspace/VibeSensor/apps/ui && npm run build`
- `cd /workspace/VibeSensor/apps/ui && npm run lint`

That validation slice matters for a few reasons:

- `tests/esp_flash_feature_bindings.spec.ts` ensures the panel still exposes and consumes the expected binding surface.
- `tests/esp_flash_feature.spec.ts` covers the panel’s feature-level behavior with realistic view updates.
- `tests/smoke.esp-flash.spec.ts` exercises the mounted UI path rather than only the isolated component seam.
- `tests/smoke.bootstrap.spec.ts` catches startup/runtime regressions that can show up when mounted panels subscribe differently after a reactive cleanup.

There was one environment-side Vite websocket proxy warning during the earlier smoke pass (`connect ECONNREFUSED 127.0.0.1:8000`), but the smoke suite itself still passed and the command exited successfully. The underlying browser validations for the ESP flash surface remained green.

A focused code-review pass over the final diff also came back without material issues.

## Risks, tradeoffs, and edge cases

The main tradeoff is intentional: the component now tracks one top-level computed model rather than many nested computed properties. In this file, that is a net simplification because the old structure was not buying real field-level savings. All of the removed computed nodes were still invalidated by the same root model signal, so the prior graph carried bookkeeping overhead without changing the user-visible update boundary in a meaningful way.

The main edge case I checked was the log autoscroll behavior, because it is the one place where the component has local effect-driven DOM behavior rather than pure JSX output. The final code still gates scrolling on `emptyState === null` and still reruns when log text changes, so the existing behavior is preserved.

I also intentionally kept the `actions` signal reads untouched. Pulling that cleanup into the same PR would have mixed two different issue scopes:

- `#2395`: flatten model-derived computed reads
- `#2396`: avoid repeated `.value` dereferences on the actions signal inside JSX handlers

Keeping those separate preserves a clean review and makes any later regression easier to attribute.

There are no known migration concerns from this PR. The external panel contract stays the same, the ESP flash workflow contract stays the same, and the UI behavior should remain identical. The win here is a smaller, flatter reactive view implementation that better matches the current architecture of the panel.
