### PR TITLE
refactor(ui): drop dead shared constants

### DIFF
--- a/apps/server/tests/hygiene/test_location_codes_sync.py
+++ b/apps/server/tests/hygiene/test_location_codes_sync.py
@@ -39,9 +39,7 @@ def test_generated_ui_constants_encode_backend_locations() -> None:
     generated = _generated_constants_ts()
     assert "export const METRIC_FIELDS" not in generated
     assert "export const LOCATION_CODES" not in generated
-    assert _extract_export_json(generated, "defaultLocationCodes") == list(
-        LOCATION_CODES.keys()
-    )
+    assert _extract_export_json(generated, "defaultLocationCodes") == list(LOCATION_CODES.keys())
 
 
 def test_domain_location_codes_match_shared() -> None:

--- a/apps/server/tests/hygiene/test_location_codes_sync.py
+++ b/apps/server/tests/hygiene/test_location_codes_sync.py
@@ -1,4 +1,4 @@
-"""Guard: backend and frontend LOCATION_CODES stay in sync."""
+"""Guard: backend location codes stay in sync with generated UI constants."""
 
 from __future__ import annotations
 
@@ -10,7 +10,6 @@ import sys
 from tests._paths import REPO_ROOT
 from vibesensor.domain.sensor import _LOCATION_CODES as DOMAIN_LOCATION_CODES
 from vibesensor.shared.locations import LOCATION_CODES
-from vibesensor.shared.strength_fields import METRIC_FIELDS
 
 _GENERATOR = REPO_ROOT / "tools" / "config" / "generate_ui_shared_constants.py"
 
@@ -35,11 +34,14 @@ def _extract_export_json(module_text: str, export_name: str) -> object:
     return json.loads(match.group("value"))
 
 
-def test_generated_ui_constants_encode_backend_sources() -> None:
-    """The shared constants generator must reflect backend location and metric literals."""
+def test_generated_ui_constants_encode_backend_locations() -> None:
+    """The shared constants generator must reflect backend location literals only."""
     generated = _generated_constants_ts()
-    assert _extract_export_json(generated, "METRIC_FIELDS") == METRIC_FIELDS
-    assert _extract_export_json(generated, "LOCATION_CODES") == list(LOCATION_CODES.keys())
+    assert "export const METRIC_FIELDS" not in generated
+    assert "export const LOCATION_CODES" not in generated
+    assert _extract_export_json(generated, "defaultLocationCodes") == list(
+        LOCATION_CODES.keys()
+    )
 
 
 def test_domain_location_codes_match_shared() -> None:

--- a/tools/config/generate_ui_shared_constants.py
+++ b/tools/config/generate_ui_shared_constants.py
@@ -1,4 +1,4 @@
-"""Generate frontend constants from shared backend literal definitions."""
+"""Generate frontend constants from shared backend location definitions."""
 
 from __future__ import annotations
 
@@ -11,7 +11,6 @@ from typing import TypeGuard
 ROOT = Path(__file__).resolve().parents[2]
 SHARED_ROOT = ROOT / "apps" / "server" / "vibesensor" / "shared"
 LOCATIONS_PATH = SHARED_ROOT / "locations.py"
-STRENGTH_FIELDS_PATH = SHARED_ROOT / "strength_fields.py"
 
 
 def _is_string_dict(value: object) -> TypeGuard[dict[str, str]]:
@@ -50,14 +49,10 @@ def _load_dict_constant(module_path: Path, constant_name: str) -> dict[str, str]
 
 def render_ui_shared_constants_module() -> str:
     location_codes = _load_dict_constant(LOCATIONS_PATH, "LOCATION_CODES")
-    metric_fields = _load_dict_constant(STRENGTH_FIELDS_PATH, "METRIC_FIELDS")
     return (
-        "// Generated from apps/server/vibesensor/shared/locations.py and "
-        "apps/server/vibesensor/shared/strength_fields.py\n"
+        "// Generated from apps/server/vibesensor/shared/locations.py\n"
         "// Do not edit manually; run make sync-contracts\n\n"
-        f"export const METRIC_FIELDS = {json.dumps(metric_fields, indent=2)} as const;\n\n"
-        f"export const LOCATION_CODES = {json.dumps(list(location_codes.keys()), indent=2)} as const;\n\n"
-        "export const defaultLocationCodes = LOCATION_CODES;\n"
+        f"export const defaultLocationCodes = {json.dumps(list(location_codes.keys()), indent=2)} as const;\n"
     )
 
 


### PR DESCRIPTION
## What
- stop generating `METRIC_FIELDS` and `LOCATION_CODES` in the UI shared constants module
- emit only `defaultLocationCodes` from shared locations
- update the hygiene guard to pin the new output shape

## Why
- UI only consumes `defaultLocationCodes`
- dead exports add noise to the generated contract surface

## Validation
- `make sync-contracts`
- `pytest -q apps/server/tests/hygiene/test_location_codes_sync.py`
- `cd apps/ui && npm run typecheck && npm run build`

## Risk / edge
- `apps/ui/src/constants.ts` is a generated local derivative and stays untracked
- runtime behavior does not change; only the generated export surface shrinks

Closes #2580
