### PR TITLE
Batch analysis settings field updates

### DIFF
--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -5,7 +5,7 @@ import type {
 import { getAnalysisSettings, setAnalysisSettings } from "../../api";
 import type { FeatureServices } from "../feature_deps_base";
 import { defaultVehicleSettings, type SettingsState } from "../ui_app_state";
-import { computed, signal } from "../ui_signals";
+import { batch, computed, signal } from "../ui_signals";
 import type {
   AnalysisPanelFieldKey,
   AnalysisPanelRenderModel,
@@ -476,14 +476,16 @@ export function createSettingsAnalysisModule(
   function handleFieldInput(
     action: { field: AnalysisPanelFieldKey; value: string },
   ): void {
-    draftValues.value = {
-      ...draftValues.value,
-      [action.field]: action.value,
-    };
-    const nextErrors = { ...fieldErrorMessages.value };
-    delete nextErrors[action.field];
-    fieldErrorMessages.value = nextErrors;
-    saveFeedback.value = null;
+    batch(() => {
+      draftValues.value = {
+        ...draftValues.value,
+        [action.field]: action.value,
+      };
+      const nextErrors = { ...fieldErrorMessages.value };
+      delete nextErrors[action.field];
+      fieldErrorMessages.value = nextErrors;
+      saveFeedback.value = null;
+    });
   }
 
   function bindHandlers(): void {

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -109,11 +109,13 @@ test("settings analysis module renders guidance and surfaces invalid input throu
   expect(focusedField).toBe("wheel_bandwidth_pct");
   expect(guidanceOpened).toBe(true);
 
+  const rendersBeforeRecovery = renders.length;
   actions?.onFieldInput({
     field: "wheel_bandwidth_pct",
     value: "5",
   });
 
+  expect(renders).toHaveLength(rendersBeforeRecovery + 1);
   const recoveredRender = lastRender(renders);
   expect(recoveredRender.fields.wheel_bandwidth_pct.invalid).toBe(false);
   expect(recoveredRender.fields.wheel_bandwidth_pct.guidance.error).toBeNull();


### PR DESCRIPTION
## Summary

This PR closes #2430 by batching the analysis-settings field-input updates in `apps/ui/src/app/features/settings_analysis_module.ts`. The existing `handleFieldInput()` action updated three separate signals in sequence: the editable draft value, the per-field error map, and the transient save-feedback message. Because the analysis panel model reads all three, a single keystroke could trigger multiple intermediate rerenders instead of one coherent update.

Closes #2430.

## Problem being solved

The analysis settings panel is already wired through a signal-backed `AnalysisPanelView` bridge. `settings_analysis_module.ts` owns a small cluster of local reactive state:

- `draftValues`
- `fieldErrorMessages`
- `saveFeedback`

Those signals feed the computed `panelModel`, which is then bound once into the mounted analysis island. The field-input handler previously did this work in three independent writes:

1. copy the edited value into `draftValues`
2. clear the edited field from `fieldErrorMessages`
3. clear `saveFeedback`

That ordering is logically correct, but it is not reactive-atomic. If the user edits a field after an invalid save, the panel can observe a transient intermediate state where the new value is already visible but the old validation error is still present. A moment later, the error clears on the next rerender. The same applies to the save-feedback banner reset.

The issue asked for the straightforward fix: wrap those related writes in `batch()` so dependents observe one settled state instead of a sequence of partial ones.

## Chosen implementation approach

I kept the change deliberately narrow.

The right place to fix this is the `handleFieldInput()` action itself, because that path is invoked directly from `panel.bindActions()` and is not already wrapped in any outer batching context. This matters because a similar-looking issue in the cars workflow turned out to be stale: the helper there already ran only inside existing outer `batch()` calls. I re-checked the analysis module carefully to avoid repeating that mistake.

For `#2430`, the problem is real:

- `handleFieldInput()` is a direct action callback
- `panelModel` reads all three signals touched by that callback
- the previous implementation updated them one by one

So the correct minimal fix is to batch only those three writes and leave the rest of the module structure alone.

## Main code changes by area

### 1. Batched the analysis field-input updates

`apps/ui/src/app/features/settings_analysis_module.ts` now imports `batch` from the shared `ui_signals` surface and wraps the body of `handleFieldInput()` in one `batch(() => { ... })`.

Inside that batch, the module still performs the same work it did before:

- clone and update `draftValues`
- clone and clear the edited field from `fieldErrorMessages`
- reset `saveFeedback` to `null`

No behavior was broadened and no other save/load/reset flow was rewritten. The goal is simply to ensure that subscribers to `panelModel` are notified once after the whole field-recovery update is complete.

### 2. Added a regression that proves the render collapse

`apps/ui/tests/settings_analysis_module.spec.ts` now verifies the specific reactive behavior this PR is meant to protect.

The test already exercised the invalid-input flow by:

1. entering an out-of-range analysis value
2. saving
3. asserting the field becomes invalid and the guidance error appears

I extended that same test with one additional assertion around the recovery path:

1. record the current render count after the invalid state is visible
2. simulate a valid replacement input for that same field
3. assert that exactly **one** new panel render occurs

That regression is important because it guards the optimization directly instead of only checking the final visible state. Without batching, the field-recovery path produces multiple renders as the value and error-clear steps land separately. With the current change, the test confirms the panel receives one coherent recovery model.

## Why this is safe

This PR does not change validation rules, API payloads, confirmation prompts, focus behavior, or save semantics.

The same state transitions still happen in the same user-visible order:

- the edited draft value is updated
- the field-specific validation marker is cleared for that field
- transient save feedback is dismissed

The only difference is that those three transitions are now published atomically to signal subscribers. That reduces unnecessary recomputation and prevents momentary mixed states in the render model.

The code inside the batch is also fully synchronous and local. There are no async calls, DOM side effects, or external callbacks inside the batched section, so the change is low-risk and easy to reason about.

## Contract, schema, config, and documentation impact

There are no transport, schema, API, or generated-contract changes in this PR.

There are also no documentation changes, because the user-facing behavior and ownership boundaries stay the same. This is an internal reactive-state optimization with a focused regression test.

## Validation and tests performed

I validated the change with the narrow analysis/settings slice plus the usual frontend gates:

- `cd apps/ui && npx playwright test tests/settings_analysis_module.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.analysis-sensors.spec.ts tests/smoke.settings.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

Everything passed. As in prior runs, lint only reported the existing Biome schema-version information message and no new lint failures.

I also ran a focused diff review after validation. That review confirmed the issue is real in the analysis module, unlike the stale cars-workflow batching issue inspected immediately beforehand, and found no material correctness problems in the final diff.

## Risks, tradeoffs, and edge cases considered

The main thing I checked here was whether an outer batch already existed, because adding a nested inner batch would have been redundant and not worth shipping. That was the exact outcome for #2429, so I verified the analysis action path separately before committing anything.

For `#2430`, the field-input action is directly bound and unbatched, so the optimization is legitimate.

I also kept the change intentionally scoped to the issue instead of broadening it into a larger batching refactor across every analysis save/load path. There are other multi-step state transitions in the module, but this PR addresses the specific user-input handler the issue identified and adds a regression for that path. That keeps the diff small, reviewable, and aligned with the backlog item.

## Out of scope / follow-up

This PR does not refactor the broader analysis module structure, nor does it attempt to batch every other state transition in the file. It also does not change how risky-value confirmation, server sync, or analysis reset flows behave.

If future profiling shows additional hot paths in this module, those can be handled in their own targeted follow-ups. This PR is only about ensuring a single analysis field edit produces one coherent panel-model update instead of multiple intermediate renders.
