### PR TITLE
Reduce dense signal reads in realtime view state

### DIFF
--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -308,20 +308,26 @@ export function createRealtimeFeatureViewState(
   const loggingPanelBaseModel = computed(() => {
     trackAppStateSlice(realtime);
     trackAppStateSlice(shell);
-    const elapsedText = realtime.loggingStatus.enabled
-      ? formatElapsed(realtime.loggingStatus.start_time_utc, elapsedNowMs.value)
-      : lastCompletedElapsedText.value;
+    const loggingStatus = realtime.loggingStatus;
+    const pendingLoggingAction = workflow.pendingLoggingAction.value;
+    const liveHealth = sensorState.liveHealth.value;
+    const connectedClients = sensorState.connectedClients.value;
+    const assignedClientCount = sensorState.assignedClientCount.value;
+    const completedElapsedText = lastCompletedElapsedText.value;
+    const elapsedText = loggingStatus.enabled
+      ? formatElapsed(loggingStatus.start_time_utc, elapsedNowMs.value)
+      : completedElapsedText;
     return buildRealtimeLoggingPanelViewModel({
-      status: realtime.loggingStatus,
-      pendingLoggingAction: workflow.pendingLoggingAction.value,
+      status: loggingStatus,
+      pendingLoggingAction,
       selectionBlockReason: selectionBlockReason(),
-      liveHealth: sensorState.liveHealth.value,
-      connectedCountText: formatInt(sensorState.connectedClients.value.length),
-      assignedCountText: formatInt(sensorState.assignedClientCount.value),
-      runIdText: recordingRunIdText(realtime.loggingStatus),
+      liveHealth,
+      connectedCountText: formatInt(connectedClients.length),
+      assignedCountText: formatInt(assignedClientCount),
+      runIdText: recordingRunIdText(loggingStatus),
       elapsedText,
-      samplesText: formatInt(realtime.loggingStatus.samples_written ?? 0),
-      lastCompletedElapsedText: lastCompletedElapsedText.value,
+      samplesText: formatInt(loggingStatus.samples_written ?? 0),
+      lastCompletedElapsedText: completedElapsedText,
       t,
       formatInt,
     });
@@ -330,29 +336,33 @@ export function createRealtimeFeatureViewState(
   const liveOverviewModel = computed<RealtimeLiveOverviewRenderModel>(() => {
     trackAppStateSlice(realtime);
     trackAppStateSlice(shell);
-    const signal = sensorState.strongestSignal.value;
+    const connectedClients = sensorState.connectedClients.value;
+    const strongestSignal = sensorState.strongestSignal.value;
+    const strongestSignalText = sensorState.strongestSignalText.value;
+    const liveHealth = sensorState.liveHealth.value;
     const activeCar = sensorState.activeCarDisplayState.value;
     const setupBlock = selectionBlockReason();
+    const recordingStateText = loggingPanelBaseModel.value.phaseText;
     return {
-      connectedSensorsText: `${formatInt(sensorState.connectedClients.value.length)} / ${formatInt(realtime.clients.length)}`,
+      connectedSensorsText: `${formatInt(connectedClients.length)} / ${formatInt(realtime.clients.length)}`,
       activeCar: {
         text: activeCar.text,
         warning: setupBlock === null && activeCar.isWarning,
       },
-      recordingStateText: loggingPanelBaseModel.value.phaseText,
+      recordingStateText,
       dataFreshnessText: dataFreshnessText(),
-      strongestSignalText: sensorState.strongestSignalText.value,
+      strongestSignalText,
       runHealth: {
-        hidden: !sensorState.liveHealth.value.showOverviewPill,
-        text: sensorState.liveHealth.value.text,
-        variant: sensorState.liveHealth.value.variant,
+        hidden: !liveHealth.showOverviewPill,
+        text: liveHealth.text,
+        variant: liveHealth.variant,
       },
       sensorCards: realtime.clients.map((client) => ({
         id: client.id,
         label: liveSensorOverviewLabel(client),
         connected: Boolean(client.connected),
         statusText: client.connected ? t("status.online") : t("status.offline"),
-        strongest: signal?.client.id === client.id,
+        strongest: strongestSignal?.client.id === client.id,
       })),
     };
   });


### PR DESCRIPTION
## Summary

Closes #2445 by reducing dense inline `.value` access inside the most crowded computed signals in `apps/ui/src/app/features/realtime_feature_view_state.ts`. This does not change the realtime feature’s behavior or computed graph. Instead, it makes the existing render-model derivations easier to read by hoisting the repeated signal snapshots into local variables at the top of the computed bodies before assembling the logging and live-overview models.

## Problem

The issue called out a readability problem rather than a functional bug. In `realtime_feature_view_state.ts`, several computed render models were still reaching directly through multiple signals inline while constructing large object literals. The clearest example was `loggingPanelBaseModel`, which mixed app-state reads and signal dereferences like:

- `workflow.pendingLoggingAction.value`
- `sensorState.liveHealth.value`
- `sensorState.connectedClients.value.length`
- `sensorState.assignedClientCount.value`
- `lastCompletedElapsedText.value`

all inside one `buildRealtimeLoggingPanelViewModel(...)` call. `liveOverviewModel` had the same pattern on the dashboard side, repeatedly pulling `.value` from `strongestSignal`, `strongestSignalText`, `liveHealth`, `connectedClients`, and `loggingPanelBaseModel`.

Nothing was technically broken, but the data flow was harder to follow than it needed to be. A reader had to mentally parse which values were plain runtime state, which were signal reads, and which values were repeated snapshots of the same signal. That is especially noisy in this file because it already coordinates AppState slices, realtime workflow state, derived sensor state, elapsed-time tracking, and multiple panel view models.

The goal here was to make those computeds legible without turning the change into a broader reactive refactor.

## Implementation approach

I started by checking whether the issue was still current after the recent realtime signal work. It is. The file already has the right overall ownership shape: realtime state is derived in one place, the expensive or behavior-sensitive pieces are already split into focused helpers, and the existing tests cover the elapsed-timer and logging-summary behavior that would catch accidental regressions.

Because of that, the right fix was the narrow one:

1. keep the current computed boundaries,
2. keep the same model-builder calls,
3. keep the same AppState/signal dependencies,
4. but move the repeated `.value` reads into local variables at the top of the computed bodies.

That preserves behavior while making the inputs to each render model explicit and readable.

## Main code changes by area

### `loggingPanelBaseModel`

This computed is still responsible for building the base logging-panel model, but it now snapshots its inputs up front instead of interleaving signal access inside the builder call.

It now reads and names:

- `loggingStatus`
- `pendingLoggingAction`
- `liveHealth`
- `connectedClients`
- `assignedClientCount`
- `completedElapsedText`

before composing `elapsedText` and calling `buildRealtimeLoggingPanelViewModel(...)`.

That gives the computed a much clearer structure:

1. read the current reactive inputs,
2. derive the one conditional piece (`elapsedText`),
3. build the panel model from named values.

The output is identical, but the relationship between the realtime logging status, the workflow signal, the sensor summaries, and the final render-model fields is now obvious on first read.

### `liveOverviewModel`

The dashboard overview model got the same treatment. Instead of repeatedly dereferencing signals inline while building the returned object, it now snapshots:

- `connectedClients`
- `strongestSignal`
- `strongestSignalText`
- `liveHealth`
- `activeCar`
- `recordingStateText`

at the top of the computed body.

That makes the returned object easier to scan because the logic now reads like a render-model assembly step rather than a mix of structure plus hidden signal dereferences. The `runHealth` and `sensorCards` sections in particular are easier to read because they now work from named local state instead of repeated `sensorState.liveHealth.value.*` or `signal?.client.id` expressions.

## What did not change

This PR intentionally does **not**:

- add new helpers,
- change the signal graph,
- split the file further,
- change how `trackAppStateSlice(...)` is used,
- or introduce any new computed layers.

It also does not attempt to “solve” every `.value` access in the file. The issue is specifically about the dense, noisy clusters inside the largest computed render models. Smaller or already-clear signal reads elsewhere in the file were left alone to avoid turning a readability cleanup into an unnecessary broad rewrite.

## Why this scope is right

There were a few tempting ways to broaden this change:

- introducing a generic helper for signal snapshots,
- extracting more shared derivation helpers,
- or restructuring the whole realtime view-state file.

I did not do that here because those are different changes with different review surfaces. This issue is about making the current computed bodies easier to read. Hoisting the repeated signal reads achieves that directly without changing the architecture or creating new abstractions that the file does not clearly need yet.

That also keeps this PR low-risk. The runtime still subscribes to the same reactive sources and still builds the same models. Only the expression shape changed.

## Validation

Because this refactor touches realtime render-model derivation, I validated both the direct unit coverage for this file and a browser slice that exercises the dashboard/logging flow:

```bash
cd apps/ui && npx playwright test tests/realtime_feature_view_state.spec.ts tests/realtime_logging_view_models.spec.ts tests/realtime_feature_workflow.spec.ts --workers=1
cd apps/ui && npx playwright test tests/realtime_logging_summary.spec.ts tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1
cd apps/ui && npm run typecheck
cd apps/ui && npm run build
cd apps/ui && npm run lint
```

That validation covers:

- elapsed-timer re-arming behavior,
- preservation of the last completed elapsed text,
- realtime logging view-model construction,
- workflow interactions that depend on the same state,
- a repeated-websocket logging-summary browser path,
- and the main bootstrap dashboard smoke path.

So the PR is checked both at the file’s direct seam and at the live dashboard surface that consumes these models.

## Risks and tradeoffs considered

The primary risk was accidentally changing reactive behavior while “cleaning up” the code—for example, by dropping a signal read, moving a dependency across a boundary, or changing when a computed observes a value. To avoid that, this PR only renames and localizes the reads that were already present. Every relevant signal and AppState field is still read inside the same computed that used it before.

A smaller tradeoff is that the computeds now use a few more local variables. That is intentional. In this case, a handful of named locals is a net readability win because it makes the model-builder inputs explicit and cuts down on repeated dotted signal access.

## Out of scope / follow-up

This PR does not address the broader “signal boilerplate” cleanup suggested by later issues such as the shared `useSignalProperties` helper. If that work lands later, it can build on this clearer render-model structure. For now, this PR keeps the fix tightly scoped to the actual dense `.value` access clusters called out in #2445.
