### PR TITLE
Refactor: share timer cleanup helpers

### DIFF
--- a/apps/ui/src/app/features/polling_controller.ts
+++ b/apps/ui/src/app/features/polling_controller.ts
@@ -1,4 +1,5 @@
 import { effect, type ReadonlySignal } from "../ui_signals";
+import { createReplaceableTimeout } from "../timer_cleanup";
 
 export interface PollingController {
   start(): void;
@@ -17,20 +18,15 @@ export function createPollingController(
 ): PollingController {
   const { enabled, poll, onErrorDelayMs } = options;
 
-  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  const pollTimer = createReplaceableTimeout();
   let pollGeneration = 0;
   let pollingActive = false;
 
-  function clearPollTimer(): void {
-    if (pollTimer === null) return;
-    clearTimeout(pollTimer);
-    pollTimer = null;
-  }
-
   function schedulePoll(delayMs: number, generation: number): void {
     if (!pollingActive || generation !== pollGeneration) return;
-    clearPollTimer();
-    pollTimer = setTimeout(() => void runPoll(generation), delayMs);
+    pollTimer.replace(() => {
+      void runPoll(generation);
+    }, delayMs);
   }
 
   async function runPoll(generation: number = pollGeneration): Promise<void> {
@@ -45,7 +41,7 @@ export function createPollingController(
   function restart(): void {
     if (!pollingActive) return;
     pollGeneration += 1;
-    clearPollTimer();
+    pollTimer.clear();
     void runPoll(pollGeneration);
   }
 
@@ -56,10 +52,10 @@ export function createPollingController(
   }
 
   function stop(): void {
-    if (!pollingActive && pollTimer === null) return;
+    if (!pollingActive) return;
     pollingActive = false;
     pollGeneration += 1;
-    clearPollTimer();
+    pollTimer.clear();
   }
 
   if (enabled) {

--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -10,6 +10,7 @@ import type {
   ShellState,
   SpectrumState,
 } from "../ui_app_state";
+import { createReplaceableInterval } from "../timer_cleanup";
 import { trackAppStateSlice } from "../ui_app_state";
 import { computed, effect, signal, type ReadonlySignal } from "../ui_signals";
 import type { AdaptedClient } from "../../transport/live_models";
@@ -199,15 +200,7 @@ export function createRealtimeFeatureViewState(
     }
     return cachedLastCompletedElapsedText;
   });
-  let loggingElapsedTimer: ReturnType<typeof setInterval> | null = null;
-
-  function clearLoggingElapsedTimer(): void {
-    if (loggingElapsedTimer === null) {
-      return;
-    }
-    clearInterval(loggingElapsedTimer);
-    loggingElapsedTimer = null;
-  }
+  const loggingElapsedTimer = createReplaceableInterval();
 
   effect(() => {
     const {
@@ -218,16 +211,15 @@ export function createRealtimeFeatureViewState(
     const shouldTick =
       handlersBound && Boolean(loggingEnabled && loggingStartTimeUtc);
     if (!shouldTick) {
-      clearLoggingElapsedTimer();
+      loggingElapsedTimer.clear();
       return;
     }
     elapsedNowMs.value = Date.now();
-    clearLoggingElapsedTimer();
-    loggingElapsedTimer = setInterval(() => {
+    loggingElapsedTimer.replace(() => {
       elapsedNowMs.value = Date.now();
     }, 1_000);
     return () => {
-      clearLoggingElapsedTimer();
+      loggingElapsedTimer.clear();
     };
   });
 

--- a/apps/ui/src/app/runtime/ui_shell_notification_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_notification_module.ts
@@ -1,5 +1,6 @@
 import type { UiShellErrorBannerModel } from "./ui_shell_chrome";
 import { signal, type ReadonlySignal } from "../ui_signals";
+import { createReplaceableTimeout } from "../timer_cleanup";
 
 type UiShellNotificationDeps = {
   window: Pick<Window, "clearTimeout" | "setTimeout">;
@@ -20,14 +21,11 @@ const HIDDEN_BANNER_MODEL: UiShellErrorBannerModel = {
 export function createUiShellNotificationModule(
   deps: UiShellNotificationDeps,
 ): UiShellNotificationModule {
-  let hideBannerTimer: ReturnType<typeof setTimeout> | null = null;
+  const hideBannerTimer = createReplaceableTimeout(deps.window);
   const bannerModel = signal<UiShellErrorBannerModel>(HIDDEN_BANNER_MODEL);
 
   function clearScheduledHide(): void {
-    if (hideBannerTimer !== null) {
-      deps.window.clearTimeout(hideBannerTimer);
-      hideBannerTimer = null;
-    }
+    hideBannerTimer.clear();
   }
 
   function clearError(): void {
@@ -45,9 +43,8 @@ export function createUiShellNotificationModule(
         text: message,
         variant: "bad",
       };
-      hideBannerTimer = deps.window.setTimeout(() => {
+      hideBannerTimer.replace(() => {
         bannerModel.value = HIDDEN_BANNER_MODEL;
-        hideBannerTimer = null;
       }, 5000);
     },
   };

--- a/apps/ui/src/app/timer_cleanup.ts
+++ b/apps/ui/src/app/timer_cleanup.ts
@@ -1,0 +1,75 @@
+type TimeoutApi = Pick<typeof globalThis, "clearTimeout" | "setTimeout">;
+type IntervalApi = Pick<typeof globalThis, "clearInterval" | "setInterval">;
+
+type ScheduledHandleStore<Handle> = {
+  clear(): void;
+  release(): void;
+  replace(nextHandle: Handle): void;
+};
+
+export interface ReplaceableTimer {
+  clear(): void;
+  replace(callback: () => void, delayMs: number): void;
+}
+
+function createScheduledHandleStore<Handle>(
+  clearHandle: (handle: Handle) => void,
+): ScheduledHandleStore<Handle> {
+  let handle: Handle | null = null;
+
+  return {
+    clear(): void {
+      if (handle === null) {
+        return;
+      }
+      clearHandle(handle);
+      handle = null;
+    },
+    release(): void {
+      handle = null;
+    },
+    replace(nextHandle: Handle): void {
+      if (handle !== null) {
+        clearHandle(handle);
+      }
+      handle = nextHandle;
+    },
+  };
+}
+
+export function createReplaceableTimeout(
+  api: TimeoutApi = globalThis,
+): ReplaceableTimer {
+  const store = createScheduledHandleStore<ReturnType<typeof setTimeout>>((handle) =>
+    api.clearTimeout(handle)
+  );
+
+  return {
+    clear(): void {
+      store.clear();
+    },
+    replace(callback: () => void, delayMs: number): void {
+      store.replace(api.setTimeout(() => {
+        store.release();
+        callback();
+      }, delayMs));
+    },
+  };
+}
+
+export function createReplaceableInterval(
+  api: IntervalApi = globalThis,
+): ReplaceableTimer {
+  const store = createScheduledHandleStore<ReturnType<typeof setInterval>>((handle) =>
+    api.clearInterval(handle)
+  );
+
+  return {
+    clear(): void {
+      store.clear();
+    },
+    replace(callback: () => void, delayMs: number): void {
+      store.replace(api.setInterval(callback, delayMs));
+    },
+  };
+}

--- a/apps/ui/tests/timer_cleanup.spec.ts
+++ b/apps/ui/tests/timer_cleanup.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "@playwright/test";
+
+import { createReplaceableInterval, createReplaceableTimeout } from "../src/app/timer_cleanup";
+
+test.describe("timer cleanup utilities", () => {
+  test("replaceable timeout clears the previous timeout before scheduling a new one", () => {
+    let nextHandle = 1;
+    const activeHandles = new Set<number>();
+    const clearedHandles: number[] = [];
+    const timeout = createReplaceableTimeout({
+      clearTimeout: ((handle?: ReturnType<typeof setTimeout>) => {
+        if (typeof handle !== "number") {
+          return;
+        }
+        activeHandles.delete(handle);
+        clearedHandles.push(handle);
+      }) as typeof clearTimeout,
+      setTimeout: ((callback: TimerHandler, delay?: number) => {
+        void callback;
+        void delay;
+        const handle = nextHandle;
+        nextHandle += 1;
+        activeHandles.add(handle);
+        return handle as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+    });
+
+    timeout.replace(() => undefined, 500);
+    timeout.replace(() => undefined, 750);
+
+    expect(Array.from(activeHandles)).toEqual([2]);
+    expect(clearedHandles).toEqual([1]);
+
+    timeout.clear();
+
+    expect(activeHandles.size).toBe(0);
+    expect(clearedHandles).toEqual([1, 2]);
+  });
+
+  test("replaceable interval clears the previous interval before starting a new one", () => {
+    let nextHandle = 1;
+    const activeHandles = new Set<number>();
+    const clearedHandles: number[] = [];
+    const interval = createReplaceableInterval({
+      clearInterval: ((handle?: ReturnType<typeof setInterval>) => {
+        if (typeof handle !== "number") {
+          return;
+        }
+        activeHandles.delete(handle);
+        clearedHandles.push(handle);
+      }) as typeof clearInterval,
+      setInterval: ((callback: TimerHandler, delay?: number) => {
+        void callback;
+        void delay;
+        const handle = nextHandle;
+        nextHandle += 1;
+        activeHandles.add(handle);
+        return handle as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval,
+    });
+
+    interval.replace(() => undefined, 1_000);
+    interval.replace(() => undefined, 2_000);
+
+    expect(Array.from(activeHandles)).toEqual([2]);
+    expect(clearedHandles).toEqual([1]);
+
+    interval.clear();
+
+    expect(activeHandles.size).toBe(0);
+    expect(clearedHandles).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
## What changed
- add `timer_cleanup.ts` with shared replaceable timeout and interval helpers
- migrate `polling_controller.ts`, `realtime_feature_view_state.ts`, and `ui_shell_notification_module.ts` to that helper
- add focused utility coverage in `tests/timer_cleanup.spec.ts`

## Why
- these callers all carried the same “store handle, clear old one, replace on restart, clean on teardown” logic
- one helper keeps that lifecycle in one place and removes repeated timer bookkeeping from feature/runtime modules
- issue text mentioned RAF too, but that path is already centralized through `createRafAnimation`, so this PR targets the real remaining duplication

## Validation
- `cd apps/ui && npx playwright test tests/timer_cleanup.spec.ts tests/polling_controller.spec.ts tests/realtime_feature_view_state.spec.ts tests/ui_shell_runtime_modules.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- helper is intentionally narrow: timeout and interval only, same replace/clear contract, no extra scheduler framework
- caller behavior stays the same; this is lifecycle consolidation, not a timer policy change

Closes #2490
