### PR TITLE
refactor(ui): narrow live overview signals

### DIFF
--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -4,6 +4,7 @@ import { useUiText } from "../ui_i18n";
 import {
   signal,
   useComputed,
+  useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
 import { createBoundViewModel } from "./view_model_binding";
@@ -67,6 +68,112 @@ const DEFAULT_OVERVIEW_STATE: RealtimeLiveOverviewBridgeState = {
   speedText: "--",
 };
 
+const REALTIME_LIVE_OVERVIEW_MODEL_KEYS = [
+  "activeCar",
+  "connectedSensorsText",
+  "dataFreshnessText",
+  "recordingStateText",
+  "runHealth",
+  "sensorCards",
+  "strongestSignalText",
+] as const;
+
+function RealtimeLiveOverviewRunHealthPill(props: {
+  runHealth: ReadonlySignal<RealtimeLiveOverviewHealthModel>;
+}) {
+  const hidden = useComputed(() => props.runHealth.value.hidden);
+  const text = useComputed(() => props.runHealth.value.text);
+  const variant = useComputed(() => props.runHealth.value.variant);
+
+  return (
+    <div
+      id="liveRunHealth"
+      class="pill"
+      data-variant={variant}
+      hidden={hidden}
+      aria-live="polite"
+    >
+      {text}
+    </div>
+  );
+}
+
+function RealtimeLiveOverviewActiveCarStat(props: {
+  activeCar: ReadonlySignal<RealtimeLiveOverviewActiveCarModel>;
+  labelText: ReadonlySignal<string>;
+}) {
+  const text = useComputed(() => props.activeCar.value.text);
+  const warning = useComputed(() => props.activeCar.value.warning);
+  const variant = useComputed(() => warning.value ? "warn" : undefined);
+  const hasIcon = useComputed(() => warning.value ? "true" : undefined);
+
+  return (
+    <div
+      id="liveActiveCar"
+      class="stat"
+      data-variant={variant}
+    >
+      <div class="stat__label">
+        {props.labelText}
+      </div>
+      <div
+        class="stat__value"
+        data-value
+        data-variant={variant}
+        data-has-icon={hasIcon}
+      >
+        {warning.value
+          ? (
+            <>
+              <span class="stat__value-icon" data-variant="warn" aria-hidden="true">
+                !
+              </span>
+              <span>{text}</span>
+            </>
+          )
+          : text}
+      </div>
+    </div>
+  );
+}
+
+function RealtimeLiveOverviewSensorRoster(props: {
+  sensorCards: ReadonlySignal<RealtimeLiveOverviewSensorCardModel[]>;
+  noSensorsText: ReadonlySignal<string>;
+}) {
+  const hasSensorCards = useComputed(() => props.sensorCards.value.length > 0);
+
+  return (
+    <div id="liveSensorRoster" class="live-sensor-roster">
+      {hasSensorCards.value
+        ? props.sensorCards.value.map((card) => {
+          const statusClass = card.connected ? "online" : "offline";
+          return (
+            <article
+              key={card.id}
+              class={card.strongest ? "live-sensor-card live-sensor-card--strongest" : "live-sensor-card"}
+            >
+              <div class="live-sensor-card__header">
+                <strong>{card.label}</strong>
+                <span
+                  class={`live-sensor-card__status-dot live-sensor-card__status-dot--${statusClass}`}
+                  role="img"
+                  aria-label={card.statusText}
+                  title={card.statusText}
+                />
+              </div>
+            </article>
+          );
+        })
+        : (
+          <div class="subtle">
+            {props.noSensorsText}
+          </div>
+        )}
+    </div>
+  );
+}
+
 function RealtimeLiveOverview(props: {
   model: ReadonlySignal<RealtimeLiveOverviewRenderModel>;
   speedText: ReadonlySignal<string>;
@@ -84,7 +191,15 @@ function RealtimeLiveOverview(props: {
   const currentSpeedLabel = useUiText("dashboard.current_speed", "Current speed");
   const sensorCoverageLabel = useUiText("dashboard.sensor_coverage", "Sensor coverage");
   const noSensorsText = useUiText("settings.sensors.no_sensors", "No sensors yet.");
-  const model = useComputed(() => props.model.value);
+  const {
+    activeCar,
+    connectedSensorsText,
+    dataFreshnessText,
+    recordingStateText,
+    runHealth,
+    sensorCards,
+    strongestSignalText,
+  } = useSignalProperties(props.model, REALTIME_LIVE_OVERVIEW_MODEL_KEYS);
 
   return (
     <>
@@ -97,15 +212,7 @@ function RealtimeLiveOverview(props: {
             {hintText}
           </div>
         </div>
-        <div
-          id="liveRunHealth"
-          class="pill"
-          data-variant={model.value.runHealth.variant}
-          hidden={model.value.runHealth.hidden}
-          aria-live="polite"
-        >
-          {model.value.runHealth.text}
-        </div>
+        <RealtimeLiveOverviewRunHealthPill runHealth={runHealth} />
       </div>
       <div class="stat-grid live-overview__stats">
         <div id="liveConnectedSensors" class="stat">
@@ -113,41 +220,16 @@ function RealtimeLiveOverview(props: {
             {connectedSensorsLabel}
           </div>
           <div class="stat__value" data-value>
-            {model.value.connectedSensorsText}
+            {connectedSensorsText}
           </div>
         </div>
-        <div
-          id="liveActiveCar"
-          class="stat"
-          data-variant={model.value.activeCar.warning ? "warn" : undefined}
-        >
-          <div class="stat__label">
-            {activeCarLabel}
-          </div>
-          <div
-            class="stat__value"
-            data-value
-            data-variant={model.value.activeCar.warning ? "warn" : undefined}
-            data-has-icon={model.value.activeCar.warning ? "true" : undefined}
-          >
-            {model.value.activeCar.warning
-              ? (
-                <>
-                  <span class="stat__value-icon" data-variant="warn" aria-hidden="true">
-                    !
-                  </span>
-                  <span>{model.value.activeCar.text}</span>
-                </>
-              )
-              : model.value.activeCar.text}
-          </div>
-        </div>
+        <RealtimeLiveOverviewActiveCarStat activeCar={activeCar} labelText={activeCarLabel} />
         <div id="liveRecordingState" class="stat">
           <div class="stat__label">
             {recordingStateLabel}
           </div>
           <div class="stat__value" data-value>
-            {model.value.recordingStateText}
+            {recordingStateText}
           </div>
         </div>
         <div id="liveDataFreshness" class="stat">
@@ -155,7 +237,7 @@ function RealtimeLiveOverview(props: {
             {dataFreshnessLabel}
           </div>
           <div class="stat__value" data-value>
-            {model.value.dataFreshnessText}
+            {dataFreshnessText}
           </div>
         </div>
         <div id="liveStrongestSignal" class="stat">
@@ -163,7 +245,7 @@ function RealtimeLiveOverview(props: {
             {strongestSignalLabel}
           </div>
           <div class="stat__value" data-value>
-            {model.value.strongestSignalText}
+            {strongestSignalText}
           </div>
         </div>
         <div class="stat">
@@ -180,33 +262,7 @@ function RealtimeLiveOverview(props: {
           {sensorCoverageLabel}
         </div>
       </div>
-      <div id="liveSensorRoster" class="live-sensor-roster">
-        {model.value.sensorCards.length
-          ? model.value.sensorCards.map((card) => {
-            const statusClass = card.connected ? "online" : "offline";
-            return (
-              <article
-                key={card.id}
-                class={card.strongest ? "live-sensor-card live-sensor-card--strongest" : "live-sensor-card"}
-              >
-                <div class="live-sensor-card__header">
-                  <strong>{card.label}</strong>
-                  <span
-                    class={`live-sensor-card__status-dot live-sensor-card__status-dot--${statusClass}`}
-                    role="img"
-                    aria-label={card.statusText}
-                    title={card.statusText}
-                  />
-                </div>
-              </article>
-            );
-          })
-          : (
-            <div class="subtle">
-              {noSensorsText}
-            </div>
-          )}
-      </div>
+      <RealtimeLiveOverviewSensorRoster sensorCards={sensorCards} noSensorsText={noSensorsText} />
     </>
   );
 }

--- a/apps/ui/tests/realtime_live_overview_signals.ts
+++ b/apps/ui/tests/realtime_live_overview_signals.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+
+import { options } from "preact";
+
+import { computed, signal } from "../src/app/ui_signals";
+import type {
+  RealtimeLiveOverviewRenderModel,
+  RealtimeLiveOverviewSensorCardModel,
+} from "../src/app/views/realtime_live_overview";
+import { mountSignalView } from "./dom_render_test_support";
+
+function requireElement<T extends Element = HTMLElement>(root: ParentNode, selector: string): T {
+  const element = root.querySelector<T>(selector);
+  assert.ok(element, `Expected element matching ${selector}`);
+  return element;
+}
+
+async function runRealtimeLiveOverviewSignalProjectionTest(): Promise<void> {
+  const connectedSensorsText = signal("2 / 4");
+  const activeCarText = signal("Roadster");
+  const activeCarWarning = signal(false);
+  const recordingStateText = signal("Stopped");
+  const dataFreshnessText = signal("Fresh");
+  const strongestSignalText = signal("68 dB");
+  const runHealthText = signal("Ready");
+  const runHealthVariant = signal<RealtimeLiveOverviewRenderModel["runHealth"]["variant"]>("ok");
+  const sensorCards = signal<RealtimeLiveOverviewSensorCardModel[]>([]);
+  const model = computed<RealtimeLiveOverviewRenderModel>(() => ({
+    activeCar: {
+      text: activeCarText.value,
+      warning: activeCarWarning.value,
+    },
+    connectedSensorsText: connectedSensorsText.value,
+    dataFreshnessText: dataFreshnessText.value,
+    recordingStateText: recordingStateText.value,
+    runHealth: {
+      hidden: false,
+      text: runHealthText.value,
+      variant: runHealthVariant.value,
+    },
+    sensorCards: sensorCards.value,
+    strongestSignalText: strongestSignalText.value,
+  }));
+  const previousDiffed = options.diffed;
+  let overviewRenderCount = 0;
+  options.diffed = (vnode) => {
+    if (typeof vnode.type === "function" && vnode.type.name === "RealtimeLiveOverview") {
+      overviewRenderCount += 1;
+    }
+    previousDiffed?.(vnode);
+  };
+
+  const harness = await mountSignalView(async () => {
+    const { mountRealtimeLiveOverview } = await import("../src/app/views/realtime_live_overview");
+    return mountRealtimeLiveOverview;
+  });
+
+  try {
+    harness.view.bindModel(model);
+    harness.view.setSpeedText("43 km/h");
+    await harness.flush();
+
+    assert.equal(overviewRenderCount, 1);
+    assert.equal(requireElement(harness.host, "#liveConnectedSensors [data-value]").textContent, "2 / 4");
+    assert.equal(requireElement(harness.host, "#liveStrongestSignal [data-value]").textContent, "68 dB");
+    assert.equal(requireElement(harness.host, "#speed").textContent, "43 km/h");
+    assert.equal(requireElement(harness.host, "#liveRunHealth").textContent, "Ready");
+
+    connectedSensorsText.value = "4 / 4";
+    strongestSignalText.value = "82 dB";
+    await harness.flush();
+
+    assert.equal(overviewRenderCount, 1);
+    assert.equal(requireElement(harness.host, "#liveConnectedSensors [data-value]").textContent, "4 / 4");
+    assert.equal(requireElement(harness.host, "#liveStrongestSignal [data-value]").textContent, "82 dB");
+
+    sensorCards.value = [
+      {
+        connected: true,
+        id: "front-left",
+        label: "Front Left",
+        statusText: "Online",
+        strongest: true,
+      },
+    ];
+    await harness.flush();
+
+    assert.equal(overviewRenderCount, 1);
+    assert.equal(harness.host.querySelectorAll(".live-sensor-card--strongest").length, 1);
+    assert.match(harness.host.textContent ?? "", /Front Left/);
+  } finally {
+    options.diffed = previousDiffed;
+    harness.cleanup();
+  }
+}
+
+await runRealtimeLiveOverviewSignalProjectionTest();
+console.log("PASS realtime live overview signal projections avoid rerender");

--- a/apps/ui/tests/signal_view_reference_tests.ts
+++ b/apps/ui/tests/signal_view_reference_tests.ts
@@ -124,7 +124,6 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
     sensorCards: reboundSensorCards.value,
     strongestSignalText: reboundStrongestSignalText.value,
   }));
-
   const harness = await mountSignalView(async () => {
     const { mountRealtimeLiveOverview } = await import("../src/app/views/realtime_live_overview");
     return mountRealtimeLiveOverview;


### PR DESCRIPTION
## size
small

## what changed
- stop reading the full realtime live overview model through repeated `model.value` access in render
- project the overview fields with `useSignalProperties()`
- move run health, active car, and sensor roster object/list reads into focused child components
- add a focused signal regression that counts `RealtimeLiveOverview` renders while scalar stats and sensor cards update

## why
- overview stat updates should bind through field-level signals instead of invalidating the whole overview component
- the sensor roster and active car warning state should only rerender on their own inputs

## validation
- `cd apps/ui && npx tsx tests/realtime_live_overview_signals.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts --project=laptop-light --workers=1`

## risks / tradeoffs / edge cases
- small refactor in one view module plus one focused signal test
- `npm run lint` still reports unrelated pre-existing warnings already present on `main`
- `npm run test:signals` has an unrelated existing settings-shell failure, so the new regression stays in its own focused signal test file instead of the omnibus reference runner

Closes #2533
