### PR TITLE
refactor(ui): queue demo transport payloads

### DIFF
--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -1,9 +1,11 @@
 import { EXPECTED_LIVE_PAYLOAD_SCHEMA_VERSION } from "../transport/live_models";
+import type { LiveWsPayload } from "../contracts/ws_payload_types";
 import { batchAppStateUpdates } from "./ui_app_state";
 import type { AppState } from "./ui_app_state";
 
 type DemoDeps = {
-  state: Pick<AppState, "transport" | "settings">;
+  queueTransportPayload(payload: LiveWsPayload): void;
+  state: Pick<AppState, "settings">;
 };
 
 declare global {
@@ -97,7 +99,7 @@ export function runDemoMode(deps: DemoDeps): void {
     baseNoise.push(0.0008 + (seed % 100) * 0.00004);
   }
 
-  const demoSpectra: Record<string, unknown> = {};
+  const demoSpectra: NonNullable<LiveWsPayload["spectra"]>["clients"] = {};
   const peakConfigs = [
     { hz: 12.3, amp: 0.032, db: 15.1, bucket: "l2" },
     { hz: 12.1, amp: 0.025, db: 14.0, bucket: "l2" },
@@ -128,7 +130,7 @@ export function runDemoMode(deps: DemoDeps): void {
     };
   });
 
-  const demoPayload = {
+  const demoPayload: LiveWsPayload = {
     schema_version: EXPECTED_LIVE_PAYLOAD_SCHEMA_VERSION,
     server_time: new Date().toISOString(),
     clients: demoClients,
@@ -162,7 +164,6 @@ export function runDemoMode(deps: DemoDeps): void {
   };
 
   batchAppStateUpdates(() => {
-    state.transport.wsState = "connected";
     state.settings.carsLoaded = true;
     state.settings.cars = [
       {
@@ -174,9 +175,8 @@ export function runDemoMode(deps: DemoDeps): void {
       },
     ];
     state.settings.activeCarId = "demo-car-1";
-    state.transport.hasReceivedPayload = true;
-    state.transport.pendingPayload = demoPayload;
   });
+  deps.queueTransportPayload(demoPayload);
 
   window.__vibesensorDemoCleanup = undefined;
 }

--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -1,10 +1,9 @@
 import { EXPECTED_LIVE_PAYLOAD_SCHEMA_VERSION } from "../transport/live_models";
-import type { LiveWsPayload } from "../contracts/ws_payload_types";
 import { batchAppStateUpdates } from "./ui_app_state";
 import type { AppState } from "./ui_app_state";
 
 type DemoDeps = {
-  queueTransportPayload(payload: LiveWsPayload): void;
+  queueTransportPayload(payload: unknown): void;
   state: Pick<AppState, "settings">;
 };
 
@@ -99,7 +98,22 @@ export function runDemoMode(deps: DemoDeps): void {
     baseNoise.push(0.0008 + (seed % 100) * 0.00004);
   }
 
-  const demoSpectra: NonNullable<LiveWsPayload["spectra"]>["clients"] = {};
+  const demoSpectra: Record<string, {
+    combined_spectrum_amp_g: number[];
+    freq: number[];
+    strength_metrics: {
+      noise_floor_amp_g: number;
+      peak_amp_g: number;
+      strength_bucket: string | null;
+      top_peaks: Array<{
+        amp: number;
+        hz: number;
+        strength_bucket: string | null;
+        vibration_strength_db: number;
+      }>;
+      vibration_strength_db: number;
+    };
+  }> = {};
   const peakConfigs = [
     { hz: 12.3, amp: 0.032, db: 15.1, bucket: "l2" },
     { hz: 12.1, amp: 0.025, db: 14.0, bucket: "l2" },
@@ -130,7 +144,7 @@ export function runDemoMode(deps: DemoDeps): void {
     };
   });
 
-  const demoPayload: LiveWsPayload = {
+  const demoPayload = {
     schema_version: EXPECTED_LIVE_PAYLOAD_SCHEMA_VERSION,
     server_time: new Date().toISOString(),
     clients: demoClients,

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -77,6 +77,7 @@ export class UiLiveTransportController {
     const isDemoMode = new URLSearchParams(window.location.search).has("demo");
     if (isDemoMode) {
       runDemoMode({
+        queueTransportPayload: (payload) => this.queueTransportPayload(payload),
         state: this.state,
       });
       return;
@@ -128,6 +129,14 @@ export class UiLiveTransportController {
     if (update.hasSelectedClientChanged) {
       this.sendSelection();
     }
+  }
+
+  private queueTransportPayload(payload: unknown): void {
+    batchAppStateUpdates(() => {
+      this.state.transport.wsState = "connected";
+      this.state.transport.hasReceivedPayload = true;
+      this.state.transport.pendingPayload = payload;
+    });
   }
 
   private connectWs(): void {

--- a/apps/ui/tests/demo_mode.spec.ts
+++ b/apps/ui/tests/demo_mode.spec.ts
@@ -14,18 +14,20 @@ test.describe("runDemoMode", () => {
     const selectedClientId = "aabbcc001122";
     const state = createAppState();
     state.transport.wsState = "reconnecting";
+    let queuedPayload: unknown = null;
 
     runDemoMode({
+      queueTransportPayload: (payload) => {
+        queuedPayload = payload;
+      },
       state,
     });
 
-    const adaptedPayload = adaptServerPayload(
-      unwrapAppStateValue(state.transport.pendingPayload),
-    );
+    const adaptedPayload = adaptServerPayload(queuedPayload);
 
-    expect(state.transport.wsState).toBe("connected");
-    expect(state.transport.hasReceivedPayload).toBe(true);
-    expect(state.transport.pendingPayload).not.toBeNull();
+    expect(state.transport.wsState).toBe("reconnecting");
+    expect(state.transport.hasReceivedPayload).toBe(false);
+    expect(unwrapAppStateValue(state.transport.pendingPayload)).toBeNull();
     expect(adaptedPayload.clients).toHaveLength(5);
     expect(adaptedPayload.spectra?.clients[selectedClientId]).toMatchObject({
       freq: expect.any(Array),


### PR DESCRIPTION
## What changed
- stop `runDemoMode()` from mutating the transport slice directly
- have `UiLiveTransportController` provide the payload-queue callback for demo boot
- update demo-mode tests so the helper proves it no longer writes transport state itself while the controller still exercises the shared queued path

## Why
- keeps demo mode on the same queued transport ingress path that the live UI uses
- avoids silent drift if the transport/adaptation pipeline changes later

## Validation
- `cd apps/ui && npx playwright test tests/demo_mode.spec.ts tests/ui_live_transport_controller.spec.ts tests/smoke.bootstrap.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- demo boot now depends on the controller to supply the transport queue callback
- the demo helper still seeds settings cars directly because that data does not come from the live websocket payload

Closes #2549