### PR TITLE
refactor(ui): drop media query fallback

### DIFF
--- a/apps/ui/src/spectrum_css_vars.ts
+++ b/apps/ui/src/spectrum_css_vars.ts
@@ -60,9 +60,5 @@ function ensureSpectrumCssVarsThemeTracking(): void {
   const refresh = () => {
     spectrumCssVarsVersion.value += 1;
   };
-  if (typeof mediaQuery.addEventListener === "function") {
-    mediaQuery.addEventListener("change", refresh);
-    return;
-  }
-  mediaQuery.addListener(refresh);
+  mediaQuery.addEventListener("change", refresh);
 }

--- a/apps/ui/tests/spectrum_css_vars.spec.ts
+++ b/apps/ui/tests/spectrum_css_vars.spec.ts
@@ -30,8 +30,8 @@ test.describe("spectrum_css_vars", () => {
         themeChangeHandler = handler;
       },
       removeEventListener: () => undefined,
-      addListener: (handler: (event: MediaQueryListEvent) => void) => {
-        themeChangeHandler = handler;
+      addListener: () => {
+        throw new Error("Deprecated MediaQueryList.addListener should not be used");
       },
       removeListener: () => undefined,
       dispatchEvent: () => false,


### PR DESCRIPTION
## What
- remove the deprecated `MediaQueryList.addListener()` fallback from `spectrum_css_vars.ts`
- simplify theme tracking to the ES2020-supported `addEventListener("change", ...)` path
- tighten the focused spec so the deprecated path throws if it is ever called again

## Why
- target browsers already support `addEventListener` on `MediaQueryList`
- the fallback adds dead branch noise to a small runtime helper

## Validation
- `cd apps/ui && npx playwright test tests/spectrum_css_vars.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck && npm run build`
- `cd apps/ui && npm run lint` (existing unrelated warnings only)

## Risk / edge
- no behavior change on supported browsers
- tests now pin the supported listener path directly

Closes #2581
