### PR TITLE
Remove unused frontend exports

### DIFF
--- a/apps/ui/src/app/car_selection_state.ts
+++ b/apps/ui/src/app/car_selection_state.ts
@@ -40,14 +40,14 @@ function isConfiguredAspectValue(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
-export function resolveActiveCar(settings: CarSelectionStateSource): CarRecord | null {
+function resolveActiveCar(settings: CarSelectionStateSource): CarRecord | null {
   if (!settings.activeCarId) {
     return null;
   }
   return settings.cars.find((car) => car.id === settings.activeCarId) ?? null;
 }
 
-export function deriveCarSelectionState(settings: CarSelectionStateSource): CarSelectionState {
+function deriveCarSelectionState(settings: CarSelectionStateSource): CarSelectionState {
   if (!settings.carsLoaded) {
     return { kind: "loading" };
   }

--- a/apps/ui/src/app/dom/dom_query.ts
+++ b/apps/ui/src/app/dom/dom_query.ts
@@ -2,7 +2,7 @@ function missingElement(owner: string, target: string): never {
   throw new Error(`${owner} requires ${target}`);
 }
 
-export function getById<T extends HTMLElement>(id: string): T | null {
+function getById<T extends HTMLElement>(id: string): T | null {
   return document.getElementById(id) as T | null;
 }
 

--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -42,7 +42,7 @@ export const SPEED_UNIT_OPTIONS = [
   { fallbackLabel: "m/s", labelKey: "speed.unit.mps", value: "mps" },
 ] as const;
 
-export const LANGUAGE_OPTIONS = [
+const LANGUAGE_OPTIONS = [
   { label: "🇺🇸 English", value: "en" },
   { label: "🇳🇱 Nederlands", value: "nl" },
 ] as const;


### PR DESCRIPTION
## Summary

This PR closes #2433 by removing four unused frontend exports that had no consumers anywhere else in `apps/ui`: `getById`, `resolveActiveCar`, `deriveCarSelectionState`, and `LANGUAGE_OPTIONS`. The runtime behavior is unchanged; the change simply narrows the module surfaces so these implementation details stay private to the files that actually use them.

Closes #2433.

## Problem being solved

The issue identified a small but real API-hygiene problem in the frontend codebase: several symbols were still exported even though no other module imported them.

The four cases were:

1. `getById` in `apps/ui/src/app/dom/dom_query.ts`
2. `resolveActiveCar` in `apps/ui/src/app/car_selection_state.ts`
3. `deriveCarSelectionState` in `apps/ui/src/app/car_selection_state.ts`
4. `LANGUAGE_OPTIONS` in `apps/ui/src/app/runtime/ui_shell_chrome.tsx`

None of those symbols were part of an intentional shared contract anymore. They were only referenced inside the module that defined them. Leaving them exported is not a functional bug, but it does create the wrong surface area:

- it implies those values are part of the supported module API
- it makes future cleanup or refactoring look riskier than it really is
- it increases the chance that a later caller starts depending on an implementation detail that should stay local

This issue is therefore about tightening ownership boundaries rather than changing behavior.

## Chosen implementation approach

I kept the fix exactly as small as the issue asked for.

The implementation has two parts:

1. confirm there are truly no external imports of the reported symbols anywhere in `apps/ui/src` or `apps/ui/tests`
2. remove only the `export` keyword from those declarations

I did not rename anything, move anything, or merge this with adjacent cleanup. The goal here is not “general frontend tidy-up”; it is specifically to make these four module-local details private again.

## Main code changes by area

### 1. `apps/ui/src/app/dom/dom_query.ts`

`getById()` is now a local helper instead of an exported helper.

That file still exports the public DOM helpers that the rest of the app actually uses:

- `requiredById`
- `queryOne`

`requiredById()` still delegates to `getById()` internally, so the implementation stays exactly the same. The only change is that outside modules can no longer import `getById()` directly, which matches the current reality of the codebase because nothing was importing it anyway.

### 2. `apps/ui/src/app/car_selection_state.ts`

`resolveActiveCar()` and `deriveCarSelectionState()` are now private functions within the module.

That file still exports the actual shared surface:

- the derived-state types
- `hasResolvedActiveCar()`
- `createCarSelectionDerivedState()`
- `getCarCompleteness()`

Both removed exports were already being used purely as internal building blocks for those higher-level exports. Making them private is the cleaner ownership model because callers should depend on the public derived-state helpers, not the file’s intermediate implementation steps.

### 3. `apps/ui/src/app/runtime/ui_shell_chrome.tsx`

`LANGUAGE_OPTIONS` is now a local constant instead of an exported one.

This constant is still used to render the language select inside the shell chrome, but there are no other imports of it. That means the constant is a view-local rendering detail, not a reusable runtime contract. Keeping it private aligns the code with that intent.

## Why this is safe

This PR does not change any behavior, rendering logic, state flow, or event handling. It only narrows module boundaries.

The important safety check here is external usage. I verified there are no remaining imports of any of the removed exports in the UI source tree or test tree. That means this is not a coordinated refactor with callers to update; it is simply removing `export` markers from symbols that were already acting as internal-only helpers in practice.

Because of that, the risk is very low:

- there are no runtime semantics changing
- there are no generated artifacts or schema changes
- there are no new branches or conditions
- there are no test fixture updates required

If a symbol had turned out to be imported elsewhere, I would have stopped and updated the issue scope accordingly. The repo-wide scan showed that the issue description is accurate as written.

## Contract, schema, config, and documentation impact

There are no API, schema, config, contract-sync, or documentation changes in this PR.

This cleanup is entirely internal to the frontend module graph. The only “contract” that changes is the TypeScript export surface of the three touched files, and in each case that surface is becoming more accurate by removing declarations that had no consumers.

## Validation and checks performed

I validated the change in two ways.

First, I ran a repo-scoped import search to make sure the removed exports truly have no external consumers:

- `cd /workspace/VibeSensor && if rg -n "import\\s+\\{[^\\n}]*(getById|resolveActiveCar|deriveCarSelectionState|LANGUAGE_OPTIONS)\\b" apps/ui/src apps/ui/tests; then exit 1; else echo "No external imports remain for removed exports."; fi`

Second, I ran the normal frontend gates:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

Those checks passed cleanly. As in earlier runs, lint only reported the existing Biome schema-version information message and no new lint failures.

I also ran a focused diff review after the implementation. That review found no material issues.

## Risks, tradeoffs, and edge cases considered

The only real risk in a change like this is hidden consumption: a forgotten import, a barrel export, or a test/tooling dependency that is easy to miss when the runtime behavior itself does not change.

That is why the main validation here is the explicit import scan rather than a broader browser test slice. Browser tests would be mostly noise for this issue because the rendered behavior is identical either way. The important truth to prove is that these exports are dead from the perspective of other modules, and the search plus typecheck does exactly that.

I also chose not to broaden the cleanup into removing any additional unused exports that were not part of this issue. The repo has plenty of adjacent cleanup opportunities, but this run is intentionally one issue at a time with small, reviewable diffs.

## Out of scope / follow-up

This PR does not change the public behavior of DOM helpers, car-selection derived state, or shell chrome rendering. It also does not try to reorganize those modules or collapse more helpers while touching them.

The scope is intentionally narrow: remove the four export markers identified in #2433 once their lack of consumers is confirmed, keep the actual public helpers intact, and leave the rest of the frontend unchanged.
