### PR TITLE
Add Vite manual chunks for vendor code splitting

### DIFF
--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -1,6 +1,32 @@
 import preact from "@preact/preset-vite";
 import { defineConfig, loadEnv } from "vite";
 
+const CHART_CHUNK_PACKAGE_PATHS = ["/uplot/"] as const;
+const VENDOR_CHUNK_PACKAGE_PATHS = [
+  "/preact/",
+  "/@preact/signals/",
+  "/@preact/signals-core/",
+  "/ajv/",
+] as const;
+
+function matchesChunkPackage(id: string, packagePaths: readonly string[]): boolean {
+  return packagePaths.some((packagePath) => id.includes(packagePath));
+}
+
+function resolveManualChunk(id: string): string | undefined {
+  const normalizedId = id.replace(/\\/g, "/");
+  if (!normalizedId.includes("/node_modules/")) {
+    return undefined;
+  }
+  if (matchesChunkPackage(normalizedId, CHART_CHUNK_PACKAGE_PATHS)) {
+    return "chart";
+  }
+  if (matchesChunkPackage(normalizedId, VENDOR_CHUNK_PACKAGE_PATHS)) {
+    return "vendor";
+  }
+  return undefined;
+}
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, ".", "");
   const backendOrigin = env.VITE_BACKEND_ORIGIN || "http://127.0.0.1:8000";
@@ -14,6 +40,11 @@ export default defineConfig(({ mode }) => {
       // Align with tsconfig.json "target": "ES2020" so vite and tsc target the
       // same language level and avoid duplicate down-transpilation.
       target: "es2020",
+      rollupOptions: {
+        output: {
+          manualChunks: resolveManualChunk,
+        },
+      },
     },
     // Our smoke tests and preview helpers target fixed URLs, so fail fast on
     // port conflicts instead of silently hopping to the next available port.


### PR DESCRIPTION
Closes #2441

## Summary

This PR adds explicit Vite `manualChunks` configuration in `apps/ui/vite.config.ts` so stable third-party libraries stop riding inside the same frequently changing application chunk. Before this change, the frontend build had no `rollupOptions.output.manualChunks` at all. The app already had one important lazy-loaded path from earlier work: the spectrum chart runtime was being loaded through a dynamic import, and the build was already emitting `spectrum_chart-*.js` / `spectrum_chart-*.css` plus `spectrum_css_vars-*.js`. But everything else that was loaded at startup still collapsed into one large main bundle.

The practical effect was visible in the production build output. On a fresh `npm run build`, the primary `index-*.js` asset was `541.41 kB` minified. That file contained both fast-changing app code and long-lived library code such as Preact, signals, and Ajv. This PR keeps the existing spectrum lazy-load behavior intact while splitting those long-lived dependencies into a stable `vendor` chunk and pulling `uplot` into a dedicated `chart` chunk that still stays off the startup path.

## Problem being solved

The issue called out a real caching problem: app code changes frequently, while the core libraries change much less often. When everything lives in one startup chunk, browsers have to re-download code that did not meaningfully change on every deployment. That is especially wasteful for libraries like:

- `preact`
- `@preact/signals`
- `@preact/signals-core`
- `ajv`

At the same time, the issue’s suggested `chart` split needed one extra scope check before applying it literally. This repo already did spectrum lazy-loading in earlier work, so the chart path was no longer part of the startup bundle in the same way it had been when the issue was first filed. The right fix in the current codebase is therefore not “invent code splitting for the chart” but “preserve the existing lazy chart path while making vendor chunking explicit for the rest of the bundle.”

## Implementation approach

The implementation stays deliberately small and local to `apps/ui/vite.config.ts`.

I added:

1. two package-path lists that define which libraries belong in the `vendor` and `chart` groups,
2. a tiny `matchesChunkPackage()` helper, and
3. a `resolveManualChunk()` function wired into `build.rollupOptions.output.manualChunks`.

The chunking rules are path-based rather than array-literal package declarations because the build consumes package subpaths and nested module files, not just bare package entry names. Normalizing the incoming module path and matching on `node_modules` package segments keeps the rule readable while still catching the concrete files Vite/Rolldown actually sees.

The final grouping is:

- `vendor`: `preact`, `@preact/signals`, `@preact/signals-core`, `ajv`
- `chart`: `uplot`

Everything else remains on Vite’s default chunking path.

## Main code changes

### `apps/ui/vite.config.ts`

This is the only production file touched in the PR.

The file previously defined only:

- the Preact plugin,
- build target alignment with `tsconfig`,
- preview port settings,
- dev server proxy settings.

It now also defines a manual chunk resolver and wires it into `build.rollupOptions.output.manualChunks`.

The important detail is that the chunk resolver only affects third-party packages under `node_modules`. It does **not** try to repartition application modules. That keeps the change aligned with the issue scope and avoids speculative chunking rules for feature code that should be handled by a separate issue if we want deeper startup splitting later.

## Resulting build output

Before the change, a clean build emitted:

- `dist/assets/spectrum_chart-CEI014L7.js` at `52.88 kB`
- `dist/assets/index-WBwhCrKM.js` at `541.41 kB`

After the change, a clean build emits:

- `dist/assets/vendor-CVd4cMpT.js` at `143.60 kB`
- `dist/assets/chart-BJIBTocQ.js` at `51.08 kB`
- `dist/assets/spectrum_chart-DHDdQNKp.js` at `1.85 kB`
- `dist/assets/index-BWWVde19.js` at `397.04 kB`

That means the main startup chunk dropped by roughly `144 kB` minified, which is the direct goal of the issue. It also means the previously large lazy chart chunk is now split into a small wrapper plus a dedicated library chunk. That preserves the existing on-demand load path while improving cache behavior if the wrapper changes but `uplot` does not.

The build no longer emits Vite’s large-chunk warning for the main app chunk because the only large startup asset now sits below the previous threshold.

## Validation

This change is build-configuration-only, so the right validation surface is frontend type/build/lint plus inspection of the emitted asset graph.

I ran:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

The build completed cleanly and produced the expected chunk split:

- `vendor-*.js`
- `chart-*.js`
- `spectrum_chart-*.js`
- `spectrum_css_vars-*.js`
- a smaller main `index-*.js`

Lint remains clean aside from the existing Biome schema-version info already present in the repo and unrelated to this change.

## Risks and tradeoffs

The main tradeoff in manual chunking is maintainability. If the chunk rules are too broad, too clever, or overly tied to today’s internals, they become a source of future bundling surprises. I kept the implementation narrow for that reason:

- it only targets libraries explicitly named in the issue or directly coupled to them,
- it only applies to `node_modules` packages,
- it does not try to outsmart application-module chunking,
- it preserves the existing lazy chart entry instead of collapsing or replacing it.

There is also a small risk that moving `uplot` into a dedicated `chart` chunk could have accidentally turned a previously lazy path into an eager startup dependency. The build output is a good sign that this did not happen: `spectrum_chart-*.js` remains a separate tiny wrapper chunk, which means the chart path is still isolated from the main app bundle.

## Out of scope

This PR does not try to solve every remaining bundle concern.

It does **not**:

- add `manualChunks` for arbitrary feature modules,
- rework the app startup sequence,
- change lazy-loading ownership for spectrum,
- add `sideEffects` metadata,
- tune CSS chunking,
- introduce a bundle visualizer dependency.

Those are separate concerns and should stay separate. This PR keeps to the smallest complete fix for the specific issue: make shared vendor chunking explicit in Vite while preserving the current lazy chart behavior.
