### PR TITLE
refactor(ui): remove translation hook

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -262,7 +262,7 @@ instead of controller-side variant class interpolation.
   `useComputed(() => model.value.foo)` line per property.
 - Use `effect()` only for narrow imperative integrations such as timers,
   persistence, canvas/uPlot bridges, or other external-library coordination.
-- Preact-rendered copy should come from `useUiTranslation()` or `useUiText()`.
+- Preact-rendered copy should come from `getUiText()` or `useUiText()`.
   Do not leave `data-i18n` attributes in JSX unless a non-Preact consumer still
   reads them.
 - Existing mutable app-state objects and manual bridge rerenders are follow-up

--- a/apps/ui/src/app/ui_i18n.ts
+++ b/apps/ui/src/app/ui_i18n.ts
@@ -19,16 +19,6 @@ export function setUiLanguage(lang: string): void {
   currentLanguage.value = normalizedLanguage;
 }
 
-export function useUiTranslation() {
-  const language = currentLanguage.value;
-
-  return (
-    key: string,
-    fallback: string,
-    vars?: Record<string, unknown>,
-  ): string => translate(language, key, vars) || fallback;
-}
-
 export function useUiText(
   key: string,
   fallback: string,

--- a/apps/ui/src/app/views/analysis_panel.tsx
+++ b/apps/ui/src/app/views/analysis_panel.tsx
@@ -1,7 +1,7 @@
 import { render } from "preact";
 import { useRef } from "preact/hooks";
 
-import { useUiTranslation } from "../ui_i18n";
+import { getUiText as t } from "../ui_i18n";
 import {
   effect,
   signal,
@@ -119,7 +119,6 @@ function AnalysisPanel(props: {
   state: ReadonlySignal<AnalysisPanelBridgeState>;
 }) {
   const state = props.state.value;
-  const t = useUiTranslation();
   const guidanceHelpRef = useRef<HTMLDetailsElement | null>(null);
   const inputRefs = useRef<Record<AnalysisPanelFieldKey, HTMLInputElement | null>>({
     wheel_bandwidth_pct: null,

--- a/apps/ui/src/app/views/analysis_panel_sections.tsx
+++ b/apps/ui/src/app/views/analysis_panel_sections.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "preact";
 
-import { useUiTranslation } from "../ui_i18n";
+import { getUiText as t } from "../ui_i18n";
 import {
   settingsFeedbackClassName,
   type SettingsFeedbackMessage,
@@ -75,7 +75,6 @@ function AnalysisField(props: {
   spec: AnalysisFieldSpec;
 }) {
   const { actions, model, onInputRef, spec } = props;
-  const t = useUiTranslation();
   return (
     <div class="field">
       <label htmlFor={spec.inputId}>
@@ -100,7 +99,6 @@ export function AnalysisGuidanceDialog(props: {
   guidanceHelpRef: { current: HTMLDetailsElement | null };
 }) {
   const { guidanceHelpRef } = props;
-  const t = useUiTranslation();
   return (
     <details
       id="analysisGuidanceHelp"
@@ -160,7 +158,6 @@ export function AnalysisFieldGroup(props: {
     titleFallback,
     titleKey,
   } = props;
-  const t = useUiTranslation();
   return (
     <section class="settings-group">
       <h3>

--- a/apps/ui/src/app/views/cars_list_section.tsx
+++ b/apps/ui/src/app/views/cars_list_section.tsx
@@ -1,4 +1,4 @@
-import { useUiTranslation } from "../ui_i18n";
+import { getUiText as t } from "../ui_i18n";
 import { inlineStateActionClass } from "./dom_helpers";
 import type {
   CarsInlineStateViewModel,
@@ -157,7 +157,6 @@ function CarsTableBody(props: {
   table: SettingsCarListTableRenderModel | null;
 }) {
   const { actions, table } = props;
-  const t = useUiTranslation();
   if (table === null) {
     return (
       <tr>
@@ -190,7 +189,6 @@ export function CarsListSection(props: {
   onOpenWizard(): void;
 }) {
   const { actions, addCarButtonRef, model, onOpenWizard } = props;
-  const t = useUiTranslation();
   return (
     <div class="panel card">
       <div class="car-tab-header">

--- a/apps/ui/src/app/views/cars_wizard_panel.tsx
+++ b/apps/ui/src/app/views/cars_wizard_panel.tsx
@@ -1,6 +1,6 @@
 import type { CarsFeatureFocusTarget } from "../features/cars_feature_workflow";
 import type { CarsFeatureManualInputState } from "../features/cars_manual_input";
-import { useUiTranslation } from "../ui_i18n";
+import { getUiText as t } from "../ui_i18n";
 import type { CarsWizardRenderModel } from "./car_wizard_view";
 import {
   CarsWizardStepNav,
@@ -35,7 +35,6 @@ export function CarsWizardPanel(props: {
   wizardModel: CarsWizardRenderModel;
 }) {
   const { actions, refs, wizardModel } = props;
-  const t = useUiTranslation();
 
   function closeWizard(): void {
     actions?.onAction({ type: "close" });

--- a/apps/ui/src/app/views/cars_wizard_sections.tsx
+++ b/apps/ui/src/app/views/cars_wizard_sections.tsx
@@ -1,7 +1,7 @@
 import type { ComponentChildren } from "preact";
 
 import type { CarsFeatureManualInputState } from "../features/cars_manual_input";
-import { useUiTranslation } from "../ui_i18n";
+import { getUiText as t } from "../ui_i18n";
 import type {
   CarsWizardOptionItem,
   CarsWizardOptionsRenderModel,
@@ -111,7 +111,6 @@ function WizardCustomEntry(props: {
   onSubmit(value: string): void;
 }) {
   const { buttonId, className, inputId, inputRef, intro, labelText, maxLength, onSubmit, placeholder } = props;
-  const t = useUiTranslation();
   return (
     <div class={className ?? "wizard-custom"}>
       {intro}
@@ -140,7 +139,6 @@ function CarsManualInputForm(props: {
   wizardModel: CarsWizardRenderModel;
 }) {
   const { emitManualInputs, refs, wizardModel } = props;
-  const t = useUiTranslation();
   return (
     <div class="settings-subgrid">
       <div class="field">
@@ -225,7 +223,6 @@ function WizardBrandStep(props: {
   onSubmitCustomBrand(value: string): void;
 }) {
   const { hidden, onSelectBrand, onSubmitCustomBrand, refs, section } = props;
-  const t = useUiTranslation();
   return (
     <div id="wizardStep0" class="wizard-step" hidden={hidden}>
       <h3>
@@ -260,7 +257,6 @@ function WizardTypeStep(props: {
   onSubmitCustomType(value: string): void;
 }) {
   const { hidden, onSelectType, onSubmitCustomType, refs, section } = props;
-  const t = useUiTranslation();
   return (
     <div id="wizardStep1" class="wizard-step" hidden={hidden}>
       <h3>
@@ -295,7 +291,6 @@ function WizardModelStep(props: {
   onSubmitCustomModel(value: string): void;
 }) {
   const { hidden, onSelectModel, onSubmitCustomModel, refs, section } = props;
-  const t = useUiTranslation();
   return (
     <div id="wizardStep2" class="wizard-step" hidden={hidden}>
       <h3>
@@ -349,7 +344,6 @@ function WizardVariantStep(props: {
   onSelectVariant(index: number): void;
 }) {
   const { hidden, onSelectVariant, refs, section } = props;
-  const t = useUiTranslation();
   return (
     <div id="wizardStep3" class="wizard-step" hidden={hidden}>
       <h3>
@@ -382,7 +376,6 @@ function WizardSpecsStep(props: {
   onSelectTire(index: number): void;
 }) {
   const { emitManualInputs, hidden, onSelectGearbox, onSelectTire, refs, wizardModel } = props;
-  const t = useUiTranslation();
   return (
     <div id="wizardStep4" class="wizard-step" hidden={hidden}>
       <div class="wizard-branch-card wizard-branch-card--library">
@@ -461,7 +454,6 @@ function WizardSpecsStep(props: {
 
 export function CarsWizardStepNav(props: { step: number }) {
   const { step } = props;
-  const t = useUiTranslation();
   return (
     <div class="wizard-step-indicators" aria-label="Add car progress">
       {WIZARD_STEP_LABELS.map((label, index) => (

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -3,7 +3,7 @@ import { useRef } from "preact/hooks";
 
 import type { UpdateStartRequestPayload } from "../../api/types";
 import type { ChoiceCardState } from "../view_style_types";
-import { useUiTranslation } from "../ui_i18n";
+import { getUiText as t } from "../ui_i18n";
 import {
   signal,
   useSignalEffect,
@@ -266,7 +266,6 @@ function InternetPanel(props: {
 }) {
   const state = props.state.value;
   const model = state.model?.value ?? DEFAULT_INTERNET_PANEL_MODEL;
-  const t = useUiTranslation();
   const ssidInputRef = useRef<HTMLInputElement | null>(null);
 
   useSignalEffect(() => {

--- a/apps/ui/src/app/views/speed_source_config_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_config_panel.tsx
@@ -1,5 +1,5 @@
 import type { DisplayedSpeedSourceMode } from "../speed_source_state";
-import { useUiTranslation } from "../ui_i18n";
+import { getUiText as t } from "../ui_i18n";
 import {
   settingsFeedbackClassName,
   type SettingsFeedbackMessage,
@@ -82,7 +82,6 @@ function SpeedSourceSummarySection(props: {
   summary: SpeedSourcePanelRenderModel["summary"];
 }) {
   const { summary } = props;
-  const t = useUiTranslation();
   return (
     <div class="speed-source-summary">
       <div class="speed-source-summary__eyebrow">
@@ -197,7 +196,6 @@ function ManualSpeedSection(props: {
   model: SpeedSourcePanelRenderModel;
 }) {
   const { actions, manualInputRef, model } = props;
-  const t = useUiTranslation();
   return (
     <div
       id="manualSpeedConfig"
@@ -289,7 +287,6 @@ function ObdConfigSection(props: {
   scanButtonRef: (element: HTMLButtonElement | null) => void;
 }) {
   const { actions, model, obdConfigRef, scanButtonRef } = props;
-  const t = useUiTranslation();
   return (
     <div
       id="obdSpeedConfig"
@@ -349,7 +346,6 @@ function GpsFallbackSection(props: {
   staleTimeoutInputRef: (element: HTMLInputElement | null) => void;
 }) {
   const { actions, model, staleTimeoutInputRef } = props;
-  const t = useUiTranslation();
   return (
     <div
       id="gpsFallbackPanel"
@@ -399,7 +395,6 @@ function SpeedSourceSaveSection(props: {
   saveFeedback: SettingsFeedbackMessage | null;
 }) {
   const { actions, saveFeedback } = props;
-  const t = useUiTranslation();
   return (
     <>
       <SettingsFeedbackSlot
@@ -439,7 +434,6 @@ export function SpeedSourceConfigPanel(props: {
     scanButtonRef,
     staleTimeoutInputRef,
   } = props;
-  const t = useUiTranslation();
   return (
     <div class="panel card">
       <strong>

--- a/apps/ui/src/app/views/speed_source_diagnostics_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_diagnostics_panel.tsx
@@ -1,4 +1,4 @@
-import { useUiTranslation } from "../ui_i18n";
+import { getUiText as t } from "../ui_i18n";
 import type {
   SpeedSourceDiagnosticsRenderModel,
   SpeedSourceGpsStatusRenderModel,
@@ -171,7 +171,6 @@ export function SpeedSourceDiagnosticsPanel(props: {
   onDiagnosticsToggle: (event: Event) => void;
 }) {
   const { diagnostics, diagnosticsDisclosureOpen, onDiagnosticsToggle } = props;
-  const t = useUiTranslation();
   return (
     <details
       id="speedSourceDiagnostics"


### PR DESCRIPTION
## what changed
- remove `useUiTranslation()` from `ui_i18n.ts`
- migrate the remaining settings/cars/analysis callers to direct `getUiText()` calls
- update the UI README guardrail to point at `getUiText()` or `useUiText()`

## why
- `useUiTranslation()` created a new translation closure on every render
- the remaining consumers only needed translated strings during render, so they can read from `getUiText()` directly
- deleting the helper avoids keeping two overlapping text-entry paths alive

## validation
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.analysis-sensors.spec.ts tests/smoke.update.spec.ts tests/smoke.cars.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## risks / tradeoffs
- callers that want signal-returning translated text should keep using `useUiText()`; this change only removes the closure-returning path
- `getUiText()` is still render-safe because it reads the language signal directly at the call site

Closes #2545
