### PR TITLE
Split cars workflow helpers into focused modules

### DIFF
--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -4,17 +4,28 @@ import type {
   CarLibraryTireOption,
   CarLibraryVariant,
 } from "../../transport/http_models";
+import {
+  cloneManualInputs,
+  createCarsManualInputStore,
+  firstMissingManualInputField,
+  tireInputsFromOption,
+  type CarsFeatureManualInputState,
+} from "./cars_manual_input";
+import {
+  createErrorOptionsState,
+  createIdleOptionsState,
+  createLoadingOptionsState,
+  createReadyOptionsState,
+  type CarsFeatureOptionsState,
+} from "./cars_option_state";
 import type { WizardSummaryData } from "../views/car_wizard_view";
 import {
   buildWizardCarName,
   buildWizardSummaryData,
   canFinishWizard,
-  DEFAULT_CARS_WIZARD_MANUAL_INPUTS,
   createInitialWizardState,
   getResolvedWizardSpecBranch,
   getWizardActionHint,
-  readWizardManualGearboxValues,
-  readWizardManualTireValues,
   resolveGearboxes,
   resolveTireOptions,
   type WizardSpecBranch,
@@ -30,22 +41,6 @@ import {
   signal,
   type ReadonlySignal,
 } from "../ui_signals";
-
-export interface CarsFeatureManualInputState {
-  finalDrive: string;
-  rim: string;
-  tireAspect: string;
-  tireWidth: string;
-  topGear: string;
-}
-
-type CarsFeatureOptionsStatus = "idle" | "loading" | "error" | "ready";
-
-export interface CarsFeatureOptionsState<TOption> {
-  message: string | null;
-  options: readonly TOption[];
-  status: CarsFeatureOptionsStatus;
-}
 
 export type CarsFeatureFocusTarget =
   | "brand-option"
@@ -120,78 +115,22 @@ export interface CarsFeatureWorkflow {
   submitCustomType(value: string): Promise<void>;
 }
 
-function createIdleOptionsState<TOption>(): CarsFeatureOptionsState<TOption> {
-  return {
-    message: null,
-    options: [],
-    status: "idle",
-  };
-}
-
-function createErrorOptionsState<TOption>(message: string): CarsFeatureOptionsState<TOption> {
-  return {
-    message,
-    options: [],
-    status: "error",
-  };
-}
-
-function createLoadingOptionsState<TOption>(message: string): CarsFeatureOptionsState<TOption> {
-  return {
-    message,
-    options: [],
-    status: "loading",
-  };
-}
-
-function createReadyOptionsState<TOption>(options: readonly TOption[]): CarsFeatureOptionsState<TOption> {
-  return {
-    message: null,
-    options: [...options],
-    status: "ready",
-  };
-}
-
-function cloneManualInputs(inputs: CarsFeatureManualInputState): CarsFeatureManualInputState {
-  return { ...inputs };
-}
-
-function parsePositiveValue(value: string): number | null {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-}
+const MANUAL_INPUT_FOCUS_TARGETS: Record<
+  keyof CarsFeatureManualInputState,
+  CarsFeatureFocusTarget
+> = {
+  finalDrive: "manual-final-drive",
+  rim: "manual-rim",
+  tireAspect: "manual-tire-aspect",
+  tireWidth: "manual-tire-width",
+  topGear: "manual-top-gear",
+};
 
 function missingManualInputFocusTarget(
   inputs: CarsFeatureManualInputState,
 ): CarsFeatureFocusTarget | null {
-  if (parsePositiveValue(inputs.tireWidth) == null) {
-    return "manual-tire-width";
-  }
-  if (parsePositiveValue(inputs.tireAspect) == null) {
-    return "manual-tire-aspect";
-  }
-  if (parsePositiveValue(inputs.rim) == null) {
-    return "manual-rim";
-  }
-  if (parsePositiveValue(inputs.finalDrive) == null) {
-    return "manual-final-drive";
-  }
-  if (parsePositiveValue(inputs.topGear) == null) {
-    return "manual-top-gear";
-  }
-  return null;
-}
-
-function tireInputsFromOption(
-  option: CarLibraryTireOption,
-  current: CarsFeatureManualInputState,
-): CarsFeatureManualInputState {
-  return {
-    ...current,
-    rim: String(option.rim_in),
-    tireAspect: String(option.tire_aspect_pct),
-    tireWidth: String(option.tire_width_mm),
-  };
+  const missingField = firstMissingManualInputField(inputs);
+  return missingField ? MANUAL_INPUT_FOCUS_TARGETS[missingField] : null;
 }
 
 export function createCarsFeatureWorkflow(
@@ -200,11 +139,8 @@ export function createCarsFeatureWorkflow(
   const transport = createCarsFeatureTransport(deps.transport);
   const wizardState = signal<WizardState>(createInitialWizardState());
   const isOpen = signal(false);
-  const manualFinalDrive = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.finalDrive);
-  const manualRim = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.rim);
-  const manualTireAspect = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.tireAspect);
-  const manualTireWidth = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.tireWidth);
-  const manualTopGear = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.topGear);
+  const wizardStep = computed(() => wizardState.value.step);
+  const manualInputs = createCarsManualInputStore(wizardStep);
   const brandOptions = signal(createIdleOptionsState<string>());
   const typeOptions = signal(createIdleOptionsState<string>());
   const modelOptions = signal(createIdleOptionsState<CarLibraryModel>());
@@ -213,44 +149,13 @@ export function createCarsFeatureWorkflow(
   const gearboxOptions = signal<readonly CarLibraryGearbox[]>([]);
   const noGearboxesMessage = signal<string | null>(null);
 
-  function readManualInputs(): CarsFeatureManualInputState {
-    return {
-      finalDrive: manualFinalDrive.value,
-      rim: manualRim.value,
-      tireAspect: manualTireAspect.value,
-      tireWidth: manualTireWidth.value,
-      topGear: manualTopGear.value,
-    };
-  }
-
-  function writeManualInputs(inputs: CarsFeatureManualInputState): void {
-    manualFinalDrive.value = inputs.finalDrive;
-    manualRim.value = inputs.rim;
-    manualTireAspect.value = inputs.tireAspect;
-    manualTireWidth.value = inputs.tireWidth;
-    manualTopGear.value = inputs.topGear;
-  }
-
   function updateWizardState(mutator: (state: WizardState) => void): void {
     const nextState = { ...wizardState.value };
     mutator(nextState);
     wizardState.value = nextState;
   }
-
-  const manualGearbox = computed(() =>
-    readWizardManualGearboxValues(wizardState.value.step, {
-      finalDrive: manualFinalDrive.value,
-      topGear: manualTopGear.value,
-    })
-  );
-
-  const manualTire = computed(() =>
-    readWizardManualTireValues(wizardState.value.step, {
-      aspect: manualTireAspect.value,
-      rim: manualRim.value,
-      width: manualTireWidth.value,
-    })
-  );
+  const manualGearbox = manualInputs.manualGearbox;
+  const manualTire = manualInputs.manualTire;
 
   const resolvedSpecBranch = computed(() => getResolvedWizardSpecBranch(wizardState.value));
 
@@ -289,7 +194,7 @@ export function createCarsFeatureWorkflow(
 
   const renderState = computed<CarsFeatureRenderState>(() => {
     const state = wizardState.value;
-    const inputs = readManualInputs();
+    const inputs = manualInputs.read();
     const currentBrandOptions = brandOptions.value;
     const currentTypeOptions = typeOptions.value;
     const currentModelOptions = modelOptions.value;
@@ -437,7 +342,7 @@ export function createCarsFeatureWorkflow(
 
   function loadSpecsStep(): void {
     const state = wizardState.value;
-    const currentManualInputs = readManualInputs();
+    const currentManualInputs = manualInputs.read();
     const nextTireOptions = resolveTireOptions(state.selectedModel, state.selectedVariant);
     const nextGearboxOptions = resolveGearboxes(state.selectedModel, state.selectedVariant);
     const nextSelectedTire = nextTireOptions.length > 0
@@ -456,7 +361,7 @@ export function createCarsFeatureWorkflow(
       tireOptions.value = nextTireOptions;
       gearboxOptions.value = nextGearboxOptions;
       noGearboxesMessage.value = nextNoGearboxesMessage;
-      writeManualInputs(nextManualInputs);
+      manualInputs.write(nextManualInputs);
       updateWizardState((nextState) => {
         nextState.selectedTire = nextSelectedTire;
         if (!nextTireOptions.length) {
@@ -503,7 +408,7 @@ export function createCarsFeatureWorkflow(
 
     async finishWizard(): Promise<boolean> {
       const state = wizardState.value;
-      const inputs = readManualInputs();
+      const inputs = manualInputs.read();
       const resolvedBranch = getResolvedWizardSpecBranch(state);
       if (resolvedBranch === "library") {
         const tire = state.selectedTire;
@@ -572,7 +477,7 @@ export function createCarsFeatureWorkflow(
 
     handleManualInputsChanged(inputs: CarsFeatureManualInputState): void {
       batch(() => {
-        writeManualInputs(inputs);
+        manualInputs.write(inputs);
         if (isOpen.value && wizardState.value.step === 4) {
           updateWizardState((state) => {
             state.specBranch = "manual";
@@ -644,7 +549,7 @@ export function createCarsFeatureWorkflow(
         updateWizardState((state) => {
           state.selectedTire = selectedTire;
         });
-        writeManualInputs(tireInputsFromOption(selectedTire, readManualInputs()));
+        manualInputs.write(tireInputsFromOption(selectedTire, manualInputs.read()));
       });
     },
 

--- a/apps/ui/src/app/features/cars_manual_input.ts
+++ b/apps/ui/src/app/features/cars_manual_input.ts
@@ -1,0 +1,127 @@
+import type { CarLibraryTireOption } from "../../transport/http_models";
+import {
+  DEFAULT_CARS_WIZARD_MANUAL_INPUTS,
+  readWizardManualGearboxValues,
+  readWizardManualTireValues,
+  type ManualGearboxValues,
+  type ManualTireValues,
+} from "./cars_wizard_state";
+import {
+  computed,
+  signal,
+  type ReadonlySignal,
+  type Signal,
+} from "../ui_signals";
+
+export interface CarsFeatureManualInputState {
+  finalDrive: string;
+  rim: string;
+  tireAspect: string;
+  tireWidth: string;
+  topGear: string;
+}
+
+export interface CarsFeatureManualInputStore {
+  readonly finalDrive: Signal<string>;
+  readonly rim: Signal<string>;
+  readonly tireAspect: Signal<string>;
+  readonly tireWidth: Signal<string>;
+  readonly topGear: Signal<string>;
+  readonly manualGearbox: ReadonlySignal<ManualGearboxValues | null>;
+  readonly manualTire: ReadonlySignal<ManualTireValues | null>;
+  read(): CarsFeatureManualInputState;
+  write(inputs: CarsFeatureManualInputState): void;
+}
+
+export function cloneManualInputs(inputs: CarsFeatureManualInputState): CarsFeatureManualInputState {
+  return { ...inputs };
+}
+
+function parsePositiveValue(value: string): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function firstMissingManualInputField(
+  inputs: CarsFeatureManualInputState,
+): keyof CarsFeatureManualInputState | null {
+  if (parsePositiveValue(inputs.tireWidth) == null) {
+    return "tireWidth";
+  }
+  if (parsePositiveValue(inputs.tireAspect) == null) {
+    return "tireAspect";
+  }
+  if (parsePositiveValue(inputs.rim) == null) {
+    return "rim";
+  }
+  if (parsePositiveValue(inputs.finalDrive) == null) {
+    return "finalDrive";
+  }
+  if (parsePositiveValue(inputs.topGear) == null) {
+    return "topGear";
+  }
+  return null;
+}
+
+export function tireInputsFromOption(
+  option: CarLibraryTireOption,
+  current: CarsFeatureManualInputState,
+): CarsFeatureManualInputState {
+  return {
+    ...current,
+    rim: String(option.rim_in),
+    tireAspect: String(option.tire_aspect_pct),
+    tireWidth: String(option.tire_width_mm),
+  };
+}
+
+export function createCarsManualInputStore(
+  step: ReadonlySignal<number>,
+): CarsFeatureManualInputStore {
+  const finalDrive = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.finalDrive);
+  const rim = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.rim);
+  const tireAspect = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.tireAspect);
+  const tireWidth = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.tireWidth);
+  const topGear = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.topGear);
+
+  function read(): CarsFeatureManualInputState {
+    return {
+      finalDrive: finalDrive.value,
+      rim: rim.value,
+      tireAspect: tireAspect.value,
+      tireWidth: tireWidth.value,
+      topGear: topGear.value,
+    };
+  }
+
+  function write(inputs: CarsFeatureManualInputState): void {
+    finalDrive.value = inputs.finalDrive;
+    rim.value = inputs.rim;
+    tireAspect.value = inputs.tireAspect;
+    tireWidth.value = inputs.tireWidth;
+    topGear.value = inputs.topGear;
+  }
+
+  return {
+    finalDrive,
+    rim,
+    tireAspect,
+    tireWidth,
+    topGear,
+    manualGearbox: computed(() =>
+      readWizardManualGearboxValues(step.value, {
+        finalDrive: finalDrive.value,
+        topGear: topGear.value,
+      })
+    ),
+    manualTire: computed(() =>
+      readWizardManualTireValues(step.value, {
+        aspect: tireAspect.value,
+        rim: rim.value,
+        width: tireWidth.value,
+      })
+    ),
+    read,
+    write,
+  };
+}

--- a/apps/ui/src/app/features/cars_option_state.ts
+++ b/apps/ui/src/app/features/cars_option_state.ts
@@ -1,0 +1,41 @@
+export type CarsFeatureOptionsStatus = "idle" | "loading" | "error" | "ready";
+
+export interface CarsFeatureOptionsState<TOption> {
+  message: string | null;
+  options: readonly TOption[];
+  status: CarsFeatureOptionsStatus;
+}
+
+export function createIdleOptionsState<TOption>(): CarsFeatureOptionsState<TOption> {
+  return {
+    message: null,
+    options: [],
+    status: "idle",
+  };
+}
+
+export function createErrorOptionsState<TOption>(message: string): CarsFeatureOptionsState<TOption> {
+  return {
+    message,
+    options: [],
+    status: "error",
+  };
+}
+
+export function createLoadingOptionsState<TOption>(message: string): CarsFeatureOptionsState<TOption> {
+  return {
+    message,
+    options: [],
+    status: "loading",
+  };
+}
+
+export function createReadyOptionsState<TOption>(
+  options: readonly TOption[],
+): CarsFeatureOptionsState<TOption> {
+  return {
+    message: null,
+    options: [...options],
+    status: "ready",
+  };
+}

--- a/apps/ui/src/app/views/car_wizard_view.ts
+++ b/apps/ui/src/app/views/car_wizard_view.ts
@@ -4,9 +4,9 @@ import type {
   CarLibraryVariant,
 } from "../../transport/http_models";
 import type {
-  CarsFeatureOptionsState,
   CarsFeatureRenderState,
 } from "../features/cars_feature_workflow";
+import type { CarsFeatureOptionsState } from "../features/cars_option_state";
 import { DEFAULT_CARS_WIZARD_MANUAL_INPUTS } from "../features/cars_wizard_state";
 
 type FormatNumber = (value: number, digits?: number) => string;

--- a/apps/ui/src/app/views/cars_wizard_panel.tsx
+++ b/apps/ui/src/app/views/cars_wizard_panel.tsx
@@ -1,4 +1,5 @@
-import type { CarsFeatureFocusTarget, CarsFeatureManualInputState } from "../features/cars_feature_workflow";
+import type { CarsFeatureFocusTarget } from "../features/cars_feature_workflow";
+import type { CarsFeatureManualInputState } from "../features/cars_manual_input";
 import { useUiTranslation } from "../ui_i18n";
 import type {
   CarsWizardOptionItem,

--- a/apps/ui/tests/car_wizard_view.spec.ts
+++ b/apps/ui/tests/car_wizard_view.spec.ts
@@ -6,9 +6,9 @@ import type {
   CarLibraryTireOption,
 } from "../src/transport/http_models";
 import type {
-  CarsFeatureOptionsState,
   CarsFeatureRenderState,
 } from "../src/app/features/cars_feature_workflow";
+import type { CarsFeatureOptionsState } from "../src/app/features/cars_option_state";
 import {
   buildCarsWizardRenderModel,
   createClosedCarsWizardRenderModel,


### PR DESCRIPTION
Closes #2440

## Summary

This PR splits the biggest remaining frontend workflow file, `apps/ui/src/app/features/cars_feature_workflow.ts`, along the two seams that are still genuinely local and repetitive in the current codebase: option-state helpers and manual-input state ownership. The issue description called out those same hotspots, and after rereading the live file against the current post-#2402 code it was clear that the file no longer needs a broader summary-derivation extraction. That work already landed earlier in `cars_wizard_state.ts`. The remaining cleanup here is narrower and more mechanical: move the option-state builders into their own owner, move the manual-input signals plus their read/write helpers into their own owner, and leave the async workflow orchestration in `cars_feature_workflow.ts`.

The result is a smaller workflow file that still owns the step transitions, transport calls, focus routing, and add-car submission rules, while the low-level state helpers that were previously buried in the middle of the file now live in modules that match their responsibilities. No behavior changes were intended, and the validation focused on proving that the split preserved the library branch, the manual branch, the wizard summary rendering, and the end-to-end add-car browser flows.

## Problem being solved

`cars_feature_workflow.ts` had become the largest frontend source file in the repo. The issue body was directionally correct, but the live code had already changed since the issue was filed:

1. the wizard-summary and action-hint derivations had already been extracted into `cars_wizard_state.ts`, and
2. the most obviously separable logic left in the workflow was the small option-state helper block plus the manual-input signal block.

Keeping those pieces inline made the workflow harder to scan because the file mixed three different concerns:

- transport and step orchestration,
- generic option-state construction,
- manual tire/gearbox input state ownership.

That structure was also forcing a few view and test modules to reach through `cars_feature_workflow.ts` just to import types that were no longer conceptually owned there. This PR fixes that ownership drift without widening into unrelated workflow cleanup.

## Implementation approach

The implementation keeps the existing public workflow behavior intact and only changes where the internal helper logic lives.

The guiding rule was simple: the workflow should still read like the orchestration owner. It should not keep inline factories for generic option-state bags or inline setup for five independent manual-input signals when those concerns can live in focused modules with stable names.

To do that, I extracted two helpers:

1. `cars_option_state.ts` for `CarsFeatureOptionsState` and the idle/loading/error/ready builders.
2. `cars_manual_input.ts` for `CarsFeatureManualInputState`, the manual-input signal store, read/write helpers, tire autofill helper, cloned state helper, and missing-field detection.

I intentionally did **not** move the async step loaders, reset flows, focus orchestration, or finish logic out of `cars_feature_workflow.ts`. Those are still the core workflow responsibilities, and splitting them further here would have made the change broader than the issue required.

## Main code changes

### `apps/ui/src/app/features/cars_option_state.ts`

This new module now owns the option-state type and the four helper constructors that were previously embedded near the top of the workflow:

- `CarsFeatureOptionsState<TOption>`
- `createIdleOptionsState()`
- `createLoadingOptionsState()`
- `createErrorOptionsState()`
- `createReadyOptionsState()`

Those helpers are pure and generic, so pulling them into their own file makes the workflow easier to read and gives the state shape a clearer owner for downstream imports.

### `apps/ui/src/app/features/cars_manual_input.ts`

This new module now owns the manual draft state rather than leaving it spread across `cars_feature_workflow.ts`.

It includes:

- the `CarsFeatureManualInputState` type,
- the five signal fields for final drive, rim, tire aspect, tire width, and top gear,
- `read()` / `write()` helpers,
- computed manual tire and manual gearbox values derived from the current step,
- `cloneManualInputs()`,
- `tireInputsFromOption()` for tire autofill, and
- `firstMissingManualInputField()` for finish-time validation.

That move matters because this was the densest non-orchestration block in the workflow. The workflow no longer needs to declare and read five separate signals inline just to keep the wizard draft alive.

### `apps/ui/src/app/features/cars_feature_workflow.ts`

The workflow now consumes those two focused owners instead of defining them inline.

Concretely, the file now:

- imports `CarsFeatureOptionsState` and its builders from `cars_option_state.ts`,
- creates one `manualInputs` owner via `createCarsManualInputStore(...)`,
- reuses `manualInputs.read()` / `manualInputs.write()` anywhere the workflow needs the current draft or wants to apply a new draft,
- derives missing-focus targets from `firstMissingManualInputField()` plus one local mapping table, and
- keeps the async brand/type/model/spec loading plus submission orchestration exactly where it belongs.

This is the center of the refactor: the workflow stays the owner of behavior, but it stops being the storage owner for every small helper concern inside that behavior.

### View and test import cleanup

The split created a small downstream ownership update:

- `car_wizard_view.ts` now imports `CarsFeatureOptionsState` from `cars_option_state.ts`,
- `cars_wizard_panel.tsx` now imports `CarsFeatureManualInputState` from `cars_manual_input.ts`,
- `car_wizard_view.spec.ts` now imports `CarsFeatureOptionsState` from the new module as well.

This keeps those files aligned with the new owners instead of continuing to depend on `cars_feature_workflow.ts` as a type umbrella for unrelated helper state.

## Validation

I validated this as a structure-preserving refactor with both focused unit coverage and browser coverage of the affected wizard flow.

Targeted logic tests:

- `cd apps/ui && npx playwright test tests/cars_feature_workflow.spec.ts tests/car_wizard_view.spec.ts tests/settings_cars_module.spec.ts --workers=1`

Cars browser coverage:

- `cd apps/ui && npx playwright test tests/smoke.car-wizard.spec.ts tests/smoke.cars.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

Standard frontend safety checks:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

That mix was chosen deliberately. The unit slice proves the extracted workflow and render-model owners still behave the same in isolation, while the smoke slice proves the real add-car wizard and cars-tab flows still work end to end after the module split.

## Risks, tradeoffs, and out-of-scope notes

The main risk in a refactor like this is not syntax-level breakage; it is accidental ownership drift. It is easy to move helpers into new files while subtly changing when signals update or which module truly owns a piece of behavior.

To avoid that, I kept the split deliberately narrow:

- no behavior changes to wizard transitions,
- no new batching semantics added to manual writes,
- no new API surface added to the views,
- no attempt to further decompose the async step loaders in the same PR.

I also did not widen this into a second round of `renderState` decomposition or another summary-model cleanup. Those are adjacent concerns, but they are separate issues with their own tradeoffs. This PR stays focused on giving the remaining low-level helper state a better home so `cars_feature_workflow.ts` can stay centered on orchestration.
