### PR TITLE
FE: Convert subscribeActiveTabChanges() from callback to signal

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -151,18 +151,16 @@ export function createAppFeatureBundle(
       internet: panels.settings.internet,
     },
     ports: {
-      getActiveSettingsTabId: () => panels.settingsShell.getActiveTabId(),
       activeViewId: runtime.navigation.activeViewId,
-      subscribeSettingsTabChanges: panels.settingsShell.subscribeActiveTabChanges,
+      activeSettingsTabId: panels.settingsShell.activeTabId,
     },
     services,
   });
   const espFlash = createEspFlashFeature({
     panel: panels.settings.espFlash,
     ports: {
-      getActiveSettingsTabId: () => panels.settingsShell.getActiveTabId(),
       activeViewId: runtime.navigation.activeViewId,
-      subscribeSettingsTabChanges: panels.settingsShell.subscribeActiveTabChanges,
+      activeSettingsTabId: panels.settingsShell.activeTabId,
     },
     services,
   });

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -10,9 +10,8 @@ import { createEspFlashFeaturePresenter } from "../views/esp_flash_feature_prese
 import type { EspFlashPanelView } from "../views/esp_flash_panel";
 
 interface EspFlashFeaturePorts {
-  getActiveSettingsTabId: () => string;
   activeViewId: ReadonlySignal<string>;
-  subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
+  activeSettingsTabId: ReadonlySignal<string>;
 }
 
 export interface EspFlashFeatureDeps {
@@ -36,10 +35,9 @@ export function createEspFlashFeature(
 ): EspFlashFeature {
   const { panel, ports, services } = ctx;
   const handlersBound = signal(false);
-  const activeSettingsTabId = signal(ports.getActiveSettingsTabId());
   const pollingEnabled = computed(() =>
     handlersBound.value
-    && isEspFlashPollingContext(ports.activeViewId.value, activeSettingsTabId.value)
+    && isEspFlashPollingContext(ports.activeViewId.value, ports.activeSettingsTabId.value)
   );
   const workflow = createEspFlashFeatureWorkflow({
     t: services.t,
@@ -51,10 +49,6 @@ export function createEspFlashFeature(
     t: services.t,
   });
   panel.bindModel(presenter.model);
-
-  ports.subscribeSettingsTabChanges((tabId) => {
-    activeSettingsTabId.value = tabId;
-  });
 
   let wasPollingEnabled = false;
   effect(() => {

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -35,10 +35,10 @@ interface SettingsCarsModulePanels {
 
 interface SettingsCarsModulePorts {
   activeViewId: ReadonlySignal<string>;
+  activeSettingsTabId: ReadonlySignal<string>;
   openAnalysisTab: () => void;
   openCarWizard: () => void;
   renderSpectrum: () => void;
-  subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
   syncAnalysisInputs: () => void;
 }
 
@@ -85,9 +85,10 @@ export function createSettingsCarsModule(
   const carSelection = createCarSelectionDerivedState(settings);
   let handlersBound = false;
   const highlightedCar = signal<CarsListHighlightedFeedback | null>(null);
-  const activeSettingsTabId = signal("carTab");
   const carsContextVisible = computed(
-    () => ctx.ports.activeViewId.value === "settingsView" && activeSettingsTabId.value === "carTab",
+    () =>
+      ctx.ports.activeViewId.value === "settingsView"
+      && ctx.ports.activeSettingsTabId.value === "carTab",
   );
 
   function hasValidActiveCar(): boolean {
@@ -244,9 +245,6 @@ export function createSettingsCarsModule(
       if (highlightedCar.value && !carsContextVisible.value) {
         untracked(clearHighlightedCarFeedback);
       }
-    });
-    ctx.ports.subscribeSettingsTabChanges((tabId) => {
-      activeSettingsTabId.value = tabId;
     });
     ctx.panels.panel.bindActions({
       onAction: (action) => {

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -106,9 +106,8 @@ export function createSettingsFeature(
       getSpeedUnit: () => ctx.state.shell.speedUnit,
       ports: {
         activeViewId: ctx.ports.activeViewId,
+        activeSettingsTabId: ctx.panels.settingsShell.activeTabId,
         renderSpeedReadout: ctx.ports.view.renderSpeedReadout,
-        subscribeSettingsTabChanges:
-          ctx.panels.settingsShell.subscribeActiveTabChanges,
       },
     });
   const gpsStatusModule: SettingsGpsStatusModule =
@@ -121,12 +120,10 @@ export function createSettingsFeature(
       formatting,
       getSpeedUnit: () => ctx.state.shell.speedUnit,
       ports: {
-        getActiveSettingsTabId: () => ctx.panels.settingsShell.getActiveTabId(),
         activeViewId: ctx.ports.activeViewId,
+        activeSettingsTabId: ctx.panels.settingsShell.activeTabId,
         syncSpeedSourceSelectionUi: speedSourceModule.syncSpeedSourceSelectionUi,
         renderSpeedReadout: ctx.ports.view.renderSpeedReadout,
-        subscribeSettingsTabChanges:
-          ctx.panels.settingsShell.subscribeActiveTabChanges,
       },
     });
   carsModule = createSettingsCarsModule({
@@ -139,9 +136,8 @@ export function createSettingsFeature(
       openAnalysisTab: () => openSettingsTab("analysisTab"),
       openCarWizard: ctx.ports.openCarWizard,
       activeViewId: ctx.ports.activeViewId,
+      activeSettingsTabId: ctx.panels.settingsShell.activeTabId,
       renderSpectrum: ctx.ports.view.renderSpectrum,
-      subscribeSettingsTabChanges:
-        ctx.panels.settingsShell.subscribeActiveTabChanges,
       syncAnalysisInputs: analysisModule.syncSettingsInputs,
     },
     services,

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -16,11 +16,10 @@ import {
 import { createPollingController } from "./polling_controller";
 
 interface SettingsGpsStatusModulePorts {
-  getActiveSettingsTabId: () => string;
   activeViewId: ReadonlySignal<string>;
+  activeSettingsTabId: ReadonlySignal<string>;
   syncSpeedSourceSelectionUi: () => void;
   renderSpeedReadout: () => void;
-  subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
 }
 
 export interface SettingsGpsStatusModuleDeps {
@@ -43,7 +42,6 @@ export function createSettingsGpsStatusModule(
   const { panel, settings } = ctx;
   const handlersBound = signal(false);
   const startupReady = signal(false);
-  const activeSettingsTabId = signal(ctx.ports.getActiveSettingsTabId());
   const presenterDeps: SettingsSpeedSourcePresenterDeps = {
     fmt: ctx.formatting.fmt,
     getSpeedUnit: ctx.getSpeedUnit,
@@ -58,14 +56,10 @@ export function createSettingsGpsStatusModule(
       ctx.ports.activeViewId.value === "dashboardView"
       || (
         ctx.ports.activeViewId.value === "settingsView"
-        && activeSettingsTabId.value === "speedSourceTab"
+        && ctx.ports.activeSettingsTabId.value === "speedSourceTab"
       )
     )
   );
-
-  ctx.ports.subscribeSettingsTabChanges((tabId) => {
-    activeSettingsTabId.value = tabId;
-  });
 
   createPollingController({
     enabled: pollingEnabled,

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -15,8 +15,8 @@ import { createSettingsSpeedSourceWorkflow } from "./settings_speed_source_workf
 
 interface SettingsSpeedSourceModulePorts {
   activeViewId: ReadonlySignal<string>;
+  activeSettingsTabId: ReadonlySignal<string>;
   renderSpeedReadout: () => void;
-  subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
 }
 
 export interface SettingsSpeedSourceModuleDeps {
@@ -68,19 +68,17 @@ export function createSettingsSpeedSourceModule(
       return;
     }
     handlersBound = true;
-    let hasSeenInitialView = false;
+    let hasSeenInitialContext = false;
     effect(() => {
       ctx.ports.activeViewId.value;
-      if (!hasSeenInitialView) {
-        hasSeenInitialView = true;
+      ctx.ports.activeSettingsTabId.value;
+      if (!hasSeenInitialContext) {
+        hasSeenInitialContext = true;
         return;
       }
       untracked(() => {
         workflow.handleNavigateContext();
       });
-    });
-    ctx.ports.subscribeSettingsTabChanges(() => {
-      workflow.handleNavigateContext();
     });
     ctx.panel.bindActions({
       onManualSpeedInput(value): void {

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -18,9 +18,8 @@ interface UpdateFeaturePanels {
 }
 
 interface UpdateFeaturePorts {
-  getActiveSettingsTabId: () => string;
   activeViewId: ReadonlySignal<string>;
-  subscribeSettingsTabChanges(listener: (tabId: string) => void): () => void;
+  activeSettingsTabId: ReadonlySignal<string>;
 }
 
 export interface UpdateFeatureDeps {
@@ -42,10 +41,9 @@ function isUpdatePollingContext(viewId: string, tabId: string): boolean {
 export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
   const { panels, ports, services } = ctx;
   const handlersBound = signal(false);
-  const activeSettingsTabId = signal(ports.getActiveSettingsTabId());
   const pollingEnabled = computed(() =>
     handlersBound.value
-    && isUpdatePollingContext(ports.activeViewId.value, activeSettingsTabId.value)
+    && isUpdatePollingContext(ports.activeViewId.value, ports.activeSettingsTabId.value)
   );
   let presenter!: UpdateFeaturePresenter;
   const workflow = createUpdateFeatureWorkflow({
@@ -67,10 +65,6 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
   });
   panels.internet.bindModel(presenter.internetPanelModel);
   panels.update.bindModel(presenter.updatePanelModel);
-
-  ports.subscribeSettingsTabChanges((tabId) => {
-    activeSettingsTabId.value = tabId;
-  });
 
   function bindUpdateHandlers(): void {
     if (handlersBound.value) {

--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -138,38 +138,25 @@ function createDeferredSettingsShellView(): {
   attach(realView: SettingsShellView): void;
   view: SettingsShellView;
 } {
-  let disposeRealViewSubscription: (() => void) | null = null;
+  let disposeRealViewSync: (() => void) | null = null;
   let realView: SettingsShellView | null = null;
   const activeTabId = signal(DEFAULT_SETTINGS_TAB_ID);
 
   return {
     view: {
+      activeTabId,
       activateTab(tabId) {
         activeTabId.value = tabId;
         realView?.activateTab(tabId);
       },
-      getActiveTabId() {
-        return activeTabId.value;
-      },
-      subscribeActiveTabChanges(listener) {
-        let initialized = false;
-        return effect(() => {
-          const nextTabId = activeTabId.value;
-          if (!initialized) {
-            initialized = true;
-            return;
-          }
-          listener(nextTabId);
-        });
-      },
     },
     attach(nextRealView) {
-      disposeRealViewSubscription?.();
+      disposeRealViewSync?.();
       realView = nextRealView;
       realView.activateTab(activeTabId.value);
-      activeTabId.value = realView.getActiveTabId();
-      disposeRealViewSubscription = realView.subscribeActiveTabChanges((nextTabId) => {
-        activeTabId.value = nextTabId;
+      activeTabId.value = realView.activeTabId.value;
+      disposeRealViewSync = effect(() => {
+        activeTabId.value = nextRealView.activeTabId.value;
       });
     },
   };

--- a/apps/ui/src/app/views/settings_shell.tsx
+++ b/apps/ui/src/app/views/settings_shell.tsx
@@ -13,13 +13,10 @@ import {
 } from "../ui_panel_host_registry";
 import { useUiText } from "../ui_i18n";
 import {
-  effect,
   useComputed,
   type ReadonlySignal,
   signal,
 } from "../ui_signals";
-
-type ViewDisposer = () => void;
 
 const SETTINGS_TABS = [
   {
@@ -69,9 +66,8 @@ const SETTINGS_TABS = [
 type SettingsShellTabId = (typeof SETTINGS_TABS)[number]["id"];
 
 export interface SettingsShellView {
+  activeTabId: ReadonlySignal<string>;
   activateTab(tabId: string): void;
-  getActiveTabId(): string;
-  subscribeActiveTabChanges(listener: (tabId: string) => void): ViewDisposer;
 }
 
 type SettingsShellProps = {
@@ -238,25 +234,12 @@ export function mountSettingsShell(
   return {
     panelHosts,
     view: {
+      activeTabId,
       activateTab(tabId: string): void {
         if (!isSettingsShellTabId(tabId)) {
           return;
         }
         setActiveTab(tabId);
-      },
-      getActiveTabId(): string {
-        return activeTabId.value;
-      },
-      subscribeActiveTabChanges(listener: (tabId: string) => void): ViewDisposer {
-        let initialized = false;
-        return effect(() => {
-          const nextTabId = activeTabId.value;
-          if (!initialized) {
-            initialized = true;
-            return;
-          }
-          listener(nextTabId);
-        });
       },
     },
   };

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -543,25 +543,15 @@ function renderEspFlashPanelDom(
 
 function createFeatureNavigationHarness(defaultTabId: string) {
   const activeViewId = signal("settingsView");
-  let activeSettingsTabId = defaultTabId;
-  const settingsTabListeners = new Set<(tabId: string) => void>();
+  const activeSettingsTabId = signal(defaultTabId);
 
   return {
     ports: {
-      getActiveSettingsTabId: () => activeSettingsTabId,
       activeViewId,
-      subscribeSettingsTabChanges(listener: (tabId: string) => void) {
-        settingsTabListeners.add(listener);
-        return () => {
-          settingsTabListeners.delete(listener);
-        };
-      },
+      activeSettingsTabId,
     },
     setActiveSettingsTabId(nextTabId: string) {
-      activeSettingsTabId = nextTabId;
-      for (const listener of settingsTabListeners) {
-        listener(nextTabId);
-      }
+      activeSettingsTabId.value = nextTabId;
     },
     setActiveViewId(nextViewId: string) {
       activeViewId.value = nextViewId;
@@ -915,6 +905,7 @@ test.describe("createEspFlashFeature polling", () => {
       const deps = createDeps();
       const feature = createEspFlashFeature(deps);
 
+      feature.bindHandlers();
       feature.startPolling();
       await flushAsyncWork();
 
@@ -984,6 +975,7 @@ test.describe("createEspFlashFeature polling", () => {
       const deps = createDeps();
       const feature = createEspFlashFeature(deps);
 
+      feature.bindHandlers();
       feature.startPolling();
       await flushAsyncWork();
 
@@ -1039,6 +1031,7 @@ test.describe("createEspFlashFeature polling", () => {
       const deps = createDeps();
       const feature = createEspFlashFeature(deps);
 
+      feature.bindHandlers();
       feature.startPolling();
       await flushAsyncWork();
 
@@ -1106,6 +1099,7 @@ test.describe("createEspFlashFeature polling", () => {
       const deps = createDeps();
       const feature = createEspFlashFeature(deps);
 
+      feature.bindHandlers();
       feature.startPolling();
       await flushAsyncWork();
 
@@ -1312,6 +1306,7 @@ test.describe("createEspFlashFeature polling", () => {
       const deps = createDeps();
       const feature = createEspFlashFeature(deps);
 
+      feature.bindHandlers();
       feature.startPolling();
       await flushAsyncWork();
       expect(pendingPollDelays(timers)).toEqual([]);
@@ -1444,6 +1439,7 @@ test.describe("createUpdateFeature polling", () => {
       const deps = createUpdateDeps();
       const feature = createUpdateFeature(deps);
 
+      feature.bindUpdateHandlers();
       feature.startPolling();
       await flushAsyncWork();
 
@@ -1480,6 +1476,7 @@ test.describe("createUpdateFeature polling", () => {
       const deps = createUpdateDeps();
       const feature = createUpdateFeature(deps);
 
+      feature.bindUpdateHandlers();
       feature.startPolling();
       await flushAsyncWork();
 
@@ -1521,6 +1518,7 @@ test.describe("createUpdateFeature polling", () => {
       deps.updateSsidInput.value = "";
       const feature = createUpdateFeature(deps);
 
+      feature.bindUpdateHandlers();
       feature.startPolling();
       await flushAsyncWork();
 
@@ -1837,6 +1835,7 @@ test.describe("createUpdateFeature polling", () => {
       const deps = createUpdateDeps();
       const feature = createUpdateFeature(deps);
 
+      feature.bindUpdateHandlers();
       feature.startPolling();
       await expectTimerDelays(timers, [10_000]);
 

--- a/apps/ui/tests/esp_flash_feature_bindings.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_bindings.spec.ts
@@ -14,9 +14,8 @@ test("bindHandlers uses panel action surfaces instead of raw DOM bindings", () =
       bindModel() {},
     },
     ports: {
-      getActiveSettingsTabId: () => "espFlashTab",
+      activeSettingsTabId: signal("espFlashTab"),
       activeViewId: signal("settingsView"),
-      subscribeSettingsTabChanges: () => () => undefined,
     },
     services: {
       t: (key) => key,

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -18,7 +18,7 @@ test("settings cars module dismisses transient creation feedback through typed t
   const state = createAppState().settings;
   const renders: CarsListRenderModel[] = [];
   const activeViewId = signal("settingsView");
-  let settingsTabListener: ((tabId: string) => void) | null = null;
+  const activeSettingsTabId = signal("carTab");
 
   const panel: CarsListPanelView = {
     bindActions() {},
@@ -41,17 +41,10 @@ test("settings cars module dismisses transient creation feedback through typed t
     },
     ports: {
       activeViewId,
+      activeSettingsTabId,
       openAnalysisTab: () => undefined,
       openCarWizard: () => undefined,
       renderSpectrum: () => undefined,
-      subscribeSettingsTabChanges(listener) {
-        settingsTabListener = listener;
-        return () => {
-          if (settingsTabListener === listener) {
-            settingsTabListener = null;
-          }
-        };
-      },
       syncAnalysisInputs: () => undefined,
     },
     services: {
@@ -102,7 +95,7 @@ test("settings cars module dismisses transient creation feedback through typed t
   expect(highlighted.table.rows[0].isHighlighted).toBe(true);
   expect(highlighted.table.rows[0].highlightedStatusText).toBe("settings.car.just_added");
 
-  settingsTabListener?.("analysisTab");
+  activeSettingsTabId.value = "analysisTab";
 
   const dismissedByTab = lastRender(renders);
   expect(dismissedByTab.guidance).toBeNull();

--- a/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
+++ b/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
@@ -8,7 +8,7 @@ import type { SpeedSourcePanelActionHandlers } from "../src/app/views/speed_sour
 test("bindHandlers uses typed panel actions and navigation subscriptions", () => {
   let handlers: SpeedSourcePanelActionHandlers | null = null;
   const activeViewId = signal("settingsView");
-  let settingsTabListener: ((tabId: string) => void) | null = null;
+  const activeSettingsTabId = signal("speedSourceTab");
 
   const module = createSettingsSpeedSourceModule({
     settings: createAppState().settings,
@@ -36,11 +36,8 @@ test("bindHandlers uses typed panel actions and navigation subscriptions", () =>
     getSpeedUnit: () => "kmh",
     ports: {
       activeViewId,
+      activeSettingsTabId,
       renderSpeedReadout() {},
-      subscribeSettingsTabChanges(listener) {
-        settingsTabListener = listener;
-        return () => undefined;
-      },
     },
   });
 
@@ -52,13 +49,12 @@ test("bindHandlers uses typed panel actions and navigation subscriptions", () =>
   expect(typeof handlers?.onSave).toBe("function");
   expect(typeof handlers?.onScanObdDevices).toBe("function");
   expect(typeof handlers?.onPairObdDevice).toBe("function");
-  expect(settingsTabListener).not.toBeNull();
 
   expect(() => {
     handlers?.onSpeedSourceChanged("manual");
     handlers?.onManualSpeedInput("80");
     handlers?.onStaleTimeoutInput("5");
-    settingsTabListener?.("analysisTab");
+    activeSettingsTabId.value = "analysisTab";
     activeViewId.value = "dashboardView";
   }).not.toThrow();
 });

--- a/apps/ui/tests/signal_view_reference_tests.ts
+++ b/apps/ui/tests/signal_view_reference_tests.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { computed, signal, useSignalProperties } from "../src/app/ui_signals";
+import { computed, effect, signal, useSignalProperties } from "../src/app/ui_signals";
 import type {
   RealtimeLiveOverviewRenderModel,
   RealtimeLiveOverviewSensorCardModel,
@@ -276,18 +276,25 @@ async function runSettingsShellReferenceTest(): Promise<void> {
 
   try {
     const observedTabs: string[] = [];
-    const dispose = harness.view.subscribeActiveTabChanges((tabId) => {
+    const shellView = harness.view.view;
+    let initialized = false;
+    const dispose = effect(() => {
+      const tabId = shellView.activeTabId.value;
+      if (!initialized) {
+        initialized = true;
+        return;
+      }
       observedTabs.push(tabId);
     });
 
-    assert.equal(harness.view.getActiveTabId(), "carTab");
+    assert.equal(shellView.activeTabId.value, "carTab");
     assert.deepEqual(observedTabs, []);
 
-    harness.view.activateTab("analysisTab");
+    shellView.activateTab("analysisTab");
     await harness.flush();
 
     assert.deepEqual(observedTabs, ["analysisTab"]);
-    assert.equal(harness.view.getActiveTabId(), "analysisTab");
+    assert.equal(shellView.activeTabId.value, "analysisTab");
     assert.equal(
       requireElement(harness.host, '[data-settings-tab="analysisTab"]').getAttribute("aria-selected"),
       "true",
@@ -295,12 +302,12 @@ async function runSettingsShellReferenceTest(): Promise<void> {
     assert.equal(requireElement(harness.host, "#analysisTab").hidden, false);
     assert.equal(requireElement(harness.host, "#carTab").hidden, true);
 
-    harness.view.activateTab("analysisTab");
+    shellView.activateTab("analysisTab");
     await harness.flush();
     assert.deepEqual(observedTabs, ["analysisTab"]);
 
     dispose();
-    harness.view.activateTab("speedSourceTab");
+    shellView.activateTab("speedSourceTab");
     await harness.flush();
     assert.deepEqual(observedTabs, ["analysisTab"]);
   } finally {

--- a/apps/ui/tests/ui_lazy_panels.spec.ts
+++ b/apps/ui/tests/ui_lazy_panels.spec.ts
@@ -60,30 +60,18 @@ function createHistoryPanelSpy() {
 
 function createSettingsShellSpy() {
   const activations: string[] = [];
-  let activeTabId = "carTab";
-  let listener: ((tabId: string) => void) | null = null;
+  const activeTabId = signal("carTab");
 
   return {
     activations,
     emit(tabId: string) {
-      activeTabId = tabId;
-      listener?.(tabId);
+      activeTabId.value = tabId;
     },
     view: {
+      activeTabId,
       activateTab(tabId) {
-        activeTabId = tabId;
+        activeTabId.value = tabId;
         activations.push(tabId);
-      },
-      getActiveTabId() {
-        return activeTabId;
-      },
-      subscribeActiveTabChanges(nextListener) {
-        listener = nextListener;
-        return () => {
-          if (listener === nextListener) {
-            listener = null;
-          }
-        };
       },
     } satisfies SettingsShellView,
   };
@@ -220,11 +208,9 @@ test.describe("createLazyUiPanels", () => {
     lazyPanels.panels.history.bindModel(historyModel);
     lazyPanels.panels.history.bindActions(historyActions);
 
-    const tabChanges: string[] = [];
-    const dispose = lazyPanels.panels.settingsShell.subscribeActiveTabChanges((tabId) => {
-      tabChanges.push(tabId);
-    });
+    expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("carTab");
     lazyPanels.panels.settingsShell.activateTab("updateTab");
+    expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("updateTab");
 
     const internetActions = {} as Parameters<InternetPanelView["bindActions"]>[0];
     const internetModel = signal({}) as unknown as Parameters<InternetPanelView["bindModel"]>[0];
@@ -258,7 +244,7 @@ test.describe("createLazyUiPanels", () => {
     expect(speedSourcePanel.diagnostics).toEqual([speedSourceDiagnostics]);
     expect(speedSourcePanel.focusManualCalls).toBe(1);
     expect(lazyPanels.panels.settings.speedSource.isObdConfigVisible()).toBe(true);
-    expect(tabChanges).toEqual(["updateTab"]);
+    expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("updateTab");
 
     lazyPanels.panels.settings.speedSource.focusScanObdDevices();
     lazyPanels.panels.settings.speedSource.focusStaleTimeoutInput();
@@ -266,15 +252,13 @@ test.describe("createLazyUiPanels", () => {
     expect(speedSourcePanel.focusStaleCalls).toBe(1);
 
     settingsShell.emit("internetTab");
-    expect(lazyPanels.panels.settingsShell.getActiveTabId()).toBe("internetTab");
-    expect(tabChanges).toEqual(["updateTab", "internetTab"]);
+    expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("internetTab");
 
     await lazyPanels.ensureViewPanels("historyView");
     await lazyPanels.ensureViewPanels("settingsView");
     expect(historyLoads).toBe(1);
     expect(settingsLoads).toBe(1);
 
-    dispose();
   });
 
   test("prefetchHiddenPanels schedules offscreen mounts through the deferred scheduler", async () => {

--- a/apps/ui/tests/update_feature_bindings.spec.ts
+++ b/apps/ui/tests/update_feature_bindings.spec.ts
@@ -18,9 +18,8 @@ test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners
       showError: () => undefined,
     },
     ports: {
-      getActiveSettingsTabId: () => "updateTab",
+      activeSettingsTabId: signal("updateTab"),
       activeViewId: signal("settingsView"),
-      subscribeSettingsTabChanges: () => () => undefined,
     },
     panels: {
       update: {


### PR DESCRIPTION
## What changed
- remove `SettingsShellView.subscribeActiveTabChanges()` and `getActiveTabId()`
- expose `SettingsShellView.activeTabId` as the one tab-state seam
- rewire deferred settings shell, settings modules, update feature, and ESP flash feature to read the signal directly
- update focused tests to assert the signal seam and bind polling handlers before polling starts

## Why
- callback bridge duplicated state and forced extra effect glue
- direct signal wiring keeps one source of truth for settings tab state
- consumers can derive context without init-skip subscription plumbing

## Validation
- `cd apps/ui && npx tsx tests/signal_view_reference_tests.ts`
- `cd apps/ui && npx playwright test tests/ui_lazy_panels.spec.ts tests/update_feature_bindings.spec.ts tests/esp_flash_feature_bindings.spec.ts tests/settings_cars_module.spec.ts tests/settings_speed_source_module_bindings.spec.ts tests/esp_flash_feature.spec.ts --workers=1`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- breaking internal seam: every consumer must use `activeTabId`
- polling tests now bind handlers first because polling without handlers is not a real production path

## Follow-up
- closes #2585
