### PR TITLE
refactor(ui): tighten vehicle settings types

### DIFF
--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -4,7 +4,11 @@ import type {
 } from "../../api/types";
 import { getAnalysisSettings, setAnalysisSettings } from "../../api";
 import type { FeatureServices } from "../feature_deps_base";
-import { defaultVehicleSettings, type SettingsState } from "../ui_app_state";
+import {
+  defaultVehicleSettings,
+  type SettingsState,
+  type VehicleSettings,
+} from "../ui_app_state";
 import { batch, computed, signal } from "../ui_signals";
 import type {
   AnalysisPanelFieldKey,
@@ -30,7 +34,7 @@ export const ANALYSIS_SETTING_KEYS = [
   "min_abs_band_hz",
   "max_band_half_width_pct",
   "tire_deflection_factor",
-] as const satisfies readonly (keyof AnalysisSettingsPayload)[];
+] as const satisfies readonly (keyof AnalysisSettingsPayload & keyof VehicleSettings)[];
 
 export interface SettingsAnalysisModuleDeps {
   panel: AnalysisPanelView;

--- a/apps/ui/src/app/runtime/ui_car_creation_command.ts
+++ b/apps/ui/src/app/runtime/ui_car_creation_command.ts
@@ -1,8 +1,9 @@
 import { addSettingsCar as addSettingsCarApi, setActiveSettingsCar as setActiveSettingsCarApi } from "../../api";
 import type { CarUpsertRequest, CarsPayload } from "../../api/types";
+import type { VehicleSettings } from "../ui_app_state";
 
 export interface UiCarCreationCommandDeps {
-  getVehicleSettings: () => Record<string, number>;
+  getVehicleSettings: () => VehicleSettings;
   syncCarsPayload: (payload: CarsPayload) => void;
   syncActiveCarToInputs: () => void;
   showCarCreationSuccess?: (carId: string, carName: string) => void;

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -162,7 +162,6 @@ export interface VehicleSettings {
   min_abs_band_hz: number;
   max_band_half_width_pct: number;
   tire_deflection_factor: number;
-  [key: string]: number;
 }
 
 export const defaultVehicleSettings: Readonly<VehicleSettings> = {

--- a/apps/ui/tests/ui_car_creation_command.spec.ts
+++ b/apps/ui/tests/ui_car_creation_command.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { createUiCarCreationCommand } from "../src/app/runtime/ui_car_creation_command";
 import type { CarUpsertRequest, CarsPayload } from "../src/api/types";
+import { defaultVehicleSettings } from "../src/app/ui_app_state";
 
 test.describe("createUiCarCreationCommand", () => {
   test("creates a car through the narrow runtime seam and preserves the activate-and-sync flow", async () => {
@@ -34,6 +35,7 @@ test.describe("createUiCarCreationCommand", () => {
     };
     const command = createUiCarCreationCommand({
       getVehicleSettings: () => ({
+        ...defaultVehicleSettings,
         tire_width_mm: 205,
         tire_aspect_pct: 55,
         rim_in: 16,
@@ -85,6 +87,7 @@ test.describe("createUiCarCreationCommand", () => {
         type: "SUV",
         variant: "Twin Motor",
         aspects: {
+          ...defaultVehicleSettings,
           tire_width_mm: 235,
           tire_aspect_pct: 45,
           rim_in: 19,
@@ -109,6 +112,7 @@ test.describe("createUiCarCreationCommand", () => {
     const lifecycleCalls: string[] = [];
     const command = createUiCarCreationCommand({
       getVehicleSettings: () => ({
+        ...defaultVehicleSettings,
         tire_width_mm: 205,
       }),
       syncCarsPayload: () => {


### PR DESCRIPTION
## What changed
- remove the loose `[key: string]: number` index signature from `VehicleSettings`
- tighten the real caller seams so `ui_car_creation_command.ts` takes a typed `VehicleSettings` baseline and `settings_analysis_module.ts` indexes through explicit key unions
- update the car-creation seam test to use the full typed baseline settings object

## Why
- restore real compile-time checking for well-known vehicle setting fields instead of allowing arbitrary string keys

## Validation
- `cd apps/ui && npx playwright test tests/ui_car_creation_command.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- intentionally keeps dynamic settings access only where the keys are explicitly typed unions; no broad record fallback remains

Closes #2553
