### PR TITLE
Remove mirrored speed-source workflow state

### DIFF
--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -137,11 +137,19 @@ export function createSettingsSpeedSourceWorkflow(
   const transport = createSettingsSpeedSourceTransport(deps.transport);
   const createPolling = deps.createPollingController ?? createPollingController;
   const speedSourceState = createSpeedSourceDerivedState(deps.settings);
-  const speedSourceDraftDirty = signal(false);
-  const selectedMode = signal<DisplayedSpeedSourceMode>(speedSourceState.displayedMode.value);
-  const manualSpeedInputValue = signal(
-    deps.settings.manualSpeedKph != null ? String(deps.settings.manualSpeedKph) : "",
+  const selectedModeDraft = signal<DisplayedSpeedSourceMode | null>(null);
+  const manualSpeedInputDraft = signal<string | null>(null);
+  const selectedMode = computed<DisplayedSpeedSourceMode>(() =>
+    selectedModeDraft.value ?? speedSourceState.displayedMode.value
   );
+  const manualSpeedInputValue = computed(() => {
+    const draft = manualSpeedInputDraft.value;
+    if (draft != null) {
+      return draft;
+    }
+    trackAppStateSlice(deps.settings);
+    return deps.settings.manualSpeedKph != null ? String(deps.settings.manualSpeedKph) : "";
+  });
   const staleTimeoutInputValue = signal("");
   let speedSourceContextVisible = false;
   let backgroundRescanRequested = false;
@@ -158,7 +166,7 @@ export function createSettingsSpeedSourceWorkflow(
     const trackedSettings = trackAppStateSlice(deps.settings);
     return {
       diagnosticsOpen: diagnosticsOpen.value,
-      draftDirty: speedSourceDraftDirty.value,
+      draftDirty: selectedModeDraft.value !== null,
       manualSpeedFeedback: cloneFeedback(manualSpeedFeedback.value),
       manualSpeedInputValue: manualSpeedInputValue.value,
       obdScanStatusMessage: obdScanStatusMessage.value,
@@ -275,11 +283,8 @@ export function createSettingsSpeedSourceWorkflow(
 
   function syncInputsFromSettings(): void {
     batch(() => {
-      speedSourceDraftDirty.value = false;
-      selectedMode.value = speedSourceState.displayedMode.value;
-      manualSpeedInputValue.value = deps.settings.manualSpeedKph != null
-        ? String(deps.settings.manualSpeedKph)
-        : "";
+      selectedModeDraft.value = null;
+      manualSpeedInputDraft.value = null;
       manualSpeedFeedback.value = null;
       staleTimeoutFeedback.value = null;
       saveFeedback.value = null;
@@ -289,14 +294,6 @@ export function createSettingsSpeedSourceWorkflow(
   }
 
   function syncFromSettings(): void {
-    if (!speedSourceDraftDirty.value) {
-      batch(() => {
-        selectedMode.value = speedSourceState.displayedMode.value;
-        manualSpeedInputValue.value = deps.settings.manualSpeedKph != null
-          ? String(deps.settings.manualSpeedKph)
-          : "";
-      });
-    }
     scheduleContextVisibilitySync();
   }
 
@@ -326,8 +323,7 @@ export function createSettingsSpeedSourceWorkflow(
 
   function handleSpeedSourceChanged(mode: DisplayedSpeedSourceMode): void {
     batch(() => {
-      speedSourceDraftDirty.value = true;
-      selectedMode.value = mode;
+      selectedModeDraft.value = mode;
       clearAllFeedback();
     });
     scheduleContextVisibilitySync();
@@ -335,7 +331,7 @@ export function createSettingsSpeedSourceWorkflow(
 
   function handleManualSpeedInput(value: string): void {
     batch(() => {
-      manualSpeedInputValue.value = value;
+      manualSpeedInputDraft.value = value;
       clearManualSpeedFeedback();
     });
   }
@@ -350,9 +346,8 @@ export function createSettingsSpeedSourceWorkflow(
   async function saveSpeedSource(): Promise<void> {
     clearAllFeedback();
 
-    const source: SpeedSourceKind = speedSourceDraftDirty.value
-      ? selectedMode.value
-      : deps.settings.speedSource;
+    const source: SpeedSourceKind =
+      selectedModeDraft.value ?? deps.settings.speedSource;
     const manualInputValue = manualSpeedInputValue.value.trim();
     const manualSpeedKph = parseManualSpeedKph(Number(manualInputValue));
     const staleValueRaw = staleTimeoutInputValue.value.trim();

--- a/apps/ui/tests/settings_speed_source_workflow.spec.ts
+++ b/apps/ui/tests/settings_speed_source_workflow.spec.ts
@@ -388,4 +388,79 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     expect(workflow.getRenderState().settings.gpsEffectiveSpeedKph).toBe(81);
     expect(harness.errors).toEqual([]);
   });
+
+  test("derives selected mode and manual input from settings when no draft exists", () => {
+    const harness = createHarness();
+    const appState = createAppState();
+    const workflow = createSettingsSpeedSourceWorkflow({
+      createPollingController: () => ({
+        restart() {},
+        start() {},
+        stop() {},
+      }),
+      renderSpeedReadout: () => undefined,
+      settings: appState.settings,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      t: createTranslator(),
+      view: createViewPorts(harness),
+    });
+
+    expect(workflow.getRenderState()).toMatchObject({
+      manualSpeedInputValue: "",
+      selectedMode: "gps",
+    });
+
+    appState.settings.manualSpeedKph = 88;
+    appState.settings.speedSource = "manual";
+    appState.settings.resolvedSpeedSource = "manual";
+
+    expect(workflow.getRenderState()).toMatchObject({
+      manualSpeedInputValue: "88",
+      selectedMode: "manual",
+    });
+    expect(harness.errors).toEqual([]);
+  });
+
+  test("keeps local manual input draft when settings change externally", () => {
+    const harness = createHarness();
+    const appState = createAppState();
+    appState.settings.speedSource = "gps";
+    appState.settings.manualSpeedKph = 80;
+
+    const workflow = createSettingsSpeedSourceWorkflow({
+      createPollingController: () => ({
+        restart() {},
+        start() {},
+        stop() {},
+      }),
+      renderSpeedReadout: () => undefined,
+      settings: appState.settings,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      t: createTranslator(),
+      view: createViewPorts(harness),
+    });
+
+    workflow.handleManualSpeedInput("90");
+    appState.settings.manualSpeedKph = 70;
+    workflow.syncFromSettings();
+
+    expect(workflow.getRenderState()).toMatchObject({
+      draftDirty: false,
+      manualSpeedInputValue: "90",
+      selectedMode: "gps",
+    });
+
+    workflow.syncInputsFromSettings();
+
+    expect(workflow.getRenderState()).toMatchObject({
+      draftDirty: false,
+      manualSpeedInputValue: "70",
+      selectedMode: "gps",
+    });
+    expect(harness.errors).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Why

`settings_speed_source_workflow.ts` kept signal copies of
`settings.speedSource` and `settings.manualSpeedKph`.
That meant extra sync code just to push AppState back into local signals, and
easy stale-state drift when settings changed outside local handlers.

Closes #2487.

## What changed

- replace mirrored `selectedMode` state with nullable `selectedModeDraft`
  override
- replace mirrored `manualSpeedInputValue` state with nullable
  `manualSpeedInputDraft` override
- derive render-state values from AppState when no local draft exists
- keep fallback-manual save behavior: if radio draft does not exist, save uses
  configured `settings.speedSource`, not derived fallback display mode
- stop `syncFromSettings()` from rewriting AppState-backed values into local
  mirrors
- add workflow tests for:
  - AppState-driven mode/manual input updates when no draft exists
  - local manual draft surviving unrelated external settings updates until
    inputs are explicitly resynced

## Validation

- `cd apps/ui && npx playwright test tests/settings_speed_source_workflow.spec.ts tests/settings_speed_source_presenter.spec.ts tests/smoke.settings.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / edge

- main edge here was fallback-manual mode. UI may display manual while saved
  source is still GPS. Save path still preserves GPS unless user made real radio
  draft.
- scope stays inside workflow state ownership. No transport or presenter
  contract change.
