### PR TITLE
Remove structuredClone fallback in transport/clone.ts

### DIFF
--- a/apps/ui/src/app/features/cars_feature.ts
+++ b/apps/ui/src/app/features/cars_feature.ts
@@ -97,8 +97,8 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
       await workflow.submitCustomModel(action.value);
       return;
     }
-    if (action.type === "manual-inputs-changed") {
-      workflow.handleManualInputsChanged(action.inputs);
+    if (action.type === "manual-input-changed") {
+      workflow.handleManualInputChanged(action.field, action.value);
       return;
     }
     await workflow.finishWizard();

--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -125,7 +125,7 @@ export interface CarsFeatureWorkflow {
   getRenderState(): CarsFeatureRenderState;
   readonly renderState: ReadonlySignal<CarsFeatureRenderState>;
   goBack(): Promise<void>;
-  handleManualInputsChanged(inputs: CarsFeatureManualInputState): void;
+  handleManualInputChanged(field: keyof CarsFeatureManualInputState, value: string): void;
   openWizard(): Promise<void>;
   selectBrand(value: string): Promise<void>;
   selectGearbox(index: number): void;
@@ -520,9 +520,15 @@ export function createCarsFeatureWorkflow(
       await loadCurrentStep();
     },
 
-    handleManualInputsChanged(inputs: CarsFeatureManualInputState): void {
+    handleManualInputChanged(
+      field: keyof CarsFeatureManualInputState,
+      value: string,
+    ): void {
       batch(() => {
-        manualInputs.write(inputs);
+        manualInputs.write({
+          ...manualInputs.read(),
+          [field]: value,
+        });
         if (isOpen.value && wizardState.value.step === 4) {
           updateWizardState((state) => {
             state.specBranch = "manual";

--- a/apps/ui/src/app/views/cars_wizard_panel.tsx
+++ b/apps/ui/src/app/views/cars_wizard_panel.tsx
@@ -13,7 +13,7 @@ export type CarsFeatureInteraction =
   | { type: "back" }
   | { type: "close" }
   | { type: "finish" }
-  | { type: "manual-inputs-changed"; inputs: CarsFeatureManualInputState }
+  | { type: "manual-input-changed"; field: keyof CarsFeatureManualInputState; value: string }
   | { type: "open" }
   | { type: "select-brand"; value: string }
   | { type: "select-gearbox"; index: number }
@@ -46,11 +46,9 @@ export function CarsWizardPanel(props: {
     value: string,
   ): void {
     actions?.onAction({
-      type: "manual-inputs-changed",
-      inputs: {
-        ...wizardModel.manualInputs,
-        [field]: value,
-      },
+      type: "manual-input-changed",
+      field,
+      value,
     });
   }
 

--- a/apps/ui/src/transport/clone.ts
+++ b/apps/ui/src/transport/clone.ts
@@ -1,9 +1,3 @@
 export function cloneTransportValue<T>(value: T): T {
-  if (value === null || value === undefined || typeof value !== "object") {
-    return value;
-  }
-  if (typeof structuredClone === "function") {
-    return structuredClone(value);
-  }
-  return JSON.parse(JSON.stringify(value)) as T;
+  return structuredClone(value);
 }

--- a/apps/ui/tests/cars_feature_workflow.spec.ts
+++ b/apps/ui/tests/cars_feature_workflow.spec.ts
@@ -5,6 +5,7 @@ import {
   type CarsFeatureFocusTarget,
   type CarsFeatureWorkflowViewPorts,
 } from "../src/app/features/cars_feature_workflow";
+import type { CarsFeatureManualInputState } from "../src/app/features/cars_manual_input";
 import type {
   CarLibraryGearbox,
   CarLibraryModel,
@@ -46,6 +47,17 @@ function createDefaultManualInputs() {
     tireWidth: "225",
     topGear: "0.64",
   };
+}
+
+function updateManualInputs(
+  workflow: ReturnType<typeof createCarsFeatureWorkflow>,
+  updates: Partial<CarsFeatureManualInputState>,
+): void {
+  for (const [field, value] of Object.entries(updates) as Array<
+    [keyof CarsFeatureManualInputState, string]
+  >) {
+    workflow.handleManualInputChanged(field, value);
+  }
 }
 
 function makeGearbox(overrides: Partial<CarLibraryGearbox> = {}): CarLibraryGearbox {
@@ -137,8 +149,7 @@ test.describe("createCarsFeatureWorkflow", () => {
     await workflow.selectBrand("BMW");
     await workflow.selectType("SUV");
     await workflow.submitCustomModel("X5 M60i");
-    workflow.handleManualInputsChanged({
-      ...createDefaultManualInputs(),
+    updateManualInputs(workflow, {
       tireWidth: "245",
       topGear: "0.68",
     });
@@ -177,8 +188,7 @@ test.describe("createCarsFeatureWorkflow", () => {
     });
 
     await workflow.openWizard();
-    workflow.handleManualInputsChanged({
-      ...createDefaultManualInputs(),
+    updateManualInputs(workflow, {
       finalDrive: "4.10",
       topGear: "0.71",
     });
@@ -223,8 +233,7 @@ test.describe("createCarsFeatureWorkflow", () => {
     await workflow.openWizard();
     await workflow.selectBrand("BMW");
     await workflow.selectType("SUV");
-    workflow.handleManualInputsChanged({
-      ...createDefaultManualInputs(),
+    updateManualInputs(workflow, {
       finalDrive: "4.10",
       topGear: "0.71",
     });
@@ -256,8 +265,7 @@ test.describe("createCarsFeatureWorkflow", () => {
     await workflow.openWizard();
 
     const initialRenderState = workflow.getRenderState();
-    workflow.handleManualInputsChanged({
-      ...createDefaultManualInputs(),
+    updateManualInputs(workflow, {
       finalDrive: "4.10",
       topGear: "0.71",
     });
@@ -285,8 +293,7 @@ test.describe("createCarsFeatureWorkflow", () => {
     await workflow.openWizard();
 
     const initialRenderState = workflow.getRenderState();
-    workflow.handleManualInputsChanged({
-      ...createDefaultManualInputs(),
+    updateManualInputs(workflow, {
       finalDrive: "4.10",
       topGear: "0.71",
     });
@@ -325,6 +332,38 @@ test.describe("createCarsFeatureWorkflow", () => {
     const rerenderState = workflow.getRenderState();
     expect(rerenderState.typeOptions).not.toBe(initialRenderState.typeOptions);
     expect(rerenderState.manualInputs).toBe(initialRenderState.manualInputs);
+  });
+
+  test("preserves prior manual edits across sequential field changes", async () => {
+    const harness = createHarness();
+    const workflow = createCarsFeatureWorkflow({
+      addCarFromWizard: async () => undefined,
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      t: createTranslator(),
+      transport: {
+        async loadBrands() {
+          return ["BMW"];
+        },
+        async loadTypes() {
+          return ["SUV"];
+        },
+      },
+      view: createViewPorts(harness),
+    });
+
+    await workflow.openWizard();
+    await workflow.selectBrand("BMW");
+    await workflow.selectType("SUV");
+    await workflow.submitCustomModel("X5 M60i");
+
+    updateManualInputs(workflow, { tireWidth: "245" });
+    updateManualInputs(workflow, { topGear: "0.68" });
+
+    expect(workflow.getRenderState().manualInputs).toEqual({
+      ...createDefaultManualInputs(),
+      tireWidth: "245",
+      topGear: "0.68",
+    });
   });
 
   test("keeps the library branch disabled until a gearbox is chosen and then submits the selected specs", async () => {

--- a/apps/ui/tests/smoke.car-wizard.spec.ts
+++ b/apps/ui/tests/smoke.car-wizard.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 import {
   activateWizardCloseButton,
@@ -8,6 +8,16 @@ import {
   installFakeWebSocket,
   requestPath,
 } from "./smoke.helpers";
+
+async function fillControlledNumberInput(
+  page: Page,
+  selector: string,
+  value: string,
+): Promise<void> {
+  const input = page.locator(selector);
+  await input.fill(value);
+  await expect(input).toHaveValue(value);
+}
 
 test("opens the add car wizard in a focused task container and restores focus when canceled", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
@@ -263,8 +273,8 @@ test("keeps the manual branch deliberate while summarizing selections and activa
   await expect(page.locator(".wizard-custom-specs__note")).toBeVisible();
   await expect(page.locator("#wizardGearboxList")).toContainText("Enter specs manually below.");
   await expect(page.locator("#wizardActionHint")).toContainText("Manual path selected");
-  await page.locator("#wizTireWidth").fill("245");
-  await page.locator("#wizGearRatio").fill("0.68");
+  await fillControlledNumberInput(page, "#wizTireWidth", "245");
+  await fillControlledNumberInput(page, "#wizGearRatio", "0.68");
   await expect(page.locator("#wizardSummaryPanel")).toContainText("245/45R18");
   await expect(page.locator("#wizardSummaryPanel")).toContainText("Top gear 0.68");
   await page.locator("#addCarWizard").evaluate((wizard) => {


### PR DESCRIPTION
## Problem

This PR started as the fix for issue #2428: remove the dead fallback branch from `apps/ui/src/transport/clone.ts`. The helper previously checked for `structuredClone`, used it when available, and otherwise fell back to `JSON.parse(JSON.stringify(value))`. That fallback no longer matches the repo’s supported frontend runtime. `apps/ui/tsconfig.json` targets `ES2020`, and `apps/ui/vite.config.ts` explicitly aligns the Vite build target to `es2020`. In the environments this UI supports, `structuredClone` is already part of the platform contract. Keeping the fallback therefore preserved an unreachable compatibility path and a second cloning behavior inside a transport-boundary helper that is reused by multiple API adapters.

While landing that cleanup, PR CI exposed a second issue on the same branch: the `UI smoke tests` job failed in the car wizard flow. The failing smoke case was not about `structuredClone` directly. It showed that back-to-back manual edits in the wizard could produce an inconsistent summary, and the full suite reproduced it reliably enough to block merge. The failure surfaced two related problems in the same UI surface: the view emitted manual-input updates by spreading `wizardModel.manualInputs`, which is just the last rendered snapshot and can lag behind rapid sequential edits, and the smoke spec asserted the summary immediately after filling controlled number inputs without first waiting for those inputs to settle visibly. The PR now covers both the requested dead-code removal and the CI-blocking wizard/input path that the branch revealed.

## Chosen approach

I kept the original issue fix narrow, then addressed the CI blocker with the smallest maintainable change in the wizard pipeline instead of waving it away as flaky. For #2428 itself, the right change was still to collapse `cloneTransportValue()` to a direct `structuredClone(value)` call. I did not add new compatibility checks, keep the primitive fast path, or touch downstream API adapter signatures because the repo’s runtime guarantees make that extra branching dishonest.

For the car wizard issue, I did not try to paper over the failure only in the smoke test. The underlying problem was that the view built each manual-input action by merging the updated field into `wizardModel.manualInputs`, which is a render snapshot rather than the live workflow store. Two quick updates can therefore race against the next render and overwrite earlier edits with stale data. The clean fix was to move that merge into the workflow, where the current manual-input store is available and authoritative. Once that was done, I also hardened the smoke test so it waits for the controlled number inputs to report their settled values before it reads the summary panel.

## Main code changes by area

### 1. Transport clone helper cleanup

`apps/ui/src/transport/clone.ts`

- Removed the `typeof structuredClone === "function"` runtime branch.
- Removed the `JSON.parse(JSON.stringify(value))` fallback.
- Removed the separate primitive/null early-return path.
- Replaced the helper body with a single `return structuredClone(value);`.

This keeps the helper aligned with the supported platform contract and removes dead behavior from a transport utility used by the HTTP adapter layer and server-payload adaptation code.

### 2. Car wizard manual-input flow

`apps/ui/src/app/views/cars_wizard_panel.tsx`

- Changed the manual-input interaction payload from “full manual input object” to “field + value”.
- Stopped the view from reconstructing the next manual-input state from `wizardModel.manualInputs`.

`apps/ui/src/app/features/cars_feature.ts`

- Updated the feature action handler to forward the new field/value interaction to the workflow.

`apps/ui/src/app/features/cars_feature_workflow.ts`

- Replaced the old bulk `handleManualInputsChanged(inputs)` entry point with `handleManualInputChanged(field, value)`.
- Moved the merge to the workflow so it writes against `manualInputs.read()` — the live store — instead of a potentially stale render snapshot.
- Kept the existing batch behavior that switches the wizard into the manual branch at step 4.

This change removes the stale-merge risk at the actual owner of the state rather than teaching the view to keep more local bookkeeping.

### 3. Test coverage

`apps/ui/tests/cars_feature_workflow.spec.ts`

- Updated the workflow tests to use field-level manual input updates.
- Added focused coverage that proves sequential field edits preserve prior manual values instead of overwriting them.

`apps/ui/tests/smoke.car-wizard.spec.ts`

- Added a small helper that fills a controlled numeric input and waits for `toHaveValue(...)` before continuing.
- Applied that helper to the manual tire-width and top-gear edits in the previously failing smoke case.

This preserves the intent of the smoke test — verify the user-visible summary and add-car flow — while making the interaction robust against controlled-input timing in the full suite.

## Contracts, config, and docs

There are no contract or schema changes in this PR. Generated contract files remained in sync. There are also no documentation updates because the requested issue and the CI blocker were both internal frontend implementation/test concerns with no user-facing workflow or developer-command changes.

## Validation

I validated the original issue fix with the standard frontend checks used for UI logic changes:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

After the smoke failure surfaced, I validated the follow-up fix with both targeted and broader coverage:

- `cd apps/ui && npx playwright test tests/cars_feature_workflow.spec.ts tests/smoke.car-wizard.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run test:smoke`

The targeted workflow/smoke coverage passed after the workflow-side merge fix, and the full smoke suite passed after hardening the controlled-number-input interaction in the smoke spec.

## Risks and tradeoffs

The main behavioral change in the issue-driven part of this PR is that `cloneTransportValue()` now always uses native `structuredClone` semantics. That is the intended platform contract, but it does mean unsupported values will fail according to native clone rules rather than drifting through an outdated fallback. For transport payloads, that is the correct failure mode.

The wizard fix changes an internal action shape from “full input snapshot” to “field/value update”. That is an intentional coordinated cleanup, not a compatibility layer. The repo controls both the producer and the consumer of that action shape, so updating both sides in one PR is cleaner than preserving the old form.

On the test side, I chose not to replace the smoke interaction with a DOM `evaluate()` assignment. Waiting for `toHaveValue(...)` keeps the test interaction closer to user behavior while still making the controlled-input state transition explicit and stable.

## Out of scope

This PR does not try to batch in the other transport cleanup issues already present in the backlog, such as removing pass-through transport wrappers or auditing clone usage more broadly. It also does not try to refactor the rest of the car wizard input/test surface beyond the CI-blocking path that surfaced here. Those remain better handled as separate focused changes.

Closes #2428
