### PR TITLE
UI: refresh spectrum CSS vars on theme change

### DIFF
--- a/apps/ui/src/spectrum_css_vars.ts
+++ b/apps/ui/src/spectrum_css_vars.ts
@@ -1,3 +1,5 @@
+import { computed, signal } from "./app/ui_signals";
+
 export interface SpectrumCssVars {
   surface: string;
   muted: string;
@@ -14,7 +16,13 @@ const DEFAULT_SPECTRUM_CSS_VARS: Readonly<SpectrumCssVars> = Object.freeze({
   tooltipFg: "#f8f9fb",
 });
 
-let cachedSpectrumCssVars: Readonly<SpectrumCssVars> | null = null;
+const THEME_MEDIA_QUERY = "(prefers-color-scheme: dark)";
+const spectrumCssVarsVersion = signal(0);
+const spectrumCssVars = computed<Readonly<SpectrumCssVars>>(() => {
+  spectrumCssVarsVersion.value;
+  return readSpectrumCssVars();
+});
+let spectrumCssVarsThemeListenerInitialized = false;
 
 function readSpectrumCssVars(): Readonly<SpectrumCssVars> {
   const rootStyle = getComputedStyle(document.documentElement);
@@ -30,13 +38,31 @@ function readSpectrumCssVars(): Readonly<SpectrumCssVars> {
 }
 
 export function getSpectrumCssVars(): Readonly<SpectrumCssVars> {
-  if (cachedSpectrumCssVars === null) {
-    cachedSpectrumCssVars = readSpectrumCssVars();
-  }
-  return cachedSpectrumCssVars;
+  ensureSpectrumCssVarsThemeTracking();
+  return spectrumCssVars.value;
 }
 
 export function refreshSpectrumCssVars(): Readonly<SpectrumCssVars> {
-  cachedSpectrumCssVars = readSpectrumCssVars();
-  return cachedSpectrumCssVars;
+  ensureSpectrumCssVarsThemeTracking();
+  spectrumCssVarsVersion.value += 1;
+  return spectrumCssVars.value;
+}
+
+function ensureSpectrumCssVarsThemeTracking(): void {
+  if (spectrumCssVarsThemeListenerInitialized) {
+    return;
+  }
+  if (typeof globalThis.matchMedia !== "function") {
+    return;
+  }
+  spectrumCssVarsThemeListenerInitialized = true;
+  const mediaQuery = globalThis.matchMedia(THEME_MEDIA_QUERY);
+  const refresh = () => {
+    spectrumCssVarsVersion.value += 1;
+  };
+  if (typeof mediaQuery.addEventListener === "function") {
+    mediaQuery.addEventListener("change", refresh);
+    return;
+  }
+  mediaQuery.addListener(refresh);
 }

--- a/apps/ui/tests/spectrum_css_vars.spec.ts
+++ b/apps/ui/tests/spectrum_css_vars.spec.ts
@@ -12,6 +12,7 @@ test.describe("spectrum_css_vars", () => {
       "--tooltip-bg": "rgba(1, 2, 3, 0.9)",
       "--tooltip-fg": "#fefefe",
     };
+    let themeChangeHandler: ((event: MediaQueryListEvent) => void) | null = null;
     let readCount = 0;
     globalThis.getComputedStyle = (() => {
       readCount += 1;
@@ -19,8 +20,22 @@ test.describe("spectrum_css_vars", () => {
         getPropertyValue(name: string): string {
           return styleValues[name] ?? "";
         },
-      } as CSSStyleDeclaration;
+        } as CSSStyleDeclaration;
     }) as typeof getComputedStyle;
+    globalThis.matchMedia = (() => ({
+      matches: false,
+      media: "(prefers-color-scheme: dark)",
+      onchange: null,
+      addEventListener: (_type: string, handler: (event: MediaQueryListEvent) => void) => {
+        themeChangeHandler = handler;
+      },
+      removeEventListener: () => undefined,
+      addListener: (handler: (event: MediaQueryListEvent) => void) => {
+        themeChangeHandler = handler;
+      },
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    })) as typeof matchMedia;
 
     try {
       const { getSpectrumCssVars, refreshSpectrumCssVars } = await import(
@@ -47,6 +62,16 @@ test.describe("spectrum_css_vars", () => {
       expect(refreshed).not.toBe(first);
       expect(getSpectrumCssVars()).toBe(refreshed);
       expect(readCount).toBe(2);
+
+      styleValues["--surface"] = "#444444";
+      themeChangeHandler?.({
+        matches: true,
+        media: "(prefers-color-scheme: dark)",
+      } as MediaQueryListEvent);
+      const autoRefreshed = getSpectrumCssVars();
+      expect(autoRefreshed.surface).toBe("#444444");
+      expect(autoRefreshed).not.toBe(refreshed);
+      expect(readCount).toBe(3);
     } finally {
       restoreDocument();
     }


### PR DESCRIPTION
## What changed
- switched `spectrum_css_vars.ts` from a forever-cache to a signal-backed cached snapshot
- wired a `matchMedia('prefers-color-scheme: dark')` listener to invalidate that cache on theme flips
- extended `spectrum_css_vars.spec.ts` to cover both manual refresh and automatic theme-change invalidation

## Why
- the old cache never invalidated, so spectrum colors stayed stale after an OS light/dark switch
- the chart consumer needed a reactive invalidation path, not just an unused refresh helper

## Validation
- `cd apps/ui && npx playwright test tests/spectrum_css_vars.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- the listener is intentionally scoped to color-scheme changes only; broader theme invalidation can stay separate if the app adds explicit theme toggles later
- `smoke.spectrum` already passed during the same issue iteration before the final `globalThis.matchMedia` test-harness alignment

Closes #2538
