### PR TITLE
Add sideEffects false hint for UI tree-shaking

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "sideEffects": false,
   "scripts": {
     "sync:contracts": "node ../../tools/config/sync_contract_artifacts.mjs",
     "sync:generated-contracts": "node ../../tools/config/sync_shared_contracts_to_ui.mjs",


### PR DESCRIPTION
Closes #2442

## Summary

This PR adds `"sideEffects": false` to `apps/ui/package.json`.

The change is intentionally small, but it is only safe if the frontend package really behaves like a side-effect-free ESM package from the bundler’s perspective. Before making the change, I audited the current `apps/ui/src` import surface and checked the modules that looked most likely to hide import-time behavior. That scope read found only two side-effect-only imports in the application source tree, both of them CSS entry imports:

- `apps/ui/src/app/start_ui_app.ts` imports `../styles/app.css`
- `apps/ui/src/spectrum_chart.ts` imports `uplot/dist/uPlot.min.css`

The sampled runtime modules that touch `window` or `document` do so inside exported functions, class methods, or feature factories rather than at module import time. That means the package does not currently appear to rely on “import this module just so its top-level code runs” behavior, which is the main thing that would make this metadata unsafe.

## Problem being solved

The issue is about tree-shaking metadata. Without a `sideEffects` field, bundlers have to be conservative when deciding whether an apparently unused import can be dropped. In practice, that means they may retain more code than necessary around unused re-exports or other edges where module-level side effects cannot be ruled out.

This repo already uses:

- ESM (`"type": "module"`)
- Vite for production builds
- a strongly module-scoped frontend architecture where most files export functions, classes, constants, or feature factories rather than mutating runtime state as soon as the module loads

That makes `sideEffects: false` a reasonable optimization hint, but the important part is confirming it against the live codebase rather than assuming it from tooling alone.

## Scope and safety audit

The key question for this issue is not “does the bundler support the field?” It does. The key question is “does this package have JS/TS modules that must be imported for their top-level runtime behavior even if their exports are not referenced?”

To answer that, I did a focused scope read on the frontend source tree.

First, I searched for side-effect-only imports in `apps/ui/src`. The only matches were CSS imports:

- the main app stylesheet import in `start_ui_app.ts`
- the uPlot stylesheet import in `spectrum_chart.ts`

That is the expected good case. CSS imports are the classic benign side-effect import in a Vite app, and they are still preserved correctly by the bundler.

Second, I sampled modules that reference browser globals and other potentially effectful APIs:

- `ui_live_transport_controller.ts`
- `realtime_feature.ts`
- `demo_mode.ts`
- `spectrum_chart.ts`

Those reads showed the global interactions inside function bodies, feature factories, and class methods rather than at module scope. Examples include:

- reading `window.location` when transport mode starts,
- assigning demo cleanup state inside `runDemoMode(...)`,
- creating timers and animation frames as part of instance methods,
- starting the app inside `startUiApp()`, not at import time.

That distinction matters. `sideEffects: false` is unsafe when a module needs to execute on import for the app to work. It is not unsafe when a module merely *contains* functions that perform effects once called.

## Implementation approach

Because the scope read came back clean, the implementation stays deliberately narrow:

- add `"sideEffects": false` to `apps/ui/package.json`
- do not widen into any source refactor
- do not add per-file overrides or speculative allowlists
- do not mix this with additional bundle-shaping changes

This keeps the PR faithful to the issue. The previous issue already added manual chunking in `vite.config.ts`, and this change should stay conceptually separate from that work. One is chunk topology. This one is package-level tree-shaking metadata.

## Main code change

### `apps/ui/package.json`

The only file changed is the frontend package manifest.

The new field sits near the existing package metadata:

```json
"type": "module",
"sideEffects": false,
"scripts": { ... }
```

There are no script changes, dependency changes, or source changes in this PR.

## Validation

Because this is package metadata that can influence bundling behavior, validation needed to cover both correctness and “did the asset graph stay sane?”

I ran:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

The build stayed green and, importantly, the emitted asset graph remained intact:

- `dist/assets/vendor-CVd4cMpT.js`
- `dist/assets/chart-BJIBTocQ.js`
- `dist/assets/spectrum_chart-DHDdQNKp.js`
- `dist/assets/index-BWWVde19.js`
- the expected CSS assets, including `chart-D9SZI6tM.css` and `index-CVVX2VOj.css`

The unchanged output is useful signal here. It shows that adding `sideEffects: false` did not accidentally drop the CSS entry imports or disturb the current chunk layout established by the previous manual-chunk work. The main bundle remains at `397.04 kB` minified, which is exactly what the current bundling configuration already produced before this metadata hint.

Lint remains clean apart from the existing Biome schema-version informational message that was already present in the repo and is unrelated to this change.

## Risks and tradeoffs

The main risk with `sideEffects: false` is correctness, not syntax. If a package marks itself side-effect-free while secretly depending on import-time behavior, bundlers can legally remove code that the app actually needs.

That is why this PR spends most of its reasoning budget on the scope audit rather than on the manifest edit itself.

There is still a general maintenance tradeoff: future contributors could introduce a module with meaningful import-time JS side effects and forget that the package manifest assumes the opposite. That is not a blocker for this PR, but it is the main thing worth remembering. Right now, the live codebase matches the metadata. If that architectural pattern changes later, the field would need to be revisited.

## Out of scope

This PR does **not**:

- change chunking rules in `vite.config.ts`
- add bundle visualizer tooling
- alter CSS imports or stylesheet ownership
- refactor modules with browser-global usage
- guarantee a visible bundle-size change on its own

That last point is intentional. `sideEffects: false` is a correctness-and-opportunity hint for tree-shaking. Depending on the current import graph, it may or may not produce a measurable diff immediately. The important thing for this issue is that the hint is now accurate for the live frontend package and safe under the current architecture.
