### PR TITLE
Signal-back ESP flash log auto-scroll

### DIFF
--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -1,11 +1,12 @@
 import { render } from "preact";
-import { useEffect, useRef } from "preact/hooks";
+import { useRef } from "preact/hooks";
 
 import { useUiText } from "../ui_i18n";
 import {
   computed,
   signal,
   useComputed,
+  useSignalEffect,
   type ReadonlySignal,
 } from "../ui_signals";
 import type { VisualVariant } from "../view_style_types";
@@ -349,14 +350,14 @@ function EspFlashPanel(props: {
     actions.value?.onCancel();
   };
 
-  useEffect(() => {
+  useSignalEffect(() => {
     const logPanel = logPanelRef.current;
     const log = model.value.log;
     if (!logPanel || log.emptyState !== null) {
       return;
     }
     logPanel.scrollTop = logPanel.scrollHeight;
-  }, [model.value.log.emptyState, model.value.log.text]);
+  });
 
   return (
     <div class="panel card">

--- a/apps/ui/tests/smoke.esp-flash.spec.ts
+++ b/apps/ui/tests/smoke.esp-flash.spec.ts
@@ -5,7 +5,10 @@ import { fulfillJson, installCommonRoutes, installFakeWebSocket, normalizePathna
 test("settings esp flash tab renders lifecycle state and live logs", async ({ page }) => {
   let statusState: "idle" | "running" | "success" = "idle";
   let logCursor = 0;
-  const logs = ["build ok", "erase ok", "upload ok"];
+  const logs = Array.from(
+    { length: 18 },
+    (_, index) => `flash line ${index}: ${"output ".repeat(12)}`,
+  );
   await installCommonRoutes(page, {
     espFlashHandler: async (route) => {
       const url = new URL(route.request().url());
@@ -64,6 +67,14 @@ test("settings esp flash tab renders lifecycle state and live logs", async ({ pa
     "Current readiness",
   );
   await expect(page.locator("#espFlashTab")).toContainText("What happens next");
+  await page.locator("#espFlashLogPanel").evaluate((panel) => {
+    if (!(panel instanceof HTMLElement)) {
+      return;
+    }
+    panel.style.height = "48px";
+    panel.style.overflowY = "auto";
+    panel.scrollTop = 0;
+  });
   await page.locator("#espFlashStartBtn").click();
   statusState = "running";
   logCursor = 2;
@@ -99,7 +110,15 @@ test("settings esp flash tab renders lifecycle state and live logs", async ({ pa
   await expect(page.locator('#espFlashJourneyPanel .maintenance-stage[aria-current="step"]')).toHaveAttribute("data-stage-phase", "flashing");
   await expect(page.locator('#espFlashJourneyPanel .maintenance-stage[data-stage-state="done"]')).toHaveCount(3);
   await expect(page.locator('#espFlashJourneyPanel .maintenance-stage[data-stage-phase="validating"] .maintenance-stage__marker')).toHaveText("✓");
-  await expect(page.locator("#espFlashLogPanel")).toContainText("erase ok");
+  await expect(page.locator("#espFlashLogPanel")).toContainText("flash line 17");
+  await expect.poll(async () =>
+    page.locator("#espFlashLogPanel").evaluate((panel) => {
+      if (!(panel instanceof HTMLElement)) {
+        return false;
+      }
+      const maxScrollTop = panel.scrollHeight - panel.clientHeight;
+      return maxScrollTop > 0 && panel.scrollTop >= maxScrollTop - 1;
+    })).toBe(true);
   await expect(page.locator("#espFlashStatusBanner")).toContainText("Success");
   await expect(page.locator('#espFlashJourneyPanel .maintenance-stage[data-stage-state="done"]')).toHaveCount(5);
   await expect(page.locator("#espFlashHistoryPanel")).toContainText("/dev/ttyUSB0");


### PR DESCRIPTION
## Summary

This PR closes #2432 by replacing the remaining log auto-scroll `useEffect` in `apps/ui/src/app/views/esp_flash_panel.tsx` with `useSignalEffect`, so the ESP flash log follows signal-driven updates without relying on a manual dependency array. The user-visible behavior stays the same: the panel still avoids scroll writes while the empty-state placeholder is showing, and once live output starts streaming, the log view follows the newest lines.

Closes #2432.

## Problem being solved

`esp_flash_panel.tsx` still had one small but clear holdout from the earlier signal-first view cleanup. The component mounted the ESP flash log panel with signals, but it was still using this React-style hook pattern for the log-follow behavior:

1. read `model.value.log.emptyState` and `model.value.log.text`
2. run a `useEffect`
3. manually list those signal-derived values in a dependency array
4. set `scrollTop = scrollHeight` when logs were present

That works, but it is inconsistent with the newer panel ownership style already used elsewhere in this UI. The issue is specifically about finishing that migration: the trigger for the scroll behavior is signal-driven state, so the hook should also be signal-native instead of carrying a hand-maintained dependency list.

This is a small issue, but it is the right kind of small cleanup: it removes an avoidable manual dependency seam in a hot view component without changing the ESP flash workflow, presenter contracts, or API surface.

## Chosen implementation approach

I kept the implementation narrow.

The runtime change is only the hook conversion itself:

1. remove `useEffect` from the `preact/hooks` import
2. import `useSignalEffect` from the shared `ui_signals` surface
3. move the existing scroll logic into that signal-native effect
4. preserve the existing guard that bails out when the log panel is absent or the empty-state placeholder is still active

I intentionally did **not** broaden this into a larger ESP flash panel refactor. There is no new helper, no presenter change, no panel contract change, and no unrelated cleanup in the logs/history/journey sections. The existing behavior was already correct; the only problem was that the reactive trigger still used the older dependency-array pattern.

## Main code changes by area

### 1. `apps/ui/src/app/views/esp_flash_panel.tsx`

The panel now imports `useSignalEffect` and no longer imports `useEffect`.

The log-follow code remains in exactly the same place inside `EspFlashPanel`, and it still uses the same practical behavior:

- look up the mounted `#espFlashLogPanel` ref
- inspect the current log state from the bound render model
- skip scrolling while the empty-state placeholder is active
- otherwise scroll the log panel to its current `scrollHeight`

The main difference is simply **how** the effect is wired. Before this change, the component carried an explicit dependency array keyed to `model.value.log.emptyState` and `model.value.log.text`. After this change, the effect is driven by the signal reads themselves, which matches the rest of the signal-backed panel migration work in this repo.

### 2. `apps/ui/tests/smoke.esp-flash.spec.ts`

I also strengthened the existing ESP flash browser smoke coverage so the behavior is exercised in a real browser layout rather than only assumed from the hook swap.

The updated smoke test now:

- streams a longer fake ESP flash log so the log panel genuinely overflows
- constrains the log panel height and enables overflow scrolling in the test setup
- verifies the panel receives the final streamed log line
- polls until the panel is actually scrolled to the bottom

That gives a regression guard for the exact behavior this issue touches: not just “the logs rendered,” but “the panel followed the incoming log output all the way to the newest line.”

I deliberately reused the existing smoke test instead of creating a broader new test harness, because the browser path is the most honest place to validate scroll behavior.

## Why this is safe

This patch changes the ownership mechanism, not the ESP flash workflow.

The following remain unchanged:

- the presenter still builds the same `EspFlashPanelRenderModel`
- the panel still mounts once and binds the same model/actions contract
- the log panel still scrolls only when the log empty state is gone
- the rest of the ESP flash screen — readiness, journey, history, start/cancel controls, and failure handling — is untouched

Because of that, the blast radius is small. The view already depended on signal-backed model updates; this PR only removes the last manual dependency array from that one log-scroll effect.

## Contract, schema, config, and documentation impact

There are no API, schema, config, or generated-contract changes in this PR.

There are also no documentation changes. The panel’s public behavior and contract remain the same, and there is no new reusable abstraction or workflow that would need README or instruction updates.

## Validation and tests performed

I validated the change with the focused ESP flash slice plus the normal frontend gates:

- `cd apps/ui && npx playwright test tests/smoke.esp-flash.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

The smoke suite passed with the strengthened scroll assertion in place, which is the important regression guard for this issue.

Typecheck and build both passed cleanly. Lint also passed with the same existing Biome schema-version info message that has been present in earlier runs; this PR did not introduce any new lint failures.

I also ran a focused diff review after the implementation. That review did not find any material issues requiring follow-up changes.

## Risks, tradeoffs, and edge cases considered

The main thing worth thinking about here is test realism.

A purely synthetic unit test for scroll position can be misleading because fake DOM environments do not compute layout the same way the browser does. That is why I chose to strengthen the existing browser smoke test instead of keeping this entirely at the “hook conversion + typecheck” level. The updated smoke test forces real overflow and proves the log panel ends at the bottom after the streamed lines land.

I also kept the runtime logic intentionally minimal. There is no extra helper for “auto-scroll to bottom on signal updates,” because extracting one here would be speculative. This issue touches one panel in one file, so the cleanest result is still the local direct effect.

Finally, I preserved the old empty-state guard exactly. When the panel is showing the placeholder message instead of active flash output, the code still avoids forcing a scroll write. That keeps the initial idle and failure-placeholder behavior aligned with the pre-existing implementation.

## Out of scope / follow-up

This PR does not refactor the broader ESP flash feature, presenter, or status polling flow. It also does not attempt a larger pass over remaining `useEffect` cleanups outside this one issue.

The goal is narrow and complete: convert the remaining ESP flash log auto-scroll effect to the repo’s signal-native pattern, prove the scroll behavior still works in the browser, and leave the rest of the ESP flash surface unchanged.
