### PR TITLE
refactor(ui): make ws client a factory

### DIFF
--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -1,7 +1,7 @@
 import { adaptServerPayload } from "../../server_payload";
 import type { AdaptedPayload } from "../../transport/live_models";
 import { runDemoMode } from "../demo_mode";
-import { WsClient } from "../../ws";
+import { createWsClient } from "../../ws";
 import {
   applyLivePayloadUpdate,
   batchAppStateUpdates,
@@ -34,6 +34,21 @@ export class UiLiveTransportController {
   }
 
   private bindTransportSignalSync(): void {
+    effect(() => {
+      trackAppStateSlice(this.state.transport);
+      const ws = this.state.transport.ws;
+      if (!ws) {
+        return;
+      }
+      const nextWsState = ws.uiState.value;
+      if (this.state.transport.wsState === nextWsState) {
+        return;
+      }
+      batchAppStateUpdates(() => {
+        this.state.transport.wsState = nextWsState;
+      });
+    });
+
     let previousPendingPayload = unwrapAppStateValue(this.state.transport.pendingPayload);
     let pendingPayloadInitialized = false;
     effect(() => {
@@ -141,9 +156,12 @@ export class UiLiveTransportController {
 
   private connectWs(): void {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    this.state.transport.ws = new WsClient({
+    this.state.transport.ws = createWsClient({
       url: `${protocol}//${window.location.host}/ws`,
-      transport: this.state.transport,
+      onMessage: (payload) => {
+        this.state.transport.hasReceivedPayload = true;
+        this.state.transport.pendingPayload = payload;
+      },
     });
     this.state.transport.ws.connect();
   }

--- a/apps/ui/src/ws.ts
+++ b/apps/ui/src/ws.ts
@@ -1,21 +1,22 @@
 import type { LiveWsPayload } from "./contracts/ws_payload_types";
 import { batchAppStateUpdates } from "./app/ui_app_state";
-import { effect, signal } from "./app/ui_signals";
+import { effect, signal, type ReadonlySignal } from "./app/ui_signals";
 
 export type WsUiState = "connecting" | "connected" | "reconnecting" | "stale" | "no_data";
-
-export interface WsTransportState {
-  wsState: WsUiState;
-  pendingPayload: unknown | null;
-  hasReceivedPayload: boolean;
-}
 
 export interface WsClientOptions {
   url: string;
   staleAfterMs?: number;
   reconnectDelayMs?: number;
   hasData?: (payload: unknown) => boolean;
-  transport: WsTransportState;
+  onMessage: (payload: unknown) => void;
+}
+
+export interface WsClient {
+  readonly uiState: ReadonlySignal<WsUiState>;
+  connect(): void;
+  close(): void;
+  send(payload: { client_id: string | null }): void;
 }
 
 function hasSpectraClients(payload: unknown): boolean {
@@ -26,74 +27,77 @@ function hasSpectraClients(payload: unknown): boolean {
   return Boolean(clients && Object.keys(clients).length > 0);
 }
 
-export class WsClient {
-  private readonly options: Required<Omit<WsClientOptions, "transport">> & {
-    transport: WsTransportState;
+export function createWsClient(options: WsClientOptions): WsClient {
+  const resolvedOptions: Required<Omit<WsClientOptions, "onMessage">> & Pick<WsClientOptions, "onMessage"> = {
+    // 3s is too aggressive on weaker Pi + hotspot links and causes false stale flicker.
+    staleAfterMs: 10000,
+    reconnectDelayMs: 1200,
+    hasData: hasSpectraClients,
+    ...options,
   };
 
-  private ws: WebSocket | null = null;
-  private readonly lastMessageAtMs = signal(0);
-  private readonly hasData = signal(false);
-  private readonly manuallyClosed = signal(false);
-  private readonly reconnectAttempt = signal(0);
-  private readonly reconnectDelayMs = signal<number | null>(null);
-  private readonly socketOpen = signal(false);
+  let ws: WebSocket | null = null;
+  const uiState = signal<WsUiState>("connecting");
+  const lastMessageAtMs = signal(0);
+  const hasReceivedData = signal(false);
+  const manuallyClosed = signal(false);
+  const reconnectAttempt = signal(0);
+  const reconnectDelayMs = signal<number | null>(null);
+  const socketOpen = signal(false);
 
-  constructor(options: WsClientOptions) {
-    this.options = {
-      // 3s is too aggressive on weaker Pi + hotspot links and causes false stale flicker.
-      staleAfterMs: 10000,
-      reconnectDelayMs: 1200,
-      hasData: hasSpectraClients,
-      ...options,
-    };
-    this.bindReconnectLifecycle();
-    this.bindStaleLifecycle();
+  bindReconnectLifecycle();
+  bindStaleLifecycle();
+
+  return {
+    uiState,
+    connect,
+    close,
+    send,
+  };
+
+  function connect(): void {
+    batchAppStateUpdates(() => {
+      manuallyClosed.value = false;
+      reconnectDelayMs.value = null;
+    });
+    open("connecting");
   }
 
-  connect(): void {
+  function close(): void {
     batchAppStateUpdates(() => {
-      this.manuallyClosed.value = false;
-      this.reconnectDelayMs.value = null;
+      manuallyClosed.value = true;
+      reconnectDelayMs.value = null;
+      socketOpen.value = false;
     });
-    this.open("connecting");
-  }
-
-  close(): void {
-    batchAppStateUpdates(() => {
-      this.manuallyClosed.value = true;
-      this.reconnectDelayMs.value = null;
-      this.socketOpen.value = false;
-    });
-    if (this.ws) {
-      this.ws.close();
-      this.ws = null;
+    if (ws) {
+      ws.close();
+      ws = null;
     }
   }
 
-  send(payload: { client_id: string | null }): void {
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(payload));
+  function send(payload: { client_id: string | null }): void {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(payload));
     }
   }
 
-  private open(initialState: WsUiState): void {
+  function open(initialState: WsUiState): void {
     batchAppStateUpdates(() => {
-      this.commitState(initialState);
-      this.hasData.value = false;
-      this.lastMessageAtMs.value = 0;
-      this.socketOpen.value = false;
+      commitState(initialState);
+      hasReceivedData.value = false;
+      lastMessageAtMs.value = 0;
+      socketOpen.value = false;
     });
-    this.ws = new WebSocket(this.options.url);
+    ws = new WebSocket(resolvedOptions.url);
 
-    this.ws.onopen = () => {
+    ws.onopen = () => {
       batchAppStateUpdates(() => {
-        this.socketOpen.value = true;
-        this.commitState("no_data");
+        socketOpen.value = true;
+        commitState("no_data");
       });
     };
 
-    this.ws.onmessage = (event) => {
+    ws.onmessage = (event) => {
       let payload: unknown;
       try {
         payload = JSON.parse(event.data);
@@ -102,77 +106,76 @@ export class WsClient {
       }
       const receivedAt = Date.now();
       batchAppStateUpdates(() => {
-        this.reconnectAttempt.value = 0;
-        this.lastMessageAtMs.value = receivedAt;
-        this.hasData.value = this.hasData.value || this.options.hasData(payload);
-        this.commitState(this.hasData.value ? "connected" : "no_data");
-        this.options.transport.hasReceivedPayload = true;
-        this.options.transport.pendingPayload = payload;
+        reconnectAttempt.value = 0;
+        lastMessageAtMs.value = receivedAt;
+        hasReceivedData.value = hasReceivedData.value || resolvedOptions.hasData(payload);
+        commitState(hasReceivedData.value ? "connected" : "no_data");
+        resolvedOptions.onMessage(payload);
       });
     };
 
-    this.ws.onclose = () => {
+    ws.onclose = () => {
       batchAppStateUpdates(() => {
-        this.ws = null;
-        this.socketOpen.value = false;
-        if (this.manuallyClosed.value) {
+        ws = null;
+        socketOpen.value = false;
+        if (manuallyClosed.value) {
           return;
         }
-        this.commitState("reconnecting");
-        this.scheduleReconnect();
+        commitState("reconnecting");
+        scheduleReconnect();
       });
     };
 
-    this.ws.onerror = () => {
+    ws.onerror = () => {
       // onclose handles reconnect transitions.
     };
   }
 
-  private scheduleReconnect(): void {
-    this.reconnectDelayMs.value = this.nextReconnectDelayMs();
+  function scheduleReconnect(): void {
+    reconnectDelayMs.value = nextReconnectDelayMs();
   }
 
-  private nextReconnectDelayMs(): number {
-    const base = Math.max(250, this.options.reconnectDelayMs);
-    const exp = Math.min(6, this.reconnectAttempt.value);
+  function nextReconnectDelayMs(): number {
+    const base = Math.max(250, resolvedOptions.reconnectDelayMs);
+    const exp = Math.min(6, reconnectAttempt.value);
     const raw = Math.min(15000, base * (2 ** exp));
     const jitter = raw * 0.25 * Math.random();
-    this.reconnectAttempt.value += 1;
+    reconnectAttempt.value += 1;
     return Math.round(raw + jitter);
   }
 
-  private bindReconnectLifecycle(): void {
+  function bindReconnectLifecycle(): void {
     effect(() => {
-      const reconnectDelayMs = this.reconnectDelayMs.value;
-      if (reconnectDelayMs === null || this.manuallyClosed.value) {
+      const pendingReconnectDelayMs = reconnectDelayMs.value;
+      if (pendingReconnectDelayMs === null || manuallyClosed.value) {
         return;
       }
       const timeoutId = window.setTimeout(() => {
         batchAppStateUpdates(() => {
-          this.reconnectDelayMs.value = null;
+          reconnectDelayMs.value = null;
         });
-        this.open("reconnecting");
-      }, reconnectDelayMs);
+        open("reconnecting");
+      }, pendingReconnectDelayMs);
       return () => {
         window.clearTimeout(timeoutId);
       };
     });
   }
 
-  private bindStaleLifecycle(): void {
+  function bindStaleLifecycle(): void {
     effect(() => {
       if (
-        !this.socketOpen.value
-        || this.manuallyClosed.value
-        || !this.hasData.value
-        || this.lastMessageAtMs.value <= 0
+        !socketOpen.value
+        || manuallyClosed.value
+        || !hasReceivedData.value
+        || lastMessageAtMs.value <= 0
       ) {
         return;
       }
-      const lastMessageAtMs = this.lastMessageAtMs.value;
+      const mostRecentMessageAtMs = lastMessageAtMs.value;
       const intervalId = window.setInterval(() => {
-        if (Date.now() - lastMessageAtMs > this.options.staleAfterMs) {
-          this.setState("stale");
+        if (Date.now() - mostRecentMessageAtMs > resolvedOptions.staleAfterMs) {
+          setState("stale");
         }
       }, 1000);
       return () => {
@@ -181,14 +184,16 @@ export class WsClient {
     });
   }
 
-  private setState(next: WsUiState): void {
+  function setState(next: WsUiState): void {
     batchAppStateUpdates(() => {
-      this.commitState(next);
+      commitState(next);
     });
   }
 
-  private commitState(next: WsUiState): void {
-    if (this.options.transport.wsState === next) return;
-    this.options.transport.wsState = next;
+  function commitState(next: WsUiState): void {
+    if (uiState.value === next) {
+      return;
+    }
+    uiState.value = next;
   }
 }

--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { EXPECTED_SCHEMA_VERSION, type LiveWsPayload } from "../src/contracts/ws_payload_types";
 import { UiLiveTransportController } from "../src/app/runtime/ui_live_transport_controller";
 import { createAppState } from "../src/app/ui_app_state";
+import { signal } from "../src/app/ui_signals";
 import { flushAsyncWork, installWindowGlobal } from "./async_test_helpers";
 
 function makeLivePayload(overrides: Partial<LiveWsPayload> = {}): LiveWsPayload {
@@ -83,6 +84,9 @@ test.describe("UiLiveTransportController", () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
     state.transport.ws = {
+      uiState: signal("connecting"),
+      close() {},
+      connect() {},
       send(selection: { client_id: string | null }) {
         sentSelections.push(selection);
       },
@@ -116,7 +120,11 @@ test.describe("UiLiveTransportController", () => {
   test("sends the current client selection when websocket state becomes ready", async () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
+    const wsUiState = signal("connecting");
     state.transport.ws = {
+      uiState: wsUiState,
+      close() {},
+      connect() {},
       send(selection: { client_id: string | null }) {
         sentSelections.push(selection);
       },
@@ -128,17 +136,41 @@ test.describe("UiLiveTransportController", () => {
       payloadErrorMessage: () => "payload error",
     });
 
-    state.transport.wsState = "no_data";
+    wsUiState.value = "no_data";
     await flushAsyncWork();
-    state.transport.wsState = "connected";
+    wsUiState.value = "connected";
     await flushAsyncWork();
-    state.transport.wsState = "stale";
+    wsUiState.value = "stale";
     await flushAsyncWork();
 
     expect(sentSelections).toEqual([
       { client_id: "client-7" },
       { client_id: "client-7" },
     ]);
+  });
+
+  test("mirrors ws client uiState into the transport slice", async () => {
+    const state = createAppState();
+    const wsUiState = signal("connecting");
+    state.transport.ws = {
+      uiState: wsUiState,
+      close() {},
+      connect() {},
+      send() {},
+    } as unknown as typeof state.transport.ws;
+
+    new UiLiveTransportController({
+      state,
+      payloadErrorMessage: () => "payload error",
+    });
+
+    wsUiState.value = "no_data";
+    await flushAsyncWork();
+    expect(state.transport.wsState).toBe("no_data");
+
+    wsUiState.value = "connected";
+    await flushAsyncWork();
+    expect(state.transport.wsState).toBe("connected");
   });
 
   test("applies payloads without requiring feature-port attachment", () => {

--- a/apps/ui/tests/ws.spec.ts
+++ b/apps/ui/tests/ws.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-import { createAppState, unwrapAppStateValue } from "../src/app/ui_app_state";
-import { WsClient } from "../src/ws";
+import { batchAppStateUpdates, createAppState, unwrapAppStateValue } from "../src/app/ui_app_state";
+import { createWsClient } from "../src/ws";
 import { installWindowGlobal } from "./async_test_helpers";
 
 class FakeWebSocket {
@@ -120,20 +120,25 @@ function installTimeoutHarness() {
   };
 }
 
-test.describe("WsClient", () => {
+test.describe("createWsClient", () => {
   test.beforeEach(() => {
     installWindowGlobal();
     FakeWebSocket.reset();
   });
 
-  test("writes websocket state and queued payloads into the transport slice", () => {
+  test("exposes signal state and forwards queued payloads through onMessage", () => {
     const originalWebSocket = globalThis.WebSocket;
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
     try {
       const state = createAppState();
-      const client = new WsClient({
+      const client = createWsClient({
         url: "ws://example.test/ws",
-        transport: state.transport,
+        onMessage: (payload) => {
+          batchAppStateUpdates(() => {
+            state.transport.hasReceivedPayload = true;
+            state.transport.pendingPayload = payload;
+          });
+        },
       });
 
       client.connect();
@@ -142,7 +147,7 @@ test.describe("WsClient", () => {
       expect(socket?.url).toBe("ws://example.test/ws");
 
       socket?.emitOpen();
-      expect(state.transport.wsState).toBe("no_data");
+      expect(client.uiState.value).toBe("no_data");
 
       const payload = {
         spectra: {
@@ -153,7 +158,7 @@ test.describe("WsClient", () => {
       };
       socket?.emitMessage(payload);
 
-      expect(state.transport.wsState).toBe("connected");
+      expect(client.uiState.value).toBe("connected");
       expect(state.transport.hasReceivedPayload).toBe(true);
       expect(unwrapAppStateValue(state.transport.pendingPayload)).toEqual(payload);
 
@@ -171,11 +176,10 @@ test.describe("WsClient", () => {
     let now = 1_000;
     Date.now = () => now;
     try {
-      const state = createAppState();
-      const client = new WsClient({
+      const client = createWsClient({
         url: "ws://example.test/ws",
-        transport: state.transport,
         staleAfterMs: 10,
+        onMessage: () => undefined,
       });
 
       client.connect();
@@ -190,12 +194,12 @@ test.describe("WsClient", () => {
         },
       });
 
-      expect(state.transport.wsState).toBe("connected");
+      expect(client.uiState.value).toBe("connected");
 
       now += 25;
       interval.tick();
 
-      expect(state.transport.wsState).toBe("stale");
+      expect(client.uiState.value).toBe("stale");
       client.close();
     } finally {
       Date.now = originalDateNow;
@@ -209,10 +213,9 @@ test.describe("WsClient", () => {
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
     const timeouts = installTimeoutHarness();
     try {
-      const state = createAppState();
-      const client = new WsClient({
+      const client = createWsClient({
         url: "ws://example.test/ws",
-        transport: state.transport,
+        onMessage: () => undefined,
       });
 
       client.connect();
@@ -220,7 +223,7 @@ test.describe("WsClient", () => {
       socket?.emitOpen();
       socket?.close();
 
-      expect(state.transport.wsState).toBe("reconnecting");
+      expect(client.uiState.value).toBe("reconnecting");
       expect(timeouts.pendingTimeoutCount()).toBe(1);
 
       timeouts.fireNext();


### PR DESCRIPTION
## What changed
- replace the remaining `WsClient` class in `apps/ui/src/ws.ts` with `createWsClient()`
- expose signal-backed `uiState`, keep `send()` / `close()`, and move payload delivery through `onMessage`
- keep app-state transport writes in `UiLiveTransportController`, which now mirrors `ws.uiState` into `transport.wsState` and queues incoming payloads through the existing render path
- update websocket and transport-controller specs for the factory API and uiState bridge

## Why
- remove the last class-style surface in this frontend transport layer
- keep websocket state ownership inside the client while the controller stays the app-state adapter

## Validation
- `cd apps/ui && npx playwright test tests/ws.spec.ts tests/ui_live_transport_controller.spec.ts tests/demo_mode.spec.ts tests/smoke.bootstrap.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- controller tests and any future websocket stubs now need `uiState` because readiness comes from the client signal instead of direct `transport.wsState` mutation
- reconnect, stale, and queued-payload behavior intentionally stay on the existing code path

Closes #2551