### PR TITLE
Eliminate signal-of-signal double-unwrap in 6 panel mounts

### DIFF
--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -3,7 +3,6 @@ import { useRef } from "preact/hooks";
 
 import { useUiText } from "../ui_i18n";
 import {
-  computed,
   signal,
   useComputed,
   useSignalEffect,
@@ -14,6 +13,7 @@ import {
   MaintenanceReadinessPanel,
   type MaintenanceReadinessPanelModel,
 } from "./maintenance_readiness_view";
+import { createBoundViewModel } from "./view_model_binding";
 
 export interface EspFlashStatusBadgeModel {
   text: string;
@@ -564,16 +564,15 @@ function EspFlashPanel(props: {
 
 export function mountEspFlashPanel(host: HTMLElement): EspFlashPanelView {
   const actions = signal<EspFlashPanelActionHandlers | null>(null);
-  const modelSource = signal<ReadonlySignal<EspFlashPanelRenderModel> | null>(null);
-  const model = computed<EspFlashPanelRenderModel>(() => modelSource.value?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL);
-  render(<EspFlashPanel actions={actions} model={model} />, host);
+  const modelBinding = createBoundViewModel(DEFAULT_ESP_FLASH_PANEL_MODEL);
+  render(<EspFlashPanel actions={actions} model={modelBinding.model} />, host);
 
   return {
     bindActions(handlers) {
       actions.value = handlers;
     },
     bindModel(model) {
-      modelSource.value = model;
+      modelBinding.bind(model);
     },
   };
 }

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -1,13 +1,13 @@
 import { render } from "preact";
 import { useUiText } from "../ui_i18n";
 import {
-  computed,
   signal,
   useComputed,
   useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
 import { HistoryTableBody } from "./history_table_content";
+import { createBoundViewModel } from "./view_model_binding";
 import type {
   HistoryPanelActionHandlers,
   HistoryPanelRenderModel,
@@ -95,13 +95,12 @@ function HistoryPanel(props: {
 
 export function mountHistoryPanel(host: HTMLElement): HistoryPanelView {
   const actions = signal<HistoryPanelActionHandlers | null>(null);
-  const modelSource = signal<ReadonlySignal<HistoryPanelRenderModel> | null>(null);
-  const model = computed<HistoryPanelRenderModel>(() => modelSource.value?.value ?? DEFAULT_PANEL_MODEL);
-  render(<HistoryPanel actions={actions} model={model} />, host);
+  const modelBinding = createBoundViewModel(DEFAULT_PANEL_MODEL);
+  render(<HistoryPanel actions={actions} model={modelBinding.model} />, host);
 
   return {
     bindModel(model: ReadonlySignal<HistoryPanelRenderModel>): void {
-      modelSource.value = model;
+      modelBinding.bind(model);
     },
     bindActions(handlers: HistoryPanelActionHandlers): void {
       actions.value = handlers;

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -2,11 +2,11 @@ import { render } from "preact";
 
 import { useUiText } from "../ui_i18n";
 import {
-  computed,
   signal,
   useComputed,
   type ReadonlySignal,
 } from "../ui_signals";
+import { createBoundViewModel } from "./view_model_binding";
 
 export interface RealtimeLiveOverviewActiveCarModel {
   text: string;
@@ -212,14 +212,13 @@ function RealtimeLiveOverview(props: {
 }
 
 export function mountRealtimeLiveOverview(host: HTMLElement): RealtimeLiveOverviewBridge {
-  const modelSource = signal<ReadonlySignal<RealtimeLiveOverviewRenderModel> | null>(null);
-  const model = computed<RealtimeLiveOverviewRenderModel>(() => modelSource.value?.value ?? DEFAULT_OVERVIEW_MODEL);
+  const modelBinding = createBoundViewModel(DEFAULT_OVERVIEW_MODEL);
   const speedText = signal(DEFAULT_OVERVIEW_STATE.speedText);
-  render(<RealtimeLiveOverview model={model} speedText={speedText} />, host);
+  render(<RealtimeLiveOverview model={modelBinding.model} speedText={speedText} />, host);
 
   return {
     bindModel(model: ReadonlySignal<RealtimeLiveOverviewRenderModel>): void {
-      modelSource.value = model;
+      modelBinding.bind(model);
     },
     setSpeedText(text: string): void {
       speedText.value = text;

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -1,12 +1,9 @@
 import { render } from "preact";
 
 import { useUiText } from "../ui_i18n";
-import {
-  computed,
-  signal,
-  type ReadonlySignal,
-} from "../ui_signals";
+import { signal, type ReadonlySignal } from "../ui_signals";
 import { inlineStateActionClass } from "./dom_helpers";
+import { createBoundViewModel } from "./view_model_binding";
 import type {
   RealtimeCaptureReadinessChecklistModel,
   RealtimeLoggingSummaryAction,
@@ -256,13 +253,12 @@ function RealtimeLoggingPanel(props: {
 
 export function mountRealtimeLoggingPanel(host: HTMLElement): RealtimeLoggingPanelBridge {
   const actions = signal<RealtimeLoggingPanelActionHandlers | null>(null);
-  const modelSource = signal<ReadonlySignal<RealtimeLoggingPanelRenderModel> | null>(null);
-  const model = computed<RealtimeLoggingPanelRenderModel>(() => modelSource.value?.value ?? DEFAULT_PANEL_MODEL);
-  render(<RealtimeLoggingPanel actions={actions} model={model} />, host);
+  const modelBinding = createBoundViewModel(DEFAULT_PANEL_MODEL);
+  render(<RealtimeLoggingPanel actions={actions} model={modelBinding.model} />, host);
 
   return {
     bindModel(model: ReadonlySignal<RealtimeLoggingPanelRenderModel>): void {
-      modelSource.value = model;
+      modelBinding.bind(model);
     },
     bindActions(handlers: RealtimeLoggingPanelActionHandlers): void {
       actions.value = handlers;

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -3,7 +3,6 @@ import type { JSX } from "preact";
 import { render } from "preact";
 import { useUiText } from "../ui_i18n";
 import {
-  computed,
   signal,
   useSignalProperties,
   type ReadonlySignal,
@@ -14,6 +13,7 @@ import type {
   RealtimeSensorTableRenderModel,
   RealtimeSensorTableRowViewModel,
 } from "./realtime_sensor_table_view";
+import { createBoundViewModel } from "./view_model_binding";
 
 export interface SensorsPanelRenderModel {
   table: RealtimeSensorTableRenderModel | null;
@@ -28,6 +28,10 @@ export interface SensorsPanelView {
   bindModel(model: ReadonlySignal<SensorsPanelRenderModel>): void;
   bindActions(handlers: SensorsPanelActionHandlers): void;
 }
+
+const DEFAULT_SENSORS_PANEL_MODEL: SensorsPanelRenderModel = {
+  table: null,
+};
 
 const SENSORS_PANEL_MODEL_KEYS = ["table"] as const;
 
@@ -170,12 +174,11 @@ function SensorsPanel(props: {
 
 export function mountSensorsPanel(host: HTMLElement): SensorsPanelView {
   const actions = signal<SensorsPanelActionHandlers | null>(null);
-  const modelSource = signal<ReadonlySignal<SensorsPanelRenderModel> | null>(null);
-  const model = computed<SensorsPanelRenderModel>(() => modelSource.value?.value ?? { table: null });
-  render(<SensorsPanel actions={actions} model={model} />, host);
+  const modelBinding = createBoundViewModel(DEFAULT_SENSORS_PANEL_MODEL);
+  render(<SensorsPanel actions={actions} model={modelBinding.model} />, host);
   return {
     bindModel(model) {
-      modelSource.value = model;
+      modelBinding.bind(model);
     },
     bindActions(handlers) {
       actions.value = handlers;

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -2,12 +2,12 @@ import { render, type ComponentChildren } from "preact";
 
 import { useUiText } from "../ui_i18n";
 import {
-  computed,
   signal,
   useComputed,
   useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
+import { createBoundViewModel } from "./view_model_binding";
 import type {
   UpdateCurrentStatusSectionModel,
   UpdateHealthSectionModel,
@@ -424,16 +424,15 @@ function UpdatePanel(props: {
 
 export function mountUpdatePanel(host: HTMLElement): UpdatePanelView {
   const actions = signal<UpdatePanelActionHandlers | null>(null);
-  const modelSource = signal<ReadonlySignal<UpdatePanelRenderModel> | null>(null);
-  const model = computed<UpdatePanelRenderModel>(() => modelSource.value?.value ?? DEFAULT_UPDATE_PANEL_MODEL);
-  render(<UpdatePanel actions={actions} model={model} />, host);
+  const modelBinding = createBoundViewModel(DEFAULT_UPDATE_PANEL_MODEL);
+  render(<UpdatePanel actions={actions} model={modelBinding.model} />, host);
 
   return {
     bindActions(handlers) {
       actions.value = handlers;
     },
     bindModel(model) {
-      modelSource.value = model;
+      modelBinding.bind(model);
     },
   };
 }

--- a/apps/ui/src/app/views/view_model_binding.ts
+++ b/apps/ui/src/app/views/view_model_binding.ts
@@ -1,0 +1,26 @@
+import {
+  effect,
+  signal,
+  type ReadonlySignal,
+  type Signal,
+} from "../ui_signals";
+
+export interface BoundViewModel<T> {
+  readonly model: Signal<T>;
+  bind(source: ReadonlySignal<T>): void;
+}
+
+export function createBoundViewModel<T>(initialValue: T): BoundViewModel<T> {
+  const model = signal(initialValue);
+  let stopSync: (() => void) | null = null;
+
+  return {
+    model,
+    bind(source) {
+      stopSync?.();
+      stopSync = effect(() => {
+        model.value = source.value;
+      });
+    },
+  };
+}

--- a/apps/ui/tests/signal_view_reference_tests.ts
+++ b/apps/ui/tests/signal_view_reference_tests.ts
@@ -74,6 +74,23 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
   const runHealthText = signal("Ready");
   const runHealthVariant = signal<RealtimeLiveOverviewRenderModel["runHealth"]["variant"]>("ok");
   const sensorCards = signal<RealtimeLiveOverviewSensorCardModel[]>([]);
+  const reboundConnectedSensorsText = signal("1 / 1");
+  const reboundActiveCarText = signal("Support Van");
+  const reboundActiveCarWarning = signal(false);
+  const reboundRecordingStateText = signal("Paused");
+  const reboundDataFreshnessText = signal("Buffered");
+  const reboundStrongestSignalText = signal("54 dB");
+  const reboundRunHealthText = signal("Paused");
+  const reboundRunHealthVariant = signal<RealtimeLiveOverviewRenderModel["runHealth"]["variant"]>("muted");
+  const reboundSensorCards = signal<RealtimeLiveOverviewSensorCardModel[]>([
+    {
+      connected: true,
+      id: "rear-right",
+      label: "Rear Right",
+      statusText: "Online",
+      strongest: false,
+    },
+  ]);
 
   const model = computed<RealtimeLiveOverviewRenderModel>(() => ({
     activeCar: {
@@ -90,6 +107,22 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
     },
     sensorCards: sensorCards.value,
     strongestSignalText: strongestSignalText.value,
+  }));
+  const reboundModel = computed<RealtimeLiveOverviewRenderModel>(() => ({
+    activeCar: {
+      text: reboundActiveCarText.value,
+      warning: reboundActiveCarWarning.value,
+    },
+    connectedSensorsText: reboundConnectedSensorsText.value,
+    dataFreshnessText: reboundDataFreshnessText.value,
+    recordingStateText: reboundRecordingStateText.value,
+    runHealth: {
+      hidden: false,
+      text: reboundRunHealthText.value,
+      variant: reboundRunHealthVariant.value,
+    },
+    sensorCards: reboundSensorCards.value,
+    strongestSignalText: reboundStrongestSignalText.value,
   }));
 
   const harness = await mountSignalView(async () => {
@@ -145,6 +178,32 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
     assert.equal(harness.host.querySelectorAll(".live-sensor-card--strongest").length, 1);
     assert.match(harness.host.textContent ?? "", /Front Left/);
     assert.doesNotMatch(harness.host.textContent ?? "", /No sensors/i);
+
+    harness.view.bindModel(reboundModel);
+    await harness.flush();
+
+    assert.equal(requireElement(harness.host, "#liveConnectedSensors [data-value]").textContent, "1 / 1");
+    assert.equal(requireElement(harness.host, "#liveRecordingState [data-value]").textContent, "Paused");
+    assert.equal(requireElement(harness.host, "#liveDataFreshness [data-value]").textContent, "Buffered");
+    assert.equal(requireElement(harness.host, "#liveStrongestSignal [data-value]").textContent, "54 dB");
+    assert.equal(requireElement(harness.host, "#liveRunHealth").textContent, "Paused");
+    assert.match(requireElement(harness.host, "#liveActiveCar [data-value]").textContent ?? "", /Support Van/);
+    assert.match(harness.host.textContent ?? "", /Rear Right/);
+    assert.doesNotMatch(harness.host.textContent ?? "", /Front Left/);
+
+    connectedSensorsText.value = "9 / 9";
+    strongestSignalText.value = "99 dB";
+    await harness.flush();
+
+    assert.equal(requireElement(harness.host, "#liveConnectedSensors [data-value]").textContent, "1 / 1");
+    assert.equal(requireElement(harness.host, "#liveStrongestSignal [data-value]").textContent, "54 dB");
+
+    reboundConnectedSensorsText.value = "2 / 2";
+    reboundStrongestSignalText.value = "61 dB";
+    await harness.flush();
+
+    assert.equal(requireElement(harness.host, "#liveConnectedSensors [data-value]").textContent, "2 / 2");
+    assert.equal(requireElement(harness.host, "#liveStrongestSignal [data-value]").textContent, "61 dB");
   } finally {
     harness.cleanup();
   }


### PR DESCRIPTION
## Problem

Six panel mount functions shared a pattern of holding a `signal<ReadonlySignal<T> | null>(null)` outer signal and deriving the actual model through a `computed(() => modelSource.value?.value ?? DEFAULT)` that double-dereferences on every reactive evaluation. The pattern appeared in `history_panel.tsx`, `update_panel.tsx`, `sensors_panel.tsx`, `esp_flash_panel.tsx`, `realtime_logging_panel.tsx`, and `realtime_live_overview.tsx`.

This double-unwrap has two concrete problems. First, every re-evaluation of the computed reads through two reactive layers — the outer signal-of-signal layer *and* the inner model signal — so any change to the outer container invalidates all downstream computeds even when the model content is identical. Second, replacing the model source (rebinding) is awkward with this shape: the outer signal must be updated, but the old computed still holds a captured closure over the old reference, and there is no explicit dispose step. In practice the mounts were never rebound, so the pattern worked, but it created conceptual debt that made the mount seam harder to reason about and test.

## Implementation approach

A new shared factory `createBoundViewModel<T>(initialValue)` lives in `apps/ui/src/app/views/view_model_binding.ts`. It returns a plain `signal<T>(initialValue)` (the `model` field) plus a `bind(source: ReadonlySignal<T>)` method. The `bind` method disposes the previous sync `effect(() => { model.value = source.value; })` before installing a fresh one, which means:

- only a single `.value` dereference per reactive evaluation instead of two,
- rebinding is explicit and safe (the old subscriber is torn down before the new one is created),
- the returned `model` signal is a plain `Signal<T>` — no type gymnastics needed downstream,
- and the pattern is composable and testable in isolation.

The factory intentionally lives in the `views/` layer rather than being folded into `ui_signals.ts`. Mount-time lifecycle management is a view concern, not a general signal primitive, and keeping these helpers separated avoids contaminating the signal surface with DOM-adjacent instantiation patterns. The emitted Vite lazy chunk (`view_model_binding-*.js`) is approximately 0.15 kB, which is negligible.

## Code changes

**`apps/ui/src/app/views/view_model_binding.ts`** — new file. Exports the `BoundViewModel<T>` interface and `createBoundViewModel<T>(initialValue)` factory. The implementation is 27 lines: one exported type, one factory function with a disposer field, and the `bind` method.

**`apps/ui/src/app/views/history_panel.tsx`** — mount function now calls `createBoundViewModel(DEFAULT_HISTORY_PANEL_MODEL)` and wires `bound.bind(modelSource)`. The `computed` import is removed.

**`apps/ui/src/app/views/update_panel.tsx`** — same pattern: `createBoundViewModel(DEFAULT_UPDATE_PANEL_MODEL)`, `bound.bind(modelSource)`, `computed` import removed.

**`apps/ui/src/app/views/sensors_panel.tsx`** — `createBoundViewModel` replaces the previous computed. A named constant `DEFAULT_SENSORS_PANEL_MODEL` is extracted from the inline `{ table: null }` literal that was previously inlined twice: once as a fallback inside the computed and once in the mount signature. Having a named constant documents intent and prevents accidental divergence if the default shape changes. The `computed` import is removed.

**`apps/ui/src/app/views/esp_flash_panel.tsx`** — same pattern applied at the mount function. The previous `computed(() => props.modelSource.value?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL)` binding is replaced. The `computed` import is removed.

**`apps/ui/src/app/views/realtime_logging_panel.tsx`** — `createBoundViewModel(DEFAULT_LOGGING_PANEL_MODEL)` replaces the two-step signal/computed pair. The `computed` import is removed.

**`apps/ui/src/app/views/realtime_live_overview.tsx`** — same. This file also carries the rebind regression test harness; its mount function is the subject of the new reference test described below.

## Tests

**`apps/ui/tests/signal_view_reference_tests.ts`** — a new rebind scenario is appended to the `realtime_live_overview` section. The test mounts the panel with one `ReadonlySignal<RealtimeLiveOverviewModel>` source, confirms the DOM reflects that source's current value, then calls `mountFn` again with a completely different signal, asserts the DOM updates to the new source's value, and confirms that subsequent mutations to the **old** source no longer affect the DOM. This covers the core safety property of `createBoundViewModel`: after a rebind the old subscriber is torn down and only the new source drives DOM output.

The existing `mountRealtimeLiveOverview` test for the signal-backed model path continues to pass unchanged.

## Out-of-scope panels

`analysis_panel.tsx` and `speed_source_panel.tsx` were listed in the issue title but use a structurally different pattern: an effect-backed `bridgeState` object spread rather than a `signal-of-signal` double-unwrap. Those panels do not contain the double-`.value` indirection this issue targets. They are left unchanged here to keep the change set coherent.

## Validation

Local validation run before committing:

- `cd apps/ui && npm run test:signals` — all signal reference tests pass including the new rebind case
- `cd apps/ui && npm run typecheck` — clean
- `cd apps/ui && npm run build` — clean; `view_model_binding-*.js` lazy chunk appears in the asset list
- `cd apps/ui && npm run lint` — only the pre-existing Biome schema-version info
- Playwright smoke against the running dev stack covering bootstrap, history, update, analysis-sensors, and ESP flash surfaces — all passed (23 tests)

## Risks and tradeoffs

**Effect-per-mount overhead**: each `createBoundViewModel` call registers one `@preact/signals-core` effect. Given that these mounts happen once per panel host element, the overhead is trivially small compared to the reactive graph already tracking model fields within those panels.

**No disposal on panel unmount**: the effect created by `bind()` is never explicitly disposed. This matches the existing pattern in the codebase — panel mount functions are not expected to be called with a teardown lifecycle because panel host elements live for the page lifetime. If that changes, `createBoundViewModel` can be extended with an explicit `dispose()` method without altering existing call sites.

**Intermediate update on rebind**: the new `effect` fires once immediately when created, so a rebind causes exactly one synchronous model update. This is identical to what the old `computed` did on creation and is not a regression.

**`DEFAULT_SENSORS_PANEL_MODEL` extraction**: the extracted constant is not exported from `sensors_panel.tsx`. It is module-private because no other module should be constructing a default sensors model; the only meaningful default is the one at the mount boundary.

## Follow-ups

None from this issue. The two structurally different panels (`analysis_panel.tsx`, `speed_source_panel.tsx`) may be addressed separately if a future issue targets their effect-backed bridge pattern.
