### PR TITLE
Batch sequential signal writes in realtime workflow

### DIFF
--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -18,6 +18,7 @@ import {
   type RealtimeState,
 } from "../ui_app_state";
 import {
+  batch,
   effect,
   signal,
   type ReadonlySignal,
@@ -235,11 +236,13 @@ export function createRealtimeFeatureWorkflow(
     try {
       nextStatus = await api.getLoggingStatus();
     } catch {
-      state.pendingLoggingAction.value = null;
-      state.loggingError.value = {
-        kind: "unavailable",
-        message: t("status.unavailable"),
-      };
+      batch(() => {
+        state.pendingLoggingAction.value = null;
+        state.loggingError.value = {
+          kind: "unavailable",
+          message: t("status.unavailable"),
+        };
+      });
       return;
     }
     realtime.loggingStatus = nextStatus;
@@ -258,45 +261,57 @@ export function createRealtimeFeatureWorkflow(
   async function startLogging(): Promise<void> {
     if (state.pendingLoggingAction.value) return;
     syncIdleCaptureReadinessSignature();
-    state.pendingLoggingAction.value = "starting";
-    state.loggingError.value = null;
+    batch(() => {
+      state.pendingLoggingAction.value = "starting";
+      state.loggingError.value = null;
+    });
     try {
       realtime.loggingStatus = await api.startLoggingRun();
       await recording.onRecordingStatusChanged();
       loggingStatusPolling.restart();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      state.pendingLoggingAction.value = null;
-      state.loggingError.value = {
-        kind: "error",
-        message: message || t("status.unavailable"),
-      };
+      batch(() => {
+        state.pendingLoggingAction.value = null;
+        state.loggingError.value = {
+          kind: "error",
+          message: message || t("status.unavailable"),
+        };
+      });
       return;
     }
-    state.pendingLoggingAction.value = null;
-    state.loggingError.value = null;
+    batch(() => {
+      state.pendingLoggingAction.value = null;
+      state.loggingError.value = null;
+    });
   }
 
   async function stopLogging(): Promise<void> {
     if (state.pendingLoggingAction.value) return;
     syncIdleCaptureReadinessSignature();
-    state.pendingLoggingAction.value = "stopping";
-    state.loggingError.value = null;
+    batch(() => {
+      state.pendingLoggingAction.value = "stopping";
+      state.loggingError.value = null;
+    });
     try {
       realtime.loggingStatus = await api.stopLoggingRun();
       await recording.onRecordingStatusChanged();
       loggingStatusPolling.restart();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      state.pendingLoggingAction.value = null;
-      state.loggingError.value = {
-        kind: "error",
-        message: message || t("status.unavailable"),
-      };
+      batch(() => {
+        state.pendingLoggingAction.value = null;
+        state.loggingError.value = {
+          kind: "error",
+          message: message || t("status.unavailable"),
+        };
+      });
       return;
     }
-    state.pendingLoggingAction.value = null;
-    state.loggingError.value = null;
+    batch(() => {
+      state.pendingLoggingAction.value = null;
+      state.loggingError.value = null;
+    });
   }
 
   async function refreshLocationOptions(): Promise<void> {


### PR DESCRIPTION
## Summary

This change eliminates unnecessary intermediate signal-subscriber notifications in `realtime_feature_workflow.ts` by wrapping pairs of sequential signal writes in `batch()` calls. Previously, writing `pendingLoggingAction` and `loggingError` as separate statements caused two rounds of subscriber notifications and downstream recomputations per write site; wrapping them in `batch()` defers all notifications until both writes are complete so each multi-signal update triggers only one notification cycle.

## Problem being solved

The `@preact/signals-core` reactive system notifies all subscribers after every individual `.value =` assignment. When two signals are written sequentially without batching, any computed signal or effect that reads both signals executes twice: once after the first write with a stale second value, and once after the second write with both values current. This is unnecessary work and can produce transient intermediate states that are never meaningful — for example, `pendingLoggingAction` cleared while `loggingError` still holds the previous error value, or `pendingLoggingAction` set to `"starting"` while `loggingError` still holds its old value before it is cleared.

The specific write sites affected were:

1. `refreshLoggingStatus()` catch block — sets `pendingLoggingAction.value = null` then `loggingError.value = { kind: "unavailable", ... }` sequentially, causing a redundant intermediate notification.
2. `startLogging()` entry — sets `pendingLoggingAction.value = "starting"` then `loggingError.value = null` sequentially.
3. `startLogging()` catch block — sets `pendingLoggingAction.value = null` then `loggingError.value = { kind: "error", ... }` sequentially.
4. `startLogging()` success block — sets `pendingLoggingAction.value = null` then `loggingError.value = null` sequentially.
5. `stopLogging()` entry — sets `pendingLoggingAction.value = "stopping"` then `loggingError.value = null` sequentially.
6. `stopLogging()` catch block — sets `pendingLoggingAction.value = null` then `loggingError.value = { kind: "error", ... }` sequentially.
7. `stopLogging()` success block — sets `pendingLoggingAction.value = null` then `loggingError.value = null` sequentially.

## Implementation approach

All paired `pendingLoggingAction` and `loggingError` writes in `refreshLoggingStatus`, `startLogging`, and `stopLogging` are wrapped in `batch(() => { ... })` calls. The `batch` function is already re-exported by `apps/ui/src/app/ui_signals.ts` alongside `signal`, `computed`, `effect`, and `untracked`, so a single import addition is all that is needed to make it available in the workflow module.

The `batch()` wrapper from `@preact/signals-core` defers subscriber notifications until the callback completes. Any computed signal that reads both `pendingLoggingAction` and `loggingError` will now recompute exactly once per logical state transition rather than twice. The reactive semantics are otherwise unchanged: each write still produces the same final values and the same stable computed results.

## Code changes

**`apps/ui/src/app/features/realtime_feature_workflow.ts`** — single file changed:

- Added `batch` to the existing destructured import from `../ui_signals`.
- `refreshLoggingStatus()` catch: the `pendingLoggingAction.value = null` + `loggingError.value = { ... }` pair is now wrapped in `batch()`.
- `startLogging()` function entry: the `pendingLoggingAction.value = "starting"` + `loggingError.value = null` pair is now wrapped in `batch()`.
- `startLogging()` catch block: the `pendingLoggingAction.value = null` + `loggingError.value = { ... }` pair is now wrapped in `batch()`.
- `startLogging()` success block: the `pendingLoggingAction.value = null` + `loggingError.value = null` pair is now wrapped in `batch()`.
- `stopLogging()` function entry: the `pendingLoggingAction.value = "stopping"` + `loggingError.value = null` pair is now wrapped in `batch()`.
- `stopLogging()` catch block: the `pendingLoggingAction.value = null` + `loggingError.value = { ... }` pair is now wrapped in `batch()`.
- `stopLogging()` success block: the `pendingLoggingAction.value = null` + `loggingError.value = null` pair is now wrapped in `batch()`.

No other files changed. No schema, contract, or configuration changes.

## Validation and tests

The existing `apps/ui/tests/realtime_feature_workflow.spec.ts` suite covers the start/stop/refresh workflow paths including logging action state and error state transitions. All 24 tests across both light and dark Playwright projects pass cleanly with no changes to test code. The batch wrappers are transparent to the observable behavior tested by those specs — the final signal values after each async operation are identical to the pre-batch behavior.

Local validation:

- `npx playwright test tests/realtime_feature_workflow.spec.ts --workers=1` — **24 passed**
- `npm run typecheck` — clean
- `npm run build` — clean, no bundle size regression

## Risks, tradeoffs, and edge cases

**No behavioral change**: `batch()` only controls *when* notifications fire, not *what* final values are written. Every test assertion on signal values passes unchanged.

**Scope boundary**: The issue specifically targets the three functions in this file. Two additional write sites exist in `startLogging()` and `stopLogging()` at the function entry (setting the pending action plus clearing the error before the async call begins). Those entry writes are also sequential pairs and are included here because they are structurally identical to the catch/success pairs and omitting them would leave the most commonly exercised path (the non-error path through start/stop) partially batched. Including them does not broaden scope meaningfully but does make the batching consistent across all write sites in the three functions.

**`refreshLoggingStatus` batching**: The catch block in `refreshLoggingStatus()` writes to the same two signals for the same reason (clear the pending action, set an error). It is included for consistency even though it is a lower-frequency path (only exercised when the background status poll fails).

**No interaction with outer `batch()` calls**: The `startLogging` and `stopLogging` entry-site `batch()` wrappers are safe even if the caller itself is already inside a batch, because `batch()` is re-entrant in `@preact/signals-core` — nested batches simply extend the outermost batch window. There are no outer batch wrappers on the calling side for these workflow functions.

## Follow-ups and out-of-scope items

Issue #2479 covers the analogous sequential write sites in `settings_speed_source_workflow.ts` and is the natural next step in the same signal-batching series.
