### PR TITLE
Reduce realtime logging useComputed boilerplate

### DIFF
--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -4,7 +4,6 @@ import { useUiText } from "../ui_i18n";
 import {
   computed,
   signal,
-  useComputed,
   type ReadonlySignal,
 } from "../ui_signals";
 import { inlineStateActionClass } from "./dom_helpers";
@@ -149,37 +148,18 @@ function RealtimeLoggingPanel(props: {
   const samplesLabel = useUiText("dashboard.recording_samples", "Samples recorded");
   const startLabel = useUiText("dashboard.start_recording", "Start Recording");
   const stopLabel = useUiText("dashboard.stop_recording", "Stop Recording");
-  const pillVariant = useComputed(() => props.model.value.pillVariant);
-  const pillText = useComputed(() => props.model.value.pillText);
-  const showPill = useComputed(() => props.model.value.showPill);
-  const summaryText = useComputed(() => props.model.value.summaryText);
-  const summaryPanel = useComputed(() => props.model.value.summaryPanel);
-  const runIdText = useComputed(() => props.model.value.runIdText);
-  const phaseText = useComputed(() => props.model.value.phaseText);
-  const elapsedText = useComputed(() => props.model.value.elapsedText);
-  const samplesText = useComputed(() => props.model.value.samplesText);
-  const checklist = useComputed(() => props.model.value.checklist);
-  const showStart = useComputed(() => props.model.value.showStart);
-  const showStop = useComputed(() => props.model.value.showStop);
-  const startDisabled = useComputed(() => props.model.value.startDisabled);
-  const stopDisabled = useComputed(() => props.model.value.stopDisabled);
-  const setupMode = useComputed(() => props.model.value.setupMode);
-  const shellLayout = useComputed(() => setupMode.value ? "setup" : undefined);
-  const loggingRowHidden = useComputed(() => !showPill.value && runIdText.value === "");
-  const showPillHidden = useComputed(() => !showPill.value);
-  const runIdHidden = useComputed(() => runIdText.value === "");
-  const showProgressSection = useComputed(() => !setupMode.value || checklist.value !== null);
-  const showStartHidden = useComputed(() => !showStart.value);
-  const showStopHidden = useComputed(() => !showStop.value);
-  const actions = useComputed(() => props.actions.value);
+  const model = props.model.value;
+  const shellLayout = model.setupMode ? "setup" : undefined;
+  const loggingRowHidden = !model.showPill && model.runIdText === "";
+  const showProgressSection = !model.setupMode || model.checklist !== null;
   const handleSummaryAction = (action: RealtimeLoggingSummaryAction) => {
-    actions.value?.onSummaryAction(action);
+    props.actions.value?.onSummaryAction(action);
   };
   const handleStartLogging = () => {
-    actions.value?.onStartLogging();
+    props.actions.value?.onStartLogging();
   };
   const handleStopLogging = () => {
-    actions.value?.onStopLogging();
+    props.actions.value?.onStopLogging();
   };
 
   return (
@@ -190,8 +170,8 @@ function RealtimeLoggingPanel(props: {
             {titleText}
           </div>
           <RealtimeLoggingSummary
-            summaryText={summaryText.value}
-            summaryPanel={summaryPanel.value}
+            summaryText={model.summaryText}
+            summaryPanel={model.summaryPanel}
             onAction={handleSummaryAction}
           />
         </div>
@@ -200,17 +180,17 @@ function RealtimeLoggingPanel(props: {
         <span
           id="loggingStatus"
           class="pill"
-          data-variant={pillVariant}
-          hidden={showPillHidden}
+          data-variant={model.pillVariant}
+          hidden={!model.showPill}
           aria-live="polite"
         >
-          {pillText}
+          {model.pillText}
         </span>
-        <span id="loggingRunId" class="subtle" hidden={runIdHidden}>
-          {runIdText}
+        <span id="loggingRunId" class="subtle" hidden={model.runIdText === ""}>
+          {model.runIdText}
         </span>
       </div>
-      {showProgressSection.value
+      {showProgressSection
         ? (
           <>
             <div class="mini-label">
@@ -222,7 +202,7 @@ function RealtimeLoggingPanel(props: {
                   {runPhaseLabel}
                 </div>
                 <div class="stat__value" data-value>
-                  {phaseText}
+                  {model.phaseText}
                 </div>
               </div>
               <div id="loggingElapsed" class="stat stat--compact">
@@ -230,7 +210,7 @@ function RealtimeLoggingPanel(props: {
                   {elapsedLabel}
                 </div>
                 <div class="stat__value" data-value>
-                  {elapsedText}
+                  {model.elapsedText}
                 </div>
               </div>
               <div id="loggingSamples" class="stat stat--compact">
@@ -238,11 +218,11 @@ function RealtimeLoggingPanel(props: {
                   {samplesLabel}
                 </div>
                 <div class="stat__value" data-value>
-                  {samplesText}
+                  {model.samplesText}
                 </div>
               </div>
             </div>
-            <RealtimeLoggingChecklist checklist={checklist.value} />
+            <RealtimeLoggingChecklist checklist={model.checklist} />
           </>
         )
         : null}
@@ -252,8 +232,8 @@ function RealtimeLoggingPanel(props: {
           class="btn btn--primary"
           type="button"
 
-          hidden={showStartHidden}
-          disabled={startDisabled}
+          hidden={!model.showStart}
+          disabled={model.startDisabled}
           onClick={handleStartLogging}
         >
           {startLabel}
@@ -263,8 +243,8 @@ function RealtimeLoggingPanel(props: {
           class="btn btn--danger-quiet"
           type="button"
 
-          hidden={showStopHidden}
-          disabled={stopDisabled}
+          hidden={!model.showStop}
+          disabled={model.stopDisabled}
           onClick={handleStopLogging}
         >
           {stopLabel}


### PR DESCRIPTION
## Summary

This PR reduces the `useComputed()` boilerplate in
`apps/ui/src/app/views/realtime_logging_panel.tsx` without changing the
panel’s public bridge contract or user-facing behavior. Before this change,
the component created a long row of single-property computed signals such as
`pillText`, `summaryText`, `runIdText`, `elapsedText`, `showStart`,
`showStop`, and several more, even though each one only unwrapped a single
field from `props.model.value`. The panel then added another layer of tiny
derived computeds for simple booleans like whether the logging row should be
hidden or whether the setup layout should be active. That structure was
technically correct, but it made the component noisy to read and harder to
maintain than the live logic actually required.

The change here keeps the cleanup deliberately narrow. I did not introduce a
new shared helper, change the upstream view-model shape, or alter the bridge
mount API. Instead, the panel now snapshots `props.model.value` once during
render, derives the handful of simple booleans inline, and reads
`props.actions.value` directly inside the click handlers. That removes the
local boilerplate while preserving the current feature boundaries and leaving
later helper-oriented follow-up issues free to decide whether a shared pattern
is still worthwhile elsewhere.

## Problem

Issue #2435 called out one specific hotspot in the current migrated UI: the
realtime logging panel still had a large block of `useComputed(() =>
props.model.value.someField)` declarations that did not add meaningful local
behavior. They were effectively pass-through wrappers around the same render
model signal. In practice, the component had become more verbose than the UI it
renders. A reader had to scan past a long wall of near-identical signal
definitions before reaching the actual logging-summary, progress, and action
markup.

That extra ceremony also obscured the few pieces of logic that are genuinely
local to the component. The important decisions in this panel are simple: when
to use the setup layout, when the logging status row should be hidden, and when
the progress section should still render during setup. Those conditions were
buried among many pass-through signal declarations, which made the component
feel more complex than it is.

## Implementation approach

The fix replaces the per-property signal wrappers with one render-time model
snapshot:

- `const model = props.model.value`

From there, the component reads the fields it needs directly from `model` and
computes the few local booleans inline:

- `shellLayout`
- `loggingRowHidden`
- `showProgressSection`

The event handlers were simplified in the same spirit. Instead of mirroring the
action handlers through another computed signal, the button and summary-action
callbacks now read `props.actions.value` directly at call time. That keeps the
actions source explicit and removes another bit of local indirection.

This is intentionally not a cross-file abstraction pass. There are similar
patterns in a few other panels, and there is already later backlog work aimed
at broader signal-property cleanup. For this issue, the most maintainable cut
was to simplify the one panel the issue names, keep the behavior identical, and
avoid creating a new helper that could overlap awkwardly with later dedicated
cleanup.

## Main code changes

All code changes are contained in one file:

- `apps/ui/src/app/views/realtime_logging_panel.tsx`

Within that file, the main updates are:

1. Removed the `useComputed` import because the component no longer needs a
   separate computed signal for every model field.
2. Deleted the long block of single-field computed wrappers for pill state,
   summary state, run metadata, progress values, checklist visibility, and
   action-button visibility.
3. Replaced the second-layer derived computeds (`shellLayout`,
   `loggingRowHidden`, `showPillHidden`, `runIdHidden`, `showProgressSection`,
   `showStartHidden`, `showStopHidden`) with straightforward inline booleans
   based on the current `model` snapshot.
4. Simplified the three action handlers so they invoke `props.actions.value`
   directly instead of routing through a separate mirrored `actions` computed.
5. Updated the JSX to read directly from `model.*` for summary, status, run ID,
   elapsed/sample text, checklist state, and start/stop button visibility.

Nothing about the bridge contract changed. `mountRealtimeLoggingPanel()` still
mounts once, still binds the external model signal through `bindModel()`, and
still accepts action handlers through `bindActions()`. No upstream feature,
workflow, or presenter code needed to change.

## Validation

I validated the change against the two most relevant browser surfaces plus the
standard frontend gates:

- `cd apps/ui && npx playwright test tests/realtime_logging_summary.spec.ts tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

The most important targeted guard here is
`tests/realtime_logging_summary.spec.ts`, because it proves the no-car Live CTA
in `#loggingSummary` stays stable while repeated websocket payloads arrive. That
test matters for this cleanup because a too-naive rewrite could accidentally
introduce churn in the logging summary subtree even if the visible text still
looked correct. The targeted smoke continued to pass, so the simplified panel
still preserves the current CTA stability behavior.

The broader bootstrap smoke also stayed green, which confirms the panel still
renders correctly through startup, live recording state transitions, and saved
run navigation.

## Risks, tradeoffs, and follow-ups

The main tradeoff in this PR is scope discipline. I intentionally did not
generalize the pattern into a shared helper, because that would start to blend
this issue into later backlog items about broader signal-property abstractions.
If the repo still wants a shared `useSignalProperties` helper later, that work
can happen with a wider survey and consistent adoption plan instead of being
introduced opportunistically from one panel cleanup.

There are also no schema, contract, or documentation changes in this PR because
none are needed. The render model shape is unchanged, the mounted panel API is
unchanged, and the user-visible logging experience is unchanged. This is purely
a local readability and maintenance improvement inside the view implementation.

Closes #2435
