### PR TITLE
Remove pass-through fromTransportPayload/toTransportPayload wrappers

### DIFF
--- a/apps/ui/src/api/car_library.ts
+++ b/apps/ui/src/api/car_library.ts
@@ -1,16 +1,16 @@
 import { apiJson } from "./http";
-import { fromTransportPayload } from "../transport/http_adapters";
+import { cloneTransportValue } from "../transport/clone";
 import type * as Local from "../transport/http_models";
 import type * as Transport from "./types";
 
 export async function getCarLibraryBrands(): Promise<Local.CarLibraryBrandsPayload> {
-  return fromTransportPayload<Transport.CarLibraryBrandsPayload, Local.CarLibraryBrandsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.CarLibraryBrandsPayload>("/api/car-library/brands"),
   );
 }
 
 export async function getCarLibraryTypes(brand: string): Promise<Local.CarLibraryTypesPayload> {
-  return fromTransportPayload<Transport.CarLibraryTypesPayload, Local.CarLibraryTypesPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.CarLibraryTypesPayload>(
       `/api/car-library/types?brand=${encodeURIComponent(brand)}`,
     ),
@@ -21,7 +21,7 @@ export async function getCarLibraryModels(
   brand: string,
   type: string,
 ): Promise<Local.CarLibraryModelsPayload> {
-  return fromTransportPayload<Transport.CarLibraryModelsPayload, Local.CarLibraryModelsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.CarLibraryModelsPayload>(
       `/api/car-library/models?brand=${encodeURIComponent(brand)}&type=${encodeURIComponent(type)}`,
     ),

--- a/apps/ui/src/api/clients.ts
+++ b/apps/ui/src/api/clients.ts
@@ -1,12 +1,12 @@
 import { apiJson } from "./http";
-import { fromTransportPayload } from "../transport/http_adapters";
+import { cloneTransportValue } from "../transport/clone";
 import type * as Local from "../transport/http_models";
 import type * as Transport from "./types";
 
 const JSON_HEADERS: HeadersInit = { "Content-Type": "application/json" };
 
 export async function getClientLocations(): Promise<Local.ClientLocationsResponse> {
-  return fromTransportPayload<Transport.ClientLocationsResponse, Local.ClientLocationsResponse>(
+  return cloneTransportValue(
     await apiJson<Transport.ClientLocationsResponse>("/api/client-locations"),
   );
 }

--- a/apps/ui/src/api/history.ts
+++ b/apps/ui/src/api/history.ts
@@ -1,5 +1,5 @@
 import { apiJson, apiJsonResponse } from "./http";
-import { fromTransportPayload } from "../transport/http_adapters";
+import { cloneTransportValue } from "../transport/clone";
 import type * as Local from "../transport/http_models";
 import type * as Transport from "./types";
 
@@ -12,13 +12,13 @@ export function historyReportPdfUrl(runId: string, lang: string): string {
 }
 
 export async function getHistory(): Promise<Local.HistoryListPayload> {
-  return fromTransportPayload<Transport.HistoryListPayload, Local.HistoryListPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.HistoryListPayload>("/api/history"),
   );
 }
 
 export async function deleteHistoryRun(runId: string): Promise<Local.DeleteHistoryRunPayload> {
-  return fromTransportPayload<Transport.DeleteHistoryRunPayload, Local.DeleteHistoryRunPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.DeleteHistoryRunPayload>(`/api/history/${encodeURIComponent(runId)}`, {
       method: "DELETE",
     }),
@@ -26,7 +26,7 @@ export async function deleteHistoryRun(runId: string): Promise<Local.DeleteHisto
 }
 
 export async function getHistoryRun(runId: string): Promise<Local.HistoryRunPayload> {
-  return fromTransportPayload<Transport.HistoryRunPayload, Local.HistoryRunPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.HistoryRunPayload>(`/api/history/${encodeURIComponent(runId)}`),
   );
 }
@@ -42,11 +42,11 @@ export async function getHistoryInsights(
     throw new Error("Empty history insights response");
   }
   if (response.status === 202) {
-    return fromTransportPayload<Transport.HistoryInsightsAnalyzingPayload, Local.HistoryInsightsAnalyzingPayload>(
+    return cloneTransportValue(
       response.body as Transport.HistoryInsightsAnalyzingPayload,
     );
   }
-  return fromTransportPayload<Transport.HistoryInsightsPayload, Local.HistoryInsightsPayload>(
+  return cloneTransportValue(
     response.body as Transport.HistoryInsightsPayload,
   );
 }

--- a/apps/ui/src/api/logging.ts
+++ b/apps/ui/src/api/logging.ts
@@ -1,22 +1,22 @@
 import { apiJson } from "./http";
-import { fromTransportPayload } from "../transport/http_adapters";
+import { cloneTransportValue } from "../transport/clone";
 import type * as Local from "../transport/http_models";
 import type * as Transport from "./types";
 
 export async function getLoggingStatus(): Promise<Local.LoggingStatusPayload> {
-  return fromTransportPayload<Transport.LoggingStatusPayload, Local.LoggingStatusPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.LoggingStatusPayload>("/api/recording/status"),
   );
 }
 
 export async function startLoggingRun(): Promise<Local.LoggingStatusPayload> {
-  return fromTransportPayload<Transport.LoggingStatusPayload, Local.LoggingStatusPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.LoggingStatusPayload>("/api/recording/start", { method: "POST" }),
   );
 }
 
 export async function stopLoggingRun(): Promise<Local.LoggingStatusPayload> {
-  return fromTransportPayload<Transport.LoggingStatusPayload, Local.LoggingStatusPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.LoggingStatusPayload>("/api/recording/stop", { method: "POST" }),
   );
 }

--- a/apps/ui/src/api/settings.ts
+++ b/apps/ui/src/api/settings.ts
@@ -1,5 +1,5 @@
 import { apiJson } from "./http";
-import { fromTransportPayload, toTransportPayload } from "../transport/http_adapters";
+import { cloneTransportValue } from "../transport/clone";
 import type * as Local from "../transport/http_models";
 import type * as Transport from "./types";
 
@@ -7,13 +7,13 @@ const JSON_HEADERS: HeadersInit = { "Content-Type": "application/json" };
 const OBD_SCAN_TIMEOUT_MS = 20_000;
 
 export async function getSettingsLanguage(): Promise<Local.LanguagePayload> {
-  return fromTransportPayload<Transport.LanguagePayload, Local.LanguagePayload>(
+  return cloneTransportValue(
     await apiJson<Transport.LanguagePayload>("/api/settings/language"),
   );
 }
 
 export async function setSettingsLanguage(language: string): Promise<Local.LanguagePayload> {
-  return fromTransportPayload<Transport.LanguagePayload, Local.LanguagePayload>(
+  return cloneTransportValue(
     await apiJson<Transport.LanguagePayload>("/api/settings/language", {
       method: "PUT",
       headers: JSON_HEADERS,
@@ -23,13 +23,13 @@ export async function setSettingsLanguage(language: string): Promise<Local.Langu
 }
 
 export async function getSettingsSpeedUnit(): Promise<Local.SpeedUnitPayload> {
-  return fromTransportPayload<Transport.SpeedUnitPayload, Local.SpeedUnitPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.SpeedUnitPayload>("/api/settings/speed-unit"),
   );
 }
 
 export async function setSettingsSpeedUnit(speedUnit: string): Promise<Local.SpeedUnitPayload> {
-  return fromTransportPayload<Transport.SpeedUnitPayload, Local.SpeedUnitPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.SpeedUnitPayload>("/api/settings/speed-unit", {
       method: "PUT",
       headers: JSON_HEADERS,
@@ -39,7 +39,7 @@ export async function setSettingsSpeedUnit(speedUnit: string): Promise<Local.Spe
 }
 
 export async function getAnalysisSettings(): Promise<Local.AnalysisSettingsPayload> {
-  return fromTransportPayload<Transport.AnalysisSettingsPayload, Local.AnalysisSettingsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.AnalysisSettingsPayload>("/api/settings/analysis"),
   );
 }
@@ -47,29 +47,29 @@ export async function getAnalysisSettings(): Promise<Local.AnalysisSettingsPaylo
 export async function setAnalysisSettings(
   payload: Local.AnalysisSettingsRequest,
 ): Promise<Local.AnalysisSettingsPayload> {
-  return fromTransportPayload<Transport.AnalysisSettingsPayload, Local.AnalysisSettingsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.AnalysisSettingsPayload>("/api/settings/analysis", {
       method: "PUT",
       headers: JSON_HEADERS,
       body: JSON.stringify(
-        toTransportPayload<Local.AnalysisSettingsRequest, Transport.AnalysisSettingsRequest>(payload),
+        cloneTransportValue(payload),
       ),
     }),
   );
 }
 
 export async function getSettingsCars(): Promise<Local.CarsPayload> {
-  return fromTransportPayload<Transport.CarsPayload, Local.CarsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.CarsPayload>("/api/settings/cars"),
   );
 }
 
 export async function addSettingsCar(car: Local.CarUpsertRequest): Promise<Local.CarsPayload> {
-  return fromTransportPayload<Transport.CarsPayload, Local.CarsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.CarsPayload>("/api/settings/cars", {
       method: "POST",
       headers: JSON_HEADERS,
-      body: JSON.stringify(toTransportPayload<Local.CarUpsertRequest, Transport.CarUpsertRequest>(car)),
+      body: JSON.stringify(cloneTransportValue(car)),
     }),
   );
 }
@@ -78,17 +78,17 @@ export async function updateSettingsCar(
   carId: string,
   car: Local.CarUpsertRequest,
 ): Promise<Local.CarsPayload> {
-  return fromTransportPayload<Transport.CarsPayload, Local.CarsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.CarsPayload>(`/api/settings/cars/${encodeURIComponent(carId)}`, {
       method: "PUT",
       headers: JSON_HEADERS,
-      body: JSON.stringify(toTransportPayload<Local.CarUpsertRequest, Transport.CarUpsertRequest>(car)),
+      body: JSON.stringify(cloneTransportValue(car)),
     }),
   );
 }
 
 export async function deleteSettingsCar(carId: string): Promise<Local.CarsPayload> {
-  return fromTransportPayload<Transport.CarsPayload, Local.CarsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.CarsPayload>(`/api/settings/cars/${encodeURIComponent(carId)}`, {
       method: "DELETE",
     }),
@@ -96,7 +96,7 @@ export async function deleteSettingsCar(carId: string): Promise<Local.CarsPayloa
 }
 
 export async function setActiveSettingsCar(carId: string): Promise<Local.CarsPayload> {
-  return fromTransportPayload<Transport.CarsPayload, Local.CarsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.CarsPayload>("/api/settings/cars/active", {
       method: "PUT",
       headers: JSON_HEADERS,
@@ -106,7 +106,7 @@ export async function setActiveSettingsCar(carId: string): Promise<Local.CarsPay
 }
 
 export async function getSettingsSpeedSource(): Promise<Local.SpeedSourcePayload> {
-  return fromTransportPayload<Transport.SpeedSourcePayload, Local.SpeedSourcePayload>(
+  return cloneTransportValue(
     await apiJson<Transport.SpeedSourcePayload>("/api/settings/speed-source"),
   );
 }
@@ -114,23 +114,23 @@ export async function getSettingsSpeedSource(): Promise<Local.SpeedSourcePayload
 export async function updateSettingsSpeedSource(
   data: Local.SpeedSourceRequest,
 ): Promise<Local.SpeedSourcePayload> {
-  return fromTransportPayload<Transport.SpeedSourcePayload, Local.SpeedSourcePayload>(
+  return cloneTransportValue(
     await apiJson<Transport.SpeedSourcePayload>("/api/settings/speed-source", {
       method: "PUT",
       headers: JSON_HEADERS,
-      body: JSON.stringify(toTransportPayload<Local.SpeedSourceRequest, Transport.SpeedSourceRequest>(data)),
+      body: JSON.stringify(cloneTransportValue(data)),
     }),
   );
 }
 
 export async function getSpeedSourceStatus(): Promise<Local.SpeedSourceStatusPayload> {
-  return fromTransportPayload<Transport.SpeedSourceStatusPayload, Local.SpeedSourceStatusPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.SpeedSourceStatusPayload>("/api/settings/speed-source/status"),
   );
 }
 
 export async function scanSettingsObdDevices(): Promise<Local.ObdScanPayload> {
-  return fromTransportPayload<Transport.ObdScanPayload, Local.ObdScanPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.ObdScanPayload>("/api/settings/obd/scan", {
       method: "POST",
       timeoutMs: OBD_SCAN_TIMEOUT_MS,
@@ -139,7 +139,7 @@ export async function scanSettingsObdDevices(): Promise<Local.ObdScanPayload> {
 }
 
 export async function pairSettingsObdDevice(macAddress: string): Promise<Local.ObdPairPayload> {
-  return fromTransportPayload<Transport.ObdPairPayload, Local.ObdPairPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.ObdPairPayload>("/api/settings/obd/pair", {
       method: "POST",
       headers: JSON_HEADERS,
@@ -149,25 +149,25 @@ export async function pairSettingsObdDevice(macAddress: string): Promise<Local.O
 }
 
 export async function getSettingsObdStatus(): Promise<Local.ObdStatusPayload> {
-  return fromTransportPayload<Transport.ObdStatusPayload, Local.ObdStatusPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.ObdStatusPayload>("/api/settings/obd/status"),
   );
 }
 
 export async function getUpdateStatus(): Promise<Local.UpdateStatusPayload> {
-  return fromTransportPayload<Transport.UpdateStatusPayload, Local.UpdateStatusPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.UpdateStatusPayload>("/api/update/status"),
   );
 }
 
 export async function getUpdateInternetStatus(): Promise<Local.UsbInternetStatusPayload> {
-  return fromTransportPayload<Transport.UsbInternetStatusPayload, Local.UsbInternetStatusPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.UsbInternetStatusPayload>("/api/update/internet-status"),
   );
 }
 
 export async function getHealthStatus(): Promise<Local.HealthStatusPayload> {
-  return fromTransportPayload<Transport.HealthStatusPayload, Local.HealthStatusPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.HealthStatusPayload>("/api/health"),
   );
 }
@@ -175,19 +175,19 @@ export async function getHealthStatus(): Promise<Local.HealthStatusPayload> {
 export async function startUpdate(
   payload: Local.UpdateStartRequestPayload,
 ): Promise<Local.UpdateStartPayload> {
-  return fromTransportPayload<Transport.UpdateStartPayload, Local.UpdateStartPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.UpdateStartPayload>("/api/update/start", {
       method: "POST",
       headers: JSON_HEADERS,
       body: JSON.stringify(
-        toTransportPayload<Local.UpdateStartRequestPayload, Transport.UpdateStartRequestPayload>(payload),
+        cloneTransportValue(payload),
       ),
     }),
   );
 }
 
 export async function cancelUpdate(): Promise<Local.UpdateCancelPayload> {
-  return fromTransportPayload<Transport.UpdateCancelPayload, Local.UpdateCancelPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.UpdateCancelPayload>("/api/update/cancel", {
       method: "POST",
     }),
@@ -195,7 +195,7 @@ export async function cancelUpdate(): Promise<Local.UpdateCancelPayload> {
 }
 
 export async function getEspFlashPorts(): Promise<Local.EspFlashPortsPayload> {
-  return fromTransportPayload<Transport.EspFlashPortsPayload, Local.EspFlashPortsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.EspFlashPortsPayload>("/api/esp-flash/ports"),
   );
 }
@@ -204,7 +204,7 @@ export async function startEspFlash(
   port: string | null,
   auto_detect: boolean,
 ): Promise<Local.EspFlashStartPayload> {
-  return fromTransportPayload<Transport.EspFlashStartPayload, Local.EspFlashStartPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.EspFlashStartPayload>("/api/esp-flash/start", {
       method: "POST",
       headers: JSON_HEADERS,
@@ -214,13 +214,13 @@ export async function startEspFlash(
 }
 
 export async function getEspFlashStatus(): Promise<Local.EspFlashStatusPayload> {
-  return fromTransportPayload<Transport.EspFlashStatusPayload, Local.EspFlashStatusPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.EspFlashStatusPayload>("/api/esp-flash/status"),
   );
 }
 
 export async function getEspFlashLogs(after: number): Promise<Local.EspFlashLogsPayload> {
-  return fromTransportPayload<Transport.EspFlashLogsPayload, Local.EspFlashLogsPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.EspFlashLogsPayload>(
       `/api/esp-flash/logs?after=${encodeURIComponent(String(after))}`,
     ),
@@ -228,7 +228,7 @@ export async function getEspFlashLogs(after: number): Promise<Local.EspFlashLogs
 }
 
 export async function cancelEspFlash(): Promise<Local.EspFlashCancelPayload> {
-  return fromTransportPayload<Transport.EspFlashCancelPayload, Local.EspFlashCancelPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.EspFlashCancelPayload>("/api/esp-flash/cancel", {
       method: "POST",
     }),
@@ -236,7 +236,7 @@ export async function cancelEspFlash(): Promise<Local.EspFlashCancelPayload> {
 }
 
 export async function getEspFlashHistory(): Promise<Local.EspFlashHistoryPayload> {
-  return fromTransportPayload<Transport.EspFlashHistoryPayload, Local.EspFlashHistoryPayload>(
+  return cloneTransportValue(
     await apiJson<Transport.EspFlashHistoryPayload>("/api/esp-flash/history"),
   );
 }

--- a/apps/ui/src/transport/http_adapters.ts
+++ b/apps/ui/src/transport/http_adapters.ts
@@ -1,9 +1,0 @@
-import { cloneTransportValue } from "./clone";
-
-export function fromTransportPayload<TTransport, TLocal>(payload: TTransport): TLocal {
-  return cloneTransportValue(payload) as unknown as TLocal;
-}
-
-export function toTransportPayload<TLocal, TTransport>(payload: TLocal): TTransport {
-  return cloneTransportValue(payload) as unknown as TTransport;
-}

--- a/apps/ui/tests/transport_clone.spec.ts
+++ b/apps/ui/tests/transport_clone.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { fromTransportPayload, toTransportPayload } from "../src/transport/http_adapters";
+import { cloneTransportValue } from "../src/transport/clone";
 import type { CarUpsertRequest, CarsPayload } from "../src/transport/http_models";
 
-test("fromTransportPayload clones nested response payloads into local transport DTOs", () => {
+test("cloneTransportValue clones nested response payloads", () => {
   const transportPayload: CarsPayload = {
     active_car_id: "car-1",
     cars: [
@@ -20,7 +20,7 @@ test("fromTransportPayload clones nested response payloads into local transport 
     ],
   };
 
-  const localPayload = fromTransportPayload<CarsPayload, CarsPayload>(transportPayload);
+  const localPayload = cloneTransportValue(transportPayload);
   localPayload.cars[0].name = "Track";
   localPayload.cars[0].aspects.tire_width_mm = 275;
 
@@ -28,7 +28,7 @@ test("fromTransportPayload clones nested response payloads into local transport 
   expect(transportPayload.cars[0].aspects.tire_width_mm).toBe(255);
 });
 
-test("toTransportPayload clones request payloads before boundary serialization", () => {
+test("cloneTransportValue clones request payloads before boundary serialization", () => {
   const localPayload: CarUpsertRequest = {
     name: "Project Car",
     type: "Sedan",
@@ -39,7 +39,7 @@ test("toTransportPayload clones request payloads before boundary serialization",
     variant: "Prototype",
   };
 
-  const transportPayload = toTransportPayload<CarUpsertRequest, CarUpsertRequest>(localPayload);
+  const transportPayload = cloneTransportValue(localPayload);
   transportPayload.name = "Prototype";
   transportPayload.aspects.current_gear_ratio = 0.71;
 


### PR DESCRIPTION
## Why

Wrapper file no do work. `fromTransportPayload()` / `toTransportPayload()` only call `cloneTransportValue()` + cast. No validation. No transform. No domain logic. Extra layer hide real path.

## Size

Medium. Seven files changed. One dead module deleted. One focused test renamed. No API/schema/runtime contract change.

## What changed

- replace wrapper calls in `api/history.ts`, `api/car_library.ts`, `api/logging.ts`, `api/clients.ts`, `api/settings.ts` with direct `cloneTransportValue(...)`
- replace request-body wrapper calls in `settings.ts` with `JSON.stringify(cloneTransportValue(...))`
- delete `apps/ui/src/transport/http_adapters.ts`
- move focused clone test from `tests/http_transport_adapters.spec.ts` to `tests/transport_clone.spec.ts`

Blast radius check:

- live callers were five API modules + one focused test
- zero wrapper refs remain after edit

## Validation

- `rg 'fromTransportPayload|toTransportPayload|http_adapters' apps/ui` -> no matches
- `cd apps/ui && npx playwright test tests/transport_clone.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoff

- behavior same: still deep clone
- callers now say real dependency out loud: `cloneTransportValue`
- no wrapper choice left, simpler import graph

## Out

- no broader clone-usage audit
- no `http_models.ts` flatten
- no contract or payload shape change

Closes #2481
