### PR TITLE
refactor(ui): narrow spectrum legend signals

### DIFF
--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -26,6 +26,7 @@ type MutableSpectrumPanelChartDom = {
 };
 
 const SPECTRUM_BAND_TOGGLE_KEYS = ["bandsVisible", "hasBands", "text"] as const;
+const SPECTRUM_BAND_LEGEND_KEYS = ["emptyText", "items", "visible"] as const;
 
 function requireSpectrumElement<T extends HTMLElement>(
   element: T | null,
@@ -35,6 +36,96 @@ function requireSpectrumElement<T extends HTMLElement>(
     return element;
   }
   throw new Error(`Spectrum UI requires ${target}`);
+}
+
+function SpectrumBandLegend(props: {
+  bandLegend: ReadonlySignal<SpectrumBandLegendModel>;
+}) {
+  const {
+    emptyText,
+    items,
+    visible,
+  } = useSignalProperties(props.bandLegend, SPECTRUM_BAND_LEGEND_KEYS);
+  const hidden = useComputed(() => !visible.value);
+
+  return (
+    <div id="bandLegend" class="legend band-legend" hidden={hidden}>
+      {visible.value
+        ? items.value.length
+          ? items.value.map((item) => (
+            <div
+              key={item.labelText}
+              class="legend-item legend-item--band"
+              data-band-state="active"
+              style={`--band-color: ${item.color}`}
+            >
+              <span class="swatch" style={`--swatch-color: ${item.color}`} />
+              <span>{item.labelText}</span>
+            </div>
+          ))
+          : (
+            <div class="legend-item legend-item--band" data-band-state="empty">
+              {emptyText}
+            </div>
+          )
+        : null}
+    </div>
+  );
+}
+
+function SpectrumSensorLegend(props: {
+  sensorLegend: ReadonlySignal<SpectrumSensorLegendModel | null>;
+  sensorLegendHandlers: ReadonlySignal<SpectrumLegendHandlers | null>;
+}) {
+  const hasLegend = useComputed(() => {
+    const legend = props.sensorLegend.value;
+    return legend !== null && legend.items.length > 0 && props.sensorLegendHandlers.value !== null;
+  });
+  if (!hasLegend.value) {
+    return null;
+  }
+
+  const sensorLegend = props.sensorLegend.value;
+  const sensorLegendHandlers = props.sensorLegendHandlers.value;
+  if (sensorLegend === null || sensorLegendHandlers === null) {
+    return null;
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        class="legend-item legend-item--interactive legend-item--reset"
+        aria-pressed={sensorLegend.reset.ariaPressed ? "true" : "false"}
+        title={sensorLegend.reset.titleText}
+        aria-label={sensorLegend.reset.ariaLabel}
+        data-legend-state={sensorLegend.reset.active ? "active" : undefined}
+        onClick={() => sensorLegendHandlers.onReset()}
+      >
+        <span class="legend-item__label">{sensorLegend.reset.labelText}</span>
+      </button>
+      {sensorLegend.items.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          class="legend-item legend-item--interactive"
+          aria-pressed={item.ariaPressed ? "true" : "false"}
+          title={item.titleText}
+          aria-label={item.ariaLabel}
+          data-legend-state={item.active ? "active" : item.muted ? "muted" : undefined}
+          onClick={() => sensorLegendHandlers.onSelect(item.id)}
+        >
+          <span class="swatch" style={`--swatch-color: ${item.color}`} />
+          <span class="legend-item__text-group">
+            <span class="legend-item__label">{item.labelText}</span>
+            {item.detailText
+              ? <span class="legend-item__meta">{item.detailText}</span>
+              : null}
+          </span>
+        </button>
+      ))}
+    </>
+  );
 }
 
 function SpectrumPanel(props: {
@@ -62,10 +153,6 @@ function SpectrumPanel(props: {
     bandToggleHasBands.value && bandToggleBandsVisible.value ? "true" : "false"
   );
   const bandToggleHidden = useComputed(() => !bandToggleHasBands.value);
-  const bandLegendHidden = useComputed(() => !props.bandLegend.value.visible);
-  const bandLegend = props.bandLegend.value;
-  const sensorLegend = props.sensorLegend.value;
-  const sensorLegendHandlers = props.sensorLegendHandlers.value;
 
   return (
     <>
@@ -110,70 +197,17 @@ function SpectrumPanel(props: {
             >
               {bandToggleText}
             </button>
-            <div id="bandLegend" class="legend band-legend" hidden={bandLegendHidden}>
-              {bandLegend.visible
-                ? bandLegend.items.length
-                  ? bandLegend.items.map((item) => (
-                    <div
-                      key={item.labelText}
-                      class="legend-item legend-item--band"
-                      data-band-state="active"
-                      style={`--band-color: ${item.color}`}
-                    >
-                      <span class="swatch" style={`--swatch-color: ${item.color}`} />
-                      <span>{item.labelText}</span>
-                    </div>
-                  ))
-                  : (
-                    <div class="legend-item legend-item--band" data-band-state="empty">
-                      {bandLegend.emptyText}
-                    </div>
-                  )
-                : null}
-            </div>
+            <SpectrumBandLegend bandLegend={props.bandLegend} />
           </div>
         </div>
         <div id="spectrumInspector" class="spectrum-inspector" aria-live="polite">
           {props.inspectorText}
         </div>
         <div id="legend" class="legend">
-          {sensorLegend && sensorLegend.items.length > 0 && sensorLegendHandlers
-            ? (
-              <>
-                <button
-                  type="button"
-                  class="legend-item legend-item--interactive legend-item--reset"
-                  aria-pressed={sensorLegend.reset.ariaPressed ? "true" : "false"}
-                  title={sensorLegend.reset.titleText}
-                  aria-label={sensorLegend.reset.ariaLabel}
-                  data-legend-state={sensorLegend.reset.active ? "active" : undefined}
-                  onClick={() => sensorLegendHandlers?.onReset()}
-                >
-                  <span class="legend-item__label">{sensorLegend.reset.labelText}</span>
-                </button>
-                {sensorLegend.items.map((item) => (
-                  <button
-                    key={item.id}
-                    type="button"
-                    class="legend-item legend-item--interactive"
-                    aria-pressed={item.ariaPressed ? "true" : "false"}
-                    title={item.titleText}
-                    aria-label={item.ariaLabel}
-                    data-legend-state={item.active ? "active" : item.muted ? "muted" : undefined}
-                    onClick={() => sensorLegendHandlers?.onSelect(item.id)}
-                  >
-                    <span class="swatch" style={`--swatch-color: ${item.color}`} />
-                    <span class="legend-item__text-group">
-                      <span class="legend-item__label">{item.labelText}</span>
-                      {item.detailText
-                        ? <span class="legend-item__meta">{item.detailText}</span>
-                        : null}
-                    </span>
-                  </button>
-                ))}
-              </>
-            )
-            : null}
+          <SpectrumSensorLegend
+            sensorLegend={props.sensorLegend}
+            sensorLegendHandlers={props.sensorLegendHandlers}
+          />
         </div>
       </div>
     </>

--- a/apps/ui/tests/spectrum_panel_signals.ts
+++ b/apps/ui/tests/spectrum_panel_signals.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+
+import { options } from "preact";
+
+import type {
+  SpectrumBandLegendModel,
+  SpectrumPanelBandToggleModel,
+  SpectrumSensorLegendModel,
+} from "../src/app/runtime/spectrum_panel_view";
+import { mountSignalView } from "./dom_render_test_support";
+
+function requireElement<T extends Element = HTMLElement>(root: ParentNode, selector: string): T {
+  const element = root.querySelector<T>(selector);
+  assert.ok(element, `Expected element matching ${selector}`);
+  return element;
+}
+
+async function runSpectrumPanelSignalProjectionTest(): Promise<void> {
+  const previousDiffed = options.diffed;
+  let spectrumPanelRenderCount = 0;
+  options.diffed = (vnode) => {
+    if (typeof vnode.type === "function" && vnode.type.name === "SpectrumPanel") {
+      spectrumPanelRenderCount += 1;
+    }
+    previousDiffed?.(vnode);
+  };
+
+  const harness = await mountSignalView(async () => {
+    const { mountSpectrumPanel } = await import("../src/app/views/spectrum_panel");
+    return mountSpectrumPanel;
+  });
+
+  try {
+    await harness.flush();
+    assert.equal(spectrumPanelRenderCount, 1);
+
+    const bandToggleModel: SpectrumPanelBandToggleModel = {
+      bandsVisible: true,
+      hasBands: true,
+      text: "Hide reference bands",
+    };
+    harness.view.renderBandToggle(bandToggleModel);
+    await harness.flush();
+
+    const bandToggleBaseline = spectrumPanelRenderCount;
+    assert.equal(requireElement<HTMLButtonElement>(harness.host, "#spectrumBandToggle").textContent, "Hide reference bands");
+
+    const bandLegendModel: SpectrumBandLegendModel = {
+      visible: true,
+      items: [{ color: "#f59e0b", labelText: "Wheel 1x" }],
+      emptyText: "No reference band",
+    };
+    harness.view.renderBandLegend(bandLegendModel);
+    await harness.flush();
+
+    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+    assert.match(requireElement(harness.host, "#bandLegend").textContent ?? "", /Wheel 1x/);
+
+    let resetClicks = 0;
+    const selectedIds: string[] = [];
+    const sensorLegendModel: SpectrumSensorLegendModel = {
+      reset: {
+        labelText: "All sensor traces",
+        titleText: "Show all traces",
+        ariaLabel: "Show all sensor traces",
+        ariaPressed: true,
+        active: true,
+      },
+      items: [{
+        id: "front-left",
+        labelText: "Front Left",
+        color: "#2563eb",
+        detailText: "12.0 dB",
+        titleText: "Focus Front Left",
+        ariaLabel: "Focus Front Left",
+        ariaPressed: false,
+        active: false,
+        muted: false,
+      }],
+    };
+    harness.view.renderSensorLegend(sensorLegendModel, {
+      onReset: () => {
+        resetClicks += 1;
+      },
+      onSelect: (entryId) => {
+        selectedIds.push(entryId);
+      },
+    });
+    await harness.flush();
+
+    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+    assert.match(requireElement(harness.host, "#legend").textContent ?? "", /Front Left/);
+    assert.match(requireElement(harness.host, "#legend").textContent ?? "", /12.0 dB/);
+
+    requireElement<HTMLButtonElement>(harness.host, ".legend-item--reset").click();
+    requireElement<HTMLButtonElement>(harness.host, '[aria-label="Focus Front Left"]').click();
+    assert.equal(resetClicks, 1);
+    assert.deepEqual(selectedIds, ["front-left"]);
+
+    harness.view.renderSensorLegend({
+      ...sensorLegendModel,
+      items: [{
+        ...sensorLegendModel.items[0],
+        detailText: "13.0 dB",
+        active: true,
+        ariaPressed: true,
+      }],
+    }, {
+      onReset: () => {
+        resetClicks += 1;
+      },
+      onSelect: (entryId) => {
+        selectedIds.push(entryId);
+      },
+    });
+    await harness.flush();
+
+    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+    assert.match(requireElement(harness.host, "#legend").textContent ?? "", /13.0 dB/);
+  } finally {
+    options.diffed = previousDiffed;
+    harness.cleanup();
+  }
+}
+
+await runSpectrumPanelSignalProjectionTest();
+console.log("PASS spectrum panel legend signal projections avoid rerender");


### PR DESCRIPTION
## size
small

## what changed
- stop reading the band legend, sensor legend, and sensor legend handlers at the top of `SpectrumPanel`
- move the band legend and sensor legend sections into focused child components that own those signal reads
- add a focused signal regression that counts `SpectrumPanel` renders while legend models update

## why
- legend updates should not invalidate the chart wrapper, overlay, toolbar, inspector, and the rest of the panel
- this keeps the existing band-toggle signal pattern and extends it to the two legend sections

## validation
- `cd apps/ui && npx tsx tests/spectrum_panel_signals.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/smoke.spectrum.spec.ts --project=laptop-light --workers=1`

## risks / tradeoffs / edge cases
- small refactor in one view module plus one focused signal test
- `npm run lint` still reports unrelated pre-existing warnings already present on `main`
- this stays separate from issue `#2547`; it only narrows the existing legend signal ownership without extracting standalone legend components yet

Closes #2534
