### PR TITLE
refactor(ui): split analysis panel sections

### DIFF
--- a/apps/ui/src/app/views/analysis_panel.tsx
+++ b/apps/ui/src/app/views/analysis_panel.tsx
@@ -1,4 +1,4 @@
-import { render, type JSX } from "preact";
+import { render } from "preact";
 import { useRef } from "preact/hooks";
 
 import { useUiTranslation } from "../ui_i18n";
@@ -10,52 +10,28 @@ import {
   type ReadonlySignal,
 } from "../ui_signals";
 import {
-  settingsFeedbackClassName,
-  type SettingsFeedbackMessage,
-} from "./settings_feedback";
+  ORDER_BAND_FIELDS,
+  UNCERTAINTY_FIELDS,
+  type AnalysisPanelActionHandlers,
+  type AnalysisPanelCarAvailability,
+  type AnalysisPanelFieldKey,
+  type AnalysisPanelRenderModel,
+  type SettingsAnalysisGuidanceRenderModel,
+} from "./analysis_panel_models";
+import {
+  AnalysisFieldGroup,
+  AnalysisGuidanceDialog,
+  AnalysisSaveFeedback,
+} from "./analysis_panel_sections";
 
-export interface SettingsAnalysisGuidanceLine {
-  label: string;
-  value: string;
-}
-
-export interface SettingsAnalysisGuidanceRenderModel {
-  error: SettingsFeedbackMessage | null;
-  lines: readonly SettingsAnalysisGuidanceLine[];
-}
-
-export type AnalysisPanelFieldKey =
-  | "wheel_bandwidth_pct"
-  | "driveshaft_bandwidth_pct"
-  | "engine_bandwidth_pct"
-  | "speed_uncertainty_pct"
-  | "tire_diameter_uncertainty_pct"
-  | "final_drive_uncertainty_pct"
-  | "gear_uncertainty_pct"
-  | "min_abs_band_hz"
-  | "max_band_half_width_pct";
-
-export interface AnalysisPanelFieldRenderModel {
-  guidance: SettingsAnalysisGuidanceRenderModel;
-  invalid: boolean;
-  value: string;
-}
-
-export interface AnalysisPanelRenderModel {
-  fields: Record<AnalysisPanelFieldKey, AnalysisPanelFieldRenderModel>;
-  saveFeedback: SettingsFeedbackMessage | null;
-}
-
-export interface AnalysisPanelCarAvailability {
-  hasActiveCar: boolean;
-  isLoading: boolean;
-}
-
-export interface AnalysisPanelActionHandlers {
-  onFieldInput(action: { field: AnalysisPanelFieldKey; value: string }): void;
-  onReset(): void;
-  onSave(): void;
-}
+export type {
+  AnalysisPanelActionHandlers,
+  AnalysisPanelCarAvailability,
+  AnalysisPanelFieldKey,
+  AnalysisPanelRenderModel,
+  SettingsAnalysisGuidanceLine,
+  SettingsAnalysisGuidanceRenderModel,
+} from "./analysis_panel_models";
 
 export interface AnalysisPanelView {
   bindActions(handlers: AnalysisPanelActionHandlers): void;
@@ -64,15 +40,6 @@ export interface AnalysisPanelView {
   focusField(field: AnalysisPanelFieldKey): void;
   openGuidance(): void;
 }
-
-type AnalysisFieldSpec = {
-  fallbackLabel: string;
-  guidanceId: string;
-  inputId: string;
-  key: AnalysisPanelFieldKey;
-  labelKey: string;
-  step: string;
-};
 
 type AnalysisPanelBridgeState = {
   actions: AnalysisPanelActionHandlers | null;
@@ -146,162 +113,6 @@ const DEFAULT_ANALYSIS_CAR_AVAILABILITY: AnalysisPanelCarAvailability = {
   isLoading: false,
 };
 
-const ORDER_BAND_FIELDS: readonly AnalysisFieldSpec[] = [
-  {
-    fallbackLabel: "Wheel Bandwidth (%)",
-    guidanceId: "wheelBandwidthGuidance",
-    inputId: "wheelBandwidthInput",
-    key: "wheel_bandwidth_pct",
-    labelKey: "settings.wheel_bandwidth",
-    step: "0.1",
-  },
-  {
-    fallbackLabel: "Driveshaft Bandwidth (%)",
-    guidanceId: "driveshaftBandwidthGuidance",
-    inputId: "driveshaftBandwidthInput",
-    key: "driveshaft_bandwidth_pct",
-    labelKey: "settings.driveshaft_bandwidth",
-    step: "0.1",
-  },
-  {
-    fallbackLabel: "Engine Bandwidth (%)",
-    guidanceId: "engineBandwidthGuidance",
-    inputId: "engineBandwidthInput",
-    key: "engine_bandwidth_pct",
-    labelKey: "settings.engine_bandwidth",
-    step: "0.1",
-  },
-  {
-    fallbackLabel: "Min Half-width (Hz)",
-    guidanceId: "minAbsBandHzGuidance",
-    inputId: "minAbsBandHzInput",
-    key: "min_abs_band_hz",
-    labelKey: "settings.min_half_width",
-    step: "0.1",
-  },
-  {
-    fallbackLabel: "Max Half-width (%)",
-    guidanceId: "maxBandHalfWidthGuidance",
-    inputId: "maxBandHalfWidthInput",
-    key: "max_band_half_width_pct",
-    labelKey: "settings.max_half_width",
-    step: "0.1",
-  },
-] as const;
-
-const UNCERTAINTY_FIELDS: readonly AnalysisFieldSpec[] = [
-  {
-    fallbackLabel: "Speed Uncertainty (%)",
-    guidanceId: "speedUncertaintyGuidance",
-    inputId: "speedUncertaintyInput",
-    key: "speed_uncertainty_pct",
-    labelKey: "settings.speed_uncertainty",
-    step: "0.1",
-  },
-  {
-    fallbackLabel: "Tire Diameter Uncertainty (%)",
-    guidanceId: "tireDiameterUncertaintyGuidance",
-    inputId: "tireDiameterUncertaintyInput",
-    key: "tire_diameter_uncertainty_pct",
-    labelKey: "settings.tire_diameter_uncertainty",
-    step: "0.1",
-  },
-  {
-    fallbackLabel: "Final Drive Uncertainty (%)",
-    guidanceId: "finalDriveUncertaintyGuidance",
-    inputId: "finalDriveUncertaintyInput",
-    key: "final_drive_uncertainty_pct",
-    labelKey: "settings.final_drive_uncertainty",
-    step: "0.1",
-  },
-  {
-    fallbackLabel: "Gear/Slip Uncertainty (%)",
-    guidanceId: "gearUncertaintyGuidance",
-    inputId: "gearUncertaintyInput",
-    key: "gear_uncertainty_pct",
-    labelKey: "settings.gear_slip_uncertainty",
-    step: "0.1",
-  },
-] as const;
-
-function SettingsFeedbackBlock(props: {
-  message: SettingsFeedbackMessage;
-}) {
-  const { message } = props;
-  return (
-    <div
-      class={settingsFeedbackClassName(message)}
-      aria-live={message.tone === "error" ? "assertive" : "polite"}
-    >
-      {message.title ? (
-        <strong class="settings-feedback__title">{message.title}</strong>
-      ) : null}
-      <span class="settings-feedback__body">{message.body}</span>
-      {message.detail ? (
-        <span class="settings-feedback__detail">{message.detail}</span>
-      ) : null}
-    </div>
-  );
-}
-
-function handleFieldInput(
-  actions: AnalysisPanelActionHandlers | null,
-  field: AnalysisPanelFieldKey,
-  event: JSX.TargetedEvent<HTMLInputElement, Event>,
-): void {
-  actions?.onFieldInput({
-    field,
-    value: event.currentTarget.value,
-  });
-}
-
-function AnalysisFieldGuidance(props: {
-  guidanceId: string;
-  model: SettingsAnalysisGuidanceRenderModel;
-}) {
-  const { guidanceId, model } = props;
-  return (
-    <div id={guidanceId} class="subtle settings-field-guidance">
-      {model.lines.map((line) => (
-        <div key={`${guidanceId}-${line.label}`} class="settings-field-guidance__row">
-          <span class="settings-field-guidance__label">{line.label}</span>
-          {" "}
-          <span class="settings-field-guidance__value">{line.value}</span>
-        </div>
-      ))}
-      {model.error ? <SettingsFeedbackBlock message={model.error} /> : null}
-    </div>
-  );
-}
-
-function AnalysisField(props: {
-  actions: AnalysisPanelActionHandlers | null;
-  model: AnalysisPanelFieldRenderModel;
-  onInputRef: (element: HTMLInputElement | null) => void;
-  spec: AnalysisFieldSpec;
-}) {
-  const { actions, model, onInputRef, spec } = props;
-  const t = useUiTranslation();
-  return (
-    <div class="field">
-      <label htmlFor={spec.inputId}>
-        {t(spec.labelKey, spec.fallbackLabel)}
-      </label>
-      <input
-        id={spec.inputId}
-        ref={onInputRef}
-        type="number"
-        step={spec.step}
-        inputMode="decimal"
-        value={model.value}
-        aria-invalid={model.invalid ? "true" : undefined}
-        onInput={(event) => handleFieldInput(actions, spec.key, event)}
-      />
-      <AnalysisFieldGuidance guidanceId={spec.guidanceId} model={model.guidance} />
-    </div>
-  );
-}
-
 function AnalysisPanel(props: {
   guidanceOpenRequest: ReadonlySignal<number>;
   inputFocusRequest: ReadonlySignal<AnalysisFieldFocusRequest | null>;
@@ -343,51 +154,7 @@ function AnalysisPanel(props: {
   const noCarSelected = !state.availability.hasActiveCar && !state.availability.isLoading;
   return (
     <div class="panel card settings-layout">
-      <details
-        id="analysisGuidanceHelp"
-        ref={guidanceHelpRef}
-        class="settings-help-disclosure settings-help-disclosure--banner"
-      >
-        <summary class="settings-help-disclosure__summary">
-          <span class="settings-help-disclosure__heading">
-            <strong
-              class="settings-help-disclosure__title"
-
-            >
-              {t("settings.analysis.guidance_title", "Safe starting point")}
-            </strong>
-            <span
-              class="settings-help-disclosure__caption"
-
-            >
-              {t(
-                "settings.analysis.guidance_summary",
-                "Keep the defaults unless the data is unusually noisy or the vehicle specs are approximate.",
-              )}
-            </span>
-          </span>
-        </summary>
-        <div class="settings-help-disclosure__body">
-          <div
-            class="subtle"
-
-          >
-            {t(
-              "settings.analysis.guidance_intro",
-              "Most users should keep the defaults. Use wider bands or higher uncertainty only when your data is unusually noisy or your vehicle specs are approximate.",
-            )}
-          </div>
-          <div
-            class="subtle"
-
-          >
-            {t(
-              "settings.analysis.guidance_guardrail",
-              "Values outside the guided range will ask for confirmation before they are saved.",
-            )}
-          </div>
-        </div>
-      </details>
+      <AnalysisGuidanceDialog guidanceHelpRef={guidanceHelpRef} />
       <div
         id="analysisNoCarMessage"
         class="empty-state empty-state--inline"
@@ -400,109 +167,46 @@ function AnalysisPanel(props: {
         )}
       </div>
       <div class="settings-groups">
-        <section class="settings-group">
-          <h3>
-            {t("settings.group.order_band_widths", "Order Band Widths")}
-          </h3>
-          <details
-            id="analysisOrderBandHelp"
-            class="settings-help-disclosure settings-help-disclosure--inline"
-          >
-            <summary class="settings-help-disclosure__summary">
-              <span
-                class="settings-help-disclosure__title"
-
-              >
-                {t("settings.analysis.more_guidance", "Why this matters")}
-              </span>
-            </summary>
-            <div class="settings-help-disclosure__body">
-              <div
-                class="subtle"
-
-              >
-                {t(
-                  "settings.analysis.group.order_band_widths_help",
-                  "These values control how far the app searches around each expected order. Wider bands tolerate more speed drift but can blend nearby faults together.",
-                )}
-              </div>
-            </div>
-          </details>
-          <div class="settings-subgrid">
-            {ORDER_BAND_FIELDS.map((field) => (
-              <AnalysisField
-                key={field.key}
-                actions={state.actions}
-                model={state.model.fields[field.key]}
-                onInputRef={(element) => {
-                  inputRefs.current[field.key] = element;
-                }}
-                spec={field}
-              />
-            ))}
-          </div>
-        </section>
-
-        <section class="settings-group">
-          <h3>
-            {t("settings.group.uncertainty_model", "Uncertainty Model")}
-          </h3>
-          <details
-            id="analysisUncertaintyHelp"
-            class="settings-help-disclosure settings-help-disclosure--inline"
-          >
-            <summary class="settings-help-disclosure__summary">
-              <span
-                class="settings-help-disclosure__title"
-
-              >
-                {t("settings.analysis.more_guidance", "Why this matters")}
-              </span>
-            </summary>
-            <div class="settings-help-disclosure__body">
-              <div class="subtle">
-                <span>
-                  {t(
-                    "settings.uncertainty_defaults",
-                    "Defaults use tire wear from 10/32 in to 2/32 in plus safety margin.",
-                  )}
-                </span>
-              </div>
-              <div
-                class="subtle"
-
-              >
-                {t(
-                  "settings.analysis.group.uncertainty_model_help",
-                  "Use these only when vehicle data is approximate, modified, or worn. Higher uncertainty makes matching more tolerant, but it can lower specificity and confidence.",
-                )}
-              </div>
-            </div>
-          </details>
-          <div class="settings-subgrid settings-subgrid--aligned-labels">
-            {UNCERTAINTY_FIELDS.map((field) => (
-              <AnalysisField
-                key={field.key}
-                actions={state.actions}
-                model={state.model.fields[field.key]}
-                onInputRef={(element) => {
-                  inputRefs.current[field.key] = element;
-                }}
-                spec={field}
-              />
-            ))}
-          </div>
-        </section>
+        <AnalysisFieldGroup
+          actions={state.actions}
+          fields={ORDER_BAND_FIELDS}
+          helpBody={[
+            {
+              key: "settings.analysis.group.order_band_widths_help",
+              fallback:
+                "These values control how far the app searches around each expected order. Wider bands tolerate more speed drift but can blend nearby faults together.",
+            },
+          ]}
+          helpId="analysisOrderBandHelp"
+          inputRefs={inputRefs.current}
+          modelFields={state.model.fields}
+          titleFallback="Order Band Widths"
+          titleKey="settings.group.order_band_widths"
+        />
+        <AnalysisFieldGroup
+          actions={state.actions}
+          fields={UNCERTAINTY_FIELDS}
+          helpBody={[
+            {
+              key: "settings.uncertainty_defaults",
+              fallback:
+                "Defaults use tire wear from 10/32 in to 2/32 in plus safety margin.",
+            },
+            {
+              key: "settings.analysis.group.uncertainty_model_help",
+              fallback:
+                "Use these only when vehicle data is approximate, modified, or worn. Higher uncertainty makes matching more tolerant, but it can lower specificity and confidence.",
+            },
+          ]}
+          helpId="analysisUncertaintyHelp"
+          inputRefs={inputRefs.current}
+          modelFields={state.model.fields}
+          subgridClassName="settings-subgrid settings-subgrid--aligned-labels"
+          titleFallback="Uncertainty Model"
+          titleKey="settings.group.uncertainty_model"
+        />
       </div>
-      <div
-        id="analysisSaveFeedback"
-        class="settings-feedback-slot"
-        hidden={state.model.saveFeedback === null}
-      >
-        {state.model.saveFeedback ? (
-          <SettingsFeedbackBlock message={state.model.saveFeedback} />
-        ) : null}
-      </div>
+      <AnalysisSaveFeedback message={state.model.saveFeedback} />
       <div class="settings-actions settings-actions--sticky">
         <button
           id="resetAnalysisBtn"

--- a/apps/ui/src/app/views/analysis_panel_models.ts
+++ b/apps/ui/src/app/views/analysis_panel_models.ts
@@ -1,0 +1,131 @@
+import type { SettingsFeedbackMessage } from "./settings_feedback";
+
+export interface SettingsAnalysisGuidanceLine {
+  label: string;
+  value: string;
+}
+
+export interface SettingsAnalysisGuidanceRenderModel {
+  error: SettingsFeedbackMessage | null;
+  lines: readonly SettingsAnalysisGuidanceLine[];
+}
+
+export type AnalysisPanelFieldKey =
+  | "wheel_bandwidth_pct"
+  | "driveshaft_bandwidth_pct"
+  | "engine_bandwidth_pct"
+  | "speed_uncertainty_pct"
+  | "tire_diameter_uncertainty_pct"
+  | "final_drive_uncertainty_pct"
+  | "gear_uncertainty_pct"
+  | "min_abs_band_hz"
+  | "max_band_half_width_pct";
+
+export interface AnalysisPanelFieldRenderModel {
+  guidance: SettingsAnalysisGuidanceRenderModel;
+  invalid: boolean;
+  value: string;
+}
+
+export interface AnalysisPanelRenderModel {
+  fields: Record<AnalysisPanelFieldKey, AnalysisPanelFieldRenderModel>;
+  saveFeedback: SettingsFeedbackMessage | null;
+}
+
+export interface AnalysisPanelCarAvailability {
+  hasActiveCar: boolean;
+  isLoading: boolean;
+}
+
+export interface AnalysisPanelActionHandlers {
+  onFieldInput(action: { field: AnalysisPanelFieldKey; value: string }): void;
+  onReset(): void;
+  onSave(): void;
+}
+
+export type AnalysisFieldSpec = {
+  fallbackLabel: string;
+  guidanceId: string;
+  inputId: string;
+  key: AnalysisPanelFieldKey;
+  labelKey: string;
+  step: string;
+};
+
+export const ORDER_BAND_FIELDS: readonly AnalysisFieldSpec[] = [
+  {
+    fallbackLabel: "Wheel Bandwidth (%)",
+    guidanceId: "wheelBandwidthGuidance",
+    inputId: "wheelBandwidthInput",
+    key: "wheel_bandwidth_pct",
+    labelKey: "settings.wheel_bandwidth",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Driveshaft Bandwidth (%)",
+    guidanceId: "driveshaftBandwidthGuidance",
+    inputId: "driveshaftBandwidthInput",
+    key: "driveshaft_bandwidth_pct",
+    labelKey: "settings.driveshaft_bandwidth",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Engine Bandwidth (%)",
+    guidanceId: "engineBandwidthGuidance",
+    inputId: "engineBandwidthInput",
+    key: "engine_bandwidth_pct",
+    labelKey: "settings.engine_bandwidth",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Min Half-width (Hz)",
+    guidanceId: "minAbsBandHzGuidance",
+    inputId: "minAbsBandHzInput",
+    key: "min_abs_band_hz",
+    labelKey: "settings.min_half_width",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Max Half-width (%)",
+    guidanceId: "maxBandHalfWidthGuidance",
+    inputId: "maxBandHalfWidthInput",
+    key: "max_band_half_width_pct",
+    labelKey: "settings.max_half_width",
+    step: "0.1",
+  },
+] as const;
+
+export const UNCERTAINTY_FIELDS: readonly AnalysisFieldSpec[] = [
+  {
+    fallbackLabel: "Speed Uncertainty (%)",
+    guidanceId: "speedUncertaintyGuidance",
+    inputId: "speedUncertaintyInput",
+    key: "speed_uncertainty_pct",
+    labelKey: "settings.speed_uncertainty",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Tire Diameter Uncertainty (%)",
+    guidanceId: "tireDiameterUncertaintyGuidance",
+    inputId: "tireDiameterUncertaintyInput",
+    key: "tire_diameter_uncertainty_pct",
+    labelKey: "settings.tire_diameter_uncertainty",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Final Drive Uncertainty (%)",
+    guidanceId: "finalDriveUncertaintyGuidance",
+    inputId: "finalDriveUncertaintyInput",
+    key: "final_drive_uncertainty_pct",
+    labelKey: "settings.final_drive_uncertainty",
+    step: "0.1",
+  },
+  {
+    fallbackLabel: "Gear/Slip Uncertainty (%)",
+    guidanceId: "gearUncertaintyGuidance",
+    inputId: "gearUncertaintyInput",
+    key: "gear_uncertainty_pct",
+    labelKey: "settings.gear_slip_uncertainty",
+    step: "0.1",
+  },
+] as const;

--- a/apps/ui/src/app/views/analysis_panel_sections.tsx
+++ b/apps/ui/src/app/views/analysis_panel_sections.tsx
@@ -1,0 +1,216 @@
+import type { JSX } from "preact";
+
+import { useUiTranslation } from "../ui_i18n";
+import {
+  settingsFeedbackClassName,
+  type SettingsFeedbackMessage,
+} from "./settings_feedback";
+import type {
+  AnalysisFieldSpec,
+  AnalysisPanelActionHandlers,
+  AnalysisPanelFieldKey,
+  AnalysisPanelFieldRenderModel,
+  SettingsAnalysisGuidanceRenderModel,
+} from "./analysis_panel_models";
+
+type AnalysisHelpText = {
+  fallback: string;
+  key: string;
+};
+
+function SettingsFeedbackBlock(props: {
+  message: SettingsFeedbackMessage;
+}) {
+  const { message } = props;
+  return (
+    <div
+      class={settingsFeedbackClassName(message)}
+      aria-live={message.tone === "error" ? "assertive" : "polite"}
+    >
+      {message.title ? (
+        <strong class="settings-feedback__title">{message.title}</strong>
+      ) : null}
+      <span class="settings-feedback__body">{message.body}</span>
+      {message.detail ? (
+        <span class="settings-feedback__detail">{message.detail}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function handleFieldInput(
+  actions: AnalysisPanelActionHandlers | null,
+  field: AnalysisPanelFieldKey,
+  event: JSX.TargetedEvent<HTMLInputElement, Event>,
+): void {
+  actions?.onFieldInput({
+    field,
+    value: event.currentTarget.value,
+  });
+}
+
+function AnalysisFieldGuidance(props: {
+  guidanceId: string;
+  model: SettingsAnalysisGuidanceRenderModel;
+}) {
+  const { guidanceId, model } = props;
+  return (
+    <div id={guidanceId} class="subtle settings-field-guidance">
+      {model.lines.map((line) => (
+        <div key={`${guidanceId}-${line.label}`} class="settings-field-guidance__row">
+          <span class="settings-field-guidance__label">{line.label}</span>
+          {" "}
+          <span class="settings-field-guidance__value">{line.value}</span>
+        </div>
+      ))}
+      {model.error ? <SettingsFeedbackBlock message={model.error} /> : null}
+    </div>
+  );
+}
+
+function AnalysisField(props: {
+  actions: AnalysisPanelActionHandlers | null;
+  model: AnalysisPanelFieldRenderModel;
+  onInputRef: (element: HTMLInputElement | null) => void;
+  spec: AnalysisFieldSpec;
+}) {
+  const { actions, model, onInputRef, spec } = props;
+  const t = useUiTranslation();
+  return (
+    <div class="field">
+      <label htmlFor={spec.inputId}>
+        {t(spec.labelKey, spec.fallbackLabel)}
+      </label>
+      <input
+        id={spec.inputId}
+        ref={onInputRef}
+        type="number"
+        step={spec.step}
+        inputMode="decimal"
+        value={model.value}
+        aria-invalid={model.invalid ? "true" : undefined}
+        onInput={(event) => handleFieldInput(actions, spec.key, event)}
+      />
+      <AnalysisFieldGuidance guidanceId={spec.guidanceId} model={model.guidance} />
+    </div>
+  );
+}
+
+export function AnalysisGuidanceDialog(props: {
+  guidanceHelpRef: { current: HTMLDetailsElement | null };
+}) {
+  const { guidanceHelpRef } = props;
+  const t = useUiTranslation();
+  return (
+    <details
+      id="analysisGuidanceHelp"
+      ref={guidanceHelpRef}
+      class="settings-help-disclosure settings-help-disclosure--banner"
+    >
+      <summary class="settings-help-disclosure__summary">
+        <span class="settings-help-disclosure__heading">
+          <strong class="settings-help-disclosure__title">
+            {t("settings.analysis.guidance_title", "Safe starting point")}
+          </strong>
+          <span class="settings-help-disclosure__caption">
+            {t(
+              "settings.analysis.guidance_summary",
+              "Keep the defaults unless the data is unusually noisy or the vehicle specs are approximate.",
+            )}
+          </span>
+        </span>
+      </summary>
+      <div class="settings-help-disclosure__body">
+        <div class="subtle">
+          {t(
+            "settings.analysis.guidance_intro",
+            "Most users should keep the defaults. Use wider bands or higher uncertainty only when your data is unusually noisy or your vehicle specs are approximate.",
+          )}
+        </div>
+        <div class="subtle">
+          {t(
+            "settings.analysis.guidance_guardrail",
+            "Values outside the guided range will ask for confirmation before they are saved.",
+          )}
+        </div>
+      </div>
+    </details>
+  );
+}
+
+export function AnalysisFieldGroup(props: {
+  actions: AnalysisPanelActionHandlers | null;
+  fields: readonly AnalysisFieldSpec[];
+  helpBody: readonly AnalysisHelpText[];
+  helpId: string;
+  inputRefs: Record<AnalysisPanelFieldKey, HTMLInputElement | null>;
+  modelFields: Record<AnalysisPanelFieldKey, AnalysisPanelFieldRenderModel>;
+  subgridClassName?: string;
+  titleFallback: string;
+  titleKey: string;
+}) {
+  const {
+    actions,
+    fields,
+    helpBody,
+    helpId,
+    inputRefs,
+    modelFields,
+    subgridClassName = "settings-subgrid",
+    titleFallback,
+    titleKey,
+  } = props;
+  const t = useUiTranslation();
+  return (
+    <section class="settings-group">
+      <h3>
+        {t(titleKey, titleFallback)}
+      </h3>
+      <details
+        id={helpId}
+        class="settings-help-disclosure settings-help-disclosure--inline"
+      >
+        <summary class="settings-help-disclosure__summary">
+          <span class="settings-help-disclosure__title">
+            {t("settings.analysis.more_guidance", "Why this matters")}
+          </span>
+        </summary>
+        <div class="settings-help-disclosure__body">
+          {helpBody.map((item) => (
+            <div key={item.key} class="subtle">
+              {t(item.key, item.fallback)}
+            </div>
+          ))}
+        </div>
+      </details>
+      <div class={subgridClassName}>
+        {fields.map((field) => (
+          <AnalysisField
+            key={field.key}
+            actions={actions}
+            model={modelFields[field.key]}
+            onInputRef={(element) => {
+              inputRefs[field.key] = element;
+            }}
+            spec={field}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function AnalysisSaveFeedback(props: {
+  message: SettingsFeedbackMessage | null;
+}) {
+  const { message } = props;
+  return (
+    <div
+      id="analysisSaveFeedback"
+      class="settings-feedback-slot"
+      hidden={message === null}
+    >
+      {message ? <SettingsFeedbackBlock message={message} /> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

`analysis_panel.tsx` held too much in one file: top guidance banner, repeated field-group sections, save feedback, field row helpers, plus bridge shell/focus effects. Hard to navigate. Easy to mix layout with bridge logic.

## Size

Medium. 3 files changed in one view area. No runtime/API/schema change. Rendered analysis settings surface should stay same.

## What changed

- extract shared analysis field/spec contracts into `analysis_panel_models.ts`
- extract `AnalysisGuidanceDialog`, reusable `AnalysisFieldGroup`, and `AnalysisSaveFeedback` into `analysis_panel_sections.tsx`
- keep `analysis_panel.tsx` as thin bridge shell with local refs, focus effect, guidance-open effect, and action row
- preserve existing IDs, button wiring, input wiring, and typed exports from `analysis_panel.tsx`

## Validation

- `cd apps/ui && npx playwright test tests/settings_analysis_module.spec.ts tests/smoke.analysis-sensors.spec.ts tests/smoke.settings.spec.ts --project=laptop-light --workers=1 -g 'settings analysis module renders guidance|analysis guidance can reopen|analysis tab adds guided helper copy|analysis settings show a field-specific error|failed analysis save preserves'`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoff

- main risk was UI drift in guidance/focus/save-feedback markup after split
- kept stable DOM anchors like `#analysisGuidanceHelp`, `#wheelBandwidthInput`, `#analysisSaveFeedback`
- typed bridge contract stays on same `analysis_panel.tsx` import path, so callers no churn

## Out

- no analysis-settings workflow logic change
- no translation/content change
- no CSS/layout redesign

Closes #2484
