### PR TITLE
Split cars wizard summary computeds

### DIFF
--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -252,6 +252,41 @@ export function createCarsFeatureWorkflow(
     })
   );
 
+  const resolvedSpecBranch = computed(() => getResolvedWizardSpecBranch(wizardState.value));
+
+  const canFinish = computed(() =>
+    canFinishWizard(
+      wizardState.value,
+      resolvedSpecBranch.value === "manual" ? manualTire.value : null,
+      resolvedSpecBranch.value === "manual" ? manualGearbox.value : null,
+    )
+  );
+
+  const actionHint = computed(() => {
+    const state = wizardState.value;
+    if (state.step !== 4) {
+      return "";
+    }
+    const branch = resolvedSpecBranch.value;
+    return getWizardActionHint(state, {
+      fmt: deps.fmt,
+      manualGearbox: branch === "manual" ? manualGearbox.value : null,
+      manualTire: branch === "manual" ? manualTire.value : null,
+      t: deps.t,
+    });
+  });
+
+  const summaryData = computed<WizardSummaryData>(() => {
+    const state = wizardState.value;
+    const branch = resolvedSpecBranch.value;
+    return buildWizardSummaryData(state, {
+      fmt: deps.fmt,
+      manualGearbox: branch === "manual" ? manualGearbox.value : null,
+      manualTire: branch === "manual" ? manualTire.value : null,
+      t: deps.t,
+    });
+  });
+
   const renderState = computed<CarsFeatureRenderState>(() => {
     const state = wizardState.value;
     const inputs = readManualInputs();
@@ -262,22 +297,13 @@ export function createCarsFeatureWorkflow(
     const currentTireOptions = tireOptions.value;
     const currentGearboxOptions = gearboxOptions.value;
     const currentNoGearboxesMessage = noGearboxesMessage.value;
-    const currentManualGearbox = manualGearbox.value;
-    const currentManualTire = manualTire.value;
     return {
-      actionHint: state.step === 4
-        ? getWizardActionHint(state, {
-          fmt: deps.fmt,
-          manualGearbox: currentManualGearbox,
-          manualTire: currentManualTire,
-          t: deps.t,
-        })
-        : "",
+      actionHint: actionHint.value,
       brandOptions: {
         ...currentBrandOptions,
         options: [...currentBrandOptions.options],
       },
-      canFinish: canFinishWizard(state, currentManualTire, currentManualGearbox),
+      canFinish: canFinish.value,
       gearboxOptions: [...currentGearboxOptions],
       isOpen: isOpen.value,
       manualInputs: cloneManualInputs(inputs),
@@ -286,16 +312,11 @@ export function createCarsFeatureWorkflow(
         options: [...currentModelOptions.options],
       },
       noGearboxesMessage: currentNoGearboxesMessage,
-      resolvedSpecBranch: getResolvedWizardSpecBranch(state),
+      resolvedSpecBranch: resolvedSpecBranch.value,
       selectedGearbox: state.selectedGearbox,
       selectedTire: state.selectedTire,
       step: state.step,
-      summaryData: buildWizardSummaryData(state, {
-        fmt: deps.fmt,
-        manualGearbox: currentManualGearbox,
-        manualTire: currentManualTire,
-        t: deps.t,
-      }),
+      summaryData: summaryData.value,
       tireOptions: [...currentTireOptions],
       typeOptions: {
         ...currentTypeOptions,

--- a/apps/ui/tests/cars_feature_workflow.spec.ts
+++ b/apps/ui/tests/cars_feature_workflow.spec.ts
@@ -239,6 +239,35 @@ test.describe("createCarsFeatureWorkflow", () => {
     });
   });
 
+  test("keeps summary data stable while pre-spec manual drafts change", async () => {
+    const harness = createHarness();
+    const workflow = createCarsFeatureWorkflow({
+      addCarFromWizard: async () => undefined,
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      t: createTranslator(),
+      transport: {
+        async loadBrands() {
+          return ["BMW"];
+        },
+      },
+      view: createViewPorts(harness),
+    });
+
+    await workflow.openWizard();
+
+    const initialRenderState = workflow.getRenderState();
+    workflow.handleManualInputsChanged({
+      ...createDefaultManualInputs(),
+      finalDrive: "4.10",
+      topGear: "0.71",
+    });
+
+    const rerenderState = workflow.getRenderState();
+    expect(rerenderState.step).toBe(0);
+    expect(rerenderState.summaryData).toBe(initialRenderState.summaryData);
+    expect(rerenderState.actionHint).toBe(initialRenderState.actionHint);
+  });
+
   test("keeps the library branch disabled until a gearbox is chosen and then submits the selected specs", async () => {
     const harness = createHarness();
     const addCalls: Array<{


### PR DESCRIPTION
## Summary

This PR narrows the expensive wizard-derived computations in `apps/ui/src/app/features/cars_feature_workflow.ts` so the cars wizard no longer rebuilds its action hint, finishability, and summary data on every broad `renderState` invalidation.

The underlying issue is not that the wizard lacked computed state, but that the most expensive derived values still lived inline inside the top-level `renderState` computed. That meant unrelated signal changes could force `getWizardActionHint()`, `canFinishWizard()`, and `buildWizardSummaryData()` to run again even when their real inputs had not changed. This change extracts those derivations into their own narrower computeds and keeps the array-cloning cleanup out of scope for the later dedicated issue.

## Problem being solved

Before this change, `renderState` in `cars_feature_workflow.ts` was doing too much at once:

- reading broad wizard state
- reading all manual draft signals
- reading multiple option lists
- cloning several option arrays
- rebuilding the wizard action hint inline
- recalculating finishability inline
- rebuilding the wizard summary object inline

That shape made `renderState` a hot dependency fan-in point. Even though some parts of the returned render model legitimately needed to change on every manual keystroke, the summary/hint/finishability logic did not always need the same broad invalidation surface. In particular, when the wizard is not yet on the manual branch, manual draft edits should not force those heavier derivations to rebuild.

The issue called out `buildWizardSummaryData()` specifically, but the same pattern applied to `getWizardActionHint()` and `canFinishWizard()`, so the clean cut is to split all three into narrower computeds in the same workflow owner.

## Implementation approach

I kept the refactor focused on dependency narrowing rather than broader data-shape cleanup.

The final structure now separates four derived values from the broad `renderState` computed:

1. `resolvedSpecBranch`
2. `canFinish`
3. `actionHint`
4. `summaryData`

Those computeds still live in the same workflow module, still use the same helpers, and still return the same user-visible data. The difference is that they now decide whether to subscribe to manual draft signals based on the current wizard step/branch instead of always reading `manualTire.value` and `manualGearbox.value` up front.

That conditional dependency behavior is the core of the fix. When the wizard is not on the manual branch, those computeds now pass `null` through the existing helper APIs and avoid subscribing to the manual-value computeds. When the wizard is on the manual branch, they still subscribe and recompute exactly as before.

I intentionally did **not** remove the option-array cloning from `renderState` in this PR. A separate open issue now tracks that cleanup, and bundling both changes together would blur the performance story and make the review harder than it needs to be.

## Main code changes by area

`apps/ui/src/app/features/cars_feature_workflow.ts`

- added a dedicated `resolvedSpecBranch` computed
- added a dedicated `canFinish` computed
- added a dedicated `actionHint` computed
- added a dedicated `summaryData` computed
- updated `renderState` to reuse those derived values instead of rebuilding them inline

The important detail is how those computeds read manual values:

- when the wizard is not on step 4, `actionHint` returns `""` immediately and does not subscribe to manual draft state
- when the resolved branch is not `"manual"`, `canFinish`, `actionHint`, and `summaryData` reuse the existing helper functions but pass `null` manual values instead of reading `manualTire.value` / `manualGearbox.value`
- when the resolved branch is `"manual"`, they still subscribe to the manual-value computeds and preserve the existing behavior

That keeps the public workflow contract identical while tightening the reactive dependency graph.

`apps/ui/tests/cars_feature_workflow.spec.ts`

- added a focused regression test proving that pre-spec manual draft edits keep `summaryData` reference-stable

I originally tried a stronger assertion in the library-spec path, but the live workflow intentionally flips `specBranch` to `"manual"` when the user edits manual fields at step 4. That means summary data *should* change there. The final regression test targets the true optimization boundary instead: manual draft edits before the spec step should not force a summary rebuild, because the summary path only depends on wizard state in that phase.

That test makes the performance-oriented refactor observable without introducing implementation-only hooks or mocking the helper functions.

## Validation and tests

I validated the change with the narrowest existing cars-flow coverage that matches the touched area:

- `cd apps/ui && npx playwright test tests/cars_feature_workflow.spec.ts tests/settings_cars_module.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.car-wizard.spec.ts tests/smoke.cars.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

That mix matters here:

- the workflow test file exercises the reactive derivation logic directly
- the settings-cars module test confirms the surrounding module contract still behaves
- the car-wizard and cars smoke flows confirm the live UI path still behaves correctly in the browser

During implementation, the first regression-test attempt failed for a good reason: step-4 manual edits intentionally switch the workflow to the manual branch, so the summary is expected to change there. I adjusted the test to cover the real dependency-narrowing boundary instead of encoding a false invariant. The final validation run is fully green.

I also ran a focused diff review after the local validation completed, and it reported no material issues.

## Risks, tradeoffs, and edge cases

The main risk in this PR is subtle dependency drift: a refactor like this can accidentally stop subscribing to a value that *should* still trigger recomputation. To keep that risk low, I preserved the existing helper functions and user-visible outputs and changed only *when* the manual draft signals are read, not the derived value algorithms themselves.

The main tradeoff is that `renderState` still clones option arrays and option-state objects, which means the top-level computed is still broader than it could eventually become. That is intentional. This PR narrows the expensive wizard derivations without silently folding in the separate clone-removal work that now has its own issue.

## Out of scope

This PR does not remove the option-array cloning in `renderState`, does not change manual-input write batching, does not alter how the wizard switches between manual and library branches, and does not change the panel/view model contract. It is the focused computed-splitting cleanup requested in `#2402`, with one regression test added to make the optimization boundary concrete.

Closes #2402
