### PR TITLE
Replace closest()/querySelectorAll() with Preact refs in shell components

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -152,18 +152,6 @@ function normalizeMenuIndex(index: number): number {
   return ((index % SHELL_NAV_ITEMS.length) + SHELL_NAV_ITEMS.length) % SHELL_NAV_ITEMS.length;
 }
 
-function focusMenuButton(
-  event: JSX.TargetedKeyboardEvent<HTMLButtonElement>,
-  nextIndex: number,
-): void {
-  const menu = event.currentTarget.closest(".menu");
-  if (!(menu instanceof HTMLElement)) {
-    return;
-  }
-  const buttons = Array.from(menu.querySelectorAll<HTMLButtonElement>(".menu-btn"));
-  buttons[normalizeMenuIndex(nextIndex)]?.focus();
-}
-
 function SettingsFeedbackSlot(props: {
   id: string;
   message: SettingsFeedbackMessage | null;
@@ -292,6 +280,7 @@ function UiShellChrome(props: UiShellChromeProps) {
   const model = props.model.value;
   const statusHidden = model.activeViewId === "dashboardView";
   const appErrorVariant = model.appErrorBanner.variant ?? undefined;
+  const menuButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useSignalEffect(() => {
     const lang = props.model.value.selectedLanguage;
@@ -301,6 +290,10 @@ function UiShellChrome(props: UiShellChromeProps) {
 
   function activateView(viewId: string): void {
     bridge.current.activateView(viewId);
+  }
+
+  function focusMenuButton(nextIndex: number): void {
+    menuButtonRefs.current[normalizeMenuIndex(nextIndex)]?.focus();
   }
 
   function handleMenuKeyDown(
@@ -316,27 +309,27 @@ function UiShellChrome(props: UiShellChromeProps) {
       event.preventDefault();
       const nextIndex = normalizeMenuIndex(index + 1);
       activateView(model.navItems[nextIndex].viewId);
-      focusMenuButton(event, nextIndex);
+      focusMenuButton(nextIndex);
       return;
     }
     if (event.key === "ArrowLeft") {
       event.preventDefault();
       const nextIndex = normalizeMenuIndex(index - 1);
       activateView(model.navItems[nextIndex].viewId);
-      focusMenuButton(event, nextIndex);
+      focusMenuButton(nextIndex);
       return;
     }
     if (event.key === "Home") {
       event.preventDefault();
       activateView(model.navItems[0].viewId);
-      focusMenuButton(event, 0);
+      focusMenuButton(0);
       return;
     }
     if (event.key === "End") {
       event.preventDefault();
       const nextIndex = model.navItems.length - 1;
       activateView(model.navItems[nextIndex].viewId);
-      focusMenuButton(event, nextIndex);
+      focusMenuButton(nextIndex);
     }
   }
 
@@ -365,6 +358,7 @@ function UiShellChrome(props: UiShellChromeProps) {
                 return (
                   <button
                     key={item.viewId}
+                    ref={(el) => { menuButtonRefs.current[index] = el; }}
                     type="button"
                     class={isActive ? "menu-btn active" : "menu-btn"}
                     data-view={item.viewId}

--- a/apps/ui/src/app/views/settings_shell.tsx
+++ b/apps/ui/src/app/views/settings_shell.tsx
@@ -1,4 +1,5 @@
 import { render, type JSX } from "preact";
+import { useRef } from "preact/hooks";
 
 import { useUiText } from "../ui_i18n";
 import {
@@ -76,22 +77,12 @@ function normalizeSettingsTabIndex(index: number): number {
   return ((index % SETTINGS_TABS.length) + SETTINGS_TABS.length) % SETTINGS_TABS.length;
 }
 
-function focusSettingsTab(
-  event: JSX.TargetedKeyboardEvent<HTMLButtonElement>,
-  nextIndex: number,
-): void {
-  const nav = event.currentTarget.closest(".settings-tabs");
-  if (!(nav instanceof HTMLElement)) {
-    return;
-  }
-  const buttons = Array.from(nav.querySelectorAll<HTMLButtonElement>(".settings-tab"));
-  buttons[normalizeSettingsTabIndex(nextIndex)]?.focus();
-}
-
 function SettingsShellTabButton(props: {
   activeTabId: ReadonlySignal<SettingsShellTabId>;
   index: number;
   onActivateTab(tabId: SettingsShellTabId): void;
+  onFocusTab(index: number): void;
+  onRef(el: HTMLButtonElement | null): void;
   tab: (typeof SETTINGS_TABS)[number];
 }) {
   const { index, onActivateTab, tab } = props;
@@ -113,32 +104,33 @@ function SettingsShellTabButton(props: {
       event.preventDefault();
       const nextIndex = normalizeSettingsTabIndex(index + 1);
       onActivateTab(SETTINGS_TABS[nextIndex].id);
-      focusSettingsTab(event, nextIndex);
+      props.onFocusTab(nextIndex);
       return;
     }
     if (event.key === "ArrowLeft") {
       event.preventDefault();
       const nextIndex = normalizeSettingsTabIndex(index - 1);
       onActivateTab(SETTINGS_TABS[nextIndex].id);
-      focusSettingsTab(event, nextIndex);
+      props.onFocusTab(nextIndex);
       return;
     }
     if (event.key === "Home") {
       event.preventDefault();
       onActivateTab(SETTINGS_TABS[0].id);
-      focusSettingsTab(event, 0);
+      props.onFocusTab(0);
       return;
     }
     if (event.key === "End") {
       event.preventDefault();
       const nextIndex = SETTINGS_TABS.length - 1;
       onActivateTab(SETTINGS_TABS[nextIndex].id);
-      focusSettingsTab(event, nextIndex);
+      props.onFocusTab(nextIndex);
     }
   }
 
   return (
     <button
+      ref={props.onRef}
       type="button"
       class={tabClass}
       data-settings-tab={tab.id}
@@ -176,6 +168,11 @@ function SettingsShellTabPanel(props: {
 
 function SettingsShell(props: SettingsShellProps) {
   const { onActivateTab } = props;
+  const tabButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  function focusTabAtIndex(index: number): void {
+    tabButtonRefs.current[normalizeSettingsTabIndex(index)]?.focus();
+  }
 
   return (
     <>
@@ -187,6 +184,8 @@ function SettingsShell(props: SettingsShellProps) {
               activeTabId={props.activeTabId}
               index={index}
               onActivateTab={onActivateTab}
+              onFocusTab={focusTabAtIndex}
+              onRef={(el) => { tabButtonRefs.current[index] = el; }}
               tab={tab}
             />
           );


### PR DESCRIPTION
## Problem

Two shell components — `settings_shell.tsx` and `ui_shell_chrome.tsx` — implement keyboard navigation for their respective tab bars using free-standing DOM-traversal helper functions. When a user presses Arrow keys, Home, or End, those helpers call `event.currentTarget.closest(".settings-tabs")` (or `".menu"`) then `querySelectorAll(".settings-tab")` (or `".menu-btn"`) to locate peer buttons before calling `.focus()`.

This pattern couples focus management to CSS class names and ambient DOM layout rather than to the component's own render tree. It also prevents TypeScript from tracking which DOM nodes the component owns and breaks in any test or server-side rendering context where `closest()` and `querySelectorAll()` are unavailable or return unexpected results.

## Approach

Replace both DOM-traversal focus helpers with `useRef`-backed ref arrays. Each tab button receives an `onRef` callback that stores its `HTMLButtonElement` into the owning component's ref array. When a keyboard event triggers focus movement, the owning component looks up the target index directly in that array instead of performing a DOM query.

This is the idiomatic Preact/React pattern for coordinating focus between sibling elements: refs are stable across renders, TypeScript can narrow their types, and they require no ambient DOM assumptions.

## Code Changes

### `apps/ui/src/app/views/settings_shell.tsx`

**Removed** the `focusSettingsTab()` free function, which previously used `event.currentTarget.closest(".settings-tabs")` and `nav.querySelectorAll<HTMLButtonElement>(".settings-tab")` to locate peer buttons.

**Added** two new props to `SettingsShellTabButton`:
- `onFocusTab(index: number) => void` — called by `handleTabKeyDown` instead of the removed DOM helper.
- `onRef(el: HTMLButtonElement | null) => void` — a ref callback that lets the parent store a reference to the rendered `<button>`.

The `<button>` element now receives `ref={props.onRef}`.

**Updated `SettingsShell`** to create a `tabButtonRefs = useRef<(HTMLButtonElement | null)[]>([])` array and a local `focusTabAtIndex()` helper. The SETTINGS_TABS map now passes `onFocusTab={focusTabAtIndex}` and `onRef={(el) => { tabButtonRefs.current[index] = el; }}` to each `SettingsShellTabButton`.

### `apps/ui/src/app/runtime/ui_shell_chrome.tsx`

**Removed** the `focusMenuButton()` free function, which previously used `event.currentTarget.closest(".menu")` and `menu.querySelectorAll<HTMLButtonElement>(".menu-btn")` to locate peer nav buttons.

**Added** `menuButtonRefs = useRef<(HTMLButtonElement | null)[]>([])` inside `UiShellChrome` and a local `focusMenuButton(nextIndex)` helper that performs the index lookup directly.

**Updated `handleMenuKeyDown`** to call the local `focusMenuButton(nextIndex)` instead of the removed DOM-traversal helper.

**Added** `ref={(el) => { menuButtonRefs.current[index] = el; }}` to the `<button>` element rendered inside `model.navItems.map()`.

## Schema, Contract, and Documentation Changes

No public API, schema, or i18n contract changes. The settings shell and shell chrome public interfaces are unchanged; the only change is in how focus is managed internally.

No documentation update is required — the ref-based focus pattern is already the repo's recommended approach for sibling-focus coordination (see `apps/ui/README.md` § "Signal hooks").

## Validation and Tests

- `npm run typecheck` — clean, no new errors.
- `npm run build` — clean, bundle sizes unchanged.
- `npm run lint` — clean, only the pre-existing Biome schema-version info.
- `npx playwright test tests/smoke.settings-shell.spec.ts tests/smoke.bootstrap.spec.ts --config=.ai-temp/playwright.full.local.config.ts --project=laptop-light --workers=1` — **6 passed**, including both settings-shell keyboard navigation assertions (Arrow key traversal, Home/End, click activation) and the full bootstrap smoke.

The keyboard navigation behavior exercised by `smoke.settings-shell.spec.ts` is unchanged: Arrow Right/Left cycle between tabs, Home/End jump to the first/last tab, and focus follows the active tab in both components.

## Risks and Tradeoffs

**Ref array initialisation:** `tabButtonRefs.current` and `menuButtonRefs.current` begin as empty arrays. The `?.focus()` optional chain guards against attempting to focus a not-yet-populated slot (e.g., before the first render commit). In practice the ref array is fully populated immediately after the first render because all buttons are always rendered.

**Key re-use with Preact reconciliation:** Both `SettingsShellTabButton` and the nav map use stable `key={tab.id}` / `key={item.viewId}`, so Preact does not unmount and remount button elements during normal navigation. The ref array therefore stays coherent across re-renders without needing a cleanup effect.

**Alternative considered — single container ref + query inside component:** It would be possible to keep a single ref on the `<nav>` element and call `querySelectorAll` at focus time from inside the component. This is marginally simpler but still couples focus to CSS class names and is harder to test. The per-button ref array is the conventional approach when the full set of focusable elements is known at render time.

## Follow-ups and Out-of-Scope Items

This PR addresses only the two named shell components. Any other `closest()`/`querySelectorAll()` usage elsewhere in the codebase was already removed by earlier issues in this backlog run and is not present in the current source tree.
