### PR TITLE
Add shared useSignalProperties helper

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -246,6 +246,9 @@ instead of controller-side variant class interpolation.
 - Inside Preact components, prefer `useComputed()`, `useSignal()`, and
   `useSignalEffect()` over ad-hoc local refs or render-time signal reads when a
   hook-scoped reactive owner is clearer.
+- When several JSX bindings unwrap stable properties from the same model signal,
+  prefer `useSignalProperties()` from `app/ui_signals.ts` over repeating one
+  `useComputed(() => model.value.foo)` line per property.
 - Use `effect()` only for narrow imperative integrations such as timers,
   persistence, canvas/uPlot bridges, or other external-library coordination.
 - Preact-rendered copy should come from `useUiTranslation()` or `useUiText()`.

--- a/apps/ui/src/app/ui_signals.ts
+++ b/apps/ui/src/app/ui_signals.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "preact/hooks";
 import {
   batch,
   computed,
@@ -11,6 +12,20 @@ import {
   type Signal,
 } from "@preact/signals";
 
+type SignalPropertyMap<
+  T extends object,
+  K extends readonly (keyof T & string)[],
+> = {
+  readonly [P in K[number]]: ReadonlySignal<T[P]>;
+};
+
+type MutableSignalPropertyMap<
+  T extends object,
+  K extends readonly (keyof T & string)[],
+> = {
+  -readonly [P in K[number]]: ReadonlySignal<T[P]>;
+};
+
 /**
  * Canonical import surface for shared frontend reactive state.
  *
@@ -21,3 +36,17 @@ import {
  */
 export { batch, computed, effect, signal, untracked, useComputed, useSignal, useSignalEffect };
 export type { ReadonlySignal, Signal };
+
+export function useSignalProperties<
+  T extends object,
+  const K extends readonly (keyof T & string)[],
+>(source: ReadonlySignal<T>, keys: K): SignalPropertyMap<T, K> {
+  const keysSignature = JSON.stringify(keys);
+  return useMemo(() => {
+    const properties = {} as MutableSignalPropertyMap<T, K>;
+    for (const key of keys) {
+      properties[key] = computed(() => source.value[key]);
+    }
+    return properties;
+  }, [source, keysSignature]);
+}

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -4,6 +4,7 @@ import {
   computed,
   signal,
   useComputed,
+  useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
 import { HistoryTableBody } from "./history_table_content";
@@ -19,6 +20,12 @@ const DEFAULT_PANEL_MODEL: HistoryPanelRenderModel = {
   table: null,
 };
 
+const HISTORY_PANEL_MODEL_KEYS = [
+  "deleteAllRunsDisabled",
+  "historySummaryText",
+  "table",
+] as const;
+
 function HistoryPanel(props: {
   actions: ReadonlySignal<HistoryPanelActionHandlers | null>;
   model: ReadonlySignal<HistoryPanelRenderModel>;
@@ -30,9 +37,10 @@ function HistoryPanel(props: {
   const samplesLabel = useUiText("history.table.size", "Samples");
   const actionsLabel = useUiText("history.table.actions", "Actions");
   const actions = useComputed(() => props.actions.value);
-  const deleteAllRunsDisabled = useComputed(() => props.model.value.deleteAllRunsDisabled);
-  const historySummaryText = useComputed(() => props.model.value.historySummaryText);
-  const table = useComputed(() => props.model.value.table);
+  const { deleteAllRunsDisabled, historySummaryText, table } = useSignalProperties(
+    props.model,
+    HISTORY_PANEL_MODEL_KEYS,
+  );
   const handleRefreshHistory = () => {
     actions.value?.onRefreshHistory();
   };

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -5,7 +5,7 @@ import { useUiText } from "../ui_i18n";
 import {
   computed,
   signal,
-  useComputed,
+  useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
 import type {
@@ -28,6 +28,8 @@ export interface SensorsPanelView {
   bindModel(model: ReadonlySignal<SensorsPanelRenderModel>): void;
   bindActions(handlers: SensorsPanelActionHandlers): void;
 }
+
+const SENSORS_PANEL_MODEL_KEYS = ["table"] as const;
 
 function handleSensorAction(
   event: JSX.TargetedMouseEvent<HTMLButtonElement>,
@@ -133,7 +135,7 @@ function SensorsPanel(props: {
   const nameLabel = useUiText("settings.sensors.name", "Name");
   const locationLabel = useUiText("settings.sensors.location", "Location");
   const actionsLabel = useUiText("settings.sensors.actions", "Actions");
-  const table = useComputed(() => props.model.value.table);
+  const { table } = useSignalProperties(props.model, SENSORS_PANEL_MODEL_KEYS);
   return (
     <div class="panel card">
       <strong>

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -3,6 +3,7 @@ import { getUiText } from "../ui_i18n";
 import {
   signal,
   useComputed,
+  useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
 import type {
@@ -23,6 +24,8 @@ type MutableSpectrumPanelChartDom = {
   specChartWrap: HTMLElement | null;
   specChart: HTMLElement | null;
 };
+
+const SPECTRUM_BAND_TOGGLE_KEYS = ["bandsVisible", "hasBands", "text"] as const;
 
 function requireSpectrumElement<T extends HTMLElement>(
   element: T | null,
@@ -50,12 +53,14 @@ function SpectrumPanel(props: {
   const hintText = useComputed(() => getUiText("spectrum.controls_hint", props.header.value.hintText));
   const overlayHidden = useComputed(() => props.overlayMessage.value === null);
   const overlayText = useComputed(() => props.overlayMessage.value ?? "Waiting for sensor data...");
-  const bandToggleHasBands = useComputed(() => props.bandToggle.value.hasBands);
-  const bandToggleBandsVisible = useComputed(() => props.bandToggle.value.bandsVisible);
+  const {
+    bandsVisible: bandToggleBandsVisible,
+    hasBands: bandToggleHasBands,
+    text: bandToggleText,
+  } = useSignalProperties(props.bandToggle, SPECTRUM_BAND_TOGGLE_KEYS);
   const bandTogglePressed = useComputed(() =>
     bandToggleHasBands.value && bandToggleBandsVisible.value ? "true" : "false"
   );
-  const bandToggleText = useComputed(() => props.bandToggle.value.text);
   const bandToggleHidden = useComputed(() => !bandToggleHasBands.value);
   const bandLegendHidden = useComputed(() => !props.bandLegend.value.visible);
   const bandLegend = props.bandLegend.value;

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -5,6 +5,7 @@ import {
   computed,
   signal,
   useComputed,
+  useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
 import type {
@@ -35,6 +36,15 @@ export interface UpdatePanelActionHandlers {
   onCancel(): void;
   onStart(): void;
 }
+
+const UPDATE_PANEL_MODEL_KEYS = [
+  "cancelButtonDisabled",
+  "cancelButtonHidden",
+  "startButtonDisabled",
+  "startButtonHidden",
+  "startButtonLabelText",
+  "status",
+] as const;
 
 export interface UpdatePanelView {
   bindActions(handlers: UpdatePanelActionHandlers): void;
@@ -336,12 +346,14 @@ function UpdatePanel(props: {
   );
   const cancelLabel = useUiText("settings.update.cancel", "Cancel Update");
   const actions = useComputed(() => props.actions.value);
-  const status = useComputed(() => props.model.value.status);
-  const startButtonHidden = useComputed(() => props.model.value.startButtonHidden);
-  const startButtonDisabled = useComputed(() => props.model.value.startButtonDisabled);
-  const startButtonLabelText = useComputed(() => props.model.value.startButtonLabelText);
-  const cancelButtonHidden = useComputed(() => props.model.value.cancelButtonHidden);
-  const cancelButtonDisabled = useComputed(() => props.model.value.cancelButtonDisabled);
+  const {
+    cancelButtonDisabled,
+    cancelButtonHidden,
+    startButtonDisabled,
+    startButtonHidden,
+    startButtonLabelText,
+    status,
+  } = useSignalProperties(props.model, UPDATE_PANEL_MODEL_KEYS);
   const handleStart = () => {
     actions.value?.onStart();
   };

--- a/apps/ui/tests/signal_view_reference_tests.ts
+++ b/apps/ui/tests/signal_view_reference_tests.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { computed, signal } from "../src/app/ui_signals";
+import { computed, signal, useSignalProperties } from "../src/app/ui_signals";
 import type {
   RealtimeLiveOverviewRenderModel,
   RealtimeLiveOverviewSensorCardModel,
@@ -150,6 +150,66 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
   }
 }
 
+async function runSignalPropertiesHelperReferenceTest(): Promise<void> {
+  const badgeText = signal("Idle");
+  const hidden = signal(true);
+  const tone = signal<"muted" | "ok">("muted");
+  const model = computed(() => ({
+    hidden: hidden.value,
+    text: badgeText.value,
+    tone: tone.value,
+  }));
+  let renderCount = 0;
+
+  const harness = await mountSignalView(async () => {
+    const { h, render } = await import("preact");
+    return (host) => {
+      function SignalPropertiesView() {
+        renderCount += 1;
+        const { hidden, text, tone } = useSignalProperties(model, ["hidden", "text", "tone"] as const);
+        return h(
+          "div",
+          {},
+          h(
+            "span",
+            {
+              "data-variant": tone,
+              hidden,
+              id: "signalPropertiesBadge",
+            },
+            text,
+          ),
+        );
+      }
+
+      render(h(SignalPropertiesView, {}), host);
+      return {};
+    };
+  });
+
+  try {
+    await harness.flush();
+
+    const badge = requireElement<HTMLElement>(harness.host, "#signalPropertiesBadge");
+    assert.equal(renderCount, 1);
+    assert.equal(badge.textContent, "Idle");
+    assert.equal(badge.getAttribute("data-variant"), "muted");
+    assert.equal(badge.hidden, true);
+
+    badgeText.value = "Ready";
+    hidden.value = false;
+    tone.value = "ok";
+    await harness.flush();
+
+    assert.equal(renderCount, 1);
+    assert.equal(badge.textContent, "Ready");
+    assert.equal(badge.getAttribute("data-variant"), "ok");
+    assert.equal(badge.hidden, false);
+  } finally {
+    harness.cleanup();
+  }
+}
+
 async function runSettingsShellReferenceTest(): Promise<void> {
   const harness = await mountSignalView(async () => {
     const { mountSettingsShell } = await import("../src/app/views/settings_shell");
@@ -198,6 +258,10 @@ const referenceTests = [
   {
     name: "realtime live overview computed-driven output",
     run: runRealtimeLiveOverviewReferenceTest,
+  },
+  {
+    name: "useSignalProperties returns direct binding signals",
+    run: runSignalPropertiesHelperReferenceTest,
   },
   {
     name: "settings shell effect-backed subscription seam",


### PR DESCRIPTION
## Summary

This PR adds a shared `useSignalProperties()` helper to `apps/ui/src/app/ui_signals.ts` and uses it in the remaining live view components that still repeated the same per-property `useComputed(() => model.value.foo)` pattern. The helper now covers the current property-unwrapping sites in `history_panel.tsx`, `update_panel.tsx`, `sensors_panel.tsx`, and the band-toggle slice of `spectrum_panel.tsx`, while preserving the same direct signal-binding behavior those views already relied on.

The important scope correction is that issue #2451 was partially stale by the time I picked it up. Earlier frontend cleanup work had already removed the biggest repetitive consumers named in the issue body, so the real remaining work was narrower than the original description. This PR follows the issue’s intent, but it does so against the live codebase rather than the older file list.

Closes #2451.

## Problem

The current frontend architecture prefers signal-backed island state and direct signal JSX bindings, but a few view files still had repetitive property-level unwrapping code like:

```ts
const foo = useComputed(() => props.model.value.foo);
```

That pattern is fine in isolation, but the remaining consumers had reached the point where the repetition obscured the actual view logic more than it clarified it. `update_panel.tsx` was the clearest example, with several adjacent one-line property computeds that were all just exposing fields from the same model signal. `history_panel.tsx` and `sensors_panel.tsx` had smaller versions of the same pattern, and `spectrum_panel.tsx` still had a similar group for the band-toggle model.

At the same time, the issue body no longer matched the live code exactly. The previously named large repeaters in `realtime_logging_panel.tsx`, `ui_shell_chrome.tsx`, and the older `esp_flash_panel.tsx` property split had already been cleaned up by earlier issues. That meant the honest fix was not a repo-wide abstraction pass. It was a narrow shared helper for the few real remaining sites that still repeated the same property-signal wiring today.

## Implementation approach

The chosen approach was to add one helper at the canonical shared signal entrypoint instead of inventing a second helper module or introducing file-local copies.

`useSignalProperties()` takes a stable source signal plus a tuple of property keys and returns a typed object of readonly per-property signals. The helper is implemented with `useMemo()` and `computed()`:

1. `useMemo()` ensures the property-signal map is built once per source/key-set combination rather than mutating signal state during render.
2. `computed()` keeps each returned property signal subscribed only to the property access it represents.
3. `JSON.stringify(keys)` is used as the key signature so the helper can safely rebuild if the requested property tuple changes, without relying on a fragile separator string.

That structure matters because the first draft exposed a real regression in the new reference coverage: my initial helper mutated internal signal state during render, which caused an extra render and failed the direct-binding expectation. The final implementation fixes that by using `useMemo()` instead of render-time signal writes.

## Main code changes

### `apps/ui/src/app/ui_signals.ts`

This file now exports `useSignalProperties()` alongside the existing canonical signal helpers. Keeping it here matters because the repo already treats `ui_signals.ts` as the documented shared reactive import surface for runtime, feature, and view code. The helper stays close to the existing `signal`, `computed`, `useComputed`, `useSignal`, and `useSignalEffect` surface instead of creating a parallel utilities module.

### `apps/ui/src/app/views/update_panel.tsx`

This was the largest remaining consumer. The adjacent single-property `useComputed()` declarations for `status`, `startButtonHidden`, `startButtonDisabled`, `startButtonLabelText`, `cancelButtonHidden`, and `cancelButtonDisabled` are now replaced by one destructuring call to `useSignalProperties(props.model, UPDATE_PANEL_MODEL_KEYS)`. The local action handlers remain unchanged, so the refactor only touches the repeated model-unwrapping layer.

### `apps/ui/src/app/views/history_panel.tsx`

The history toolbar/table view now uses the helper for `deleteAllRunsDisabled`, `historySummaryText`, and `table`. The action-handler binding still uses its own focused `useComputed()` because it is not part of the repeated model-property pattern this issue targets.

### `apps/ui/src/app/views/sensors_panel.tsx`

This file had only one remaining direct model-property computed (`table`), but it still participates in the same stable model-signal pattern and keeps the helper usage consistent across the remaining settings-panel consumers.

### `apps/ui/src/app/views/spectrum_panel.tsx`

The helper is used only for the band-toggle property cluster (`hasBands`, `bandsVisible`, and `text`). The other spectrum computeds stay local because they are not just simple property projections: some wrap translation lookups, some derive booleans from nullable overlay state, and others depend on multiple reactive inputs.

### `apps/ui/tests/signal_view_reference_tests.ts`

The new reference case proves the helper returns signals that still participate in direct JSX signal binding without rerendering the component. That is the most important guard in this PR, because it validates the helper against the repo’s preferred signal-view pattern instead of only checking TypeScript types.

### `apps/ui/README.md`

The shared reactive state guidance now mentions `useSignalProperties()` for repeated stable property bindings so the documented view pattern matches the live helper surface.

## Validation

I kept validation centered on the touched helper and the four live consumers:

- `cd apps/ui && npm run test:signals`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/smoke.history.spec.ts tests/smoke.update.spec.ts tests/smoke.spectrum.spec.ts tests/smoke.analysis-sensors.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1`

That mix covers the helper itself, the current direct-signal reference path, the affected view surfaces, and the normal frontend type/build/lint gates.

I also ran a focused review pass over the final diff. The only issue it surfaced was a theoretical key-signature edge case in the first `keys.join(...)` implementation, which is why the final branch uses `JSON.stringify(keys)` instead.

## Risks, tradeoffs, and scope boundaries

The biggest tradeoff is that this helper is intentionally narrow. It does not try to absorb every `useComputed()` in the UI. Some of the remaining view-level computeds represent real local derivations, multi-signal combinations, translated copy, or boolean state built from more than one source. Converting those to a shared property helper would make the code less clear, not more.

That is also why this PR does not force the stale original issue file list back into scope. The helper is applied where the live repo still has the simple repeated property-unwrapping pattern and left out where the remaining computeds are doing actual derivation work.

The edge case I specifically guarded against during implementation was accidentally changing direct signal-binding behavior. The first draft proved that was a real risk, because the helper caused an extra render until it moved from render-time signal mutation to `useMemo()`. The final reference coverage locks that behavior in place so later refactors do not regress it.

## Out of scope

This PR does not rewrite other view-level `useComputed()` usage, add a more general signal selector framework, or change any panel behavior or UX. It only introduces the smallest shared helper that still solves the real remaining repetitive pattern in the live codebase.
