### PR TITLE
Lazy-load non-critical UI panels at startup

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -84,9 +84,10 @@ source-of-truth export commands remain the only writers for those files.
 | File | Purpose |
 |------|---------|
 | `main.ts` | Thin Vite entry that boots the UI runtime |
-| `app/start_ui_app.ts` | CSS-aware startup entry that mounts the Preact shell first, resolves and mounts the centralized panel bootstrap from shell-rendered hosts, then constructs and starts the app runtime |
+| `app/start_ui_app.ts` | CSS-aware startup entry that mounts the Preact shell first, boots dashboard panels immediately, then starts the runtime with deferred history/settings panel loaders |
 | `app/ui_panel_host_registry.ts` | Centralized host registry for dashboard, history, and settings panel mount points so startup and tests stop depending on one host getter module per panel |
-| `app/ui_panel_bootstrap.ts` | Centralized host registry and panel-mount bootstrap for dashboard, history, and settings islands so startup/runtime stop wiring one host getter per panel |
+| `app/ui_panel_bootstrap.ts` | Centralized panel bootstrap that keeps dashboard mounts synchronous while exposing lazy history/settings loaders from the shared host registry |
+| `app/ui_lazy_panels.ts` | Deferred panel manager that gives the runtime full panel contracts up front, then attaches real history/settings islands on first activation or idle prefetch |
 | `app/dom/` | Focused DOM lookup helpers that remain after the panel bootstrap cleanup, including `requiredById` and other non-panel runtime locators |
 | `app/ui_app_runtime.ts` | Thin UI composition root that creates the shell, spectrum, transport, feature bundle, and startup coordinator from local helper wiring instead of deferred attachment seams |
 | `app/ui_app_state.ts` | Canonical AppState shape plus reactive slice helpers that keep object-style reads/writes working while shared shell/transport/realtime/history/settings/spectrum state becomes signal-observable |

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -7,10 +7,8 @@ import {
   signal,
   type ReadonlySignal,
 } from "../ui_signals";
-import {
-  DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL,
-  type SpeedSourcePanelView,
-} from "../views/speed_source_panel";
+import { DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL } from "../views/speed_source_panel_defaults";
+import type { SpeedSourcePanelView } from "../views/speed_source_panel";
 import {
   buildSpeedSourceDiagnosticsRenderModel,
   type SettingsSpeedSourcePresenterDeps,

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -48,6 +48,7 @@ type UiShellControllerDeps = {
   chrome: UiShellChromeView;
   chromeActions: UiShellChromeActionBridge;
   liveOverview: RealtimeLiveOverviewBridge;
+  onViewActivated?: (viewId: string) => Promise<void> | void;
   state: AppState;
 };
 
@@ -91,15 +92,20 @@ export class UiShellController {
     this.appShellWrap = queryOne<HTMLElement>(".wrap");
     this.liveOverview = deps.liveOverview;
     this.bindFeatureHandlers = deps.bindFeatureHandlers;
+    this.notifications = createUiShellNotificationModule({
+      window,
+    });
     this.navigation = createUiShellNavigationModule({
       shell: this.state.shell,
       viewIds: SHELL_NAV_ITEMS.map((item) => item.viewId),
+      onViewActivated: deps.onViewActivated,
+      onViewActivationFailed: (viewId, error) => {
+        console.error(`[VibeSensor] Failed to activate view "${viewId}".`, error);
+        this.notifications.showError(this.t("status.view_load_failed"));
+      },
       onDashboardViewActivated: () => {
         this.state.spectrum.spectrumPlot?.resize();
       },
-    });
-    this.notifications = createUiShellNotificationModule({
-      window,
     });
     this.status = createUiShellStatusModule({
       realtime: this.state.realtime,

--- a/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
@@ -4,6 +4,8 @@ import { signal, type ReadonlySignal } from "../ui_signals";
 export const DEFAULT_SHELL_VIEW_ID = "dashboardView";
 
 type UiShellNavigationDeps = {
+  onViewActivated?: (viewId: string) => Promise<void> | void;
+  onViewActivationFailed?: (viewId: string, error: unknown) => void;
   onDashboardViewActivated?: () => void;
   shell: ShellState;
   viewIds: readonly string[];
@@ -22,17 +24,41 @@ export function createUiShellNavigationModule(
   deps: UiShellNavigationDeps,
 ): UiShellNavigationModule {
   const activeViewId = signal(normalizeActiveViewId(deps.shell.activeViewId, deps.viewIds));
+  let pendingActivationToken = 0;
   deps.shell.activeViewId = activeViewId.value;
+
+  const applyActiveView = (nextViewId: string): void => {
+    activeViewId.value = nextViewId;
+    deps.shell.activeViewId = nextViewId;
+    if (nextViewId === DEFAULT_SHELL_VIEW_ID) {
+      deps.onDashboardViewActivated?.();
+    }
+  };
 
   return {
     activeViewId,
     setActiveView(viewId) {
       const nextViewId = normalizeActiveViewId(viewId, deps.viewIds);
-      activeViewId.value = nextViewId;
-      deps.shell.activeViewId = nextViewId;
-      if (nextViewId === DEFAULT_SHELL_VIEW_ID) {
-        deps.onDashboardViewActivated?.();
+      const activationToken = ++pendingActivationToken;
+      const activationResult =
+        nextViewId === DEFAULT_SHELL_VIEW_ID
+          ? undefined
+          : deps.onViewActivated?.(nextViewId);
+      if (activationResult === undefined) {
+        applyActiveView(nextViewId);
+        return;
       }
+      void Promise.resolve(activationResult).then(() => {
+        if (activationToken !== pendingActivationToken) {
+          return;
+        }
+        applyActiveView(nextViewId);
+      }).catch((error) => {
+        if (activationToken !== pendingActivationToken) {
+          return;
+        }
+        deps.onViewActivationFailed?.(nextViewId, error);
+      });
     },
   };
 }

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -1,7 +1,7 @@
 import "../styles/app.css";
-import { mountUiPanels } from "./ui_panel_bootstrap";
 import { createAppState } from "./ui_app_state";
 import { UiAppRuntime } from "./ui_app_runtime";
+import { createLazyUiPanels } from "./ui_lazy_panels";
 import {
   createUiShellChromeActionBridge,
   getUiShellChromeHost,
@@ -12,11 +12,13 @@ export function startUiApp(): void {
   const state = createAppState();
   const shellChromeActions = createUiShellChromeActionBridge();
   const shellChrome = mountUiShellChrome(getUiShellChromeHost(), shellChromeActions);
-  const panels = mountUiPanels();
+  const lazyPanels = createLazyUiPanels();
   new UiAppRuntime({
     shellChrome,
-    panels,
+    panels: lazyPanels.panels,
+    ensureViewPanels: lazyPanels.ensureViewPanels,
     state,
     shellChromeActions,
   }).start();
+  lazyPanels.prefetchHiddenPanels();
 }

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -22,6 +22,7 @@ import type { UiMountedPanels } from "./ui_panel_bootstrap";
 export interface UiAppRuntimeDeps {
   shellChrome: UiShellChromeView;
   panels: UiMountedPanels;
+  ensureViewPanels?: (viewId: string) => Promise<void> | void;
   state?: AppState;
   shellChromeActions?: UiShellChromeActionBridge;
 }
@@ -98,6 +99,7 @@ export class UiAppRuntime {
       chrome: deps.shellChrome,
       chromeActions: shellChromeActions,
       liveOverview: deps.panels.dashboard.liveOverview,
+      onViewActivated: deps.ensureViewPanels,
     });
     spectrum = new UiSpectrumController({
       state,

--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -1,0 +1,565 @@
+import type { UiPanelHostRegistry } from "./ui_panel_host_registry";
+import { resolveUiPanelHosts } from "./ui_panel_host_registry";
+import {
+  mountDashboardPanels,
+  mountHistoryPanelLazy,
+  mountSettingsPanelsLazy,
+  type UiMountedDashboardPanels,
+  type UiMountedLazyPanels,
+  type UiMountedPanels,
+} from "./ui_panel_bootstrap";
+import { effect, signal } from "./ui_signals";
+import type { AnalysisPanelView } from "./views/analysis_panel";
+import type { CarsPanelView } from "./views/cars_panel";
+import type { EspFlashPanelView } from "./views/esp_flash_panel";
+import type { HistoryPanelView } from "./views/history_table_view";
+import type { InternetPanelView } from "./views/internet_panel";
+import type { SensorsPanelView } from "./views/sensors_panel";
+import type { SettingsShellView } from "./views/settings_shell";
+import type { SpeedSourcePanelView } from "./views/speed_source_panel";
+import type { UpdatePanelView } from "./views/update_panel";
+
+const HISTORY_VIEW_ID = "historyView";
+const SETTINGS_VIEW_ID = "settingsView";
+const DEFAULT_SETTINGS_TAB_ID = "carTab";
+
+type DeferredWorkScheduler = (task: () => void) => void;
+
+export interface UiLazyPanels {
+  panels: UiMountedPanels;
+  ensureViewPanels(viewId: string): Promise<void>;
+  prefetchHiddenPanels(): void;
+}
+
+export interface CreateUiLazyPanelsDeps {
+  hosts?: UiPanelHostRegistry;
+  mountDashboardPanels?: (hosts: UiPanelHostRegistry) => UiMountedDashboardPanels;
+  loadHistoryPanel?: (hosts: UiPanelHostRegistry) => Promise<HistoryPanelView>;
+  loadSettingsPanels?: (hosts: UiPanelHostRegistry) => Promise<UiMountedLazyPanels>;
+  scheduleDeferredWork?: DeferredWorkScheduler;
+}
+
+function scheduleDeferredWork(task: () => void): void {
+  setTimeout(task, 0);
+}
+
+function createDeferredHistoryPanelView(): {
+  attach(realView: HistoryPanelView): void;
+  view: HistoryPanelView;
+} {
+  type HistoryModel = Parameters<HistoryPanelView["bindModel"]>[0];
+  type HistoryActions = Parameters<HistoryPanelView["bindActions"]>[0];
+
+  let actions: HistoryActions | null = null;
+  let model: HistoryModel | null = null;
+  let realView: HistoryPanelView | null = null;
+
+  return {
+    view: {
+      bindModel(nextModel) {
+        model = nextModel;
+        realView?.bindModel(nextModel);
+      },
+      bindActions(nextActions) {
+        actions = nextActions;
+        realView?.bindActions(nextActions);
+      },
+    },
+    attach(nextRealView) {
+      realView = nextRealView;
+      if (model !== null) {
+        realView.bindModel(model);
+      }
+      if (actions !== null) {
+        realView.bindActions(actions);
+      }
+    },
+  };
+}
+
+function createDeferredSettingsShellView(): {
+  attach(realView: SettingsShellView): void;
+  view: SettingsShellView;
+} {
+  let disposeRealViewSubscription: (() => void) | null = null;
+  let realView: SettingsShellView | null = null;
+  const activeTabId = signal(DEFAULT_SETTINGS_TAB_ID);
+
+  return {
+    view: {
+      activateTab(tabId) {
+        activeTabId.value = tabId;
+        realView?.activateTab(tabId);
+      },
+      getActiveTabId() {
+        return activeTabId.value;
+      },
+      subscribeActiveTabChanges(listener) {
+        let initialized = false;
+        return effect(() => {
+          const nextTabId = activeTabId.value;
+          if (!initialized) {
+            initialized = true;
+            return;
+          }
+          listener(nextTabId);
+        });
+      },
+    },
+    attach(nextRealView) {
+      disposeRealViewSubscription?.();
+      realView = nextRealView;
+      realView.activateTab(activeTabId.value);
+      activeTabId.value = realView.getActiveTabId();
+      disposeRealViewSubscription = realView.subscribeActiveTabChanges((nextTabId) => {
+        activeTabId.value = nextTabId;
+      });
+    },
+  };
+}
+
+function createDeferredCarsPanelView(): {
+  attach(realView: CarsPanelView): void;
+  view: CarsPanelView;
+} {
+  type CarsListActions = Parameters<CarsPanelView["list"]["bindActions"]>[0];
+  type CarsListModel = Parameters<CarsPanelView["list"]["bindModel"]>[0];
+  type CarsWizardActions = Parameters<CarsPanelView["wizard"]["bindActions"]>[0];
+  type CarsWizardFocusTarget = Parameters<CarsPanelView["wizard"]["focus"]>[0];
+  type CarsWizardModel = Parameters<CarsPanelView["wizard"]["bindModel"]>[0];
+
+  let listActions: CarsListActions | null = null;
+  let listModel: CarsListModel | null = null;
+  let realView: CarsPanelView | null = null;
+  let wizardActions: CarsWizardActions | null = null;
+  let wizardFocusTarget: CarsWizardFocusTarget | null = null;
+  let wizardModel: CarsWizardModel | null = null;
+
+  return {
+    view: {
+      list: {
+        bindModel(nextModel) {
+          listModel = nextModel;
+          realView?.list.bindModel(nextModel);
+        },
+        bindActions(nextActions) {
+          listActions = nextActions;
+          realView?.list.bindActions(nextActions);
+        },
+      },
+      wizard: {
+        bindModel(nextModel) {
+          wizardModel = nextModel;
+          realView?.wizard.bindModel(nextModel);
+        },
+        bindActions(nextActions) {
+          wizardActions = nextActions;
+          realView?.wizard.bindActions(nextActions);
+        },
+        focus(target) {
+          wizardFocusTarget = target;
+          realView?.wizard.focus(target);
+          if (realView !== null) {
+            wizardFocusTarget = null;
+          }
+        },
+      },
+    },
+    attach(nextRealView) {
+      realView = nextRealView;
+      if (listModel !== null) {
+        realView.list.bindModel(listModel);
+      }
+      if (listActions !== null) {
+        realView.list.bindActions(listActions);
+      }
+      if (wizardModel !== null) {
+        realView.wizard.bindModel(wizardModel);
+      }
+      if (wizardActions !== null) {
+        realView.wizard.bindActions(wizardActions);
+      }
+      if (wizardFocusTarget !== null) {
+        realView.wizard.focus(wizardFocusTarget);
+        wizardFocusTarget = null;
+      }
+    },
+  };
+}
+
+function createDeferredAnalysisPanelView(): {
+  attach(realView: AnalysisPanelView): void;
+  view: AnalysisPanelView;
+} {
+  type AnalysisActions = Parameters<AnalysisPanelView["bindActions"]>[0];
+  type AnalysisCarAvailability = Parameters<AnalysisPanelView["bindCarAvailability"]>[0];
+  type AnalysisFocusField = Parameters<AnalysisPanelView["focusField"]>[0];
+  type AnalysisModel = Parameters<AnalysisPanelView["bindModel"]>[0];
+
+  let actions: AnalysisActions | null = null;
+  let carAvailability: AnalysisCarAvailability | null = null;
+  let focusField: AnalysisFocusField | null = null;
+  let guidanceOpenRequested = false;
+  let model: AnalysisModel | null = null;
+  let realView: AnalysisPanelView | null = null;
+
+  return {
+    view: {
+      bindModel(nextModel) {
+        model = nextModel;
+        realView?.bindModel(nextModel);
+      },
+      bindActions(nextActions) {
+        actions = nextActions;
+        realView?.bindActions(nextActions);
+      },
+      bindCarAvailability(nextCarAvailability) {
+        carAvailability = nextCarAvailability;
+        realView?.bindCarAvailability(nextCarAvailability);
+      },
+      openGuidance() {
+        guidanceOpenRequested = true;
+        realView?.openGuidance();
+        if (realView !== null) {
+          guidanceOpenRequested = false;
+        }
+      },
+      focusField(nextFocusField) {
+        focusField = nextFocusField;
+        realView?.focusField(nextFocusField);
+        if (realView !== null) {
+          focusField = null;
+        }
+      },
+    },
+    attach(nextRealView) {
+      realView = nextRealView;
+      if (model !== null) {
+        realView.bindModel(model);
+      }
+      if (actions !== null) {
+        realView.bindActions(actions);
+      }
+      if (carAvailability !== null) {
+        realView.bindCarAvailability(carAvailability);
+      }
+      if (guidanceOpenRequested) {
+        realView.openGuidance();
+        guidanceOpenRequested = false;
+      }
+      if (focusField !== null) {
+        realView.focusField(focusField);
+        focusField = null;
+      }
+    },
+  };
+}
+
+function createDeferredSensorsPanelView(): {
+  attach(realView: SensorsPanelView): void;
+  view: SensorsPanelView;
+} {
+  type SensorsActions = Parameters<SensorsPanelView["bindActions"]>[0];
+  type SensorsModel = Parameters<SensorsPanelView["bindModel"]>[0];
+
+  let actions: SensorsActions | null = null;
+  let model: SensorsModel | null = null;
+  let realView: SensorsPanelView | null = null;
+
+  return {
+    view: {
+      bindModel(nextModel) {
+        model = nextModel;
+        realView?.bindModel(nextModel);
+      },
+      bindActions(nextActions) {
+        actions = nextActions;
+        realView?.bindActions(nextActions);
+      },
+    },
+    attach(nextRealView) {
+      realView = nextRealView;
+      if (model !== null) {
+        realView.bindModel(model);
+      }
+      if (actions !== null) {
+        realView.bindActions(actions);
+      }
+    },
+  };
+}
+
+function createDeferredSpeedSourcePanelView(): {
+  attach(realView: SpeedSourcePanelView): void;
+  view: SpeedSourcePanelView;
+} {
+  type SpeedSourceActions = Parameters<SpeedSourcePanelView["bindActions"]>[0];
+  type SpeedSourceDiagnostics = Parameters<SpeedSourcePanelView["bindDiagnostics"]>[0];
+  type SpeedSourceModel = Parameters<SpeedSourcePanelView["bindModel"]>[0];
+  type PendingFocusTarget = "manual" | "scan" | "stale";
+
+  let actions: SpeedSourceActions | null = null;
+  let diagnostics: SpeedSourceDiagnostics | null = null;
+  let model: SpeedSourceModel | null = null;
+  let pendingFocusTarget: PendingFocusTarget | null = null;
+  let realView: SpeedSourcePanelView | null = null;
+
+  const flushPendingFocusTarget = (): void => {
+    if (realView === null || pendingFocusTarget === null) {
+      return;
+    }
+    if (pendingFocusTarget === "manual") {
+      realView.focusManualSpeedInput();
+    } else if (pendingFocusTarget === "scan") {
+      realView.focusScanObdDevices();
+    } else {
+      realView.focusStaleTimeoutInput();
+    }
+    pendingFocusTarget = null;
+  };
+
+  return {
+    view: {
+      bindModel(nextModel) {
+        model = nextModel;
+        realView?.bindModel(nextModel);
+      },
+      bindActions(nextActions) {
+        actions = nextActions;
+        realView?.bindActions(nextActions);
+      },
+      bindDiagnostics(nextDiagnostics) {
+        diagnostics = nextDiagnostics;
+        realView?.bindDiagnostics(nextDiagnostics);
+      },
+      focusManualSpeedInput() {
+        pendingFocusTarget = "manual";
+        flushPendingFocusTarget();
+      },
+      focusScanObdDevices() {
+        pendingFocusTarget = "scan";
+        flushPendingFocusTarget();
+      },
+      focusStaleTimeoutInput() {
+        pendingFocusTarget = "stale";
+        flushPendingFocusTarget();
+      },
+      isObdConfigVisible() {
+        if (realView !== null) {
+          return realView.isObdConfigVisible();
+        }
+        return model?.value.obdConfigVisible ?? false;
+      },
+    },
+    attach(nextRealView) {
+      realView = nextRealView;
+      if (model !== null) {
+        realView.bindModel(model);
+      }
+      if (actions !== null) {
+        realView.bindActions(actions);
+      }
+      if (diagnostics !== null) {
+        realView.bindDiagnostics(diagnostics);
+      }
+      flushPendingFocusTarget();
+    },
+  };
+}
+
+function createDeferredUpdatePanelView(): {
+  attach(realView: UpdatePanelView): void;
+  view: UpdatePanelView;
+} {
+  type UpdateActions = Parameters<UpdatePanelView["bindActions"]>[0];
+  type UpdateModel = Parameters<UpdatePanelView["bindModel"]>[0];
+
+  let actions: UpdateActions | null = null;
+  let model: UpdateModel | null = null;
+  let realView: UpdatePanelView | null = null;
+
+  return {
+    view: {
+      bindModel(nextModel) {
+        model = nextModel;
+        realView?.bindModel(nextModel);
+      },
+      bindActions(nextActions) {
+        actions = nextActions;
+        realView?.bindActions(nextActions);
+      },
+    },
+    attach(nextRealView) {
+      realView = nextRealView;
+      if (model !== null) {
+        realView.bindModel(model);
+      }
+      if (actions !== null) {
+        realView.bindActions(actions);
+      }
+    },
+  };
+}
+
+function createDeferredInternetPanelView(): {
+  attach(realView: InternetPanelView): void;
+  view: InternetPanelView;
+} {
+  type InternetActions = Parameters<InternetPanelView["bindActions"]>[0];
+  type InternetModel = Parameters<InternetPanelView["bindModel"]>[0];
+
+  let actions: InternetActions | null = null;
+  let focusSsidRequested = false;
+  let model: InternetModel | null = null;
+  let realView: InternetPanelView | null = null;
+
+  return {
+    view: {
+      bindModel(nextModel) {
+        model = nextModel;
+        realView?.bindModel(nextModel);
+      },
+      bindActions(nextActions) {
+        actions = nextActions;
+        realView?.bindActions(nextActions);
+      },
+      focusSsidInput() {
+        focusSsidRequested = true;
+        realView?.focusSsidInput();
+        if (realView !== null) {
+          focusSsidRequested = false;
+        }
+      },
+    },
+    attach(nextRealView) {
+      realView = nextRealView;
+      if (model !== null) {
+        realView.bindModel(model);
+      }
+      if (actions !== null) {
+        realView.bindActions(actions);
+      }
+      if (focusSsidRequested) {
+        realView.focusSsidInput();
+        focusSsidRequested = false;
+      }
+    },
+  };
+}
+
+function createDeferredEspFlashPanelView(): {
+  attach(realView: EspFlashPanelView): void;
+  view: EspFlashPanelView;
+} {
+  type EspFlashActions = Parameters<EspFlashPanelView["bindActions"]>[0];
+  type EspFlashModel = Parameters<EspFlashPanelView["bindModel"]>[0];
+
+  let actions: EspFlashActions | null = null;
+  let model: EspFlashModel | null = null;
+  let realView: EspFlashPanelView | null = null;
+
+  return {
+    view: {
+      bindModel(nextModel) {
+        model = nextModel;
+        realView?.bindModel(nextModel);
+      },
+      bindActions(nextActions) {
+        actions = nextActions;
+        realView?.bindActions(nextActions);
+      },
+    },
+    attach(nextRealView) {
+      realView = nextRealView;
+      if (model !== null) {
+        realView.bindModel(model);
+      }
+      if (actions !== null) {
+        realView.bindActions(actions);
+      }
+    },
+  };
+}
+
+export function createLazyUiPanels(deps: CreateUiLazyPanelsDeps = {}): UiLazyPanels {
+  const hosts = deps.hosts ?? resolveUiPanelHosts();
+  const dashboard = (deps.mountDashboardPanels ?? mountDashboardPanels)(hosts);
+  const history = createDeferredHistoryPanelView();
+  const settingsShell = createDeferredSettingsShellView();
+  const settings = {
+    analysis: createDeferredAnalysisPanelView(),
+    cars: createDeferredCarsPanelView(),
+    espFlash: createDeferredEspFlashPanelView(),
+    internet: createDeferredInternetPanelView(),
+    sensors: createDeferredSensorsPanelView(),
+    speedSource: createDeferredSpeedSourcePanelView(),
+    update: createDeferredUpdatePanelView(),
+  };
+  let historyMountPromise: Promise<void> | null = null;
+  let settingsMountPromise: Promise<void> | null = null;
+
+  const attachSettingsPanels = (mountedPanels: UiMountedLazyPanels): void => {
+    settingsShell.attach(mountedPanels.settingsShell);
+    settings.cars.attach(mountedPanels.settings.cars);
+    settings.analysis.attach(mountedPanels.settings.analysis);
+    settings.internet.attach(mountedPanels.settings.internet);
+    settings.update.attach(mountedPanels.settings.update);
+    settings.sensors.attach(mountedPanels.settings.sensors);
+    settings.speedSource.attach(mountedPanels.settings.speedSource);
+    settings.espFlash.attach(mountedPanels.settings.espFlash);
+  };
+
+  const ensureHistoryMounted = (): Promise<void> => {
+    if (historyMountPromise === null) {
+      historyMountPromise = (deps.loadHistoryPanel ?? mountHistoryPanelLazy)(hosts).then(
+        (realView) => {
+          history.attach(realView);
+        },
+      );
+    }
+    return historyMountPromise;
+  };
+
+  const ensureSettingsMounted = (): Promise<void> => {
+    if (settingsMountPromise === null) {
+      settingsMountPromise = (deps.loadSettingsPanels ?? mountSettingsPanelsLazy)(hosts).then(
+        (mountedPanels) => {
+          attachSettingsPanels(mountedPanels);
+        },
+      );
+    }
+    return settingsMountPromise;
+  };
+
+  return {
+    panels: {
+      dashboard,
+      history: history.view,
+      settingsShell: settingsShell.view,
+      settings: {
+        analysis: settings.analysis.view,
+        cars: settings.cars.view,
+        espFlash: settings.espFlash.view,
+        internet: settings.internet.view,
+        sensors: settings.sensors.view,
+        speedSource: settings.speedSource.view,
+        update: settings.update.view,
+      },
+    },
+    ensureViewPanels(viewId) {
+      if (viewId === HISTORY_VIEW_ID) {
+        return ensureHistoryMounted();
+      }
+      if (viewId === SETTINGS_VIEW_ID) {
+        return ensureSettingsMounted();
+      }
+      return Promise.resolve();
+    },
+    prefetchHiddenPanels() {
+      (deps.scheduleDeferredWork ?? scheduleDeferredWork)(() => {
+        void ensureHistoryMounted();
+        void ensureSettingsMounted();
+      });
+    },
+  };
+}

--- a/apps/ui/src/app/ui_panel_bootstrap.ts
+++ b/apps/ui/src/app/ui_panel_bootstrap.ts
@@ -3,12 +3,11 @@ import {
   resolveUiPanelHosts,
   type UiPanelHostRegistry,
 } from "./ui_panel_host_registry";
-import { mountAnalysisPanel, type AnalysisPanelView } from "./views/analysis_panel";
-import { mountCarsPanel, type CarsPanelView } from "./views/cars_panel";
-import { mountEspFlashPanel, type EspFlashPanelView } from "./views/esp_flash_panel";
-import { mountHistoryPanel } from "./views/history_panel";
+import type { AnalysisPanelView } from "./views/analysis_panel";
+import type { CarsPanelView } from "./views/cars_panel";
+import type { EspFlashPanelView } from "./views/esp_flash_panel";
 import type { HistoryPanelView } from "./views/history_table_view";
-import { mountInternetPanel, type InternetPanelView } from "./views/internet_panel";
+import type { InternetPanelView } from "./views/internet_panel";
 import {
   mountRealtimeLoggingPanel,
   type RealtimeLoggingPanelBridge,
@@ -17,41 +16,80 @@ import {
   mountRealtimeLiveOverview,
   type RealtimeLiveOverviewBridge,
 } from "./views/realtime_live_overview";
-import { mountSensorsPanel, type SensorsPanelView } from "./views/sensors_panel";
-import { mountSettingsShell, type SettingsShellView } from "./views/settings_shell";
-import { mountSpeedSourcePanel, type SpeedSourcePanelView } from "./views/speed_source_panel";
+import type { SensorsPanelView } from "./views/sensors_panel";
+import type { SettingsShellView } from "./views/settings_shell";
+import type { SpeedSourcePanelView } from "./views/speed_source_panel";
 import { mountSpectrumPanel } from "./views/spectrum_panel";
-import { mountUpdatePanel, type UpdatePanelView } from "./views/update_panel";
+import type { UpdatePanelView } from "./views/update_panel";
+
+export interface UiMountedDashboardPanels {
+  spectrum: SpectrumPanelView;
+  liveOverview: RealtimeLiveOverviewBridge;
+  logging: RealtimeLoggingPanelBridge;
+}
+
+export interface UiMountedSettingsPanels {
+  cars: CarsPanelView;
+  analysis: AnalysisPanelView;
+  internet: InternetPanelView;
+  update: UpdatePanelView;
+  sensors: SensorsPanelView;
+  speedSource: SpeedSourcePanelView;
+  espFlash: EspFlashPanelView;
+}
 
 export interface UiMountedPanels {
-  dashboard: {
-    spectrum: SpectrumPanelView;
-    liveOverview: RealtimeLiveOverviewBridge;
-    logging: RealtimeLoggingPanelBridge;
-  };
+  dashboard: UiMountedDashboardPanels;
   history: HistoryPanelView;
   settingsShell: SettingsShellView;
-  settings: {
-    cars: CarsPanelView;
-    analysis: AnalysisPanelView;
-    internet: InternetPanelView;
-    update: UpdatePanelView;
-    sensors: SensorsPanelView;
-    speedSource: SpeedSourcePanelView;
-    espFlash: EspFlashPanelView;
+  settings: UiMountedSettingsPanels;
+}
+
+export type UiMountedLazyPanels = Pick<UiMountedPanels, "settingsShell" | "settings">;
+
+export function mountDashboardPanels(
+  hosts: UiPanelHostRegistry = resolveUiPanelHosts(),
+): UiMountedDashboardPanels {
+  return {
+    spectrum: mountSpectrumPanel(hosts.dashboard.spectrum),
+    liveOverview: mountRealtimeLiveOverview(hosts.dashboard.liveOverview),
+    logging: mountRealtimeLoggingPanel(hosts.dashboard.logging),
   };
 }
 
-export function mountUiPanels(hosts: UiPanelHostRegistry = resolveUiPanelHosts()): UiMountedPanels {
+export async function mountHistoryPanelLazy(
+  hosts: UiPanelHostRegistry = resolveUiPanelHosts(),
+): Promise<HistoryPanelView> {
+  const { mountHistoryPanel } = await import("./views/history_panel");
+  return mountHistoryPanel(hosts.history);
+}
+
+export async function mountSettingsPanelsLazy(
+  hosts: UiPanelHostRegistry = resolveUiPanelHosts(),
+): Promise<UiMountedLazyPanels> {
+  const settingsShellModulePromise = import("./views/settings_shell");
+  const settingsPanelModulesPromise = Promise.all([
+    import("./views/cars_panel"),
+    import("./views/analysis_panel"),
+    import("./views/internet_panel"),
+    import("./views/update_panel"),
+    import("./views/sensors_panel"),
+    import("./views/speed_source_panel"),
+    import("./views/esp_flash_panel"),
+  ]);
+  const { mountSettingsShell } = await settingsShellModulePromise;
   const settingsShell = mountSettingsShell(hosts.settingsShell);
   const settingsHosts = hosts.resolveSettingsPanels();
+  const [
+    { mountCarsPanel },
+    { mountAnalysisPanel },
+    { mountInternetPanel },
+    { mountUpdatePanel },
+    { mountSensorsPanel },
+    { mountSpeedSourcePanel },
+    { mountEspFlashPanel },
+  ] = await settingsPanelModulesPromise;
   return {
-    dashboard: {
-      spectrum: mountSpectrumPanel(hosts.dashboard.spectrum),
-      liveOverview: mountRealtimeLiveOverview(hosts.dashboard.liveOverview),
-      logging: mountRealtimeLoggingPanel(hosts.dashboard.logging),
-    },
-    history: mountHistoryPanel(hosts.history),
     settingsShell,
     settings: {
       cars: mountCarsPanel(settingsHosts.cars),

--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -10,6 +10,7 @@ import {
 } from "../ui_signals";
 import { SpeedSourceConfigPanel } from "./speed_source_config_panel";
 import { SpeedSourceDiagnosticsPanel } from "./speed_source_diagnostics_panel";
+import { DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL } from "./speed_source_panel_defaults";
 import type {
   SettingsFeedbackMessage,
 } from "./settings_feedback";
@@ -147,38 +148,6 @@ const DEFAULT_SPEED_SOURCE_PANEL_MODEL: SpeedSourcePanelRenderModel = {
     currentSourceText: "--",
     effectiveSpeedText: "--",
     fallbackActiveText: "--",
-  },
-};
-
-export const DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL: SpeedSourceDiagnosticsRenderModel = {
-  gps: {
-    deviceText: "--",
-    effectiveSpeedText: "--",
-    fallbackText: "--",
-    lastErrorText: "--",
-    lastUpdateText: "--",
-    rawSpeedText: "--",
-    reconnectText: "--",
-    stateText: "--",
-  },
-  obd: {
-    backoffText: "--",
-    configuredDeviceText: "--",
-    connectedText: "--",
-    debugHintText: "--",
-    effectiveCadenceText: "--",
-    errorsText: "--",
-    lastRpmText: "--",
-    modeText: "--",
-    pairingText: "--",
-    rawResponseText: "--",
-    requestRttText: "--",
-    rfcommChannelText: "--",
-    rpmAgeText: "--",
-    targetCadenceText: "--",
-    timeoutsText: "--",
-    trustedText: "--",
-    visible: false,
   },
 };
 

--- a/apps/ui/src/app/views/speed_source_panel_defaults.ts
+++ b/apps/ui/src/app/views/speed_source_panel_defaults.ts
@@ -1,0 +1,33 @@
+import type { SpeedSourceDiagnosticsRenderModel } from "./speed_source_panel";
+
+export const DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL: SpeedSourceDiagnosticsRenderModel = {
+  gps: {
+    deviceText: "--",
+    effectiveSpeedText: "--",
+    fallbackText: "--",
+    lastErrorText: "--",
+    lastUpdateText: "--",
+    rawSpeedText: "--",
+    reconnectText: "--",
+    stateText: "--",
+  },
+  obd: {
+    backoffText: "--",
+    configuredDeviceText: "--",
+    connectedText: "--",
+    debugHintText: "--",
+    effectiveCadenceText: "--",
+    errorsText: "--",
+    lastRpmText: "--",
+    modeText: "--",
+    pairingText: "--",
+    rawResponseText: "--",
+    requestRttText: "--",
+    rfcommChannelText: "--",
+    rpmAgeText: "--",
+    targetCadenceText: "--",
+    timeoutsText: "--",
+    trustedText: "--",
+    visible: false,
+  },
+};

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -465,6 +465,7 @@
   "status.running": "Running",
   "status.stopped": "Stopped",
   "status.unavailable": "Unavailable",
+  "status.view_load_failed": "This view could not be loaded right now.",
   "speed.gps": "{value} {unit} · GPS",
   "speed.obd2": "{value} {unit} · OBD2",
   "speed.override": "{value} {unit} · Manual override",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -465,6 +465,7 @@
   "status.running": "Lopend",
   "status.stopped": "Gestopt",
   "status.unavailable": "Niet beschikbaar",
+  "status.view_load_failed": "Deze weergave kon nu niet worden geladen.",
   "speed.gps": "{value} {unit} · GPS",
   "speed.obd2": "{value} {unit} · OBD2",
   "speed.override": "{value} {unit} · Handmatige override",

--- a/apps/ui/tests/ui_lazy_panels.spec.ts
+++ b/apps/ui/tests/ui_lazy_panels.spec.ts
@@ -1,0 +1,266 @@
+import { expect, test } from "@playwright/test";
+
+import { createLazyUiPanels } from "../src/app/ui_lazy_panels";
+import type { UiMountedDashboardPanels } from "../src/app/ui_panel_bootstrap";
+import type { UiPanelHostRegistry } from "../src/app/ui_panel_host_registry";
+import { signal } from "../src/app/ui_signals";
+import type { HistoryPanelView } from "../src/app/views/history_table_view";
+import type { InternetPanelView } from "../src/app/views/internet_panel";
+import type { SettingsShellView } from "../src/app/views/settings_shell";
+
+function fakeElement(): HTMLElement {
+  return new EventTarget() as unknown as HTMLElement;
+}
+
+function createFakeHosts(): UiPanelHostRegistry {
+  return {
+    dashboard: {
+      spectrum: fakeElement(),
+      liveOverview: fakeElement(),
+      logging: fakeElement(),
+    },
+    history: fakeElement(),
+    settingsShell: fakeElement(),
+    resolveSettingsPanels() {
+      return {
+        cars: fakeElement(),
+        analysis: fakeElement(),
+        internet: fakeElement(),
+        update: fakeElement(),
+        sensors: fakeElement(),
+        speedSource: fakeElement(),
+        espFlash: fakeElement(),
+      };
+    },
+  };
+}
+
+function createDashboardPanels(): UiMountedDashboardPanels {
+  return {
+    spectrum: {} as UiMountedDashboardPanels["spectrum"],
+    liveOverview: {
+      setSpeedText() {
+        return undefined;
+      },
+    } as UiMountedDashboardPanels["liveOverview"],
+    logging: {} as UiMountedDashboardPanels["logging"],
+  };
+}
+
+function createHistoryPanelSpy() {
+  type HistoryActions = Parameters<HistoryPanelView["bindActions"]>[0];
+  type HistoryModel = Parameters<HistoryPanelView["bindModel"]>[0];
+
+  const actions: HistoryActions[] = [];
+  const models: HistoryModel[] = [];
+
+  return {
+    actions,
+    models,
+    view: {
+      bindActions(nextActions) {
+        actions.push(nextActions);
+      },
+      bindModel(nextModel) {
+        models.push(nextModel);
+      },
+    } satisfies HistoryPanelView,
+  };
+}
+
+function createSettingsShellSpy() {
+  const activations: string[] = [];
+  let activeTabId = "carTab";
+  let listener: ((tabId: string) => void) | null = null;
+
+  return {
+    activations,
+    emit(tabId: string) {
+      activeTabId = tabId;
+      listener?.(tabId);
+    },
+    view: {
+      activateTab(tabId) {
+        activeTabId = tabId;
+        activations.push(tabId);
+      },
+      getActiveTabId() {
+        return activeTabId;
+      },
+      subscribeActiveTabChanges(nextListener) {
+        listener = nextListener;
+        return () => {
+          if (listener === nextListener) {
+            listener = null;
+          }
+        };
+      },
+    } satisfies SettingsShellView,
+  };
+}
+
+function createInternetPanelSpy() {
+  type InternetActions = Parameters<InternetPanelView["bindActions"]>[0];
+  type InternetModel = Parameters<InternetPanelView["bindModel"]>[0];
+
+  const actions: InternetActions[] = [];
+  let focusCalls = 0;
+  const models: InternetModel[] = [];
+
+  return {
+    actions,
+    get focusCalls() {
+      return focusCalls;
+    },
+    models,
+    view: {
+      bindActions(nextActions) {
+        actions.push(nextActions);
+      },
+      bindModel(nextModel) {
+        models.push(nextModel);
+      },
+      focusSsidInput() {
+        focusCalls += 1;
+      },
+    } satisfies InternetPanelView,
+  };
+}
+
+test.describe("createLazyUiPanels", () => {
+  test("mounts dashboard immediately and replays deferred history/settings bindings", async () => {
+    const hosts = createFakeHosts();
+    const historyPanel = createHistoryPanelSpy();
+    const internetPanel = createInternetPanelSpy();
+    const settingsShell = createSettingsShellSpy();
+    let dashboardMounts = 0;
+    let historyLoads = 0;
+    let settingsLoads = 0;
+
+    const lazyPanels = createLazyUiPanels({
+      hosts,
+      mountDashboardPanels: () => {
+        dashboardMounts += 1;
+        return createDashboardPanels();
+      },
+      loadHistoryPanel: async () => {
+        historyLoads += 1;
+        return historyPanel.view;
+      },
+      loadSettingsPanels: async () => {
+        settingsLoads += 1;
+        return {
+          settingsShell: settingsShell.view,
+          settings: {
+            cars: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["cars"],
+            analysis: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["analysis"],
+            internet: internetPanel.view,
+            update: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["update"],
+            sensors: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["sensors"],
+            speedSource: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["speedSource"],
+            espFlash: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["espFlash"],
+          },
+        };
+      },
+    });
+
+    expect(dashboardMounts).toBe(1);
+    expect(historyLoads).toBe(0);
+    expect(settingsLoads).toBe(0);
+
+    const historyActions = {} as Parameters<HistoryPanelView["bindActions"]>[0];
+    const historyModel = signal({}) as unknown as Parameters<HistoryPanelView["bindModel"]>[0];
+    lazyPanels.panels.history.bindModel(historyModel);
+    lazyPanels.panels.history.bindActions(historyActions);
+
+    const tabChanges: string[] = [];
+    const dispose = lazyPanels.panels.settingsShell.subscribeActiveTabChanges((tabId) => {
+      tabChanges.push(tabId);
+    });
+    lazyPanels.panels.settingsShell.activateTab("updateTab");
+
+    const internetActions = {} as Parameters<InternetPanelView["bindActions"]>[0];
+    const internetModel = signal({}) as unknown as Parameters<InternetPanelView["bindModel"]>[0];
+    lazyPanels.panels.settings.internet.bindModel(internetModel);
+    lazyPanels.panels.settings.internet.bindActions(internetActions);
+    lazyPanels.panels.settings.internet.focusSsidInput();
+
+    await lazyPanels.ensureViewPanels("historyView");
+    expect(historyLoads).toBe(1);
+    expect(historyPanel.models).toEqual([historyModel]);
+    expect(historyPanel.actions).toEqual([historyActions]);
+
+    await lazyPanels.ensureViewPanels("settingsView");
+    expect(settingsLoads).toBe(1);
+    expect(settingsShell.activations).toEqual(["updateTab"]);
+    expect(internetPanel.models).toEqual([internetModel]);
+    expect(internetPanel.actions).toEqual([internetActions]);
+    expect(internetPanel.focusCalls).toBe(1);
+    expect(tabChanges).toEqual(["updateTab"]);
+
+    settingsShell.emit("internetTab");
+    expect(lazyPanels.panels.settingsShell.getActiveTabId()).toBe("internetTab");
+    expect(tabChanges).toEqual(["updateTab", "internetTab"]);
+
+    await lazyPanels.ensureViewPanels("historyView");
+    await lazyPanels.ensureViewPanels("settingsView");
+    expect(historyLoads).toBe(1);
+    expect(settingsLoads).toBe(1);
+
+    dispose();
+  });
+
+  test("prefetchHiddenPanels schedules offscreen mounts through the deferred scheduler", async () => {
+    const hosts = createFakeHosts();
+    const historyPanel = createHistoryPanelSpy();
+    const settingsShell = createSettingsShellSpy();
+    const internetPanel = createInternetPanelSpy();
+    let historyLoads = 0;
+    let scheduledTask: (() => void) | null = null;
+    let settingsLoads = 0;
+
+    const lazyPanels = createLazyUiPanels({
+      hosts,
+      mountDashboardPanels: () => createDashboardPanels(),
+      loadHistoryPanel: async () => {
+        historyLoads += 1;
+        return historyPanel.view;
+      },
+      loadSettingsPanels: async () => {
+        settingsLoads += 1;
+        return {
+          settingsShell: settingsShell.view,
+          settings: {
+            cars: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["cars"],
+            analysis: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["analysis"],
+            internet: internetPanel.view,
+            update: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["update"],
+            sensors: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["sensors"],
+            speedSource: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["speedSource"],
+            espFlash: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["espFlash"],
+          },
+        };
+      },
+      scheduleDeferredWork: (task) => {
+        scheduledTask = task;
+      },
+    });
+
+    lazyPanels.prefetchHiddenPanels();
+    expect(historyLoads).toBe(0);
+    expect(settingsLoads).toBe(0);
+    expect(scheduledTask).not.toBeNull();
+
+    scheduledTask?.();
+    await Promise.resolve();
+    expect(historyLoads).toBe(1);
+    expect(settingsLoads).toBe(1);
+
+    scheduledTask = null;
+    lazyPanels.prefetchHiddenPanels();
+    scheduledTask?.();
+    await Promise.resolve();
+    expect(historyLoads).toBe(1);
+    expect(settingsLoads).toBe(1);
+  });
+});

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -42,11 +42,15 @@ function testTranslation(key: string, vars?: Record<string, unknown>): string {
 test.describe("createUiShellNavigationModule", () => {
   test("setActiveView updates signal-backed state and falls back to dashboard", () => {
     const state = createAppState();
+    const activatedViews: string[] = [];
     let resizeCalls = 0;
 
     const module = createUiShellNavigationModule({
       shell: state.shell,
       viewIds: [DEFAULT_SHELL_VIEW_ID, "historyView"],
+      onViewActivated: (viewId) => {
+        activatedViews.push(viewId);
+      },
       onDashboardViewActivated: () => {
         resizeCalls += 1;
       },
@@ -55,12 +59,66 @@ test.describe("createUiShellNavigationModule", () => {
     module.setActiveView("historyView");
     expect(state.shell.activeViewId).toBe("historyView");
     expect(module.activeViewId.value).toBe("historyView");
+    expect(activatedViews).toEqual(["historyView"]);
     expect(resizeCalls).toBe(0);
 
     module.setActiveView("missingView");
     expect(state.shell.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
     expect(module.activeViewId.value).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(activatedViews).toEqual(["historyView"]);
     expect(resizeCalls).toBe(1);
+  });
+
+  test("waits for async lazy-view activation before switching views", async () => {
+    const state = createAppState();
+    let resolveActivation: (() => void) | null = null;
+
+    const module = createUiShellNavigationModule({
+      shell: state.shell,
+      viewIds: [DEFAULT_SHELL_VIEW_ID, "settingsView"],
+      onViewActivated: (viewId) =>
+        viewId === "settingsView"
+          ? new Promise<void>((resolve) => {
+              resolveActivation = resolve;
+            })
+          : undefined,
+    });
+
+    module.setActiveView("settingsView");
+    expect(state.shell.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(module.activeViewId.value).toBe(DEFAULT_SHELL_VIEW_ID);
+
+    resolveActivation?.();
+    await Promise.resolve();
+
+    expect(state.shell.activeViewId).toBe("settingsView");
+    expect(module.activeViewId.value).toBe("settingsView");
+  });
+
+  test("keeps the current view when lazy activation fails", async () => {
+    const state = createAppState();
+    const activationErrors: string[] = [];
+
+    const module = createUiShellNavigationModule({
+      shell: state.shell,
+      viewIds: [DEFAULT_SHELL_VIEW_ID, "settingsView"],
+      onViewActivated: async () => {
+        throw new Error("chunk failed");
+      },
+      onViewActivationFailed: (viewId, error) => {
+        activationErrors.push(
+          `${viewId}:${error instanceof Error ? error.message : String(error)}`,
+        );
+      },
+    });
+
+    module.setActiveView("settingsView");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(state.shell.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(module.activeViewId.value).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(activationErrors).toEqual(["settingsView:chunk failed"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #2446 by keeping the dashboard panels on the startup path and deferring the history and settings panel mounts until they are actually needed. The new startup flow still gives the runtime the same full panel contracts it expects today, but it stops eagerly mounting offscreen history/settings islands during initial load. The first activation of those views now resolves their lazy mounts before switching views, and idle prefetch still warms them shortly after startup to keep cold-navigation latency low.

## Problem

The issue was still accurate in the current codebase. `apps/ui/src/app/ui_panel_bootstrap.ts` eagerly mounted every panel at startup:

- dashboard panels (`spectrum`, `live overview`, `logging`)
- history panel
- settings shell
- all seven settings sub-panels

That meant the initial UI parse/mount path included a large amount of code that was not visible on first paint. Only the dashboard is shown when the app starts, yet the history/settings islands and their related panel code were already being loaded and mounted.

The obvious fix from the issue text—“just don’t mount those panels yet”—is no longer enough on its own because the runtime has changed since the earlier panel/bootstrap cleanup. After the null-view removal work, the feature/runtime graph expects real panel contracts to exist up front. So the right implementation here was **lazy mounting**, not lazy feature creation. The runtime still needed stable history/settings view objects immediately, but the actual history/settings Preact islands could be attached later.

## Implementation approach

I split the solution into three layers:

1. keep only the dashboard mounts eager,
2. provide deferred wrapper views for history/settings so feature wiring stays unchanged,
3. activate lazy views only after their panel mounts resolve, with idle prefetch to hide most of that cost.

That preserves the existing feature ownership model and avoids reintroducing null bridges or a second runtime path.

## Main code changes by area

### `ui_panel_bootstrap.ts`: eager dashboard, lazy history/settings loaders

`apps/ui/src/app/ui_panel_bootstrap.ts` no longer statically imports and mounts every panel. It now:

- keeps the three dashboard mounts synchronous (`spectrum`, `liveOverview`, `logging`)
- exposes `mountHistoryPanelLazy()`
- exposes `mountSettingsPanelsLazy()`

The settings/history paths now use dynamic `import()` so those modules can split into separate chunks instead of riding the startup bundle.

### `ui_lazy_panels.ts`: deferred wrapper contracts

The new `apps/ui/src/app/ui_lazy_panels.ts` is the core compatibility layer. It creates stable wrapper views for:

- history
- settings shell
- cars
- analysis
- internet/update
- sensors
- speed source
- ESP flash

Each wrapper stores the latest bound model/actions and replays them once the real island attaches. For the few imperative seams that still matter (focus requests, tab activation, guidance reopening, diagnostics focus, SSID focus), the wrapper queues those calls and flushes them into the real view after attach.

That lets `UiAppRuntime` and the feature bundle keep receiving a full `UiMountedPanels` graph immediately, even though the real history/settings islands are not mounted yet.

### Startup/runtime wiring

`apps/ui/src/app/start_ui_app.ts` now creates lazy panels instead of eagerly calling `mountUiPanels()`. Startup behavior is:

1. mount shell chrome
2. mount dashboard panels eagerly
3. build runtime with the deferred panel wrappers
4. start the runtime
5. schedule idle prefetch for hidden history/settings panels

`apps/ui/src/app/ui_app_runtime.ts` now passes a single `ensureViewPanels()` callback into the shell controller. No feature wiring or runtime ownership had to be broadened beyond that.

### Navigation waits for lazy mounts before switching views

The most important follow-up change landed in `apps/ui/src/app/runtime/ui_shell_navigation_module.ts`. The first version of the lazy loading worked locally, but a review pass correctly identified a cold-navigation race: the shell could flip into `settingsView` or `historyView` before the lazy mount promise resolved, leaving a brief empty surface.

The final version fixes that by:

- starting lazy activation when a non-dashboard view is requested,
- waiting for the lazy mount promise before applying the new active view,
- using an activation token so rapid navigation changes do not replay stale activations,
- keeping dashboard activation synchronous,
- and catching lazy activation failures instead of leaving an unhandled rejection.

If a lazy activation fails, the app stays on the current safe view and the shell shows an error banner.

### Shell error handling

`apps/ui/src/app/runtime/ui_shell_controller.ts` now passes a lazy-activation failure handler into the navigation module. That handler:

- logs the underlying error for diagnosis
- shows a user-facing shell banner via `status.view_load_failed`

The new translation key was added to both English and Dutch catalogs.

### Keeping `speed_source_panel.tsx` lazily splittable

While validating the chunk split, Vite surfaced an important warning: `speed_source_panel.tsx` was still being pulled onto the startup path because `settings_gps_status_module.ts` imported `DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL` from the panel module itself.

To keep the speed-source panel genuinely lazy-loadable, I extracted that shared default into the new `apps/ui/src/app/views/speed_source_panel_defaults.ts`. The panel and the GPS status module now both import the default from that smaller module instead of forcing the entire panel file into the startup graph.

### Docs and tests

`apps/ui/README.md` now documents the startup shape more accurately:

- dashboard panels mount immediately
- history/settings are deferred
- `ui_lazy_panels.ts` owns the deferred-wrapper layer

I also added focused tests instead of relying only on smoke coverage:

- `apps/ui/tests/ui_lazy_panels.spec.ts` verifies dashboard panels mount immediately, deferred bindings replay into lazy history/settings panels, and idle prefetch schedules only one lazy load per surface
- `apps/ui/tests/ui_shell_runtime_modules.spec.ts` now verifies both async activation waiting and lazy activation failure handling

## Validation

I validated the change with both focused unit coverage and browser/runtime coverage:

```bash
cd apps/ui && npx playwright test tests/ui_lazy_panels.spec.ts tests/ui_shell_runtime_modules.spec.ts --workers=1
cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.history.spec.ts tests/smoke.settings.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1
cd apps/ui && npm run typecheck
cd apps/ui && npm run build
cd apps/ui && npm run lint
```

The production build now emits separate lazy chunks for the previously eager offscreen surfaces, including:

- `history_panel-*.js`
- `settings_shell-*.js`
- `cars_panel-*.js`
- `analysis_panel-*.js`
- `internet_panel-*.js`
- `update_panel-*.js`
- `sensors_panel-*.js`
- `speed_source_panel-*.js`
- `esp_flash_panel-*.js`

That confirms the non-critical settings/history panel code is no longer pinned to the startup bundle.

## Risks and tradeoffs considered

The main risk in this issue was not the dynamic import itself; it was preserving the existing runtime/feature contracts while lazy-loading the real panel owners. That is why the change uses deferred wrappers instead of a broader feature-creation rewrite.

I also explicitly handled the two biggest UX risks:

1. **blank cold-navigation states** — fixed by waiting for lazy mounts before switching into the new view
2. **lazy import failures** — fixed by catching activation failures, keeping the current view active, and surfacing a shell error banner

Idle prefetch remains in place because it gives the app most of the startup win from this issue without forcing every first navigation to pay the full lazy-load cost.

## Out of scope

This PR does not lazy-create settings/history feature workflows themselves. Those are still composed eagerly, which keeps the runtime architecture stable and avoids a much larger refactor. The issue only asked to defer initialization of non-visible panels, and this change does that while preserving the current runtime ownership seams.
