### PR TITLE
Localize cars wizard Escape handling

### DIFF
--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -114,23 +114,6 @@ function CarsPanel(props: {
   }, [wizardModel.isOpen]);
 
   useEffect(() => {
-    if (!wizardModel.isOpen) {
-      return;
-    }
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") {
-        return;
-      }
-      event.preventDefault();
-      state.wizardActions?.onAction({ type: "close" });
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [wizardModel.isOpen, state.wizardActions]);
-
-  useEffect(() => {
     if (!wizardFocusRequest) {
       return;
     }

--- a/apps/ui/src/app/views/cars_wizard_panel.tsx
+++ b/apps/ui/src/app/views/cars_wizard_panel.tsx
@@ -343,6 +343,14 @@ export function CarsWizardPanel(props: {
     });
   }
 
+  function handleWizardKeyDown(event: KeyboardEvent): void {
+    if (event.key !== "Escape") {
+      return;
+    }
+    event.preventDefault();
+    closeWizard();
+  }
+
   return (
     <div class="wizard-modal-layer" hidden={!wizardModel.isOpen}>
       <div
@@ -359,6 +367,8 @@ export function CarsWizardPanel(props: {
         aria-modal="true"
         aria-labelledby="wizardTitle"
         data-spec-branch={wizardModel.specBranch ?? undefined}
+        tabIndex={-1}
+        onKeyDown={handleWizardKeyDown}
         ref={refs.addCarWizardRef}
       >
         <div class="wizard-header">

--- a/apps/ui/tests/smoke.car-wizard.spec.ts
+++ b/apps/ui/tests/smoke.car-wizard.spec.ts
@@ -51,6 +51,41 @@ test("opens the add car wizard in a focused task container and restores focus wh
   await expect(page.locator("#addCarBtn")).toBeFocused();
 });
 
+test("closes the add car wizard from Escape on the focused input and restores focus", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "/api/settings/cars": {
+        cars: [{ id: "car-1", name: "Audit Demo Car", type: "sedan", aspects: {} }],
+        active_car_id: "car-1",
+      },
+    }),
+  });
+  await page.route("**/api/car-library/**", async (route) => {
+    const path = requestPath(route);
+    if (path === "/api/car-library/brands") {
+      await fulfillJson(route, { brands: ["BMW", "Volvo"] });
+      return;
+    }
+    await fulfillJson(route, { brands: [], types: [], models: [] });
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="carTab"]').click();
+  await page.locator("#addCarBtn").click();
+
+  const customBrandInput = page.locator("#wizardCustomBrand");
+  await customBrandInput.click();
+  await expect(customBrandInput).toBeFocused();
+  await customBrandInput.press("Escape");
+
+  await expect(page.locator("#addCarWizard")).toBeHidden();
+  await expect(page.locator("#wizardBackdrop")).toBeHidden();
+  await expect(page.locator("#addCarBtn")).toBeFocused();
+});
+
 test("uses the full mobile viewport and keeps the final action visible on short screens", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 667 });
   await installCommonRoutes(page, {


### PR DESCRIPTION
## Summary

This PR closes #2405 by moving the cars wizard Escape-key handling off the global document listener in `cars_panel.tsx` and onto the wizard dialog itself in `cars_wizard_panel.tsx`. The title of the issue mentions `useRef` and `useEffect`, but the body describes the real cleanup that makes sense in the current codebase: stop registering a document-level `keydown` listener and let the mounted dialog handle Escape locally through normal Preact event ownership.

Closes #2405.

## Problem being solved

Before this change, `apps/ui/src/app/views/cars_panel.tsx` installed a `document.addEventListener("keydown", ...)` listener inside a `useEffect` whenever the wizard opened. That code worked, but it was broader than necessary for a component-local dialog interaction. The issue body explicitly called that out and suggested moving the behavior to the wizard container itself.

## Chosen implementation approach

I followed the issue body rather than the stale title wording.

The narrow, behavior-preserving implementation is:

1. Delete the document-level Escape listener from `cars_panel.tsx`.
2. Add a local `onKeyDown` handler to the `#addCarWizard` dialog root in `cars_wizard_panel.tsx`.
3. Make the dialog root focusable with `tabIndex={-1}` so it is a legitimate local keyboard target.
4. Add browser coverage that presses Escape from a focused input inside the wizard and verifies that the dialog closes and focus returns to `#addCarBtn`.

This keeps the cleanup squarely inside the current component boundaries instead of layering more ref/effect machinery onto an interaction that the dialog can already own directly.

## Main code changes by area

### 1. Removed the global document listener from `cars_panel.tsx`

The old `useEffect` in `cars_panel.tsx` attached a `keydown` listener to `document` whenever `wizardModel.isOpen` was true and cleaned it up on effect teardown. Its only job was to intercept Escape and dispatch the wizard close action.

That effect is now deleted entirely. `cars_panel.tsx` still owns the wizard open/close transition tracking, scroll reset, focus restoration, and follow-up focus requests. The change removes only the one global keyboard hook that did not need to live there.

### 2. The wizard dialog now owns Escape locally

In `apps/ui/src/app/views/cars_wizard_panel.tsx`, the dialog root `#addCarWizard` now gets:

- `tabIndex={-1}`
- `onKeyDown={handleWizardKeyDown}`

The local handler is intentionally small:

- ignore non-Escape keys
- `preventDefault()` for Escape
- call the existing `closeWizard()` helper, which routes through the same typed action path the rest of the wizard already uses

This means the wizard continues to close through the same action contract as the close button and backdrop. The only change is that the keyboard event is now caught at the dialog boundary instead of at `document`.

### 3. Added a focused smoke regression for Escape

`apps/ui/tests/smoke.car-wizard.spec.ts` now includes a regression that:

1. opens the Add Car wizard from the Settings > Cars tab
2. focuses the custom-brand input inside the open dialog
3. presses Escape
4. asserts that the wizard and backdrop are hidden
5. asserts that focus returns to `#addCarBtn`

That test matters because it exercises the behavior that the new ownership model actually depends on: keyboard events bubbling from a focused child control inside the dialog to the dialog root handler.

The first draft of the test assumed the real browser flow initially focused `#wizardCustomBrand`. That expectation turned out to be too strict in the live DOM, even though the workflow does request focus internally in some cases. I adjusted the regression to focus the input explicitly before pressing Escape. That still tests the important behavior without over-asserting unrelated initial-focus details.

## Why this is safe

The safety question here is whether moving Escape off `document` changes which focused elements can still trigger a close. In the actual wizard flow, it does not.

The dialog already contains the wizard’s interactive controls, and keyboard events from focused descendants bubble to the dialog root. That makes the dialog a natural place to own Escape. The important close path is also unchanged:

- Escape still ends in the same `closeWizard()` helper
- `closeWizard()` still dispatches the same typed `{ type: "close" }` action
- `cars_panel.tsx` still performs the existing focus-restoration logic when the wizard transitions from open to closed

So the PR changes event ownership, not close semantics.

## Contract, schema, config, and documentation impact

There are no API, schema, config, or generated-contract changes in this PR. No server payloads or transport behavior change.

There are also no user-facing copy or CSS contract changes. The dialog gains `tabIndex={-1}`, but that is an interaction-ownership change on the existing wizard root rather than a new visible feature.

## Validation and tests

I validated this change with the focused cars browser slice plus the standard frontend checks:

- `cd apps/ui && npx playwright test tests/smoke.car-wizard.spec.ts tests/smoke.cars.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

Everything passed. As in prior runs, lint reported only the existing Biome schema-version information message and no new lint failures.

I also ran a focused diff review after validation. That review confirmed there were no remaining document-level keyboard listeners for this surface and no regression in the panel’s focus-management or close contract.

## Risks, tradeoffs, and edge cases considered

The main risk would be missing Escape events if focus were outside the dialog subtree while the wizard was open. In the actual flow, the wizard is modal, focus is managed into wizard controls, and the relevant keyboard interactions originate inside the dialog. The new smoke regression covers the important case of pressing Escape from a focused input, which is the case most likely to regress when moving from document-global to local event ownership.

I also deliberately did not broaden the change into the rest of the wizard focus choreography. Focus restoration and open/close transition tracking still belong to `cars_panel.tsx`, and this PR leaves that working behavior alone.

## Out of scope / follow-up

This PR does not refactor the rest of the wizard focus choreography, nor does it change how specific focus targets are resolved after workflow updates. It also does not alter the close button or backdrop behavior.

The goal is deliberately modest: make Escape a dialog-owned interaction instead of a document-owned one, keep the existing close/focus behavior, and lock it in with a browser regression.
