### PR TITLE
UI: migrate shell AppState slice to direct signals

### DIFF
--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -110,7 +110,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
   }
   const panelModel = computed(() => {
     trackAppStateSlice(history);
-    trackAppStateSlice(shell);
     return buildPanelRenderModel();
   });
   panel.bindModel(panelModel);
@@ -191,7 +190,6 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     let initialized = false;
     let previousLanguage = shell.lang;
     effect(() => {
-      trackAppStateSlice(shell);
       const currentLanguage = shell.lang;
       if (!initialized) {
         initialized = true;

--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -299,7 +299,6 @@ export function createRealtimeFeatureViewState(
 
   const loggingPanelBaseModel = computed(() => {
     trackAppStateSlice(realtime);
-    trackAppStateSlice(shell);
     const loggingStatus = realtime.loggingStatus;
     const pendingLoggingAction = workflow.pendingLoggingAction.value;
     const liveHealth = sensorState.liveHealth.value;
@@ -327,7 +326,6 @@ export function createRealtimeFeatureViewState(
 
   const liveOverviewModel = computed<RealtimeLiveOverviewRenderModel>(() => {
     trackAppStateSlice(realtime);
-    trackAppStateSlice(shell);
     const connectedClients = sensorState.connectedClients.value;
     const strongestSignal = sensorState.strongestSignal.value;
     const strongestSignalText = sensorState.strongestSignalText.value;
@@ -360,7 +358,6 @@ export function createRealtimeFeatureViewState(
   });
 
   const loggingPanelModel = computed<RealtimeLoggingPanelRenderModel>(() => {
-    trackAppStateSlice(shell);
     const baseModel = buildLoggingRenderModel(loggingPanelBaseModel.value);
     const loggingError = workflow.loggingError.value;
     if (loggingError === null) {
@@ -371,7 +368,6 @@ export function createRealtimeFeatureViewState(
 
   const sensorsPanelModel = computed<SensorsPanelRenderModel>(() => {
     trackAppStateSlice(realtime);
-    trackAppStateSlice(shell);
     return {
       table: buildRealtimeSensorTableRenderModel({
         clients: realtime.clients,
@@ -384,7 +380,6 @@ export function createRealtimeFeatureViewState(
   const idleCaptureReadinessSignature = computed(() => {
     trackAppStateSlice(realtime);
     trackAppStateSlice(settings);
-    trackAppStateSlice(shell);
     const clientsSignature = realtime.clients
       .map((client) =>
         [

--- a/apps/ui/src/app/features/realtime_sensor_state.ts
+++ b/apps/ui/src/app/features/realtime_sensor_state.ts
@@ -79,7 +79,6 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
 
   const locationOptions = computed<LocationOption[]>(() => {
     trackAppStateSlice(realtime);
-    trackAppStateSlice(shell);
     return buildLocationOptions(realtime.locationCodes);
   });
 
@@ -147,7 +146,6 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
 
   const strongestSignalText = computed(() => {
     trackAppStateSlice(realtime);
-    trackAppStateSlice(shell);
     const signal = strongestSignal.value;
     if (!signal) {
       return t("dashboard.strongest_signal_none");
@@ -159,7 +157,6 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
   });
 
   const activeCarDisplayState = computed<ActiveCarDisplayState>(() => {
-    trackAppStateSlice(shell);
     const selection = carSelection.selection.value;
     if (selection.kind === "loading") {
       return {
@@ -187,7 +184,6 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
 
   const liveHealth = computed<LiveHealth>(() => {
     trackAppStateSlice(realtime);
-    trackAppStateSlice(shell);
     if (realtime.loggingStatus.write_error) {
       return {
         variant: "bad",

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -1,6 +1,6 @@
 import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import { createCarSelectionDerivedState } from "../car_selection_state";
-import { trackAppStateSlice, type SettingsState, type ShellState } from "../ui_app_state";
+import type { SettingsState, ShellState } from "../ui_app_state";
 import { effect, untracked, type ReadonlySignal } from "../ui_signals";
 import type { CarsPayload } from "../../api/types";
 import {
@@ -151,7 +151,6 @@ export function createSettingsFeature(
   let initializedLanguage = false;
   let previousLanguage = ctx.state.shell.lang;
   effect(() => {
-    trackAppStateSlice(ctx.state.shell);
     const currentLanguage = ctx.state.shell.lang;
     if (!initializedLanguage) {
       initializedLanguage = true;

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -1,7 +1,7 @@
 import * as I18N from "../../i18n";
 import { formatIntLocale } from "../../format";
 import { setUiLanguage } from "../ui_i18n";
-import { trackAppStateSlice, type AppState } from "../ui_app_state";
+import type { AppState } from "../ui_app_state";
 import {
   computed,
   effect,
@@ -192,7 +192,6 @@ export class UiShellController {
     let initialized = false;
     let previousLanguage = this.state.shell.lang;
     effect(() => {
-      trackAppStateSlice(this.state.shell);
       const currentLanguage = this.state.shell.lang;
       if (!initialized) {
         initialized = true;

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -65,7 +65,6 @@ export function createUiShellStatusModule(
 
   const wsLinkState = computed<UiShellBadgeModel>(() => {
     trackAppStateSlice(deps.transport);
-    trackAppStateSlice(deps.shell);
     if (deps.transport.payloadError) {
       return {
         text: deps.t("ws.payload_error_pill"),
@@ -81,7 +80,6 @@ export function createUiShellStatusModule(
 
   const speedReadoutText = computed(() => {
     trackAppStateSlice(deps.realtime);
-    trackAppStateSlice(deps.shell);
     const unitLabel = selectedSpeedUnitLabel();
     if (
       typeof deps.realtime.speedMps === "number" &&

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -124,7 +124,6 @@ export class UiSpectrumController {
     let initialized = false;
     let previousLanguage = this.state.shell.lang;
     effect(() => {
-      trackAppStateSlice(this.state.shell);
       const currentLanguage = this.state.shell.lang;
       if (!initialized) {
         initialized = true;

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -21,6 +21,8 @@ const reactiveTargetProxies = new WeakMap<object, WeakMap<Signal<number>, object
 const reactiveProxyTargets = new WeakMap<object, object>();
 const reactiveSliceSignals = new WeakMap<object, Signal<number>>();
 
+type SignalStateScalar = boolean | null | number | string | undefined;
+
 function isProxyableObject(value: unknown): value is object {
   if (value === null || typeof value !== "object") {
     return false;
@@ -90,6 +92,29 @@ function createReactiveProxy<T extends object>(target: T, rootSignal: Signal<num
 
 function createReactiveStateSlice<T extends object>(value: T): T {
   return createReactiveProxy(value, signal(0));
+}
+
+function createSignalStateSlice<T extends Record<string, SignalStateScalar>>(value: T): T {
+  const sliceSignal = signal(0);
+  const slice = {} as T;
+  for (const [key, initialValue] of Object.entries(value) as [keyof T, T[keyof T]][]) {
+    const propertySignal = signal(initialValue);
+    Object.defineProperty(slice, key, {
+      enumerable: true,
+      get() {
+        return propertySignal.value;
+      },
+      set(nextValue: T[keyof T]) {
+        if (Object.is(propertySignal.value, nextValue)) {
+          return;
+        }
+        propertySignal.value = nextValue;
+        sliceSignal.value += 1;
+      },
+    });
+  }
+  reactiveSliceSignals.set(slice as object, sliceSignal);
+  return slice;
 }
 
 function requireReactiveSliceSignal<T extends object>(slice: T): Signal<number> {
@@ -324,7 +349,7 @@ export interface AppState {
 
 export function createAppState(): AppState {
   return {
-    shell: createReactiveStateSlice({
+    shell: createSignalStateSlice({
       lang: "en",
       speedUnit: "kmh",
       activeViewId: "dashboardView",

--- a/apps/ui/tests/ui_app_state.spec.ts
+++ b/apps/ui/tests/ui_app_state.spec.ts
@@ -9,6 +9,30 @@ import {
 import { effect } from "../src/app/ui_signals";
 
 test.describe("ui_app_state reactivity", () => {
+  test("tracks shell writes directly through field signals without slice tracking", () => {
+    const state = createAppState();
+    const seenShellState: string[] = [];
+
+    const dispose = effect(() => {
+      seenShellState.push(`${state.shell.lang}:${state.shell.speedUnit}:${state.shell.activeViewId}`);
+    });
+
+    expect(seenShellState).toEqual(["en:kmh:dashboardView"]);
+
+    batchAppStateUpdates(() => {
+      state.shell.lang = "nl";
+      state.shell.speedUnit = "mps";
+      state.shell.activeViewId = "historyView";
+    });
+
+    expect(seenShellState).toEqual([
+      "en:kmh:dashboardView",
+      "nl:mps:historyView",
+    ]);
+
+    dispose();
+  });
+
   test("tracks direct slice writes through a stable slice signal", () => {
     const state = createAppState();
     const seenStates: string[] = [];


### PR DESCRIPTION
## What changed
- `createAppState().shell` now uses direct signal-backed field accessors instead of the proxy wrapper
- shell consumers stopped calling `trackAppStateSlice(shell)` and react from direct field reads
- added shell field reactivity coverage in `ui_app_state.spec.ts`

## Why
- issue asks for a slice-by-slice AppState migration
- `shell` is flat, shared widely, and the lowest-risk place to prove the pattern

## Validation
- `cd apps/ui && npx playwright test tests/ui_app_state.spec.ts tests/ui_shell_runtime_modules.spec.ts tests/ui_spectrum_controller.spec.ts tests/history_feature_modules.spec.ts tests/realtime_feature_view_state.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- only the `shell` slice moved off the proxy path here
- nested and dynamic-write slices still use the proxy helpers for now; that stays safer than forcing a one-shot rewrite beyond this issue

Closes #2536