### PR TITLE
UI: convert SpectrumChart to signal-driven factory

### DIFF
--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -2,6 +2,7 @@ import type uPlot from "uplot";
 
 import { SPECTRUM_TWEEN_DURATION_MS } from "../../config";
 import { convertSpectrumAmplitudesToDbInPlace } from "../../spectrum";
+import type { SpectrumSeriesMeta, SpectrumText } from "../../spectrum_chart";
 import { getSpectrumCssVars } from "../../spectrum_css_vars";
 import { chartSeriesPalette, orderBandFills } from "../../theme";
 import { createRafAnimation } from "../dom/raf_animation";
@@ -10,11 +11,11 @@ import {
   type SpectrumHeavyFrame,
 } from "../spectrum_animation";
 import type { AppState, ChartBand } from "../ui_app_state";
-import { effect, signal, untracked } from "../ui_signals";
+import { computed, effect, signal, untracked, type ReadonlySignal } from "../ui_signals";
 import type { SpectrumPanelChartDom } from "./spectrum_panel_view";
 import { closestFrequencyIndex, freqGridsMatch, type SpectrumFocusMarker, type SpectrumSeriesEntry } from "./spectrum_shared";
 
-type SpectrumChartModule = Pick<typeof import("../../spectrum_chart"), "SpectrumChart">;
+type SpectrumChartModule = Pick<typeof import("../../spectrum_chart"), "createSpectrumChart">;
 
 const bandKeyPresentation: Record<string, { color: string; labelKey: string }> = {
   wheel_1x: { color: orderBandFills.wheel1, labelKey: "bands.wheel_1x" },
@@ -78,12 +79,28 @@ export class SpectrumCanvasRenderer {
 
   private readonly currentFreqAxis = signal<readonly number[]>([]);
 
+  private readonly chartSeriesMeta = signal<readonly SpectrumSeriesMeta[]>([]);
+
+  private readonly chartData = signal<uPlot.AlignedData>([[]]);
+
+  private readonly chartHeight = signal(360);
+
+  private readonly chartPlugins = signal<readonly uPlot.Plugin[]>([]);
+
+  private readonly chartText: ReadonlySignal<SpectrumText>;
+
   constructor(
     private readonly deps: SpectrumCanvasRendererDeps,
   ) {
     this.spectrumBandPlugin = this.createBandPlugin();
     this.onAsyncChartUpdate = deps.onAsyncChartUpdate ?? (() => undefined);
     this.loadChartModule = deps.loadChartModule ?? loadSpectrumChartModule;
+    this.chartPlugins.value = [this.spectrumBandPlugin];
+    this.chartText = computed(() => ({
+      title: this.deps.t("chart.spectrum_title"),
+      axisHz: this.deps.t("chart.axis.hz"),
+      axisAmplitude: this.deps.t("chart.axis.amplitude"),
+    }));
     this.initTweenEffect();
   }
 
@@ -195,6 +212,14 @@ export class SpectrumCanvasRenderer {
     this.pendingPreparedFrame.value = prepared;
     this.currentEntries.value = prepared.entries;
     this.currentFreqAxis.value = prepared.freqAxis;
+    this.chartSeriesMeta.value = prepared.entries.map((entry) => ({
+      label: entry.label,
+      color: entry.color,
+    }));
+    this.chartData.value = [
+      prepared.freqAxis,
+      ...prepared.entries.map((entry) => entry.values),
+    ];
 
     if (!prepared.frame) {
       this.tweenTarget.value = null;
@@ -202,11 +227,10 @@ export class SpectrumCanvasRenderer {
       this.currentFreqAxis.value = [];
       this.spectrumLastFrame.value = null;
       this.pendingPreparedFrame.value = null;
-      this.deps.state.spectrum.spectrumPlot?.setData([[], ...prepared.entries.map(() => [] as number[])]);
       return;
     }
 
-    if (!this.ensureSpectrumPlot(prepared.entries)) {
+    if (!this.ensureSpectrumPlot()) {
       return;
     }
 
@@ -231,10 +255,10 @@ export class SpectrumCanvasRenderer {
     if (!freqAxis.length || !entries.length) {
       return;
     }
-    this.deps.state.spectrum.spectrumPlot?.setData([
+    this.chartData.value = [
       freqAxis.slice(),
       ...entries.map((entry) => entry.values),
-    ]);
+    ];
   }
 
   setSeriesIsolation(seriesIndex: number | null): void {
@@ -250,7 +274,7 @@ export class SpectrumCanvasRenderer {
       return;
     }
     this.currentFreqAxis.value = frame.freq;
-    this.deps.state.spectrum.spectrumPlot.setData([frame.freq, ...frame.values]);
+    this.chartData.value = [frame.freq, ...frame.values];
     this.spectrumLastFrame.value = frame;
   }
 
@@ -361,44 +385,33 @@ export class SpectrumCanvasRenderer {
     };
   }
 
-  private recreateSpectrumPlot(
-    seriesMeta: readonly SpectrumSeriesEntry[],
-    chartModule: SpectrumChartModule,
-  ): void {
+  private createSpectrumPlot(chartModule: SpectrumChartModule): void {
     this.tweenTarget.value = null;
     this.spectrumLastFrame.value = null;
     if (this.deps.state.spectrum.spectrumPlot) {
       this.deps.state.spectrum.spectrumPlot.destroy();
       this.deps.state.spectrum.spectrumPlot = null;
     }
-    this.deps.state.spectrum.spectrumPlot = new chartModule.SpectrumChart(
-      this.deps.dom.specChart,
-      360,
-      this.deps.dom.specChartWrap,
-    );
-    this.deps.state.spectrum.spectrumPlot.ensurePlot(
-      Array.from(seriesMeta),
-      {
-        title: this.deps.t("chart.spectrum_title"),
-        axisHz: this.deps.t("chart.axis.hz"),
-        axisAmplitude: this.deps.t("chart.axis.amplitude"),
-      },
-      [this.spectrumBandPlugin],
-    );
+    this.deps.state.spectrum.spectrumPlot = chartModule.createSpectrumChart({
+      hostEl: this.deps.dom.specChart,
+      measureEl: this.deps.dom.specChartWrap,
+      height: this.chartHeight,
+      seriesMeta: this.chartSeriesMeta,
+      data: this.chartData,
+      text: this.chartText,
+      plugins: this.chartPlugins,
+    });
   }
 
-  private ensureSpectrumPlot(seriesMeta: readonly SpectrumSeriesEntry[]): boolean {
-    if (
-      this.deps.state.spectrum.spectrumPlot
-      && this.deps.state.spectrum.spectrumPlot.getSeriesCount() === seriesMeta.length + 1
-    ) {
+  private ensureSpectrumPlot(): boolean {
+    if (this.deps.state.spectrum.spectrumPlot) {
       this.deps.state.spectrum.chartLoadErrorDetail = null;
       return true;
     }
     if (this.chartModule.value) {
       this.deps.state.spectrum.chartLoading = false;
       this.deps.state.spectrum.chartLoadErrorDetail = null;
-      this.recreateSpectrumPlot(seriesMeta, this.chartModule.value);
+      this.createSpectrumPlot(this.chartModule.value);
       return this.deps.state.spectrum.spectrumPlot !== null;
     }
     if (this.chartLoadPromise) {
@@ -414,7 +427,7 @@ export class SpectrumCanvasRenderer {
         if (!latestPrepared?.frame) {
           return;
         }
-        this.recreateSpectrumPlot(latestPrepared.entries, module);
+        this.createSpectrumPlot(module);
         const rerender = latestPrepared;
         this.pendingPreparedFrame.value = null;
         this.renderPreparedFrame(rerender);

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -135,12 +135,6 @@ export class UiSpectrumController {
       }
       previousLanguage = currentLanguage;
       untracked(() => {
-        if (this.state.spectrum.spectrumPlot) {
-          this.state.spectrum.spectrumPlot.destroy();
-          this.state.spectrum.spectrumPlot = null;
-          this.renderSpectrum();
-          return;
-        }
         this.renderSpectrumHeader();
         this.updateSpectrumOverlay();
       });

--- a/apps/ui/src/spectrum_chart.ts
+++ b/apps/ui/src/spectrum_chart.ts
@@ -4,6 +4,13 @@ import uPlot from "uplot";
 
 import { SPECTRUM_DB_MAX, SPECTRUM_DB_MIN } from "./config";
 import { getSpectrumCssVars } from "./spectrum_css_vars";
+import {
+  computed,
+  effect,
+  signal,
+  untracked,
+  type ReadonlySignal,
+} from "./app/ui_signals";
 
 export interface SpectrumSeriesMeta {
   label: string;
@@ -16,40 +23,69 @@ export interface SpectrumText {
   axisAmplitude: string;
 }
 
-export class SpectrumChart {
-  private static readonly FIXED_Y_RANGE: [number, number] = [SPECTRUM_DB_MIN, SPECTRUM_DB_MAX];
+export interface SpectrumChart {
+  destroy(): void;
+  resize(): void;
+  setSeriesIsolation(seriesIdx: number | null): void;
+}
 
-  private plot: uPlot | null = null;
-  private readonly hostEl: HTMLElement;
-  private readonly measureEl: HTMLElement;
-  private readonly height: number;
-  private resizeObserver: ResizeObserver | null = null;
-  private resizeRaf: number | null = null;
+export interface CreateSpectrumChartDeps {
+  hostEl: HTMLElement;
+  measureEl?: HTMLElement | null;
+  height?: ReadonlySignal<number>;
+  seriesMeta: ReadonlySignal<readonly SpectrumSeriesMeta[]>;
+  data: ReadonlySignal<uPlot.AlignedData>;
+  text: ReadonlySignal<SpectrumText>;
+  plugins?: ReadonlySignal<readonly uPlot.Plugin[]>;
+}
 
-  constructor(hostEl: HTMLElement, height = 360, measureEl?: HTMLElement | null) {
-    this.hostEl = hostEl;
-    this.measureEl = measureEl || hostEl;
-    this.height = height;
-    this.startResizeObserver();
-  }
+const DEFAULT_HEIGHT = 360;
+const EMPTY_DATA: uPlot.AlignedData = [[]];
 
-  ensurePlot(seriesMeta: SpectrumSeriesMeta[], text: SpectrumText, plugins: uPlot.Plugin[] = []): void {
-    if (this.plot && this.plot.series.length === seriesMeta.length + 1) {
+export function createSpectrumChart(deps: CreateSpectrumChartDeps): SpectrumChart {
+  const measureEl = deps.measureEl ?? deps.hostEl;
+  const height = deps.height ?? signal(DEFAULT_HEIGHT);
+  const plugins = deps.plugins ?? computed<readonly uPlot.Plugin[]>(() => []);
+  const width = signal(computeWidth(measureEl));
+  const plot = signal<uPlot | null>(null);
+  let resizeRaf: number | null = null;
+  let disposed = false;
+
+  const stopResizeObserver = effect(() => {
+    width.value = computeWidth(measureEl);
+    const resizeObserver = new ResizeObserver(() => {
+      if (resizeRaf !== null) {
+        window.cancelAnimationFrame(resizeRaf);
+      }
+      resizeRaf = window.requestAnimationFrame(() => {
+        resizeRaf = null;
+        width.value = computeWidth(measureEl);
+      });
+    });
+    resizeObserver.observe(measureEl);
+    return () => {
+      resizeObserver.disconnect();
+      if (resizeRaf !== null) {
+        window.cancelAnimationFrame(resizeRaf);
+        resizeRaf = null;
+      }
+    };
+  });
+
+  const stopPlotLifecycle = effect(() => {
+    const seriesMeta = deps.seriesMeta.value;
+    const text = deps.text.value;
+    const currentPlugins = Array.from(plugins.value);
+    if (!seriesMeta.length) {
+      plot.value = null;
       return;
     }
     const cssVars = getSpectrumCssVars();
-
-    this.destroyPlot();
-    const series: uPlot.Series[] = [{ label: "Hz" }];
-    for (const item of seriesMeta) {
-      series.push({ label: item.label, stroke: item.color, width: 2 });
-    }
-
-    this.plot = new uPlot(
+    const nextPlot = new uPlot(
       {
         title: "",
-        width: this.computeWidth(),
-        height: this.height,
+        width: untracked(() => width.value),
+        height: untracked(() => height.value),
         focus: { alpha: 0.16 },
         cursor: {
           x: true,
@@ -66,7 +102,7 @@ export class SpectrumChart {
         scales: {
           x: { time: false },
           y: {
-            range: SpectrumChart.FIXED_Y_RANGE as uPlot.Range.MinMax,
+            range: [SPECTRUM_DB_MIN, SPECTRUM_DB_MAX] as uPlot.Range.MinMax,
           },
         },
         axes: [
@@ -81,71 +117,77 @@ export class SpectrumChart {
             grid: { stroke: cssVars.border, width: 1 },
           },
         ],
-        series,
-        plugins,
+        series: [{ label: "Hz" }, ...seriesMeta.map((item) => ({
+          label: item.label,
+          stroke: item.color,
+          width: 2,
+        }))],
+        plugins: currentPlugins,
       },
-      [[]],
-      this.hostEl,
+      untracked(() => deps.data.value.length ? deps.data.value : EMPTY_DATA),
+      deps.hostEl,
     );
-  }
-
-  setData(data: uPlot.AlignedData): void {
-    if (!this.plot) return;
-    this.plot.setData(data);
-  }
-
-  setSeriesIsolation(seriesIdx: number | null): void {
-    const plot = this.plot;
-    if (!plot) return;
-    plot.batch(() => {
-      for (let index = 1; index < plot.series.length; index += 1) {
-        plot.setSeries(index, { show: seriesIdx === null || index === seriesIdx }, false);
+    plot.value = nextPlot;
+    return () => {
+      if (plot.value === nextPlot) {
+        plot.value = null;
       }
+      nextPlot.destroy();
+    };
+  });
+
+  const stopDataSync = effect(() => {
+    const currentPlot = plot.value;
+    if (!currentPlot) {
+      return;
+    }
+    currentPlot.setData(deps.data.value);
+  });
+
+  const stopSizeSync = effect(() => {
+    const currentPlot = plot.value;
+    if (!currentPlot) {
+      return;
+    }
+    currentPlot.setSize({
+      width: width.value,
+      height: height.value,
     });
-  }
+  });
 
-  resize(): void {
-    if (!this.plot) return;
-    this.plot.setSize({ width: this.computeWidth(), height: this.height });
-  }
-
-  getSeriesCount(): number {
-    return this.plot ? this.plot.series.length : 0;
-  }
-
-  destroy(): void {
-    if (this.resizeObserver) {
-      this.resizeObserver.disconnect();
-      this.resizeObserver = null;
-    }
-    if (this.resizeRaf !== null) {
-      window.cancelAnimationFrame(this.resizeRaf);
-      this.resizeRaf = null;
-    }
-    this.destroyPlot();
-  }
-
-  private destroyPlot(): void {
-    if (this.plot) {
-      this.plot.destroy();
-      this.plot = null;
-    }
-  }
-
-  private startResizeObserver(): void {
-    this.resizeObserver = new ResizeObserver(() => {
-      if (this.resizeRaf !== null) {
-        window.cancelAnimationFrame(this.resizeRaf);
+  return {
+    destroy(): void {
+      if (disposed) {
+        return;
       }
-      this.resizeRaf = window.requestAnimationFrame(() => {
-        this.resizeRaf = null;
-        this.resize();
+      disposed = true;
+      stopSizeSync();
+      stopDataSync();
+      stopPlotLifecycle();
+      stopResizeObserver();
+      plot.value = null;
+    },
+    resize(): void {
+      width.value = computeWidth(measureEl);
+    },
+    setSeriesIsolation(seriesIdx: number | null): void {
+      const currentPlot = plot.value;
+      if (!currentPlot) {
+        return;
+      }
+      currentPlot.batch(() => {
+        for (let index = 1; index < currentPlot.series.length; index += 1) {
+          currentPlot.setSeries(
+            index,
+            { show: seriesIdx === null || index === seriesIdx },
+            false,
+          );
+        }
       });
-    });
-    this.resizeObserver.observe(this.measureEl);
-  }
+    },
+  };
+}
 
-  private computeWidth(): number {
-    return Math.max(320, Math.floor(this.measureEl.getBoundingClientRect().width));
-  }
+function computeWidth(measureEl: HTMLElement): number {
+  return Math.max(320, Math.floor(measureEl.getBoundingClientRect().width));
 }

--- a/apps/ui/tests/spectrum_canvas_renderer.spec.ts
+++ b/apps/ui/tests/spectrum_canvas_renderer.spec.ts
@@ -2,7 +2,8 @@ import { expect, test } from "@playwright/test";
 
 import type { SpectrumPanelChartDom } from "../src/app/runtime/spectrum_panel_view";
 import { createAppState } from "../src/app/ui_app_state";
-import type { SpectrumChart } from "../src/spectrum_chart";
+import { effect } from "../src/app/ui_signals";
+import type { CreateSpectrumChartDeps, SpectrumChart } from "../src/spectrum_chart";
 import type { AdaptedClient } from "../src/transport/live_models";
 import { createDeferred, flushSignalUpdates, installWindowGlobal } from "./async_test_helpers";
 import { createElementStub, installDocumentStub } from "./spectrum_test_support";
@@ -128,31 +129,30 @@ test.describe("SpectrumCanvasRenderer", () => {
         },
       };
 
-      const chartModule = createDeferred<{ SpectrumChart: typeof SpectrumChart }>();
-      const createdCharts: FakeSpectrumChart[] = [];
-      class FakeSpectrumChart {
-        private seriesCount = 0;
-        public readonly setDataCalls: Array<readonly unknown[]> = [];
-
-        constructor(..._args: unknown[]) {
-          createdCharts.push(this);
-        }
-
-        ensurePlot(seriesMeta: Array<{ label: string; color: string }>): void {
-          this.seriesCount = seriesMeta.length + 1;
-        }
-
-        setData(data: readonly unknown[]): void {
-          this.setDataCalls.push(data);
-        }
-
-        setSeriesIsolation(): void {}
-
-        getSeriesCount(): number {
-          return this.seriesCount;
-        }
-
-        destroy(): void {}
+      const chartModule = createDeferred<{
+        createSpectrumChart: (deps: CreateSpectrumChartDeps) => SpectrumChart;
+      }>();
+      const createdCharts: Array<{
+        dataSnapshots: Array<readonly unknown[]>;
+        seriesCount: number;
+      }> = [];
+      function createFakeSpectrumChart(deps: CreateSpectrumChartDeps): SpectrumChart {
+        const chartState = {
+          dataSnapshots: [] as Array<readonly unknown[]>,
+          seriesCount: 0,
+        };
+        const stop = effect(() => {
+          chartState.seriesCount = deps.seriesMeta.value.length + 1;
+          chartState.dataSnapshots.push(deps.data.value as readonly unknown[]);
+        });
+        createdCharts.push(chartState);
+        return {
+          destroy() {
+            stop();
+          },
+          resize() {},
+          setSeriesIsolation() {},
+        };
       }
 
       const renderer = new SpectrumCanvasRenderer({
@@ -177,16 +177,88 @@ test.describe("SpectrumCanvasRenderer", () => {
       expect(createdCharts).toHaveLength(0);
 
       chartModule.resolve({
-        SpectrumChart: FakeSpectrumChart as unknown as typeof SpectrumChart,
+        createSpectrumChart: createFakeSpectrumChart,
       });
       await flushSignalUpdates();
 
       expect(state.spectrum.chartLoading).toBe(false);
       expect(state.spectrum.chartLoadErrorDetail).toBeNull();
       expect(createdCharts).toHaveLength(1);
-      expect(state.spectrum.spectrumPlot).toBe(createdCharts[0] as unknown as SpectrumChart);
-      expect(createdCharts[0].setDataCalls).toHaveLength(1);
-      expect(createdCharts[0].setDataCalls[0]?.[0]).toEqual([10, 15, 20]);
+      expect(state.spectrum.spectrumPlot).not.toBeNull();
+      expect(createdCharts[0].dataSnapshots.at(-1)?.[0]).toEqual([10, 15, 20]);
+      expect(createdCharts[0].seriesCount).toBe(2);
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("passes reactive chart text updates through the factory signals", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const { SpectrumCanvasRenderer } = await import(
+        "../src/app/runtime/spectrum_canvas_renderer"
+      );
+      const state = createAppState();
+      state.realtime.clients = [makeClient("sensor-a", "Front Right Wheel")];
+      state.spectrum.spectra.clients = {
+        "sensor-a": {
+          freq: [10, 15, 20],
+          combined: [1, 0.75, 0.5],
+          strength_metrics: {
+            noise_floor_amp_g: 0.1,
+            peak_amp_g: 1,
+            strength_bucket: null,
+            top_peaks: [{
+              amp: 1,
+              hz: 10,
+              strength_bucket: null,
+              vibration_strength_db: 12,
+            }],
+            vibration_strength_db: 12,
+          },
+        },
+      };
+      const axisTexts: string[] = [];
+      let createCalls = 0;
+
+      const renderer = new SpectrumCanvasRenderer({
+        state,
+        dom: {
+          specChart: createElementStub("div"),
+          specChartWrap: createElementStub("div"),
+        } as unknown as SpectrumPanelChartDom,
+        t: (key) => `${state.shell.lang}:${key}`,
+        getBandsVisible: () => false,
+        getChartBands: () => [],
+        getFocusMarker: () => null,
+        onCursorDataIndexChange: () => undefined,
+        loadChartModule: async () => ({
+          createSpectrumChart(deps: CreateSpectrumChartDeps): SpectrumChart {
+            createCalls += 1;
+            const stop = effect(() => {
+              axisTexts.push(deps.text.value.axisHz);
+            });
+            return {
+              destroy() {
+                stop();
+              },
+              resize() {},
+              setSeriesIsolation() {},
+            };
+          },
+        }),
+      });
+
+      const prepared = renderer.prepareFrame();
+      renderer.renderPreparedFrame(prepared);
+      await flushSignalUpdates();
+
+      state.shell.lang = "nl";
+      await flushSignalUpdates();
+
+      expect(createCalls).toBe(1);
+      expect(axisTexts).toContain("en:chart.axis.hz");
+      expect(axisTexts.at(-1)).toBe("nl:chart.axis.hz");
     } finally {
       restoreDocument();
     }


### PR DESCRIPTION
## What changed
- replaced the `SpectrumChart` class with a signal-driven `createSpectrumChart()` factory handle
- moved chart config/data ownership into `spectrum_canvas_renderer.ts`, which now feeds series, data, text, plugins, and size through signals
- dropped the controller-side destroy/recreate path on language changes because chart text now reacts through the factory
- expanded renderer coverage for async chart creation and reactive text updates

## Why
- the renderer already owns chart lifecycle, so the class API was the wrong seam
- this makes chart updates react through effects instead of imperative `ensurePlot()` / `setData()` calls

## Validation
- `cd apps/ui && npx playwright test tests/spectrum_canvas_renderer.spec.ts tests/ui_spectrum_controller.spec.ts tests/ui_shell_runtime_modules.spec.ts`
- `cd apps/ui && npx playwright test tests/smoke.spectrum.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- this keeps the public chart handle small (`resize`, `setSeriesIsolation`, `destroy`) but it is still a runtime bridge around uPlot, not a pure view component
- `ui_spectrum_controller.ts` was only the visible caller; the real behavior change is in the renderer because that is where the chart instance actually lives

Closes #2537