### PR TITLE
refactor(ui): use signal props in live view

### DIFF
--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -81,9 +81,10 @@ const REALTIME_LIVE_OVERVIEW_MODEL_KEYS = [
 function RealtimeLiveOverviewRunHealthPill(props: {
   runHealth: ReadonlySignal<RealtimeLiveOverviewHealthModel>;
 }) {
-  const hidden = useComputed(() => props.runHealth.value.hidden);
-  const text = useComputed(() => props.runHealth.value.text);
-  const variant = useComputed(() => props.runHealth.value.variant);
+  const { hidden, text, variant } = useSignalProperties(
+    props.runHealth,
+    ["hidden", "text", "variant"] as const,
+  );
 
   return (
     <div
@@ -102,8 +103,7 @@ function RealtimeLiveOverviewActiveCarStat(props: {
   activeCar: ReadonlySignal<RealtimeLiveOverviewActiveCarModel>;
   labelText: ReadonlySignal<string>;
 }) {
-  const text = useComputed(() => props.activeCar.value.text);
-  const warning = useComputed(() => props.activeCar.value.warning);
+  const { text, warning } = useSignalProperties(props.activeCar, ["text", "warning"] as const);
   const variant = useComputed(() => warning.value ? "warn" : undefined);
   const hasIcon = useComputed(() => warning.value ? "true" : undefined);
 


### PR DESCRIPTION
## What changed
- replace manual property `useComputed()` calls in `RealtimeLiveOverviewRunHealthPill` with `useSignalProperties()`
- replace manual property `useComputed()` calls in `RealtimeLiveOverviewActiveCarStat` with `useSignalProperties()`
- keep `useComputed()` only for real derivations (`variant`, `hasIcon`, roster length)

## Why
- issue asked for consistent use of the existing cached helper instead of repeating one-property `useComputed()` wrappers
- change is mechanical and keeps behavior the same

## Validation
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.cars.spec.ts --workers=1`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- low risk; helper swap only
- `npm run lint` still reports pre-existing unrelated Biome warnings outside this change
