### PR TITLE
Remove dead frontend CSS selectors

### DIFF
--- a/apps/ui/src/styles/adaptive.css
+++ b/apps/ui/src/styles/adaptive.css
@@ -54,14 +54,6 @@
     align-items: flex-start;
     flex-direction: column;
   }
-  .live-speed-row {
-    grid-template-columns: 1fr;
-  }
-  .live-speed-row input,
-  .live-speed-row .btn {
-    width: 100%;
-    min-width: 0;
-  }
   .history-details-preview { grid-template-columns: 1fr; }
   .history-toolbar {
     align-items: flex-start;

--- a/apps/ui/src/styles/components.css
+++ b/apps/ui/src/styles/components.css
@@ -174,8 +174,7 @@ button[hidden],
 .card__title { margin: 0; font-size: 1rem; font-weight: 700; }
 .card__subtle,
 .subtle,
-.mini-label,
-.matrix-note { color: var(--muted); font-size: 0.86rem; }
+.mini-label { color: var(--muted); font-size: 0.86rem; }
 
 .stat-grid {
   display: grid;

--- a/apps/ui/src/styles/history-detail.css
+++ b/apps/ui/src/styles/history-detail.css
@@ -290,12 +290,6 @@
   color: var(--brand-600);
 }
 
-.history-panel-header__subtitle {
-  color: var(--muted);
-  font-size: 0.84rem;
-  max-width: 34rem;
-}
-
 .history-panel-state {
   margin-top: var(--space-3);
   padding: var(--space-3);
@@ -321,8 +315,7 @@
   flex-wrap: wrap;
 }
 
-.history-findings-overview__eyebrow,
-.history-findings-overview__count {
+.history-findings-overview__eyebrow {
   font-size: 0.76rem;
   font-weight: 700;
   letter-spacing: 0.04em;

--- a/apps/ui/src/styles/maintenance.css
+++ b/apps/ui/src/styles/maintenance.css
@@ -248,14 +248,6 @@
   background: var(--surface);
 }
 
-.maintenance-journey__title {
-  font-size: 0.82rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--muted);
-  font-weight: 700;
-}
-
 .maintenance-stage-list {
   list-style: none;
   margin: 0;

--- a/apps/ui/src/styles/realtime.css
+++ b/apps/ui/src/styles/realtime.css
@@ -125,61 +125,6 @@
   color: var(--brand-700);
 }
 
-/* Spectrum + Car map split */
-.spectrum-split {
-  display: grid;
-  grid-template-columns: 1fr 200px;
-  gap: var(--space-4);
-  align-items: start;
-}
-.spectrum-split__chart { min-width: 0; }
-.spectrum-split__map { display: flex; align-items: flex-start; justify-content: center; }
-
-.car-map {
-  position: relative;
-  width: 200px;
-  aspect-ratio: 200 / 340;
-}
-.car-map__svg {
-  width: 100%;
-  height: 100%;
-  display: block;
-}
-.car-map__body {
-  fill: var(--surface-2);
-  stroke: var(--border-strong);
-  stroke-width: 1.5;
-}
-.car-map__wheel {
-  fill: var(--muted);
-  opacity: 0.35;
-}
-.car-map__axle {
-  stroke: var(--border);
-  stroke-width: 1;
-  stroke-dasharray: 4 3;
-}
-.car-map__windshield {
-  fill: none;
-  stroke: var(--border);
-  stroke-width: 1;
-}
-.car-map__dots {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-}
-
-@media (max-width: 980px) {
-  .spectrum-split {
-    grid-template-columns: 1fr;
-  }
-  .spectrum-split__map {
-    justify-content: center;
-  }
-  .car-map { width: 160px; }
-}
-
 @media (max-width: 720px) {
   .status-grid__row,
   .maintenance-action-row,
@@ -491,9 +436,7 @@
   border: 1px solid rgba(20, 32, 51, 0.2);
 }
 
-.logging-row,
-.live-speed-row,
-.live-speed-readout { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
+.logging-row { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
 .logging-row { justify-content: space-between; }
 .logging-row .subtle[hidden] { display: none; }
 .logging-actions {
@@ -533,23 +476,6 @@
 .logging-actions .btn[hidden] {
   display: none;
 }
-.live-speed-readout { margin-top: var(--space-3); }
-.live-speed-row {
-  margin-top: var(--space-3);
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--space-2);
-}
-.live-speed-row label {
-  grid-column: 1 / -1;
-  min-width: 0;
-}
-.live-speed-row input {
-  width: 9rem;
-}
-.live-speed-row .btn {
-  min-width: 9.5rem;
-}
 
 .speed {
   min-width: 0;
@@ -564,62 +490,3 @@
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
-
-.rotational-speeds {
-  margin-top: var(--space-3);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--surface-2);
-  padding: var(--space-3);
-  display: grid;
-  gap: var(--space-2);
-}
-
-.rotational-speeds__title {
-  font-size: 0.82rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--muted);
-  font-weight: 700;
-}
-
-.rotational-speed-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.rotational-speed-row__label {
-  color: var(--text);
-  font-size: 0.9rem;
-}
-
-.rotational-speed-row__value {
-  font-variant-numeric: tabular-nums;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.rotational-speed-row__mode {
-  height: 24px;
-  font-size: 0.72rem;
-  padding: 0 var(--space-2);
-  white-space: nowrap;
-}
-
-.rotational-speeds__basis,
-.rotational-speeds__reason {
-  margin-top: var(--space-1);
-}
-
-.rotational-speeds__assumptions { margin-top: var(--space-2); font-size: 0.78rem; color: var(--muted); }
-.rotational-speeds__assumptions summary { cursor: pointer; user-select: none; }
-.rotational-assumptions-body { padding: var(--space-1) 0 0 var(--space-3); line-height: 1.6; }
-
-.card__time-label { font-size: 0.72rem; color: var(--muted); margin-left: var(--space-2); }
-.strength-scale-toggle { font-size: 0.72rem; color: var(--muted); margin-left: auto; display: flex; align-items: center; gap: 4px; cursor: pointer; }
-
-.log-box { max-height: 230px; overflow: auto; font-size: 0.9rem; line-height: 1.35; }
-.log-row { padding: var(--space-2) 0; border-bottom: 1px solid var(--border); }
-.log-time { color: var(--muted); font-size: 0.78rem; }


### PR DESCRIPTION
## Summary

Closes #2437.

This PR removes CSS selectors that are genuinely dead in the current frontend, but it does **not** follow the issue body literally. During the scope read it became clear that the original “~83 unused selectors” audit is now stale. A large portion of the classes named in the issue are still live today (`btn--danger`, `menu-btn`, `stat-grid`, `maintenance-card--hero`, `wizard-options`, and others), some classes are still reached through template-string variant construction, and the history selectors listed in the issue are no longer even owned by `history.css` because that stylesheet was split earlier into `history-detail.css` and `history-table.css`. Because of that drift, the right fix here was not to delete the entire issue list mechanically. Instead, this change re-ran the selector audit against the live `.ts`, `.tsx`, and `.html` surfaces and then removed only the selectors that have no current consumer.

## Problem being solved

The repo had accumulated several CSS blocks that belonged to older UI iterations rather than the current Preact-rendered surfaces. Those selectors were still shipped in the frontend bundle even though the corresponding markup no longer exists. The stale selectors were concentrated mostly in `realtime.css`, with a few one-off leftovers in shared/component styles and in the history and maintenance surfaces. Keeping those rules around increases CSS payload, makes future cleanup issues harder to reason about, and creates exactly the kind of misleading issue body that #2437 had become.

The main risk here was that the issue itself was over-reporting dead CSS. If I had simply removed everything it named, this would have regressed active UI surfaces because many of those selectors are still live, and some of the “unused” variant classes are only visible through runtime string construction like ``history-warning-banner--${warning.severity}`` and ``history-row__summary-chip--${tone}``. The implementation therefore had to distinguish between truly dead selectors and selectors that only look unused if you search for a fully expanded literal.

## Implementation approach

The cleanup was driven by a live-code audit rather than by the stale issue list. I searched the current app source, tests, and static HTML for the selectors named in the issue, checked adjacent selector families when a dead block appeared, and then verified whether the remaining CSS was still referenced through direct markup, test selectors, or dynamic class composition.

That audit produced a much narrower but still meaningful cleanup:

1. `apps/ui/src/styles/realtime.css` contained the biggest dead cluster. This included the old `spectrum-split` / `car-map` layout block, the unused `live-speed-readout` and `live-speed-row` rules, an entire orphaned `rotational-speeds*` family, and a handful of single dead selectors such as `card__time-label`, `strength-scale-toggle`, `log-box`, `log-row`, and `log-time`.
2. `apps/ui/src/styles/adaptive.css` still carried responsive rules for `live-speed-row`, so those media-query leftovers were removed together with the base selector family.
3. `apps/ui/src/styles/history-detail.css` still carried two unused selectors: `history-panel-header__subtitle` and `history-findings-overview__count`. The latter was previously grouped with the still-live `history-findings-overview__eyebrow`, so that combined rule was narrowed instead of deleting the whole declaration.
4. `apps/ui/src/styles/maintenance.css` still had a dead `maintenance-journey__title` selector even though the journey card no longer renders that node.
5. `apps/ui/src/styles/components.css` still grouped `matrix-note` with the live shared muted-text helpers, so that dead selector was removed from the shared rule without affecting `card__subtle`, `subtle`, or `mini-label`.

## Main code changes by area

### Realtime and spectrum CSS

The biggest change is in `realtime.css`, where the diff deletes legacy layout and diagnostic CSS that no current view emits. The removed `spectrum-split` / `car-map` family appears to be residue from an older chart-plus-vehicle-map presentation. None of the live spectrum or realtime islands render those classes now, and the current spectrum panel still keeps its active toolbar, legend, controls, and chart selectors intact.

The cleanup also removes the unused `live-speed-readout` / `live-speed-row` family. The live overview still renders the current speed through the `speed` class, so the current readout styling remains. What disappeared here is only the older wrapper and input-row styling that no current TSX view produces. Because `adaptive.css` still had a mobile override for the same dead class family, that responsive fragment was removed too.

The final `realtime.css` trim is the orphaned `rotational-speeds*` block and several unused helper selectors (`card__time-label`, `strength-scale-toggle`, `log-box`, `log-row`, `log-time`). Those names no longer appear in the current view layer or tests, so they were safe deletions.

### History CSS

The history portion of the issue body was especially stale because the file ownership has changed since the issue was written. `history.css` is now only a manifest that imports `history-table.css` and `history-detail.css`. After checking the live detail markup, the only dead selectors still present there were `history-panel-header__subtitle` and `history-findings-overview__count`. Everything dynamic around diagnosis and warning variants stayed in place because those selectors are still reached by runtime class composition.

### Shared and maintenance CSS

The cleanup also trims two tiny but real leftovers outside realtime/history. In `maintenance.css`, `maintenance-journey__title` no longer has a matching node in the update or ESP-flash journey markup. In `components.css`, `matrix-note` was still piggybacking on the shared muted-text rule even though there is no current consumer for that class.

## Validation

I validated this in the current frontend pipeline with:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/realtime_logging_summary.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.spectrum.spec.ts tests/smoke.history.spec.ts tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

That slice covers the touched surfaces directly: realtime/logging, spectrum, history, update, and ESP flash. I also ran a focused diff review after the audit to make sure I had not removed any selectors that are only referenced through non-obvious live paths.

## Risks, tradeoffs, and out-of-scope items

The main tradeoff is that this PR intentionally solves the **current** dead CSS problem rather than trying to force the repo back to the exact selector counts in the original issue body. That is the safer and more maintainable choice because the codebase has moved since the issue was filed. As a result, this PR leaves many issue-listed selectors alone, but only because they are still live or dynamically composed today.

I also did not broaden this into a full stylesheet reorganization. `#2438` is already queued to split `realtime.css`, so this change stays focused on removing dead rules rather than reshaping the whole file structure. The result is a small, reviewable cleanup that reduces stale CSS without conflating it with the upcoming stylesheet-splitting work.
