### PR TITLE
Refactor realtime logging view-model builders

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -142,7 +142,9 @@ source-of-truth export commands remain the only writers for those files.
 | `app/views/history_panel.tsx` | Signal-backed Preact owner for the history panel shell that renders summary/toolbar chrome and binds typed row actions through a semantic bridge |
 | `app/views/history_table_content.tsx` | History island JSX renderer that turns typed row/detail models into empty state, table rows, expanded evidence cards, and action affordances |
 | `app/views/history_table_view.ts` | Thin history-panel bridge that defines the typed empty/table render contract consumed by the Preact history island |
-| `app/views/realtime_logging_view_models.ts` | Typed realtime logging and readiness view-model builders for summary, checklist, and control-state derivation |
+| `app/views/realtime_capture_readiness_models.ts` | Typed capture-readiness helpers and checklist builders reused by realtime logging and sensor-health derivation |
+| `app/views/realtime_logging_summary_models.ts` | Typed realtime logging summary-panel builders for blocked/setup/post-run states and CTA mapping |
+| `app/views/realtime_logging_view_models.ts` | Thin realtime logging panel compositor and stable re-export surface over the focused readiness and summary builders |
 | `app/views/realtime_live_overview.tsx` | Signal-backed Preact owner for the live overview card that consumes typed status/sensor models without manual island rerender loops |
 | `app/views/realtime_logging_panel.tsx` | Signal-backed Preact owner for the run-recording card that renders typed logging/readiness models, owns the setup-layout marker locally, and binds start/stop plus summary CTA actions through the shared bridge |
 | `app/views/settings_car_list_view.ts` | Typed saved-car list and guidance view-model builders reused by the car-management island for row, empty-state, and highlight rendering |
@@ -225,10 +227,12 @@ mutation flow, and signal-backed workflow state, `realtime_feature_view_state.ts
 derives the live overview/logging/sensors models plus idle readiness signatures
 from shared AppState slices, `app/views/realtime_live_overview.tsx` and
 `app/views/realtime_logging_panel.tsx` consume bound model signals inside their
-signal-backed islands, and `realtime_logging_view_models.ts` still owns the
-logging/readiness model builders reused by that derived state. `app/views/` now
-owns typed view-model builders, event-target decoding, and signal-backed Preact
-surfaces for reusable multi-action panels.
+signal-backed islands, `realtime_capture_readiness_models.ts` owns the
+readiness/checklist helpers, `realtime_logging_summary_models.ts` owns the
+logging summary-panel builders, and `realtime_logging_view_models.ts` stays the
+top-level logging panel compositor and stable re-export surface reused by that
+derived state. `app/views/` now owns typed view-model builders, event-target
+decoding, and signal-backed Preact surfaces for reusable multi-action panels.
 
 `src/transport/` owns transport-specific helpers such as clone and live-model
 surfaces, while `api/types.ts` owns generated HTTP alias exports used across

--- a/apps/ui/src/app/views/realtime_capture_readiness_models.ts
+++ b/apps/ui/src/app/views/realtime_capture_readiness_models.ts
@@ -1,0 +1,216 @@
+import type { LoggingStatusPayload } from "../../api/types";
+
+export type CaptureReadinessPayload = NonNullable<LoggingStatusPayload["capture_readiness"]>;
+export type CaptureReadinessCheckPayload = CaptureReadinessPayload["checks"][number];
+
+export interface RealtimeCaptureReadinessChecklistItemModel {
+  checkKey: CaptureReadinessCheckPayload["check_key"];
+  state: CaptureReadinessCheckPayload["state"];
+  labelText: string;
+  stateText: string;
+  detailText: string;
+}
+
+export interface RealtimeCaptureReadinessChecklistModel {
+  titleText: string;
+  items: readonly RealtimeCaptureReadinessChecklistItemModel[];
+}
+
+export interface CaptureReadinessTextDeps {
+  t: (key: string, vars?: Record<string, unknown>) => string;
+  formatInt: (value: number) => string;
+}
+
+const CAPTURE_READINESS_ORDER = [
+  "sensors_ready",
+  "reference_ready",
+  "speed_stable",
+  "capture_ready",
+] as const;
+
+export function captureReadinessCheck(
+  readiness: CaptureReadinessPayload | null,
+  checkKey: CaptureReadinessCheckPayload["check_key"],
+): CaptureReadinessCheckPayload | null {
+  return readiness?.checks.find((check) => check.check_key === checkKey) ?? null;
+}
+
+function captureReadinessDetailNumber(
+  check: CaptureReadinessCheckPayload | null,
+  key: string,
+): number | null {
+  const value = check?.details?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function captureReadinessStateText(
+  state: CaptureReadinessCheckPayload["state"],
+  deps: CaptureReadinessTextDeps,
+): string {
+  return deps.t(`dashboard.capture_readiness.state.${state}`);
+}
+
+function captureReadinessCheckLabel(
+  checkKey: CaptureReadinessCheckPayload["check_key"],
+  deps: CaptureReadinessTextDeps,
+): string {
+  return deps.t(`dashboard.capture_readiness.${checkKey}.label`);
+}
+
+export function captureReadinessDetailText(
+  check: CaptureReadinessCheckPayload,
+  deps: CaptureReadinessTextDeps,
+): string {
+  const { t, formatInt } = deps;
+  if (check.check_key === "sensors_ready") {
+    const liveSensorCount = Math.max(
+      0,
+      Math.ceil(captureReadinessDetailNumber(check, "live_sensor_count") ?? 0),
+    );
+    const unassignedSensorCount = Math.max(
+      0,
+      Math.ceil(captureReadinessDetailNumber(check, "unassigned_sensor_count") ?? 0),
+    );
+    const quietPeriodRemaining = Math.max(
+      0,
+      Math.ceil(captureReadinessDetailNumber(check, "quiet_period_remaining_s") ?? 0),
+    );
+    if (check.reason_key === "no_live_sensors") {
+      return t("dashboard.capture_readiness.sensors_ready.no_live_sensors");
+    }
+    if (check.reason_key === "sensor_locations_missing") {
+      return t("dashboard.capture_readiness.sensors_ready.sensor_locations_missing", {
+        count: formatInt(unassignedSensorCount),
+      });
+    }
+    if (check.reason_key === "recent_integrity_events") {
+      return t("dashboard.capture_readiness.sensors_ready.recent_integrity_events", {
+        seconds: formatInt(quietPeriodRemaining),
+      });
+    }
+    if (check.reason_key === "limited_sensor_coverage") {
+      return t("dashboard.capture_readiness.sensors_ready.limited_sensor_coverage", {
+        count: formatInt(liveSensorCount),
+      });
+    }
+    return t("dashboard.capture_readiness.sensors_ready.ready", {
+      count: formatInt(liveSensorCount),
+    });
+  }
+
+  if (check.check_key === "reference_ready") {
+    if (check.reason_key === "active_car_missing") {
+      return t("dashboard.capture_readiness.reference_ready.active_car_missing");
+    }
+    if (check.reason_key === "order_reference_incomplete") {
+      return t("dashboard.capture_readiness.reference_ready.order_reference_incomplete");
+    }
+    if (check.reason_key === "speed_source_missing") {
+      return t("dashboard.capture_readiness.reference_ready.speed_source_missing");
+    }
+    if (check.reason_key === "speed_source_not_live") {
+      return t("dashboard.capture_readiness.reference_ready.speed_source_not_live");
+    }
+    if (check.reason_key === "speed_source_fallback_active") {
+      return t("dashboard.capture_readiness.reference_ready.speed_source_fallback_active");
+    }
+    if (check.reason_key === "speed_sample_stale") {
+      return t("dashboard.capture_readiness.reference_ready.speed_sample_stale");
+    }
+    if (check.reason_key === "speed_sample_missing") {
+      return t("dashboard.capture_readiness.reference_ready.speed_sample_missing");
+    }
+    if (check.reason_key === "obd_rpm_missing") {
+      return t("dashboard.capture_readiness.reference_ready.obd_rpm_missing");
+    }
+    if (check.reason_key === "obd_rpm_stale") {
+      return t("dashboard.capture_readiness.reference_ready.obd_rpm_stale");
+    }
+    return t("dashboard.capture_readiness.reference_ready.ready");
+  }
+
+  if (check.check_key === "speed_stable") {
+    const dwellRemaining = Math.max(
+      0,
+      Math.ceil(captureReadinessDetailNumber(check, "dwell_remaining_s") ?? 0),
+    );
+    const minimumSpeed = Math.max(
+      0,
+      Math.ceil(captureReadinessDetailNumber(check, "minimum_speed_kmh") ?? 20),
+    );
+    if (check.reason_key === "speed_sample_missing") {
+      return t("dashboard.capture_readiness.speed_stable.speed_sample_missing");
+    }
+    if (check.reason_key === "speed_too_low") {
+      return t("dashboard.capture_readiness.speed_stable.speed_too_low", {
+        minimumSpeed: formatInt(minimumSpeed),
+      });
+    }
+    if (check.reason_key === "speed_stabilizing") {
+      return t("dashboard.capture_readiness.speed_stable.speed_stabilizing", {
+        seconds: formatInt(dwellRemaining),
+      });
+    }
+    if (check.reason_key === "speed_variation_high") {
+      return t("dashboard.capture_readiness.speed_stable.speed_variation_high");
+    }
+    return t("dashboard.capture_readiness.speed_stable.ready");
+  }
+
+  if (check.reason_key === "capture_blocked") {
+    return t("dashboard.capture_readiness.capture_ready.capture_blocked");
+  }
+  if (check.reason_key === "ready_with_warnings") {
+    return t("dashboard.capture_readiness.capture_ready.ready_with_warnings");
+  }
+  return t("dashboard.capture_readiness.capture_ready.ready");
+}
+
+export function captureReadinessSummaryText(
+  readiness: CaptureReadinessPayload | null,
+  deps: CaptureReadinessTextDeps,
+): string {
+  if (!readiness) {
+    return "";
+  }
+  const primaryCheck = readiness.is_ready
+    ? readiness.checks.find((check) => check.state === "warn" && check.check_key !== "capture_ready")
+    : readiness.checks.find((check) => check.state === "fail" && check.check_key !== "capture_ready");
+  if (primaryCheck) {
+    return captureReadinessDetailText(primaryCheck, deps);
+  }
+  if (readiness.is_ready) {
+    return "";
+  }
+  const overallCheck = captureReadinessCheck(readiness, "capture_ready");
+  return overallCheck ? captureReadinessDetailText(overallCheck, deps) : "";
+}
+
+export function buildRealtimeCaptureReadinessChecklistModel(
+  readiness: CaptureReadinessPayload | null,
+  params: CaptureReadinessTextDeps & { setupMode: boolean },
+): RealtimeCaptureReadinessChecklistModel | null {
+  if (!readiness) {
+    return null;
+  }
+  const items = CAPTURE_READINESS_ORDER
+    .filter((checkKey) => checkKey !== "capture_ready")
+    .map((checkKey) => captureReadinessCheck(readiness, checkKey))
+    .filter((check): check is CaptureReadinessCheckPayload => (
+      check !== null && (!params.setupMode || check.state !== "pass")
+    ))
+    .map((check) => ({
+      checkKey: check.check_key,
+      state: check.state,
+      labelText: captureReadinessCheckLabel(check.check_key, params),
+      stateText: captureReadinessStateText(check.state, params),
+      detailText: captureReadinessDetailText(check, params),
+    }));
+  if (!items.length) {
+    return null;
+  }
+  return {
+    titleText: params.t("dashboard.capture_readiness.title"),
+    items,
+  };
+}

--- a/apps/ui/src/app/views/realtime_logging_summary_models.ts
+++ b/apps/ui/src/app/views/realtime_logging_summary_models.ts
@@ -1,0 +1,138 @@
+import type {
+  InlineStateActionVariant,
+  InlineStatePanelElement,
+} from "./dom_helpers";
+import {
+  captureReadinessCheck,
+  captureReadinessDetailText,
+  type CaptureReadinessPayload,
+  type CaptureReadinessTextDeps,
+  type CaptureReadinessCheckPayload,
+} from "./realtime_capture_readiness_models";
+
+export const REALTIME_LOGGING_SUMMARY_ACTIONS = [
+  "open-history",
+  "open-cars",
+  "open-add-car",
+  "open-sensors",
+  "open-speed-source",
+] as const;
+
+export type RealtimeLoggingSummaryAction = (typeof REALTIME_LOGGING_SUMMARY_ACTIONS)[number];
+
+export interface RealtimeLoggingSummaryPanelModel
+  extends Omit<InlineStatePanelElement, "action"> {
+  action?: {
+    action: RealtimeLoggingSummaryAction;
+    labelText: string;
+    variant?: InlineStateActionVariant;
+  };
+}
+
+function setupRecordingAction(
+  check: CaptureReadinessCheckPayload,
+  deps: CaptureReadinessTextDeps,
+): RealtimeLoggingSummaryPanelModel["action"] | undefined {
+  const { t } = deps;
+  if (check.check_key === "sensors_ready") {
+    return {
+      action: "open-sensors",
+      labelText: t("dashboard.logging.blocked.setup.action.sensors"),
+    };
+  }
+  if (check.check_key === "reference_ready") {
+    if (check.reason_key === "active_car_missing" || check.reason_key === "order_reference_incomplete") {
+      return {
+        action: "open-cars",
+        labelText: t("dashboard.logging.blocked.setup.action.cars"),
+      };
+    }
+    return {
+      action: "open-speed-source",
+      labelText: t("dashboard.logging.blocked.setup.action.speed_source"),
+    };
+  }
+  if (check.check_key === "speed_stable" && check.reason_key === "speed_sample_missing") {
+    return {
+      action: "open-speed-source",
+      labelText: t("dashboard.logging.blocked.setup.action.speed_source"),
+    };
+  }
+  return undefined;
+}
+
+export function buildBlockedRecordingPanel(
+  blockReason: "no_cars" | "no_active",
+  deps: CaptureReadinessTextDeps,
+): RealtimeLoggingSummaryPanelModel {
+  const { t } = deps;
+  if (blockReason === "no_cars") {
+    return {
+      titleText: t("dashboard.logging.blocked.no_cars.title"),
+      bodyText: t("dashboard.logging.blocked.no_cars.body"),
+      detailText: t("dashboard.logging.blocked.no_cars.detail"),
+      action: {
+        action: "open-add-car",
+        labelText: t("dashboard.logging.blocked.no_cars.action"),
+        variant: "success",
+      },
+    };
+  }
+  return {
+    titleText: t("dashboard.logging.blocked.no_active.title"),
+    bodyText: t("dashboard.logging.blocked.no_active.body"),
+    detailText: t("dashboard.logging.blocked.no_active.detail"),
+    action: {
+      action: "open-cars",
+      labelText: t("dashboard.logging.blocked.no_active.action"),
+    },
+  };
+}
+
+export function buildSetupRecordingPanel(
+  readiness: CaptureReadinessPayload | null,
+  deps: CaptureReadinessTextDeps,
+): RealtimeLoggingSummaryPanelModel | null {
+  if (!readiness || readiness.is_ready) {
+    return null;
+  }
+  const primaryCheck = readiness.checks.find((check) => (
+    check.state === "fail" && check.check_key !== "capture_ready"
+  )) ?? captureReadinessCheck(readiness, "capture_ready");
+  if (!primaryCheck) {
+    return null;
+  }
+  return {
+    titleText: deps.t("dashboard.logging.blocked.setup.title"),
+    bodyText: captureReadinessDetailText(primaryCheck, deps),
+    action: setupRecordingAction(primaryCheck, deps),
+  };
+}
+
+export function buildPostRunSummaryPanel(
+  kind: "processing" | "saved",
+  runId: string,
+  deps: CaptureReadinessTextDeps,
+): RealtimeLoggingSummaryPanelModel {
+  const { t } = deps;
+  if (kind === "processing") {
+    return {
+      titleText: t("dashboard.logging.processing.title", { runId }),
+      bodyText: t("dashboard.logging.processing.body"),
+      detailText: t("dashboard.logging.processing.detail"),
+      action: {
+        action: "open-history",
+        labelText: t("dashboard.logging.processing.action"),
+      },
+    };
+  }
+  return {
+    titleText: t("dashboard.logging.saved.title", { runId }),
+    bodyText: t("dashboard.logging.saved.body"),
+    detailText: t("dashboard.logging.saved.detail"),
+    action: {
+      action: "open-history",
+      labelText: t("dashboard.logging.saved.action"),
+    },
+  };
+}

--- a/apps/ui/src/app/views/realtime_logging_view_models.ts
+++ b/apps/ui/src/app/views/realtime_logging_view_models.ts
@@ -1,45 +1,34 @@
 import type { LiveHealth } from "../features/realtime_sensor_state";
 import type { LoggingStatusPayload } from "../../api/types";
-import type {
-  InlineStateActionVariant,
-  InlineStatePanelElement,
-} from "./dom_helpers";
+import {
+  buildRealtimeCaptureReadinessChecklistModel,
+  captureReadinessSummaryText,
+  type CaptureReadinessTextDeps,
+  type RealtimeCaptureReadinessChecklistModel,
+} from "./realtime_capture_readiness_models";
+import {
+  buildBlockedRecordingPanel,
+  buildPostRunSummaryPanel,
+  buildSetupRecordingPanel,
+  type RealtimeLoggingSummaryPanelModel,
+} from "./realtime_logging_summary_models";
 
-export const REALTIME_LOGGING_SUMMARY_ACTIONS = [
-  "open-history",
-  "open-cars",
-  "open-add-car",
-  "open-sensors",
-  "open-speed-source",
-] as const;
+export {
+  buildRealtimeCaptureReadinessChecklistModel,
+  captureReadinessCheck,
+  captureReadinessSummaryText,
+  type CaptureReadinessCheckPayload,
+  type CaptureReadinessPayload,
+  type RealtimeCaptureReadinessChecklistItemModel,
+  type RealtimeCaptureReadinessChecklistModel,
+} from "./realtime_capture_readiness_models";
+export {
+  REALTIME_LOGGING_SUMMARY_ACTIONS,
+  type RealtimeLoggingSummaryAction,
+  type RealtimeLoggingSummaryPanelModel,
+} from "./realtime_logging_summary_models";
 
-export type RealtimeLoggingSummaryAction = (typeof REALTIME_LOGGING_SUMMARY_ACTIONS)[number];
 export type RealtimeLoggingPendingAction = "starting" | "stopping" | null;
-
-export type CaptureReadinessPayload = NonNullable<LoggingStatusPayload["capture_readiness"]>;
-export type CaptureReadinessCheckPayload = CaptureReadinessPayload["checks"][number];
-
-export interface RealtimeLoggingSummaryPanelModel
-  extends Omit<InlineStatePanelElement, "action"> {
-  action?: {
-    action: RealtimeLoggingSummaryAction;
-    labelText: string;
-    variant?: InlineStateActionVariant;
-  };
-}
-
-export interface RealtimeCaptureReadinessChecklistItemModel {
-  checkKey: CaptureReadinessCheckPayload["check_key"];
-  state: CaptureReadinessCheckPayload["state"];
-  labelText: string;
-  stateText: string;
-  detailText: string;
-}
-
-export interface RealtimeCaptureReadinessChecklistModel {
-  titleText: string;
-  items: readonly RealtimeCaptureReadinessChecklistItemModel[];
-}
 
 export interface RealtimeLoggingPanelViewModel {
   pillVariant: "muted" | "ok" | "warn" | "bad";
@@ -60,11 +49,6 @@ export interface RealtimeLoggingPanelViewModel {
   nextLastCompletedElapsedText: string;
 }
 
-export interface CaptureReadinessTextDeps {
-  t: (key: string, vars?: Record<string, unknown>) => string;
-  formatInt: (value: number) => string;
-}
-
 export interface BuildRealtimeLoggingPanelViewModelParams
   extends CaptureReadinessTextDeps {
   status: LoggingStatusPayload;
@@ -77,308 +61,6 @@ export interface BuildRealtimeLoggingPanelViewModelParams
   elapsedText: string;
   samplesText: string;
   lastCompletedElapsedText: string;
-}
-
-const CAPTURE_READINESS_ORDER = [
-  "sensors_ready",
-  "reference_ready",
-  "speed_stable",
-  "capture_ready",
-] as const;
-
-export function captureReadinessCheck(
-  readiness: CaptureReadinessPayload | null,
-  checkKey: CaptureReadinessCheckPayload["check_key"],
-): CaptureReadinessCheckPayload | null {
-  return readiness?.checks.find((check) => check.check_key === checkKey) ?? null;
-}
-
-function captureReadinessDetailNumber(
-  check: CaptureReadinessCheckPayload | null,
-  key: string,
-): number | null {
-  const value = check?.details?.[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function captureReadinessStateText(
-  state: CaptureReadinessCheckPayload["state"],
-  deps: CaptureReadinessTextDeps,
-): string {
-  return deps.t(`dashboard.capture_readiness.state.${state}`);
-}
-
-function captureReadinessCheckLabel(
-  checkKey: CaptureReadinessCheckPayload["check_key"],
-  deps: CaptureReadinessTextDeps,
-): string {
-  return deps.t(`dashboard.capture_readiness.${checkKey}.label`);
-}
-
-function captureReadinessDetailText(
-  check: CaptureReadinessCheckPayload,
-  deps: CaptureReadinessTextDeps,
-): string {
-  const { t, formatInt } = deps;
-  if (check.check_key === "sensors_ready") {
-    const liveSensorCount = Math.max(
-      0,
-      Math.ceil(captureReadinessDetailNumber(check, "live_sensor_count") ?? 0),
-    );
-    const unassignedSensorCount = Math.max(
-      0,
-      Math.ceil(captureReadinessDetailNumber(check, "unassigned_sensor_count") ?? 0),
-    );
-    const quietPeriodRemaining = Math.max(
-      0,
-      Math.ceil(captureReadinessDetailNumber(check, "quiet_period_remaining_s") ?? 0),
-    );
-    if (check.reason_key === "no_live_sensors") {
-      return t("dashboard.capture_readiness.sensors_ready.no_live_sensors");
-    }
-    if (check.reason_key === "sensor_locations_missing") {
-      return t("dashboard.capture_readiness.sensors_ready.sensor_locations_missing", {
-        count: formatInt(unassignedSensorCount),
-      });
-    }
-    if (check.reason_key === "recent_integrity_events") {
-      return t("dashboard.capture_readiness.sensors_ready.recent_integrity_events", {
-        seconds: formatInt(quietPeriodRemaining),
-      });
-    }
-    if (check.reason_key === "limited_sensor_coverage") {
-      return t("dashboard.capture_readiness.sensors_ready.limited_sensor_coverage", {
-        count: formatInt(liveSensorCount),
-      });
-    }
-    return t("dashboard.capture_readiness.sensors_ready.ready", {
-      count: formatInt(liveSensorCount),
-    });
-  }
-
-  if (check.check_key === "reference_ready") {
-    if (check.reason_key === "active_car_missing") {
-      return t("dashboard.capture_readiness.reference_ready.active_car_missing");
-    }
-    if (check.reason_key === "order_reference_incomplete") {
-      return t("dashboard.capture_readiness.reference_ready.order_reference_incomplete");
-    }
-    if (check.reason_key === "speed_source_missing") {
-      return t("dashboard.capture_readiness.reference_ready.speed_source_missing");
-    }
-    if (check.reason_key === "speed_source_not_live") {
-      return t("dashboard.capture_readiness.reference_ready.speed_source_not_live");
-    }
-    if (check.reason_key === "speed_source_fallback_active") {
-      return t("dashboard.capture_readiness.reference_ready.speed_source_fallback_active");
-    }
-    if (check.reason_key === "speed_sample_stale") {
-      return t("dashboard.capture_readiness.reference_ready.speed_sample_stale");
-    }
-    if (check.reason_key === "speed_sample_missing") {
-      return t("dashboard.capture_readiness.reference_ready.speed_sample_missing");
-    }
-    if (check.reason_key === "obd_rpm_missing") {
-      return t("dashboard.capture_readiness.reference_ready.obd_rpm_missing");
-    }
-    if (check.reason_key === "obd_rpm_stale") {
-      return t("dashboard.capture_readiness.reference_ready.obd_rpm_stale");
-    }
-    return t("dashboard.capture_readiness.reference_ready.ready");
-  }
-
-  if (check.check_key === "speed_stable") {
-    const dwellRemaining = Math.max(
-      0,
-      Math.ceil(captureReadinessDetailNumber(check, "dwell_remaining_s") ?? 0),
-    );
-    const minimumSpeed = Math.max(
-      0,
-      Math.ceil(captureReadinessDetailNumber(check, "minimum_speed_kmh") ?? 20),
-    );
-    if (check.reason_key === "speed_sample_missing") {
-      return t("dashboard.capture_readiness.speed_stable.speed_sample_missing");
-    }
-    if (check.reason_key === "speed_too_low") {
-      return t("dashboard.capture_readiness.speed_stable.speed_too_low", {
-        minimumSpeed: formatInt(minimumSpeed),
-      });
-    }
-    if (check.reason_key === "speed_stabilizing") {
-      return t("dashboard.capture_readiness.speed_stable.speed_stabilizing", {
-        seconds: formatInt(dwellRemaining),
-      });
-    }
-    if (check.reason_key === "speed_variation_high") {
-      return t("dashboard.capture_readiness.speed_stable.speed_variation_high");
-    }
-    return t("dashboard.capture_readiness.speed_stable.ready");
-  }
-
-  if (check.reason_key === "capture_blocked") {
-    return t("dashboard.capture_readiness.capture_ready.capture_blocked");
-  }
-  if (check.reason_key === "ready_with_warnings") {
-    return t("dashboard.capture_readiness.capture_ready.ready_with_warnings");
-  }
-  return t("dashboard.capture_readiness.capture_ready.ready");
-}
-
-export function captureReadinessSummaryText(
-  readiness: CaptureReadinessPayload | null,
-  deps: CaptureReadinessTextDeps,
-): string {
-  if (!readiness) {
-    return "";
-  }
-  const primaryCheck = readiness.is_ready
-    ? readiness.checks.find((check) => check.state === "warn" && check.check_key !== "capture_ready")
-    : readiness.checks.find((check) => check.state === "fail" && check.check_key !== "capture_ready");
-  if (primaryCheck) {
-    return captureReadinessDetailText(primaryCheck, deps);
-  }
-  if (readiness.is_ready) {
-    return "";
-  }
-  const overallCheck = captureReadinessCheck(readiness, "capture_ready");
-  return overallCheck ? captureReadinessDetailText(overallCheck, deps) : "";
-}
-
-function setupRecordingAction(
-  check: CaptureReadinessCheckPayload,
-  deps: CaptureReadinessTextDeps,
-): RealtimeLoggingSummaryPanelModel["action"] | undefined {
-  const { t } = deps;
-  if (check.check_key === "sensors_ready") {
-    return {
-      action: "open-sensors",
-      labelText: t("dashboard.logging.blocked.setup.action.sensors"),
-    };
-  }
-  if (check.check_key === "reference_ready") {
-    if (check.reason_key === "active_car_missing" || check.reason_key === "order_reference_incomplete") {
-      return {
-        action: "open-cars",
-        labelText: t("dashboard.logging.blocked.setup.action.cars"),
-      };
-    }
-    return {
-      action: "open-speed-source",
-      labelText: t("dashboard.logging.blocked.setup.action.speed_source"),
-    };
-  }
-  if (check.check_key === "speed_stable" && check.reason_key === "speed_sample_missing") {
-    return {
-      action: "open-speed-source",
-      labelText: t("dashboard.logging.blocked.setup.action.speed_source"),
-    };
-  }
-  return undefined;
-}
-
-function buildBlockedRecordingPanel(
-  blockReason: "no_cars" | "no_active",
-  deps: CaptureReadinessTextDeps,
-): RealtimeLoggingSummaryPanelModel {
-  const { t } = deps;
-  if (blockReason === "no_cars") {
-    return {
-      titleText: t("dashboard.logging.blocked.no_cars.title"),
-      bodyText: t("dashboard.logging.blocked.no_cars.body"),
-      detailText: t("dashboard.logging.blocked.no_cars.detail"),
-      action: {
-        action: "open-add-car",
-        labelText: t("dashboard.logging.blocked.no_cars.action"),
-        variant: "success",
-      },
-    };
-  }
-  return {
-    titleText: t("dashboard.logging.blocked.no_active.title"),
-    bodyText: t("dashboard.logging.blocked.no_active.body"),
-    detailText: t("dashboard.logging.blocked.no_active.detail"),
-    action: {
-      action: "open-cars",
-      labelText: t("dashboard.logging.blocked.no_active.action"),
-    },
-  };
-}
-
-function buildSetupRecordingPanel(
-  readiness: CaptureReadinessPayload | null,
-  deps: CaptureReadinessTextDeps,
-): RealtimeLoggingSummaryPanelModel | null {
-  if (!readiness || readiness.is_ready) {
-    return null;
-  }
-  const primaryCheck = readiness.checks.find((check) => (
-    check.state === "fail" && check.check_key !== "capture_ready"
-  )) ?? captureReadinessCheck(readiness, "capture_ready");
-  if (!primaryCheck) {
-    return null;
-  }
-  return {
-    titleText: deps.t("dashboard.logging.blocked.setup.title"),
-    bodyText: captureReadinessDetailText(primaryCheck, deps),
-    action: setupRecordingAction(primaryCheck, deps),
-  };
-}
-
-function buildPostRunSummaryPanel(
-  kind: "processing" | "saved",
-  runId: string,
-  deps: CaptureReadinessTextDeps,
-): RealtimeLoggingSummaryPanelModel {
-  const { t } = deps;
-  if (kind === "processing") {
-    return {
-      titleText: t("dashboard.logging.processing.title", { runId }),
-      bodyText: t("dashboard.logging.processing.body"),
-      detailText: t("dashboard.logging.processing.detail"),
-      action: {
-        action: "open-history",
-        labelText: t("dashboard.logging.processing.action"),
-      },
-    };
-  }
-  return {
-    titleText: t("dashboard.logging.saved.title", { runId }),
-    bodyText: t("dashboard.logging.saved.body"),
-    detailText: t("dashboard.logging.saved.detail"),
-    action: {
-      action: "open-history",
-      labelText: t("dashboard.logging.saved.action"),
-    },
-  };
-}
-
-export function buildRealtimeCaptureReadinessChecklistModel(
-  readiness: CaptureReadinessPayload | null,
-  params: CaptureReadinessTextDeps & { setupMode: boolean },
-): RealtimeCaptureReadinessChecklistModel | null {
-  if (!readiness) {
-    return null;
-  }
-  const items = CAPTURE_READINESS_ORDER
-    .filter((checkKey) => checkKey !== "capture_ready")
-    .map((checkKey) => captureReadinessCheck(readiness, checkKey))
-    .filter((check): check is CaptureReadinessCheckPayload => (
-      check !== null && (!params.setupMode || check.state !== "pass")
-    ))
-    .map((check) => ({
-      checkKey: check.check_key,
-      state: check.state,
-      labelText: captureReadinessCheckLabel(check.check_key, params),
-      stateText: captureReadinessStateText(check.state, params),
-      detailText: captureReadinessDetailText(check, params),
-    }));
-  if (!items.length) {
-    return null;
-  }
-  return {
-    titleText: params.t("dashboard.capture_readiness.title"),
-    items,
-  };
 }
 
 export function buildRealtimeLoggingPanelViewModel(


### PR DESCRIPTION
## What change

- split capture-readiness detail, summary, and checklist builders into `realtime_capture_readiness_models.ts`
- split blocked/setup/post-run summary panel builders and CTA mapping into `realtime_logging_summary_models.ts`
- keep `realtime_logging_view_models.ts` as thin top-level compositor plus stable re-export surface so callers do not churn
- update `apps/ui/README.md` ownership map for the new view-module split

## Why

- old file mixed two different jobs: capture-readiness formatting and top-level logging panel phase composition
- smaller modules cut merge-conflict surface and make the logging panel logic easier to find
- stable exports in the original file keep the rest of the realtime stack unchanged

## Validation

- `cd apps/ui && npx playwright test tests/realtime_logging_view_models.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / edges

- low risk: no API, contract, or behavior change intended
- main edge is import/type drift between the new focused modules and the stable re-export file; focused tests plus typecheck cover that path
- out of scope: further splitting the top-level phase/state compositor; this change only extracts the clear readiness and summary-builder seams from issue `#2496`

Closes #2496
