### PR TITLE
refactor(ui): use signal for polling state

### DIFF
--- a/apps/ui/src/app/features/polling_controller.ts
+++ b/apps/ui/src/app/features/polling_controller.ts
@@ -1,4 +1,4 @@
-import { effect, type ReadonlySignal } from "../ui_signals";
+import { effect, signal, type ReadonlySignal } from "../ui_signals";
 import { createReplaceableTimeout } from "../timer_cleanup";
 
 export interface PollingController {
@@ -20,10 +20,10 @@ export function createPollingController(
 
   const pollTimer = createReplaceableTimeout();
   let pollGeneration = 0;
-  let pollingActive = false;
+  const pollingActive = signal(false);
 
   function schedulePoll(delayMs: number, generation: number): void {
-    if (!pollingActive || generation !== pollGeneration) return;
+    if (!pollingActive.value || generation !== pollGeneration) return;
     pollTimer.replace(() => {
       void runPoll(generation);
     }, delayMs);
@@ -39,21 +39,21 @@ export function createPollingController(
   }
 
   function restart(): void {
-    if (!pollingActive) return;
+    if (!pollingActive.value) return;
     pollGeneration += 1;
     pollTimer.clear();
     void runPoll(pollGeneration);
   }
 
   function start(): void {
-    if (pollingActive) return;
-    pollingActive = true;
+    if (pollingActive.value) return;
+    pollingActive.value = true;
     restart();
   }
 
   function stop(): void {
-    if (!pollingActive) return;
-    pollingActive = false;
+    if (!pollingActive.value) return;
+    pollingActive.value = false;
     pollGeneration += 1;
     pollTimer.clear();
   }


### PR DESCRIPTION
## What changed
- replace `createPollingController()` local `pollingActive` boolean with a signal-backed active flag
- keep the generation-based cancellation guard and the existing enabled-effect lifecycle semantics unchanged

## Why
- remove manual boolean lifecycle bookkeeping from the polling owner without changing caller behavior

## Validation
- `cd apps/ui && npx playwright test tests/polling_controller.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- intentionally narrow cleanup: the generation counter stays because it still owns async cancellation safety

Closes #2552
