### PR TITLE
Split cars workflow renderState into grouped computeds

### DIFF
--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -79,6 +79,29 @@ export interface CarsFeatureRenderState {
   variantOptions: readonly CarLibraryVariant[];
 }
 
+type CarsFeatureOptionsRenderState = Pick<
+  CarsFeatureRenderState,
+  | "brandOptions"
+  | "gearboxOptions"
+  | "modelOptions"
+  | "noGearboxesMessage"
+  | "tireOptions"
+  | "typeOptions"
+  | "variantOptions"
+>;
+
+type CarsFeatureWizardMetaRenderState = Pick<
+  CarsFeatureRenderState,
+  | "actionHint"
+  | "canFinish"
+  | "isOpen"
+  | "resolvedSpecBranch"
+  | "selectedGearbox"
+  | "selectedTire"
+  | "step"
+  | "summaryData"
+>;
+
 export interface CarsFeatureWorkflowViewPorts {
   focus(target: CarsFeatureFocusTarget): void;
 }
@@ -192,33 +215,55 @@ export function createCarsFeatureWorkflow(
     });
   });
 
-  const renderState = computed<CarsFeatureRenderState>(() => {
+  const optionsRenderState = computed<CarsFeatureOptionsRenderState>(() => ({
+    brandOptions: brandOptions.value,
+    gearboxOptions: gearboxOptions.value,
+    modelOptions: modelOptions.value,
+    noGearboxesMessage: noGearboxesMessage.value,
+    tireOptions: tireOptions.value,
+    typeOptions: typeOptions.value,
+    variantOptions: variantOptions.value,
+  }));
+
+  const manualInputRenderState = computed<CarsFeatureManualInputState>(() =>
+    cloneManualInputs(manualInputs.read())
+  );
+
+  const wizardMetaRenderState = computed<CarsFeatureWizardMetaRenderState>(() => {
     const state = wizardState.value;
-    const inputs = manualInputs.read();
-    const currentBrandOptions = brandOptions.value;
-    const currentTypeOptions = typeOptions.value;
-    const currentModelOptions = modelOptions.value;
-    const currentVariantOptions = variantOptions.value;
-    const currentTireOptions = tireOptions.value;
-    const currentGearboxOptions = gearboxOptions.value;
-    const currentNoGearboxesMessage = noGearboxesMessage.value;
     return {
       actionHint: actionHint.value,
-      brandOptions: currentBrandOptions,
       canFinish: canFinish.value,
-      gearboxOptions: currentGearboxOptions,
       isOpen: isOpen.value,
-      manualInputs: cloneManualInputs(inputs),
-      modelOptions: currentModelOptions,
-      noGearboxesMessage: currentNoGearboxesMessage,
       resolvedSpecBranch: resolvedSpecBranch.value,
       selectedGearbox: state.selectedGearbox,
       selectedTire: state.selectedTire,
       step: state.step,
       summaryData: summaryData.value,
-      tireOptions: currentTireOptions,
-      typeOptions: currentTypeOptions,
-      variantOptions: currentVariantOptions,
+    };
+  });
+
+  const renderState = computed<CarsFeatureRenderState>(() => {
+    const optionsState = optionsRenderState.value;
+    const manualInputsState = manualInputRenderState.value;
+    const wizardMetaState = wizardMetaRenderState.value;
+    return {
+      actionHint: wizardMetaState.actionHint,
+      brandOptions: optionsState.brandOptions,
+      canFinish: wizardMetaState.canFinish,
+      gearboxOptions: optionsState.gearboxOptions,
+      isOpen: wizardMetaState.isOpen,
+      manualInputs: manualInputsState,
+      modelOptions: optionsState.modelOptions,
+      noGearboxesMessage: optionsState.noGearboxesMessage,
+      resolvedSpecBranch: wizardMetaState.resolvedSpecBranch,
+      selectedGearbox: wizardMetaState.selectedGearbox,
+      selectedTire: wizardMetaState.selectedTire,
+      step: wizardMetaState.step,
+      summaryData: wizardMetaState.summaryData,
+      tireOptions: optionsState.tireOptions,
+      typeOptions: optionsState.typeOptions,
+      variantOptions: optionsState.variantOptions,
     };
   });
 

--- a/apps/ui/tests/cars_feature_workflow.spec.ts
+++ b/apps/ui/tests/cars_feature_workflow.spec.ts
@@ -300,6 +300,33 @@ test.describe("createCarsFeatureWorkflow", () => {
     expect(rerenderState.gearboxOptions).toBe(initialRenderState.gearboxOptions);
   });
 
+  test("keeps manual input references stable while option state changes", async () => {
+    const harness = createHarness();
+    const workflow = createCarsFeatureWorkflow({
+      addCarFromWizard: async () => undefined,
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      t: createTranslator(),
+      transport: {
+        async loadBrands() {
+          return ["BMW"];
+        },
+        async loadTypes() {
+          return ["SUV"];
+        },
+      },
+      view: createViewPorts(harness),
+    });
+
+    await workflow.openWizard();
+
+    const initialRenderState = workflow.getRenderState();
+    await workflow.selectBrand("BMW");
+
+    const rerenderState = workflow.getRenderState();
+    expect(rerenderState.typeOptions).not.toBe(initialRenderState.typeOptions);
+    expect(rerenderState.manualInputs).toBe(initialRenderState.manualInputs);
+  });
+
   test("keeps the library branch disabled until a gearbox is chosen and then submits the selected specs", async () => {
     const harness = createHarness();
     const addCalls: Array<{


### PR DESCRIPTION
## Summary

This PR finishes the remaining `renderState` split described in #2450 by breaking the broad top-level computed in `apps/ui/src/app/features/cars_feature_workflow.ts` into smaller grouped computeds and then recomposing the public render model from those grouped pieces. The external `CarsFeatureRenderState` contract stays the same, but the internal dependency graph is narrower: option changes now flow through an option-specific computed, wizard-meta changes flow through a wizard-meta computed, and manual input changes flow through a dedicated manual-input computed instead of every update rebuilding one large object from many unrelated sources.

That is the important distinction for this issue. This change is not a broad rewrite of the cars workflow and it does not alter how the wizard behaves. It is a focused reactive-ownership cleanup that narrows invalidation inside an existing workflow file while keeping the public render surface stable for the rest of the cars feature and its views.

Closes #2450.

## Problem

Even after the earlier cars workflow cleanup issues landed, `cars_feature_workflow.ts` still had one remaining broad computed that pulled together wizard state, summary/action-hint derivations, option arrays, selected library choices, the no-gearboxes message, and cloned manual inputs in one place. That meant the top-level `renderState` depended on a wide set of source signals, so a change in one concern still re-ran the whole composition path for the others.

Issue #2402 had already removed part of that weight by extracting summary-related derivations into smaller computeds, so the live code no longer matched the issue body exactly line for line. But the body was still directionally correct: the remaining hotspot was the top-level `renderState` computed itself, not the already-extracted summary helpers. The honest fix here was to finish that remaining split instead of inventing a new abstraction or trying to broaden this into a larger cars workflow refactor.

## Implementation approach

The chosen implementation follows the issue’s suggested decomposition and keeps it intentionally literal:

1. `optionsRenderState` groups the option-array and option-message inputs that come from the library-selection flow.
2. `manualInputRenderState` owns the manual-input clone so that manual draft state has one focused derived owner.
3. `wizardMetaRenderState` groups the wizard-step metadata, selected library choices, summary data, finishability, and action hint.
4. The public `renderState` computed becomes a thin composition layer that reads those three grouped computeds and assembles the final `CarsFeatureRenderState`.

This keeps the public shape unchanged while narrowing which parts of the dependency graph need to update when only one concern changes. The refactor also stays inside the existing workflow file rather than moving logic into another helper module, because this issue is specifically about the structure of the computed graph, not about introducing a new reusable utility or another level of indirection.

## Main code changes

### `apps/ui/src/app/features/cars_feature_workflow.ts`

The workflow now defines two new private grouped render-state types:

- `CarsFeatureOptionsRenderState`
- `CarsFeatureWizardMetaRenderState`

These are both `Pick<>`-based slices of the existing `CarsFeatureRenderState`, which keeps the field definitions anchored to the current public render contract instead of duplicating separate handwritten interfaces. The manual-input slice reuses the already-existing `CarsFeatureManualInputState` type.

From there, the old one-shot `renderState` computation is split into three smaller computeds:

- `optionsRenderState`
- `manualInputRenderState`
- `wizardMetaRenderState`

`optionsRenderState` reads only the brand/type/model/variant/tire/gearbox option sources and the no-gearboxes message. `manualInputRenderState` reads only the manual input state and preserves the existing cloning behavior by continuing to call `cloneManualInputs(manualInputs.read())`. `wizardMetaRenderState` reads only the wizard state plus the already-existing derived summary/action-hint/finishability signals.

The top-level `renderState` then becomes a simple composition step that reads those grouped computeds and maps their fields back into the unchanged `CarsFeatureRenderState` output. No caller-facing property names changed, and no external imports needed to move.

### `apps/ui/tests/cars_feature_workflow.spec.ts`

The new regression test covers the key observable behavior that was still missing after the earlier cars workflow cleanup work: unchanged manual inputs should keep the same object identity when only option state changes.

The test opens the wizard, captures the initial render state, changes the selected brand so the downstream type options update, and then asserts two things:

1. the option state actually changed (`typeOptions` is a new reference), and
2. the unrelated manual input state did not (`manualInputs` keeps the same reference).

That is the most important proof for this issue because it confirms the grouped computed split is visible at the actual render-state boundary rather than only in the internal implementation shape.

## Validation

I kept validation focused on the cars workflow surfaces that this change can realistically affect:

- `cd apps/ui && npx playwright test tests/cars_feature_workflow.spec.ts tests/settings_cars_module.spec.ts --workers=1`
- `cd apps/ui && npx playwright test tests/smoke.car-wizard.spec.ts tests/smoke.cars.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

I also ran a focused review pass over the final diff before packaging the branch. That review did not surface any material bugs, missing dependency edges, or type-shape regressions in the computed split.

## Risks, tradeoffs, and edge cases

The main tradeoff in this PR is that it intentionally preserves the current `cloneManualInputs()` behavior instead of trying to solve the nearby clone-removal question at the same time. That was deliberate. Issue #2450 is about splitting the computed graph, and folding a clone-removal change into the same diff would blur the intent and make the regression surface wider than necessary.

Similarly, this PR does not try to further reorganize the cars workflow into new modules. The current file already went through adjacent cleanup work in earlier issues, and the remaining problem here was localized to the structure of the render-state composition. Keeping the fix in place makes the change easier to review and keeps the before/after behavior easier to compare.

The edge case to care about in a refactor like this is accidental dependency loss: if one of the grouped computeds stopped reading a source that the old broad computed depended on, parts of the UI could stop updating. That is why the implementation keeps the public `CarsFeatureRenderState` shape unchanged, preserves the existing derived summary/action-hint inputs, and adds the new object-identity regression around manual inputs while leaving the broader cars workflow and smoke tests in place.

## Out of scope

This PR does not remove `cloneManualInputs()`, introduce a shared helper for grouped signal properties, or change the cars wizard UX. Those remain separate questions covered by adjacent backlog items. The goal here is simply to finish the remaining `renderState` decomposition in a narrow, behavior-preserving way.
