### PR TITLE
Move shell DOM mutations into signal-driven rendering

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -81,6 +81,7 @@ export interface UiShellChromeRenderModel {
   activeViewId: string;
   appErrorBanner: UiShellErrorBannerModel;
   confirmationDialog: UiConfirmationDialogModel | null;
+  connectionState: "degraded" | "live";
   languageFeedback: SettingsFeedbackMessage | null;
   languageLabelText: string;
   navItems: readonly UiShellChromeNavItemModel[];
@@ -117,6 +118,7 @@ const DEFAULT_SHELL_CHROME_MODEL: UiShellChromeRenderModel = {
     variant: null,
   },
   confirmationDialog: null,
+  connectionState: "live",
   languageFeedback: null,
   languageLabelText: "Language",
   navItems: SHELL_NAV_ITEMS.map((item) => ({
@@ -291,6 +293,12 @@ function UiShellChrome(props: UiShellChromeProps) {
   const statusHidden = model.activeViewId === "dashboardView";
   const appErrorVariant = model.appErrorBanner.variant ?? undefined;
 
+  useSignalEffect(() => {
+    const lang = props.model.value.selectedLanguage;
+    const documentElement = globalThis.document?.documentElement;
+    if (documentElement) documentElement.lang = lang;
+  });
+
   function activateView(viewId: string): void {
     bridge.current.activateView(viewId);
   }
@@ -333,7 +341,7 @@ function UiShellChrome(props: UiShellChromeProps) {
   }
 
   return (
-    <div class="wrap">
+    <div class="wrap" data-connection-state={model.connectionState}>
       <header class="site-header">
         <div class="site-header__main">
           <div class="site-header__nav">

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -1,6 +1,5 @@
 import * as I18N from "../../i18n";
 import { formatIntLocale } from "../../format";
-import { queryOne } from "../dom/dom_query";
 import { setUiLanguage } from "../ui_i18n";
 import { trackAppStateSlice, type AppState } from "../ui_app_state";
 import {
@@ -63,8 +62,6 @@ export class UiShellController {
 
   private readonly chrome: UiShellChromeView;
 
-  private readonly appShellWrap: HTMLElement | null;
-
   private readonly liveOverview: RealtimeLiveOverviewBridge;
 
   private readonly navigation: UiShellNavigationModule;
@@ -89,7 +86,6 @@ export class UiShellController {
   constructor(deps: UiShellControllerDeps) {
     this.state = deps.state;
     this.chrome = deps.chrome;
-    this.appShellWrap = queryOne<HTMLElement>(".wrap");
     this.liveOverview = deps.liveOverview;
     this.bindFeatureHandlers = deps.bindFeatureHandlers;
     this.notifications = createUiShellNotificationModule({
@@ -196,10 +192,6 @@ export class UiShellController {
       }
       untracked(() => {
         setUiLanguage(currentLanguage);
-        const documentElement = globalThis.document?.documentElement;
-        if (documentElement) {
-          documentElement.lang = currentLanguage;
-        }
       });
     });
   }
@@ -207,11 +199,7 @@ export class UiShellController {
   private bindReactiveStatusSync(): void {
     effect(() => {
       const model = this.chromeRenderModel.value;
-      const connectionState = this.status.connectionState.value;
       untracked(() => {
-        if (this.appShellWrap) {
-          this.appShellWrap.dataset.connectionState = connectionState;
-        }
         this.chrome.setModel(model);
       });
     });
@@ -231,6 +219,7 @@ export class UiShellController {
         activeViewId: this.state.shell.activeViewId,
         appErrorBanner: this.notifications.bannerModel.value,
         confirmationDialog: this.confirmation.dialogModel.value,
+        connectionState: this.status.connectionState.value,
         languageFeedback: this.preferences.languageFeedback.value,
         languageLabelText: this.t("settings.language"),
         navItems: SHELL_NAV_ITEMS.map((item) => ({


### PR DESCRIPTION
## Problem

Two imperative DOM mutations in `UiShellController` bypassed the signal/render pipeline:

1. **`dataset.connectionState`** — `bindReactiveStatusSync()` ran an `effect()` that read both the computed chrome render model and `this.status.connectionState` separately, then inside `untracked()` set `this.appShellWrap.dataset.connectionState = connectionState` directly on a DOM node queried at constructor time (`queryOne<HTMLElement>(".wrap")`). This sat outside the Preact render tree and meant the degraded-overlay CSS could only be applied after an imperative side-effect fired — a fragile seam where the render model and the actual attribute on the page could theoretically diverge.

2. **`documentElement.lang`** — `bindReactiveLanguageSync()` tracked language state and inside `untracked()` called both `setUiLanguage(currentLanguage)` (needed to update the i18n system) and `documentElement.lang = currentLanguage` (purely a DOM side-effect). The second assignment had no connection to the Preact component tree and mutated the root `<html>` element from a controller effect.

Both patterns follow the old pre-signal style of the codebase: query a DOM node at startup, store a reference, write to it imperatively whenever state changes. This issue (#2474) is part of the broader migration that moves all such mutations into the signal-driven render path.

## Approach

### `connectionState` → JSX attribute

The `.wrap[data-connection-state="degraded"]` CSS rule in `shell.css` (~line 194) already targets the `.wrap` element, which is the root div rendered by `UiShellChrome`. Moving the attribute assignment into JSX keeps the CSS selector working without any stylesheet change — it simply needs `data-connection-state={model.connectionState}` on that root element.

`connectionState: "degraded" | "live"` is added to `UiShellChromeRenderModel` (with `"live"` as the default in `DEFAULT_SHELL_CHROME_MODEL`) and to `createChromeRenderModel()` in `UiShellController`, which reads it from the already-available `this.status.connectionState.value`. The computed render model already updates reactively whenever `connectionState` changes; the chrome island consumes it via a signal prop.

### `document.lang` → `useSignalEffect`

Rather than assigning `documentElement.lang` from the controller, this assignment moves into a `useSignalEffect` inside the `UiShellChrome` component body. The effect reads `props.model.value.selectedLanguage` directly from the signal (not from a destructured snapshot) so it subscribes to future signal updates. `useSignalEffect` was already imported in `ui_shell_chrome.tsx` (used in `ConfirmationDialog`), so no new import is needed.

This means the `<html lang="...">` attribute is now updated as a side-effect tied to the component lifecycle of `UiShellChrome` — if the component unmounts, the effect is cleaned up automatically.

## Code changes

### `apps/ui/src/app/runtime/ui_shell_chrome.tsx`

- **Interface**: `connectionState: "degraded" | "live"` added to `UiShellChromeRenderModel`, placed alphabetically between `confirmationDialog` and `languageFeedback`.
- **Default**: `connectionState: "live"` added to `DEFAULT_SHELL_CHROME_MODEL`.
- **JSX render**: `data-connection-state={model.connectionState}` added to the root `.wrap` div, making the CSS selector continue to work with no selector change.
- **Signal effect**: `useSignalEffect(() => { document.documentElement.lang = props.model.value.selectedLanguage; })` added inside the `UiShellChrome` component body.

### `apps/ui/src/app/runtime/ui_shell_controller.ts`

- **Removed import**: `import { queryOne } "../dom/dom_query" from no longer needed.` 
- **Removed field**: `private readonly appShellWrap: HTMLElement | null;` — no longer needed.
- **Removed constructor line**: `this.appShellWrap = queryOne<HTMLElement>(".wrap");` — no longer needed.
- **`bindReactiveLanguageSync()`**: removed `documentElement.lang = currentLanguage` from inside the `untracked()` block. `setUiLanguage()` call is preserved as it updates the i18n system.
- **`bindReactiveStatusSync()`**: removed the separate `connectionState` read and the `if (this.appShellWrap)` block that mutated `dataset.connectionState`. The effect body now only calls `this.chrome.setModel(model)` via `untracked()`, which is simpler and correct.
- **`createChromeRenderModel()`**: `connectionState: this.status.connectionState.value` added to the computed object returned.

## CSS selector preserved

The `shell.css` rule `.wrap[data-connection-state="degraded"] .view { opacity: 0.55; ... }` is unchanged. The `.wrap` class is on the root element rendered by `UiShellChrome`, so moving the data attribute to a JSX prop keeps the selector working exactly as before. No stylesheet edits were required.

## `UiShellStatusModule` unchanged

The module already exposes `connectionState: ReadonlySignal<"degraded" | "live">` (line 39 of `ui_shell_status_module.ts`). This PR only adds a read of that signal's value inside `createChromeRenderModel()`.

## Validation

- **Typecheck**: `npm run typecheck` — green.
- **Build**: `npm run build` — green; no bundle size regression; lazy panel chunks all still present.
- **Lint**: `npm run lint` — clean; only the pre-existing Biome schema-version info.
- **Shell unit tests**: `npx playwright test tests/ui_shell_runtime_modules.spec.ts --workers=1` — 48 passed.
- **Bootstrap smoke**: `npx playwright test tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1` — 4 passed (dark/light mode readiness cards, full bootstrap flow, saved-run state redirect).

## Risks and tradeoffs

**CSS selector**: The only risk was whether the CSS selector would still apply after moving the attribute into JSX. Because `UiShellChrome` renders the `.wrap` root div unconditionally, `data-connection-state` is always present in the DOM from first render, which is actually an improvement over the old imperative path where the attribute required a separate effect to fire first.

**`useSignalEffect` cleanup**: The `document.lang` assignment now clears itself if `UiShellChrome` unmounts. In production the shell chrome mounts once and never unmounts, so this is no behavioral change. In tests it means the lang assignment is cleaned up between test cases, which is strictly better.

**Scope of `connectionState` type**: Adding the field to `UiShellChromeRenderModel` means the render model interface now carries it, which is accurate — the render model already describes everything the chrome component needs to render correctly.

## Follow-ups and out-of-scope items

This PR covers the two specific shell DOM mutations called out in issue #2474. Remaining shell DOM patterns (closest(), querySelectorAll() in shell views) are tracked in #2475 and later issues.
