### PR TITLE
perf(ui): memoize history table rows

### DIFF
--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -87,7 +87,7 @@ function HistoryPanel(props: {
           </tr>
         </thead>
         <tbody id="historyTableBody">
-          <HistoryTableBody handlers={actions.value} table={table.value} />
+          <HistoryTableBody handlers={actions.value} table={table} />
         </tbody>
       </table>
     </>

--- a/apps/ui/src/app/views/history_table_content.tsx
+++ b/apps/ui/src/app/views/history_table_content.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "preact";
 
+import { useComputed, useSignal, type ReadonlySignal } from "../ui_signals";
 import { inlineStateActionClass } from "./dom_helpers";
 import type {
   HistoryPanelActionHandlers,
@@ -15,7 +16,7 @@ import type {
   HistorySecondaryFindingViewModel,
   HistorySummaryChipTone,
 } from "./history_table_models";
-import { buildHistoryTableRowsViewModel } from "./history_table_presenters";
+import { createHistoryTableRowsMemo } from "./history_table_presenters";
 
 type HistoryHeatmapZoneStyle = JSX.CSSProperties & {
   "--history-heatmap-accent"?: string;
@@ -60,6 +61,20 @@ function handleRunAction(
     type: "run-action",
     action,
     runId,
+  });
+}
+
+function useHistoryTableRows(
+  table: ReadonlySignal<HistoryPanelTableRenderModel | null>,
+): ReadonlySignal<HistoryRowViewModel[] | null> {
+  const rowsMemo = useSignal(createHistoryTableRowsMemo());
+
+  return useComputed(() => {
+    const nextTable = table.value;
+    if (nextTable === null || nextTable.kind !== "rows") {
+      return null;
+    }
+    return rowsMemo.value(nextTable.params);
   });
 }
 
@@ -518,31 +533,48 @@ function HistoryRow(props: {
 
 export function HistoryTableBody(props: {
   handlers: HistoryPanelActionHandlers | null;
-  table: HistoryPanelTableRenderModel | null;
+  table: ReadonlySignal<HistoryPanelTableRenderModel | null>;
 }) {
-  const { handlers, table } = props;
-  if (table === null) {
+  const { handlers } = props;
+  const tableKind = useComputed(() => props.table.value?.kind ?? null);
+  const emptyStateTranslate = useComputed(() =>
+    props.table.value?.kind === "empty" ? props.table.value.t : null
+  );
+  const historyExportUrl = useComputed(() =>
+    props.table.value?.kind === "rows" ? props.table.value.params.historyExportUrl : null
+  );
+  const rows = useHistoryTableRows(props.table);
+
+  if (tableKind.value === null) {
     return (
       <tr>
         <td colSpan={4}>No runs found.</td>
       </tr>
     );
   }
-  if (table.kind === "empty") {
-    return <HistoryEmptyStateRow handlers={handlers} t={table.t} />;
+  if (tableKind.value === "empty") {
+    const translate = emptyStateTranslate.value;
+    if (translate === null) {
+      throw new Error("History empty-state translation missing");
+    }
+    return <HistoryEmptyStateRow handlers={handlers} t={translate} />;
   }
 
-  const rows = buildHistoryTableRowsViewModel(table.params);
+  const currentRows = rows.value;
+  const currentHistoryExportUrl = historyExportUrl.value;
+  if (currentRows === null || currentHistoryExportUrl === null) {
+    throw new Error("History row params missing");
+  }
   return (
     <>
-      {rows.flatMap((row) => [
+      {currentRows.flatMap((row) => [
         <HistoryRow key={`row:${row.runId}`} handlers={handlers} row={row} />,
         row.details ? (
           <HistoryDetailsRow
             key={`details:${row.runId}`}
             details={row.details}
             handlers={handlers}
-            historyExportUrl={table.params.historyExportUrl}
+            historyExportUrl={currentHistoryExportUrl}
             row={row}
           />
         ) : null,

--- a/apps/ui/src/app/views/history_table_presenters.ts
+++ b/apps/ui/src/app/views/history_table_presenters.ts
@@ -130,3 +130,112 @@ export function buildHistoryTableRowsViewModel(params: PresenterParams): History
     buildRowViewModel(run, params.runDetailsById[run.run_id] ?? EMPTY_RUN_DETAIL, params),
   );
 }
+
+type HistoryRowsMemoKey = Pick<
+  PresenterParams,
+  "expandedRunId" | "fmt" | "fmtTs" | "formatInt" | "t"
+> & {
+  detailState: Array<
+    readonly [
+      runId: string,
+      preview: RunDetail["preview"],
+      previewLoading: boolean,
+      previewError: string,
+      insights: RunDetail["insights"],
+      insightsLoading: boolean,
+      insightsError: string,
+      pdfLoading: boolean,
+      pdfError: string,
+    ]
+  >;
+  runState: Array<
+    readonly [
+      runRef: HistoryEntry,
+      runId: string,
+      status: HistoryEntry["status"],
+      errorMessage: HistoryEntry["error_message"],
+      sampleCount: HistoryEntry["sample_count"],
+      startTimeUtc: HistoryEntry["start_time_utc"],
+      carName: HistoryEntry["car_name"],
+    ]
+  >;
+};
+
+function buildHistoryRowsMemoKey(params: PresenterParams): HistoryRowsMemoKey {
+  return {
+    expandedRunId: params.expandedRunId,
+    t: params.t,
+    fmt: params.fmt,
+    fmtTs: params.fmtTs,
+    formatInt: params.formatInt,
+    runState: params.runs.map((run) => [
+      run,
+      run.run_id,
+      run.status,
+      run.error_message,
+      run.sample_count,
+      run.start_time_utc,
+      run.car_name,
+    ] as const),
+    detailState: params.runs.map((run) => {
+      const detail = params.runDetailsById[run.run_id] ?? EMPTY_RUN_DETAIL;
+      return [
+        run.run_id,
+        detail.preview,
+        detail.previewLoading,
+        detail.previewError,
+        detail.insights,
+        detail.insightsLoading,
+        detail.insightsError,
+        detail.pdfLoading,
+        detail.pdfError,
+      ] as const;
+    }),
+  };
+}
+
+function shallowTupleListEqual<T extends readonly unknown[]>(left: T[], right: T[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    const leftEntry = left[index];
+    const rightEntry = right[index];
+    if (!leftEntry || !rightEntry || leftEntry.length !== rightEntry.length) {
+      return false;
+    }
+    for (let tupleIndex = 0; tupleIndex < leftEntry.length; tupleIndex += 1) {
+      if (leftEntry[tupleIndex] !== rightEntry[tupleIndex]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function sameHistoryRowsMemoKey(left: HistoryRowsMemoKey | null, right: HistoryRowsMemoKey): boolean {
+  return left !== null
+    && left.expandedRunId === right.expandedRunId
+    && left.t === right.t
+    && left.fmt === right.fmt
+    && left.fmtTs === right.fmtTs
+    && left.formatInt === right.formatInt
+    && shallowTupleListEqual(left.runState, right.runState)
+    && shallowTupleListEqual(left.detailState, right.detailState);
+}
+
+export function createHistoryTableRowsMemo(): (params: PresenterParams) => HistoryRowViewModel[] {
+  let previousKey: HistoryRowsMemoKey | null = null;
+  let previousRows: HistoryRowViewModel[] = [];
+
+  return (params: PresenterParams) => {
+    const nextKey = buildHistoryRowsMemoKey(params);
+    if (sameHistoryRowsMemoKey(previousKey, nextKey)) {
+      return previousRows;
+    }
+
+    previousKey = nextKey;
+    previousRows = buildHistoryTableRowsViewModel(params);
+    return previousRows;
+  };
+}

--- a/apps/ui/tests/history_table_body_signals.ts
+++ b/apps/ui/tests/history_table_body_signals.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+
+import type { HistoryEntry } from "../src/api/types";
+import type { RunDetail } from "../src/app/ui_app_state";
+import { createHistoryTableRowsMemo } from "../src/app/views/history_table_presenters";
+
+function testTranslation(key: string, vars?: Record<string, unknown>): string {
+  return vars ? `${key}:${JSON.stringify(vars)}` : key;
+}
+
+function historyListRun(runId: string): HistoryEntry {
+  return {
+    run_id: runId,
+    start_time_utc: "2026-01-01T00:00:00Z",
+    end_time_utc: "2026-01-01T00:00:12Z",
+    sample_count: 42,
+    status: "complete",
+    car_name: "Track Car",
+    error_message: null,
+  } as HistoryEntry;
+}
+
+function defaultDetail(detail: Partial<RunDetail>): RunDetail {
+  return {
+    preview: null,
+    previewLoading: false,
+    previewError: "",
+    insights: null,
+    insightsLoading: false,
+    insightsError: "",
+    pdfLoading: false,
+    pdfError: "",
+    ...detail,
+  };
+}
+
+async function runHistoryTableRowsMemoTest(): Promise<void> {
+  const memoizeRows = createHistoryTableRowsMemo();
+  const runs = [historyListRun("run-001")];
+  const runDetailsById = {
+    "run-001": defaultDetail({}),
+  };
+  const fmt = (value: number, digits = 0) => Number(value).toFixed(digits);
+  const fmtTs = (iso: string) => iso;
+  const formatInt = (value: number) => String(value);
+  const historyExportUrl = (runId: string) => `/api/history/${runId}/export`;
+
+  const firstRows = memoizeRows({
+    runs,
+    expandedRunId: null,
+    runDetailsById,
+    t: testTranslation,
+    fmt,
+    fmtTs,
+    formatInt,
+    historyExportUrl,
+  });
+  const secondRows = memoizeRows({
+    runs,
+    expandedRunId: null,
+    runDetailsById,
+    t: testTranslation,
+    fmt,
+    fmtTs,
+    formatInt,
+    historyExportUrl,
+  });
+
+  assert.equal(firstRows, secondRows);
+  assert.equal(firstRows[0]?.isExpanded, false);
+
+  runDetailsById["run-001"].previewLoading = true;
+  const loadingRows = memoizeRows({
+    runs,
+    expandedRunId: null,
+    runDetailsById,
+    t: testTranslation,
+    fmt,
+    fmtTs,
+    formatInt,
+    historyExportUrl,
+  });
+
+  assert.notEqual(loadingRows, firstRows);
+  assert.equal(loadingRows[0]?.summaryHeadline, "history.row_summary_loading");
+
+  const expandedRows = memoizeRows({
+    runs,
+    expandedRunId: "run-001",
+    runDetailsById,
+    t: testTranslation,
+    fmt,
+    fmtTs,
+    formatInt,
+    historyExportUrl,
+  });
+
+  assert.notEqual(expandedRows, firstRows);
+  assert.equal(expandedRows[0]?.isExpanded, true);
+}
+
+await runHistoryTableRowsMemoTest();
+console.log("PASS history table rows memoize stable presenter inputs");


### PR DESCRIPTION
## what changed
- pass the history table signal into `HistoryTableBody` instead of flattening before render
- derive row view models from a computed signal instead of rebuilding them in render
- memoize presenter output so wrapper churn reuses the old row array when row inputs did not change
- add focused regression coverage for stable-input reuse and in-place detail invalidation

## why
- `HistoryTableBody` was rebuilding row view models every parent rerender
- history panel wrapper objects churn often, so naive computed-on-wrapper still wastes work
- row reuse needs to stay correct when nested run detail state mutates in place

## validation
- `cd apps/ui && npx tsx tests/history_table_body_signals.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/smoke.history.spec.ts tests/smoke.history-layout.spec.ts`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint` *(same pre-existing warnings only)*

## risks / tradeoffs
- memo reuse depends on comparing the row-relevant run and detail fields, so future presenter inputs need to extend that key if they affect row output
- this keeps invalidation broad enough to catch in-place detail updates instead of chasing finer-grained signals that the current history state does not expose

Closes #2542
