### PR TITLE
fix(ui): keep recovery retry enabled

### DIFF
--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -197,7 +197,7 @@ function buildActionSummary(
       ]
     : readinessItems;
   return {
-    canStart: !isRunning && !hasBlockedItem,
+    canStart: !isRunning && (isRecoveryState || !hasBlockedItem),
     startLabel: t(
       isRecoveryState ? "settings.update.retry" : "settings.update.start",
     ),

--- a/apps/ui/tests/smoke.update.spec.ts
+++ b/apps/ui/tests/smoke.update.spec.ts
@@ -526,3 +526,90 @@ test("settings update failure shows retry guidance, failed-stage retention, and 
     ),
   ).toHaveAttribute("data-stage-state", "attention");
 });
+
+test("settings update recovery keeps Retry Update enabled even when readiness stays blocked", async ({
+  page,
+}) => {
+  await installCommonRoutes(page);
+  await page.route("**/api/update/status", async (route) => {
+    await fulfillJson(route, {
+      state: "failed",
+      phase: "downloading",
+      transport: "usb_internet",
+      ssid: null,
+      uplink_interface: null,
+      started_at: 1,
+      phase_started_at: 1,
+      phase_elapsed_s: 42,
+      finished_at: 2,
+      last_success_at: null,
+      updated_at: 2,
+      issues: [
+        {
+          phase: "downloading",
+          message: "GitHub release download timed out",
+          detail: "The upstream connection dropped while fetching the release package.",
+        },
+      ],
+      log_tail: [],
+      exit_code: 28,
+      runtime: {
+        version: "1.2.3",
+        commit: "abcdef1234567890",
+        ui_source_hash: "ui-hash",
+        static_assets_hash: "feedfacecafebeef",
+        static_build_source_hash: "build-hash",
+        static_build_commit: "build-commit",
+        assets_verified: true,
+        has_packaged_static: true,
+      },
+    });
+  });
+  await page.route("**/api/health", async (route) => {
+    await fulfillJson(route, {
+      status: "degraded",
+      processing_state: "idle",
+      processing_failures: 0,
+      degradation_reasons: ["disk"],
+      data_loss: {
+        affected_clients: 0,
+        tracked_clients: 0,
+        frames_dropped: 0,
+        queue_overflow_drops: 0,
+        server_queue_drops: 0,
+        parse_errors: 0,
+      },
+      persistence: {
+        analysis_in_progress: false,
+        analysis_queue_depth: 0,
+        write_error: "disk full",
+        analysis_active_run_id: null,
+        analysis_started_at: null,
+        analysis_elapsed_s: null,
+      },
+    });
+  });
+  await page.route("**/api/update/internet-status", async (route) => {
+    await fulfillJson(route, {
+      detected: false,
+      usable: false,
+      interface_name: null,
+      connection_name: null,
+      driver: null,
+      ipv4_addresses: [],
+      gateway: null,
+      has_default_route: false,
+      diagnostic: "USB internet is not available.",
+    });
+  });
+  await installFakeWebSocket(page);
+  await page.goto("/");
+  await page.locator("#tab-settings").click();
+  await page.locator('[data-settings-tab="internetTab"]').click();
+  await expect(page.locator("#updateReadinessSummary")).toContainText(
+    "Clear the blocked item before retrying.",
+  );
+  await page.locator('[data-settings-tab="updateTab"]').click();
+  await expect(page.locator("#updateStartBtn")).toHaveText("Retry Update");
+  await expect(page.locator("#updateStartBtn")).toBeEnabled();
+});

--- a/apps/ui/tests/update_feature_presenter.spec.ts
+++ b/apps/ui/tests/update_feature_presenter.spec.ts
@@ -242,6 +242,76 @@ test.describe("buildUpdateFeaturePanelModels", () => {
       "settings.update.hide_password",
     );
   });
+
+  test("keeps retry enabled when recovery state still has blocked readiness items", () => {
+    const models = buildUpdateFeaturePanelModels(
+      {
+        internetStatus: makeInternet(),
+        healthStatus: makeHealth({
+          status: "degraded",
+          degradation_reasons: ["db"],
+          persistence: {
+            analysis_active_run_id: null,
+            analysis_elapsed_s: null,
+            analysis_in_progress: false,
+            analysis_queue_depth: 0,
+            analysis_started_at: null,
+            write_error: "disk full",
+          },
+        }),
+        updateStatus: makeStatus({
+          state: "failed",
+          phase: "downloading",
+          transport: "usb_internet",
+          issues: [
+            {
+              phase: "downloading",
+              message: "GitHub release download timed out",
+              detail: "Upstream connectivity dropped during fetch.",
+            },
+          ],
+          started_at: 1,
+          finished_at: 2,
+          exit_code: 28,
+        }),
+        updateState: "failed",
+        updateTransport: "usb_internet",
+      },
+      {
+        passwordInputValue: "",
+        passwordVisible: false,
+        selectedTransport: "usb_internet",
+        ssidInputValue: "",
+      },
+      { t },
+    );
+
+    expect(models.canStart).toBe(true);
+    expect(models.updatePanel).toMatchObject({
+      startButtonDisabled: false,
+      startButtonHidden: false,
+      startButtonLabelText: "settings.update.retry",
+    });
+    expect(models.transport).toBe("wifi");
+    expect(models.internetPanel.readiness.summary).toBe(
+      "settings.update.recovery.summary_blocked",
+    );
+    expect(models.internetPanel.readiness.items).toContainEqual({
+      label: "settings.update.recovery.item.next_step",
+      detail: "settings.update.recovery.item.next_step_blocked",
+      state: "blocked",
+    });
+    expect(models.internetPanel.transportChoices.usb_internet).toMatchObject({
+      disabled: true,
+      inputDisabled: true,
+      selected: false,
+    });
+    expect(models.internetPanel.transportChoices.wifi).toMatchObject({
+      disabled: false,
+      inputDisabled: false,
+      selected: true,
+    });
+  });
 });
 
 test.describe("createUpdateFeaturePresenter", () => {

--- a/apps/ui/tests/update_feature_workflow.spec.ts
+++ b/apps/ui/tests/update_feature_workflow.spec.ts
@@ -235,4 +235,31 @@ test.describe("createUpdateFeatureWorkflow", () => {
     expect(harness.viewCalls).toEqual(["focusSsidInput"]);
     expect(harness.errors).toEqual([]);
   });
+
+  test("still validates wifi inputs when a recovery retry bypasses readiness blocking", async () => {
+    const harness = createHarness();
+    const workflow = createUpdateFeatureWorkflow({
+      t: (key) => key,
+      showError: (message) => {
+        harness.errors.push(message);
+      },
+      view: createViewPorts(harness),
+      api: {
+        async startUpdate() {
+          throw new Error("should not be called");
+        },
+      },
+    });
+
+    await workflow.startUpdate({
+      canStart: true,
+      password: "",
+      ssid: "",
+      transport: "wifi",
+      usbAvailable: false,
+    });
+
+    expect(harness.viewCalls).toEqual(["focusSsidInput"]);
+    expect(harness.errors).toEqual([]);
+  });
 });


### PR DESCRIPTION
## what
- keep `canStart` true in non-running recovery states so `Retry Update` stays enabled
- keep transport-specific validation in the workflow path, so missing Wi-Fi SSIDs still focus the input and unavailable USB still blocks on click
- add presenter, workflow, and smoke coverage for blocked recovery retries

## why
- failed OTA states were inheriting readiness-wide blocking and greying out the retry action
- users need a direct retry path after failure without first clearing unrelated blocked readiness items

## validation
- `cd apps/ui && npx playwright test tests/update_feature_presenter.spec.ts tests/update_feature_workflow.spec.ts tests/smoke.update.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run test:visual` still shows an unrelated existing local failure set in `tests/esp_flash_feature.spec.ts` and `tests/visual.spec.ts`

## risk
- running-state behavior stays the same: start/retry remains hidden while an update is active and `Cancel Update` remains the active control

Closes #2558
