### PR TITLE
Move internet panel inline styles into CSS classes

### DIFF
--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -291,9 +291,8 @@ function InternetPanel(props: {
         </div>
         <div
           id="internetStatusPanel"
-          class="maintenance-stack"
+          class="maintenance-stack internet-panel__status"
           aria-live="polite"
-          style="margin-top:1rem;"
         >
           {model.internetStatus ? (
             <InternetStatusCard model={model.internetStatus} />
@@ -368,7 +367,7 @@ function InternetPanel(props: {
                 ref={ssidInputRef}
                 autoComplete="off"
                 maxLength={64}
-                style="width:100%;max-width:20rem;"
+                class="internet-panel__input"
                 value={model.ssidInputValue}
                 disabled={model.controlsLocked}
                 onInput={(event) =>
@@ -382,13 +381,13 @@ function InternetPanel(props: {
               >
                 {t("settings.update.password", "Wi-Fi Password")}
               </label>
-              <div style="display:flex;gap:0.5rem;align-items:center;">
+              <div class="internet-panel__input-row">
                 <input
                   type={model.passwordInputType}
                   id="updatePasswordInput"
                   autoComplete="off"
                   maxLength={128}
-                  style="width:100%;max-width:20rem;"
+                  class="internet-panel__input"
                   value={model.passwordInputValue}
                   disabled={model.controlsLocked}
                   onInput={(event) =>

--- a/apps/ui/src/styles/settings-transport.css
+++ b/apps/ui/src/styles/settings-transport.css
@@ -94,3 +94,18 @@
   font-size: 0.84rem;
   line-height: 1.45;
 }
+
+.internet-panel__status {
+  margin-top: var(--space-4);
+}
+
+.internet-panel__input {
+  width: 100%;
+  max-width: 20rem;
+}
+
+.internet-panel__input-row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}


### PR DESCRIPTION
## Summary

Closes #2444 by removing the remaining inline layout styles from `apps/ui/src/app/views/internet_panel.tsx` and moving that presentation responsibility into the existing `apps/ui/src/styles/settings-transport.css` owner. The behavior and layout stay the same, but the internet panel now follows the same stylesheet-driven pattern used across the rest of the settings/update surfaces instead of bypassing CSS through `style=` attributes.

## Problem

The issue called out four inline styles still living inside `internet_panel.tsx`: one for the status panel spacing, two for the SSID/password input sizing, and one for the password row flex layout. Those inline declarations were small, but they were the wrong ownership boundary for this UI. They sat directly in JSX even though the surrounding screen already routes its visual styling through the shared settings and maintenance stylesheets.

Leaving them inline had a few concrete downsides:

1. They bypassed the normal stylesheet layer, which makes the panel harder to reason about when scanning the frontend style owners.
2. They were not reusable and could not participate cleanly in any future responsive or theming adjustments that happen in CSS.
3. They kept `internet_panel.tsx` responsible for both structure and tiny layout details, even though the repo has been steadily moving these panels toward clearer Preact/view ownership plus stylesheet ownership.

This was intentionally a narrow cleanup issue, so the goal here was not to redesign the panel or split more CSS files. The real task was to remove those last inline style pockets without creating a second styling path for the same transport/internet surface.

## Implementation approach

Before editing, I rechecked the live panel and the nearby stylesheet ownership. The key decision was whether these rules should move into a new dedicated internet stylesheet or into the existing `settings-transport.css` file. The current code already treats that stylesheet as the owner for the transport- and internet-adjacent settings UI, so introducing a brand-new stylesheet for three tiny rules would have added structure without adding clarity.

Because of that, the implementation keeps the existing ownership model intact:

- `internet_panel.tsx` now applies semantic class names where those inline styles used to be.
- `settings-transport.css` now defines the corresponding layout rules.

That keeps the change reviewable and avoids broad CSS churn while still fully resolving the issue.

## Main code changes by area

### `apps/ui/src/app/views/internet_panel.tsx`

The JSX change is intentionally small and mechanical:

- The status container now uses `class="maintenance-stack internet-panel__status"` instead of an inline `margin-top:1rem`.
- The SSID input now uses `class="internet-panel__input"` instead of an inline `width:100%;max-width:20rem`.
- The password input uses that same `internet-panel__input` class so both fields stay aligned through one shared rule.
- The password field wrapper now uses `class="internet-panel__input-row"` instead of an inline `display:flex;gap:0.5rem;align-items:center`.

No IDs changed, no event wiring changed, and no model/action flow changed. The component still owns the same inputs, focus behavior, and updater interactions as before. This PR only changes how the layout is expressed.

### `apps/ui/src/styles/settings-transport.css`

This file now owns the three extracted rules:

- `.internet-panel__status`
- `.internet-panel__input`
- `.internet-panel__input-row`

The actual values were kept aligned with the previous UI:

- the status block still gets the same top spacing,
- the text inputs still fill available width while capping at `20rem`,
- and the password row still uses a horizontal flex layout with the same gap/alignment behavior.

Where it made sense, the CSS now leans on existing spacing tokens instead of hardcoding everything in JSX. That keeps the result more consistent with the rest of the stylesheet layer while preserving the visual behavior the panel already had.

## Why this approach

I kept this fix deliberately narrow for two reasons.

First, the issue is about the remaining inline styles, not about a larger transport/internet redesign. The surrounding update and internet flows already went through broader ownership cleanup in earlier issues, so widening this change into a bigger CSS reorganization would have mixed concerns and made the review noisier than necessary.

Second, the existing stylesheet seam is already good enough. `settings-transport.css` is a sensible owner for transport and internet layout rules, so extending it with a few semantic classes is cleaner than inventing a separate `internet.css` file just to hold three small selectors. That keeps the file graph stable and matches the current frontend organization.

## Validation

Because this PR changes markup classes and stylesheet ownership rather than business logic, I validated the exact UI surface it touches plus the standard frontend gates:

```bash
cd apps/ui && npx playwright test tests/smoke.update.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1
cd apps/ui && npm run typecheck
cd apps/ui && npm run build
cd apps/ui && npm run lint
```

The targeted smoke suite is the important browser guard here because it exercises the update/internet tab behavior that depends on these DOM nodes:

- rendering idle readiness guidance,
- showing usable USB internet state,
- restoring persisted Wi-Fi SSID values after reboot,
- toggling password visibility without losing the draft,
- and showing update failure context.

That means the PR is covered both structurally (build/type/lint) and on the live browser surface most likely to regress from a class or layout change.

## Risks and tradeoffs considered

The main risk in a change this small is accidental selector drift: renaming classes or touching wrapper markup in a way that breaks the layout or any test selectors. I avoided that by preserving all existing element IDs and interaction wiring. The tests still find the same inputs and status container by their existing IDs, so this change does not force any downstream selector migration.

Another tradeoff was whether to use generic utility names versus semantic names. The issue suggested both directions. I chose semantic names (`internet-panel__status`, `internet-panel__input`, `internet-panel__input-row`) because they fit this codebase’s stylesheet conventions better than adding one-off generic utilities for a single panel.

## Out of scope

This PR does not:

- split `settings-transport.css`,
- touch updater business logic,
- change internet panel behavior,
- or refactor other inline or repetitive style patterns elsewhere in the app.

Those broader cleanups belong to other issues in the queue. This change is intentionally the smallest complete resolution for the remaining inline-style residue in `internet_panel.tsx`.
