### PR TITLE
refactor(ui): collapse car wizard refs

### DIFF
--- a/apps/ui/src/app/views/cars_wizard_focus.ts
+++ b/apps/ui/src/app/views/cars_wizard_focus.ts
@@ -4,11 +4,22 @@ import type { CarsFeatureFocusTarget } from "../features/cars_feature_workflow";
 import { useSignalEffect, type ReadonlySignal } from "../ui_signals";
 import type { CarsWizardRenderModel } from "./car_wizard_view";
 
-export type CarsWizardOptionRefs = {
+export type CarsWizardFocusElements = {
+  addCarWizard: HTMLDivElement | null;
   brandOption: HTMLButtonElement | null;
+  closeButton: HTMLButtonElement | null;
+  customBrandInput: HTMLInputElement | null;
+  customModelInput: HTMLInputElement | null;
+  customTypeInput: HTMLInputElement | null;
+  finalDriveInput: HTMLInputElement | null;
   gearboxOption: HTMLButtonElement | null;
+  manualAddButton: HTMLButtonElement | null;
   modelOption: HTMLButtonElement | null;
+  rimInput: HTMLInputElement | null;
+  tireAspectInput: HTMLInputElement | null;
   tireOption: HTMLButtonElement | null;
+  tireWidthInput: HTMLInputElement | null;
+  topGearInput: HTMLInputElement | null;
   typeOption: HTMLButtonElement | null;
   variantOption: HTMLButtonElement | null;
 };
@@ -18,46 +29,46 @@ export type CarsWizardFocusRequest = {
   token: number;
 };
 
-type CarsWizardFocusRefs = {
-  closeButton: HTMLButtonElement | null;
-  customBrandInput: HTMLInputElement | null;
-  customModelInput: HTMLInputElement | null;
-  customTypeInput: HTMLInputElement | null;
-  finalDriveInput: HTMLInputElement | null;
-  manualAddButton: HTMLButtonElement | null;
-  optionRefs: CarsWizardOptionRefs;
-  rimInput: HTMLInputElement | null;
-  tireAspectInput: HTMLInputElement | null;
-  tireWidthInput: HTMLInputElement | null;
-  topGearInput: HTMLInputElement | null;
-};
-
 export type CarsWizardElementRefs = {
-  addCarWizardRef: { current: HTMLDivElement | null };
-  optionRefs: { current: CarsWizardOptionRefs };
-  wizardCloseBtnRef: { current: HTMLButtonElement | null };
-  wizardCustomBrandInputRef: { current: HTMLInputElement | null };
-  wizardCustomModelInputRef: { current: HTMLInputElement | null };
-  wizardCustomTypeInputRef: { current: HTMLInputElement | null };
-  wizardManualAddBtnRef: { current: HTMLButtonElement | null };
-  wizFinalDriveInputRef: { current: HTMLInputElement | null };
-  wizGearRatioInputRef: { current: HTMLInputElement | null };
-  wizRimInputRef: { current: HTMLInputElement | null };
-  wizTireAspectInputRef: { current: HTMLInputElement | null };
-  wizTireWidthInputRef: { current: HTMLInputElement | null };
+  elements: { current: CarsWizardFocusElements };
+  setElementRef: <Key extends keyof CarsWizardFocusElements>(
+    key: Key,
+  ) => (element: CarsWizardFocusElements[Key]) => void;
 };
 
 function focusElement(target: HTMLElement | null | undefined): void {
   target?.focus();
 }
 
+function createCarsWizardFocusElements(): CarsWizardFocusElements {
+  return {
+    addCarWizard: null,
+    brandOption: null,
+    closeButton: null,
+    customBrandInput: null,
+    customModelInput: null,
+    customTypeInput: null,
+    finalDriveInput: null,
+    gearboxOption: null,
+    manualAddButton: null,
+    modelOption: null,
+    rimInput: null,
+    tireAspectInput: null,
+    tireOption: null,
+    tireWidthInput: null,
+    topGearInput: null,
+    typeOption: null,
+    variantOption: null,
+  };
+}
+
 export function resolveWizardFocusTarget(
   target: CarsFeatureFocusTarget,
-  refs: CarsWizardFocusRefs,
+  refs: CarsWizardFocusElements,
 ): HTMLElement | null {
   switch (target) {
     case "brand-option":
-      return refs.optionRefs.brandOption ?? refs.customBrandInput;
+      return refs.brandOption ?? refs.customBrandInput;
     case "close":
       return refs.closeButton;
     case "custom-brand":
@@ -69,7 +80,7 @@ export function resolveWizardFocusTarget(
     case "finish":
       return refs.manualAddButton;
     case "gearbox-option":
-      return refs.optionRefs.gearboxOption ?? refs.manualAddButton;
+      return refs.gearboxOption ?? refs.manualAddButton;
     case "manual-final-drive":
       return refs.finalDriveInput;
     case "manual-rim":
@@ -81,13 +92,13 @@ export function resolveWizardFocusTarget(
     case "manual-top-gear":
       return refs.topGearInput;
     case "model-option":
-      return refs.optionRefs.modelOption ?? refs.customModelInput;
+      return refs.modelOption ?? refs.customModelInput;
     case "spec-selection":
-      return refs.optionRefs.tireOption ?? refs.optionRefs.gearboxOption ?? refs.tireWidthInput;
+      return refs.tireOption ?? refs.gearboxOption ?? refs.tireWidthInput;
     case "type-option":
-      return refs.optionRefs.typeOption ?? refs.customTypeInput;
+      return refs.typeOption ?? refs.customTypeInput;
     case "variant-option":
-      return refs.optionRefs.variantOption;
+      return refs.variantOption;
   }
 }
 
@@ -99,28 +110,14 @@ export function useCarsWizardFocusManager(props: {
   wizardRefs: CarsWizardElementRefs;
 } {
   const addCarButtonRef = useRef<HTMLButtonElement | null>(null);
-  const addCarWizardRef = useRef<HTMLDivElement | null>(null);
-  const wizardCloseBtnRef = useRef<HTMLButtonElement | null>(null);
-  const wizardCustomBrandInputRef = useRef<HTMLInputElement | null>(null);
-  const wizardCustomModelInputRef = useRef<HTMLInputElement | null>(null);
-  const wizardCustomTypeInputRef = useRef<HTMLInputElement | null>(null);
-  const wizardManualAddBtnRef = useRef<HTMLButtonElement | null>(null);
-  const wizFinalDriveInputRef = useRef<HTMLInputElement | null>(null);
-  const wizGearRatioInputRef = useRef<HTMLInputElement | null>(null);
-  const wizRimInputRef = useRef<HTMLInputElement | null>(null);
-  const wizTireAspectInputRef = useRef<HTMLInputElement | null>(null);
-  const wizTireWidthInputRef = useRef<HTMLInputElement | null>(null);
-  const optionRefs = useRef<CarsWizardOptionRefs>({
-    brandOption: null,
-    gearboxOption: null,
-    modelOption: null,
-    tireOption: null,
-    typeOption: null,
-    variantOption: null,
-  });
+  const elements = useRef<CarsWizardFocusElements>(createCarsWizardFocusElements());
   const lastReturnFocusTargetRef = useRef<HTMLElement | null>(null);
   const lastHandledFocusRequestTokenRef = useRef(0);
   const lastWizardOpenStateRef = useRef(props.state.value.wizardModel?.value.isOpen ?? false);
+
+  const setElementRef: CarsWizardElementRefs["setElementRef"] = (key) => (element) => {
+    elements.current[key] = element;
+  };
 
   useSignalEffect(() => {
     const isOpen = props.state.value.wizardModel?.value.isOpen ?? false;
@@ -132,8 +129,8 @@ export function useCarsWizardFocusManager(props: {
       lastReturnFocusTargetRef.current =
         activeElement && activeElement !== document.body ? activeElement : addCarButtonRef.current;
       queueMicrotask(() => {
-        if (addCarWizardRef.current) {
-          addCarWizardRef.current.scrollTop = 0;
+        if (elements.current.addCarWizard) {
+          elements.current.addCarWizard.scrollTop = 0;
         }
       });
     }
@@ -158,39 +155,15 @@ export function useCarsWizardFocusManager(props: {
     }
     lastHandledFocusRequestTokenRef.current = wizardFocusRequest.token;
     queueMicrotask(() => {
-      focusElement(
-        resolveWizardFocusTarget(wizardFocusRequest.target, {
-          closeButton: wizardCloseBtnRef.current,
-          customBrandInput: wizardCustomBrandInputRef.current,
-          customModelInput: wizardCustomModelInputRef.current,
-          customTypeInput: wizardCustomTypeInputRef.current,
-          finalDriveInput: wizFinalDriveInputRef.current,
-          manualAddButton: wizardManualAddBtnRef.current,
-          optionRefs: optionRefs.current,
-          rimInput: wizRimInputRef.current,
-          tireAspectInput: wizTireAspectInputRef.current,
-          tireWidthInput: wizTireWidthInputRef.current,
-          topGearInput: wizGearRatioInputRef.current,
-        }),
-      );
+      focusElement(resolveWizardFocusTarget(wizardFocusRequest.target, elements.current));
     });
   });
 
   return {
     addCarButtonRef,
     wizardRefs: {
-      addCarWizardRef,
-      optionRefs,
-      wizardCloseBtnRef,
-      wizardCustomBrandInputRef,
-      wizardCustomModelInputRef,
-      wizardCustomTypeInputRef,
-      wizardManualAddBtnRef,
-      wizFinalDriveInputRef,
-      wizGearRatioInputRef,
-      wizRimInputRef,
-      wizTireAspectInputRef,
-      wizTireWidthInputRef,
+      elements,
+      setElementRef,
     },
   };
 }

--- a/apps/ui/src/app/views/cars_wizard_panel.tsx
+++ b/apps/ui/src/app/views/cars_wizard_panel.tsx
@@ -77,7 +77,7 @@ export function CarsWizardPanel(props: {
         data-spec-branch={wizardModel.specBranch ?? undefined}
         tabIndex={-1}
         onKeyDown={handleWizardKeyDown}
-        ref={refs.addCarWizardRef}
+        ref={refs.setElementRef("addCarWizard")}
       >
         <div class="wizard-header">
           <div class="wizard-header__text">
@@ -99,7 +99,7 @@ export function CarsWizardPanel(props: {
             class="btn btn--muted wizard-close"
             aria-label="Close wizard"
             onClick={closeWizard}
-            ref={refs.wizardCloseBtnRef}
+            ref={refs.setElementRef("closeButton")}
           >
             {"\u00d7"}
           </button>
@@ -146,7 +146,7 @@ export function CarsWizardPanel(props: {
                   hidden={!wizardModel.finishVisible}
                   disabled={!wizardModel.finishEnabled}
                   onClick={() => actions?.onAction({ type: "finish" })}
-                  ref={refs.wizardManualAddBtnRef}
+                  ref={refs.setElementRef("manualAddButton")}
                 >
                   {t("settings.car.finish_add", "Add Car")}
                 </button>

--- a/apps/ui/src/app/views/cars_wizard_sections.tsx
+++ b/apps/ui/src/app/views/cars_wizard_sections.tsx
@@ -44,10 +44,10 @@ function wizardOptionAttributeProps(
 }
 
 function submitCurrentInputValue(
-  inputRef: { current: HTMLInputElement | null },
+  input: HTMLInputElement | null,
   onSubmit: (value: string) => void,
 ): void {
-  onSubmit(inputRef.current?.value?.trim() ?? "");
+  onSubmit(input?.value?.trim() ?? "");
 }
 
 function WizardOptionButton(props: {
@@ -103,14 +103,16 @@ function WizardCustomEntry(props: {
   buttonId: string;
   className?: string;
   inputId: string;
-  inputRef: { current: HTMLInputElement | null };
+  inputKey: "customBrandInput" | "customModelInput" | "customTypeInput";
   intro?: ComponentChildren;
   labelText: string;
   maxLength: number;
+  refs: CarsWizardElementRefs;
   placeholder: string;
   onSubmit(value: string): void;
 }) {
-  const { buttonId, className, inputId, inputRef, intro, labelText, maxLength, onSubmit, placeholder } = props;
+  const { buttonId, className, inputId, inputKey, intro, labelText, maxLength, onSubmit, placeholder, refs } =
+    props;
   return (
     <div class={className ?? "wizard-custom"}>
       {intro}
@@ -120,12 +122,12 @@ function WizardCustomEntry(props: {
         type="text"
         maxLength={maxLength}
         placeholder={placeholder}
-        ref={inputRef}
+        ref={refs.setElementRef(inputKey)}
       />
       <button
         id={buttonId}
         class="btn btn--primary"
-        onClick={() => submitCurrentInputValue(inputRef, onSubmit)}
+        onClick={() => submitCurrentInputValue(refs.elements.current[inputKey], onSubmit)}
       >
         {t("settings.car.use_custom", "Use Custom")}
       </button>
@@ -152,7 +154,7 @@ function CarsManualInputForm(props: {
           step="1"
           value={wizardModel.manualInputs.tireWidth}
           onInput={(event) => emitManualInputs("tireWidth", event.currentTarget.value)}
-          ref={refs.wizTireWidthInputRef}
+          ref={refs.setElementRef("tireWidthInput")}
         />
       </div>
       <div class="field">
@@ -166,7 +168,7 @@ function CarsManualInputForm(props: {
           step="1"
           value={wizardModel.manualInputs.tireAspect}
           onInput={(event) => emitManualInputs("tireAspect", event.currentTarget.value)}
-          ref={refs.wizTireAspectInputRef}
+          ref={refs.setElementRef("tireAspectInput")}
         />
       </div>
       <div class="field">
@@ -180,7 +182,7 @@ function CarsManualInputForm(props: {
           step="0.5"
           value={wizardModel.manualInputs.rim}
           onInput={(event) => emitManualInputs("rim", event.currentTarget.value)}
-          ref={refs.wizRimInputRef}
+          ref={refs.setElementRef("rimInput")}
         />
       </div>
       <div class="field">
@@ -194,7 +196,7 @@ function CarsManualInputForm(props: {
           min="0.1"
           value={wizardModel.manualInputs.finalDrive}
           onInput={(event) => emitManualInputs("finalDrive", event.currentTarget.value)}
-          ref={refs.wizFinalDriveInputRef}
+          ref={refs.setElementRef("finalDriveInput")}
         />
       </div>
       <div class="field">
@@ -208,7 +210,7 @@ function CarsManualInputForm(props: {
           min="0.1"
           value={wizardModel.manualInputs.topGear}
           onInput={(event) => emitManualInputs("topGear", event.currentTarget.value)}
-          ref={refs.wizGearRatioInputRef}
+          ref={refs.setElementRef("topGearInput")}
         />
       </div>
     </div>
@@ -232,18 +234,17 @@ function WizardBrandStep(props: {
         id="wizardBrandList"
         onSelectOption={(item) => onSelectBrand(item.value)}
         section={section}
-        firstOptionRef={(element) => {
-          refs.optionRefs.current.brandOption = element;
-        }}
+        firstOptionRef={refs.setElementRef("brandOption")}
       />
       <WizardCustomEntry
         buttonId="wizardCustomBrandBtn"
         inputId="wizardCustomBrand"
-        inputRef={refs.wizardCustomBrandInputRef}
+        inputKey="customBrandInput"
         labelText={t("settings.car.or_custom_brand", "Or type a custom brand:")}
         maxLength={32}
         onSubmit={onSubmitCustomBrand}
         placeholder="e.g. Mercedes-Benz"
+        refs={refs}
       />
     </div>
   );
@@ -266,18 +267,17 @@ function WizardTypeStep(props: {
         id="wizardTypeList"
         onSelectOption={(item) => onSelectType(item.value)}
         section={section}
-        firstOptionRef={(element) => {
-          refs.optionRefs.current.typeOption = element;
-        }}
+        firstOptionRef={refs.setElementRef("typeOption")}
       />
       <WizardCustomEntry
         buttonId="wizardCustomTypeBtn"
         inputId="wizardCustomType"
-        inputRef={refs.wizardCustomTypeInputRef}
+        inputKey="customTypeInput"
         labelText={t("settings.car.or_custom_type", "Or type a custom type:")}
         maxLength={32}
         onSubmit={onSubmitCustomType}
         placeholder="e.g. Van"
+        refs={refs}
       />
     </div>
   );
@@ -306,15 +306,13 @@ function WizardModelStep(props: {
           onSelectModel(index);
         }}
         section={section}
-        firstOptionRef={(element) => {
-          refs.optionRefs.current.modelOption = element;
-        }}
+        firstOptionRef={refs.setElementRef("modelOption")}
       />
       <WizardCustomEntry
         buttonId="wizardCustomModelBtn"
         className="wizard-custom wizard-custom--branch"
         inputId="wizardCustomModel"
-        inputRef={refs.wizardCustomModelInputRef}
+        inputKey="customModelInput"
         intro={(
           <>
             <strong class="wizard-branch-label">
@@ -332,6 +330,7 @@ function WizardModelStep(props: {
         maxLength={64}
         onSubmit={onSubmitCustomModel}
         placeholder="e.g. C-Class W205"
+        refs={refs}
       />
     </div>
   );
@@ -359,9 +358,7 @@ function WizardVariantStep(props: {
           onSelectVariant(index);
         }}
         section={section}
-        firstOptionRef={(element) => {
-          refs.optionRefs.current.variantOption = element;
-        }}
+        firstOptionRef={refs.setElementRef("variantOption")}
       />
     </div>
   );
@@ -393,37 +390,33 @@ function WizardSpecsStep(props: {
         <h3>
           {t("settings.car.step_wheels", "Select Wheels")}
         </h3>
-        <WizardOptions
-          id="wizardTireList"
+      <WizardOptions
+        id="wizardTireList"
           onSelectOption={(item) => {
             const index = parseWizardOptionIndex(item.value);
             if (index == null) {
               return;
-            }
-            onSelectTire(index);
-          }}
-          section={wizardModel.tireOptions}
-          firstOptionRef={(element) => {
-            refs.optionRefs.current.tireOption = element;
-          }}
-        />
+          }
+          onSelectTire(index);
+        }}
+        section={wizardModel.tireOptions}
+        firstOptionRef={refs.setElementRef("tireOption")}
+      />
         <h3 class="wizard-section-title">
           {t("settings.car.step_gearbox", "Select Gearbox")}
         </h3>
-        <WizardOptions
-          id="wizardGearboxList"
+      <WizardOptions
+        id="wizardGearboxList"
           onSelectOption={(item) => {
             const index = parseWizardOptionIndex(item.value);
             if (index == null) {
               return;
-            }
-            onSelectGearbox(index);
-          }}
-          section={wizardModel.gearboxOptions}
-          firstOptionRef={(element) => {
-            refs.optionRefs.current.gearboxOption = element;
-          }}
-        />
+          }
+          onSelectGearbox(index);
+        }}
+        section={wizardModel.gearboxOptions}
+        firstOptionRef={refs.setElementRef("gearboxOption")}
+      />
       </div>
       <div class="wizard-branch-divider">
         <span>

--- a/apps/ui/tests/cars_wizard_focus.spec.ts
+++ b/apps/ui/tests/cars_wizard_focus.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  resolveWizardFocusTarget,
+  type CarsWizardFocusElements,
+} from "../src/app/views/cars_wizard_focus";
+
+function makeFocusElements(
+  overrides: Partial<CarsWizardFocusElements> = {},
+): CarsWizardFocusElements {
+  return {
+    addCarWizard: null,
+    brandOption: null,
+    closeButton: null,
+    customBrandInput: null,
+    customModelInput: null,
+    customTypeInput: null,
+    finalDriveInput: null,
+    gearboxOption: null,
+    manualAddButton: null,
+    modelOption: null,
+    rimInput: null,
+    tireAspectInput: null,
+    tireOption: null,
+    tireWidthInput: null,
+    topGearInput: null,
+    typeOption: null,
+    variantOption: null,
+    ...overrides,
+  };
+}
+
+test.describe("resolveWizardFocusTarget", () => {
+  test("falls back from option targets to the matching manual control", () => {
+    const customBrandInput = {} as HTMLInputElement;
+    const customModelInput = {} as HTMLInputElement;
+    const customTypeInput = {} as HTMLInputElement;
+    const manualAddButton = {} as HTMLButtonElement;
+    const tireWidthInput = {} as HTMLInputElement;
+
+    const refs = makeFocusElements({
+      customBrandInput,
+      customModelInput,
+      customTypeInput,
+      manualAddButton,
+      tireWidthInput,
+    });
+
+    expect(resolveWizardFocusTarget("brand-option", refs)).toBe(customBrandInput);
+    expect(resolveWizardFocusTarget("model-option", refs)).toBe(customModelInput);
+    expect(resolveWizardFocusTarget("type-option", refs)).toBe(customTypeInput);
+    expect(resolveWizardFocusTarget("gearbox-option", refs)).toBe(manualAddButton);
+    expect(resolveWizardFocusTarget("spec-selection", refs)).toBe(tireWidthInput);
+  });
+
+  test("prefers the first available option control before fallback inputs", () => {
+    const tireOption = {} as HTMLButtonElement;
+    const gearboxOption = {} as HTMLButtonElement;
+    const tireWidthInput = {} as HTMLInputElement;
+    const brandOption = {} as HTMLButtonElement;
+    const customBrandInput = {} as HTMLInputElement;
+
+    expect(
+      resolveWizardFocusTarget(
+        "spec-selection",
+        makeFocusElements({ gearboxOption, tireOption, tireWidthInput }),
+      ),
+    ).toBe(tireOption);
+    expect(
+      resolveWizardFocusTarget(
+        "gearbox-option",
+        makeFocusElements({ gearboxOption, manualAddButton: {} as HTMLButtonElement }),
+      ),
+    ).toBe(gearboxOption);
+    expect(
+      resolveWizardFocusTarget(
+        "brand-option",
+        makeFocusElements({ brandOption, customBrandInput }),
+      ),
+    ).toBe(brandOption);
+  });
+});


### PR DESCRIPTION
## What changed
- replace 13 separate wizard element refs with one typed ref bag in `useCarsWizardFocusManager()`
- flatten option refs into the same bag and resolve focus directly from keyed elements
- switch wizard panel/sections to callback refs and add focused `cars_wizard_focus.spec.ts`

## Why
- cuts ref boilerplate and makes new focus targets a single keyed change instead of a new threaded ref path
- keeps the focus fallback rules in one place

## Validation
- `cd apps/ui && npx playwright test tests/cars_wizard_focus.spec.ts tests/smoke.cars.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- callback refs replace mutable ref objects in the wizard view path, so the risk is concentrated in ref wiring
- the new focused resolver spec locks the fallback order

Closes #2546