### PR TITLE
Remove dead cars wizard reset helper

### DIFF
--- a/apps/ui/src/app/features/cars_wizard_state.ts
+++ b/apps/ui/src/app/features/cars_wizard_state.ts
@@ -63,10 +63,6 @@ export function createInitialWizardState(): WizardState {
   };
 }
 
-export function resetWizardState(state: WizardState): void {
-  Object.assign(state, createInitialWizardState());
-}
-
 export function resolveGearboxes(
   model: CarLibraryModel | null,
   variant: CarLibraryVariant | null,


### PR DESCRIPTION
## Summary

This PR closes #2434 by deleting the dead `resetWizardState()` helper from `apps/ui/src/app/features/cars_wizard_state.ts`. The issue correctly identified one remaining `Object.assign(state, createInitialWizardState())` path, but the current codebase no longer uses that helper anywhere. The live cars workflow already resets wizard state through direct signal assignment, so the clean fix is to remove the stale mutation helper entirely rather than rewrite unused code into a different unused form.

Closes #2434.

## Problem being solved

The issue was filed against this code in `cars_wizard_state.ts`:

```ts
Object.assign(state, createInitialWizardState());
```

The concern behind the issue is sound. In the current frontend architecture, wizard state is signal-backed, so mutating an existing object in place is the wrong ownership pattern. Signal consumers should observe a fresh value assignment, not an in-place mutation path that preserves object identity.

However, the first thing I checked was whether that `Object.assign(...)` path was still live.

It is not.

Today, the actual cars workflow resets the wizard through:

```ts
wizardState.value = createInitialWizardState();
```

inside `apps/ui/src/app/features/cars_feature_workflow.ts`.

That means the issue body is a little stale: the reactivity-safe reset already exists in the real execution path. The only remaining `Object.assign(...)` lived inside an exported helper named `resetWizardState()`, and that helper had no callers anywhere in the UI source or test tree.

So the real problem to solve is narrower than the issue description suggests:

- remove the stale mutation helper
- remove the last `Object.assign(...)` reset path from this module
- keep the already-correct live signal assignment path unchanged

## Chosen implementation approach

I chose deletion rather than replacement.

There were two possible approaches after confirming the helper was unused:

1. keep the dead helper and rewrite it to a spread-based or signal-assignment style anyway
2. delete the dead helper entirely

The second option is cleaner and more correct.

If a function is genuinely unused, rewriting it just preserves dead code in a slightly prettier form. This repo’s guidance is explicitly biased toward removing dead code and avoiding compatibility scaffolding or parallel paths when one canonical path already exists. In this case, the canonical path is already in `cars_feature_workflow.ts`, so the helper in `cars_wizard_state.ts` should simply disappear.

That makes the final diff very small, but it also makes it more honest: the PR does not pretend to change live wizard behavior when the live behavior was already correct.

## Main code changes by area

### 1. `apps/ui/src/app/features/cars_wizard_state.ts`

The only code change is the removal of:

```ts
export function resetWizardState(state: WizardState): void {
  Object.assign(state, createInitialWizardState());
}
```

Nothing else in the module changes.

The remaining public surface of the file still includes the helpers that are actually used:

- `createInitialWizardState()`
- the manual tire/gearbox readers
- wizard completion helpers
- wizard summary helpers
- other view/workflow support functions

So this is not a broader API redesign. It is a dead-export deletion that also removes the last stale mutation pattern from the file.

### 2. Verified the live reset path stays untouched

The meaningful behavioral point is that the cars workflow continues to reset wizard state by assigning a fresh object to the signal:

- `wizardState.value = createInitialWizardState()`

That was already the right pattern before this PR, and this PR leaves it exactly as-is.

In other words, the PR improves code hygiene without changing how the cars wizard actually behaves at runtime.

## Why this is safe

This change is safe for two independent reasons.

First, there are no remaining callers of `resetWizardState()`. I verified that with a repo-wide search over both `apps/ui/src` and `apps/ui/tests`. Deleting the helper therefore does not orphan any live code path.

Second, the runtime path that matters was already using the correct signal reset pattern. The cars feature workflow still creates a fresh wizard state object and assigns it to the signal. That means deleting the dead helper cannot regress the real reset behavior because that behavior does not depend on the helper.

This is exactly the kind of cleanup where deletion is lower risk than substitution. Replacing the dead helper would still leave an unnecessary public symbol behind and suggest there are two supported reset mechanisms when in reality there is only one live one.

## Contract, schema, config, and documentation impact

There are no schema, config, API, or generated-contract changes in this PR.

There are also no documentation changes. The cars wizard’s user-visible behavior is unchanged, and there is no new architectural seam to document. This is internal code hygiene in a single feature helper module.

The only contract change is the TypeScript export surface of `cars_wizard_state.ts`, which becomes more accurate by dropping an exported function that had no consumers.

## Validation and checks performed

I validated the change in three ways.

First, I verified the dead helper is truly unused and that the stale mutation pattern is gone:

- `cd /workspace/VibeSensor/apps/ui && if rg -n "resetWizardState\\(" src tests; then exit 1; else echo "No resetWizardState references remain."; fi`
- `cd /workspace/VibeSensor/apps/ui && if rg -n "Object.assign\\(" src/app/features/cars_wizard_state.ts; then exit 1; else echo "No Object.assign remains in cars_wizard_state.ts."; fi`

Second, I ran focused cars wizard coverage:

- `cd /workspace/VibeSensor/apps/ui && npx playwright test tests/cars_feature_workflow.spec.ts tests/car_wizard_view.spec.ts --workers=1`

Third, I ran the normal frontend gates:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

All of those checks passed. As in prior runs, lint only reported the existing Biome schema-version information message and no new lint failures.

I also ran a focused diff review after the implementation. That review found no material issues.

## Risks, tradeoffs, and edge cases considered

The only meaningful risk here was that the helper might have a hidden consumer outside the obvious workflow file. That is why the import/reference scan mattered more than broad browser smoke coverage for this issue. Once the scan confirmed there were no callers, deletion became the lowest-risk option.

There is also a small tradeoff in how the PR is framed: the issue title suggests “replace `Object.assign` with spread,” but the live code no longer needs that transformation because the mutation path is already dead. I chose the cleaner architectural outcome over a literal-but-misleading patch. The PR removes the anti-pattern completely instead of preserving an unused helper just to match the wording of the issue body.

## Out of scope / follow-up

This PR does not refactor the broader cars workflow, manual-input signals, or wizard summary logic. It also does not change the already-correct live reset assignment in `cars_feature_workflow.ts`.

The scope is intentionally narrow and complete: remove the dead exported helper that still contained the stale `Object.assign(...)` reset, prove it has no consumers, and leave the live signal-backed wizard reset path as the single canonical implementation.
