### PR TITLE
UI: Remove useMemo from useSignalProperties — use signal-only memoization

### DIFF
--- a/apps/ui/src/app/ui_signals.ts
+++ b/apps/ui/src/app/ui_signals.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "preact/hooks";
 import {
   batch,
   computed,
@@ -37,16 +36,36 @@ type MutableSignalPropertyMap<
 export { batch, computed, effect, signal, untracked, useComputed, useSignal, useSignalEffect };
 export type { ReadonlySignal, Signal };
 
+const signalPropertiesCache = new WeakMap<object, WeakMap<object, object>>();
+
+function getOrCreateSignalPropertyMap<
+  T extends object,
+  const K extends readonly (keyof T & string)[],
+>(source: ReadonlySignal<T>, keys: K): SignalPropertyMap<T, K> {
+  const sourceCacheKey = source as object;
+  let sourceCache = signalPropertiesCache.get(sourceCacheKey);
+  if (!sourceCache) {
+    sourceCache = new WeakMap<object, object>();
+    signalPropertiesCache.set(sourceCacheKey, sourceCache);
+  }
+
+  const keysCacheKey = keys as object;
+  const cachedProperties = sourceCache.get(keysCacheKey);
+  if (cachedProperties) {
+    return cachedProperties as SignalPropertyMap<T, K>;
+  }
+
+  const properties = {} as MutableSignalPropertyMap<T, K>;
+  for (const key of keys) {
+    properties[key] = computed(() => source.value[key]);
+  }
+  sourceCache.set(keysCacheKey, properties);
+  return properties;
+}
+
 export function useSignalProperties<
   T extends object,
   const K extends readonly (keyof T & string)[],
 >(source: ReadonlySignal<T>, keys: K): SignalPropertyMap<T, K> {
-  const keysSignature = JSON.stringify(keys);
-  return useMemo(() => {
-    const properties = {} as MutableSignalPropertyMap<T, K>;
-    for (const key of keys) {
-      properties[key] = computed(() => source.value[key]);
-    }
-    return properties;
-  }, [source, keysSignature]);
+  return getOrCreateSignalPropertyMap(source, keys);
 }

--- a/apps/ui/tests/use_signal_properties_signals.ts
+++ b/apps/ui/tests/use_signal_properties_signals.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+
+import { computed, signal, useSignalProperties } from "../src/app/ui_signals";
+
+const MODEL_KEYS = ["hidden", "text"] as const;
+
+function createModelSignals() {
+  const hidden = signal(true);
+  const text = signal("Idle");
+  const model = computed(() => ({
+    hidden: hidden.value,
+    text: text.value,
+  }));
+  return { hidden, model, text };
+}
+
+async function runUseSignalPropertiesSignalCacheTest(): Promise<void> {
+  const first = createModelSignals();
+  const second = createModelSignals();
+
+  const firstProperties = useSignalProperties(first.model, MODEL_KEYS);
+  const firstPropertiesAgain = useSignalProperties(first.model, MODEL_KEYS);
+  const secondProperties = useSignalProperties(second.model, MODEL_KEYS);
+
+  assert.equal(firstProperties, firstPropertiesAgain);
+  assert.equal(firstProperties.hidden, firstPropertiesAgain.hidden);
+  assert.equal(firstProperties.text, firstPropertiesAgain.text);
+  assert.notEqual(firstProperties, secondProperties);
+
+  assert.equal(firstProperties.hidden.value, true);
+  assert.equal(firstProperties.text.value, "Idle");
+
+  first.hidden.value = false;
+  first.text.value = "Running";
+
+  assert.equal(firstProperties.hidden.value, false);
+  assert.equal(firstProperties.text.value, "Running");
+  assert.equal(secondProperties.hidden.value, true);
+  assert.equal(secondProperties.text.value, "Idle");
+}
+
+await runUseSignalPropertiesSignalCacheTest();
+console.log("PASS useSignalProperties caches signal projections without hooks");


### PR DESCRIPTION
## Size
medium

## What changed
- replace the `useMemo` + `JSON.stringify(keys)` path in `useSignalProperties()` with a pure `WeakMap` cache keyed by source signal and key tuple
- remove the last hooks import from `ui_signals.ts`
- add focused coverage that exercises `useSignalProperties()` outside component render and proves the cached projections stay reactive

## Why
- keep the helper on the signal side instead of mixing hooks into the shared signals module
- stop paying per-call key-signature churn when callers already pass stable key tuples

## Validation
- `cd apps/ui && npx tsx tests/use_signal_properties_signals.ts`
- `cd apps/ui && npx tsx tests/realtime_live_overview_signals.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.history.spec.ts tests/smoke.update.spec.ts tests/smoke.analysis-sensors.spec.ts tests/smoke.spectrum.spec.ts`

## Risks / edges
- the cache assumes the common case in this repo: callers pass stable module-level key tuples
- different key-array identities still work; they just use separate cache entries

Closes #2541
