### PR TITLE
refactor(ui): compute speed source bridge

### DIFF
--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -3,9 +3,9 @@ import { render } from "preact";
 import type { DisplayedSpeedSourceMode } from "../speed_source_state";
 import type { ChoiceCardState } from "../view_style_types";
 import {
+  computed,
   effect,
   signal,
-  untracked,
   type ReadonlySignal,
 } from "../ui_signals";
 import { SpeedSourceConfigPanel } from "./speed_source_config_panel";
@@ -188,12 +188,21 @@ function SpeedSourcePanel(props: {
 }
 
 export function mountSpeedSourcePanel(host: HTMLElement): SpeedSourcePanelView {
-  const bridgeState = signal<SpeedSourcePanelBridgeState>({
-    actions: null,
-    diagnostics: DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL,
-    diagnosticsDisclosureOpen: false,
-    model: DEFAULT_SPEED_SOURCE_PANEL_MODEL,
+  const actions = signal<SpeedSourcePanelActionHandlers | null>(null);
+  const diagnosticsSignal = signal<ReadonlySignal<SpeedSourceDiagnosticsRenderModel> | null>(null);
+  const diagnosticsDisclosureOpen = signal(false);
+  const modelSignal = signal<ReadonlySignal<SpeedSourcePanelRenderModel> | null>(null);
+  effect(() => {
+    if (modelSignal.value?.value.diagnosticsShouldOpen) {
+      diagnosticsDisclosureOpen.value = true;
+    }
   });
+  const bridgeState = computed<SpeedSourcePanelBridgeState>(() => ({
+    actions: actions.value,
+    diagnostics: diagnosticsSignal.value?.value ?? DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL,
+    diagnosticsDisclosureOpen: diagnosticsDisclosureOpen.value,
+    model: modelSignal.value?.value ?? DEFAULT_SPEED_SOURCE_PANEL_MODEL,
+  }));
   let manualSpeedInput: HTMLInputElement | null = null;
   let obdConfig: HTMLElement | null = null;
   let scanObdDevicesBtn: HTMLButtonElement | null = null;
@@ -207,11 +216,8 @@ export function mountSpeedSourcePanel(host: HTMLElement): SpeedSourcePanelView {
         obdConfig = element;
       }}
       onDiagnosticsToggle={(event) => {
-        bridgeState.value = {
-          ...bridgeState.value,
-          diagnosticsDisclosureOpen:
-            (event.currentTarget as HTMLDetailsElement | null)?.open ?? false,
-        };
+        diagnosticsDisclosureOpen.value =
+          (event.currentTarget as HTMLDetailsElement | null)?.open ?? false;
       }}
       scanButtonRef={(element) => {
         scanObdDevicesBtn = element;
@@ -226,27 +232,13 @@ export function mountSpeedSourcePanel(host: HTMLElement): SpeedSourcePanelView {
 
   return {
     bindActions(handlers): void {
-      bridgeState.value = { ...bridgeState.value, actions: handlers };
+      actions.value = handlers;
     },
     bindDiagnostics(model): void {
-      effect(() => {
-        const currentBridgeState = untracked(() => bridgeState.value);
-        bridgeState.value = {
-          ...currentBridgeState,
-          diagnostics: model.value,
-        };
-      });
+      diagnosticsSignal.value = model;
     },
     bindModel(model): void {
-      effect(() => {
-        const currentBridgeState = untracked(() => bridgeState.value);
-        bridgeState.value = {
-          ...currentBridgeState,
-          diagnosticsDisclosureOpen:
-            currentBridgeState.diagnosticsDisclosureOpen || model.value.diagnosticsShouldOpen,
-          model: model.value,
-        };
-      });
+      modelSignal.value = model;
     },
     focusManualSpeedInput(): void {
       manualSpeedInput?.focus();

--- a/apps/ui/tests/speed_source_panel_signals.ts
+++ b/apps/ui/tests/speed_source_panel_signals.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+
+import { signal } from "../src/app/ui_signals";
+import { DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL } from "../src/app/views/speed_source_panel_defaults";
+import type {
+  SpeedSourceDiagnosticsRenderModel,
+  SpeedSourcePanelRenderModel,
+} from "../src/app/views/speed_source_panel";
+import { mountSignalView } from "./dom_render_test_support";
+
+function createSpeedSourcePanelModel(
+  currentSourceText: string,
+  diagnosticsShouldOpen: boolean,
+): SpeedSourcePanelRenderModel {
+  return {
+    choiceCards: {
+      gps: { badgeText: null, selected: true, state: null },
+      manual: { badgeText: null, selected: false, state: null },
+      obd2: { badgeText: null, selected: false, state: null },
+    },
+    diagnosticsShouldOpen,
+    manualConfigVisible: false,
+    manualSpeedFeedback: null,
+    manualSpeedInputValue: "",
+    obdConfigVisible: false,
+    obdConfiguredDeviceText: "--",
+    obdDevices: [],
+    obdScanStatusText: "Scan to discover nearby Bluetooth OBD adapters.",
+    obdSelectionInvalid: false,
+    scanObdDevicesDisabled: false,
+    saveFeedback: null,
+    selectedMode: "gps",
+    showGpsFallbackPanel: false,
+    staleTimeoutFeedback: null,
+    staleTimeoutInputValue: "10",
+    summary: {
+      currentSourceText,
+      effectiveSpeedText: `${currentSourceText} effective`,
+      fallbackActiveText: "Inactive",
+    },
+  };
+}
+
+function createDiagnosticsModel(stateText: string): SpeedSourceDiagnosticsRenderModel {
+  return {
+    gps: {
+      ...DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL.gps,
+      stateText,
+    },
+    obd: DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL.obd,
+  };
+}
+
+function requireElement<T extends Element = HTMLElement>(root: ParentNode, selector: string): T {
+  const element = root.querySelector<T>(selector);
+  assert.ok(element, `Expected element matching ${selector}`);
+  return element;
+}
+
+async function runSpeedSourcePanelSignalBindingTest(): Promise<void> {
+  const harness = await mountSignalView(async () => {
+    const { mountSpeedSourcePanel } = await import("../src/app/views/speed_source_panel");
+    return mountSpeedSourcePanel;
+  });
+
+  try {
+    const firstModel = signal(createSpeedSourcePanelModel("GPS primary", false));
+    const secondModel = signal(createSpeedSourcePanelModel("OBD fallback", true));
+    const firstDiagnostics = signal(createDiagnosticsModel("idle"));
+    const secondDiagnostics = signal(createDiagnosticsModel("locked"));
+
+    harness.view.bindModel(firstModel);
+    harness.view.bindDiagnostics(firstDiagnostics);
+    await harness.flush();
+
+    const currentSource = requireElement<HTMLElement>(harness.host, "#speedSourceCurrentSource");
+    const diagnosticsState = requireElement<HTMLElement>(harness.host, "#gpsStatusState");
+    const diagnosticsDetails =
+      requireElement<HTMLDetailsElement>(harness.host, "#speedSourceDiagnostics");
+
+    assert.match(currentSource.textContent ?? "", /GPS primary/);
+    assert.match(diagnosticsState.textContent ?? "", /idle/);
+    assert.equal(diagnosticsDetails.hasAttribute("open"), false);
+
+    firstModel.value = createSpeedSourcePanelModel("GPS updated", false);
+    firstDiagnostics.value = createDiagnosticsModel("searching");
+    await harness.flush();
+
+    assert.match(currentSource.textContent ?? "", /GPS updated/);
+    assert.match(diagnosticsState.textContent ?? "", /searching/);
+    assert.equal(diagnosticsDetails.hasAttribute("open"), false);
+
+    harness.view.bindModel(secondModel);
+    harness.view.bindDiagnostics(secondDiagnostics);
+    await harness.flush();
+
+    assert.match(currentSource.textContent ?? "", /OBD fallback/);
+    assert.match(diagnosticsState.textContent ?? "", /locked/);
+    assert.equal(diagnosticsDetails.hasAttribute("open"), true);
+
+    firstModel.value = createSpeedSourcePanelModel("stale first", false);
+    firstDiagnostics.value = createDiagnosticsModel("stale");
+    await harness.flush();
+
+    assert.match(currentSource.textContent ?? "", /OBD fallback/);
+    assert.match(diagnosticsState.textContent ?? "", /locked/);
+    assert.equal(diagnosticsDetails.hasAttribute("open"), true);
+
+    secondModel.value = createSpeedSourcePanelModel("OBD closed request", false);
+    secondDiagnostics.value = createDiagnosticsModel("streaming");
+    await harness.flush();
+
+    assert.match(currentSource.textContent ?? "", /OBD closed request/);
+    assert.match(diagnosticsState.textContent ?? "", /streaming/);
+    assert.equal(diagnosticsDetails.hasAttribute("open"), true);
+  } finally {
+    harness.cleanup();
+  }
+}
+
+await runSpeedSourcePanelSignalBindingTest();
+console.log("PASS speed source panel signal bindings rebind without stale bridge state");


### PR DESCRIPTION
## What changed
- replace `speed_source_panel.tsx` bridge-state merge effects with separate source signals plus one `computed()` bridge state
- keep diagnostics disclosure open-state as local signal and latch it open when the bound model requests diagnostics
- add `speed_source_panel_signals.ts` mounted-view regression for signal rebinding and disclosure-open behavior

## Why
- issue target was the same manual state-sync anti-pattern removed from `analysis_panel.tsx`
- speed source panel had one extra behavior edge: diagnostics can be locally toggled but also forced open by presenter/workflow state
- refactor keeps that edge behavior while removing the `effect()` + `untracked()` merge path

## Validation
- `cd apps/ui && npx tsx tests/speed_source_panel_signals.ts`
- `cd apps/ui && npx playwright test tests/settings_speed_source_module_bindings.spec.ts --workers=1`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- kept one small `effect()` for the disclosure latch because this state is not pure projection; it mixes local UI toggle state with presenter-driven reopen requests
- `npm run lint` still reports pre-existing unrelated Biome warnings outside this change
