### PR TITLE
Replace history download DOM pattern with shared utility

### DIFF
--- a/apps/ui/src/app/dom/download.ts
+++ b/apps/ui/src/app/dom/download.ts
@@ -1,0 +1,12 @@
+const DOWNLOAD_REVOKE_DELAY_MS = 1000;
+
+export function triggerBlobDownload(blob: Blob, fileName: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(objectUrl), DOWNLOAD_REVOKE_DELAY_MS);
+}

--- a/apps/ui/src/app/features/history_download.ts
+++ b/apps/ui/src/app/features/history_download.ts
@@ -1,4 +1,4 @@
-const DOWNLOAD_REVOKE_DELAY_MS = 1000;
+import { triggerBlobDownload } from "../dom/download";
 
 export function filenameFromDisposition(headerValue: string | null, fallback: string): string {
   if (!headerValue) {
@@ -38,12 +38,5 @@ export async function downloadBlobFile(url: string, fallbackName: string): Promi
     response.headers.get("content-disposition"),
     fallbackName || "download.bin",
   );
-  const objectUrl = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = objectUrl;
-  anchor.download = fileName;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  setTimeout(() => URL.revokeObjectURL(objectUrl), DOWNLOAD_REVOKE_DELAY_MS);
+  triggerBlobDownload(blob, fileName);
 }

--- a/apps/ui/tests/history_download.spec.ts
+++ b/apps/ui/tests/history_download.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  downloadBlobFile,
+  filenameFromDisposition,
+} from "../src/app/features/history_download";
+
+test("filenameFromDisposition decodes UTF-8 and falls back when needed", () => {
+  expect(
+    filenameFromDisposition(
+      "attachment; filename*=UTF-8''run%20%C3%BC.pdf",
+      "fallback.pdf",
+    ),
+  ).toBe("run ü.pdf");
+  expect(
+    filenameFromDisposition('attachment; filename="run-001_report.pdf"', "fallback.pdf"),
+  ).toBe("run-001_report.pdf");
+  expect(filenameFromDisposition(null, "fallback.pdf")).toBe("fallback.pdf");
+  expect(filenameFromDisposition("attachment", "fallback.pdf")).toBe("fallback.pdf");
+});
+
+test("downloadBlobFile downloads with decoded filename and revokes the blob URL", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalDocument = (globalThis as { document?: Document }).document;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const originalSetTimeout = globalThis.setTimeout;
+  const anchorState = { href: "", download: "", clicks: 0, removed: 0 };
+  const revoked: string[] = [];
+
+  globalThis.fetch = (async () =>
+    new Response("PDF", {
+      status: 200,
+      headers: {
+        "content-type": "application/pdf",
+        "content-disposition": "attachment; filename*=UTF-8''run%20%C3%BC.pdf",
+      },
+    })) as typeof fetch;
+  (globalThis as { document?: Document }).document = {
+    body: {
+      appendChild() {
+        /* no-op */
+      },
+    } as unknown as HTMLBodyElement,
+    createElement(tagName: string) {
+      expect(tagName).toBe("a");
+      return {
+        set href(value: string) {
+          anchorState.href = value;
+        },
+        get href() {
+          return anchorState.href;
+        },
+        set download(value: string) {
+          anchorState.download = value;
+        },
+        get download() {
+          return anchorState.download;
+        },
+        click() {
+          anchorState.clicks += 1;
+        },
+        remove() {
+          anchorState.removed += 1;
+        },
+      } as unknown as HTMLAnchorElement;
+    },
+  } as Document;
+  URL.createObjectURL = (() => "blob:history-download-test") as typeof URL.createObjectURL;
+  URL.revokeObjectURL = ((url: string) => {
+    revoked.push(url);
+  }) as typeof URL.revokeObjectURL;
+  globalThis.setTimeout = ((handler: TimerHandler) => {
+    if (typeof handler === "function") {
+      handler();
+    }
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+
+  try {
+    await downloadBlobFile("/api/history/run-001/report.pdf", "fallback.pdf");
+  } finally {
+    globalThis.fetch = originalFetch;
+    (globalThis as { document?: Document }).document = originalDocument;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    globalThis.setTimeout = originalSetTimeout;
+  }
+
+  expect(anchorState.download).toBe("run ü.pdf");
+  expect(anchorState.href).toBe("blob:history-download-test");
+  expect(anchorState.clicks).toBe(1);
+  expect(anchorState.removed).toBe(1);
+  expect(revoked).toEqual(["blob:history-download-test"]);
+});

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
 
 import { createHistoryFeature } from "../src/app/features/history_feature";
-import { downloadBlobFile } from "../src/app/features/history_download";
 import { createAppState, type RunDetail } from "../src/app/ui_app_state";
 import { effect } from "../src/app/ui_signals";
 import type {
@@ -479,79 +478,6 @@ test("history feature preloads collapsed row context for completed runs", async 
   ]);
 });
 
-test("downloadBlobFile downloads with decoded filename and revokes the blob URL", async () => {
-  const originalFetch = globalThis.fetch;
-  const originalDocument = (globalThis as { document?: Document }).document;
-  const originalCreateObjectURL = URL.createObjectURL;
-  const originalRevokeObjectURL = URL.revokeObjectURL;
-  const originalSetTimeout = globalThis.setTimeout;
-  const anchorState = { href: "", download: "", clicks: 0, removed: 0 };
-  const revoked: string[] = [];
-
-  globalThis.fetch = (async () => new Response("PDF", {
-    status: 200,
-    headers: {
-      "content-type": "application/pdf",
-      "content-disposition": "attachment; filename*=UTF-8''run%20%C3%BC.pdf",
-    },
-  })) as typeof fetch;
-  (globalThis as { document?: Document }).document = {
-    body: {
-      appendChild() {
-        /* no-op */
-      },
-    } as unknown as HTMLBodyElement,
-    createElement(tagName: string) {
-      expect(tagName).toBe("a");
-      return {
-        set href(value: string) {
-          anchorState.href = value;
-        },
-        get href() {
-          return anchorState.href;
-        },
-        set download(value: string) {
-          anchorState.download = value;
-        },
-        get download() {
-          return anchorState.download;
-        },
-        click() {
-          anchorState.clicks += 1;
-        },
-        remove() {
-          anchorState.removed += 1;
-        },
-      } as unknown as HTMLAnchorElement;
-    },
-  } as Document;
-  URL.createObjectURL = (() => "blob:history-download-test") as typeof URL.createObjectURL;
-  URL.revokeObjectURL = ((url: string) => {
-    revoked.push(url);
-  }) as typeof URL.revokeObjectURL;
-  globalThis.setTimeout = ((handler: TimerHandler) => {
-    if (typeof handler === "function") {
-      handler();
-    }
-    return 0 as unknown as ReturnType<typeof setTimeout>;
-  }) as typeof setTimeout;
-
-  try {
-    await downloadBlobFile("/api/history/run-001/report.pdf", "fallback.pdf");
-  } finally {
-    globalThis.fetch = originalFetch;
-    (globalThis as { document?: Document }).document = originalDocument;
-    URL.createObjectURL = originalCreateObjectURL;
-    URL.revokeObjectURL = originalRevokeObjectURL;
-    globalThis.setTimeout = originalSetTimeout;
-  }
-
-  expect(anchorState.download).toBe("run ü.pdf");
-  expect(anchorState.href).toBe("blob:history-download-test");
-  expect(anchorState.clicks).toBe(1);
-  expect(anchorState.removed).toBe(1);
-  expect(revoked).toEqual(["blob:history-download-test"]);
-});
 
 test("history feature reports partial delete failures without splitting render ownership", async () => {
   const state = createAppState();


### PR DESCRIPTION
## Summary

This PR replaces the imperative blob-download DOM sequence inside
`apps/ui/src/app/features/history_download.ts` with a small shared utility in
`apps/ui/src/app/dom/download.ts`. The behavior is intentionally unchanged: the
history feature still fetches the file, derives the best filename from the
`Content-Disposition` header, creates a blob URL, triggers the browser
download, and revokes the blob URL after the same safe delay. The main change
is ownership. The DOM-specific anchor work now lives in one reusable helper,
and the history download test coverage now lives in a focused spec instead of
being buried inside the large history omnibus module.

Closes #2449.

## Problem

Issue #2449 pointed out that the history download helper still performed a
small but explicit block of manual DOM work inline:

1. create a temporary anchor
2. assign the blob URL
3. assign the filename
4. append the element to `document.body`
5. click it
6. remove it
7. revoke the object URL later

That pattern is common in browser code, but it was sitting directly in a
feature module whose main job is otherwise business-level history download
logic: fetch the file, interpret the response, derive the filename, and surface
errors cleanly. Keeping the anchor manipulation inline was not a correctness
bug, but it made the feature module more DOM-specific than it needed to be and
left no shared home for this browser download pattern if another feature needs
it later.

The issue body was also slightly stale on the path name: the live code now sits
in `apps/ui/src/app/features/history_download.ts`, not under `app/views/`.
After checking the repo-wide call sites, though, the core problem statement was
still accurate. There was exactly one live `createObjectURL` + temporary anchor
download flow in app code, and it was only used from the history feature.

## Implementation approach

I kept the fix deliberately narrow and behavior-preserving.

Instead of changing the history feature contract, browser flow, or revoke
timing, this PR introduces a tiny DOM utility:

- `apps/ui/src/app/dom/download.ts`

That module exports `triggerBlobDownload(blob, fileName)`, which owns the
browser-only work of creating the blob URL, creating and clicking the temporary
anchor, removing it, and scheduling the delayed `URL.revokeObjectURL()` call.

With that in place, `history_download.ts` stays responsible for the feature
logic that actually belongs there:

- fetch the requested file
- surface HTTP error details
- decode the filename from `Content-Disposition`
- hand the resulting `Blob` + resolved filename to the DOM helper

This keeps the feature module focused on history-download semantics rather than
browser element choreography.

I also used the opportunity to improve the test layout rather than just moving
production code around. The focused `downloadBlobFile` assertion was previously
embedded inside `tests/history_feature_modules.spec.ts`, which is already a
large regression file covering many unrelated history-owner behaviors. Instead
of expanding that omnibus test file further, the download-specific coverage now
lives in a dedicated `tests/history_download.spec.ts`.

## Main code changes

### 1. Added `app/dom/download.ts`

The new DOM utility centralizes the imperative anchor pattern in one place:

- create the blob URL
- create the anchor
- set `href` and `download`
- append to `document.body`
- click
- remove
- revoke the URL after the existing 1-second delay

Nothing about the actual behavior changes here. This is the same sequence the
history feature already used, simply moved into a shared utility module where
future download flows can reuse it.

### 2. Simplified `history_download.ts`

`apps/ui/src/app/features/history_download.ts` now imports
`triggerBlobDownload()` and delegates the DOM work there. The feature file keeps
`filenameFromDisposition()` and `downloadBlobFile()` focused on response
handling and filename resolution instead of direct element mutation.

### 3. Moved focused download tests into `history_download.spec.ts`

The new focused spec now covers:

- UTF-8 and simple filename parsing behavior in `filenameFromDisposition()`
- the end-to-end `downloadBlobFile()` flow, including anchor setup, click,
  removal, and delayed blob URL revocation

That preserves the behavior coverage the repo already had, but places it next
to the download seam instead of inside the broader history-owner module tests.

### 4. Trimmed `history_feature_modules.spec.ts`

The large history omnibus spec no longer carries the low-level download helper
test. It stays focused on the actual history feature ownership and render-state
behavior, while the download seam gets its own dedicated test module.

## Validation

I validated this change proportionately around the touched surface:

```bash
cd apps/ui
npx playwright test tests/history_download.spec.ts tests/history_feature_modules.spec.ts --workers=1
npx playwright test tests/smoke.history.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1 -g "history PDF download revokes object URL with safe delay"
npm run typecheck
npm run build
npm run lint
```

That covers both the focused node-side download seam and the browser-level
history PDF download behavior that verifies the object URL still revokes after a
safe delay rather than immediately.

## Risks and tradeoffs

The biggest risk in a refactor like this is accidentally changing browser
download behavior while “cleaning up” the code. I avoided that by keeping the
DOM sequence intact and moving it byte-for-byte into the utility instead of
trying to modernize or generalize the flow further.

I also did not introduce dependency injection or a larger abstraction layer
around downloads. That would have widened the scope beyond what this issue
needs. The new helper is intentionally small: it is just enough to centralize
the browser-specific pattern and give future features one canonical place to
reuse it.

The test change makes a similar tradeoff. I did not attempt to rewrite the
browser smoke or change the history feature contract. I only moved the focused
unit-style assertion into a dedicated spec so the download seam is easier to
find and maintain.

## Out of scope

This PR does not change history feature behavior, alter the browser download
UX, rename action selectors, or add a generalized cross-platform file-download
framework. It is a narrow extraction that keeps the history feature logic the
same while centralizing the DOM-specific blob-download pattern in one shared
utility.
