### PR TITLE
refactor(ui): compute analysis bridge state

### DIFF
--- a/apps/ui/src/app/views/analysis_panel.tsx
+++ b/apps/ui/src/app/views/analysis_panel.tsx
@@ -3,9 +3,8 @@ import { useRef } from "preact/hooks";
 
 import { getUiText as t } from "../ui_i18n";
 import {
-  effect,
+  computed,
   signal,
-  untracked,
   useSignalEffect,
   type ReadonlySignal,
 } from "../ui_signals";
@@ -233,11 +232,14 @@ function AnalysisPanel(props: {
 }
 
 export function mountAnalysisPanel(host: HTMLElement): AnalysisPanelView {
-  const bridgeState = signal<AnalysisPanelBridgeState>({
-    actions: null,
-    availability: DEFAULT_ANALYSIS_CAR_AVAILABILITY,
-    model: DEFAULT_ANALYSIS_PANEL_MODEL,
-  });
+  const actions = signal<AnalysisPanelActionHandlers | null>(null);
+  const availabilitySignal = signal<ReadonlySignal<AnalysisPanelCarAvailability> | null>(null);
+  const modelSignal = signal<ReadonlySignal<AnalysisPanelRenderModel> | null>(null);
+  const bridgeState = computed<AnalysisPanelBridgeState>(() => ({
+    actions: actions.value,
+    availability: availabilitySignal.value?.value ?? DEFAULT_ANALYSIS_CAR_AVAILABILITY,
+    model: modelSignal.value?.value ?? DEFAULT_ANALYSIS_PANEL_MODEL,
+  }));
   const inputFocusRequest = signal<AnalysisFieldFocusRequest | null>(null);
   const guidanceOpenRequest = signal(0);
   let focusRequestToken = 0;
@@ -252,25 +254,13 @@ export function mountAnalysisPanel(host: HTMLElement): AnalysisPanelView {
 
   return {
     bindActions(handlers) {
-      bridgeState.value = { ...bridgeState.value, actions: handlers };
+      actions.value = handlers;
     },
     bindCarAvailability(state) {
-      effect(() => {
-        const currentBridgeState = untracked(() => bridgeState.value);
-        bridgeState.value = {
-          ...currentBridgeState,
-          availability: state.value,
-        };
-      });
+      availabilitySignal.value = state;
     },
     bindModel(model) {
-      effect(() => {
-        const currentBridgeState = untracked(() => bridgeState.value);
-        bridgeState.value = {
-          ...currentBridgeState,
-          model: model.value,
-        };
-      });
+      modelSignal.value = model;
     },
     focusField(field) {
       focusRequestToken += 1;

--- a/apps/ui/tests/analysis_panel_signals.ts
+++ b/apps/ui/tests/analysis_panel_signals.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+
+import { signal } from "../src/app/ui_signals";
+import type {
+  AnalysisPanelCarAvailability,
+  AnalysisPanelFieldKey,
+  AnalysisPanelRenderModel,
+} from "../src/app/views/analysis_panel";
+import { mountSignalView } from "./dom_render_test_support";
+
+const ANALYSIS_FIELD_KEYS = [
+  "wheel_bandwidth_pct",
+  "driveshaft_bandwidth_pct",
+  "engine_bandwidth_pct",
+  "speed_uncertainty_pct",
+  "tire_diameter_uncertainty_pct",
+  "final_drive_uncertainty_pct",
+  "gear_uncertainty_pct",
+  "min_abs_band_hz",
+  "max_band_half_width_pct",
+] as const satisfies readonly AnalysisPanelFieldKey[];
+
+function createAnalysisModel(wheelBandwidth: string): AnalysisPanelRenderModel {
+  const fields = Object.fromEntries(
+    ANALYSIS_FIELD_KEYS.map((key) => [
+      key,
+      {
+        guidance: {
+          error: null,
+          lines:
+            key === "wheel_bandwidth_pct"
+              ? [{ label: "Current", value: `${wheelBandwidth}%` }]
+              : [],
+        },
+        invalid: false,
+        value: key === "wheel_bandwidth_pct" ? wheelBandwidth : "",
+      },
+    ]),
+  ) as AnalysisPanelRenderModel["fields"];
+  return {
+    fields,
+    saveFeedback: null,
+  };
+}
+
+function requireElement<T extends Element = HTMLElement>(root: ParentNode, selector: string): T {
+  const element = root.querySelector<T>(selector);
+  assert.ok(element, `Expected element matching ${selector}`);
+  return element;
+}
+
+async function runAnalysisPanelSignalBindingTest(): Promise<void> {
+  const harness = await mountSignalView(async () => {
+    const { mountAnalysisPanel } = await import("../src/app/views/analysis_panel");
+    return mountAnalysisPanel;
+  });
+
+  try {
+    const firstAvailability = signal<AnalysisPanelCarAvailability>({
+      hasActiveCar: false,
+      isLoading: false,
+    });
+    const secondAvailability = signal<AnalysisPanelCarAvailability>({
+      hasActiveCar: true,
+      isLoading: false,
+    });
+    const firstModel = signal(createAnalysisModel("5"));
+    const secondModel = signal(createAnalysisModel("11"));
+
+    harness.view.bindCarAvailability(firstAvailability);
+    harness.view.bindModel(firstModel);
+    await harness.flush();
+
+    const noCarMessage = requireElement<HTMLElement>(harness.host, "#analysisNoCarMessage");
+    const saveButton = requireElement<HTMLButtonElement>(harness.host, "#saveAnalysisBtn");
+    const wheelBandwidthGuidance = requireElement<HTMLElement>(harness.host, "#wheelBandwidthGuidance");
+
+    assert.equal(noCarMessage.hidden, false);
+    assert.equal(saveButton.disabled, true);
+    assert.match(wheelBandwidthGuidance.textContent ?? "", /Current 5%/);
+
+    firstAvailability.value = {
+      hasActiveCar: true,
+      isLoading: false,
+    };
+    firstModel.value = createAnalysisModel("8");
+    await harness.flush();
+
+    assert.equal(noCarMessage.hidden, true);
+    assert.equal(saveButton.disabled, false);
+    assert.match(wheelBandwidthGuidance.textContent ?? "", /Current 8%/);
+
+    harness.view.bindCarAvailability(secondAvailability);
+    harness.view.bindModel(secondModel);
+    await harness.flush();
+
+    assert.equal(noCarMessage.hidden, true);
+    assert.equal(saveButton.disabled, false);
+    assert.match(wheelBandwidthGuidance.textContent ?? "", /Current 11%/);
+
+    firstAvailability.value = {
+      hasActiveCar: false,
+      isLoading: false,
+    };
+    firstModel.value = createAnalysisModel("13");
+    await harness.flush();
+
+    assert.equal(noCarMessage.hidden, true);
+    assert.equal(saveButton.disabled, false);
+    assert.match(wheelBandwidthGuidance.textContent ?? "", /Current 11%/);
+
+    secondAvailability.value = {
+      hasActiveCar: false,
+      isLoading: false,
+    };
+    secondModel.value = createAnalysisModel("15");
+    await harness.flush();
+
+    assert.equal(noCarMessage.hidden, false);
+    assert.equal(saveButton.disabled, true);
+    assert.match(wheelBandwidthGuidance.textContent ?? "", /Current 15%/);
+  } finally {
+    harness.cleanup();
+  }
+}
+
+await runAnalysisPanelSignalBindingTest();
+console.log("PASS analysis panel signal bindings rebind without stale bridge state");


### PR DESCRIPTION
## What
- replace the analysis panel's manual bridge-state effect merges with separate source signals and one computed bridge state
- stop using `untracked()` bridge copies to push `availability` and `model` into mutable local state
- add a focused mounted signal test that proves rebinding switches to the latest model and availability sources

## Why
- the old bridge state was doing derived-state work imperatively
- the mounted signal test caught a real first-pass shadowing bug in `bindModel()`, so the seam now has direct regression coverage

## Validation
- `cd apps/ui && npx tsx tests/analysis_panel_signals.ts`
- `cd apps/ui && npx playwright test tests/settings_analysis_module.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck && npm run build`
- `cd apps/ui && npm run lint` (existing unrelated warnings only)

## Risk / edge
- localized to `analysis_panel.tsx`
- no public API change; the bridge still exposes the same methods

Closes #2582
