### PR TITLE
Trim API transport deep cloning

### DIFF
--- a/apps/ui/src/api/car_library.ts
+++ b/apps/ui/src/api/car_library.ts
@@ -1,19 +1,14 @@
 import { apiJson } from "./http";
-import { cloneTransportValue } from "../transport/clone";
 import type * as Local from "../api/types";
 import type * as Transport from "./types";
 
 export async function getCarLibraryBrands(): Promise<Local.CarLibraryBrandsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.CarLibraryBrandsPayload>("/api/car-library/brands"),
-  );
+  return await apiJson<Transport.CarLibraryBrandsPayload>("/api/car-library/brands");
 }
 
 export async function getCarLibraryTypes(brand: string): Promise<Local.CarLibraryTypesPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.CarLibraryTypesPayload>(
-      `/api/car-library/types?brand=${encodeURIComponent(brand)}`,
-    ),
+  return await apiJson<Transport.CarLibraryTypesPayload>(
+    `/api/car-library/types?brand=${encodeURIComponent(brand)}`,
   );
 }
 
@@ -21,9 +16,7 @@ export async function getCarLibraryModels(
   brand: string,
   type: string,
 ): Promise<Local.CarLibraryModelsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.CarLibraryModelsPayload>(
-      `/api/car-library/models?brand=${encodeURIComponent(brand)}&type=${encodeURIComponent(type)}`,
-    ),
+  return await apiJson<Transport.CarLibraryModelsPayload>(
+    `/api/car-library/models?brand=${encodeURIComponent(brand)}&type=${encodeURIComponent(type)}`,
   );
 }

--- a/apps/ui/src/api/clients.ts
+++ b/apps/ui/src/api/clients.ts
@@ -1,14 +1,11 @@
 import { apiJson } from "./http";
-import { cloneTransportValue } from "../transport/clone";
 import type * as Local from "../api/types";
 import type * as Transport from "./types";
 
 const JSON_HEADERS: HeadersInit = { "Content-Type": "application/json" };
 
 export async function getClientLocations(): Promise<Local.ClientLocationsResponse> {
-  return cloneTransportValue(
-    await apiJson<Transport.ClientLocationsResponse>("/api/client-locations"),
-  );
+  return await apiJson<Transport.ClientLocationsResponse>("/api/client-locations");
 }
 
 export async function setClientLocation(clientId: string, locationCode: string): Promise<void> {

--- a/apps/ui/src/api/history.ts
+++ b/apps/ui/src/api/history.ts
@@ -1,5 +1,4 @@
 import { apiJson, apiJsonResponse } from "./http";
-import { cloneTransportValue } from "../transport/clone";
 import type * as Local from "../api/types";
 import type * as Transport from "./types";
 
@@ -12,23 +11,17 @@ export function historyReportPdfUrl(runId: string, lang: string): string {
 }
 
 export async function getHistory(): Promise<Local.HistoryListPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.HistoryListPayload>("/api/history"),
-  );
+  return await apiJson<Transport.HistoryListPayload>("/api/history");
 }
 
 export async function deleteHistoryRun(runId: string): Promise<Local.DeleteHistoryRunPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.DeleteHistoryRunPayload>(`/api/history/${encodeURIComponent(runId)}`, {
-      method: "DELETE",
-    }),
-  );
+  return await apiJson<Transport.DeleteHistoryRunPayload>(`/api/history/${encodeURIComponent(runId)}`, {
+    method: "DELETE",
+  });
 }
 
 export async function getHistoryRun(runId: string): Promise<Local.HistoryRunPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.HistoryRunPayload>(`/api/history/${encodeURIComponent(runId)}`),
-  );
+  return await apiJson<Transport.HistoryRunPayload>(`/api/history/${encodeURIComponent(runId)}`);
 }
 
 export async function getHistoryInsights(
@@ -42,11 +35,7 @@ export async function getHistoryInsights(
     throw new Error("Empty history insights response");
   }
   if (response.status === 202) {
-    return cloneTransportValue(
-      response.body as Transport.HistoryInsightsAnalyzingPayload,
-    );
+    return response.body as Transport.HistoryInsightsAnalyzingPayload;
   }
-  return cloneTransportValue(
-    response.body as Transport.HistoryInsightsPayload,
-  );
+  return response.body as Transport.HistoryInsightsPayload;
 }

--- a/apps/ui/src/api/logging.ts
+++ b/apps/ui/src/api/logging.ts
@@ -1,22 +1,15 @@
 import { apiJson } from "./http";
-import { cloneTransportValue } from "../transport/clone";
 import type * as Local from "../api/types";
 import type * as Transport from "./types";
 
 export async function getLoggingStatus(): Promise<Local.LoggingStatusPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.LoggingStatusPayload>("/api/recording/status"),
-  );
+  return await apiJson<Transport.LoggingStatusPayload>("/api/recording/status");
 }
 
 export async function startLoggingRun(): Promise<Local.LoggingStatusPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.LoggingStatusPayload>("/api/recording/start", { method: "POST" }),
-  );
+  return await apiJson<Transport.LoggingStatusPayload>("/api/recording/start", { method: "POST" });
 }
 
 export async function stopLoggingRun(): Promise<Local.LoggingStatusPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.LoggingStatusPayload>("/api/recording/stop", { method: "POST" }),
-  );
+  return await apiJson<Transport.LoggingStatusPayload>("/api/recording/stop", { method: "POST" });
 }

--- a/apps/ui/src/api/settings.ts
+++ b/apps/ui/src/api/settings.ts
@@ -1,5 +1,4 @@
 import { apiJson } from "./http";
-import { cloneTransportValue } from "../transport/clone";
 import type * as Local from "../api/types";
 import type * as Transport from "./types";
 
@@ -7,236 +6,176 @@ const JSON_HEADERS: HeadersInit = { "Content-Type": "application/json" };
 const OBD_SCAN_TIMEOUT_MS = 20_000;
 
 export async function getSettingsLanguage(): Promise<Local.LanguagePayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.LanguagePayload>("/api/settings/language"),
-  );
+  return await apiJson<Transport.LanguagePayload>("/api/settings/language");
 }
 
 export async function setSettingsLanguage(language: string): Promise<Local.LanguagePayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.LanguagePayload>("/api/settings/language", {
-      method: "PUT",
-      headers: JSON_HEADERS,
-      body: JSON.stringify({ language }),
-    }),
-  );
+  return await apiJson<Transport.LanguagePayload>("/api/settings/language", {
+    method: "PUT",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ language }),
+  });
 }
 
 export async function getSettingsSpeedUnit(): Promise<Local.SpeedUnitPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.SpeedUnitPayload>("/api/settings/speed-unit"),
-  );
+  return await apiJson<Transport.SpeedUnitPayload>("/api/settings/speed-unit");
 }
 
 export async function setSettingsSpeedUnit(speedUnit: string): Promise<Local.SpeedUnitPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.SpeedUnitPayload>("/api/settings/speed-unit", {
-      method: "PUT",
-      headers: JSON_HEADERS,
-      body: JSON.stringify({ speed_unit: speedUnit }),
-    }),
-  );
+  return await apiJson<Transport.SpeedUnitPayload>("/api/settings/speed-unit", {
+    method: "PUT",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ speed_unit: speedUnit }),
+  });
 }
 
 export async function getAnalysisSettings(): Promise<Local.AnalysisSettingsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.AnalysisSettingsPayload>("/api/settings/analysis"),
-  );
+  return await apiJson<Transport.AnalysisSettingsPayload>("/api/settings/analysis");
 }
 
 export async function setAnalysisSettings(
   payload: Local.AnalysisSettingsRequest,
 ): Promise<Local.AnalysisSettingsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.AnalysisSettingsPayload>("/api/settings/analysis", {
-      method: "PUT",
-      headers: JSON_HEADERS,
-      body: JSON.stringify(
-        cloneTransportValue(payload),
-      ),
-    }),
-  );
+  return await apiJson<Transport.AnalysisSettingsPayload>("/api/settings/analysis", {
+    method: "PUT",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(payload),
+  });
 }
 
 export async function getSettingsCars(): Promise<Local.CarsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.CarsPayload>("/api/settings/cars"),
-  );
+  return await apiJson<Transport.CarsPayload>("/api/settings/cars");
 }
 
 export async function addSettingsCar(car: Local.CarUpsertRequest): Promise<Local.CarsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.CarsPayload>("/api/settings/cars", {
-      method: "POST",
-      headers: JSON_HEADERS,
-      body: JSON.stringify(cloneTransportValue(car)),
-    }),
-  );
+  return await apiJson<Transport.CarsPayload>("/api/settings/cars", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(car),
+  });
 }
 
 export async function updateSettingsCar(
   carId: string,
   car: Local.CarUpsertRequest,
 ): Promise<Local.CarsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.CarsPayload>(`/api/settings/cars/${encodeURIComponent(carId)}`, {
-      method: "PUT",
-      headers: JSON_HEADERS,
-      body: JSON.stringify(cloneTransportValue(car)),
-    }),
-  );
+  return await apiJson<Transport.CarsPayload>(`/api/settings/cars/${encodeURIComponent(carId)}`, {
+    method: "PUT",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(car),
+  });
 }
 
 export async function deleteSettingsCar(carId: string): Promise<Local.CarsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.CarsPayload>(`/api/settings/cars/${encodeURIComponent(carId)}`, {
-      method: "DELETE",
-    }),
-  );
+  return await apiJson<Transport.CarsPayload>(`/api/settings/cars/${encodeURIComponent(carId)}`, {
+    method: "DELETE",
+  });
 }
 
 export async function setActiveSettingsCar(carId: string): Promise<Local.CarsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.CarsPayload>("/api/settings/cars/active", {
-      method: "PUT",
-      headers: JSON_HEADERS,
-      body: JSON.stringify({ car_id: carId }),
-    }),
-  );
+  return await apiJson<Transport.CarsPayload>("/api/settings/cars/active", {
+    method: "PUT",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ car_id: carId }),
+  });
 }
 
 export async function getSettingsSpeedSource(): Promise<Local.SpeedSourcePayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.SpeedSourcePayload>("/api/settings/speed-source"),
-  );
+  return await apiJson<Transport.SpeedSourcePayload>("/api/settings/speed-source");
 }
 
 export async function updateSettingsSpeedSource(
   data: Local.SpeedSourceRequest,
 ): Promise<Local.SpeedSourcePayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.SpeedSourcePayload>("/api/settings/speed-source", {
-      method: "PUT",
-      headers: JSON_HEADERS,
-      body: JSON.stringify(cloneTransportValue(data)),
-    }),
-  );
+  return await apiJson<Transport.SpeedSourcePayload>("/api/settings/speed-source", {
+    method: "PUT",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(data),
+  });
 }
 
 export async function getSpeedSourceStatus(): Promise<Local.SpeedSourceStatusPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.SpeedSourceStatusPayload>("/api/settings/speed-source/status"),
-  );
+  return await apiJson<Transport.SpeedSourceStatusPayload>("/api/settings/speed-source/status");
 }
 
 export async function scanSettingsObdDevices(): Promise<Local.ObdScanPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.ObdScanPayload>("/api/settings/obd/scan", {
-      method: "POST",
-      timeoutMs: OBD_SCAN_TIMEOUT_MS,
-    }),
-  );
+  return await apiJson<Transport.ObdScanPayload>("/api/settings/obd/scan", {
+    method: "POST",
+    timeoutMs: OBD_SCAN_TIMEOUT_MS,
+  });
 }
 
 export async function pairSettingsObdDevice(macAddress: string): Promise<Local.ObdPairPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.ObdPairPayload>("/api/settings/obd/pair", {
-      method: "POST",
-      headers: JSON_HEADERS,
-      body: JSON.stringify({ mac_address: macAddress }),
-    }),
-  );
+  return await apiJson<Transport.ObdPairPayload>("/api/settings/obd/pair", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ mac_address: macAddress }),
+  });
 }
 
 export async function getSettingsObdStatus(): Promise<Local.ObdStatusPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.ObdStatusPayload>("/api/settings/obd/status"),
-  );
+  return await apiJson<Transport.ObdStatusPayload>("/api/settings/obd/status");
 }
 
 export async function getUpdateStatus(): Promise<Local.UpdateStatusPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.UpdateStatusPayload>("/api/update/status"),
-  );
+  return await apiJson<Transport.UpdateStatusPayload>("/api/update/status");
 }
 
 export async function getUpdateInternetStatus(): Promise<Local.UsbInternetStatusPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.UsbInternetStatusPayload>("/api/update/internet-status"),
-  );
+  return await apiJson<Transport.UsbInternetStatusPayload>("/api/update/internet-status");
 }
 
 export async function getHealthStatus(): Promise<Local.HealthStatusPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.HealthStatusPayload>("/api/health"),
-  );
+  return await apiJson<Transport.HealthStatusPayload>("/api/health");
 }
 
 export async function startUpdate(
   payload: Local.UpdateStartRequestPayload,
 ): Promise<Local.UpdateStartPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.UpdateStartPayload>("/api/update/start", {
-      method: "POST",
-      headers: JSON_HEADERS,
-      body: JSON.stringify(
-        cloneTransportValue(payload),
-      ),
-    }),
-  );
+  return await apiJson<Transport.UpdateStartPayload>("/api/update/start", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(payload),
+  });
 }
 
 export async function cancelUpdate(): Promise<Local.UpdateCancelPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.UpdateCancelPayload>("/api/update/cancel", {
-      method: "POST",
-    }),
-  );
+  return await apiJson<Transport.UpdateCancelPayload>("/api/update/cancel", {
+    method: "POST",
+  });
 }
 
 export async function getEspFlashPorts(): Promise<Local.EspFlashPortsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.EspFlashPortsPayload>("/api/esp-flash/ports"),
-  );
+  return await apiJson<Transport.EspFlashPortsPayload>("/api/esp-flash/ports");
 }
 
 export async function startEspFlash(
   port: string | null,
   auto_detect: boolean,
 ): Promise<Local.EspFlashStartPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.EspFlashStartPayload>("/api/esp-flash/start", {
-      method: "POST",
-      headers: JSON_HEADERS,
-      body: JSON.stringify({ port, auto_detect }),
-    }),
-  );
+  return await apiJson<Transport.EspFlashStartPayload>("/api/esp-flash/start", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ port, auto_detect }),
+  });
 }
 
 export async function getEspFlashStatus(): Promise<Local.EspFlashStatusPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.EspFlashStatusPayload>("/api/esp-flash/status"),
-  );
+  return await apiJson<Transport.EspFlashStatusPayload>("/api/esp-flash/status");
 }
 
 export async function getEspFlashLogs(after: number): Promise<Local.EspFlashLogsPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.EspFlashLogsPayload>(
-      `/api/esp-flash/logs?after=${encodeURIComponent(String(after))}`,
-    ),
+  return await apiJson<Transport.EspFlashLogsPayload>(
+    `/api/esp-flash/logs?after=${encodeURIComponent(String(after))}`,
   );
 }
 
 export async function cancelEspFlash(): Promise<Local.EspFlashCancelPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.EspFlashCancelPayload>("/api/esp-flash/cancel", {
-      method: "POST",
-    }),
-  );
+  return await apiJson<Transport.EspFlashCancelPayload>("/api/esp-flash/cancel", {
+    method: "POST",
+  });
 }
 
 export async function getEspFlashHistory(): Promise<Local.EspFlashHistoryPayload> {
-  return cloneTransportValue(
-    await apiJson<Transport.EspFlashHistoryPayload>("/api/esp-flash/history"),
-  );
+  return await apiJson<Transport.EspFlashHistoryPayload>("/api/esp-flash/history");
 }

--- a/apps/ui/tests/api_clone_usage.spec.ts
+++ b/apps/ui/tests/api_clone_usage.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+
+import { addSettingsCar } from "../src/api/settings";
+import { getHistoryInsights } from "../src/api/history";
+import { getLoggingStatus } from "../src/api/logging";
+import type {
+  CarUpsertRequest,
+  CarsPayload,
+  HistoryInsightsAnalyzingPayload,
+  LoggingStatusPayload,
+} from "../src/api/types";
+import { installWindowGlobal, jsonResponse } from "./async_test_helpers";
+
+test.describe("API adapter clone usage", () => {
+  test.beforeEach(() => {
+    installWindowGlobal();
+  });
+
+  test("returns logging status without structuredClone", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalStructuredClone = globalThis.structuredClone;
+    const payload: LoggingStatusPayload = {
+      enabled: false,
+      run_id: null,
+      write_error: null,
+      analysis_in_progress: false,
+      start_time_utc: null,
+      samples_written: 0,
+      samples_dropped: 0,
+      last_completed_run_id: null,
+      last_completed_run_error: null,
+      capture_readiness: null,
+    };
+    let structuredCloneCalls = 0;
+
+    globalThis.structuredClone = ((value: unknown) => {
+      structuredCloneCalls += 1;
+      return originalStructuredClone(value);
+    }) as typeof structuredClone;
+    globalThis.fetch = (async () => jsonResponse(payload)) as typeof fetch;
+
+    try {
+      await expect(getLoggingStatus()).resolves.toEqual(payload);
+      expect(structuredCloneCalls).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.structuredClone = originalStructuredClone;
+    }
+  });
+
+  test("serializes car payloads without structuredClone", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalStructuredClone = globalThis.structuredClone;
+    const requestPayload: CarUpsertRequest = {
+      name: "Project Car",
+      type: "Sedan",
+      variant: "Prototype",
+      aspects: {
+        tire_width_mm: 225,
+        current_gear_ratio: 0.82,
+      },
+    };
+    const responsePayload: CarsPayload = {
+      active_car_id: null,
+      cars: [],
+    };
+    let structuredCloneCalls = 0;
+    let requestBody = "";
+
+    globalThis.structuredClone = ((value: unknown) => {
+      structuredCloneCalls += 1;
+      return originalStructuredClone(value);
+    }) as typeof structuredClone;
+    globalThis.fetch = (async (_input: string | URL | RequestInfo, init?: RequestInit) => {
+      requestBody = String(init?.body ?? "");
+      return jsonResponse(responsePayload);
+    }) as typeof fetch;
+
+    try {
+      await expect(addSettingsCar(requestPayload)).resolves.toEqual(responsePayload);
+      expect(JSON.parse(requestBody)).toEqual(requestPayload);
+      expect(structuredCloneCalls).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.structuredClone = originalStructuredClone;
+    }
+  });
+
+  test("returns history insights bodies without structuredClone", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalStructuredClone = globalThis.structuredClone;
+    const payload: HistoryInsightsAnalyzingPayload = {
+      status: "analyzing",
+      run_id: "run-001",
+    };
+    let structuredCloneCalls = 0;
+
+    globalThis.structuredClone = ((value: unknown) => {
+      structuredCloneCalls += 1;
+      return originalStructuredClone(value);
+    }) as typeof structuredClone;
+    globalThis.fetch = (async () => jsonResponse(payload, { status: 202 })) as typeof fetch;
+
+    try {
+      await expect(getHistoryInsights("run-001", "en")).resolves.toEqual(payload);
+      expect(structuredCloneCalls).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.structuredClone = originalStructuredClone;
+    }
+  });
+});


### PR DESCRIPTION
## What change

- remove `cloneTransportValue()` from the UI HTTP adapter layer in `api/car_library.ts`, `api/clients.ts`, `api/history.ts`, `api/logging.ts`, and `api/settings.ts`
- stop cloning request payloads right before `JSON.stringify(...)`
- keep `cloneTransportValue()` for real non-HTTP isolation seams such as live WebSocket payload adaptation
- add `tests/api_clone_usage.spec.ts` to prove representative GET, POST, and `apiJsonResponse()` adapter paths do not call `structuredClone`

## Why

- `apiJson()` already returns fresh objects from `JSON.parse()`
- the adapter layer usually hands those payloads straight to state replacement or immediate consumers; it does not share and mutate them in place
- cloning request payloads before `JSON.stringify(...)` buys nothing because serialization does not mutate inputs
- removing these clones cuts avoidable deep-copy work without dropping the clone helper from the places that still need hard isolation

## Validation

- `cd apps/ui && npx playwright test tests/api_clone_usage.spec.ts tests/transport_clone.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / edges

- medium but contained: many adapter entrypoints changed, but all follow the same boundary rule
- biggest edge is assuming all HTTP adapter consumers treat returned payloads as owned values; that is already how the UI uses `apiJson()` results today
- helper still stays in repo because WebSocket/server adaptation still needs clone-based isolation
- out of scope: removing clone usage from non-HTTP transport paths

Closes #2497
