### PR TITLE
Signal-back WsClient internal state

### DIFF
--- a/apps/ui/src/ws.ts
+++ b/apps/ui/src/ws.ts
@@ -1,5 +1,6 @@
 import type { LiveWsPayload } from "./contracts/ws_payload_types";
 import { batchAppStateUpdates } from "./app/ui_app_state";
+import { signal } from "./app/ui_signals";
 
 export type WsUiState = "connecting" | "connected" | "reconnecting" | "stale" | "no_data";
 
@@ -31,11 +32,10 @@ export class WsClient {
   };
 
   private ws: WebSocket | null = null;
-  private state: WsUiState;
   private reconnectTimer: number | null = null;
   private staleTimer: number | null = null;
-  private lastMessageAtMs = 0;
-  private hasData = false;
+  private readonly lastMessageAtMs = signal(0);
+  private readonly hasData = signal(false);
   private manuallyClosed = false;
   private reconnectAttempt = 0;
 
@@ -47,7 +47,6 @@ export class WsClient {
       hasData: hasSpectraClients,
       ...options,
     };
-    this.state = this.options.transport.wsState;
   }
 
   connect(): void {
@@ -81,9 +80,11 @@ export class WsClient {
   }
 
   private open(initialState: WsUiState): void {
-    this.setState(initialState);
-    this.hasData = false;
-    this.lastMessageAtMs = 0;
+    batchAppStateUpdates(() => {
+      this.commitState(initialState);
+      this.hasData.value = false;
+      this.lastMessageAtMs.value = 0;
+    });
     this.ws = new WebSocket(this.options.url);
 
     this.ws.onopen = () => {
@@ -98,11 +99,11 @@ export class WsClient {
         return;
       }
       const receivedAt = Date.now();
-      this.lastMessageAtMs = receivedAt;
-      this.hasData = this.hasData || this.options.hasData(payload);
       this.reconnectAttempt = 0;
       batchAppStateUpdates(() => {
-        this.commitState(this.hasData ? "connected" : "no_data");
+        this.lastMessageAtMs.value = receivedAt;
+        this.hasData.value = this.hasData.value || this.options.hasData(payload);
+        this.commitState(this.hasData.value ? "connected" : "no_data");
         this.options.transport.hasReceivedPayload = true;
         this.options.transport.pendingPayload = payload;
       });
@@ -141,11 +142,11 @@ export class WsClient {
 
   private tickStale(): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
-    if (!this.hasData || this.lastMessageAtMs <= 0) {
+    if (!this.hasData.value || this.lastMessageAtMs.value <= 0) {
       this.setState("no_data");
       return;
     }
-    if (Date.now() - this.lastMessageAtMs > this.options.staleAfterMs) {
+    if (Date.now() - this.lastMessageAtMs.value > this.options.staleAfterMs) {
       this.setState("stale");
     }
   }
@@ -157,8 +158,7 @@ export class WsClient {
   }
 
   private commitState(next: WsUiState): void {
-    if (this.state === next) return;
-    this.state = next;
+    if (this.options.transport.wsState === next) return;
     this.options.transport.wsState = next;
   }
 }

--- a/apps/ui/tests/ws.spec.ts
+++ b/apps/ui/tests/ws.spec.ts
@@ -52,6 +52,34 @@ class FakeWebSocket {
   }
 }
 
+function installIntervalHarness() {
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+  let intervalHandler: (() => void) | null = null;
+
+  globalThis.setInterval = ((handler: TimerHandler) => {
+    intervalHandler = handler as () => void;
+    return 1 as unknown as ReturnType<typeof setInterval>;
+  }) as typeof setInterval;
+
+  globalThis.clearInterval = (() => {
+    intervalHandler = null;
+  }) as typeof clearInterval;
+
+  return {
+    tick(): void {
+      if (!intervalHandler) {
+        throw new Error("No interval handler installed");
+      }
+      intervalHandler();
+    },
+    restore(): void {
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    },
+  };
+}
+
 test.describe("WsClient", () => {
   test.beforeEach(() => {
     installWindowGlobal();
@@ -91,6 +119,47 @@ test.describe("WsClient", () => {
 
       client.close();
     } finally {
+      globalThis.WebSocket = originalWebSocket;
+    }
+  });
+
+  test("marks the transport stale after signal-backed message timing expires", () => {
+    const originalWebSocket = globalThis.WebSocket;
+    const originalDateNow = Date.now;
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    const interval = installIntervalHarness();
+    let now = 1_000;
+    Date.now = () => now;
+    try {
+      const state = createAppState();
+      const client = new WsClient({
+        url: "ws://example.test/ws",
+        transport: state.transport,
+        staleAfterMs: 10,
+      });
+
+      client.connect();
+
+      const socket = FakeWebSocket.instances[0];
+      socket?.emitOpen();
+      socket?.emitMessage({
+        spectra: {
+          clients: {
+            "client-1": {},
+          },
+        },
+      });
+
+      expect(state.transport.wsState).toBe("connected");
+
+      now += 25;
+      interval.tick();
+
+      expect(state.transport.wsState).toBe("stale");
+      client.close();
+    } finally {
+      Date.now = originalDateNow;
+      interval.restore();
       globalThis.WebSocket = originalWebSocket;
     }
   });


### PR DESCRIPTION
## Summary

This PR removes the remaining shadow websocket state inside `WsClient` and
moves that internal bookkeeping onto the existing reactive transport surface.
The issue behind the change is not the public transport contract itself — the
shared transport slice already exists and the live transport controller already
reacts from it — but the fact that `apps/ui/src/ws.ts` still carried its own
private copies of state such as `this.state`, `this.hasData`, and
`this.lastMessageAtMs`.

That duplication made `WsClient` harder to reason about because the class was
tracking the same websocket lifecycle in two places at once: a local
imperative copy and the reactive `transport` slice. The narrow goal here was to
remove that redundant internal layer without broadening the work into another
transport rewrite. In other words, this PR cleans up `WsClient` internals while
leaving the already-merged signal-backed transport pipeline intact.

## Implementation approach

I kept the issue scoped to `apps/ui/src/ws.ts` and its focused tests. The live
transport controller, AppState transport slice shape, and demo-mode queue path
were already in a good place after the earlier websocket/store refactors, so
the cleanest fix here was to replace the remaining private shadow state rather
than inventing a second reactive seam around the class.

The resulting design follows the issue suggestion directly:

1. the private `this.state` field is gone, and websocket state now reads and
   writes through `transport.wsState`,
2. `this.hasData` is now a signal,
3. `this.lastMessageAtMs` is now a signal.

That means the class keeps its imperative responsibilities where they still
make sense — the live `WebSocket` instance, reconnect timer IDs, manual-close
flag, and reconnect-attempt counter — while the state that represents transport
status and data freshness now lives in one reactive system instead of being
duplicated.

## Main code changes

In `apps/ui/src/ws.ts`, I imported the canonical `signal()` helper from
`app/ui_signals` and converted the `hasData` and `lastMessageAtMs` fields from
plain private values into signals. The intent is not to expose these fields
publicly, but to make the websocket client’s own internal freshness bookkeeping
follow the same reactive model used elsewhere in the UI runtime.

I also removed the private `state` field entirely. Before this change, the
class constructor copied `transport.wsState` into `this.state`, and
`commitState()` had to keep those two values synchronized manually. After this
change, `commitState()` checks `transport.wsState` directly and writes back to
the same reactive transport slice, so there is no longer a second copy of the
websocket lifecycle inside the class.

The `open()` path now resets the reactive freshness signals (`hasData` and
`lastMessageAtMs`) inside the same batched update that applies the initial
transport state. That preserves the previous behavior while keeping the signal
updates aligned with the shared transport write.

The websocket `onmessage` path now updates the reactive timestamp and
data-seen flag before committing the next transport state and queuing the raw
payload. The key point here is that the message handler still behaves the same
from the outside — new payloads move the websocket state to `connected` when
real spectrum data is present, set `hasReceivedPayload`, and write the raw
payload into `transport.pendingPayload` — but the source of truth for the
freshness inputs is now signal-backed instead of plain local fields.

The one meaningful follow-up from review was to preserve the original ordering
of `reconnectAttempt = 0`. In the initial refactor pass, that reset moved into
the batched signal/app-state update. The final cut restores the old ordering by
resetting the reconnect attempt immediately before the batch, so the class keeps
the same sequencing it had before while still shedding the duplicated state.

The stale-timer path in `tickStale()` now reads from the signal-backed freshness
fields instead of plain numbers and booleans. That is the behaviorally
important part of the change: stale detection still depends on “have we seen
real data yet?” and “how long ago was the last message?”, but those values now
live in reactive state instead of imperative shadow state.

## Test coverage and validation

I kept validation focused on the websocket and transport slice because that is
the real blast radius here.

`apps/ui/tests/ws.spec.ts` now adds a new stale-timer regression. The existing
test already proved that `WsClient` writes websocket state and queued payloads
into the transport slice. The new test goes one step further and verifies that
after a real payload arrives, advancing the clock beyond `staleAfterMs` still
drives the transport state to `stale`. That directly covers the most important
behavior touched by moving `lastMessageAtMs` and `hasData` to signals.

I also reran the focused transport consumers so the refactor stayed compatible
with the code that reacts to the transport slice:

- `cd apps/ui && npx playwright test tests/ws.spec.ts tests/ui_live_transport_controller.spec.ts tests/demo_mode.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1 -g "ui bootstrap smoke: tabs, ws state, recording, history"`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

That validation matters because this issue sits on the same transport surface
used by live websocket payload application, demo-mode transport startup, and the
mounted shell/bootstrap flow. The focused suites stayed green before and after
the small review follow-up, and the smoke bootstrap slice still confirms the
mounted app can boot, reflect websocket state, and keep the core dashboard flow
alive on the current code.

## Risks, tradeoffs, and out of scope

The main risk here was accidentally changing transport timing while removing the
shadow state. I specifically avoided broad changes to reconnect logic, timer
ownership, payload parsing, or the public `WsTransportState` contract for that
reason. This PR does not try to redesign `WsClient` into a fully declarative
signal owner; it only removes the duplicated internal state that was no longer
pulling its weight.

That means some imperative fields remain, intentionally. The live socket
instance, reconnect timer IDs, stale timer ID, manual-close flag, and reconnect
attempt counter are still plain class fields because they represent imperative
resource ownership rather than shared reactive state. The goal was to move the
observable transport status and freshness inputs onto signals, not to force
every private field into the same model.

Closes #2398
