### PR TITLE
refactor(ui): inject raf api

### DIFF
--- a/apps/ui/src/app/dom/raf_animation.ts
+++ b/apps/ui/src/app/dom/raf_animation.ts
@@ -1,3 +1,5 @@
+export type RafApi = Pick<typeof globalThis, "cancelAnimationFrame" | "requestAnimationFrame">;
+
 export interface RafAnimationCallbacks {
   durationMs: number;
   onFrame: (alpha: number) => void;
@@ -14,12 +16,15 @@ export interface RafAnimation {
  * Calling `start()` cancels any in-progress loop and begins a fresh one.
  * Calling `stop()` cancels without invoking `onComplete`.
  */
-export function createRafAnimation(callbacks: RafAnimationCallbacks): RafAnimation {
+export function createRafAnimation(
+  callbacks: RafAnimationCallbacks,
+  api: RafApi = globalThis,
+): RafAnimation {
   let handle: number | null = null;
 
   const stop = (): void => {
     if (handle !== null) {
-      window.cancelAnimationFrame(handle);
+      api.cancelAnimationFrame(handle);
       handle = null;
     }
   };
@@ -32,12 +37,12 @@ export function createRafAnimation(callbacks: RafAnimationCallbacks): RafAnimati
       callbacks.onFrame(alpha);
       if (alpha >= 1) {
         handle = null;
-        callbacks.onComplete();
-        return;
-      }
-      handle = window.requestAnimationFrame(animate);
+      callbacks.onComplete();
+      return;
+    }
+      handle = api.requestAnimationFrame(animate);
     };
-    handle = window.requestAnimationFrame(animate);
+    handle = api.requestAnimationFrame(animate);
   };
 
   return { start, stop };

--- a/apps/ui/tests/raf_animation.spec.ts
+++ b/apps/ui/tests/raf_animation.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+
+import { createRafAnimation, type RafApi } from "../src/app/dom/raf_animation";
+
+function createFakeRafApi() {
+  let nextHandle = 1;
+  const scheduled = new Map<number, FrameRequestCallback>();
+  const cancelled: number[] = [];
+
+  const api: RafApi = {
+    cancelAnimationFrame(handle: number): void {
+      cancelled.push(handle);
+      scheduled.delete(handle);
+    },
+    requestAnimationFrame(callback: FrameRequestCallback): number {
+      const handle = nextHandle;
+      nextHandle += 1;
+      scheduled.set(handle, callback);
+      return handle;
+    },
+  };
+
+  return { api, cancelled, scheduled };
+}
+
+test.describe("createRafAnimation", () => {
+  test("cancels the in-flight frame before restarting or stopping", () => {
+    const { api, cancelled, scheduled } = createFakeRafApi();
+    const animation = createRafAnimation(
+      {
+        durationMs: 250,
+        onComplete: () => undefined,
+        onFrame: () => undefined,
+      },
+      api,
+    );
+
+    animation.start();
+    expect(Array.from(scheduled.keys())).toEqual([1]);
+
+    animation.start();
+    expect(cancelled).toEqual([1]);
+    expect(Array.from(scheduled.keys())).toEqual([2]);
+
+    animation.stop();
+    expect(cancelled).toEqual([1, 2]);
+    expect(scheduled.size).toBe(0);
+  });
+
+  test("drives frames and completion through the injected raf api", () => {
+    const { api, scheduled } = createFakeRafApi();
+    const alphaFrames: number[] = [];
+    let completed = 0;
+    const animation = createRafAnimation(
+      {
+        durationMs: 10,
+        onComplete: () => {
+          completed += 1;
+        },
+        onFrame: (alpha) => {
+          alphaFrames.push(alpha);
+        },
+      },
+      api,
+    );
+
+    animation.start();
+
+    const firstFrame = scheduled.get(1);
+    expect(firstFrame).toBeDefined();
+    scheduled.delete(1);
+    firstFrame?.(performance.now());
+
+    const secondFrame = scheduled.get(2);
+    expect(secondFrame).toBeDefined();
+    scheduled.delete(2);
+    secondFrame?.(performance.now() + 20);
+
+    expect(alphaFrames).toHaveLength(2);
+    expect(alphaFrames[0]).toBeGreaterThanOrEqual(0);
+    expect(alphaFrames[0]).toBeLessThan(1);
+    expect(alphaFrames[1]).toBe(1);
+    expect(completed).toBe(1);
+    expect(scheduled.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## what
- add an optional `RafApi` argument to `createRafAnimation()`, defaulting to `globalThis`
- keep existing renderer call sites unchanged
- add focused RAF coverage for restart/cancel and completion through the injected API

## why
- `timer_cleanup.ts` already accepts injectable timer APIs
- `raf_animation.ts` was the remaining timing helper still pinned to browser globals

## validation
- `cd apps/ui && npx playwright test tests/raf_animation.spec.ts tests/timer_cleanup.spec.ts tests/spectrum_canvas_renderer.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## risk
- tiny API expansion only
- existing callers stay on the same runtime path because the new parameter is optional

Closes #2554
