### PR TITLE
Signal-back cars focus management

### DIFF
--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -89,6 +89,7 @@ function CarsPanel(props: {
     variantOption: null,
   });
   const lastReturnFocusTargetRef = useRef<HTMLElement | null>(null);
+  const lastHandledFocusRequestTokenRef = useRef(0);
   const lastWizardOpenStateRef = useRef(wizardModel.isOpen);
 
   useSignalEffect(() => {
@@ -119,9 +120,13 @@ function CarsPanel(props: {
 
   useSignalEffect(() => {
     const wizardFocusRequest = props.wizardFocusRequest.value;
-    if (!wizardFocusRequest) {
+    if (
+      !wizardFocusRequest ||
+      wizardFocusRequest.token === lastHandledFocusRequestTokenRef.current
+    ) {
       return;
     }
+    lastHandledFocusRequestTokenRef.current = wizardFocusRequest.token;
     queueMicrotask(() => {
       focusElement(
         resolveWizardFocusTarget(wizardFocusRequest.target, {

--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -1,10 +1,10 @@
 import { render } from "preact";
-import { useEffect, useRef } from "preact/hooks";
+import { useRef } from "preact/hooks";
 
 import type { CarsFeatureFocusTarget } from "../features/cars_feature_workflow";
 import {
   signal,
-  useSignal,
+  useSignalEffect,
   type ReadonlySignal,
 } from "../ui_signals";
 import {
@@ -66,7 +66,6 @@ function CarsPanel(props: {
   wizardFocusRequest: ReadonlySignal<CarsWizardFocusRequest | null>;
 }) {
   const state = props.state.value;
-  const wizardFocusRequest = props.wizardFocusRequest.value;
   const model = state.model?.value ?? DEFAULT_CARS_PANEL_MODEL;
   const wizardModel = state.wizardModel?.value ?? createClosedCarsWizardRenderModel();
   const addCarBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -90,49 +89,57 @@ function CarsPanel(props: {
     variantOption: null,
   });
   const lastReturnFocusTargetRef = useRef<HTMLElement | null>(null);
-  const lastWizardOpenState = useSignal(wizardModel.isOpen);
+  const lastWizardOpenStateRef = useRef(wizardModel.isOpen);
 
-  useEffect(() => {
-    const wasOpen = lastWizardOpenState.value;
-    if (wizardModel.isOpen && !wasOpen) {
+  useSignalEffect(() => {
+    const isOpen = props.state.value.wizardModel?.value.isOpen ?? false;
+    const wasOpen = lastWizardOpenStateRef.current;
+    if (isOpen && !wasOpen) {
       const activeElement = document.activeElement instanceof HTMLElement
         ? document.activeElement
         : null;
       lastReturnFocusTargetRef.current =
         activeElement && activeElement !== document.body ? activeElement : addCarBtnRef.current;
-      if (addCarWizardRef.current) {
-        addCarWizardRef.current.scrollTop = 0;
-      }
+      queueMicrotask(() => {
+        if (addCarWizardRef.current) {
+          addCarWizardRef.current.scrollTop = 0;
+        }
+      });
     }
-    if (!wizardModel.isOpen && wasOpen) {
+    if (!isOpen && wasOpen) {
       const target = lastReturnFocusTargetRef.current;
-      const safeTarget = target && document.contains(target) ? target : addCarBtnRef.current;
-      focusElement(safeTarget);
       lastReturnFocusTargetRef.current = null;
+      queueMicrotask(() => {
+        const safeTarget = target && document.contains(target) ? target : addCarBtnRef.current;
+        focusElement(safeTarget);
+      });
     }
-    lastWizardOpenState.value = wizardModel.isOpen;
-  }, [wizardModel.isOpen]);
+    lastWizardOpenStateRef.current = isOpen;
+  });
 
-  useEffect(() => {
+  useSignalEffect(() => {
+    const wizardFocusRequest = props.wizardFocusRequest.value;
     if (!wizardFocusRequest) {
       return;
     }
-    focusElement(
-      resolveWizardFocusTarget(wizardFocusRequest.target, {
-        closeButton: wizardCloseBtnRef.current,
-        customBrandInput: wizardCustomBrandInputRef.current,
-        customModelInput: wizardCustomModelInputRef.current,
-        customTypeInput: wizardCustomTypeInputRef.current,
-        finalDriveInput: wizFinalDriveInputRef.current,
-        manualAddButton: wizardManualAddBtnRef.current,
-        optionRefs: optionRefs.current,
-        rimInput: wizRimInputRef.current,
-        tireAspectInput: wizTireAspectInputRef.current,
-        tireWidthInput: wizTireWidthInputRef.current,
-        topGearInput: wizGearRatioInputRef.current,
-      }),
-    );
-  }, [wizardFocusRequest]);
+    queueMicrotask(() => {
+      focusElement(
+        resolveWizardFocusTarget(wizardFocusRequest.target, {
+          closeButton: wizardCloseBtnRef.current,
+          customBrandInput: wizardCustomBrandInputRef.current,
+          customModelInput: wizardCustomModelInputRef.current,
+          customTypeInput: wizardCustomTypeInputRef.current,
+          finalDriveInput: wizFinalDriveInputRef.current,
+          manualAddButton: wizardManualAddBtnRef.current,
+          optionRefs: optionRefs.current,
+          rimInput: wizRimInputRef.current,
+          tireAspectInput: wizTireAspectInputRef.current,
+          tireWidthInput: wizTireWidthInputRef.current,
+          topGearInput: wizGearRatioInputRef.current,
+        }),
+      );
+    });
+  });
 
   const wizardRefs: CarsWizardElementRefs = {
     addCarWizardRef,


### PR DESCRIPTION
## Summary

This PR closes #2431 by moving the remaining cars-wizard focus-management logic in `apps/ui/src/app/views/cars_panel.tsx` from dependency-array `useEffect` hooks to signal-native `useSignalEffect` ownership. The final implementation keeps the same visible behavior as before — wizard open tracking, return-focus on close, wizard focus requests, and scroll reset — while removing the manual dependency arrays the issue called out.

Closes #2431.

## Problem being solved

After the earlier cars-panel cleanup work, `cars_panel.tsx` still had two focus-related `useEffect` hooks:

1. an effect keyed by `wizardModel.isOpen` that:
   - remembered the previously focused element
   - reset the wizard scroll position on open
   - restored focus when the wizard closed
2. an effect keyed by `wizardFocusRequest` that:
   - resolved the requested wizard focus target
   - focused the corresponding element

The old document-level Escape listener that once lived in a third effect is already gone via #2405, so the current issue is narrower than the original description implies. What remains is specifically the focus-management seam.

The issue’s core point is still valid: these effects are driven by signal-backed values, but they were still expressed with `useEffect` plus manual dependency arrays instead of the repo’s newer signal-native pattern.

## Chosen implementation approach

I followed the issue goal, but there was one important nuance: the first direct `useSignalEffect` conversion regressed the cars wizard smoke suite.

Why? Because `useEffect` gave the old code post-commit timing for DOM focus work. A straight swap to `useSignalEffect` moved that work earlier, and the browser could still lose the restored focus when the wizard DOM finished updating. The regression showed up immediately in all of the smoke assertions that expect `#addCarBtn` to regain focus after cancel, Escape, and successful wizard completion.

So the final approach is:

1. replace the two focus `useEffect` hooks with `useSignalEffect`
2. move the previous-open snapshot off a signal and onto a ref
3. keep the actual DOM focus/scroll work deferred with `queueMicrotask()` so it still lands after the DOM update completes

That preserves the behavior the app already depended on while still achieving the signal-native ownership the issue asked for.

## Main code changes by area

### 1. Removed the remaining `useEffect` imports from `cars_panel.tsx`

`cars_panel.tsx` no longer imports `useEffect` from `preact/hooks`. The component still uses refs for DOM nodes, but the reactive trigger side is now handled through `useSignalEffect` from the shared `ui_signals` surface.

This matches the newer signal-first ownership style already used in other panels such as `analysis_panel.tsx` and `internet_panel.tsx`.

### 2. Replaced the previous-open signal with a ref

Before this PR, the component kept `lastWizardOpenState` in a local signal via `useSignal()`. That worked with `useEffect`, because the effect only reran from the explicit dependency array.

With `useSignalEffect`, that same pattern would have been risky because the effect would both read and write the local signal, creating exactly the kind of self-subscription edge the issue was trying to clean up.

The fix is simple and more appropriate for this value anyway: the prior-open snapshot is now stored in `lastWizardOpenStateRef`. It is purely imperative transition bookkeeping, not user-visible reactive state, so a ref is the right tool.

### 3. Converted the open/close focus tracking to `useSignalEffect`

The wizard open/close effect now reads from the live signal sources directly:

- `props.state.value`
- the bound wizard model signal’s `.value.isOpen`

That gives signal-native tracking instead of the old dependency array on `wizardModel.isOpen`.

The same edge-detection behavior is preserved:

- when the wizard opens, remember the prior active element
- when it closes, restore focus to the remembered element if still present, otherwise fall back to `#addCarBtn`

### 4. Deferred focus and scroll work with `queueMicrotask()`

This is the important correctness detail in the final patch.

The signal effect still owns the transitions, but the DOM-mutating work is deferred:

- wizard scroll reset is queued on open
- return-focus is queued on close
- focus-request targeting is queued when a new wizard focus request arrives

That keeps the focus operations aligned with the committed DOM tree rather than racing the render/update that triggered them.

This is not extra fallback machinery or a new abstraction layer. It is the minimal timing preservation needed to make the signal-native version behave like the previous, already-correct `useEffect` version.

### 5. Preserved one-shot focus-request semantics

The follow-up CI failure exposed one more subtle difference between the old and new ownership models.

`wizardFocusRequest` is a signal carrying a monotonically increasing `token`. Under the old `useEffect([wizardFocusRequest])` pattern, a given request object was naturally processed once when the dependency changed. With the signal-native version, later renders could still observe the same non-null request value unless the component explicitly remembered which token it had already handled.

The final patch now keeps `lastHandledFocusRequestTokenRef` and ignores already-processed request tokens. That preserves the old one-shot behavior and prevents later renders from replaying a stale focus request into the wrong field.

### 6. Kept the rest of the cars panel contract unchanged

I did not broaden the change into the cars workflow, wizard actions, focus-target resolution, or the dialog-local Escape handling from #2405. `resolveWizardFocusTarget()` still does the same mapping work, and the list/wizard bridge contract remains the same.

That keeps this PR squarely focused on reactive ownership rather than mixing it with unrelated cars-panel cleanup.

## Why this is safe

The user-visible behavior stays the same:

- opening the wizard still captures the previous focus target
- closing the wizard still restores focus safely
- explicit wizard focus requests still land on the correct element
- the wizard still scrolls back to the top when reopened

The diff changes *how* those transitions are triggered, not *what* they do.

I also validated the tricky part by intentionally following the failing path rather than assuming the first refactor was correct. The initial direct swap broke four smoke assertions, and the first fix still left a CI-only replay bug in the manual-branch wizard smoke. The current version fixes both the post-commit timing issue and the stale-request replay issue while keeping the signal-based ownership, which gives much higher confidence than a “green on first try” refactor would have here.

## Contract, schema, config, and documentation impact

There are no API, schema, config, or generated-contract changes in this PR.

There are also no documentation changes because the cars panel’s public behavior and bridge surface remain the same. This is an internal ownership/timing refactor inside the existing view module.

## Validation and tests performed

I validated the final patch with the focused cars/settings slice:

- `cd apps/ui && npx playwright test tests/settings_cars_module.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.car-wizard.spec.ts tests/smoke.cars.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

Everything passed. As in prior runs, lint only reported the existing Biome schema-version information message and no new lint failures.

I also ran a focused diff review on the final implementation. That review found no material issues.

## Risks, tradeoffs, and edge cases considered

The main tradeoff in this PR is that signal-native ownership alone was not enough; the DOM timing and request-replay semantics still mattered. I chose the small `queueMicrotask()` deferral plus explicit request-token dedupe rather than backing away from `useSignalEffect` entirely, because that preserves all of the goals:

- no manual dependency arrays
- no focus regression
- no stale focus-request replay on later renders

I also deliberately did not introduce a shared helper for deferred focus management. This is a one-file change, and extracting a general utility now would be speculative abstraction.

## Out of scope / follow-up

This PR does not refactor the broader cars workflow or the wizard focus-target mapping helpers. It also does not touch the already-completed Escape-key cleanup from #2405.

The goal is narrowly to make the remaining cars-panel focus effects signal-native without regressing the existing focus and wizard behavior, and the final patch does exactly that.