### PR TITLE
Reduce ui_shell_chrome useComputed boilerplate

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef } from "preact/hooks";
 import { requiredById } from "../dom/dom_query";
 import {
   signal,
-  useComputed,
   type ReadonlySignal,
 } from "../ui_signals";
 import type { UiConfirmationDialogModel } from "./ui_confirmation_module";
@@ -285,27 +284,9 @@ function ShellViewSection(props: ShellViewSectionProps) {
 
 function UiShellChrome(props: UiShellChromeProps) {
   const { bridge } = props;
-  const activeViewId = useComputed(() => props.model.value.activeViewId);
-  const appErrorBanner = useComputed(() => props.model.value.appErrorBanner);
-  const confirmationDialog = useComputed(() => props.model.value.confirmationDialog);
-  const languageFeedback = useComputed(() => props.model.value.languageFeedback);
-  const languageLabelText = useComputed(() => props.model.value.languageLabelText);
-  const navItems = useComputed(() => props.model.value.navItems);
-  const selectedLanguage = useComputed(() => props.model.value.selectedLanguage);
-  const selectedSpeedUnit = useComputed(() => props.model.value.selectedSpeedUnit);
-  const shellLiveStatus = useComputed(() => props.model.value.shellLiveStatus);
-  const speedUnitFeedback = useComputed(() => props.model.value.speedUnitFeedback);
-  const speedUnitLabelText = useComputed(() => props.model.value.speedUnitLabelText);
-  const speedUnitOptionLabels = useComputed(() => props.model.value.speedUnitOptionLabels);
-  const wsLinkState = useComputed(() => props.model.value.wsLinkState);
-  const statusHidden = useComputed(() => activeViewId.value === "dashboardView");
-  const appErrorHidden = useComputed(() => appErrorBanner.value.hidden);
-  const appErrorVariant = useComputed(() => appErrorBanner.value.variant ?? undefined);
-  const appErrorText = useComputed(() => appErrorBanner.value.text);
-  const wsLinkVariant = useComputed(() => wsLinkState.value.variant);
-  const wsLinkText = useComputed(() => wsLinkState.value.text);
-  const shellLiveVariant = useComputed(() => shellLiveStatus.value.variant);
-  const shellLiveText = useComputed(() => shellLiveStatus.value.text);
+  const model = props.model.value;
+  const statusHidden = model.activeViewId === "dashboardView";
+  const appErrorVariant = model.appErrorBanner.variant ?? undefined;
 
   function activateView(viewId: string): void {
     bridge.current.activateView(viewId);
@@ -317,33 +298,33 @@ function UiShellChrome(props: UiShellChromeProps) {
   ): void {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      activateView(navItems.value[index].viewId);
+      activateView(model.navItems[index].viewId);
       return;
     }
     if (event.key === "ArrowRight") {
       event.preventDefault();
       const nextIndex = normalizeMenuIndex(index + 1);
-      activateView(navItems.value[nextIndex].viewId);
+      activateView(model.navItems[nextIndex].viewId);
       focusMenuButton(event, nextIndex);
       return;
     }
     if (event.key === "ArrowLeft") {
       event.preventDefault();
       const nextIndex = normalizeMenuIndex(index - 1);
-      activateView(navItems.value[nextIndex].viewId);
+      activateView(model.navItems[nextIndex].viewId);
       focusMenuButton(event, nextIndex);
       return;
     }
     if (event.key === "Home") {
       event.preventDefault();
-      activateView(navItems.value[0].viewId);
+      activateView(model.navItems[0].viewId);
       focusMenuButton(event, 0);
       return;
     }
     if (event.key === "End") {
       event.preventDefault();
-      const nextIndex = navItems.value.length - 1;
-      activateView(navItems.value[nextIndex].viewId);
+      const nextIndex = model.navItems.length - 1;
+      activateView(model.navItems[nextIndex].viewId);
       focusMenuButton(event, nextIndex);
     }
   }
@@ -368,8 +349,8 @@ function UiShellChrome(props: UiShellChromeProps) {
               </picture>
             </h1>
             <nav class="menu" aria-label="Primary" role="tablist">
-              {navItems.value.map((item, index) => {
-                const isActive = item.viewId === activeViewId.value;
+              {model.navItems.map((item, index) => {
+                const isActive = item.viewId === model.activeViewId;
                 return (
                   <button
                     key={item.viewId}
@@ -392,38 +373,38 @@ function UiShellChrome(props: UiShellChromeProps) {
           </div>
           <div class="site-header__preferences">
             <label class="header-select" htmlFor="speedUnitSelect">
-              <span class="mini-label">{speedUnitLabelText}</span>
+              <span class="mini-label">{model.speedUnitLabelText}</span>
               <select
                 id="speedUnitSelect"
                 class="unit-picker"
-                aria-label={speedUnitLabelText}
-                aria-describedby={speedUnitFeedback.value ? "speedUnitFeedback" : undefined}
-                aria-invalid={speedUnitFeedback.value?.tone === "error" ? "true" : undefined}
-                value={selectedSpeedUnit}
+                aria-label={model.speedUnitLabelText}
+                aria-describedby={model.speedUnitFeedback ? "speedUnitFeedback" : undefined}
+                aria-invalid={model.speedUnitFeedback?.tone === "error" ? "true" : undefined}
+                value={model.selectedSpeedUnit}
                 onChange={(event) => {
                   void bridge.current.saveSpeedUnit(event.currentTarget.value);
                 }}
               >
                 {SPEED_UNIT_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value}>
-                    {speedUnitOptionLabels.value[option.value] ?? option.fallbackLabel}
+                    {model.speedUnitOptionLabels[option.value] ?? option.fallbackLabel}
                   </option>
                 ))}
               </select>
               <SettingsFeedbackSlot
                 id="speedUnitFeedback"
-                message={speedUnitFeedback.value}
+                message={model.speedUnitFeedback}
               />
             </label>
             <label class="header-select" htmlFor="languageSelect">
-              <span class="mini-label">{languageLabelText}</span>
+              <span class="mini-label">{model.languageLabelText}</span>
               <select
                 id="languageSelect"
                 class="lang-picker"
-                aria-label={languageLabelText}
-                aria-describedby={languageFeedback.value ? "languageFeedback" : undefined}
-                aria-invalid={languageFeedback.value?.tone === "error" ? "true" : undefined}
-                value={selectedLanguage}
+                aria-label={model.languageLabelText}
+                aria-describedby={model.languageFeedback ? "languageFeedback" : undefined}
+                aria-invalid={model.languageFeedback?.tone === "error" ? "true" : undefined}
+                value={model.selectedLanguage}
                 onChange={(event) => {
                   void bridge.current.saveLanguage(event.currentTarget.value);
                 }}
@@ -436,7 +417,7 @@ function UiShellChrome(props: UiShellChromeProps) {
               </select>
               <SettingsFeedbackSlot
                 id="languageFeedback"
-                message={languageFeedback.value}
+                message={model.languageFeedback}
               />
             </label>
           </div>
@@ -446,18 +427,18 @@ function UiShellChrome(props: UiShellChromeProps) {
             <div
               id="linkState"
               class="pill"
-              data-variant={wsLinkVariant}
+              data-variant={model.wsLinkState.variant}
               aria-live="polite"
             >
-              {wsLinkText}
+              {model.wsLinkState.text}
             </div>
             <div
               id="shellLiveStatus"
               class="pill"
-              data-variant={shellLiveVariant}
+              data-variant={model.shellLiveStatus.variant}
               aria-live="polite"
             >
-              {shellLiveText}
+              {model.shellLiveStatus.text}
             </div>
           </div>
         </div>
@@ -466,16 +447,16 @@ function UiShellChrome(props: UiShellChromeProps) {
       <div
         id="appErrorBanner"
         class="connection-banner app-error-banner"
-        hidden={appErrorHidden}
+        hidden={model.appErrorBanner.hidden}
         data-variant={appErrorVariant}
         aria-live="assertive"
         role="alert"
       >
-        {appErrorText}
+        {model.appErrorBanner.text}
       </div>
 
       <ShellViewSection
-        activeViewId={activeViewId.value}
+        activeViewId={model.activeViewId}
         ariaLabelledBy="tab-dashboard"
         viewId="dashboardView"
       >
@@ -483,7 +464,7 @@ function UiShellChrome(props: UiShellChromeProps) {
       </ShellViewSection>
 
       <ShellViewSection
-        activeViewId={activeViewId.value}
+        activeViewId={model.activeViewId}
         ariaLabelledBy="tab-history"
         viewId="historyView"
       >
@@ -491,15 +472,15 @@ function UiShellChrome(props: UiShellChromeProps) {
       </ShellViewSection>
 
       <ShellViewSection
-        activeViewId={activeViewId.value}
+        activeViewId={model.activeViewId}
         ariaLabelledBy="tab-settings"
         viewId="settingsView"
       >
         <SettingsViewHosts />
       </ShellViewSection>
 
-      {confirmationDialog.value
-        ? <ConfirmationDialog bridge={bridge} model={confirmationDialog.value} />
+      {model.confirmationDialog
+        ? <ConfirmationDialog bridge={bridge} model={model.confirmationDialog} />
         : null}
     </div>
   );


### PR DESCRIPTION
## Summary

This PR reduces the `useComputed()` boilerplate inside
`apps/ui/src/app/runtime/ui_shell_chrome.tsx` without changing the shell
chrome contract, the mounted host layout, or the user-facing header behavior.
The issue identified a long block of signal wrappers that were only unwrapping
individual properties from `props.model.value`, followed by another layer of
tiny derived computeds for the error banner, live badges, and status visibility.
That arrangement was correct, but it made the shell owner harder to read than
the current behavior required.

The change here follows the same local cleanup pattern used in the previous
logging-panel issue, but with wider validation because the shell owner is more
sensitive than a leaf panel. Instead of mirroring many one-field reads through
separate computed signals, `UiShellChrome` now snapshots `props.model.value`
once during render, derives the few simple booleans inline, and reads the rest
of the header/nav/status state directly from `model.*`. No new helper was
introduced, no upstream model shape changed, and no new reactive abstraction
was added. This keeps the fix narrow while leaving the later backlog item about
a shared signal-properties helper free to make that decision repo-wide.

## Problem

The shell chrome component had accumulated a repetitive block of
`useComputed(() => props.model.value.someField)` declarations for:

- active view
- app error banner
- confirmation dialog
- language field state
- nav items
- speed-unit field state
- shell websocket/live badges

It then added another layer of single-purpose computeds for values such as
`statusHidden`, `appErrorVariant`, `appErrorText`, `wsLinkVariant`,
`wsLinkText`, `shellLiveVariant`, and `shellLiveText`. That left the component
front-loaded with signal plumbing before a reader could even reach the actual
shell markup.

The boilerplate also hid the few pieces of logic that are actually local to the
component: whether the header status row should be hidden on the dashboard, how
the app error banner derives its variant, and how keyboard navigation resolves
the next shell tab. The shell owner is conceptually straightforward, but the
amount of repeated signal unwrapping made it look more complicated than it is.

## Implementation approach

The implementation replaces the repeated field wrappers with one render-time
model snapshot:

- `const model = props.model.value`

From there, the component derives only the few remaining local values it really
needs:

- `statusHidden`
- `appErrorVariant`

Everything else now reads directly from `model.*` in JSX or in the shell
keyboard-navigation handler. That includes nav items, selected header values,
feedback slots, websocket/live badge text, error-banner content, tab-panel
visibility, and the confirmation-dialog presence check.

The key design choice here is what **not** to do:

1. I did not introduce a shared helper such as `useSignalProperties()`, because
   there is already a later backlog issue aimed specifically at that broader
   abstraction.
2. I did not change the `UiShellChromeRenderModel` shape or split it into new
   upstream signals, because that would broaden the issue from a local view
   cleanup into a larger runtime contract change.
3. I did not alter the shell bridge APIs, host IDs, or panel ownership
   boundaries.

That keeps the change aligned with the issue scope: reduce local boilerplate,
not redesign the shell data flow.

## Main code changes

All production changes live in one file:

- `apps/ui/src/app/runtime/ui_shell_chrome.tsx`

Within that file, the diff does four concrete things:

1. Removes the `useComputed` import, because the component no longer needs a
   separate computed signal for each field on the render model.
2. Deletes the block of one-property computed wrappers and the follow-on
   computed layer for simple banner/status/badge values.
3. Rewrites the shell tab keyboard handler to read view IDs directly from
   `model.navItems` instead of going through the old `navItems` computed.
4. Updates the rendered JSX to read directly from `model` for:
   - nav item labels and active-tab state
   - speed-unit and language selectors
   - feedback slot visibility/content
   - websocket and live-status pills
   - app error banner text and hidden state
   - tab-panel active view ID
   - confirmation dialog rendering

Nothing else in the runtime stack changed. `mountUiShellChrome()` still owns a
plain signal-backed render model and still exposes the same `setModel()` view
contract. The shell action bridge is unchanged, the host lookup is unchanged,
and the startup/runtime composition path is unchanged.

## Validation

Because this file is the top-level shell owner, I used a broader frontend slice
than the previous logging-panel cleanup:

- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.settings.spec.ts tests/smoke.settings-shell.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

That mix matters here for a reason. `UiShellChrome` is not just another leaf
panel; it owns the shell header, primary navigation, and the stable host
sections that wrap the dashboard/history/settings panel roots. A too-naive
cleanup could risk breaking startup view placement, tab navigation, status-pill
visibility, or the header controls that save speed-unit and language settings.

The runtime-module tests stayed green, and the browser slice also stayed green
across:

- bootstrap navigation
- saved-run startup routing
- shell tab click/keyboard synchronization
- speed-unit selector behavior
- language selector save/revert behavior
- shell status visibility across views

So the simpler render path still preserves the live shell behavior.

## Risks, tradeoffs, and follow-ups

The main tradeoff is intentionally leaving broader cleanup on the table. There
are similar signal-unwrapping patterns elsewhere, and the backlog already has a
follow-up item to consider a shared helper for that pattern. This PR does not
try to solve that repo-wide. It only removes the local repetition in the shell
chrome component named by the issue.

There are also no schema, contract, API, or documentation changes in this PR.
The shell render model shape is unchanged, the bridge contract is unchanged,
and the mounted host IDs remain exactly the same. That is important because the
rest of the frontend runtime already composes around those shell seams.

In short, this PR keeps the shell owner easier to read while preserving the
same runtime boundaries and behavior, and it does so with validation broad
enough to cover the shell-specific regression surface.

Closes #2436
