### PR TITLE
Replace confirmation focus effect with useSignalEffect

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -1,10 +1,11 @@
 import { render, type ComponentChildren, type JSX } from "preact";
-import { useEffect, useRef } from "preact/hooks";
+import { useRef } from "preact/hooks";
 
 import { requiredById } from "../dom/dom_query";
 import {
   signal,
   type ReadonlySignal,
+  useSignalEffect,
 } from "../ui_signals";
 import type { UiConfirmationDialogModel } from "./ui_confirmation_module";
 import {
@@ -195,9 +196,11 @@ function ConfirmationDialog(props: {
   const { bridge, model } = props;
   const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
 
-  useEffect(() => {
-    confirmButtonRef.current?.focus();
-  }, [model.messageText]);
+  useSignalEffect(() => {
+    if (model.messageText) {
+      confirmButtonRef.current?.focus();
+    }
+  });
 
   return (
     <div class="app-modal-layer">

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -69,13 +69,16 @@ export async function installFakeWebSocket(page: Page, options: FakeWebSocketOpt
 export async function confirmPrompt(page: Page): Promise<void> {
   const dialog = page.locator(".confirmation-dialog");
   await expect(dialog).toBeVisible();
-  await dialog.locator(".btn--danger").click();
+  const confirmButton = dialog.locator(".btn--danger");
+  await expect(confirmButton).toBeFocused();
+  await confirmButton.click();
   await expect(dialog).toHaveCount(0);
 }
 
 export async function cancelPrompt(page: Page): Promise<void> {
   const dialog = page.locator(".confirmation-dialog");
   await expect(dialog).toBeVisible();
+  await expect(dialog.locator(".btn--danger")).toBeFocused();
   await dialog.locator("button:not(.btn--danger)").click();
   await expect(dialog).toHaveCount(0);
 }


### PR DESCRIPTION
Closes #2443

## Summary

This PR replaces the remaining hook-array confirmation-focus seam in `apps/ui/src/app/runtime/ui_shell_chrome.tsx` with `useSignalEffect`, and it adds smoke-level assertions that the confirm button is actually focused when the confirmation dialog appears.

The issue was intentionally narrow: there was still one spot in the shell chrome where a computed signal value (`model.messageText`) was flowing through a React-style `useEffect(..., [dependency])` pattern instead of the signal-native tracking pattern that the rest of the migrated UI already uses. The behavior itself was correct — the confirm button was auto-focused when the dialog opened — but the implementation was still hooks-array driven. This PR finishes that cleanup without widening into the rest of the dialog component.

## Problem being solved

The live code in `ui_shell_chrome.tsx` still contained:

```ts
useEffect(() => {
  confirmButtonRef.current?.focus();
}, [model.messageText]);
```

That works, but it is no longer the preferred pattern in this repo now that the confirmation dialog model is signal-driven. `model.messageText` is a signal-backed value, so the more direct and consistent approach is to let the reactive effect track the signal usage itself instead of manually threading the derived value through a dependency array.

This is partly a consistency cleanup, but it also matters for maintainability. Signal-native effects are easier to read in these migrated islands because they make the dependency source explicit in the effect body rather than splitting the logic between the callback and the dependency list. The issue is small, but it is the kind of leftover seam that gets harder to notice later once the rest of the frontend has fully settled on the signal model.

## Scope read and approach

Before changing the code, I re-read the live shell chrome file and searched the surrounding confirmation flow.

That scope check showed:

1. the remaining dialog focus logic really is isolated to `ConfirmationDialog` inside `ui_shell_chrome.tsx`,
2. the dialog model already comes from the signal-backed confirmation module,
3. there was no broader dialog ownership or timing bug to fix here,
4. the only thing that needed changing was the effect style and a small regression guard.

That led to a deliberately small implementation:

- remove the `useEffect` import,
- pull `useSignalEffect` from the shared `ui_signals` import surface,
- gate the focus call on `model.messageText` inside the signal effect, and
- strengthen the smoke helper so the test suite now proves the confirm button is focused before either confirm or cancel flows interact with the dialog.

## Main code changes

### `apps/ui/src/app/runtime/ui_shell_chrome.tsx`

The shell chrome now uses `useSignalEffect` inside `ConfirmationDialog`.

The new effect is:

```ts
useSignalEffect(() => {
  if (model.messageText) {
    confirmButtonRef.current?.focus();
  }
});
```

This preserves the existing behavior while switching the ownership model from dependency-array hooks to signal-native tracking.

The `if (model.messageText)` guard matters. It keeps the effect tied to the dialog’s visible/open state and avoids trying to focus the confirm button when there is no active confirmation message.

Nothing else about the dialog changed:

- the bridge actions are unchanged,
- Escape handling is unchanged,
- confirm and cancel button wiring is unchanged,
- markup and accessibility roles are unchanged.

### `apps/ui/tests/smoke.helpers.ts`

The smoke helper now asserts the behavior the issue is really about.

Both `confirmPrompt(page)` and `cancelPrompt(page)` already waited for `.confirmation-dialog` to become visible before interacting with it. This PR adds one more expectation before the click:

- the confirm button (`.btn--danger`) must be focused.

That is important because it turns a behavior that was previously implicit into an explicit regression guard. If a later refactor switches back to a non-reactive effect, breaks focus timing, or leaves focus on the invoking element, the existing settings smoke flows will now catch it.

I chose to place the assertion in the shared helper rather than in a one-off test because the confirmation dialog is a shared shell surface used by multiple features. The helper makes that invariant reusable anywhere the dialog appears.

## Validation

Because this issue changes both a shared shell component and a generic smoke helper, validation needed to cover:

1. the confirmation module/runtime slice,
2. a real browser flow that opens the dialog,
3. normal frontend safety checks.

I ran:

- `cd apps/ui && npx playwright test tests/ui_confirmation_module.spec.ts tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.settings.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

I also reran a smaller focused smoke slice around the confirmation cases:

- `cd apps/ui && npx playwright test tests/smoke.settings.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1 -g "analysis settings ask for confirmation before saving risky values|analysis tab adds guided helper copy and can reset tuning to defaults"`

Everything passed.

The smoke coverage matters most here. It proves the dialog still opens, still focuses the confirm button, still allows cancel, and still allows confirm in a real browser flow rather than only in a unit-level signal test.

## Risks and tradeoffs

The risk here is mainly around timing. Focus behavior can be surprisingly sensitive to render order, ref hydration, and reactive timing differences. A naïve reactive rewrite can preserve the logic “on paper” while still missing the moment when the DOM node is ready to receive focus.

This PR keeps that risk low because:

- it does not change the dialog structure,
- it does not change when the dialog mounts,
- it uses the existing `confirmButtonRef`,
- it adds a real browser assertion for the focused element.

The only tradeoff is that the smoke helper is now slightly stricter. That is intentional. The issue is specifically about auto-focus behavior, so letting the helper accept an unfocused confirm button would leave the regression gap open.

## Out of scope

This PR does **not**:

- redesign the confirmation dialog,
- change the confirmation module queueing behavior,
- alter confirm/cancel text, translations, or styling,
- touch the settings/business logic that triggers confirmations,
- replace unrelated `useEffect` usage elsewhere in the shell.

It stays focused on the final remaining confirmation-focus seam named in the issue and adds just enough coverage to keep that cleanup from regressing.
