### PR TITLE
fix(ui): isolate smoke startup from backend

### DIFF
--- a/apps/ui/src/app/runtime/ui_startup_coordinator.ts
+++ b/apps/ui/src/app/runtime/ui_startup_coordinator.ts
@@ -39,6 +39,8 @@ export class UiStartupCoordinator {
 
   private readonly defaultViewId: string;
 
+  private readonly isDemoMode: boolean;
+
   private readonly warn: StartupWarn;
 
   constructor(deps: UiStartupCoordinatorDeps) {
@@ -46,6 +48,7 @@ export class UiStartupCoordinator {
     this.transport = deps.transport;
     this.features = deps.features;
     this.defaultViewId = deps.defaultViewId;
+    this.isDemoMode = new URLSearchParams(window.location.search).has("demo");
     this.warn = deps.warn ?? ((message, error) => console.warn(message, error));
   }
 
@@ -69,6 +72,39 @@ export class UiStartupCoordinator {
   }
 
   private createStartupPlan(): UiStartupPlan {
+    const asyncTasks = this.isDemoMode
+      ? []
+      : [
+          {
+            name: "hydrate persisted preferences",
+            run: () => this.shell.hydratePersistedPreferences(),
+          },
+          {
+            name: "refresh location options",
+            run: () => this.features.realtime.refreshLocationOptions(),
+          },
+          {
+            name: "load speed source",
+            run: () => this.features.settings.loadSpeedSourceFromServer(),
+          },
+          {
+            name: "load analysis settings",
+            run: () => this.features.settings.loadAnalysisSettingsFromServer(),
+          },
+          {
+            name: "load cars",
+            run: () => this.features.settings.loadCarsFromServer(),
+          },
+          {
+            name: "refresh logging status",
+            run: () => this.features.realtime.refreshLoggingStatus(),
+          },
+          {
+            name: "refresh history",
+            run: () => this.features.history.refreshHistory(),
+          },
+        ];
+
     return {
       initialSyncTasks: [
         () => this.shell.start(this.defaultViewId),
@@ -76,36 +112,7 @@ export class UiStartupCoordinator {
       finalSyncTasks: [
         () => this.transport.startTransportMode(),
       ],
-      asyncTasks: [
-        {
-          name: "hydrate persisted preferences",
-          run: () => this.shell.hydratePersistedPreferences(),
-        },
-        {
-          name: "refresh location options",
-          run: () => this.features.realtime.refreshLocationOptions(),
-        },
-        {
-          name: "load speed source",
-          run: () => this.features.settings.loadSpeedSourceFromServer(),
-        },
-        {
-          name: "load analysis settings",
-          run: () => this.features.settings.loadAnalysisSettingsFromServer(),
-        },
-        {
-          name: "load cars",
-          run: () => this.features.settings.loadCarsFromServer(),
-        },
-        {
-          name: "refresh logging status",
-          run: () => this.features.realtime.refreshLoggingStatus(),
-        },
-        {
-          name: "refresh history",
-          run: () => this.features.history.refreshHistory(),
-        },
-      ],
+      asyncTasks,
     };
   }
 }

--- a/apps/ui/tests/smoke.esp-flash.spec.ts
+++ b/apps/ui/tests/smoke.esp-flash.spec.ts
@@ -143,6 +143,7 @@ test("settings esp flash status falls back to idle when API omits state", async 
       await fulfillJson(route, {});
     },
   });
+  await installFakeWebSocket(page);
   await page.goto("/");
   await page.locator("#tab-settings").click();
   await page.locator('[data-settings-tab="espFlashTab"]').click();
@@ -196,6 +197,7 @@ test("settings esp flash failure shows retry guidance, retained failed stage, an
       await fulfillJson(route, {});
     },
   });
+  await installFakeWebSocket(page);
   await page.goto("/");
   await page.locator("#tab-settings").click();
   await page.locator('[data-settings-tab="espFlashTab"]').click();


### PR DESCRIPTION
## What changed
- skip startup bootstrap API hydration when the UI is launched in `?demo=1` mode so demo-only smoke runs stay self-contained
- add the missing fake websocket setup to the ESP flash smoke cases that boot the real app shell without a backend

## Root cause
The `UI smoke tests` job only starts the Vite dev server. In that environment, Vite proxies `/api` and `/ws` to `127.0.0.1:8000`, but no backend is running.

Two separate harness gaps produced the noisy `ECONNREFUSED` logs:
- demo-mode startup still ran the normal async bootstrap fetches even though demo transport is self-contained
- two ESP flash smoke tests did not stub `WebSocket`, so app startup still tried `/ws`

The suite stayed green because the affected bootstrap readers degrade gracefully on transport failures, but the logs looked like a real regression.

## Why this fix
Skipping backend bootstrap in demo mode preserves the seeded demo state instead of overwriting it with empty mock responses, and adding the missing fake websocket keeps the ESP flash smoke coverage isolated from the backend too.

## Validation
- `cd apps/ui && PATH=/tmp/vibesensor-node22-bin:$PATH npm exec -- playwright test --config=playwright.smoke.config.ts tests/smoke.spectrum.spec.ts tests/smoke.settings-alignment.spec.ts tests/smoke.esp-flash.spec.ts --project=laptop-light --workers=1`
- `cd apps/ui && PATH=/tmp/vibesensor-node22-bin:$PATH npm run test:smoke`
- `cd apps/ui && PATH=/tmp/vibesensor-node22-bin:$PATH npm run typecheck`
