### PR TITLE
UI: Replace createBoundViewModel effect-sync bridge with direct signal pass-through

### DIFF
--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -13,7 +13,7 @@ import {
   MaintenanceReadinessPanel,
   type MaintenanceReadinessPanelModel,
 } from "./maintenance_readiness_view";
-import { createBoundViewModel } from "./view_model_binding";
+import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
 
 export interface EspFlashStatusBadgeModel {
   text: string;
@@ -307,7 +307,7 @@ function EspFlashHistoryContent(props: {
 
 function EspFlashPanel(props: {
   actions: ReadonlySignal<EspFlashPanelActionHandlers | null>;
-  model: ReadonlySignal<EspFlashPanelRenderModel>;
+  model: ReadonlySignal<ReadonlySignal<EspFlashPanelRenderModel> | null>;
 }) {
   const titleText = useUiText("settings.esp_flash.title", "ESP Flash");
   const hintText = useUiText("settings.esp_flash.hint", "Flash ESP firmware from local source on this Pi.");
@@ -335,7 +335,7 @@ function EspFlashPanel(props: {
     "Recent flashes stay here so the next operator can see what happened last.",
   );
   const actions = useComputed(() => props.actions.value);
-  const model = useComputed(() => props.model.value);
+  const model = useDeferredViewModel(props.model, DEFAULT_ESP_FLASH_PANEL_MODEL);
   const logPanelRef = useRef<HTMLDivElement | null>(null);
   const handleSelectPort = (value: string) => {
     actions.value?.onSelectPort(value);
@@ -564,7 +564,7 @@ function EspFlashPanel(props: {
 
 export function mountEspFlashPanel(host: HTMLElement): EspFlashPanelView {
   const actions = signal<EspFlashPanelActionHandlers | null>(null);
-  const modelBinding = createBoundViewModel(DEFAULT_ESP_FLASH_PANEL_MODEL);
+  const modelBinding = createDeferredViewModel<EspFlashPanelRenderModel>();
   render(<EspFlashPanel actions={actions} model={modelBinding.model} />, host);
 
   return {

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -7,7 +7,7 @@ import {
   type ReadonlySignal,
 } from "../ui_signals";
 import { HistoryTableBody } from "./history_table_content";
-import { createBoundViewModel } from "./view_model_binding";
+import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
 import type {
   HistoryPanelActionHandlers,
   HistoryPanelRenderModel,
@@ -28,7 +28,7 @@ const HISTORY_PANEL_MODEL_KEYS = [
 
 function HistoryPanel(props: {
   actions: ReadonlySignal<HistoryPanelActionHandlers | null>;
-  model: ReadonlySignal<HistoryPanelRenderModel>;
+  model: ReadonlySignal<ReadonlySignal<HistoryPanelRenderModel> | null>;
 }) {
   const refreshLabel = useUiText("history.refresh", "Refresh History");
   const deleteAllLabel = useUiText("history.delete_all", "Delete All Runs");
@@ -37,8 +37,9 @@ function HistoryPanel(props: {
   const samplesLabel = useUiText("history.table.size", "Samples");
   const actionsLabel = useUiText("history.table.actions", "Actions");
   const actions = useComputed(() => props.actions.value);
+  const model = useDeferredViewModel(props.model, DEFAULT_PANEL_MODEL);
   const { deleteAllRunsDisabled, historySummaryText, table } = useSignalProperties(
-    props.model,
+    model,
     HISTORY_PANEL_MODEL_KEYS,
   );
   const handleRefreshHistory = () => {
@@ -95,7 +96,7 @@ function HistoryPanel(props: {
 
 export function mountHistoryPanel(host: HTMLElement): HistoryPanelView {
   const actions = signal<HistoryPanelActionHandlers | null>(null);
-  const modelBinding = createBoundViewModel(DEFAULT_PANEL_MODEL);
+  const modelBinding = createDeferredViewModel<HistoryPanelRenderModel>();
   render(<HistoryPanel actions={actions} model={modelBinding.model} />, host);
 
   return {

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -7,7 +7,7 @@ import {
   useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
-import { createBoundViewModel } from "./view_model_binding";
+import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
 
 export interface RealtimeLiveOverviewActiveCarModel {
   text: string;
@@ -175,7 +175,7 @@ function RealtimeLiveOverviewSensorRoster(props: {
 }
 
 function RealtimeLiveOverview(props: {
-  model: ReadonlySignal<RealtimeLiveOverviewRenderModel>;
+  model: ReadonlySignal<ReadonlySignal<RealtimeLiveOverviewRenderModel> | null>;
   speedText: ReadonlySignal<string>;
 }) {
   const titleText = useUiText("dashboard.live_overview", "Live overview");
@@ -191,6 +191,7 @@ function RealtimeLiveOverview(props: {
   const currentSpeedLabel = useUiText("dashboard.current_speed", "Current speed");
   const sensorCoverageLabel = useUiText("dashboard.sensor_coverage", "Sensor coverage");
   const noSensorsText = useUiText("settings.sensors.no_sensors", "No sensors yet.");
+  const model = useDeferredViewModel(props.model, DEFAULT_OVERVIEW_MODEL);
   const {
     activeCar,
     connectedSensorsText,
@@ -199,7 +200,7 @@ function RealtimeLiveOverview(props: {
     runHealth,
     sensorCards,
     strongestSignalText,
-  } = useSignalProperties(props.model, REALTIME_LIVE_OVERVIEW_MODEL_KEYS);
+  } = useSignalProperties(model, REALTIME_LIVE_OVERVIEW_MODEL_KEYS);
 
   return (
     <>
@@ -268,7 +269,7 @@ function RealtimeLiveOverview(props: {
 }
 
 export function mountRealtimeLiveOverview(host: HTMLElement): RealtimeLiveOverviewBridge {
-  const modelBinding = createBoundViewModel(DEFAULT_OVERVIEW_MODEL);
+  const modelBinding = createDeferredViewModel<RealtimeLiveOverviewRenderModel>();
   const speedText = signal(DEFAULT_OVERVIEW_STATE.speedText);
   render(<RealtimeLiveOverview model={modelBinding.model} speedText={speedText} />, host);
 

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -8,7 +8,7 @@ import {
   type ReadonlySignal,
 } from "../ui_signals";
 import { inlineStateActionClass } from "./dom_helpers";
-import { createBoundViewModel } from "./view_model_binding";
+import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
 import type {
   RealtimeCaptureReadinessChecklistModel,
   RealtimeLoggingSummaryAction,
@@ -164,7 +164,7 @@ function RealtimeLoggingChecklist(props: {
 
 function RealtimeLoggingPanel(props: {
   actions: ReadonlySignal<RealtimeLoggingPanelActionHandlers | null>;
-  model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
+  model: ReadonlySignal<ReadonlySignal<RealtimeLoggingPanelRenderModel> | null>;
 }) {
   const titleText = useUiText("dashboard.run_recording", "Run Recording");
   const runProgressLabel = useUiText("dashboard.recording_progress", "Run progress");
@@ -174,6 +174,7 @@ function RealtimeLoggingPanel(props: {
   const startLabel = useUiText("dashboard.start_recording", "Start Recording");
   const stopLabel = useUiText("dashboard.stop_recording", "Stop Recording");
   const actions = useComputed(() => props.actions.value);
+  const model = useDeferredViewModel(props.model, DEFAULT_PANEL_MODEL);
   const {
     checklist,
     elapsedText,
@@ -190,7 +191,7 @@ function RealtimeLoggingPanel(props: {
     stopDisabled,
     summaryPanel,
     summaryText,
-  } = useSignalProperties(props.model, REALTIME_LOGGING_PANEL_MODEL_KEYS);
+  } = useSignalProperties(model, REALTIME_LOGGING_PANEL_MODEL_KEYS);
   const shellLayout = useComputed(() => setupMode.value ? "setup" : undefined);
   const loggingRowHidden = useComputed(() => !showPill.value && runIdText.value === "");
   const pillHidden = useComputed(() => !showPill.value);
@@ -302,7 +303,7 @@ function RealtimeLoggingPanel(props: {
 
 export function mountRealtimeLoggingPanel(host: HTMLElement): RealtimeLoggingPanelBridge {
   const actions = signal<RealtimeLoggingPanelActionHandlers | null>(null);
-  const modelBinding = createBoundViewModel(DEFAULT_PANEL_MODEL);
+  const modelBinding = createDeferredViewModel<RealtimeLoggingPanelRenderModel>();
   render(<RealtimeLoggingPanel actions={actions} model={modelBinding.model} />, host);
 
   return {

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -4,6 +4,7 @@ import { render } from "preact";
 import { useUiText } from "../ui_i18n";
 import {
   signal,
+  useComputed,
   useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
@@ -13,7 +14,7 @@ import type {
   RealtimeSensorTableRenderModel,
   RealtimeSensorTableRowViewModel,
 } from "./realtime_sensor_table_view";
-import { createBoundViewModel } from "./view_model_binding";
+import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
 
 export interface SensorsPanelRenderModel {
   table: RealtimeSensorTableRenderModel | null;
@@ -129,7 +130,7 @@ function SensorsTableBody(props: {
 
 function SensorsPanel(props: {
   actions: ReadonlySignal<SensorsPanelActionHandlers | null>;
-  model: ReadonlySignal<SensorsPanelRenderModel>;
+  model: ReadonlySignal<ReadonlySignal<SensorsPanelRenderModel> | null>;
 }) {
   const titleText = useUiText("settings.sensors.title", "Sensors");
   const hintText = useUiText(
@@ -139,7 +140,9 @@ function SensorsPanel(props: {
   const nameLabel = useUiText("settings.sensors.name", "Name");
   const locationLabel = useUiText("settings.sensors.location", "Location");
   const actionsLabel = useUiText("settings.sensors.actions", "Actions");
-  const { table } = useSignalProperties(props.model, SENSORS_PANEL_MODEL_KEYS);
+  const actions = useComputed(() => props.actions.value);
+  const model = useDeferredViewModel(props.model, DEFAULT_SENSORS_PANEL_MODEL);
+  const { table } = useSignalProperties(model, SENSORS_PANEL_MODEL_KEYS);
   return (
     <div class="panel card">
       <strong>
@@ -164,7 +167,7 @@ function SensorsPanel(props: {
             </tr>
           </thead>
           <tbody id="sensorsSettingsBody">
-            <SensorsTableBody actions={props.actions.value} table={table.value} />
+            <SensorsTableBody actions={actions.value} table={table.value} />
           </tbody>
         </table>
       </div>
@@ -174,7 +177,7 @@ function SensorsPanel(props: {
 
 export function mountSensorsPanel(host: HTMLElement): SensorsPanelView {
   const actions = signal<SensorsPanelActionHandlers | null>(null);
-  const modelBinding = createBoundViewModel(DEFAULT_SENSORS_PANEL_MODEL);
+  const modelBinding = createDeferredViewModel<SensorsPanelRenderModel>();
   render(<SensorsPanel actions={actions} model={modelBinding.model} />, host);
   return {
     bindModel(model) {

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -7,7 +7,7 @@ import {
   useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
-import { createBoundViewModel } from "./view_model_binding";
+import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
 import type {
   UpdateCurrentStatusSectionModel,
   UpdateHealthSectionModel,
@@ -333,7 +333,7 @@ function UpdateStatusContent(props: {
 
 function UpdatePanel(props: {
   actions: ReadonlySignal<UpdatePanelActionHandlers | null>;
-  model: ReadonlySignal<UpdatePanelRenderModel>;
+  model: ReadonlySignal<ReadonlySignal<UpdatePanelRenderModel> | null>;
 }) {
   const titleText = useUiText("settings.update.title", "System Update");
   const hintText = useUiText(
@@ -346,6 +346,7 @@ function UpdatePanel(props: {
   );
   const cancelLabel = useUiText("settings.update.cancel", "Cancel Update");
   const actions = useComputed(() => props.actions.value);
+  const model = useDeferredViewModel(props.model, DEFAULT_UPDATE_PANEL_MODEL);
   const {
     cancelButtonDisabled,
     cancelButtonHidden,
@@ -353,7 +354,7 @@ function UpdatePanel(props: {
     startButtonHidden,
     startButtonLabelText,
     status,
-  } = useSignalProperties(props.model, UPDATE_PANEL_MODEL_KEYS);
+  } = useSignalProperties(model, UPDATE_PANEL_MODEL_KEYS);
   const handleStart = () => {
     actions.value?.onStart();
   };
@@ -424,7 +425,7 @@ function UpdatePanel(props: {
 
 export function mountUpdatePanel(host: HTMLElement): UpdatePanelView {
   const actions = signal<UpdatePanelActionHandlers | null>(null);
-  const modelBinding = createBoundViewModel(DEFAULT_UPDATE_PANEL_MODEL);
+  const modelBinding = createDeferredViewModel<UpdatePanelRenderModel>();
   render(<UpdatePanel actions={actions} model={modelBinding.model} />, host);
 
   return {

--- a/apps/ui/src/app/views/view_model_binding.ts
+++ b/apps/ui/src/app/views/view_model_binding.ts
@@ -1,26 +1,28 @@
 import {
-  effect,
   signal,
+  useComputed,
   type ReadonlySignal,
   type Signal,
 } from "../ui_signals";
 
-export interface BoundViewModel<T> {
-  readonly model: Signal<T>;
+export interface DeferredViewModel<T> {
+  readonly model: Signal<ReadonlySignal<T> | null>;
   bind(source: ReadonlySignal<T>): void;
 }
 
-export function createBoundViewModel<T>(initialValue: T): BoundViewModel<T> {
-  const model = signal(initialValue);
-  let stopSync: (() => void) | null = null;
-
+export function createDeferredViewModel<T>(): DeferredViewModel<T> {
+  const model = signal<ReadonlySignal<T> | null>(null);
   return {
     model,
     bind(source) {
-      stopSync?.();
-      stopSync = effect(() => {
-        model.value = source.value;
-      });
+      model.value = source;
     },
   };
+}
+
+export function useDeferredViewModel<T>(
+  source: ReadonlySignal<ReadonlySignal<T> | null>,
+  initialValue: T,
+): ReadonlySignal<T> {
+  return useComputed(() => source.value?.value ?? initialValue);
 }

--- a/apps/ui/tests/view_model_binding_signals.ts
+++ b/apps/ui/tests/view_model_binding_signals.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+
+import { options } from "preact";
+
+import {
+  computed,
+  signal,
+  useComputed,
+  type ReadonlySignal,
+} from "../src/app/ui_signals";
+import {
+  createDeferredViewModel,
+  useDeferredViewModel,
+} from "../src/app/views/view_model_binding";
+import { mountSignalView } from "./dom_render_test_support";
+
+function requireElement<T extends Element = HTMLElement>(root: ParentNode, selector: string): T {
+  const element = root.querySelector<T>(selector);
+  assert.ok(element, `Expected element matching ${selector}`);
+  return element;
+}
+
+async function runDeferredViewModelSignalTest(): Promise<void> {
+  const firstText = signal("Idle");
+  const secondText = signal("Ready");
+  const firstModel = computed(() => ({ text: firstText.value }));
+  const secondModel = computed(() => ({ text: secondText.value }));
+  const binding = createDeferredViewModel<{ text: string }>();
+  const previousDiffed = options.diffed;
+  let renderCount = 0;
+  options.diffed = (vnode) => {
+    if (typeof vnode.type === "function" && vnode.type.name === "DeferredViewModelProbe") {
+      renderCount += 1;
+    }
+    previousDiffed?.(vnode);
+  };
+
+  const harness = await mountSignalView(async () => {
+    const { h, render } = await import("preact");
+    return (host) => {
+      function DeferredViewModelProbe(props: {
+        model: ReadonlySignal<ReadonlySignal<{ text: string }> | null>;
+      }) {
+        const model = useDeferredViewModel(props.model, { text: "Loading" });
+        const text = useComputed(() => model.value.text);
+        return h("span", { id: "bindingProbe" }, text);
+      }
+
+      render(h(DeferredViewModelProbe, { model: binding.model }), host);
+      return {};
+    };
+  });
+
+  try {
+    await harness.flush();
+    assert.equal(renderCount, 1);
+    assert.equal(requireElement(harness.host, "#bindingProbe").textContent, "Loading");
+
+    binding.bind(firstModel);
+    await harness.flush();
+    assert.equal(renderCount, 1);
+    assert.equal(requireElement(harness.host, "#bindingProbe").textContent, "Idle");
+
+    firstText.value = "Running";
+    await harness.flush();
+    assert.equal(renderCount, 1);
+    assert.equal(requireElement(harness.host, "#bindingProbe").textContent, "Running");
+
+    binding.bind(secondModel);
+    await harness.flush();
+    assert.equal(renderCount, 1);
+    assert.equal(requireElement(harness.host, "#bindingProbe").textContent, "Ready");
+
+    firstText.value = "Stale";
+    await harness.flush();
+    assert.equal(requireElement(harness.host, "#bindingProbe").textContent, "Ready");
+
+    secondText.value = "Flashing";
+    await harness.flush();
+    assert.equal(renderCount, 1);
+    assert.equal(requireElement(harness.host, "#bindingProbe").textContent, "Flashing");
+  } finally {
+    options.diffed = previousDiffed;
+    harness.cleanup();
+  }
+}
+
+await runDeferredViewModelSignalTest();
+console.log("PASS deferred view model signals rebind without rerender");


### PR DESCRIPTION
## Size
medium

## What changed
- replace `createBoundViewModel()` with `createDeferredViewModel()` plus `useDeferredViewModel()`
- flatten deferred model sources inside the history, realtime logging, live overview, sensors, update, and ESP flash panels
- add focused signal coverage for late bind, rebind, and no-rerender behavior

## Why
- remove one local signal + sync effect hop from every deferred panel mount
- keep the existing late `bindModel()` flow without deferring the whole render path

## Validation
- `cd apps/ui && npx tsx tests/view_model_binding_signals.ts`
- `cd apps/ui && npx tsx tests/realtime_live_overview_signals.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/smoke.history.spec.ts tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts tests/smoke.analysis-sensors.spec.ts`

## Risks / edges
- each consumer keeps an explicit default model fallback until `bindModel()` provides the real source signal
- `analysis_panel.tsx` has a separate bridge pattern and stays out of scope here

Closes #2539
