### PR TITLE
refactor(ui): drop cloneManualInputs helper

### DIFF
--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -5,7 +5,6 @@ import type {
   CarLibraryVariant,
 } from "../../api/types";
 import {
-  cloneManualInputs,
   createCarsManualInputStore,
   firstMissingManualInputField,
   tireInputsFromOption,
@@ -225,9 +224,7 @@ export function createCarsFeatureWorkflow(
     variantOptions: variantOptions.value,
   }));
 
-  const manualInputRenderState = computed<CarsFeatureManualInputState>(() =>
-    cloneManualInputs(manualInputs.read())
-  );
+  const manualInputRenderState = computed<CarsFeatureManualInputState>(() => manualInputs.read());
 
   const wizardMetaRenderState = computed<CarsFeatureWizardMetaRenderState>(() => {
     const state = wizardState.value;

--- a/apps/ui/src/app/features/cars_manual_input.ts
+++ b/apps/ui/src/app/features/cars_manual_input.ts
@@ -34,10 +34,6 @@ export interface CarsFeatureManualInputStore {
   write(inputs: CarsFeatureManualInputState): void;
 }
 
-export function cloneManualInputs(inputs: CarsFeatureManualInputState): CarsFeatureManualInputState {
-  return { ...inputs };
-}
-
 function parsePositiveValue(value: string): number | null {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;


### PR DESCRIPTION
## Why

`cloneManualInputs()` no own logic. It only shallow-spread result from `manualInputs.read()`. Workflow render-state already gets fresh snapshot from store. Extra copy no value.

## Size

Tiny. 2 files changed. No runtime/API/schema change.

## What changed

- delete `cloneManualInputs()` from `cars_manual_input.ts`
- switch `cars_feature_workflow.ts` to use `manualInputs.read()` directly

## Validation

- `rg 'cloneManualInputs' apps/ui` -> no matches
- `cd apps/ui && npx playwright test tests/cars_feature_workflow.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoff

- very low risk: remove redundant shallow copy only
- behavior stays same because store read already returns fresh object

## Out

- no wizard behavior change
- no manual-input store contract change
- no broader cars workflow cleanup

Closes #2483
