### PR TITLE
refactor(ui): share tablist key nav

### DIFF
--- a/apps/ui/src/app/dom/tab_list_keyboard_navigation.ts
+++ b/apps/ui/src/app/dom/tab_list_keyboard_navigation.ts
@@ -1,0 +1,47 @@
+import type { JSX } from "preact";
+
+export function normalizeTabListIndex(index: number, count: number): number {
+  if (count <= 0) {
+    return 0;
+  }
+  return ((index % count) + count) % count;
+}
+
+export function handleTabListKeyboardNavigation<TTabId>(props: {
+  count: number;
+  event: JSX.TargetedKeyboardEvent<HTMLButtonElement>;
+  focusTabAt(index: number): void;
+  getTabIdAt(index: number): TTabId;
+  index: number;
+  onActivateTab(tabId: TTabId): void;
+}): void {
+  const { count, event, focusTabAt, getTabIdAt, index, onActivateTab } = props;
+  if (count <= 0) {
+    return;
+  }
+
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    onActivateTab(getTabIdAt(index));
+    return;
+  }
+
+  let nextIndex: number | null = null;
+  if (event.key === "ArrowRight") {
+    nextIndex = normalizeTabListIndex(index + 1, count);
+  } else if (event.key === "ArrowLeft") {
+    nextIndex = normalizeTabListIndex(index - 1, count);
+  } else if (event.key === "Home") {
+    nextIndex = 0;
+  } else if (event.key === "End") {
+    nextIndex = count - 1;
+  }
+
+  if (nextIndex === null) {
+    return;
+  }
+
+  event.preventDefault();
+  onActivateTab(getTabIdAt(nextIndex));
+  focusTabAt(nextIndex);
+}

--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -8,6 +8,10 @@ import {
   type UiPanelHostRegistry,
 } from "../ui_panel_host_registry";
 import {
+  handleTabListKeyboardNavigation,
+  normalizeTabListIndex,
+} from "../dom/tab_list_keyboard_navigation";
+import {
   useComputed,
   useSignalProperties,
   signal,
@@ -198,10 +202,6 @@ const DEFAULT_DIALOG_MODEL: UiShellChromeDialogModel = {
 
 function noop(): void {
   return;
-}
-
-function normalizeMenuIndex(index: number): number {
-  return ((index % SHELL_NAV_ITEMS.length) + SHELL_NAV_ITEMS.length) % SHELL_NAV_ITEMS.length;
 }
 
 function SettingsFeedbackSlot(props: {
@@ -399,44 +399,21 @@ function ShellNavigation(props: {
   }
 
   function focusMenuButton(nextIndex: number): void {
-    menuButtonRefs.current[normalizeMenuIndex(nextIndex)]?.focus();
+    menuButtonRefs.current[normalizeTabListIndex(nextIndex, navItems.value.length)]?.focus();
   }
 
   function handleMenuKeyDown(
     index: number,
     event: JSX.TargetedKeyboardEvent<HTMLButtonElement>,
   ): void {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      activateView(navItems.value[index].viewId);
-      return;
-    }
-    if (event.key === "ArrowRight") {
-      event.preventDefault();
-      const nextIndex = normalizeMenuIndex(index + 1);
-      activateView(navItems.value[nextIndex].viewId);
-      focusMenuButton(nextIndex);
-      return;
-    }
-    if (event.key === "ArrowLeft") {
-      event.preventDefault();
-      const nextIndex = normalizeMenuIndex(index - 1);
-      activateView(navItems.value[nextIndex].viewId);
-      focusMenuButton(nextIndex);
-      return;
-    }
-    if (event.key === "Home") {
-      event.preventDefault();
-      activateView(navItems.value[0].viewId);
-      focusMenuButton(0);
-      return;
-    }
-    if (event.key === "End") {
-      event.preventDefault();
-      const nextIndex = navItems.value.length - 1;
-      activateView(navItems.value[nextIndex].viewId);
-      focusMenuButton(nextIndex);
-    }
+    handleTabListKeyboardNavigation({
+      count: navItems.value.length,
+      event,
+      focusTabAt: focusMenuButton,
+      getTabIdAt: (nextIndex) => navItems.value[nextIndex].viewId,
+      index,
+      onActivateTab: activateView,
+    });
   }
 
   return (

--- a/apps/ui/src/app/views/settings_shell.tsx
+++ b/apps/ui/src/app/views/settings_shell.tsx
@@ -2,6 +2,10 @@ import { render, type JSX } from "preact";
 import { useRef } from "preact/hooks";
 
 import {
+  handleTabListKeyboardNavigation,
+  normalizeTabListIndex,
+} from "../dom/tab_list_keyboard_navigation";
+import {
   createUiSettingsPanelHostRefs,
   resolveUiSettingsPanelHosts,
   type UiSettingsPanelHostRefs,
@@ -80,10 +84,6 @@ function isSettingsShellTabId(value: string): value is SettingsShellTabId {
   return SETTINGS_TABS.some((tab) => tab.id === value);
 }
 
-function normalizeSettingsTabIndex(index: number): number {
-  return ((index % SETTINGS_TABS.length) + SETTINGS_TABS.length) % SETTINGS_TABS.length;
-}
-
 function SettingsShellTabButton(props: {
   activeTabId: ReadonlySignal<SettingsShellTabId>;
   index: number;
@@ -102,37 +102,14 @@ function SettingsShellTabButton(props: {
   function handleTabKeyDown(
     event: JSX.TargetedKeyboardEvent<HTMLButtonElement>,
   ): void {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      onActivateTab(tab.id);
-      return;
-    }
-    if (event.key === "ArrowRight") {
-      event.preventDefault();
-      const nextIndex = normalizeSettingsTabIndex(index + 1);
-      onActivateTab(SETTINGS_TABS[nextIndex].id);
-      props.onFocusTab(nextIndex);
-      return;
-    }
-    if (event.key === "ArrowLeft") {
-      event.preventDefault();
-      const nextIndex = normalizeSettingsTabIndex(index - 1);
-      onActivateTab(SETTINGS_TABS[nextIndex].id);
-      props.onFocusTab(nextIndex);
-      return;
-    }
-    if (event.key === "Home") {
-      event.preventDefault();
-      onActivateTab(SETTINGS_TABS[0].id);
-      props.onFocusTab(0);
-      return;
-    }
-    if (event.key === "End") {
-      event.preventDefault();
-      const nextIndex = SETTINGS_TABS.length - 1;
-      onActivateTab(SETTINGS_TABS[nextIndex].id);
-      props.onFocusTab(nextIndex);
-    }
+    handleTabListKeyboardNavigation({
+      count: SETTINGS_TABS.length,
+      event,
+      focusTabAt: props.onFocusTab,
+      getTabIdAt: (nextIndex) => SETTINGS_TABS[nextIndex].id,
+      index,
+      onActivateTab,
+    });
   }
 
   return (
@@ -179,7 +156,7 @@ function SettingsShell(props: SettingsShellProps) {
   const tabButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   function focusTabAtIndex(index: number): void {
-    tabButtonRefs.current[normalizeSettingsTabIndex(index)]?.focus();
+    tabButtonRefs.current[normalizeTabListIndex(index, SETTINGS_TABS.length)]?.focus();
   }
 
   return (

--- a/apps/ui/tests/tab_list_keyboard_navigation.spec.ts
+++ b/apps/ui/tests/tab_list_keyboard_navigation.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+import type { JSX } from "preact";
+
+import {
+  handleTabListKeyboardNavigation,
+  normalizeTabListIndex,
+} from "../src/app/dom/tab_list_keyboard_navigation";
+
+function makeKeyboardEvent(key: string): {
+  event: JSX.TargetedKeyboardEvent<HTMLButtonElement>;
+  wasPrevented: () => boolean;
+} {
+  let prevented = false;
+  return {
+    event: {
+      key,
+      preventDefault() {
+        prevented = true;
+      },
+    } as unknown as JSX.TargetedKeyboardEvent<HTMLButtonElement>,
+    wasPrevented: () => prevented,
+  };
+}
+
+test.describe("tab_list_keyboard_navigation", () => {
+  test("normalizes wrapped tab indexes", () => {
+    expect(normalizeTabListIndex(3, 3)).toBe(0);
+    expect(normalizeTabListIndex(-1, 3)).toBe(2);
+    expect(normalizeTabListIndex(0, 0)).toBe(0);
+  });
+
+  test("activates and focuses wrapped arrow navigation targets", () => {
+    const activated: string[] = [];
+    const focused: number[] = [];
+    const { event, wasPrevented } = makeKeyboardEvent("ArrowLeft");
+
+    handleTabListKeyboardNavigation({
+      count: 3,
+      event,
+      focusTabAt: (index) => focused.push(index),
+      getTabIdAt: (index) => ["live", "history", "settings"][index] ?? "",
+      index: 0,
+      onActivateTab: (tabId) => activated.push(tabId),
+    });
+
+    expect(wasPrevented()).toBe(true);
+    expect(activated).toEqual(["settings"]);
+    expect(focused).toEqual([2]);
+  });
+
+  test("activates current tab on enter and space without moving focus", () => {
+    for (const key of ["Enter", " "]) {
+      const activated: string[] = [];
+      const focused: number[] = [];
+      const { event, wasPrevented } = makeKeyboardEvent(key);
+
+      handleTabListKeyboardNavigation({
+        count: 3,
+        event,
+        focusTabAt: (index) => focused.push(index),
+        getTabIdAt: (index) => ["live", "history", "settings"][index] ?? "",
+        index: 1,
+        onActivateTab: (tabId) => activated.push(tabId),
+      });
+
+      expect(wasPrevented()).toBe(true);
+      expect(activated).toEqual(["history"]);
+      expect(focused).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## What changed
- add a shared tab-list keyboard helper for index wrapping and key handling
- route `ShellNavigation` and `SettingsShellTabButton` through the same helper instead of duplicated handlers
- add focused `tab_list_keyboard_navigation.spec.ts` coverage for wrap and activation behavior

## Why
- keeps the shell and settings tablists on one keyboard contract
- makes later tablist changes hit one utility instead of two copied handlers

## Validation
- `cd apps/ui && npx playwright test tests/tab_list_keyboard_navigation.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.settings-shell.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- shared key handling means future tablist quirks need to stay compatible across both current callers
- focused helper coverage plus both smoke paths keep the shared behavior pinned

Closes #2548