### PR TITLE
Hoist inline action signal reads

### DIFF
--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -333,8 +333,21 @@ function EspFlashPanel(props: {
     "settings.esp_flash.history_intro",
     "Recent flashes stay here so the next operator can see what happened last.",
   );
+  const actions = useComputed(() => props.actions.value);
   const model = useComputed(() => props.model.value);
   const logPanelRef = useRef<HTMLDivElement | null>(null);
+  const handleSelectPort = (value: string) => {
+    actions.value?.onSelectPort(value);
+  };
+  const handleRefreshPorts = () => {
+    actions.value?.onRefreshPorts();
+  };
+  const handleStart = () => {
+    actions.value?.onStart();
+  };
+  const handleCancel = () => {
+    actions.value?.onCancel();
+  };
 
   useEffect(() => {
     const logPanel = logPanelRef.current;
@@ -385,8 +398,7 @@ function EspFlashPanel(props: {
                   id="espFlashPortSelect"
                   disabled={model.value.portSelectDisabled}
                   value={model.value.selectedPortValue}
-                  onChange={(event) =>
-                    props.actions.value?.onSelectPort(event.currentTarget.value)}
+                  onChange={(event) => handleSelectPort(event.currentTarget.value)}
                 >
                   {model.value.portOptions.map((option) => (
                     <option key={option.value} value={option.value}>
@@ -399,7 +411,7 @@ function EspFlashPanel(props: {
                   id="espFlashRefreshPortsBtn"
                   class="btn btn--muted"
                   disabled={model.value.refreshPortsDisabled}
-                  onClick={() => props.actions.value?.onRefreshPorts()}
+                  onClick={handleRefreshPorts}
                 >
                   {refreshLabel}
                 </button>
@@ -451,7 +463,7 @@ function EspFlashPanel(props: {
                   class="btn btn--success"
                   hidden={model.value.startButtonHidden}
                   disabled={model.value.startButtonDisabled}
-                  onClick={() => props.actions.value?.onStart()}
+                  onClick={handleStart}
                 >
                   {model.value.startButtonLabelText}
                 </button>
@@ -461,7 +473,7 @@ function EspFlashPanel(props: {
                   class="btn btn--danger"
                   hidden={model.value.cancelButtonHidden}
                   disabled={model.value.cancelButtonDisabled}
-                  onClick={() => props.actions.value?.onCancel()}
+                  onClick={handleCancel}
                 >
                   {cancelLabel}
                 </button>

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -29,9 +29,16 @@ function HistoryPanel(props: {
   const startedLabel = useUiText("history.table.updated", "Started");
   const samplesLabel = useUiText("history.table.size", "Samples");
   const actionsLabel = useUiText("history.table.actions", "Actions");
+  const actions = useComputed(() => props.actions.value);
   const deleteAllRunsDisabled = useComputed(() => props.model.value.deleteAllRunsDisabled);
   const historySummaryText = useComputed(() => props.model.value.historySummaryText);
   const table = useComputed(() => props.model.value.table);
+  const handleRefreshHistory = () => {
+    actions.value?.onRefreshHistory();
+  };
+  const handleDeleteAllRuns = () => {
+    actions.value?.onDeleteAllRuns();
+  };
 
   return (
     <>
@@ -46,7 +53,7 @@ function HistoryPanel(props: {
             id="refreshHistoryBtn"
             class="btn btn--muted"
             type="button"
-            onClick={() => props.actions.value?.onRefreshHistory()}
+            onClick={handleRefreshHistory}
           >
             {refreshLabel}
           </button>
@@ -55,7 +62,7 @@ function HistoryPanel(props: {
             class="btn btn--danger-quiet"
             type="button"
             disabled={deleteAllRunsDisabled}
-            onClick={() => props.actions.value?.onDeleteAllRuns()}
+            onClick={handleDeleteAllRuns}
           >
             {deleteAllLabel}
           </button>
@@ -71,7 +78,7 @@ function HistoryPanel(props: {
           </tr>
         </thead>
         <tbody id="historyTableBody">
-          <HistoryTableBody handlers={props.actions.value} table={table.value} />
+          <HistoryTableBody handlers={actions.value} table={table.value} />
         </tbody>
       </table>
     </>

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -171,6 +171,16 @@ function RealtimeLoggingPanel(props: {
   const showProgressSection = useComputed(() => !setupMode.value || checklist.value !== null);
   const showStartHidden = useComputed(() => !showStart.value);
   const showStopHidden = useComputed(() => !showStop.value);
+  const actions = useComputed(() => props.actions.value);
+  const handleSummaryAction = (action: RealtimeLoggingSummaryAction) => {
+    actions.value?.onSummaryAction(action);
+  };
+  const handleStartLogging = () => {
+    actions.value?.onStartLogging();
+  };
+  const handleStopLogging = () => {
+    actions.value?.onStopLogging();
+  };
 
   return (
     <div class="realtime-logging-shell" data-layout={shellLayout}>
@@ -182,7 +192,7 @@ function RealtimeLoggingPanel(props: {
           <RealtimeLoggingSummary
             summaryText={summaryText.value}
             summaryPanel={summaryPanel.value}
-            onAction={props.actions.value?.onSummaryAction ?? null}
+            onAction={handleSummaryAction}
           />
         </div>
       </div>
@@ -244,7 +254,7 @@ function RealtimeLoggingPanel(props: {
 
           hidden={showStartHidden}
           disabled={startDisabled}
-          onClick={() => props.actions.value?.onStartLogging()}
+          onClick={handleStartLogging}
         >
           {startLabel}
         </button>
@@ -255,7 +265,7 @@ function RealtimeLoggingPanel(props: {
 
           hidden={showStopHidden}
           disabled={stopDisabled}
-          onClick={() => props.actions.value?.onStopLogging()}
+          onClick={handleStopLogging}
         >
           {stopLabel}
         </button>

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -335,12 +335,19 @@ function UpdatePanel(props: {
     "Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.",
   );
   const cancelLabel = useUiText("settings.update.cancel", "Cancel Update");
+  const actions = useComputed(() => props.actions.value);
   const status = useComputed(() => props.model.value.status);
   const startButtonHidden = useComputed(() => props.model.value.startButtonHidden);
   const startButtonDisabled = useComputed(() => props.model.value.startButtonDisabled);
   const startButtonLabelText = useComputed(() => props.model.value.startButtonLabelText);
   const cancelButtonHidden = useComputed(() => props.model.value.cancelButtonHidden);
   const cancelButtonDisabled = useComputed(() => props.model.value.cancelButtonDisabled);
+  const handleStart = () => {
+    actions.value?.onStart();
+  };
+  const handleCancel = () => {
+    actions.value?.onCancel();
+  };
   return (
     <div class="panel card">
       <div class="maintenance-layout maintenance-layout--compact">
@@ -373,7 +380,7 @@ function UpdatePanel(props: {
                 class="btn btn--success"
                 hidden={startButtonHidden}
                 disabled={startButtonDisabled}
-                onClick={() => props.actions.value?.onStart()}
+                onClick={handleStart}
               >
                 {startButtonLabelText}
               </button>
@@ -383,7 +390,7 @@ function UpdatePanel(props: {
                 class="btn btn--danger"
                 hidden={cancelButtonHidden}
                 disabled={cancelButtonDisabled}
-                onClick={() => props.actions.value?.onCancel()}
+                onClick={handleCancel}
               >
                 {cancelLabel}
               </button>


### PR DESCRIPTION
## Summary

Closes #2396.

This PR removes the remaining inline `props.actions.value?.on...()` handler reads from the four view files called out by the issue: `esp_flash_panel.tsx`, `update_panel.tsx`, `realtime_logging_panel.tsx`, and `history_panel.tsx`. Each of those views now hoists its action bag once through `useComputed(() => props.actions.value)` and routes JSX through named callbacks instead of repeatedly reaching through the signal inside the markup itself.

The user-visible behavior is intentionally unchanged. The goal is to clean up the reactive handler path after the larger panel/reactivity migration, so these views stop mixing signal access and event wiring directly in JSX.

## Problem being solved

Before this change, the affected views still contained a leftover pattern like:

```tsx
onClick={() => props.actions.value?.onStart()}
```

and, in the realtime logging summary case:

```tsx
onAction={props.actions.value?.onSummaryAction ?? null}
```

That worked, but it left each view repeatedly resolving the same action signal inline in render code. The issue called out eleven such sites across four files. After the recent signal-backed panel migration, that pattern was one of the remaining bits of reactive bookkeeping noise in otherwise-clean view components.

This is intentionally a narrow cleanup. It is **not** another pass at flattening model reads from `props.model`, because that work was already handled by the immediately preceding issue (`#2395`). It is also **not** a broad sweep across every action signal read in the frontend. The issue text is specifically about the inline handler pattern in these four files, so this PR keeps the scope there and leaves unrelated action usage alone.

## Implementation approach

I chose the lighter of the issue’s suggested fixes: hoist the action signal once per view and have JSX call named wrapper functions.

In each touched component, the pattern now starts with:

```ts
const actions = useComputed(() => props.actions.value);
```

From there, the component defines the few event callbacks it needs:

- `handleStart`
- `handleCancel`
- `handleRefreshPorts`
- `handleSelectPort`
- `handleSummaryAction`
- `handleRefreshHistory`
- `handleDeleteAllRuns`
- and the corresponding realtime logging start/stop callbacks

JSX now binds those named callbacks instead of inline closures that directly dereference `props.actions.value`.

This keeps the action-signal access localized to one place per component and makes the event surface easier to scan in review. It also matches the direction already taken elsewhere in this migration: keep views data-in / DOM-out, and avoid embedding low-level runtime wiring details deep inside JSX attributes when a small wrapper function makes the ownership clearer.

## Main code changes by area

### `apps/ui/src/app/views/esp_flash_panel.tsx`

The ESP flash panel already had its model reads flattened in `#2395`, but its port-select and button handlers still reached directly into `props.actions.value`.

This PR adds one computed action bag plus four named callbacks:

- port selection
- refresh ports
- start flash
- cancel flash

The panel still uses the same IDs, the same render model, and the same action-handler contract. Only the action access path changed.

### `apps/ui/src/app/views/update_panel.tsx`

The update panel had the same inline pattern on the start and cancel buttons. Those two handlers are now hoisted into local named callbacks backed by one computed action signal.

Again, this is intentionally small: no status rendering logic, i18n copy, or updater state wiring changed.

### `apps/ui/src/app/views/realtime_logging_panel.tsx`

This file had the trickiest case because it includes both button handlers and the `RealtimeLoggingSummary` child callback.

The panel now:

- hoists the action signal once
- uses named callbacks for start/stop logging
- passes a named `handleSummaryAction` wrapper into `RealtimeLoggingSummary`

This preserves the current behavior while removing the direct inline signal dereference from the render tree.

### `apps/ui/src/app/views/history_panel.tsx`

The history toolbar buttons now use named callbacks backed by the hoisted action signal. Since the file now already owns that computed action bag, `HistoryTableBody` also receives `actions.value` instead of mixing the old direct `props.actions.value` path beside the new callbacks.

That change is still within scope because it keeps the same goal inside the same issue file: make the action flow consistent and stop reaching back into `props.actions` ad hoc once the view has already hoisted its handler source.

## Validation and tests

I kept validation focused on the four touched surfaces and the browser paths most likely to notice a broken handler hookup:

- ESP flash
- update
- history
- realtime logging / dashboard CTA flow

The following commands passed locally:

- `cd /workspace/VibeSensor/apps/ui && npx playwright test tests/esp_flash_feature.spec.ts tests/esp_flash_feature_bindings.spec.ts tests/update_feature_bindings.spec.ts tests/history_feature_modules.spec.ts --workers=1`
- `cd /workspace/VibeSensor/apps/ui && npx playwright test tests/realtime_logging_summary.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts tests/smoke.history.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd /workspace/VibeSensor/apps/ui && npm run typecheck`
- `cd /workspace/VibeSensor/apps/ui && npm run build`
- `cd /workspace/VibeSensor/apps/ui && npm run lint`

These checks matter for different reasons:

- `esp_flash_feature_bindings.spec.ts` and `update_feature_bindings.spec.ts` guard the panel-action wiring directly.
- `history_feature_modules.spec.ts` covers the shared owner flow behind the history buttons.
- `realtime_logging_summary.spec.ts` verifies the no-car dashboard CTA still stays stable while repeated websocket payloads arrive.
- The smoke tests make sure the real mounted UI still responds correctly through the action surface after the callback refactor.

One validation wrinkle is worth calling out explicitly because it is environmental, not a product regression: `tests/realtime_logging_summary.spec.ts` failed when I first ran it under the default Playwright config, which matches an earlier quirk already seen in this run. Rerunning that browser test under `.ai-temp/playwright.full.local.config.ts` passed cleanly, and the broader smoke slice stayed green there as well.

A focused code-review pass over the final diff also came back without material issues.

## Risks, tradeoffs, and edge cases

The main tradeoff is that each view now owns a few small named callbacks instead of embedding the action lookup inline in JSX. That adds a small amount of local code, but it improves readability and keeps the signal access path consistent.

I deliberately did **not** broaden this into a larger “all action signals everywhere” cleanup. For example, there are other action-signal usage patterns in the codebase, but the issue only called out this specific inline handler shape in these specific files. Pulling more files into the PR would make the review less focused and blur the backlog boundary.

I also kept the mount contracts unchanged. The affected views still accept the same `ReadonlySignal<...ActionHandlers | null>` inputs, and the surrounding feature/runtime wiring does not need to know that the handler resolution moved out of JSX. That keeps the change low-risk and easy to reason about.

There are no schema, contract, config, or documentation changes here. The benefit is a cleaner reactive view layer: one hoisted action source per component, clearer named callbacks, and less signal plumbing embedded directly in JSX attributes.
