### PR TITLE
Convert realtime derivations to computed signals

### DIFF
--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -52,6 +52,15 @@ interface LoggingElapsedTickInputs {
   loggingStartTimeUtc: string | null;
 }
 
+function sameLoggingElapsedTickInputs(
+  left: LoggingElapsedTickInputs,
+  right: LoggingElapsedTickInputs,
+): boolean {
+  return left.handlersBound === right.handlersBound
+    && left.loggingEnabled === right.loggingEnabled
+    && left.loggingStartTimeUtc === right.loggingStartTimeUtc;
+}
+
 function formatElapsed(
   startTimeUtc: string | null | undefined,
   nowMs: number,
@@ -153,11 +162,42 @@ export function createRealtimeFeatureViewState(
     formatInt,
   });
   const elapsedNowMs = signal(Date.now());
-  const lastCompletedElapsedText = signal("--");
-  const loggingElapsedTickInputs = signal<LoggingElapsedTickInputs>({
+  let cachedLastCompletedElapsedText = "--";
+  let cachedLoggingElapsedTickInputs: LoggingElapsedTickInputs = {
     handlersBound: workflow.handlersBound.value,
     loggingEnabled: realtime.loggingStatus.enabled,
     loggingStartTimeUtc: realtime.loggingStatus.start_time_utc ?? null,
+  };
+  const loggingElapsedTickInputs = computed<LoggingElapsedTickInputs>(() => {
+    const handlersBound = workflow.handlersBound.value;
+    trackAppStateSlice(realtime);
+    const nextTickInputs = {
+      handlersBound,
+      loggingEnabled: realtime.loggingStatus.enabled,
+      loggingStartTimeUtc: realtime.loggingStatus.start_time_utc ?? null,
+    } satisfies LoggingElapsedTickInputs;
+    if (sameLoggingElapsedTickInputs(cachedLoggingElapsedTickInputs, nextTickInputs)) {
+      return cachedLoggingElapsedTickInputs;
+    }
+    cachedLoggingElapsedTickInputs = nextTickInputs;
+    return nextTickInputs;
+  });
+  const lastCompletedElapsedText = computed(() => {
+    trackAppStateSlice(realtime);
+    if (realtime.loggingStatus.enabled) {
+      cachedLastCompletedElapsedText = formatElapsed(
+        realtime.loggingStatus.start_time_utc,
+        elapsedNowMs.value,
+      );
+      return cachedLastCompletedElapsedText;
+    }
+    if (
+      !realtime.loggingStatus.analysis_in_progress
+      && !realtime.loggingStatus.last_completed_run_id
+    ) {
+      cachedLastCompletedElapsedText = "--";
+    }
+    return cachedLastCompletedElapsedText;
   });
   let loggingElapsedTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -168,25 +208,6 @@ export function createRealtimeFeatureViewState(
     clearInterval(loggingElapsedTimer);
     loggingElapsedTimer = null;
   }
-
-  effect(() => {
-    const handlersBound = workflow.handlersBound.value;
-    trackAppStateSlice(realtime);
-    const nextTickInputs = {
-      handlersBound,
-      loggingEnabled: realtime.loggingStatus.enabled,
-      loggingStartTimeUtc: realtime.loggingStatus.start_time_utc ?? null,
-    } satisfies LoggingElapsedTickInputs;
-    const currentTickInputs = loggingElapsedTickInputs.value;
-    if (
-      currentTickInputs.handlersBound === nextTickInputs.handlersBound
-      && currentTickInputs.loggingEnabled === nextTickInputs.loggingEnabled
-      && currentTickInputs.loggingStartTimeUtc === nextTickInputs.loggingStartTimeUtc
-    ) {
-      return;
-    }
-    loggingElapsedTickInputs.value = nextTickInputs;
-  });
 
   effect(() => {
     const {
@@ -208,23 +229,6 @@ export function createRealtimeFeatureViewState(
     return () => {
       clearLoggingElapsedTimer();
     };
-  });
-
-  effect(() => {
-    trackAppStateSlice(realtime);
-    if (realtime.loggingStatus.enabled) {
-      lastCompletedElapsedText.value = formatElapsed(
-        realtime.loggingStatus.start_time_utc,
-        elapsedNowMs.value,
-      );
-      return;
-    }
-    if (
-      !realtime.loggingStatus.analysis_in_progress
-      && !realtime.loggingStatus.last_completed_run_id
-    ) {
-      lastCompletedElapsedText.value = "--";
-    }
   });
 
   function selectionBlockReason(): "no_cars" | "no_active" | null {

--- a/apps/ui/tests/realtime_feature_view_state.spec.ts
+++ b/apps/ui/tests/realtime_feature_view_state.spec.ts
@@ -78,3 +78,81 @@ test("realtime view state only re-arms its elapsed timer when logging tick input
     globalThis.clearInterval = originalClearInterval;
   }
 });
+
+test("realtime view state preserves the last completed elapsed text through processing and saved states", () => {
+  const state = createAppState();
+  const workflow = createRealtimeFeatureWorkflowState();
+  const originalDateNow = Date.now;
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+
+  Date.now = () => Date.parse("2026-04-16T00:01:23Z");
+  globalThis.setInterval = ((handler: TimerHandler, timeout?: number) => {
+    void handler;
+    void timeout;
+    const timerId = originalSetInterval(() => undefined, 60_000);
+    originalClearInterval(timerId);
+    return timerId;
+  }) as typeof setInterval;
+  globalThis.clearInterval = ((intervalId?: ReturnType<typeof setInterval>) => {
+    if (intervalId === undefined) {
+      return;
+    }
+  }) as typeof clearInterval;
+
+  try {
+    const viewState = createRealtimeFeatureViewState({
+      state: {
+        realtime: state.realtime,
+        settings: state.settings,
+        shell: state.shell,
+        spectrum: state.spectrum,
+      },
+      services: {
+        t: (key) => key,
+      },
+      formatting: {
+        formatInt: (value) => String(value),
+      },
+      workflow,
+    });
+
+    workflow.handlersBound.value = true;
+    state.realtime.loggingStatus = {
+      ...state.realtime.loggingStatus,
+      enabled: true,
+      start_time_utc: "2026-04-16T00:00:00Z",
+      last_completed_run_id: null,
+    };
+
+    expect(viewState.loggingPanelModel.value.elapsedText).toBe("1:23");
+
+    state.realtime.loggingStatus = {
+      ...state.realtime.loggingStatus,
+      enabled: false,
+      analysis_in_progress: true,
+      start_time_utc: null,
+      last_completed_run_id: "run-1",
+    };
+
+    expect(viewState.loggingPanelModel.value.elapsedText).toBe("1:23");
+
+    state.realtime.loggingStatus = {
+      ...state.realtime.loggingStatus,
+      analysis_in_progress: false,
+    };
+
+    expect(viewState.loggingPanelModel.value.elapsedText).toBe("1:23");
+
+    state.realtime.loggingStatus = {
+      ...state.realtime.loggingStatus,
+      last_completed_run_id: null,
+    };
+
+    expect(viewState.loggingPanelModel.value.elapsedText).toBe("--");
+  } finally {
+    Date.now = originalDateNow;
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+  }
+});


### PR DESCRIPTION
Closes #2439

## Summary

This PR converts the two value-deriving reactive paths in `apps/ui/src/app/features/realtime_feature_view_state.ts` from signal-writing `effect()` blocks into `computed()` signals, while preserving the behavior that the realtime logging UI depends on. The issue description correctly identified the two targets, but the merged code revealed one extra constraint that mattered for a safe fix: the old `loggingElapsedTickInputs` effect was not only deriving three timer-driving fields, it was also acting as an identity guard because `trackAppStateSlice(realtime)` is coarse. Without preserving that guard, unrelated realtime AppState writes such as selection changes would create a new object on every recomputation and re-arm the elapsed timer unnecessarily.

The second reactive path, `lastCompletedElapsedText`, also turned out to be slightly subtler than a naive `effect()` to `computed()` rename. The old effect was not just formatting the currently running elapsed time; it also intentionally retained the previous elapsed string while the logging run moved through `analysis_in_progress` and `last_completed_run_id` states where the live payload no longer carries a usable `start_time_utc`. This PR keeps that behavior intact by moving the retention into a computed-backed cache instead of a signal that is written from an effect.

## Problem and why this change exists

The old code used two effects to derive values from other reactive sources:

1. a `loggingElapsedTickInputs` effect that read `workflow.handlersBound`, `realtime.loggingStatus.enabled`, and `realtime.loggingStatus.start_time_utc`, then wrote the combined object into a signal, and
2. a `lastCompletedElapsedText` effect that wrote a formatted elapsed string into another signal.

Those are derivations, not imperative integrations. The imperative work here is the timer effect that starts and stops `setInterval()`. Leaving the derivations in `effect()` meant the derived values were updated asynchronously through signal writes instead of existing directly in the reactive graph as computed state. That makes the data flow harder to reason about and makes this part of the realtime feature look more side-effect-heavy than it is.

The trick is that removing the effects mechanically would have introduced regressions. The first derivation needed stable object reuse to avoid timer churn. The second needed to preserve the previous elapsed string after logging stops, because the saved/processing states intentionally keep showing the last captured duration even though the runtime status may already have cleared `start_time_utc`.

## Implementation approach

The implementation keeps the imperative timer effect in place and narrows the refactor to the two genuinely derived values.

For `loggingElapsedTickInputs`, I replaced the writable signal plus effect with a `computed<LoggingElapsedTickInputs>()`. The computed still reads the same three live inputs, but it now compares the freshly derived object with the previously cached one and returns the cached object when the fields have not actually changed. That preserves the old "do not notify unless something meaningful changed" behavior without routing the value through a side-effectful write.

For `lastCompletedElapsedText`, I replaced the writable signal plus effect with a `computed()` backed by a small local cache string. When logging is enabled, the computed refreshes the cached text from `formatElapsed(...)`. When logging is fully idle with neither processing nor a saved run, the cache resets to `"--"`. In the intermediate processing/saved states, the computed simply returns the retained value. That matches the previous behavior exactly, but it keeps the value in the computed graph instead of updating it through a signal write.

## Main code changes

### `realtime_feature_view_state.ts`

The core change is in `createRealtimeFeatureViewState()`:

- added `sameLoggingElapsedTickInputs()` to make the identity-preserving comparison explicit and easy to review;
- replaced the old `loggingElapsedTickInputs` signal/effect pair with a computed that reuses the previous object when `handlersBound`, `loggingEnabled`, and `loggingStartTimeUtc` are unchanged;
- replaced the old `lastCompletedElapsedText` signal/effect pair with a computed that refreshes or resets a local cache based on the current logging state;
- kept the actual timer `effect()` intact, since that effect owns the real imperative side effect in this area: starting, clearing, and re-arming the interval.

That split is important. The derived values now live in the reactive graph, while the timer remains the only effect because it truly integrates with an external runtime API.

### `realtime_feature_view_state.spec.ts`

The existing timer regression test stays in place and continues to guard the main subtlety around coarse AppState tracking: unrelated realtime writes must not re-arm the timer. That test is still valuable after the refactor because it proves the computed-backed object reuse is preserving the previous semantics.

I also added a new focused regression that exercises the retained elapsed-text behavior directly. The test drives the realtime logging status through these transitions:

1. enabled logging with a fixed mocked clock,
2. disabled logging with `analysis_in_progress = true`,
3. disabled logging with `last_completed_run_id` still present, and
4. fully idle logging with no processing and no saved run.

The assertions confirm that the view state keeps showing the last completed elapsed string through processing and saved states, and only resets back to `"--"` when realtime status fully returns to idle.

## Validation

I validated this as a narrow realtime-state refactor with both targeted unit coverage and browser-level coverage for the affected UI surface.

Focused tests:

- `cd apps/ui && npx playwright test tests/realtime_feature_view_state.spec.ts tests/realtime_logging_view_models.spec.ts tests/realtime_feature_workflow.spec.ts --workers=1`

Browser coverage:

- `cd apps/ui && npx playwright test tests/realtime_logging_summary.spec.ts tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

Frontend safety checks:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

That mix was intentional. The unit slice covers the exact timer and retained-elapsed semantics in isolation, while the browser slice confirms the live logging panel and the broader bootstrap surface still behave correctly after the reactive change. The standard frontend checks stayed green as well.

## Risks, tradeoffs, and out-of-scope notes

The main risk in this issue was not syntax-level correctness; it was accidentally changing reactive behavior while "cleaning up" the derivations. Two regressions were easy to introduce:

1. returning a fresh `loggingElapsedTickInputs` object on every coarse realtime invalidation, which would cause timer churn, and
2. recomputing `lastCompletedElapsedText` only from current status fields, which would drop the retained elapsed string as soon as `start_time_utc` disappears during processing/saved states.

The final implementation is deliberately conservative about those behaviors. It adopts computed signals, which is the architectural goal of the issue, but it keeps the old runtime semantics intact by preserving object identity and cached elapsed text where the current UI depends on them.

I did not broaden this change into a larger cleanup of `buildRealtimeLoggingPanelViewModel()` or the `nextLastCompletedElapsedText` field exposed there. That model-level field is adjacent to this issue, but touching it here would mix a reactive-graph cleanup with a separate render-model contract discussion. The goal of this PR is narrower: move the two derivations into computed state without regressing the timer lifecycle or the saved/processing display behavior.
