### PR TITLE
Fix: keep spectrum overlay in sync

### DIFF
--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -180,7 +180,6 @@ export class UiSpectrumController {
       previousHasReceivedPayload = nextHasReceivedPayload;
       if (spectraChanged) {
         untracked(() => this.renderSpectrum());
-        return;
       }
       if (transportChanged) {
         untracked(() => this.updateSpectrumOverlay());

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import type { SpectrumPanelView } from "../src/app/runtime/spectrum_panel_view";
 import { createAppState } from "../src/app/ui_app_state";
+import { batch } from "../src/app/ui_signals";
 import { installWindowGlobal } from "./async_test_helpers";
 import { createElementStub, installDocumentStub } from "./spectrum_test_support";
 
@@ -88,6 +89,39 @@ test.describe("UiSpectrumController", () => {
       state.transport.wsState = "stale";
 
       expect(panel.lastOverlayMessage).toBe("spectrum.stale");
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("runs overlay sync when spectra and transport change in the same batch", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const UiSpectrumController = await importUiSpectrumController();
+      const state = createAppState();
+      const panel = createPanelStub();
+      const controller = new UiSpectrumController({
+        state,
+        panel: panel.panel,
+        t: (key) => key,
+      });
+      let renderCalls = 0;
+      let overlayCalls = 0;
+
+      controller.renderSpectrum = () => {
+        renderCalls += 1;
+      };
+      controller.updateSpectrumOverlay = () => {
+        overlayCalls += 1;
+      };
+
+      batch(() => {
+        state.spectrum.spectra = { ...state.spectrum.spectra };
+        state.transport.wsState = "stale";
+      });
+
+      expect(renderCalls).toBe(1);
+      expect(overlayCalls).toBe(1);
     } finally {
       restoreDocument();
     }


### PR DESCRIPTION
## What changed
- remove the early `return` in `ui_spectrum_controller.ts` transport sync effect
- add a regression test that batches spectrum and transport mutations and asserts both controller paths run

## Why
- when both changes landed together, the controller could render the spectrum and skip the separate overlay sync path
- this keeps the effect honest: render work and overlay work can both run in the same batch

## Validation
- `cd apps/ui && npx playwright test tests/ui_spectrum_controller.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

Closes #2491
