### PR TITLE
Simplify cars highlight feedback flow

### DIFF
--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -84,7 +84,11 @@ export function createSettingsCarsModule(
   const transport = createSettingsCarsTransport(ctx.transport);
   const carSelection = createCarSelectionDerivedState(settings);
   let handlersBound = false;
-  const highlightedCarFeedback = signal<CarsListHighlightedFeedback | null>(null);
+  const highlightedCar = signal<CarsListHighlightedFeedback | null>(null);
+  const activeSettingsTabId = signal("carTab");
+  const carsContextVisible = computed(
+    () => ctx.ports.activeViewId.value === "settingsView" && activeSettingsTabId.value === "carTab",
+  );
 
   function hasValidActiveCar(): boolean {
     return carSelection.hasResolvedActiveCar.value;
@@ -100,7 +104,7 @@ export function createSettingsCarsModule(
     return {
       guidance: buildCarsGuidanceRenderModel({
         carSelectionState,
-        highlightedCarFeedback: highlightedCarFeedback.value,
+        highlightedCarFeedback: highlightedCar.value,
         t,
       }),
       table: carSelectionState.kind === "loading"
@@ -108,7 +112,7 @@ export function createSettingsCarsModule(
         : buildSettingsCarListRenderModel({
           activeCarId: settings.activeCarId,
           cars: settings.cars,
-          highlightedCarId: highlightedCarFeedback.value?.carId ?? null,
+          highlightedCarId: highlightedCar.value?.carId ?? null,
           fmt: formatting.fmt,
           t,
         }),
@@ -128,14 +132,7 @@ export function createSettingsCarsModule(
   function renderCarList(): void {}
 
   function clearHighlightedCarFeedback(): void {
-    highlightedCarFeedback.value = null;
-  }
-
-  function dismissHighlightedCarFeedback(): void {
-    if (!highlightedCarFeedback.value) {
-      return;
-    }
-    clearHighlightedCarFeedback();
+    highlightedCar.value = null;
   }
 
   function syncCarsPayload(payload: CarsPayload): void {
@@ -147,10 +144,10 @@ export function createSettingsCarsModule(
       : false;
     settings.activeCarId = hasRequestedActive ? requestedActiveCarId : null;
     if (
-      highlightedCarFeedback.value &&
-      !settings.cars.some((car) => car.id === highlightedCarFeedback.value?.carId)
+      highlightedCar.value
+      && !settings.cars.some((car) => car.id === highlightedCar.value?.carId)
     ) {
-      highlightedCarFeedback.value = null;
+      highlightedCar.value = null;
     }
   }
 
@@ -243,23 +240,13 @@ export function createSettingsCarsModule(
       return;
     }
     handlersBound = true;
-    let hasSeenInitialView = false;
     effect(() => {
-      const activeViewId = ctx.ports.activeViewId.value;
-      if (!hasSeenInitialView) {
-        hasSeenInitialView = true;
-        return;
-      }
-      if (activeViewId !== "settingsView") {
-        untracked(() => {
-          dismissHighlightedCarFeedback();
-        });
+      if (highlightedCar.value && !carsContextVisible.value) {
+        untracked(clearHighlightedCarFeedback);
       }
     });
     ctx.ports.subscribeSettingsTabChanges((tabId) => {
-      if (tabId !== "carTab") {
-        dismissHighlightedCarFeedback();
-      }
+      activeSettingsTabId.value = tabId;
     });
     ctx.panels.panel.bindActions({
       onAction: (action) => {
@@ -292,7 +279,7 @@ export function createSettingsCarsModule(
     loadCarsFromServer,
     renderCarList,
     showCarCreationSuccess(carId: string, carName: string): void {
-      highlightedCarFeedback.value = { carId, carName };
+      highlightedCar.value = { carId, carName };
     },
     syncActiveCarToInputs,
     syncCarsPayload,


### PR DESCRIPTION
## Why

`settings_cars_module.ts` treated created-car highlight feedback like transient
event signal. Tab-change callback, view-change callback, payload sync, and
action handlers all reached in to clear it.

That worked, but flow was noisy and lifecycle rule was simple: show highlight
while Cars settings context is visible, drop it when that context is gone or an
action consumes it.

Closes #2488.

## What changed

- keep highlighted car data as explicit UI state
- add tracked Cars-context visibility (`settingsView` + `carTab`)
- let one effect clear highlight when Cars context stops being visible
- keep activate / complete / delete success paths clearing the highlight because
  those actions resolve the temporary state
- keep render-model contract unchanged for guidance banner and highlighted row

## Validation

- `cd apps/ui && npx playwright test tests/settings_cars_module.spec.ts tests/settings_car_feedback_reset.spec.ts tests/smoke.cars.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / edge

- main risk was dismiss timing drift when leaving Cars through either settings
  tab changes or full app view changes. Focused module test and browser smoke
  keep both paths covered.
- scope stays inside cars-module feedback lifecycle. No API or view contract
  change.
