### PR TITLE
Remove cars workflow renderState clones

### DIFF
--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -299,30 +299,21 @@ export function createCarsFeatureWorkflow(
     const currentNoGearboxesMessage = noGearboxesMessage.value;
     return {
       actionHint: actionHint.value,
-      brandOptions: {
-        ...currentBrandOptions,
-        options: [...currentBrandOptions.options],
-      },
+      brandOptions: currentBrandOptions,
       canFinish: canFinish.value,
-      gearboxOptions: [...currentGearboxOptions],
+      gearboxOptions: currentGearboxOptions,
       isOpen: isOpen.value,
       manualInputs: cloneManualInputs(inputs),
-      modelOptions: {
-        ...currentModelOptions,
-        options: [...currentModelOptions.options],
-      },
+      modelOptions: currentModelOptions,
       noGearboxesMessage: currentNoGearboxesMessage,
       resolvedSpecBranch: resolvedSpecBranch.value,
       selectedGearbox: state.selectedGearbox,
       selectedTire: state.selectedTire,
       step: state.step,
       summaryData: summaryData.value,
-      tireOptions: [...currentTireOptions],
-      typeOptions: {
-        ...currentTypeOptions,
-        options: [...currentTypeOptions.options],
-      },
-      variantOptions: [...currentVariantOptions],
+      tireOptions: currentTireOptions,
+      typeOptions: currentTypeOptions,
+      variantOptions: currentVariantOptions,
     };
   });
 

--- a/apps/ui/tests/cars_feature_workflow.spec.ts
+++ b/apps/ui/tests/cars_feature_workflow.spec.ts
@@ -268,6 +268,38 @@ test.describe("createCarsFeatureWorkflow", () => {
     expect(rerenderState.actionHint).toBe(initialRenderState.actionHint);
   });
 
+  test("keeps option references stable while unrelated manual drafts change", async () => {
+    const harness = createHarness();
+    const workflow = createCarsFeatureWorkflow({
+      addCarFromWizard: async () => undefined,
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      t: createTranslator(),
+      transport: {
+        async loadBrands() {
+          return ["BMW"];
+        },
+      },
+      view: createViewPorts(harness),
+    });
+
+    await workflow.openWizard();
+
+    const initialRenderState = workflow.getRenderState();
+    workflow.handleManualInputsChanged({
+      ...createDefaultManualInputs(),
+      finalDrive: "4.10",
+      topGear: "0.71",
+    });
+
+    const rerenderState = workflow.getRenderState();
+    expect(rerenderState.brandOptions).toBe(initialRenderState.brandOptions);
+    expect(rerenderState.typeOptions).toBe(initialRenderState.typeOptions);
+    expect(rerenderState.modelOptions).toBe(initialRenderState.modelOptions);
+    expect(rerenderState.variantOptions).toBe(initialRenderState.variantOptions);
+    expect(rerenderState.tireOptions).toBe(initialRenderState.tireOptions);
+    expect(rerenderState.gearboxOptions).toBe(initialRenderState.gearboxOptions);
+  });
+
   test("keeps the library branch disabled until a gearbox is chosen and then submits the selected specs", async () => {
     const harness = createHarness();
     const addCalls: Array<{


### PR DESCRIPTION
## Summary

This PR closes #2404 by removing redundant array and option-state cloning from the `renderState` computed inside `apps/ui/src/app/features/cars_feature_workflow.ts`. The workflow already keeps its option-bearing signals immutable by replacing them wholesale at the write boundary, so cloning those same values again every time `renderState` recomputed was not providing any additional safety. It was only fabricating fresh references and extra garbage collection churn on recomputes triggered by unrelated wizard state changes.

Closes #2404.

## Problem being solved

In the current cars workflow, `renderState` is the computed bridge object that packages the wizard state for downstream consumers. Before this change, it rebuilt several option-bearing values like this on every recomputation:

- clone the outer `brandOptions`, `typeOptions`, and `modelOptions` state objects
- clone their nested `.options` arrays
- clone `variantOptions`, `tireOptions`, and `gearboxOptions`

That pattern is reasonable when callers might be mutating shared arrays in place. But that is not how this workflow actually works anymore. The option signals are already updated through immutable replacement:

- `createReadyOptionsState()` clones incoming option arrays once when they are written
- downstream reset paths replace those signals with fresh arrays or fresh idle-state objects
- the wizard render-model builder reads and maps those arrays but does not mutate them

Because of that architecture, the render-time clones were just creating fresh references each time `renderState` re-ran, even when the option values themselves had not changed.

## Chosen implementation approach

I kept the solution focused on the exact seam described by the issue: the `renderState` computed in `cars_feature_workflow.ts`. The implementation has two parts:

1. Stop cloning values that are already immutable signal replacements.
2. Add a regression that locks the desired identity behavior in place.

## Main code changes by area

### 1. `renderState` now forwards existing option signal values directly

The core workflow change is in `apps/ui/src/app/features/cars_feature_workflow.ts`.

Before this PR, the computed returned:

- a copied `brandOptions` object with a copied `.options` array
- a copied `modelOptions` object with a copied `.options` array
- a copied `typeOptions` object with a copied `.options` array
- cloned `variantOptions`, `tireOptions`, and `gearboxOptions` arrays

After this PR, the computed returns the existing signal-backed values directly:

- `brandOptions: currentBrandOptions`
- `modelOptions: currentModelOptions`
- `typeOptions: currentTypeOptions`
- `variantOptions: currentVariantOptions`
- `tireOptions: currentTireOptions`
- `gearboxOptions: currentGearboxOptions`

The rest of the render state remains unchanged. In particular:

- `manualInputs` is still cloned because it is built from several individual field signals and intentionally exposed as a detached snapshot
- summary/action-hint/can-finish behavior is unchanged
- wizard state, selection state, and no-gearboxes messaging are unchanged

So the PR tightens only the references that were already safe to share.

### 2. New regression coverage proves unrelated recomputes keep stable option references

The new test in `apps/ui/tests/cars_feature_workflow.spec.ts` exercises the exact failure mode behind the issue.

It opens the wizard, captures the initial render state, changes only manual draft inputs, and then verifies that the option-bearing references are stable across the recompute:

- `brandOptions`
- `typeOptions`
- `modelOptions`
- `variantOptions`
- `tireOptions`
- `gearboxOptions`

That test is important because manual-input edits are a good example of a recompute trigger that should not imply new option objects. With the old cloning behavior, those references changed even though the option signals themselves did not. With this PR, the test proves they remain stable.

## Why this is safe

The safety question for this change is not “can arrays ever be mutated in JavaScript?” but “does this workflow rely on render-time cloning for immutability today?” The answer is no.

The relevant ownership boundaries already enforce immutability earlier:

- idle/error/loading option states are created as fresh objects
- ready option states clone their input arrays when written
- reset paths replace option arrays instead of mutating them
- `buildCarsWizardRenderModel()` consumes these values read-only and maps them into separate UI render models

That means `renderState` is not the immutability boundary. It is only a consumer-facing packaging layer. Keeping clones there just duplicates work that has already been done.

## Contract, schema, config, and documentation impact

There are no API, schema, or config changes in this PR. The public TypeScript shape of `CarsFeatureRenderState` stays the same. No view contracts, transport models, or generated shared contracts change.

I also did not update documentation for this one because it does not introduce a new pattern; it removes unnecessary copying inside an already-established signal-backed workflow. The interesting behavioral guarantee is captured in the new regression test instead.

## Validation and tests

I validated this change with the same focused cars slice used for nearby workflow work:

- `cd apps/ui && npx playwright test tests/cars_feature_workflow.spec.ts tests/settings_cars_module.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.car-wizard.spec.ts tests/smoke.cars.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

Everything passed. As in prior runs, lint reported only the existing Biome schema-version information message and no new lint failures.

I also ran a focused diff review after validation. That review confirmed the write side is already immutable and the downstream render-model builder only reads/maps these arrays, so removing the render-time clones does not expose a hidden mutation dependency.

## Risks, tradeoffs, and edge cases considered

The primary risk here would be a downstream consumer mutating one of the arrays that now flows through `renderState` by reference. I checked the actual consumer path before making the change. The cars wizard render-model builder maps over these arrays into fresh UI option models and does not mutate the source arrays. That keeps the shared-reference change safe.

Another possible concern is whether empty-array fallback paths could still generate new references at write time. They can in some code paths, but that is acceptable because those are signal writes, not render-time recomputes. This PR is specifically about avoiding new references when only unrelated reactive inputs change and the option signals themselves have not been reassigned.

## Out of scope / follow-up

This PR does not change how option arrays are produced at transport/load time, nor does it alter the manual-input snapshot behavior. The goal is simply to stop `renderState` from cloning values that are already immutable by construction and to preserve stable option references across unrelated recomputes.
