### PR TITLE
FE: Eliminate redundant effect()-to-setModel bridge in UiShellController

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -14,7 +14,6 @@ import {
 import {
   useComputed,
   useSignalProperties,
-  signal,
   type ReadonlySignal,
   useSignalEffect,
 } from "../ui_signals";
@@ -23,6 +22,10 @@ import {
   settingsFeedbackClassName,
   type SettingsFeedbackMessage,
 } from "../views/settings_feedback";
+import {
+  createDeferredViewModel,
+  useDeferredViewModel,
+} from "../views/view_model_binding";
 import type { VisualVariant } from "../view_style_types";
 const SHELL_OWNER = "UI shell";
 const SHELL_CHROME_HOST_ID = "appShellChromeRoot";
@@ -135,19 +138,19 @@ export type UiShellChromeRenderModel =
   & UiShellChromeDialogModel;
 
 export interface UiShellChromeView {
-  setDialogModel(model: UiShellChromeDialogModel): void;
-  setNavigationModel(model: UiShellChromeNavigationModel): void;
-  setPreferencesModel(model: UiShellChromePreferencesModel): void;
-  setStatusModel(model: UiShellChromeStatusModel): void;
+  bindDialogModel(model: ReadonlySignal<UiShellChromeDialogModel>): void;
+  bindNavigationModel(model: ReadonlySignal<UiShellChromeNavigationModel>): void;
+  bindPreferencesModel(model: ReadonlySignal<UiShellChromePreferencesModel>): void;
+  bindStatusModel(model: ReadonlySignal<UiShellChromeStatusModel>): void;
 }
 
 type UiShellChromeProps = {
   bridge: UiShellChromeActionBridge;
-  dialogModel: ReadonlySignal<UiShellChromeDialogModel>;
-  navigationModel: ReadonlySignal<UiShellChromeNavigationModel>;
+  dialogModel: ReadonlySignal<ReadonlySignal<UiShellChromeDialogModel> | null>;
+  navigationModel: ReadonlySignal<ReadonlySignal<UiShellChromeNavigationModel> | null>;
   panelHostRefs: UiPanelHostRefs;
-  preferencesModel: ReadonlySignal<UiShellChromePreferencesModel>;
-  statusModel: ReadonlySignal<UiShellChromeStatusModel>;
+  preferencesModel: ReadonlySignal<ReadonlySignal<UiShellChromePreferencesModel> | null>;
+  statusModel: ReadonlySignal<ReadonlySignal<UiShellChromeStatusModel> | null>;
 };
 
 type ShellViewSectionProps = {
@@ -673,12 +676,12 @@ function ConfirmationDialogLayer(props: {
 function UiShellChrome(props: UiShellChromeProps) {
   const {
     bridge,
-    dialogModel,
-    navigationModel,
     panelHostRefs,
-    preferencesModel,
-    statusModel,
   } = props;
+  const dialogModel = useDeferredViewModel(props.dialogModel, DEFAULT_DIALOG_MODEL);
+  const navigationModel = useDeferredViewModel(props.navigationModel, DEFAULT_NAVIGATION_MODEL);
+  const preferencesModel = useDeferredViewModel(props.preferencesModel, DEFAULT_PREFERENCES_MODEL);
+  const statusModel = useDeferredViewModel(props.statusModel, DEFAULT_STATUS_MODEL);
 
   return (
     <ShellChromeFrame statusModel={statusModel}>
@@ -730,19 +733,19 @@ export function mountUiShellChrome(
   host: HTMLElement,
   bridge: UiShellChromeActionBridge,
 ): UiShellChromeView & { panelHosts: UiPanelHostRegistry } {
-  const dialogModel = signal<UiShellChromeDialogModel>(DEFAULT_DIALOG_MODEL);
-  const navigationModel = signal<UiShellChromeNavigationModel>(DEFAULT_NAVIGATION_MODEL);
+  const dialogModel = createDeferredViewModel<UiShellChromeDialogModel>();
+  const navigationModel = createDeferredViewModel<UiShellChromeNavigationModel>();
   const panelHostRefs = createUiPanelHostRefs();
-  const preferencesModel = signal<UiShellChromePreferencesModel>(DEFAULT_PREFERENCES_MODEL);
-  const statusModel = signal<UiShellChromeStatusModel>(DEFAULT_STATUS_MODEL);
+  const preferencesModel = createDeferredViewModel<UiShellChromePreferencesModel>();
+  const statusModel = createDeferredViewModel<UiShellChromeStatusModel>();
   render(
     <UiShellChrome
       bridge={bridge}
-      dialogModel={dialogModel}
-      navigationModel={navigationModel}
+      dialogModel={dialogModel.model}
+      navigationModel={navigationModel.model}
       panelHostRefs={panelHostRefs}
-      preferencesModel={preferencesModel}
-      statusModel={statusModel}
+      preferencesModel={preferencesModel.model}
+      statusModel={statusModel.model}
     />,
     host,
   );
@@ -750,17 +753,17 @@ export function mountUiShellChrome(
 
   return {
     panelHosts,
-    setDialogModel(nextModel) {
-      dialogModel.value = nextModel;
+    bindDialogModel(model) {
+      dialogModel.bind(model);
     },
-    setNavigationModel(nextModel) {
-      navigationModel.value = nextModel;
+    bindNavigationModel(model) {
+      navigationModel.bind(model);
     },
-    setPreferencesModel(nextModel) {
-      preferencesModel.value = nextModel;
+    bindPreferencesModel(model) {
+      preferencesModel.bind(model);
     },
-    setStatusModel(nextModel) {
-      statusModel.value = nextModel;
+    bindStatusModel(model) {
+      statusModel.bind(model);
     },
   };
 }

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -138,8 +138,9 @@ export class UiShellController {
     this.preferencesRenderModel = this.createPreferencesRenderModel();
     this.statusRenderModel = this.createStatusRenderModel();
     this.dialogRenderModel = this.createDialogRenderModel();
+    this.bindChromeModelSignals();
     this.bindReactiveLanguageSync();
-    this.bindReactiveChromeSync();
+    this.bindReactiveSpeedReadoutSync();
   }
 
   t(key: string, vars?: Record<string, unknown>): string {
@@ -207,35 +208,14 @@ export class UiShellController {
     });
   }
 
-  private bindReactiveChromeSync(): void {
-    effect(() => {
-      const model = this.navigationRenderModel.value;
-      untracked(() => {
-        this.chrome.setNavigationModel(model);
-      });
-    });
+  private bindChromeModelSignals(): void {
+    this.chrome.bindNavigationModel(this.navigationRenderModel);
+    this.chrome.bindPreferencesModel(this.preferencesRenderModel);
+    this.chrome.bindStatusModel(this.statusRenderModel);
+    this.chrome.bindDialogModel(this.dialogRenderModel);
+  }
 
-    effect(() => {
-      const model = this.preferencesRenderModel.value;
-      untracked(() => {
-        this.chrome.setPreferencesModel(model);
-      });
-    });
-
-    effect(() => {
-      const model = this.statusRenderModel.value;
-      untracked(() => {
-        this.chrome.setStatusModel(model);
-      });
-    });
-
-    effect(() => {
-      const model = this.dialogRenderModel.value;
-      untracked(() => {
-        this.chrome.setDialogModel(model);
-      });
-    });
-
+  private bindReactiveSpeedReadoutSync(): void {
     effect(() => {
       const speedText = this.status.speedReadoutText.value;
       untracked(() => {

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -2,7 +2,13 @@ import { expect, test } from "@playwright/test";
 
 import { createAppState } from "../src/app/ui_app_state";
 import { UiShellController } from "../src/app/runtime/ui_shell_controller";
-import { createUiShellChromeActionBridge } from "../src/app/runtime/ui_shell_chrome";
+import {
+  createUiShellChromeActionBridge,
+  type UiShellChromeDialogModel,
+  type UiShellChromeNavigationModel,
+  type UiShellChromePreferencesModel,
+  type UiShellChromeStatusModel,
+} from "../src/app/runtime/ui_shell_chrome";
 import {
   DEFAULT_SHELL_VIEW_ID,
   createUiShellNavigationModule,
@@ -10,6 +16,7 @@ import {
 import { createUiShellNotificationModule } from "../src/app/runtime/ui_shell_notification_module";
 import { createUiShellPreferencesModule } from "../src/app/runtime/ui_shell_preferences_module";
 import { createUiShellStatusModule } from "../src/app/runtime/ui_shell_status_module";
+import type { ReadonlySignal } from "../src/app/ui_signals";
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -55,21 +62,37 @@ function createChromeViewRecorder() {
     preferences: 0,
     status: 0,
   };
+  const models: {
+    dialog: ReadonlySignal<UiShellChromeDialogModel> | null;
+    navigation: ReadonlySignal<UiShellChromeNavigationModel> | null;
+    preferences: ReadonlySignal<UiShellChromePreferencesModel> | null;
+    status: ReadonlySignal<UiShellChromeStatusModel> | null;
+  } = {
+    dialog: null,
+    navigation: null,
+    preferences: null,
+    status: null,
+  };
 
   return {
     counts,
+    models,
     view: {
-      setDialogModel() {
+      bindDialogModel(model: ReadonlySignal<UiShellChromeDialogModel>) {
         counts.dialog += 1;
+        models.dialog = model;
       },
-      setNavigationModel() {
+      bindNavigationModel(model: ReadonlySignal<UiShellChromeNavigationModel>) {
         counts.navigation += 1;
+        models.navigation = model;
       },
-      setPreferencesModel() {
+      bindPreferencesModel(model: ReadonlySignal<UiShellChromePreferencesModel>) {
         counts.preferences += 1;
+        models.preferences = model;
       },
-      setStatusModel() {
+      bindStatusModel(model: ReadonlySignal<UiShellChromeStatusModel>) {
         counts.status += 1;
+        models.status = model;
       },
     },
   };
@@ -183,15 +206,23 @@ test.describe("UiShellController", () => {
       preferences: 1,
       status: 1,
     });
+    expect(chrome.models.status?.value.shellLiveStatus).toEqual({
+      text: "No live signal",
+      variant: "muted",
+    });
+    const initialDialogModel = chrome.models.dialog?.value;
+    const initialNavigationModel = chrome.models.navigation?.value;
+    const initialPreferencesModel = chrome.models.preferences?.value;
 
     controller.setLiveStatus("warn", "Signal weak");
 
-    expect(chrome.counts).toEqual({
-      dialog: 1,
-      navigation: 1,
-      preferences: 1,
-      status: 2,
+    expect(chrome.models.status?.value.shellLiveStatus).toEqual({
+      text: "Signal weak",
+      variant: "warn",
     });
+    expect(chrome.models.dialog?.value).toEqual(initialDialogModel);
+    expect(chrome.models.navigation?.value).toEqual(initialNavigationModel);
+    expect(chrome.models.preferences?.value).toEqual(initialPreferencesModel);
   });
 
   test("routes notification banner updates through the dialog model only", () => {
@@ -214,15 +245,25 @@ test.describe("UiShellController", () => {
       preferences: 1,
       status: 1,
     });
+    expect(chrome.models.dialog?.value.appErrorBanner).toEqual({
+      hidden: true,
+      text: "",
+      variant: null,
+    });
+    const initialNavigationModel = chrome.models.navigation?.value;
+    const initialPreferencesModel = chrome.models.preferences?.value;
+    const initialStatusModel = chrome.models.status?.value;
 
     controller.showError("save failed");
 
-    expect(chrome.counts).toEqual({
-      dialog: 2,
-      navigation: 1,
-      preferences: 1,
-      status: 1,
+    expect(chrome.models.dialog?.value.appErrorBanner).toEqual({
+      hidden: false,
+      text: "save failed",
+      variant: "bad",
     });
+    expect(chrome.models.navigation?.value).toEqual(initialNavigationModel);
+    expect(chrome.models.preferences?.value).toEqual(initialPreferencesModel);
+    expect(chrome.models.status?.value).toEqual(initialStatusModel);
   });
 
 });


### PR DESCRIPTION
## What changed
- remove `UiShellController` effect boilerplate that pushed chrome models through `set*Model()` methods
- switch `mountUiShellChrome()` to deferred signal bindings for navigation, preferences, status, and dialog models
- update shell runtime tests to assert the bound signal seam instead of setter call counts

## Why
- controller already owns computed render-model signals
- chrome can read those signals directly without per-model push effects
- deferred binding keeps current startup order and drops bridge noise

## Validation
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts tests/ui_shell_chrome.spec.ts --workers=1`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risks / tradeoffs
- shell chrome mount path now depends on deferred model binding instead of local mutable model signals
- live overview speed text still uses its existing effect bridge; this PR only removes the chrome `set*Model()` bridge

## Follow-up
- closes #2586
