### PR TITLE
Audit and add missing batch() calls in settings_speed_source_workflow.ts

### DIFF
--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -10,6 +10,7 @@ import {
   type DisplayedSpeedSourceMode,
 } from "../speed_source_state";
 import {
+  batchAppStateUpdates,
   trackAppStateSlice,
   type SettingsState,
 } from "../ui_app_state";
@@ -300,13 +301,17 @@ export function createSettingsSpeedSourceWorkflow(
   }
 
   function applyPayload(payload: SpeedSourcePayload): void {
-    deps.settings.speedSource = payload.speed_source;
-    deps.settings.manualSpeedKph = payload.manual_speed_kph;
-    deps.settings.obdDeviceMac = payload.obd_device_mac ?? null;
-    deps.settings.obdDeviceName = payload.obd_device_name ?? null;
-    deps.settings.resolvedSpeedSource = null;
-    staleTimeoutInputValue.value = String(payload.stale_timeout_s);
-    syncInputsFromSettings();
+    batch(() => {
+      batchAppStateUpdates(() => {
+        deps.settings.speedSource = payload.speed_source;
+        deps.settings.manualSpeedKph = payload.manual_speed_kph;
+        deps.settings.obdDeviceMac = payload.obd_device_mac ?? null;
+        deps.settings.obdDeviceName = payload.obd_device_name ?? null;
+        deps.settings.resolvedSpeedSource = null;
+      });
+      staleTimeoutInputValue.value = String(payload.stale_timeout_s);
+      syncInputsFromSettings();
+    });
     deps.renderSpeedReadout();
   }
 
@@ -329,13 +334,17 @@ export function createSettingsSpeedSourceWorkflow(
   }
 
   function handleManualSpeedInput(value: string): void {
-    manualSpeedInputValue.value = value;
-    clearManualSpeedFeedback();
+    batch(() => {
+      manualSpeedInputValue.value = value;
+      clearManualSpeedFeedback();
+    });
   }
 
   function handleStaleTimeoutInput(value: string): void {
-    staleTimeoutInputValue.value = value;
-    clearStaleTimeoutFeedback();
+    batch(() => {
+      staleTimeoutInputValue.value = value;
+      clearStaleTimeoutFeedback();
+    });
   }
 
   async function saveSpeedSource(): Promise<void> {
@@ -360,39 +369,45 @@ export function createSettingsSpeedSourceWorkflow(
     const activeSource = activeSourceLabel(deps.settings, deps.t);
 
     if (manualSpeedInvalid) {
-      manualSpeedFeedback.value = {
-        body: deps.t("settings.speed.manual_invalid"),
-        compact: true,
-        tone: "error",
-      };
-      showSaveFeedback(
-        deps.t("settings.speed.manual_invalid"),
-        deps.t("settings.speed.validation_active_detail", { source: activeSource }),
-      );
+      batch(() => {
+        manualSpeedFeedback.value = {
+          body: deps.t("settings.speed.manual_invalid"),
+          compact: true,
+          tone: "error",
+        };
+        showSaveFeedback(
+          deps.t("settings.speed.manual_invalid"),
+          deps.t("settings.speed.validation_active_detail", { source: activeSource }),
+        );
+      });
       deps.view.focusManualSpeedInput();
       return;
     }
 
     if (staleTimeoutInvalid) {
-      staleTimeoutFeedback.value = {
-        body: deps.t("settings.speed.stale_timeout_invalid"),
-        compact: true,
-        tone: "error",
-      };
-      showSaveFeedback(
-        deps.t("settings.speed.stale_timeout_invalid"),
-        deps.t("settings.speed.validation_active_detail", { source: activeSource }),
-      );
+      batch(() => {
+        staleTimeoutFeedback.value = {
+          body: deps.t("settings.speed.stale_timeout_invalid"),
+          compact: true,
+          tone: "error",
+        };
+        showSaveFeedback(
+          deps.t("settings.speed.stale_timeout_invalid"),
+          deps.t("settings.speed.validation_active_detail", { source: activeSource }),
+        );
+      });
       deps.view.focusStaleTimeoutInput();
       return;
     }
 
     if (source === "obd2" && !deps.settings.obdDeviceMac) {
-      obdSelectionError.value = true;
-      showSaveFeedback(
-        deps.t("settings.speed.obd_missing_device_error"),
-        deps.t("settings.speed.validation_active_detail", { source: activeSource }),
-      );
+      batch(() => {
+        obdSelectionError.value = true;
+        showSaveFeedback(
+          deps.t("settings.speed.obd_missing_device_error"),
+          deps.t("settings.speed.validation_active_detail", { source: activeSource }),
+        );
+      });
       deps.view.focusScanObdDevices();
       return;
     }
@@ -420,20 +435,24 @@ export function createSettingsSpeedSourceWorkflow(
     if (scanInFlight.value || pairInFlightMac.value !== null) {
       return;
     }
-    scanInFlight.value = true;
-    if (mode === "manual") {
-      clearObdSelectionFeedback();
-      obdScanStatusMessage.value = deps.t("settings.speed.obd_scanning");
-    }
+    batch(() => {
+      scanInFlight.value = true;
+      if (mode === "manual") {
+        clearObdSelectionFeedback();
+        obdScanStatusMessage.value = deps.t("settings.speed.obd_scanning");
+      }
+    });
     syncBackgroundRescan();
     try {
       const payload = await transport.scanObdDevices();
       if (mode === "manual") {
-        setScannedDevices(payload.devices);
         backgroundRescanRequested = true;
-        obdScanStatusMessage.value = payload.devices.length > 0
-          ? deps.t("settings.speed.obd_scan_found", { count: payload.devices.length })
-          : deps.t("settings.speed.obd_scan_empty");
+        batch(() => {
+          setScannedDevices(payload.devices);
+          obdScanStatusMessage.value = payload.devices.length > 0
+            ? deps.t("settings.speed.obd_scan_found", { count: payload.devices.length })
+            : deps.t("settings.speed.obd_scan_empty");
+        });
         syncBackgroundRescan();
       } else {
         mergeScannedDevices(payload.devices);
@@ -451,22 +470,28 @@ export function createSettingsSpeedSourceWorkflow(
 
   async function pairObdDevice(macAddress: string): Promise<void> {
     clearObdSelectionFeedback();
-    pairInFlightMac.value = macAddress;
-    obdScanStatusMessage.value = deps.t("settings.speed.obd_pairing");
+    batch(() => {
+      pairInFlightMac.value = macAddress;
+      obdScanStatusMessage.value = deps.t("settings.speed.obd_pairing");
+    });
     syncBackgroundRescan();
     try {
       const payload = await transport.pairObdDevice(macAddress);
-      deps.settings.obdDeviceMac = payload.configured_device_mac ?? null;
-      deps.settings.obdDeviceName = payload.configured_device_name ?? null;
-      mergeScannedDevices([{
-        connected: payload.connected,
-        mac_address: payload.configured_device_mac ?? macAddress,
-        name: payload.configured_device_name ?? null,
-        paired: payload.paired,
-        rfcomm_channel: payload.rfcomm_channel,
-        trusted: payload.trusted,
-      }]);
-      obdScanStatusMessage.value = deps.t("settings.speed.obd_pair_success");
+      batch(() => {
+        batchAppStateUpdates(() => {
+          deps.settings.obdDeviceMac = payload.configured_device_mac ?? null;
+          deps.settings.obdDeviceName = payload.configured_device_name ?? null;
+        });
+        mergeScannedDevices([{
+          connected: payload.connected,
+          mac_address: payload.configured_device_mac ?? macAddress,
+          name: payload.configured_device_name ?? null,
+          paired: payload.paired,
+          rfcomm_channel: payload.rfcomm_channel,
+          trusted: payload.trusted,
+        }]);
+        obdScanStatusMessage.value = deps.t("settings.speed.obd_pair_success");
+      });
     } catch (error) {
       obdScanStatusMessage.value = deps.t("settings.speed.obd_pair_failed");
       deps.showError(error instanceof Error ? error.message : deps.t("settings.speed.obd_pair_failed"));

--- a/apps/ui/tests/settings_speed_source_workflow.spec.ts
+++ b/apps/ui/tests/settings_speed_source_workflow.spec.ts
@@ -10,6 +10,7 @@ import type {
   SpeedSourceRequest,
 } from "../src/transport/http_models";
 import { createAppState } from "../src/app/ui_app_state";
+import { effect } from "../src/app/ui_signals";
 
 type WorkflowHarness = {
   contextVisible: boolean;
@@ -84,6 +85,55 @@ function makeObdDevice(
 }
 
 test.describe("createSettingsSpeedSourceWorkflow", () => {
+  test("applies loaded payload updates as one render-state invalidation", async () => {
+    const harness = createHarness();
+    const appState = createAppState();
+    const workflow = createSettingsSpeedSourceWorkflow({
+      renderSpeedReadout: () => undefined,
+      settings: appState.settings,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      t: createTranslator(),
+      transport: {
+        async loadSpeedSource() {
+          return makeSpeedSourcePayload({
+            manual_speed_kph: 90,
+            obd_device_mac: "00:22:d9:00:1b:b1",
+            obd_device_name: "OBDLink CX",
+            speed_source: "manual",
+            stale_timeout_s: 12,
+          });
+        },
+      },
+      view: createViewPorts(harness),
+    });
+    const seenSnapshots: string[] = [];
+
+    const dispose = effect(() => {
+      const state = workflow.renderState.value;
+      seenSnapshots.push([
+        state.selectedMode,
+        state.manualSpeedInputValue,
+        state.staleTimeoutInputValue,
+        state.settings.speedSource,
+        String(state.settings.manualSpeedKph),
+      ].join(":"));
+    });
+
+    expect(seenSnapshots).toEqual(["gps:::gps:null"]);
+
+    await workflow.loadSpeedSourceFromServer();
+
+    expect(seenSnapshots).toEqual([
+      "gps:::gps:null",
+      "manual:90:12:manual:90",
+    ]);
+    expect(harness.errors).toEqual([]);
+
+    dispose();
+  });
+
   test("keeps the configured GPS source when saving fallback-manual edits without a radio change", async () => {
     const harness = createHarness();
     const appState = createAppState();
@@ -158,6 +208,47 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
         tone: "error",
       },
     });
+  });
+
+  test("clears manual validation feedback in one render-state invalidation", async () => {
+    const harness = createHarness();
+    const appState = createAppState();
+    const workflow = createSettingsSpeedSourceWorkflow({
+      renderSpeedReadout: () => undefined,
+      settings: appState.settings,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      t: createTranslator(),
+      view: createViewPorts(harness),
+    });
+
+    workflow.handleSpeedSourceChanged("manual");
+    await workflow.saveSpeedSource();
+
+    const seenSnapshots: string[] = [];
+    const dispose = effect(() => {
+      const state = workflow.renderState.value;
+      seenSnapshots.push([
+        state.manualSpeedInputValue,
+        state.manualSpeedFeedback?.body ?? "none",
+        state.saveFeedback?.body ?? "none",
+      ].join(":"));
+    });
+
+    expect(seenSnapshots).toEqual([
+      ":settings.speed.manual_invalid:settings.speed.manual_invalid",
+    ]);
+
+    workflow.handleManualSpeedInput("80");
+
+    expect(seenSnapshots).toEqual([
+      ":settings.speed.manual_invalid:settings.speed.manual_invalid",
+      "80:none:none",
+    ]);
+    expect(harness.errors).toEqual([]);
+
+    dispose();
   });
 
   test("scans and pairs OBD devices without DOM bindings", async () => {


### PR DESCRIPTION
## Problem

This PR fixes issue #2479 by auditing `apps/ui/src/app/features/settings_speed_source_workflow.ts` for synchronous multi-write state transitions that were still notifying render-state subscribers one field at a time. The issue description was directionally right but incomplete: the workflow already had some `batch()` coverage in helper methods such as `clearAllFeedback()`, `syncInputsFromSettings()`, and `handleSpeedSourceChanged()`. The real work here was to identify the remaining gaps instead of blindly wrapping the whole file.

`createSettingsSpeedSourceWorkflow()` exposes a `renderState` computed that reads a wide surface area: workflow signals such as `selectedMode`, `manualSpeedInputValue`, `staleTimeoutInputValue`, scan/pair status, feedback messages, and an AppState-backed settings slice via `trackAppStateSlice(deps.settings)`. When synchronous workflow code mutates several of those inputs one after another without batching, subscribers can observe intermediate partial states and recompute multiple times during one logical action. That is wasted work in the reactive graph and makes the workflow harder to reason about because render consumers can briefly see transitions that are not meaningful user states.

## Chosen approach

I kept the fix owner-correct and narrow. Instead of introducing new abstractions or trying to redesign the feature, I audited the existing synchronous write paths and wrapped only the logical multi-write transitions that were still unbatched. For AppState-backed settings writes, I used the repo’s existing `batchAppStateUpdates()` helper so the settings slice participates in the same atomic transition model as the workflow signals. For workflow-owned signals, I used `batch()` directly around the specific write groups that should publish as one render-state update.

I also added focused subscriber-facing tests in `apps/ui/tests/settings_speed_source_workflow.spec.ts`. These tests do not inspect implementation details or count raw setter calls. Instead, they subscribe to `workflow.renderState` with `effect()` and prove that consumers now see one final snapshot for two representative multi-write paths: applying a loaded payload and clearing validation feedback during manual input editing.

## Main code changes

### 1. Batch payload application at the workflow boundary

`apps/ui/src/app/features/settings_speed_source_workflow.ts`

`applyPayload()` previously wrote five settings fields directly onto `deps.settings`, then updated `staleTimeoutInputValue`, then called `syncInputsFromSettings()`. Because `renderState` tracks both the settings slice and several workflow signals, that sequence could trigger multiple recomputations while one payload was being applied.

This PR changes `applyPayload()` to:

- wrap the whole transition in `batch()`,
- wrap the settings-slice writes inside `batchAppStateUpdates()`,
- keep the stale-timeout input write and `syncInputsFromSettings()` inside the same outer batch.

That keeps payload application coherent for both AppState readers and workflow-signal readers.

### 2. Batch manual and stale-timeout input updates with feedback clearing

The workflow’s input handlers were still doing this pattern:

- write the input value,
- call a helper that clears one or more feedback signals.

That meant subscribers could see the input update first and the feedback clear later, even though both belong to one user action. `handleManualSpeedInput()` and `handleStaleTimeoutInput()` now wrap those combined changes in `batch()`.

### 3. Batch validation-state updates inside `saveSpeedSource()`

The invalid-save branches were still publishing error state in pieces:

- set field-level feedback,
- call `showSaveFeedback()` to update the save banner and diagnostics state,
- then focus the relevant field.

The focus side effect stays outside batching, but the reactive state updates now publish together. This applies to:

- invalid manual speed,
- invalid stale-timeout input,
- missing OBD selection for OBD mode.

That keeps the render model from walking through incomplete error states.

### 4. Batch scan and pair lifecycle state transitions

The OBD scan/pair flow had several remaining synchronous multi-write groups:

- manual scan start (`scanInFlight`, cleared OBD feedback, scan status),
- manual scan success (`scannedDevices`, scan status),
- pair start (`pairInFlightMac`, pair status),
- pair success (configured OBD settings, merged scanned device state, pair status).

Those transitions are now batched. For pair success, the configured device fields on `deps.settings` are updated through `batchAppStateUpdates()` inside the outer workflow batch so AppState subscribers and workflow subscribers move together.

I did not force batching onto paths that only update one reactive field plus a non-reactive side effect. For example, the scan/pair failure branches still set one status signal and then call `showError(...)`. That is not a missed batching case because there is only one reactive write in those blocks.

## Test coverage

I added two focused regression tests to `apps/ui/tests/settings_speed_source_workflow.spec.ts`.

1. **Loaded payload batching**

This test subscribes to `workflow.renderState`, calls `loadSpeedSourceFromServer()`, and asserts that subscribers see only:

- the initial snapshot,
- the final fully applied snapshot.

Without the batching fix, this path would expose intermediate render states while the settings slice and workflow inputs updated one by one.

2. **Manual validation clear batching**

This test first drives the workflow into an invalid manual-speed state so both field-level and save-level feedback are present. It then subscribes to `workflow.renderState`, calls `handleManualSpeedInput("80")`, and asserts that subscribers see one follow-up snapshot where:

- the manual input value is updated,
- the field-level feedback is gone,
- the save feedback is gone.

Without batching, this action would produce multiple intermediate subscriber notifications as the input and feedback fields cleared separately.

## Validation

I validated the change with the existing frontend checks that match the touched area:

- `cd apps/ui && npx playwright test tests/settings_speed_source_workflow.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

The targeted workflow test file is the right local regression surface here because the issue is about reactive workflow state transitions rather than a rendered UI layout change. Typecheck and build confirm the updated batching/helper usage still fits the app’s normal frontend contract and production bundle.

## Risks and tradeoffs

The intended behavior change is subscriber timing. Consumers of `renderState` now see fewer intermediate states during several workflow operations because logically related writes publish together. That is the desired outcome for this issue, but it is still the key tradeoff to call out explicitly: anything depending on transient partial snapshots would no longer observe them.

In this module that is a positive cleanup, not a compatibility concern. The workflow already models actions like “apply payload”, “clear validation while editing”, “start scan”, and “complete pair” as coherent state transitions. Publishing partial internal steps to render subscribers adds noise rather than useful behavior.

I also kept the scope bounded. This PR does not attempt a repo-wide batching sweep or a broader redesign of the settings feature. It only closes the concrete batching gaps in `settings_speed_source_workflow.ts` that still affected render-state recomputation and adds focused tests to keep those paths atomic.

Closes #2479
