### PR TITLE
refactor(ui): drop dead tooltip hosts

### DIFF
--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -7,8 +7,6 @@
   </head>
   <body>
     <div id="appShellChromeRoot"></div>
-    <div id="matrixTooltip" class="matrix-tooltip"></div>
-    <div id="strengthTooltip" class="matrix-tooltip strength-tooltip"></div>
 
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/apps/ui/src/styles/components.css
+++ b/apps/ui/src/styles/components.css
@@ -282,22 +282,6 @@ button[hidden],
   color: var(--pill-warn-text);
 }
 
-.matrix-tooltip {
-  position: fixed;
-  z-index: 50;
-  max-width: 320px;
-  display: none;
-  pointer-events: none;
-  background: var(--tooltip-bg);
-  color: var(--tooltip-fg);
-  border-radius: var(--radius-sm);
-  padding: var(--space-2) var(--space-3);
-  font-size: 0.82rem;
-  line-height: 1.3;
-  white-space: pre-line;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
-}
-
 .app-modal-layer {
   position: fixed;
   inset: 0;

--- a/apps/ui/src/styles/theme.css
+++ b/apps/ui/src/styles/theme.css
@@ -92,9 +92,6 @@
 
   .uplot .u-select { background: rgba(167, 139, 250, 0.15); }
 
-  .matrix-tooltip {
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
-  }
 }
 
 /* ── Drive / tablet sizing mode ────────────────────────────── */


### PR DESCRIPTION
## What changed
- remove the two static tooltip host divs from `index.html`
- delete the orphan `.matrix-tooltip` CSS and its dark-mode override

## Why
- those hosts were already dead: no runtime code reads `matrixTooltip` or `strengthTooltip` anymore
- deleting the orphan DOM keeps the shell fully Preact-owned without reintroducing fake wiring for unused elements

## Validation
- `cd apps/ui && rg -n "matrixTooltip|strengthTooltip|matrix-tooltip|strength-tooltip" . || true`
- `cd apps/ui && npx playwright test tests/smoke.spectrum.spec.ts tests/smoke.bootstrap.spec.ts`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- this assumes the old tooltip hosts are truly dead; repo-wide search found no remaining runtime consumers
- the spectrum and bootstrap smoke paths cover the main surfaces that would have noticed missing tooltip DOM

Closes #2550