### PR TITLE
Inline spectrum panel signal defaults

### DIFF
--- a/apps/ui/src/app/runtime/spectrum_panel_view.ts
+++ b/apps/ui/src/app/runtime/spectrum_panel_view.ts
@@ -46,16 +46,18 @@ export interface SpectrumPanelChartDom {
   specChart: HTMLElement;
 }
 
+export interface SpectrumPanelBandToggleModel {
+  hasBands: boolean;
+  bandsVisible: boolean;
+  text: string;
+}
+
 export interface SpectrumPanelView {
   readonly chartDom: SpectrumPanelChartDom;
   bindBandToggle(onToggle: () => void): void;
   renderHeader(model: SpectrumPanelHeaderModel): void;
   renderOverlay(message: string | null): void;
-  renderBandToggle(model: {
-    hasBands: boolean;
-    bandsVisible: boolean;
-    text: string;
-  }): void;
+  renderBandToggle(model: SpectrumPanelBandToggleModel): void;
   renderSensorLegend(
     model: SpectrumSensorLegendModel | null,
     handlers?: {

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -7,6 +7,7 @@ import {
 } from "../ui_signals";
 import type {
   SpectrumBandLegendModel,
+  SpectrumPanelBandToggleModel,
   SpectrumPanelChartDom,
   SpectrumPanelHeaderModel,
   SpectrumPanelView,
@@ -23,56 +24,6 @@ type MutableSpectrumPanelChartDom = {
   specChart: HTMLElement | null;
 };
 
-type SpectrumPanelBridgeState = {
-  header: SpectrumPanelHeaderModel;
-  overlayMessage: string | null;
-  bandToggle: {
-    hasBands: boolean;
-    bandsVisible: boolean;
-    text: string;
-  };
-  sensorLegend: SpectrumSensorLegendModel | null;
-  sensorLegendHandlers: SpectrumLegendHandlers | null;
-  bandLegend: SpectrumBandLegendModel;
-  inspectorText: string;
-  onBandToggle: (() => void) | null;
-};
-
-const DEFAULT_PANEL_STATE: SpectrumPanelBridgeState = {
-  header: {
-    titleText: "Multi-Sensor Blended Spectrum",
-    hintText: "Use the trace chips to isolate one sensor at a time. Turn on reference bands when you need order context.",
-  },
-  overlayMessage: null,
-  bandToggle: {
-    hasBands: false,
-    bandsVisible: false,
-    text: "Show reference bands",
-  },
-  sensorLegend: null,
-  sensorLegendHandlers: null,
-  bandLegend: {
-    visible: false,
-    items: [],
-    emptyText: "No reference band",
-  },
-  inspectorText: "Use the trace chips or hover the chart to inspect the current peak.",
-  onBandToggle: null,
-};
-
-function createDefaultPanelState(): SpectrumPanelBridgeState {
-  return {
-    header: { ...DEFAULT_PANEL_STATE.header },
-    overlayMessage: DEFAULT_PANEL_STATE.overlayMessage,
-    bandToggle: { ...DEFAULT_PANEL_STATE.bandToggle },
-    sensorLegend: DEFAULT_PANEL_STATE.sensorLegend,
-    sensorLegendHandlers: DEFAULT_PANEL_STATE.sensorLegendHandlers,
-    bandLegend: { ...DEFAULT_PANEL_STATE.bandLegend, items: [...DEFAULT_PANEL_STATE.bandLegend.items] },
-    inspectorText: DEFAULT_PANEL_STATE.inspectorText,
-    onBandToggle: DEFAULT_PANEL_STATE.onBandToggle,
-  };
-}
-
 function requireSpectrumElement<T extends HTMLElement>(
   element: T | null,
   target: string,
@@ -85,7 +36,7 @@ function requireSpectrumElement<T extends HTMLElement>(
 
 function SpectrumPanel(props: {
   bandLegend: ReadonlySignal<SpectrumBandLegendModel>;
-  bandToggle: ReadonlySignal<SpectrumPanelBridgeState["bandToggle"]>;
+  bandToggle: ReadonlySignal<SpectrumPanelBandToggleModel>;
   chartDom: MutableSpectrumPanelChartDom;
   header: ReadonlySignal<SpectrumPanelHeaderModel>;
   inspectorText: ReadonlySignal<string>;
@@ -225,15 +176,25 @@ function SpectrumPanel(props: {
 }
 
 export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
-  const defaultState = createDefaultPanelState();
-  const header = signal<SpectrumPanelHeaderModel>(defaultState.header);
-  const overlayMessage = signal<string | null>(defaultState.overlayMessage);
-  const bandToggle = signal(defaultState.bandToggle);
-  const sensorLegend = signal<SpectrumSensorLegendModel | null>(defaultState.sensorLegend);
-  const sensorLegendHandlers = signal<SpectrumLegendHandlers | null>(defaultState.sensorLegendHandlers);
-  const bandLegend = signal(defaultState.bandLegend);
-  const inspectorText = signal(defaultState.inspectorText);
-  const onBandToggle = signal<(() => void) | null>(defaultState.onBandToggle);
+  const header = signal<SpectrumPanelHeaderModel>({
+    titleText: "Multi-Sensor Blended Spectrum",
+    hintText: "Use the trace chips to isolate one sensor at a time. Turn on reference bands when you need order context.",
+  });
+  const overlayMessage = signal<string | null>(null);
+  const bandToggle = signal<SpectrumPanelBandToggleModel>({
+    hasBands: false,
+    bandsVisible: false,
+    text: "Show reference bands",
+  });
+  const sensorLegend = signal<SpectrumSensorLegendModel | null>(null);
+  const sensorLegendHandlers = signal<SpectrumLegendHandlers | null>(null);
+  const bandLegend = signal<SpectrumBandLegendModel>({
+    visible: false,
+    items: [],
+    emptyText: "No reference band",
+  });
+  const inspectorText = signal("Use the trace chips or hover the chart to inspect the current peak.");
+  const onBandToggle = signal<(() => void) | null>(null);
   const chartDom: MutableSpectrumPanelChartDom = {
     specChartWrap: null,
     specChart: null,
@@ -271,7 +232,7 @@ export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
     renderOverlay(message: string | null): void {
       overlayMessage.value = message;
     },
-    renderBandToggle(model: { hasBands: boolean; bandsVisible: boolean; text: string }): void {
+    renderBandToggle(model: SpectrumPanelBandToggleModel): void {
       bandToggle.value = model;
     },
     renderSensorLegend(


### PR DESCRIPTION
## Summary

This PR removes the clone-on-init default-state pattern from `apps/ui/src/app/views/spectrum_panel.tsx` and lets each spectrum-panel signal declare its own literal mount-time default directly inside `mountSpectrumPanel()`.

The issue is intentionally small, and the final change stays that way. The runtime behavior of the spectrum panel is unchanged: it still mounts once, still exposes the same `SpectrumPanelView` bridge methods, and still starts with the same header, overlay, band-toggle, legend, and inspector defaults. The difference is that those defaults now live where the signals are created instead of being funneled through an aggregate `DEFAULT_PANEL_STATE` object and a `createDefaultPanelState()` cloning helper that no longer fits how the panel actually works.

## Problem being solved

Before this change, `spectrum_panel.tsx` still carried a mutable-state-era initialization pattern:

- a full `SpectrumPanelBridgeState` aggregate type
- a frozen-looking `DEFAULT_PANEL_STATE` object
- a `createDefaultPanelState()` helper that cloned nested objects and arrays
- signal initialization that immediately unpacked that cloned object back into independent signals

That pattern made sense when one mutable bridge object might have been shared or copied around. It is unnecessary now that the panel already uses field-level signals for each piece of state. Each signal gets its own value at mount time and then updates independently through the existing bridge methods. There is no later consumer of the aggregate default object, so the clone helper is just extra indirection and extra code to maintain.

The issue calls this out directly, and the current code still matched that description. This PR removes that leftover bootstrapping residue without changing the public panel contract.

## Implementation approach

I kept the cut deliberately narrow:

1. preserve the existing `SpectrumPanelView` behavior and method names
2. remove only the aggregate default-object boot path
3. keep all default values identical
4. avoid inventing any new runtime behavior or ownership layers

The only adjacent cleanup I included is naming the band-toggle model in the runtime view-contract file. Once the aggregate `SpectrumPanelBridgeState` type goes away, the old `SpectrumPanelBridgeState["bandToggle"]` reference becomes a dead dependency on a type that no longer has a reason to exist. Promoting that inline shape into a named `SpectrumPanelBandToggleModel` keeps the view contract explicit and avoids replacing one awkward leftover with another.

## Main code changes by area

`apps/ui/src/app/views/spectrum_panel.tsx`

- deleted the aggregate `SpectrumPanelBridgeState` type
- deleted `DEFAULT_PANEL_STATE`
- deleted `createDefaultPanelState()`
- initialized the spectrum panel signals directly with their literal defaults inside `mountSpectrumPanel()`

That means:

- `header` now starts from its literal `titleText` and `hintText`
- `overlayMessage` starts from `null`
- `bandToggle` starts from its literal `{ hasBands, bandsVisible, text }` object
- `sensorLegend` and `sensorLegendHandlers` start from `null`
- `bandLegend` starts from its literal empty-state object
- `inspectorText` starts from its existing idle copy
- `onBandToggle` starts from `null`

These are the same values the old helper produced. The change is only that they are now declared inline at the signal creation site instead of being copied out of a temporary aggregate object.

The rest of the file stays structurally the same. The panel still renders through the same signal-backed JSX surface, still captures chart DOM refs the same way, and still exposes the same `renderHeader`, `renderOverlay`, `renderBandToggle`, `renderSensorLegend`, `renderBandLegend`, `renderInspectorText`, and `bindBandToggle` bridge methods.

`apps/ui/src/app/runtime/spectrum_panel_view.ts`

- added `SpectrumPanelBandToggleModel`
- updated `SpectrumPanelView.renderBandToggle()` to use that named model type

This keeps the runtime contract explicit once the old aggregate bridge-state type is gone. No caller behavior changed, because every caller was already passing the same `{ hasBands, bandsVisible, text }` shape.

## Validation and tests

I validated the change with the spectrum-focused paths that actually exercise this panel contract:

- `cd apps/ui && npx playwright test tests/ui_spectrum_controller.spec.ts tests/spectrum_interaction_controller.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.spectrum.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

That coverage is intentionally targeted:

- `ui_spectrum_controller.spec.ts` exercises the controller-to-panel contract for header and overlay updates
- `spectrum_interaction_controller.spec.ts` exercises the legend and band-toggle interaction surface
- `smoke.spectrum.spec.ts` confirms the mounted browser panel still behaves correctly through the live UI path

I also ran a focused code-review pass on the diff after the local validation completed, and it reported no material issues.

## Risks, tradeoffs, and edge cases

The main risk in a change like this is not logic complexity but accidental behavior drift from changing the default objects. To keep that risk low, I preserved the exact existing default values and kept the refactor local to mount-time initialization.

The only mild tradeoff is introducing one new named model type, `SpectrumPanelBandToggleModel`, in the runtime contract. I chose that over leaving an inline structural type in `SpectrumPanelView` or keeping the dead aggregate bridge-state type around just to name one nested property. That is a better long-term shape for a panel contract that is already field-oriented.

There are no schema, network, persistence, or DOM-contract changes here. The chart DOM accessors are unchanged, the bridge methods are unchanged, and the panel still starts in the same user-visible idle state.

## Out of scope

This PR does not rename the remaining `render*` bridge methods, does not change how the spectrum controller drives the panel, does not alter lazy chart loading, and does not attempt a broader cleanup of other panels with similar mount defaults. The goal here is the specific clone-pattern removal requested in `#2401`, kept as a small reviewable refactor.

Closes #2401
