### PR TITLE
Wrap sequential signal writes in batch() in cars_feature_workflow.ts

### DIFF
--- a/apps/ui/src/app/features/cars_manual_input.ts
+++ b/apps/ui/src/app/features/cars_manual_input.ts
@@ -7,6 +7,7 @@ import {
   type ManualTireValues,
 } from "./cars_wizard_state";
 import {
+  batch,
   computed,
   signal,
   type ReadonlySignal,
@@ -95,11 +96,13 @@ export function createCarsManualInputStore(
   }
 
   function write(inputs: CarsFeatureManualInputState): void {
-    finalDrive.value = inputs.finalDrive;
-    rim.value = inputs.rim;
-    tireAspect.value = inputs.tireAspect;
-    tireWidth.value = inputs.tireWidth;
-    topGear.value = inputs.topGear;
+    batch(() => {
+      finalDrive.value = inputs.finalDrive;
+      rim.value = inputs.rim;
+      tireAspect.value = inputs.tireAspect;
+      tireWidth.value = inputs.tireWidth;
+      topGear.value = inputs.topGear;
+    });
   }
 
   return {

--- a/apps/ui/tests/cars_manual_input.spec.ts
+++ b/apps/ui/tests/cars_manual_input.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  createCarsManualInputStore,
+  type CarsFeatureManualInputState,
+} from "../src/app/features/cars_manual_input";
+import { effect, signal } from "../src/app/ui_signals";
+
+function formatManualInputs(inputs: CarsFeatureManualInputState): string {
+  return [
+    inputs.finalDrive,
+    inputs.rim,
+    inputs.tireAspect,
+    inputs.tireWidth,
+    inputs.topGear,
+  ].join(":");
+}
+
+test.describe("createCarsManualInputStore", () => {
+  test("batches multi-field writes into one reactive invalidation", () => {
+    const step = signal(4);
+    const store = createCarsManualInputStore(step);
+    const seenSnapshots: string[] = [];
+
+    const dispose = effect(() => {
+      seenSnapshots.push(formatManualInputs(store.read()));
+    });
+
+    expect(seenSnapshots).toEqual(["3.08:18:45:225:0.64"]);
+
+    store.write({
+      finalDrive: "4.10",
+      rim: "20",
+      tireAspect: "40",
+      tireWidth: "285",
+      topGear: "0.71",
+    });
+
+    expect(seenSnapshots).toEqual([
+      "3.08:18:45:225:0.64",
+      "4.10:20:40:285:0.71",
+    ]);
+
+    dispose();
+  });
+});


### PR DESCRIPTION
## Problem

This PR fixes issue #2429 by batching the multi-field manual input write path used by the cars wizard. The issue text points at `apps/ui/src/app/features/cars_feature_workflow.ts` and calls out a five-field write sequence that updates the manual final drive, rim, tire aspect, tire width, and top gear values one signal at a time. The performance concern is valid: when a helper updates those five signals sequentially without `batch()`, any dependent computed value can observe and recompute against intermediate partial states instead of one coherent snapshot.

The codebase has shifted slightly since the issue text was written. The relevant write path no longer lives inline in `cars_feature_workflow.ts`. The workflow now delegates manual input state to `createCarsManualInputStore()` in `apps/ui/src/app/features/cars_manual_input.ts`, and the unbatched five-signal write happens inside that store’s `write()` method. `cars_feature_workflow.ts` still owns the behavior, because it creates and uses the store, but the concrete implementation site moved. This PR follows the live code instead of preserving the stale file/line reference from the issue body.

## Chosen approach

I took the narrowest complete fix: wrap the five writes inside `createCarsManualInputStore().write()` with `batch()` and add focused test coverage that proves the store now produces a single reactive invalidation for a full manual input update. I did not widen the change into a larger workflow refactor, and I did not try to touch unrelated batching candidates elsewhere in the frontend. The goal here is to resolve the specific hot path described in the issue while keeping the diff small and easy to review.

This location is the correct owner for the fix. Multiple workflow paths call `manualInputs.write(...)`, including the load/spec-selection flow and the manual-edit path. If batching were added only around a single call site in the workflow, the store would still expose an unbatched bulk-write API and other callers would remain vulnerable to the same repeated recomputation pattern. Wrapping the store-level `write()` method ensures every bulk manual-input update is delivered as one coherent signal transaction regardless of which workflow branch triggered it.

## Main code changes

### 1. Batch the store write at the actual owner

`apps/ui/src/app/features/cars_manual_input.ts`

- Imported `batch` from the shared `ui_signals` surface.
- Wrapped the `write(inputs)` implementation in `batch(() => { ... })`.
- Left the individual field assignments unchanged inside the batch block so the store continues to write the exact same values to the exact same signals.

This means:

- `finalDrive`
- `rim`
- `tireAspect`
- `tireWidth`
- `topGear`

are now published to subscribers together instead of one by one.

The external shape of `CarsFeatureManualInputStore` does not change. Callers still use `read()` and `write()` the same way. The improvement is entirely in how that existing bulk write propagates through the signal graph.

### 2. Add focused regression coverage

`apps/ui/tests/cars_manual_input.spec.ts`

- Added a new focused test module for the manual input store.
- Created a test that subscribes to the store through `effect()` and records snapshots from `store.read()`.
- Verified that a full `store.write(...)` call only produces two snapshots total: the initial state and the final fully updated state.

Without batching, this test would observe intermediate partial snapshots as each field signal updated separately. With batching in place, the store now behaves like one atomic multi-field update from the point of view of downstream reactive consumers.

I intentionally kept this test at the store layer instead of trying to infer batching indirectly through unrelated UI presenters. That makes the regression signal tighter: it proves the behavior of the owner that the issue is actually about.

## Why this is enough

The issue’s concern is repeated recomputation caused by sequential signal writes. `cars_feature_workflow.ts` reads this manual input state in several downstream computed values, including the render state and wizard summary path. Once the store’s bulk write is batched, those downstream readers no longer see the intermediate write sequence from this API. That is the core fix.

I also checked the current workflow call sites before editing. The bulk write helper is used from the workflow’s spec-loading and tire-selection paths, and those calls all benefit automatically once the store-level write is batched. There was no need to introduce a second batching wrapper at each call site because the canonical bulk-write boundary is already the store’s `write()` method.

## Contracts, config, and docs

There are no API contract changes, generated-file changes, or configuration changes in this PR. No documentation updates were needed because the behavior change is an internal frontend reactivity optimization with focused test coverage rather than a user-visible workflow change or a new developer command.

## Validation

I validated the change with the existing frontend checks that match the touched area:

- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/cars_manual_input.spec.ts tests/cars_feature_workflow.spec.ts tests/smoke.car-wizard.spec.ts --project=laptop-light --workers=1`

The targeted Playwright run intentionally covers three layers:

1. the new store-level batching test,
2. the existing cars workflow tests near the affected state owner,
3. the nearby car wizard smoke flow that exercises the same manual input surface.

That gives enough confidence that the store now batches the write correctly and that the surrounding wizard behavior still works as expected.

## Risks and tradeoffs

The behavioral risk is low because the store still writes the same values to the same signals through the same public method. The only intended change is the timing of subscriber notification: dependent computations now see one final state instead of a sequence of intermediate states during a bulk write.

That timing change is exactly what the issue asks for, but it is still worth calling out because any code that accidentally depended on partial intermediate snapshots would no longer observe them. In this frontend architecture, that is a positive outcome. The manual input store represents one logical state object, so consumers should react to completed writes, not to transient partial updates.

I deliberately did not broaden this PR into a general “audit every sequential signal write” sweep. The repo already has follow-up batching and state-management issues in adjacent modules, and those should remain separate focused diffs rather than piggybacking on this one store fix.

## Out of scope

This PR does not:

- refactor `cars_feature_workflow.ts` beyond the owner-correct batching fix,
- change the manual input field model,
- alter wizard UX or visible strings,
- audit unrelated signal-write sites elsewhere in the UI,
- add new test infrastructure.

It only makes the existing bulk manual-input store write atomic from the reactive graph’s perspective and adds the focused regression coverage needed to keep it that way.

Closes #2429
