### PR TITLE
Flatten update_feature_presenter.ts panel computeds

### DIFF
--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -23,6 +23,7 @@ import {
   getUpdateFailureSummary,
 } from "./update_journey_builder";
 import {
+  batch,
   computed,
   effect,
   signal,
@@ -349,54 +350,83 @@ export function createUpdateFeaturePresenter(
   ctx: UpdateFeaturePresenterDeps,
 ): UpdateFeaturePresenter {
   const { renderState, t } = ctx;
-  const formState = signal<UpdateFeatureFormSnapshot>({
-    passwordInputValue: "",
-    passwordVisible: false,
-    selectedTransport: "wifi",
-    ssidInputValue: "",
-  });
+  const passwordInputValue = signal("");
+  const passwordVisible = signal(false);
+  const selectedTransportInput = signal<UpdateStartRequestPayload["transport"]>("wifi");
+  const ssidInputValue = signal("");
   let hasHydratedPersistedWifiSettings = false;
 
   effect(() => {
     const state = renderState.value;
-    const currentForm = untracked(() => formState.value);
-    let nextForm = currentForm;
+    const currentSelectedTransport = untracked(() => selectedTransportInput.value);
+    const currentSsid = untracked(() => ssidInputValue.value);
+    let nextSelectedTransport: UpdateStartRequestPayload["transport"] | null = null;
+    let nextSsid: string | null = null;
 
     if (!hasHydratedPersistedWifiSettings && state.updateStatus != null) {
       hasHydratedPersistedWifiSettings = true;
       if (
         state.updateStatus.transport === "wifi"
         && state.updateStatus.ssid
-        && currentForm.ssidInputValue.trim().length === 0
+        && currentSsid.trim().length === 0
       ) {
-        nextForm = { ...nextForm, ssidInputValue: state.updateStatus.ssid };
+        nextSsid = state.updateStatus.ssid;
       }
     }
 
-    if (state.updateState === "running" && nextForm.selectedTransport !== state.updateTransport) {
-      nextForm = { ...nextForm, selectedTransport: state.updateTransport };
+    if (state.updateState === "running" && currentSelectedTransport !== state.updateTransport) {
+      nextSelectedTransport = state.updateTransport;
     }
 
-    if (nextForm !== currentForm) {
-      formState.value = nextForm;
+    if (nextSelectedTransport !== null || nextSsid !== null) {
+      batch(() => {
+        if (nextSelectedTransport !== null) {
+          selectedTransportInput.value = nextSelectedTransport;
+        }
+        if (nextSsid !== null) {
+          ssidInputValue.value = nextSsid;
+        }
+      });
     }
   });
 
-  const panelModels = computed(() =>
-    buildUpdateFeaturePanelModels(renderState.value, formState.value, { t })
+  const actionSummaryModel = computed(() =>
+    buildActionSummary(
+      renderState.value,
+      {
+        passwordInputValue: "",
+        passwordVisible: false,
+        selectedTransport: selectedTransportInput.value,
+        ssidInputValue: ssidInputValue.value,
+      },
+      t,
+    )
   );
-  const internetPanelModel = computed(() => panelModels.value.internetPanel);
-  const updatePanelModel = computed(() => panelModels.value.updatePanel);
+  const internetPanelModel = computed(() =>
+    buildInternetPanelRenderModel(
+      renderState.value,
+      {
+        passwordInputValue: passwordInputValue.value,
+        passwordVisible: passwordVisible.value,
+        selectedTransport: selectedTransportInput.value,
+        ssidInputValue: ssidInputValue.value,
+      },
+      actionSummaryModel.value,
+      t,
+    )
+  );
+  const updatePanelModel = computed(() =>
+    buildUpdatePanelRenderModel(renderState.value, actionSummaryModel.value, t)
+  );
 
   function readStartIntent(): UpdateFeatureStartIntent {
-    const form = formState.value;
     const currentRenderState = renderState.value;
-    const currentPanelModels = panelModels.value;
+    const currentActionSummary = actionSummaryModel.value;
     return {
-      canStart: currentPanelModels.canStart,
-      password: form.passwordInputValue,
-      ssid: form.ssidInputValue.trim(),
-      transport: currentPanelModels.transport,
+      canStart: currentActionSummary.canStart,
+      password: passwordInputValue.value,
+      ssid: ssidInputValue.value.trim(),
+      transport: currentActionSummary.transport,
       usbAvailable: currentRenderState.internetStatus.usable,
     };
   }
@@ -405,23 +435,20 @@ export function createUpdateFeaturePresenter(
     internetPanelModel,
     updatePanelModel,
     setPasswordInput(value) {
-      formState.value = { ...formState.value, passwordInputValue: value };
+      passwordInputValue.value = value;
     },
     setSelectedTransport(transport) {
-      formState.value = { ...formState.value, selectedTransport: transport };
+      selectedTransportInput.value = transport;
     },
     setSsidInput(value) {
-      formState.value = { ...formState.value, ssidInputValue: value };
+      ssidInputValue.value = value;
     },
     readStartIntent,
     togglePassword() {
-      formState.value = {
-        ...formState.value,
-        passwordVisible: !formState.value.passwordVisible,
-      };
+      passwordVisible.value = !passwordVisible.value;
     },
     clearPassword() {
-      formState.value = { ...formState.value, passwordInputValue: "" };
+      passwordInputValue.value = "";
     },
   };
 }

--- a/apps/ui/tests/update_feature_presenter.spec.ts
+++ b/apps/ui/tests/update_feature_presenter.spec.ts
@@ -285,4 +285,32 @@ test.describe("createUpdateFeaturePresenter", () => {
       transport: "wifi",
     });
   });
+
+  test("keeps the update panel model stable across password-only form edits", () => {
+    const renderState = signal({
+      internetStatus: makeInternet({
+        detected: true,
+        usable: true,
+        interface_name: "usb0",
+      }),
+      healthStatus: makeHealth(),
+      updateStatus: makeStatus(),
+      updateState: "idle" as const,
+      updateTransport: "wifi" as const,
+    });
+    const presenter = createUpdateFeaturePresenter({
+      renderState,
+      t,
+    });
+
+    const initialUpdatePanel = presenter.updatePanelModel.value;
+
+    presenter.setPasswordInput("secret");
+    expect(presenter.updatePanelModel.value).toBe(initialUpdatePanel);
+    expect(presenter.internetPanelModel.value.passwordInputValue).toBe("secret");
+
+    presenter.togglePassword();
+    expect(presenter.updatePanelModel.value).toBe(initialUpdatePanel);
+    expect(presenter.internetPanelModel.value.passwordInputType).toBe("text");
+  });
 });


### PR DESCRIPTION
## What changed

Flattened the intermediate `panelModels` computed inside `createUpdateFeaturePresenter()`.

- removed the combined `panelModels` computed plus the two extractor computeds
- split presenter-owned form state into targeted signals for password value, password visibility, selected transport, and SSID
- added `actionSummaryModel` as the shared derived state for startability / transport / readiness
- made `internetPanelModel` derive directly from full interactive form state
- made `updatePanelModel` derive directly from `renderState` plus the narrowed action summary
- added a regression test that proves password-only form edits do not rebuild the update panel model

## Why

Old presenter rebuilt both panel models through one shared object computed, then immediately peeled the object apart again. That had two bad properties:

- needless computed layering
- password-only internet-panel edits still invalidated the update panel path

This PR keeps the public presenter contract the same but removes the extra fan-out and narrows the dependencies that feed the update panel.

## Validation

- `cd apps/ui && npx playwright test tests/update_feature_presenter.spec.ts tests/update_status_view_models.spec.ts tests/smoke.update.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs

- Main risk was changing presenter-local signal wiring while preserving SSID hydration and running-state transport sync. Existing presenter behavior stayed covered, and the new regression locks the intended recompute boundary.
- I kept `buildUpdateFeaturePanelModels()` unchanged because the issue is about presenter internals, not its external helper surface.

## Out of scope

- No update status builder changes from `#2493`
- No broader rewrite of update workflow state ownership
- No API or contract changes

Closes #2494
