### PR TITLE
FE: replace imperative panel bind bridges with direct signal props

### DIFF
--- a/apps/ui/src/app/features/cars_feature.ts
+++ b/apps/ui/src/app/features/cars_feature.ts
@@ -41,7 +41,7 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
       t: ctx.services.t,
     })
   );
-  ctx.panel.bindModel(wizardModel);
+  ctx.panel.model.value = wizardModel;
   let handlersBound = false;
 
   function openWizard(): void {
@@ -110,11 +110,11 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
         return;
       }
       handlersBound = true;
-      ctx.panel.bindActions({
+      ctx.panel.actions.value = {
         onAction: (action) => {
           void handleInteraction(action);
         },
-      });
+      };
     },
     openWizard,
   };

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -48,7 +48,7 @@ export function createEspFlashFeature(
     renderState: workflow.renderState,
     t: services.t,
   });
-  panel.bindModel(presenter.model);
+  panel.model.value = presenter.model;
 
   let wasPollingEnabled = false;
   effect(() => {
@@ -64,7 +64,7 @@ export function createEspFlashFeature(
       return;
     }
     handlersBound.value = true;
-    panel.bindActions({
+    panel.actions.value = {
       onStart: () => {
         void workflow.startFlash();
       },
@@ -77,7 +77,7 @@ export function createEspFlashFeature(
       onSelectPort: (value) => {
         workflow.setSelectedPortValue(value);
       },
-    });
+    };
   }
 
   return {

--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -112,7 +112,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     trackAppStateSlice(history);
     return buildPanelRenderModel();
   });
-  panel.bindModel(panelModel);
+  panel.model.value = panelModel;
 
   async function loadRunPreview(runId: string, force = false): Promise<void> {
     if (!runId) {
@@ -346,7 +346,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       return;
     }
     handlersBound = true;
-    panel.bindActions({
+    panel.actions.value = {
       onRefreshHistory: () => {
         void refreshHistory();
       },
@@ -367,7 +367,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
         }
         toggleRunDetails(action.runId);
       },
-    });
+    };
   }
 
   bindReactiveLanguageSync();

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -89,9 +89,9 @@ export function createRealtimeFeature(
     },
     workflow: workflowState,
   });
-  ports.chrome.liveOverview.bindModel(viewState.liveOverviewModel);
-  ports.chrome.loggingPanel.bindModel(viewState.loggingPanelModel);
-  panels.sensorsPanel.bindModel(viewState.sensorsPanelModel);
+  ports.chrome.liveOverview.model.value = viewState.liveOverviewModel;
+  ports.chrome.loggingPanel.model.value = viewState.loggingPanelModel;
+  panels.sensorsPanel.model.value = viewState.sensorsPanelModel;
   const workflow = createRealtimeFeatureWorkflow({
     realtime: state.realtime,
     t: services.t,
@@ -129,7 +129,7 @@ export function createRealtimeFeature(
       return;
     }
     handlersBound = true;
-    ports.chrome.loggingPanel.bindActions({
+    ports.chrome.loggingPanel.actions.value = {
       onStartLogging: () => {
         void workflow.startLogging();
       },
@@ -156,9 +156,9 @@ export function createRealtimeFeature(
         }
         openSettingsView("speedSourceTab");
       },
-    });
+    };
     workflow.bindHandlers();
-    panels.sensorsPanel.bindActions({
+    panels.sensorsPanel.actions.value = {
       onSensorLocationChange: (change) => {
         void workflow.setClientLocation(change.clientId, change.locationCode);
       },
@@ -169,7 +169,7 @@ export function createRealtimeFeature(
         }
         void workflow.removeClient(action.clientId);
       },
-    });
+    };
   }
 
   return {

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -277,7 +277,7 @@ export function createSettingsAnalysisModule(
     };
   }
   const panelModel = computed(() => buildPanelModel());
-  panel.bindModel(panelModel);
+  panel.model.value = panelModel;
 
   function clearFieldValidationState(): void {
     fieldErrorMessages.value = {};
@@ -493,13 +493,13 @@ export function createSettingsAnalysisModule(
   }
 
   function bindHandlers(): void {
-    panel.bindActions({
+    panel.actions.value = {
       onFieldInput: handleFieldInput,
       onReset: () => {
         void resetAnalysisToDefaults();
       },
       onSave: saveAnalysisFromInputs,
-    });
+    };
   }
 
   return {

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -29,7 +29,7 @@ import {
 } from "./settings_cars_transport";
 
 interface SettingsCarsModulePanels {
-  analysisPanel: Pick<AnalysisPanelView, "bindCarAvailability">;
+  analysisPanel: Pick<AnalysisPanelView, "carAvailability">;
   panel: CarsListPanelView;
 }
 
@@ -127,8 +127,8 @@ export function createSettingsCarsModule(
     };
   });
   const panelModel = computed(() => createPanelModel(getCarSelectionState()));
-  ctx.panels.analysisPanel.bindCarAvailability(analysisAvailability);
-  ctx.panels.panel.bindModel(panelModel);
+  ctx.panels.analysisPanel.carAvailability.value = analysisAvailability;
+  ctx.panels.panel.model.value = panelModel;
 
   function renderCarList(): void {}
 
@@ -246,7 +246,7 @@ export function createSettingsCarsModule(
         untracked(clearHighlightedCarFeedback);
       }
     });
-    ctx.panels.panel.bindActions({
+    ctx.panels.panel.actions.value = {
       onAction: (action) => {
         if (action.type === "add") {
           ctx.ports.openCarWizard();
@@ -268,7 +268,7 @@ export function createSettingsCarsModule(
           void handleDeleteCar(action.carId);
         }
       },
-    });
+    };
   }
 
   return {

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -48,7 +48,7 @@ export function createSettingsGpsStatusModule(
     t: ctx.services.t,
   };
   const diagnosticsModel = signal(DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL);
-  panel.bindDiagnostics(diagnosticsModel);
+  panel.diagnostics.value = diagnosticsModel;
   const pollingEnabled = computed(() =>
     handlersBound.value
     && startupReady.value

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -60,7 +60,7 @@ export function createSettingsSpeedSourceModule(
   const panelModel = computed(() =>
     buildSettingsSpeedSourcePanelModel(workflow.renderState.value, presenterDeps)
   );
-  ctx.panel.bindModel(panelModel);
+  ctx.panel.model.value = panelModel;
   let handlersBound = false;
 
   function bindHandlers(): void {
@@ -80,7 +80,7 @@ export function createSettingsSpeedSourceModule(
         workflow.handleNavigateContext();
       });
     });
-    ctx.panel.bindActions({
+    ctx.panel.actions.value = {
       onManualSpeedInput(value): void {
         workflow.handleManualSpeedInput(value);
       },
@@ -99,7 +99,7 @@ export function createSettingsSpeedSourceModule(
       onStaleTimeoutInput(value): void {
         workflow.handleStaleTimeoutInput(value);
       },
-    });
+    };
     workflow.handleNavigateContext();
   }
 

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -63,23 +63,23 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
     renderState: workflow.renderState,
     t: services.t,
   });
-  panels.internet.bindModel(presenter.internetPanelModel);
-  panels.update.bindModel(presenter.updatePanelModel);
+  panels.internet.model.value = presenter.internetPanelModel;
+  panels.update.model.value = presenter.updatePanelModel;
 
   function bindUpdateHandlers(): void {
     if (handlersBound.value) {
       return;
     }
     handlersBound.value = true;
-    panels.update.bindActions({
+    panels.update.actions.value = {
       onStart: () => {
         void workflow.startUpdate(presenter.readStartIntent());
       },
       onCancel: () => {
         void workflow.cancelUpdate();
       },
-    });
-    panels.internet.bindActions({
+    };
+    panels.internet.actions.value = {
       onPasswordInput: (value) => {
         presenter.setPasswordInput(value);
       },
@@ -92,7 +92,7 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
       onSsidInput: (value) => {
         presenter.setSsidInput(value);
       },
-    });
+    };
   }
 
   return {

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -161,7 +161,7 @@ export class UiShellController {
 
   renderSpeedReadout(): void {
     untracked(() => {
-      this.liveOverview.setSpeedText(this.status.speedReadoutText.value);
+      this.liveOverview.speedText.value = this.status.speedReadoutText.value;
     });
   }
 
@@ -219,7 +219,7 @@ export class UiShellController {
     effect(() => {
       const speedText = this.status.speedReadoutText.value;
       untracked(() => {
-        this.liveOverview.setSpeedText(speedText);
+        this.liveOverview.speedText.value = speedText;
       });
     });
   }

--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -4,19 +4,59 @@ import {
   mountHistoryPanelLazy,
   mountSettingsPanelsLazy,
   type UiMountedDashboardPanels,
+  type UiMountedLazyPanelHandles,
   type UiMountedLazyPanels,
   type UiMountedPanels,
 } from "./ui_panel_bootstrap";
 import { effect, signal } from "./ui_signals";
-import type { AnalysisPanelView } from "./views/analysis_panel";
-import type { CarsPanelView } from "./views/cars_panel";
-import type { EspFlashPanelView } from "./views/esp_flash_panel";
-import type { HistoryPanelView } from "./views/history_table_view";
-import type { InternetPanelView } from "./views/internet_panel";
-import type { SensorsPanelView } from "./views/sensors_panel";
+import type {
+  AnalysisPanelActionHandlers,
+  AnalysisPanelCarAvailability,
+  AnalysisPanelFieldKey,
+  AnalysisPanelRenderModel,
+  AnalysisPanelView,
+} from "./views/analysis_panel";
+import type {
+  CarsFeatureInteractionHandlers,
+  CarsListRenderModel,
+  CarsPanelView,
+} from "./views/cars_panel";
+import type {
+  EspFlashPanelActionHandlers,
+  EspFlashPanelRenderModel,
+  EspFlashPanelView,
+} from "./views/esp_flash_panel";
+import type {
+  HistoryPanelActionHandlers,
+  HistoryPanelRenderModel,
+  HistoryPanelView,
+} from "./views/history_table_view";
+import type {
+  InternetPanelActionHandlers,
+  InternetPanelRenderModel,
+  InternetPanelView,
+} from "./views/internet_panel";
+import type {
+  SensorsPanelActionHandlers,
+  SensorsPanelRenderModel,
+  SensorsPanelView,
+} from "./views/sensors_panel";
 import type { SettingsShellView } from "./views/settings_shell";
-import type { SpeedSourcePanelView } from "./views/speed_source_panel";
-import type { UpdatePanelView } from "./views/update_panel";
+import type {
+  SpeedSourceDiagnosticsRenderModel,
+  SpeedSourcePanelActionHandlers,
+  SpeedSourcePanelRenderModel,
+  SpeedSourcePanelView,
+} from "./views/speed_source_panel";
+import type {
+  UpdatePanelActionHandlers,
+  UpdatePanelRenderModel,
+  UpdatePanelView,
+} from "./views/update_panel";
+import {
+  createDeferredModelSignal,
+  createModelActionPanelBindings,
+} from "./views/view_model_binding";
 
 const HISTORY_VIEW_ID = "historyView";
 const SETTINGS_VIEW_ID = "settingsView";
@@ -33,8 +73,11 @@ export interface UiLazyPanels {
 export interface CreateUiLazyPanelsDeps {
   hosts: UiPanelHostRegistry;
   mountDashboardPanels?: (hosts: UiPanelHostRegistry) => UiMountedDashboardPanels;
-  loadHistoryPanel?: (hosts: UiPanelHostRegistry) => Promise<HistoryPanelView>;
-  loadSettingsPanels?: (hosts: UiPanelHostRegistry) => Promise<UiMountedLazyPanels>;
+  loadHistoryPanel?: (hosts: UiPanelHostRegistry, view: HistoryPanelView) => Promise<void>;
+  loadSettingsPanels?: (
+    hosts: UiPanelHostRegistry,
+    panels: UiMountedLazyPanels,
+  ) => Promise<UiMountedLazyPanelHandles>;
   scheduleDeferredWork?: DeferredWorkScheduler;
 }
 
@@ -42,76 +85,15 @@ function scheduleDeferredWork(task: () => void): void {
   setTimeout(task, 0);
 }
 
-function createDeferredBindSlot<TView extends object, TArg>(
-  realView: { value: TView | null },
-  apply: (view: TView, arg: TArg) => void,
-): {
-  attach(view: TView): void;
-  bind(nextArg: TArg): void;
-  current: { value: TArg | null };
-} {
-  const current = { value: null as TArg | null };
-  return {
-    attach(view) {
-      if (current.value !== null) {
-        apply(view, current.value);
-      }
-    },
-    bind(nextArg) {
-      current.value = nextArg;
-      if (realView.value !== null) {
-        apply(realView.value, nextArg);
-      }
-    },
-    current,
-  };
-}
-
-function createDeferredModelActionView<
-  TModel,
-  TActions,
-  TView extends {
-    bindActions(actions: TActions): void;
-    bindModel(model: TModel): void;
-  },
->(): {
-  attach(realView: TView): void;
-  view: TView;
-} {
-  const realView = signal<TView | null>(null);
-  const actions = createDeferredBindSlot(realView, (view, nextActions: TActions) => {
-    view.bindActions(nextActions);
-  });
-  const model = createDeferredBindSlot(realView, (view, nextModel: TModel) => {
-    view.bindModel(nextModel);
-  });
-
-  return {
-    view: {
-      bindActions(nextActions) {
-        actions.bind(nextActions);
-      },
-      bindModel(nextModel) {
-        model.bind(nextModel);
-      },
-    } as TView,
-    attach(nextRealView) {
-      realView.value = nextRealView;
-      actions.attach(nextRealView);
-      model.attach(nextRealView);
-    },
-  };
-}
-
 function createDeferredHistoryPanelView(): {
-  attach(realView: HistoryPanelView): void;
   view: HistoryPanelView;
 } {
-  return createDeferredModelActionView<
-    Parameters<HistoryPanelView["bindModel"]>[0],
-    Parameters<HistoryPanelView["bindActions"]>[0],
-    HistoryPanelView
-  >();
+  return {
+    view: createModelActionPanelBindings<
+      HistoryPanelRenderModel,
+      HistoryPanelActionHandlers
+    >(),
+  };
 }
 
 function createDeferredSettingsShellView(): {
@@ -143,22 +125,19 @@ function createDeferredSettingsShellView(): {
 }
 
 function createDeferredCarsPanelView(): {
-  attach(realView: CarsPanelView): void;
+  attach(realView: Pick<CarsPanelView["wizard"], "focus">): void;
   view: CarsPanelView;
 } {
   type CarsWizardFocusTarget = Parameters<CarsPanelView["wizard"]["focus"]>[0];
-  const list = createDeferredModelActionView<
-    Parameters<CarsPanelView["list"]["bindModel"]>[0],
-    Parameters<CarsPanelView["list"]["bindActions"]>[0],
-    CarsPanelView["list"]
+  const list = createModelActionPanelBindings<
+    CarsListRenderModel,
+    { onAction(action: import("./views/settings_car_list_view").CarsListAction): void }
   >();
-  const realWizard = signal<CarsPanelView["wizard"] | null>(null);
-  const wizardActions = createDeferredBindSlot(realWizard, (view, nextActions: Parameters<CarsPanelView["wizard"]["bindActions"]>[0]) => {
-    view.bindActions(nextActions);
-  });
-  const wizardModel = createDeferredBindSlot(realWizard, (view, nextModel: Parameters<CarsPanelView["wizard"]["bindModel"]>[0]) => {
-    view.bindModel(nextModel);
-  });
+  const wizard = createModelActionPanelBindings<
+    import("./views/car_wizard_view").CarsWizardRenderModel,
+    CarsFeatureInteractionHandlers
+  >();
+  const realWizard = signal<Pick<CarsPanelView["wizard"], "focus"> | null>(null);
   const wizardFocusTarget = signal<CarsWizardFocusTarget | null>(null);
   effect(() => {
     const view = realWizard.value;
@@ -171,43 +150,27 @@ function createDeferredCarsPanelView(): {
 
   return {
     view: {
-      list: list.view,
+      list,
       wizard: {
-        bindActions(nextActions) {
-          wizardActions.bind(nextActions);
-        },
-        bindModel(nextModel) {
-          wizardModel.bind(nextModel);
-        },
+        actions: wizard.actions,
+        model: wizard.model,
         focus(target) {
           wizardFocusTarget.value = target;
         },
       },
     },
     attach(nextRealView) {
-      list.attach(nextRealView.list);
-      realWizard.value = nextRealView.wizard;
-      wizardActions.attach(nextRealView.wizard);
-      wizardModel.attach(nextRealView.wizard);
+      realWizard.value = nextRealView;
     },
   };
 }
 
 function createDeferredAnalysisPanelView(): {
-  attach(realView: AnalysisPanelView): void;
+  attach(realView: Pick<AnalysisPanelView, "focusField" | "openGuidance">): void;
   view: AnalysisPanelView;
 } {
   type AnalysisFocusField = Parameters<AnalysisPanelView["focusField"]>[0];
-  const realView = signal<AnalysisPanelView | null>(null);
-  const actions = createDeferredBindSlot(realView, (view, nextActions: Parameters<AnalysisPanelView["bindActions"]>[0]) => {
-    view.bindActions(nextActions);
-  });
-  const carAvailability = createDeferredBindSlot(realView, (view, nextCarAvailability: Parameters<AnalysisPanelView["bindCarAvailability"]>[0]) => {
-    view.bindCarAvailability(nextCarAvailability);
-  });
-  const model = createDeferredBindSlot(realView, (view, nextModel: Parameters<AnalysisPanelView["bindModel"]>[0]) => {
-    view.bindModel(nextModel);
-  });
+  const realView = signal<Pick<AnalysisPanelView, "focusField" | "openGuidance"> | null>(null);
   const focusField = signal<AnalysisFocusField | null>(null);
   const guidanceOpenRequested = signal(false);
   effect(() => {
@@ -228,15 +191,9 @@ function createDeferredAnalysisPanelView(): {
 
   return {
     view: {
-      bindActions(nextActions) {
-        actions.bind(nextActions);
-      },
-      bindCarAvailability(nextCarAvailability) {
-        carAvailability.bind(nextCarAvailability);
-      },
-      bindModel(nextModel) {
-        model.bind(nextModel);
-      },
+      actions: signal<AnalysisPanelActionHandlers | null>(null),
+      carAvailability: createDeferredModelSignal<AnalysisPanelCarAvailability>(),
+      model: createDeferredModelSignal<AnalysisPanelRenderModel>(),
       openGuidance() {
         guidanceOpenRequested.value = true;
       },
@@ -246,39 +203,35 @@ function createDeferredAnalysisPanelView(): {
     },
     attach(nextRealView) {
       realView.value = nextRealView;
-      actions.attach(nextRealView);
-      carAvailability.attach(nextRealView);
-      model.attach(nextRealView);
     },
   };
 }
 
 function createDeferredSensorsPanelView(): {
-  attach(realView: SensorsPanelView): void;
   view: SensorsPanelView;
 } {
-  return createDeferredModelActionView<
-    Parameters<SensorsPanelView["bindModel"]>[0],
-    Parameters<SensorsPanelView["bindActions"]>[0],
-    SensorsPanelView
-  >();
+  return {
+    view: createModelActionPanelBindings<
+      SensorsPanelRenderModel,
+      SensorsPanelActionHandlers
+    >(),
+  };
 }
 
 function createDeferredSpeedSourcePanelView(): {
-  attach(realView: SpeedSourcePanelView): void;
+  attach(
+    realView: Pick<
+      SpeedSourcePanelView,
+      "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+    >,
+  ): void;
   view: SpeedSourcePanelView;
 } {
   type PendingFocusTarget = "manual" | "scan" | "stale";
-  const realView = signal<SpeedSourcePanelView | null>(null);
-  const actions = createDeferredBindSlot(realView, (view, nextActions: Parameters<SpeedSourcePanelView["bindActions"]>[0]) => {
-    view.bindActions(nextActions);
-  });
-  const diagnostics = createDeferredBindSlot(realView, (view, nextDiagnostics: Parameters<SpeedSourcePanelView["bindDiagnostics"]>[0]) => {
-    view.bindDiagnostics(nextDiagnostics);
-  });
-  const model = createDeferredBindSlot(realView, (view, nextModel: Parameters<SpeedSourcePanelView["bindModel"]>[0]) => {
-    view.bindModel(nextModel);
-  });
+  const realView = signal<Pick<
+    SpeedSourcePanelView,
+    "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+  > | null>(null);
   const pendingFocusTarget = signal<PendingFocusTarget | null>(null);
   effect(() => {
     const view = realView.value;
@@ -298,15 +251,9 @@ function createDeferredSpeedSourcePanelView(): {
 
   return {
     view: {
-      bindActions(nextActions) {
-        actions.bind(nextActions);
-      },
-      bindDiagnostics(nextDiagnostics) {
-        diagnostics.bind(nextDiagnostics);
-      },
-      bindModel(nextModel) {
-        model.bind(nextModel);
-      },
+      actions: signal<SpeedSourcePanelActionHandlers | null>(null),
+      diagnostics: createDeferredModelSignal<SpeedSourceDiagnosticsRenderModel>(),
+      model: createDeferredModelSignal<SpeedSourcePanelRenderModel>(),
       focusManualSpeedInput() {
         pendingFocusTarget.value = "manual";
       },
@@ -321,40 +268,31 @@ function createDeferredSpeedSourcePanelView(): {
         if (attachedView !== null) {
           return attachedView.isObdConfigVisible();
         }
-        return model.current.value?.value.obdConfigVisible ?? false;
+        return this.model.value?.value.obdConfigVisible ?? false;
       },
     },
     attach(nextRealView) {
       realView.value = nextRealView;
-      actions.attach(nextRealView);
-      diagnostics.attach(nextRealView);
-      model.attach(nextRealView);
     },
   };
 }
 
 function createDeferredUpdatePanelView(): {
-  attach(realView: UpdatePanelView): void;
   view: UpdatePanelView;
 } {
-  return createDeferredModelActionView<
-    Parameters<UpdatePanelView["bindModel"]>[0],
-    Parameters<UpdatePanelView["bindActions"]>[0],
-    UpdatePanelView
-  >();
+  return {
+    view: createModelActionPanelBindings<
+      UpdatePanelRenderModel,
+      UpdatePanelActionHandlers
+    >(),
+  };
 }
 
 function createDeferredInternetPanelView(): {
-  attach(realView: InternetPanelView): void;
+  attach(realView: Pick<InternetPanelView, "focusSsidInput">): void;
   view: InternetPanelView;
 } {
-  const realView = signal<InternetPanelView | null>(null);
-  const actions = createDeferredBindSlot(realView, (view, nextActions: Parameters<InternetPanelView["bindActions"]>[0]) => {
-    view.bindActions(nextActions);
-  });
-  const model = createDeferredBindSlot(realView, (view, nextModel: Parameters<InternetPanelView["bindModel"]>[0]) => {
-    view.bindModel(nextModel);
-  });
+  const realView = signal<Pick<InternetPanelView, "focusSsidInput"> | null>(null);
   const focusSsidRequested = signal(false);
   effect(() => {
     const view = realView.value;
@@ -366,33 +304,27 @@ function createDeferredInternetPanelView(): {
 
   return {
     view: {
-      bindActions(nextActions) {
-        actions.bind(nextActions);
-      },
-      bindModel(nextModel) {
-        model.bind(nextModel);
-      },
+      actions: signal<InternetPanelActionHandlers | null>(null),
+      model: createDeferredModelSignal<InternetPanelRenderModel>(),
       focusSsidInput() {
         focusSsidRequested.value = true;
       },
     },
     attach(nextRealView) {
       realView.value = nextRealView;
-      actions.attach(nextRealView);
-      model.attach(nextRealView);
     },
   };
 }
 
 function createDeferredEspFlashPanelView(): {
-  attach(realView: EspFlashPanelView): void;
   view: EspFlashPanelView;
 } {
-  return createDeferredModelActionView<
-    Parameters<EspFlashPanelView["bindModel"]>[0],
-    Parameters<EspFlashPanelView["bindActions"]>[0],
-    EspFlashPanelView
-  >();
+  return {
+    view: createModelActionPanelBindings<
+      EspFlashPanelRenderModel,
+      EspFlashPanelActionHandlers
+    >(),
+  };
 }
 
 export function createLazyUiPanels(deps: CreateUiLazyPanelsDeps): UiLazyPanels {
@@ -412,35 +344,40 @@ export function createLazyUiPanels(deps: CreateUiLazyPanelsDeps): UiLazyPanels {
   let historyMountPromise: Promise<void> | null = null;
   let settingsMountPromise: Promise<void> | null = null;
 
-  const attachSettingsPanels = (mountedPanels: UiMountedLazyPanels): void => {
+  const attachSettingsPanels = (mountedPanels: UiMountedLazyPanelHandles): void => {
     settingsShell.attach(mountedPanels.settingsShell);
     settings.cars.attach(mountedPanels.settings.cars);
     settings.analysis.attach(mountedPanels.settings.analysis);
     settings.internet.attach(mountedPanels.settings.internet);
-    settings.update.attach(mountedPanels.settings.update);
-    settings.sensors.attach(mountedPanels.settings.sensors);
     settings.speedSource.attach(mountedPanels.settings.speedSource);
-    settings.espFlash.attach(mountedPanels.settings.espFlash);
   };
 
   const ensureHistoryMounted = (): Promise<void> => {
     if (historyMountPromise === null) {
-      historyMountPromise = (deps.loadHistoryPanel ?? mountHistoryPanelLazy)(hosts).then(
-        (realView) => {
-          history.attach(realView);
-        },
-      );
+      historyMountPromise = (deps.loadHistoryPanel ?? mountHistoryPanelLazy)(hosts, history.view);
     }
     return historyMountPromise;
   };
 
   const ensureSettingsMounted = (): Promise<void> => {
     if (settingsMountPromise === null) {
-      settingsMountPromise = (deps.loadSettingsPanels ?? mountSettingsPanelsLazy)(hosts).then(
-        (mountedPanels) => {
-          attachSettingsPanels(mountedPanels);
+      settingsMountPromise = (deps.loadSettingsPanels ?? mountSettingsPanelsLazy)(
+        hosts,
+        {
+          settingsShell: settingsShell.view,
+          settings: {
+            analysis: settings.analysis.view,
+            cars: settings.cars.view,
+            espFlash: settings.espFlash.view,
+            internet: settings.internet.view,
+            sensors: settings.sensors.view,
+            speedSource: settings.speedSource.view,
+            update: settings.update.view,
+          },
         },
-      );
+      ).then((mountedPanels) => {
+          attachSettingsPanels(mountedPanels);
+        });
     }
     return settingsMountPromise;
   };

--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -232,6 +232,7 @@ function createDeferredSpeedSourcePanelView(): {
     SpeedSourcePanelView,
     "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
   > | null>(null);
+  const model = createDeferredModelSignal<SpeedSourcePanelRenderModel>();
   const pendingFocusTarget = signal<PendingFocusTarget | null>(null);
   effect(() => {
     const view = realView.value;
@@ -253,7 +254,7 @@ function createDeferredSpeedSourcePanelView(): {
     view: {
       actions: signal<SpeedSourcePanelActionHandlers | null>(null),
       diagnostics: createDeferredModelSignal<SpeedSourceDiagnosticsRenderModel>(),
-      model: createDeferredModelSignal<SpeedSourcePanelRenderModel>(),
+      model,
       focusManualSpeedInput() {
         pendingFocusTarget.value = "manual";
       },
@@ -268,7 +269,7 @@ function createDeferredSpeedSourcePanelView(): {
         if (attachedView !== null) {
           return attachedView.isObdConfigVisible();
         }
-        return this.model.value?.value.obdConfigVisible ?? false;
+        return model.value?.value.obdConfigVisible ?? false;
       },
     },
     attach(nextRealView) {

--- a/apps/ui/src/app/ui_panel_bootstrap.ts
+++ b/apps/ui/src/app/ui_panel_bootstrap.ts
@@ -1,25 +1,33 @@
+import { signal } from "./ui_signals";
+import {
+  createDeferredModelSignal,
+  createModelActionPanelBindings,
+} from "./views/view_model_binding";
 import type { SpectrumPanelView } from "./runtime/spectrum_panel_view";
 import {
   type UiPanelHostRegistry,
 } from "./ui_panel_host_registry";
-import type { AnalysisPanelView } from "./views/analysis_panel";
-import type { CarsPanelView } from "./views/cars_panel";
-import type { EspFlashPanelView } from "./views/esp_flash_panel";
+import { mountAnalysisPanel, type AnalysisPanelView } from "./views/analysis_panel";
+import { mountCarsPanel, type CarsPanelView } from "./views/cars_panel";
+import { mountEspFlashPanel, type EspFlashPanelView } from "./views/esp_flash_panel";
 import type { HistoryPanelView } from "./views/history_table_view";
-import type { InternetPanelView } from "./views/internet_panel";
+import { mountInternetPanel, type InternetPanelView } from "./views/internet_panel";
 import {
   mountRealtimeLoggingPanel,
+  type RealtimeLoggingPanelActionHandlers,
   type RealtimeLoggingPanelBridge,
+  type RealtimeLoggingPanelRenderModel,
 } from "./views/realtime_logging_panel";
 import {
   mountRealtimeLiveOverview,
   type RealtimeLiveOverviewBridge,
+  type RealtimeLiveOverviewRenderModel,
 } from "./views/realtime_live_overview";
-import type { SensorsPanelView } from "./views/sensors_panel";
+import { mountSensorsPanel, type SensorsPanelView } from "./views/sensors_panel";
 import type { SettingsShellView } from "./views/settings_shell";
-import type { SpeedSourcePanelView } from "./views/speed_source_panel";
+import { mountSpeedSourcePanel, type SpeedSourcePanelView } from "./views/speed_source_panel";
 import { mountSpectrumPanel } from "./views/spectrum_panel";
-import type { UpdatePanelView } from "./views/update_panel";
+import { mountUpdatePanel, type UpdatePanelView } from "./views/update_panel";
 
 export interface UiMountedDashboardPanels {
   spectrum: SpectrumPanelView;
@@ -46,26 +54,51 @@ export interface UiMountedPanels {
 
 export type UiMountedLazyPanels = Pick<UiMountedPanels, "settingsShell" | "settings">;
 
+export interface UiMountedLazyPanelHandles {
+  settingsShell: SettingsShellView;
+  settings: {
+    analysis: Pick<AnalysisPanelView, "focusField" | "openGuidance">;
+    cars: Pick<CarsPanelView["wizard"], "focus">;
+    internet: Pick<InternetPanelView, "focusSsidInput">;
+    speedSource: Pick<
+      SpeedSourcePanelView,
+      "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+    >;
+  };
+}
+
 export function mountDashboardPanels(
   hosts: UiPanelHostRegistry,
 ): UiMountedDashboardPanels {
+  const liveOverview: RealtimeLiveOverviewBridge = {
+    model: createDeferredModelSignal<RealtimeLiveOverviewRenderModel>(),
+    speedText: signal("--"),
+  };
+  const logging: RealtimeLoggingPanelBridge = createModelActionPanelBindings<
+    RealtimeLoggingPanelRenderModel,
+    RealtimeLoggingPanelActionHandlers
+  >();
+  mountRealtimeLiveOverview(hosts.dashboard.liveOverview, liveOverview);
+  mountRealtimeLoggingPanel(hosts.dashboard.logging, logging);
   return {
     spectrum: mountSpectrumPanel(hosts.dashboard.spectrum),
-    liveOverview: mountRealtimeLiveOverview(hosts.dashboard.liveOverview),
-    logging: mountRealtimeLoggingPanel(hosts.dashboard.logging),
+    liveOverview,
+    logging,
   };
 }
 
 export async function mountHistoryPanelLazy(
   hosts: UiPanelHostRegistry,
-): Promise<HistoryPanelView> {
+  view: HistoryPanelView,
+): Promise<void> {
   const { mountHistoryPanel } = await import("./views/history_panel");
-  return mountHistoryPanel(hosts.history);
+  mountHistoryPanel(hosts.history, view);
 }
 
 export async function mountSettingsPanelsLazy(
   hosts: UiPanelHostRegistry,
-): Promise<UiMountedLazyPanels> {
+  panels: UiMountedLazyPanels,
+): Promise<UiMountedLazyPanelHandles> {
   const settingsShellModulePromise = import("./views/settings_shell");
   const settingsPanelModulesPromise = Promise.all([
     import("./views/cars_panel"),
@@ -89,16 +122,20 @@ export async function mountSettingsPanelsLazy(
     { mountSpeedSourcePanel },
     { mountEspFlashPanel },
   ] = await settingsPanelModulesPromise;
+  const cars = mountCarsPanel(settingsHosts.cars, panels.settings.cars);
+  const analysis = mountAnalysisPanel(settingsHosts.analysis, panels.settings.analysis);
+  const internet = mountInternetPanel(settingsHosts.internet, panels.settings.internet);
+  mountUpdatePanel(settingsHosts.update, panels.settings.update);
+  mountSensorsPanel(settingsHosts.sensors, panels.settings.sensors);
+  const speedSource = mountSpeedSourcePanel(settingsHosts.speedSource, panels.settings.speedSource);
+  mountEspFlashPanel(settingsHosts.espFlash, panels.settings.espFlash);
   return {
     settingsShell,
     settings: {
-      cars: mountCarsPanel(settingsHosts.cars),
-      analysis: mountAnalysisPanel(settingsHosts.analysis),
-      internet: mountInternetPanel(settingsHosts.internet),
-      update: mountUpdatePanel(settingsHosts.update),
-      sensors: mountSensorsPanel(settingsHosts.sensors),
-      speedSource: mountSpeedSourcePanel(settingsHosts.speedSource),
-      espFlash: mountEspFlashPanel(settingsHosts.espFlash),
+      cars,
+      analysis,
+      internet,
+      speedSource,
     },
   };
 }

--- a/apps/ui/src/app/views/analysis_panel.tsx
+++ b/apps/ui/src/app/views/analysis_panel.tsx
@@ -6,6 +6,7 @@ import {
   computed,
   signal,
   useSignalEffect,
+  type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
 import {
@@ -22,6 +23,7 @@ import {
   AnalysisGuidanceDialog,
   AnalysisSaveFeedback,
 } from "./analysis_panel_sections";
+import type { DeferredModelSignal } from "./view_model_binding";
 
 export type {
   AnalysisPanelActionHandlers,
@@ -32,10 +34,13 @@ export type {
   SettingsAnalysisGuidanceRenderModel,
 } from "./analysis_panel_models";
 
-export interface AnalysisPanelView {
-  bindActions(handlers: AnalysisPanelActionHandlers): void;
-  bindCarAvailability(state: ReadonlySignal<AnalysisPanelCarAvailability>): void;
-  bindModel(model: ReadonlySignal<AnalysisPanelRenderModel>): void;
+export interface AnalysisPanelBindings {
+  actions: Signal<AnalysisPanelActionHandlers | null>;
+  carAvailability: DeferredModelSignal<AnalysisPanelCarAvailability>;
+  model: DeferredModelSignal<AnalysisPanelRenderModel>;
+}
+
+export interface AnalysisPanelView extends AnalysisPanelBindings {
   focusField(field: AnalysisPanelFieldKey): void;
   openGuidance(): void;
 }
@@ -231,14 +236,14 @@ function AnalysisPanel(props: {
   );
 }
 
-export function mountAnalysisPanel(host: HTMLElement): AnalysisPanelView {
-  const actions = signal<AnalysisPanelActionHandlers | null>(null);
-  const availabilitySignal = signal<ReadonlySignal<AnalysisPanelCarAvailability> | null>(null);
-  const modelSignal = signal<ReadonlySignal<AnalysisPanelRenderModel> | null>(null);
+export function mountAnalysisPanel(
+  host: HTMLElement,
+  bindings: AnalysisPanelBindings,
+): Pick<AnalysisPanelView, "focusField" | "openGuidance"> {
   const bridgeState = computed<AnalysisPanelBridgeState>(() => ({
-    actions: actions.value,
-    availability: availabilitySignal.value?.value ?? DEFAULT_ANALYSIS_CAR_AVAILABILITY,
-    model: modelSignal.value?.value ?? DEFAULT_ANALYSIS_PANEL_MODEL,
+    actions: bindings.actions.value,
+    availability: bindings.carAvailability.value?.value ?? DEFAULT_ANALYSIS_CAR_AVAILABILITY,
+    model: bindings.model.value?.value ?? DEFAULT_ANALYSIS_PANEL_MODEL,
   }));
   const inputFocusRequest = signal<AnalysisFieldFocusRequest | null>(null);
   const guidanceOpenRequest = signal(0);
@@ -253,15 +258,6 @@ export function mountAnalysisPanel(host: HTMLElement): AnalysisPanelView {
   );
 
   return {
-    bindActions(handlers) {
-      actions.value = handlers;
-    },
-    bindCarAvailability(state) {
-      availabilitySignal.value = state;
-    },
-    bindModel(model) {
-      modelSignal.value = model;
-    },
     focusField(field) {
       focusRequestToken += 1;
       inputFocusRequest.value = { field, token: focusRequestToken };

--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -2,7 +2,9 @@ import { render } from "preact";
 
 import type { CarsFeatureFocusTarget } from "../features/cars_feature_workflow";
 import {
+  computed,
   signal,
+  type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
 import {
@@ -23,19 +25,20 @@ import {
   useCarsWizardFocusManager,
   type CarsWizardFocusRequest,
 } from "./cars_wizard_focus";
+import type { DeferredModelSignal } from "./view_model_binding";
 
 export type { CarsFeatureInteraction, CarsFeatureInteractionHandlers } from "./cars_wizard_panel";
 export type { CarsListRenderModel } from "./cars_list_section";
 
 export interface CarsListPanelView {
-  bindActions(handlers: { onAction(action: import("./settings_car_list_view").CarsListAction): void }): void;
-  bindModel(model: ReadonlySignal<CarsListRenderModel>): void;
+  actions: Signal<{ onAction(action: import("./settings_car_list_view").CarsListAction): void } | null>;
+  model: DeferredModelSignal<CarsListRenderModel>;
 }
 
 export interface CarsWizardPanelBridge {
-  bindActions(handlers: CarsFeatureInteractionHandlers): void;
+  actions: Signal<CarsFeatureInteractionHandlers | null>;
   focus(target: CarsFeatureFocusTarget): void;
-  bindModel(model: ReadonlySignal<CarsWizardRenderModel>): void;
+  model: DeferredModelSignal<CarsWizardRenderModel>;
 }
 
 export interface CarsPanelView {
@@ -84,13 +87,16 @@ function CarsPanel(props: {
   );
 }
 
-export function mountCarsPanel(host: HTMLElement): CarsPanelView {
-  const bridgeState = signal<CarsPanelBridgeState>({
-    actions: null,
-    model: null,
-    wizardActions: null,
-    wizardModel: null,
-  });
+export function mountCarsPanel(
+  host: HTMLElement,
+  bindings: Pick<CarsPanelView, "list" | "wizard">,
+): Pick<CarsPanelView["wizard"], "focus"> {
+  const bridgeState = computed<CarsPanelBridgeState>(() => ({
+      actions: bindings.list.actions.value,
+      model: bindings.list.model.value,
+      wizardActions: bindings.wizard.actions.value,
+      wizardModel: bindings.wizard.model.value,
+    }));
   const wizardFocusRequest = signal<CarsWizardFocusRequest | null>(null);
   let focusRequestToken = 0;
   render(
@@ -102,25 +108,9 @@ export function mountCarsPanel(host: HTMLElement): CarsPanelView {
   );
 
   return {
-    list: {
-      bindActions(handlers): void {
-        bridgeState.value = { ...bridgeState.value, actions: handlers };
-      },
-      bindModel(model): void {
-        bridgeState.value = { ...bridgeState.value, model };
-      },
-    },
-    wizard: {
-      bindActions(handlers): void {
-        bridgeState.value = { ...bridgeState.value, wizardActions: handlers };
-      },
-      focus(target): void {
-        focusRequestToken += 1;
-        wizardFocusRequest.value = { target, token: focusRequestToken };
-      },
-      bindModel(model): void {
-        bridgeState.value = { ...bridgeState.value, wizardModel: model };
-      },
+    focus(target): void {
+      focusRequestToken += 1;
+      wizardFocusRequest.value = { target, token: focusRequestToken };
     },
   };
 }

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -3,9 +3,9 @@ import { useRef } from "preact/hooks";
 
 import { useUiText } from "../ui_i18n";
 import {
-  signal,
   useComputed,
   useSignalEffect,
+  type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
 import type { VisualVariant } from "../view_style_types";
@@ -13,7 +13,10 @@ import {
   MaintenanceReadinessPanel,
   type MaintenanceReadinessPanelModel,
 } from "./maintenance_readiness_view";
-import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
+import {
+  type DeferredModelSignal,
+  useDeferredViewModel,
+} from "./view_model_binding";
 
 export interface EspFlashStatusBadgeModel {
   text: string;
@@ -118,8 +121,8 @@ export interface EspFlashPanelActionHandlers {
 }
 
 export interface EspFlashPanelView {
-  bindActions(handlers: EspFlashPanelActionHandlers): void;
-  bindModel(model: ReadonlySignal<EspFlashPanelRenderModel>): void;
+  actions: Signal<EspFlashPanelActionHandlers | null>;
+  model: DeferredModelSignal<EspFlashPanelRenderModel>;
 }
 
 const DEFAULT_ESP_FLASH_PANEL_MODEL: EspFlashPanelRenderModel = {
@@ -562,17 +565,6 @@ function EspFlashPanel(props: {
   );
 }
 
-export function mountEspFlashPanel(host: HTMLElement): EspFlashPanelView {
-  const actions = signal<EspFlashPanelActionHandlers | null>(null);
-  const modelBinding = createDeferredViewModel<EspFlashPanelRenderModel>();
-  render(<EspFlashPanel actions={actions} model={modelBinding.model} />, host);
-
-  return {
-    bindActions(handlers) {
-      actions.value = handlers;
-    },
-    bindModel(model) {
-      modelBinding.bind(model);
-    },
-  };
+export function mountEspFlashPanel(host: HTMLElement, view: EspFlashPanelView): void {
+  render(<EspFlashPanel actions={view.actions} model={view.model} />, host);
 }

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -1,17 +1,16 @@
 import { render } from "preact";
 import { useUiText } from "../ui_i18n";
 import {
-  signal,
   useComputed,
   useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
 import { HistoryTableBody } from "./history_table_content";
-import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
+import { useDeferredViewModel } from "./view_model_binding";
 import type {
   HistoryPanelActionHandlers,
-  HistoryPanelRenderModel,
   HistoryPanelView,
+  HistoryPanelRenderModel,
 } from "./history_table_view";
 
 const DEFAULT_PANEL_MODEL: HistoryPanelRenderModel = {
@@ -94,17 +93,6 @@ function HistoryPanel(props: {
   );
 }
 
-export function mountHistoryPanel(host: HTMLElement): HistoryPanelView {
-  const actions = signal<HistoryPanelActionHandlers | null>(null);
-  const modelBinding = createDeferredViewModel<HistoryPanelRenderModel>();
-  render(<HistoryPanel actions={actions} model={modelBinding.model} />, host);
-
-  return {
-    bindModel(model: ReadonlySignal<HistoryPanelRenderModel>): void {
-      modelBinding.bind(model);
-    },
-    bindActions(handlers: HistoryPanelActionHandlers): void {
-      actions.value = handlers;
-    },
-  };
+export function mountHistoryPanel(host: HTMLElement, view: HistoryPanelView): void {
+  render(<HistoryPanel actions={view.actions} model={view.model} />, host);
 }

--- a/apps/ui/src/app/views/history_table_view.ts
+++ b/apps/ui/src/app/views/history_table_view.ts
@@ -1,6 +1,7 @@
 import type { HistoryEntry } from "../../api/types";
 import type { RunDetail } from "../ui_app_state";
-import type { ReadonlySignal } from "../ui_signals";
+import type { Signal } from "../ui_signals";
+import type { DeferredModelSignal } from "./view_model_binding";
 
 export interface HistoryTableViewParams {
   runs: HistoryEntry[];
@@ -50,6 +51,6 @@ export interface HistoryPanelActionHandlers {
 }
 
 export interface HistoryPanelView {
-  bindModel(model: ReadonlySignal<HistoryPanelRenderModel>): void;
-  bindActions(handlers: HistoryPanelActionHandlers): void;
+  actions: Signal<HistoryPanelActionHandlers | null>;
+  model: DeferredModelSignal<HistoryPanelRenderModel>;
 }

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -5,10 +5,13 @@ import type { UpdateStartRequestPayload } from "../../api/types";
 import type { ChoiceCardState } from "../view_style_types";
 import { getUiText as t } from "../ui_i18n";
 import {
+  computed,
   signal,
+  type Signal,
   useSignalEffect,
   type ReadonlySignal,
 } from "../ui_signals";
+import type { DeferredModelSignal } from "./view_model_binding";
 import type {
   MaintenanceReadinessItem,
   MaintenanceReadinessPanelModel,
@@ -54,9 +57,12 @@ export interface InternetPanelActionHandlers {
   onTransportChange(transport: UpdateStartRequestPayload["transport"]): void;
 }
 
-export interface InternetPanelView {
-  bindActions(handlers: InternetPanelActionHandlers): void;
-  bindModel(model: ReadonlySignal<InternetPanelRenderModel>): void;
+export interface InternetPanelBindings {
+  actions: Signal<InternetPanelActionHandlers | null>;
+  model: DeferredModelSignal<InternetPanelRenderModel>;
+}
+
+export interface InternetPanelView extends InternetPanelBindings {
   focusSsidInput(): void;
 }
 
@@ -440,22 +446,19 @@ function InternetPanel(props: {
   );
 }
 
-export function mountInternetPanel(host: HTMLElement): InternetPanelView {
+export function mountInternetPanel(
+  host: HTMLElement,
+  bindings: InternetPanelBindings,
+): Pick<InternetPanelView, "focusSsidInput"> {
   const focusRequest = signal<InternetPanelFocusRequest | null>(null);
   let focusRequestToken = 0;
-  const state = signal<InternetPanelBridgeState>({
-    actions: null,
-    model: null,
-  });
+  const state = computed<InternetPanelBridgeState>(() => ({
+    actions: bindings.actions.value,
+    model: bindings.model.value,
+  }));
   render(<InternetPanel focusRequest={focusRequest} state={state} />, host);
 
   return {
-    bindActions(handlers) {
-      state.value = { ...state.value, actions: handlers };
-    },
-    bindModel(model) {
-      state.value = { ...state.value, model };
-    },
     focusSsidInput() {
       focusRequestToken += 1;
       focusRequest.value = { field: "ssid", token: focusRequestToken };

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -2,12 +2,15 @@ import { render } from "preact";
 
 import { useUiText } from "../ui_i18n";
 import {
-  signal,
   useComputed,
   useSignalProperties,
+  type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
-import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
+import {
+  type DeferredModelSignal,
+  useDeferredViewModel,
+} from "./view_model_binding";
 
 export interface RealtimeLiveOverviewActiveCarModel {
   text: string;
@@ -43,8 +46,8 @@ interface RealtimeLiveOverviewBridgeState {
 }
 
 export interface RealtimeLiveOverviewBridge {
-  bindModel(model: ReadonlySignal<RealtimeLiveOverviewRenderModel>): void;
-  setSpeedText(text: string): void;
+  model: DeferredModelSignal<RealtimeLiveOverviewRenderModel>;
+  speedText: Signal<string>;
 }
 
 const DEFAULT_OVERVIEW_MODEL: RealtimeLiveOverviewRenderModel = {
@@ -268,17 +271,9 @@ function RealtimeLiveOverview(props: {
   );
 }
 
-export function mountRealtimeLiveOverview(host: HTMLElement): RealtimeLiveOverviewBridge {
-  const modelBinding = createDeferredViewModel<RealtimeLiveOverviewRenderModel>();
-  const speedText = signal(DEFAULT_OVERVIEW_STATE.speedText);
-  render(<RealtimeLiveOverview model={modelBinding.model} speedText={speedText} />, host);
-
-  return {
-    bindModel(model: ReadonlySignal<RealtimeLiveOverviewRenderModel>): void {
-      modelBinding.bind(model);
-    },
-    setSpeedText(text: string): void {
-      speedText.value = text;
-    },
-  };
+export function mountRealtimeLiveOverview(
+  host: HTMLElement,
+  view: RealtimeLiveOverviewBridge,
+): void {
+  render(<RealtimeLiveOverview model={view.model} speedText={view.speedText} />, host);
 }

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -2,13 +2,16 @@ import { render } from "preact";
 
 import { useUiText } from "../ui_i18n";
 import {
-  signal,
   useComputed,
   useSignalProperties,
+  type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
 import { inlineStateActionClass } from "./dom_helpers";
-import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
+import {
+  type DeferredModelSignal,
+  useDeferredViewModel,
+} from "./view_model_binding";
 import type {
   RealtimeCaptureReadinessChecklistModel,
   RealtimeLoggingSummaryAction,
@@ -40,8 +43,8 @@ export interface RealtimeLoggingPanelActionHandlers {
 }
 
 export interface RealtimeLoggingPanelBridge {
-  bindModel(model: ReadonlySignal<RealtimeLoggingPanelRenderModel>): void;
-  bindActions(handlers: RealtimeLoggingPanelActionHandlers): void;
+  actions: Signal<RealtimeLoggingPanelActionHandlers | null>;
+  model: DeferredModelSignal<RealtimeLoggingPanelRenderModel>;
 }
 
 const DEFAULT_PANEL_MODEL: RealtimeLoggingPanelRenderModel = {
@@ -301,17 +304,9 @@ function RealtimeLoggingPanel(props: {
   );
 }
 
-export function mountRealtimeLoggingPanel(host: HTMLElement): RealtimeLoggingPanelBridge {
-  const actions = signal<RealtimeLoggingPanelActionHandlers | null>(null);
-  const modelBinding = createDeferredViewModel<RealtimeLoggingPanelRenderModel>();
-  render(<RealtimeLoggingPanel actions={actions} model={modelBinding.model} />, host);
-
-  return {
-    bindModel(model: ReadonlySignal<RealtimeLoggingPanelRenderModel>): void {
-      modelBinding.bind(model);
-    },
-    bindActions(handlers: RealtimeLoggingPanelActionHandlers): void {
-      actions.value = handlers;
-    },
-  };
+export function mountRealtimeLoggingPanel(
+  host: HTMLElement,
+  view: RealtimeLoggingPanelBridge,
+): void {
+  render(<RealtimeLoggingPanel actions={view.actions} model={view.model} />, host);
 }

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -3,9 +3,9 @@ import type { JSX } from "preact";
 import { render } from "preact";
 import { useUiText } from "../ui_i18n";
 import {
-  signal,
   useComputed,
   useSignalProperties,
+  type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
 import type {
@@ -14,7 +14,10 @@ import type {
   RealtimeSensorTableRenderModel,
   RealtimeSensorTableRowViewModel,
 } from "./realtime_sensor_table_view";
-import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
+import {
+  type DeferredModelSignal,
+  useDeferredViewModel,
+} from "./view_model_binding";
 
 export interface SensorsPanelRenderModel {
   table: RealtimeSensorTableRenderModel | null;
@@ -26,8 +29,8 @@ export interface SensorsPanelActionHandlers {
 }
 
 export interface SensorsPanelView {
-  bindModel(model: ReadonlySignal<SensorsPanelRenderModel>): void;
-  bindActions(handlers: SensorsPanelActionHandlers): void;
+  actions: Signal<SensorsPanelActionHandlers | null>;
+  model: DeferredModelSignal<SensorsPanelRenderModel>;
 }
 
 const DEFAULT_SENSORS_PANEL_MODEL: SensorsPanelRenderModel = {
@@ -175,16 +178,6 @@ function SensorsPanel(props: {
   );
 }
 
-export function mountSensorsPanel(host: HTMLElement): SensorsPanelView {
-  const actions = signal<SensorsPanelActionHandlers | null>(null);
-  const modelBinding = createDeferredViewModel<SensorsPanelRenderModel>();
-  render(<SensorsPanel actions={actions} model={modelBinding.model} />, host);
-  return {
-    bindModel(model) {
-      modelBinding.bind(model);
-    },
-    bindActions(handlers) {
-      actions.value = handlers;
-    },
-  };
+export function mountSensorsPanel(host: HTMLElement, view: SensorsPanelView): void {
+  render(<SensorsPanel actions={view.actions} model={view.model} />, host);
 }

--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -6,6 +6,7 @@ import {
   computed,
   effect,
   signal,
+  type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
 import { SpeedSourceConfigPanel } from "./speed_source_config_panel";
@@ -14,6 +15,7 @@ import { DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL } from "./speed_source_panel_def
 import type {
   SettingsFeedbackMessage,
 } from "./settings_feedback";
+import type { DeferredModelSignal } from "./view_model_binding";
 
 export interface SpeedSourceChoiceCardRenderModel {
   badgeText: string | null;
@@ -106,10 +108,13 @@ export interface SpeedSourcePanelActionHandlers {
   onStaleTimeoutInput(value: string): void;
 }
 
-export interface SpeedSourcePanelView {
-  bindActions(handlers: SpeedSourcePanelActionHandlers): void;
-  bindDiagnostics(model: ReadonlySignal<SpeedSourceDiagnosticsRenderModel>): void;
-  bindModel(model: ReadonlySignal<SpeedSourcePanelRenderModel>): void;
+export interface SpeedSourcePanelBindings {
+  actions: Signal<SpeedSourcePanelActionHandlers | null>;
+  diagnostics: DeferredModelSignal<SpeedSourceDiagnosticsRenderModel>;
+  model: DeferredModelSignal<SpeedSourcePanelRenderModel>;
+}
+
+export interface SpeedSourcePanelView extends SpeedSourcePanelBindings {
   focusManualSpeedInput(): void;
   focusScanObdDevices(): void;
   focusStaleTimeoutInput(): void;
@@ -187,21 +192,24 @@ function SpeedSourcePanel(props: {
   );
 }
 
-export function mountSpeedSourcePanel(host: HTMLElement): SpeedSourcePanelView {
-  const actions = signal<SpeedSourcePanelActionHandlers | null>(null);
-  const diagnosticsSignal = signal<ReadonlySignal<SpeedSourceDiagnosticsRenderModel> | null>(null);
+export function mountSpeedSourcePanel(
+  host: HTMLElement,
+  bindings: SpeedSourcePanelBindings,
+): Pick<
+  SpeedSourcePanelView,
+  "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+> {
   const diagnosticsDisclosureOpen = signal(false);
-  const modelSignal = signal<ReadonlySignal<SpeedSourcePanelRenderModel> | null>(null);
   effect(() => {
-    if (modelSignal.value?.value.diagnosticsShouldOpen) {
+    if (bindings.model.value?.value.diagnosticsShouldOpen) {
       diagnosticsDisclosureOpen.value = true;
     }
   });
   const bridgeState = computed<SpeedSourcePanelBridgeState>(() => ({
-    actions: actions.value,
-    diagnostics: diagnosticsSignal.value?.value ?? DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL,
+    actions: bindings.actions.value,
+    diagnostics: bindings.diagnostics.value?.value ?? DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL,
     diagnosticsDisclosureOpen: diagnosticsDisclosureOpen.value,
-    model: modelSignal.value?.value ?? DEFAULT_SPEED_SOURCE_PANEL_MODEL,
+    model: bindings.model.value?.value ?? DEFAULT_SPEED_SOURCE_PANEL_MODEL,
   }));
   let manualSpeedInput: HTMLInputElement | null = null;
   let obdConfig: HTMLElement | null = null;
@@ -231,15 +239,6 @@ export function mountSpeedSourcePanel(host: HTMLElement): SpeedSourcePanelView {
   );
 
   return {
-    bindActions(handlers): void {
-      actions.value = handlers;
-    },
-    bindDiagnostics(model): void {
-      diagnosticsSignal.value = model;
-    },
-    bindModel(model): void {
-      modelSignal.value = model;
-    },
     focusManualSpeedInput(): void {
       manualSpeedInput?.focus();
     },

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -2,12 +2,15 @@ import { render, type ComponentChildren } from "preact";
 
 import { useUiText } from "../ui_i18n";
 import {
-  signal,
   useComputed,
   useSignalProperties,
+  type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
-import { createDeferredViewModel, useDeferredViewModel } from "./view_model_binding";
+import {
+  type DeferredModelSignal,
+  useDeferredViewModel,
+} from "./view_model_binding";
 import type {
   UpdateCurrentStatusSectionModel,
   UpdateHealthSectionModel,
@@ -47,8 +50,8 @@ const UPDATE_PANEL_MODEL_KEYS = [
 ] as const;
 
 export interface UpdatePanelView {
-  bindActions(handlers: UpdatePanelActionHandlers): void;
-  bindModel(model: ReadonlySignal<UpdatePanelRenderModel>): void;
+  actions: Signal<UpdatePanelActionHandlers | null>;
+  model: DeferredModelSignal<UpdatePanelRenderModel>;
 }
 
 const DEFAULT_UPDATE_PANEL_MODEL: UpdatePanelRenderModel = {
@@ -423,17 +426,6 @@ function UpdatePanel(props: {
   );
 }
 
-export function mountUpdatePanel(host: HTMLElement): UpdatePanelView {
-  const actions = signal<UpdatePanelActionHandlers | null>(null);
-  const modelBinding = createDeferredViewModel<UpdatePanelRenderModel>();
-  render(<UpdatePanel actions={actions} model={modelBinding.model} />, host);
-
-  return {
-    bindActions(handlers) {
-      actions.value = handlers;
-    },
-    bindModel(model) {
-      modelBinding.bind(model);
-    },
-  };
+export function mountUpdatePanel(host: HTMLElement, view: UpdatePanelView): void {
+  render(<UpdatePanel actions={view.actions} model={view.model} />, host);
 }

--- a/apps/ui/src/app/views/view_model_binding.ts
+++ b/apps/ui/src/app/views/view_model_binding.ts
@@ -5,13 +5,31 @@ import {
   type Signal,
 } from "../ui_signals";
 
+export type DeferredModelSignal<T> = Signal<ReadonlySignal<T> | null>;
+
 export interface DeferredViewModel<T> {
-  readonly model: Signal<ReadonlySignal<T> | null>;
+  readonly model: DeferredModelSignal<T>;
   bind(source: ReadonlySignal<T>): void;
 }
 
+export function createDeferredModelSignal<T>(): DeferredModelSignal<T> {
+  return signal<ReadonlySignal<T> | null>(null);
+}
+
+export interface ModelActionPanelBindings<TModel, TActions> {
+  actions: Signal<TActions | null>;
+  model: DeferredModelSignal<TModel>;
+}
+
+export function createModelActionPanelBindings<TModel, TActions>(): ModelActionPanelBindings<TModel, TActions> {
+  return {
+    actions: signal<TActions | null>(null),
+    model: createDeferredModelSignal<TModel>(),
+  };
+}
+
 export function createDeferredViewModel<T>(): DeferredViewModel<T> {
-  const model = signal<ReadonlySignal<T> | null>(null);
+  const model = createDeferredModelSignal<T>();
   return {
     model,
     bind(source) {

--- a/apps/ui/tests/analysis_panel_signals.ts
+++ b/apps/ui/tests/analysis_panel_signals.ts
@@ -5,6 +5,7 @@ import type {
   AnalysisPanelCarAvailability,
   AnalysisPanelFieldKey,
   AnalysisPanelRenderModel,
+  AnalysisPanelView,
 } from "../src/app/views/analysis_panel";
 import { mountSignalView } from "./dom_render_test_support";
 
@@ -53,7 +54,13 @@ async function runAnalysisPanelSignalBindingTest(): Promise<void> {
   const harness = await mountSignalView(async () => {
     const { mountAnalysisPanel } = await import("../src/app/views/analysis_panel");
     return mountAnalysisPanel;
-  });
+  }, (): AnalysisPanelView => ({
+    actions: signal(null),
+    carAvailability: signal(null),
+    model: signal(null),
+    focusField() {},
+    openGuidance() {},
+  }));
 
   try {
     const firstAvailability = signal<AnalysisPanelCarAvailability>({
@@ -67,8 +74,8 @@ async function runAnalysisPanelSignalBindingTest(): Promise<void> {
     const firstModel = signal(createAnalysisModel("5"));
     const secondModel = signal(createAnalysisModel("11"));
 
-    harness.view.bindCarAvailability(firstAvailability);
-    harness.view.bindModel(firstModel);
+    harness.view.carAvailability.value = firstAvailability;
+    harness.view.model.value = firstModel;
     await harness.flush();
 
     const noCarMessage = requireElement<HTMLElement>(harness.host, "#analysisNoCarMessage");
@@ -90,8 +97,8 @@ async function runAnalysisPanelSignalBindingTest(): Promise<void> {
     assert.equal(saveButton.disabled, false);
     assert.match(wheelBandwidthGuidance.textContent ?? "", /Current 8%/);
 
-    harness.view.bindCarAvailability(secondAvailability);
-    harness.view.bindModel(secondModel);
+    harness.view.carAvailability.value = secondAvailability;
+    harness.view.model.value = secondModel;
     await harness.flush();
 
     assert.equal(noCarMessage.hidden, true);

--- a/apps/ui/tests/dom_render_test_support.ts
+++ b/apps/ui/tests/dom_render_test_support.ts
@@ -436,6 +436,18 @@ function restoreGlobal<K extends keyof DomGlobals>(
 
 export async function mountSignalView<TView>(
   loadMount: () => Promise<(host: HTMLElement) => TView> | ((host: HTMLElement) => TView),
+): Promise<MountedSignalView<TView>>;
+export async function mountSignalView<TView>(
+  loadMount: () =>
+    Promise<(host: HTMLElement, view: TView) => void> | ((host: HTMLElement, view: TView) => void),
+  createView: () => TView,
+): Promise<MountedSignalView<TView>>;
+export async function mountSignalView<TView>(
+  loadMount: () =>
+    | Promise<((host: HTMLElement) => TView) | ((host: HTMLElement, view: TView) => void)>
+    | ((host: HTMLElement) => TView)
+    | ((host: HTMLElement, view: TView) => void),
+  createView?: () => TView,
 ): Promise<MountedSignalView<TView>> {
   const restoreDom = installMountedViewDomGlobals();
   const host = globalThis.document.createElement("div");
@@ -445,7 +457,10 @@ export async function mountSignalView<TView>(
   try {
     const { render } = await import("preact");
     const mount = await loadMount();
-    const view = mount(host);
+    const view = createView ? createView() : undefined;
+    const mountedView = createView
+      ? (mount as (host: HTMLElement, view: TView) => void)(host, view)
+      : (mount as (host: HTMLElement) => TView)(host);
     return {
       cleanup(): void {
         if (cleanedUp) {
@@ -459,7 +474,7 @@ export async function mountSignalView<TView>(
         return flushSignalUpdates(rounds);
       },
       host,
-      view,
+      view: createView ? view : mountedView,
     };
   } catch (error) {
     restoreDom();

--- a/apps/ui/tests/esp_flash_feature.spec.ts
+++ b/apps/ui/tests/esp_flash_feature.spec.ts
@@ -589,28 +589,42 @@ function createDeps() {
     espFlashHistoryPanel,
   } as EspFlashPanelDom;
 
+  const panel = {
+    actions: signal<EspFlashPanelActionHandlers | null>(null),
+    model: signal<ReadonlySignal<EspFlashPanelRenderModel> | null>(null),
+  };
+
+  effect(() => {
+    const handlers = panel.actions.value;
+    if (!handlers) {
+      return;
+    }
+    dom.espFlashStartBtn.addEventListener("click", () => {
+      handlers.onStart();
+    });
+    dom.espFlashCancelBtn?.addEventListener("click", () => {
+      handlers.onCancel();
+    });
+    dom.espFlashRefreshPortsBtn?.addEventListener("click", () => {
+      handlers.onRefreshPorts();
+    });
+    dom.espFlashPortSelect?.addEventListener("change", () => {
+      handlers.onSelectPort(dom.espFlashPortSelect?.value || "__auto__");
+    });
+  });
+
+  effect(() => {
+    const model = panel.model.value;
+    if (!model) {
+      return;
+    }
+    bindReactiveModel(model, (nextModel) => {
+      renderEspFlashPanelDom(dom, nextModel);
+    });
+  });
+
   return {
-    panel: {
-      bindActions(handlers: EspFlashPanelActionHandlers) {
-        dom.espFlashStartBtn.addEventListener("click", () => {
-          handlers.onStart();
-        });
-        dom.espFlashCancelBtn?.addEventListener("click", () => {
-          handlers.onCancel();
-        });
-        dom.espFlashRefreshPortsBtn?.addEventListener("click", () => {
-          handlers.onRefreshPorts();
-        });
-        dom.espFlashPortSelect?.addEventListener("change", () => {
-          handlers.onSelectPort(dom.espFlashPortSelect?.value || "__auto__");
-        });
-      },
-      bindModel(model) {
-        bindReactiveModel(model, (nextModel) => {
-          renderEspFlashPanelDom(dom, nextModel);
-        });
-      },
-    },
+    panel,
     ports: navigation.ports,
     els: dom,
     espFlashPortSelect,
@@ -774,50 +788,77 @@ function createUpdateDeps() {
     updateStatusPanel,
   } satisfies UpdatePanelDomHarness;
 
+  const updatePanel = {
+    actions: signal<UpdatePanelActionHandlers | null>(null),
+    model: signal<ReadonlySignal<UpdatePanelRenderModel> | null>(null),
+  };
+  const internetPanel = {
+    actions: signal<InternetPanelActionHandlers | null>(null),
+    model: signal<ReadonlySignal<InternetPanelRenderModel> | null>(null),
+    focusSsidInput() {
+      internetDom.updateSsidInput?.focus();
+    },
+  };
+
+  effect(() => {
+    const handlers = updatePanel.actions.value;
+    if (!handlers) {
+      return;
+    }
+    dom.updateStartBtn.addEventListener("click", () => {
+      handlers.onStart();
+    });
+    dom.updateCancelBtn.addEventListener("click", () => {
+      handlers.onCancel();
+    });
+  });
+
+  effect(() => {
+    const model = updatePanel.model.value;
+    if (!model) {
+      return;
+    }
+    bindReactiveModel(model, (nextModel) => {
+      renderUpdatePanelDom(dom, nextModel);
+    });
+  });
+
+  effect(() => {
+    const handlers = internetPanel.actions.value;
+    if (!handlers) {
+      return;
+    }
+    internetDom.updatePasswordInput?.addEventListener("input", () => {
+      handlers.onPasswordInput(internetDom.updatePasswordInput?.value ?? "");
+    });
+    internetDom.updateTogglePasswordBtn?.addEventListener("click", () => {
+      handlers.onTogglePassword();
+    });
+    internetDom.updateTransportWifiRadio?.addEventListener("change", () => {
+      handlers.onTransportChange("wifi");
+    });
+    internetDom.updateTransportUsbRadio?.addEventListener("change", () => {
+      handlers.onTransportChange("usb_internet");
+    });
+    internetDom.updateSsidInput?.addEventListener("input", () => {
+      handlers.onSsidInput(internetDom.updateSsidInput?.value ?? "");
+    });
+  });
+
+  effect(() => {
+    const model = internetPanel.model.value;
+    if (!model) {
+      return;
+    }
+    bindReactiveModel(model, (nextModel) => {
+      renderInternetPanelDom(internetDom, nextModel);
+    });
+  });
+
   return {
     panels: {
-      update: {
-        bindActions(handlers: UpdatePanelActionHandlers) {
-          dom.updateStartBtn.addEventListener("click", () => {
-            handlers.onStart();
-          });
-          dom.updateCancelBtn.addEventListener("click", () => {
-            handlers.onCancel();
-          });
-        },
-        bindModel(model) {
-          bindReactiveModel(model, (nextModel) => {
-            renderUpdatePanelDom(dom, nextModel);
-          });
-        },
-      },
-      internet: {
-        bindActions(handlers: InternetPanelActionHandlers) {
-          internetDom.updatePasswordInput?.addEventListener("input", () => {
-            handlers.onPasswordInput(internetDom.updatePasswordInput?.value ?? "");
-          });
-          internetDom.updateTogglePasswordBtn?.addEventListener("click", () => {
-            handlers.onTogglePassword();
-          });
-          internetDom.updateTransportWifiRadio?.addEventListener("change", () => {
-            handlers.onTransportChange("wifi");
-          });
-          internetDom.updateTransportUsbRadio?.addEventListener("change", () => {
-            handlers.onTransportChange("usb_internet");
-          });
-          internetDom.updateSsidInput?.addEventListener("input", () => {
-            handlers.onSsidInput(internetDom.updateSsidInput?.value ?? "");
-          });
-        },
-        focusSsidInput() {
-          internetDom.updateSsidInput?.focus();
-        },
-        bindModel(model) {
-          bindReactiveModel(model, (nextModel) => {
-            renderInternetPanelDom(internetDom, nextModel);
-          });
-        },
-      },
+      update: updatePanel,
+      internet: internetPanel,
     },
     ports: navigation.ports,
     els: dom,

--- a/apps/ui/tests/esp_flash_feature_bindings.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_bindings.spec.ts
@@ -5,14 +5,12 @@ import { signal } from "../src/app/ui_signals";
 import type { EspFlashPanelActionHandlers } from "../src/app/views/esp_flash_panel";
 
 test("bindHandlers uses panel action surfaces instead of raw DOM bindings", () => {
-  let handlers: EspFlashPanelActionHandlers | null = null;
+  const panel = {
+    actions: signal<EspFlashPanelActionHandlers | null>(null),
+    model: signal(null),
+  };
   const feature = createEspFlashFeature({
-    panel: {
-      bindActions(nextHandlers) {
-        handlers = nextHandlers;
-      },
-      bindModel() {},
-    },
+    panel,
     ports: {
       activeSettingsTabId: signal("espFlashTab"),
       activeViewId: signal("settingsView"),
@@ -25,6 +23,7 @@ test("bindHandlers uses panel action surfaces instead of raw DOM bindings", () =
   });
 
   expect(() => feature.bindHandlers()).not.toThrow();
+  const handlers = panel.actions.value;
   expect(handlers).not.toBeNull();
   expect(typeof handlers?.onStart).toBe("function");
   expect(typeof handlers?.onCancel).toBe("function");

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { createHistoryFeature } from "../src/app/features/history_feature";
 import { createAppState, type RunDetail } from "../src/app/ui_app_state";
-import { effect } from "../src/app/ui_signals";
+import { effect, signal } from "../src/app/ui_signals";
 import type {
   HistoryPanelActionHandlers,
   HistoryPanelRenderModel,
@@ -46,19 +46,23 @@ function createHistoryElements(): {
   let latestHandlers: HistoryPanelActionHandlers | null = null;
   let renderCount = 0;
   const panel: HistoryPanelView = {
-    bindModel(model) {
-      effect(() => {
-        const nextModel = model.value;
-        renderCount += 1;
-        latestModel = nextModel;
-        historySummary.textContent = nextModel.historySummaryText;
-        deleteAllRunsBtn.disabled = nextModel.deleteAllRunsDisabled;
-      });
-    },
-    bindActions(handlers) {
-      latestHandlers = handlers;
-    },
+    actions: signal(null),
+    model: signal(null),
   };
+  effect(() => {
+    latestHandlers = panel.actions.value;
+  });
+  effect(() => {
+    const model = panel.model.value;
+    if (model === null) {
+      return;
+    }
+    const nextModel = model.value;
+    renderCount += 1;
+    latestModel = nextModel;
+    historySummary.textContent = nextModel.historySummaryText;
+    deleteAllRunsBtn.disabled = nextModel.deleteAllRunsDisabled;
+  });
   return {
     panel,
     historySummary,
@@ -370,7 +374,7 @@ test("history feature reloads the expanded run when the language changes", async
   }
 
   expect(getRenderCount()).toBeGreaterThanOrEqual(6);
-  expect(requests).toEqual([
+  expect(requests.filter((url) => url.startsWith("/api/history/"))).toEqual([
     "/api/history/run-001/insights?lang=en",
     "/api/history/run-001/insights?lang=en",
     "/api/history/run-001/insights?lang=nl",
@@ -406,7 +410,7 @@ test("history feature treats analyzing insights responses as not-yet-available",
   expect(state.history.runDetailsById["run-001"]?.insights).toBeNull();
   expect(state.history.runDetailsById["run-001"]?.insightsError).toBe("");
   expect(getRenderCount()).toBeGreaterThanOrEqual(4);
-  expect(requests).toEqual([
+  expect(requests.filter((url) => url.startsWith("/api/history/"))).toEqual([
     "/api/history/run-001/insights?lang=en",
     "/api/history/run-001/insights?lang=en",
   ]);

--- a/apps/ui/tests/realtime_live_overview_signals.ts
+++ b/apps/ui/tests/realtime_live_overview_signals.ts
@@ -4,6 +4,7 @@ import { options } from "preact";
 
 import { computed, signal } from "../src/app/ui_signals";
 import type {
+  RealtimeLiveOverviewBridge,
   RealtimeLiveOverviewRenderModel,
   RealtimeLiveOverviewSensorCardModel,
 } from "../src/app/views/realtime_live_overview";
@@ -53,11 +54,14 @@ async function runRealtimeLiveOverviewSignalProjectionTest(): Promise<void> {
   const harness = await mountSignalView(async () => {
     const { mountRealtimeLiveOverview } = await import("../src/app/views/realtime_live_overview");
     return mountRealtimeLiveOverview;
-  });
+  }, (): RealtimeLiveOverviewBridge => ({
+    model: signal(null),
+    speedText: signal("--"),
+  }));
 
   try {
-    harness.view.bindModel(model);
-    harness.view.setSpeedText("43 km/h");
+    harness.view.model.value = model;
+    harness.view.speedText.value = "43 km/h";
     await harness.flush();
 
     assert.equal(overviewRenderCount, 1);

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { createSettingsAnalysisModule } from "../src/app/features/settings_analysis_module";
 import { createAppState } from "../src/app/ui_app_state";
-import { effect } from "../src/app/ui_signals";
+import { effect, signal } from "../src/app/ui_signals";
 import type {
   AnalysisPanelActionHandlers,
   AnalysisPanelFieldKey,
@@ -47,24 +47,26 @@ test("settings analysis module renders guidance and surfaces invalid input throu
   let guidanceOpened = false;
 
   const panel: AnalysisPanelView = {
-    bindActions(nextActions) {
-      actions = nextActions;
-    },
+    actions: signal(null),
+    carAvailability: signal(null),
+    model: signal(null),
     focusField(field) {
       focusedField = field;
     },
     openGuidance() {
       guidanceOpened = true;
     },
-    bindCarAvailability() {
-      return;
-    },
-    bindModel(model) {
-      effect(() => {
-        renders.push(model.value);
-      });
-    },
   };
+  effect(() => {
+    actions = panel.actions.value;
+  });
+  effect(() => {
+    const model = panel.model.value;
+    if (model === null) {
+      return;
+    }
+    renders.push(model.value);
+  });
 
   const module = createSettingsAnalysisModule({
     panel,

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -21,21 +21,22 @@ test("settings cars module dismisses transient creation feedback through typed t
   const activeSettingsTabId = signal("carTab");
 
   const panel: CarsListPanelView = {
-    bindActions() {},
-    bindModel(model) {
-      effect(() => {
-        renders.push(model.value);
-      });
-    },
+    actions: signal(null),
+    model: signal(null),
   };
+  effect(() => {
+    const model = panel.model.value;
+    if (model === null) {
+      return;
+    }
+    renders.push(model.value);
+  });
 
   const module = createSettingsCarsModule({
     settings: state,
     panels: {
       analysisPanel: {
-        bindCarAvailability() {
-          return;
-        },
+        carAvailability: signal(null),
       },
       panel,
     },

--- a/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
+++ b/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
@@ -6,25 +6,23 @@ import { signal } from "../src/app/ui_signals";
 import type { SpeedSourcePanelActionHandlers } from "../src/app/views/speed_source_panel";
 
 test("bindHandlers uses typed panel actions and navigation subscriptions", () => {
-  let handlers: SpeedSourcePanelActionHandlers | null = null;
   const activeViewId = signal("settingsView");
   const activeSettingsTabId = signal("speedSourceTab");
+  const panel = {
+    actions: signal<SpeedSourcePanelActionHandlers | null>(null),
+    diagnostics: signal(null),
+    model: signal(null),
+    focusManualSpeedInput() {},
+    focusScanObdDevices() {},
+    focusStaleTimeoutInput() {},
+    isObdConfigVisible() {
+      return false;
+    },
+  };
 
   const module = createSettingsSpeedSourceModule({
     settings: createAppState().settings,
-    panel: {
-      bindActions(nextHandlers) {
-        handlers = nextHandlers;
-      },
-      focusManualSpeedInput() {},
-      focusScanObdDevices() {},
-      focusStaleTimeoutInput() {},
-      isObdConfigVisible() {
-        return false;
-      },
-      bindModel() {},
-      bindDiagnostics() {},
-    },
+    panel,
     services: {
       t: (key) => key,
       requestConfirmation: async () => true,
@@ -42,6 +40,7 @@ test("bindHandlers uses typed panel actions and navigation subscriptions", () =>
   });
 
   expect(() => module.bindHandlers()).not.toThrow();
+  const handlers = panel.actions.value;
   expect(handlers).not.toBeNull();
   expect(typeof handlers?.onSpeedSourceChanged).toBe("function");
   expect(typeof handlers?.onManualSpeedInput).toBe("function");

--- a/apps/ui/tests/signal_view_reference_tests.ts
+++ b/apps/ui/tests/signal_view_reference_tests.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import { computed, effect, signal, useSignalProperties } from "../src/app/ui_signals";
 import type {
+  RealtimeLiveOverviewBridge,
   RealtimeLiveOverviewRenderModel,
   RealtimeLiveOverviewSensorCardModel,
 } from "../src/app/views/realtime_live_overview";
@@ -127,11 +128,14 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
   const harness = await mountSignalView(async () => {
     const { mountRealtimeLiveOverview } = await import("../src/app/views/realtime_live_overview");
     return mountRealtimeLiveOverview;
-  });
+  }, (): RealtimeLiveOverviewBridge => ({
+    model: signal(null),
+    speedText: signal("--"),
+  }));
 
   try {
-    harness.view.bindModel(model);
-    harness.view.setSpeedText("43 km/h");
+    harness.view.model.value = model;
+    harness.view.speedText.value = "43 km/h";
     await harness.flush();
 
     assert.equal(requireElement(harness.host, "#liveConnectedSensors [data-value]").textContent, "2 / 4");
@@ -178,7 +182,7 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
     assert.match(harness.host.textContent ?? "", /Front Left/);
     assert.doesNotMatch(harness.host.textContent ?? "", /No sensors/i);
 
-    harness.view.bindModel(reboundModel);
+    harness.view.model.value = reboundModel;
     await harness.flush();
 
     assert.equal(requireElement(harness.host, "#liveConnectedSensors [data-value]").textContent, "1 / 1");

--- a/apps/ui/tests/speed_source_panel_signals.ts
+++ b/apps/ui/tests/speed_source_panel_signals.ts
@@ -4,6 +4,7 @@ import { signal } from "../src/app/ui_signals";
 import { DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL } from "../src/app/views/speed_source_panel_defaults";
 import type {
   SpeedSourceDiagnosticsRenderModel,
+  SpeedSourcePanelView,
   SpeedSourcePanelRenderModel,
 } from "../src/app/views/speed_source_panel";
 import { mountSignalView } from "./dom_render_test_support";
@@ -61,7 +62,17 @@ async function runSpeedSourcePanelSignalBindingTest(): Promise<void> {
   const harness = await mountSignalView(async () => {
     const { mountSpeedSourcePanel } = await import("../src/app/views/speed_source_panel");
     return mountSpeedSourcePanel;
-  });
+  }, (): SpeedSourcePanelView => ({
+    actions: signal(null),
+    diagnostics: signal(null),
+    model: signal(null),
+    focusManualSpeedInput() {},
+    focusScanObdDevices() {},
+    focusStaleTimeoutInput() {},
+    isObdConfigVisible() {
+      return false;
+    },
+  }));
 
   try {
     const firstModel = signal(createSpeedSourcePanelModel("GPS primary", false));
@@ -69,8 +80,8 @@ async function runSpeedSourcePanelSignalBindingTest(): Promise<void> {
     const firstDiagnostics = signal(createDiagnosticsModel("idle"));
     const secondDiagnostics = signal(createDiagnosticsModel("locked"));
 
-    harness.view.bindModel(firstModel);
-    harness.view.bindDiagnostics(firstDiagnostics);
+    harness.view.model.value = firstModel;
+    harness.view.diagnostics.value = firstDiagnostics;
     await harness.flush();
 
     const currentSource = requireElement<HTMLElement>(harness.host, "#speedSourceCurrentSource");
@@ -90,8 +101,8 @@ async function runSpeedSourcePanelSignalBindingTest(): Promise<void> {
     assert.match(diagnosticsState.textContent ?? "", /searching/);
     assert.equal(diagnosticsDetails.hasAttribute("open"), false);
 
-    harness.view.bindModel(secondModel);
-    harness.view.bindDiagnostics(secondDiagnostics);
+    harness.view.model.value = secondModel;
+    harness.view.diagnostics.value = secondDiagnostics;
     await harness.flush();
 
     assert.match(currentSource.textContent ?? "", /OBD fallback/);

--- a/apps/ui/tests/ui_lazy_panels.spec.ts
+++ b/apps/ui/tests/ui_lazy_panels.spec.ts
@@ -29,17 +29,19 @@ function createDashboardPanels(): UiMountedDashboardPanels {
   return {
     spectrum: {} as UiMountedDashboardPanels["spectrum"],
     liveOverview: {
-      setSpeedText() {
-        return undefined;
-      },
+      model: signal(null),
+      speedText: signal("--"),
     } as UiMountedDashboardPanels["liveOverview"],
-    logging: {} as UiMountedDashboardPanels["logging"],
+    logging: {
+      actions: signal(null),
+      model: signal(null),
+    } as UiMountedDashboardPanels["logging"],
   };
 }
 
 function createHistoryPanelSpy() {
-  type HistoryActions = Parameters<HistoryPanelView["bindActions"]>[0];
-  type HistoryModel = Parameters<HistoryPanelView["bindModel"]>[0];
+  type HistoryActions = NonNullable<HistoryPanelView["actions"]["value"]>;
+  type HistoryModel = NonNullable<HistoryPanelView["model"]["value"]>;
 
   const actions: HistoryActions[] = [];
   const models: HistoryModel[] = [];
@@ -47,14 +49,14 @@ function createHistoryPanelSpy() {
   return {
     actions,
     models,
-    view: {
-      bindActions(nextActions) {
-        actions.push(nextActions);
-      },
-      bindModel(nextModel) {
-        models.push(nextModel);
-      },
-    } satisfies HistoryPanelView,
+    mount(view: HistoryPanelView) {
+      if (view.actions.value) {
+        actions.push(view.actions.value);
+      }
+      if (view.model.value) {
+        models.push(view.model.value);
+      }
+    },
   };
 }
 
@@ -78,8 +80,8 @@ function createSettingsShellSpy() {
 }
 
 function createInternetPanelSpy() {
-  type InternetActions = Parameters<InternetPanelView["bindActions"]>[0];
-  type InternetModel = Parameters<InternetPanelView["bindModel"]>[0];
+  type InternetActions = NonNullable<InternetPanelView["actions"]["value"]>;
+  type InternetModel = NonNullable<InternetPanelView["model"]["value"]>;
 
   const actions: InternetActions[] = [];
   let focusCalls = 0;
@@ -91,24 +93,26 @@ function createInternetPanelSpy() {
       return focusCalls;
     },
     models,
-    view: {
-      bindActions(nextActions) {
-        actions.push(nextActions);
-      },
-      bindModel(nextModel) {
-        models.push(nextModel);
-      },
+    handle: {
       focusSsidInput() {
         focusCalls += 1;
       },
-    } satisfies InternetPanelView,
+    } satisfies Pick<InternetPanelView, "focusSsidInput">,
+    mount(view: InternetPanelView) {
+      if (view.actions.value) {
+        actions.push(view.actions.value);
+      }
+      if (view.model.value) {
+        models.push(view.model.value);
+      }
+    },
   };
 }
 
 function createSpeedSourcePanelSpy() {
-  type SpeedSourceActions = Parameters<SpeedSourcePanelView["bindActions"]>[0];
-  type SpeedSourceDiagnostics = Parameters<SpeedSourcePanelView["bindDiagnostics"]>[0];
-  type SpeedSourceModel = Parameters<SpeedSourcePanelView["bindModel"]>[0];
+  type SpeedSourceActions = NonNullable<SpeedSourcePanelView["actions"]["value"]>;
+  type SpeedSourceDiagnostics = NonNullable<SpeedSourcePanelView["diagnostics"]["value"]>;
+  type SpeedSourceModel = NonNullable<SpeedSourcePanelView["model"]["value"]>;
 
   const actions: SpeedSourceActions[] = [];
   const diagnostics: SpeedSourceDiagnostics[] = [];
@@ -116,7 +120,7 @@ function createSpeedSourcePanelSpy() {
   let focusScanCalls = 0;
   let focusStaleCalls = 0;
   const models: SpeedSourceModel[] = [];
-  let obdConfigVisible = false;
+  let mountedView: SpeedSourcePanelView | null = null;
 
   return {
     actions,
@@ -131,33 +135,38 @@ function createSpeedSourcePanelSpy() {
       return focusStaleCalls;
     },
     isObdConfigVisible() {
-      return obdConfigVisible;
+      return mountedView?.model.value?.value.obdConfigVisible ?? false;
     },
     models,
-    view: {
-      bindActions(nextActions) {
-        actions.push(nextActions);
-      },
-      bindDiagnostics(nextDiagnostics) {
-        diagnostics.push(nextDiagnostics);
-      },
-      bindModel(nextModel) {
-        models.push(nextModel);
-        obdConfigVisible = nextModel.value.obdConfigVisible;
-      },
-      focusManualSpeedInput() {
-        focusManualCalls += 1;
-      },
-      focusScanObdDevices() {
-        focusScanCalls += 1;
-      },
-      focusStaleTimeoutInput() {
-        focusStaleCalls += 1;
-      },
-      isObdConfigVisible() {
-        return obdConfigVisible;
-      },
-    } satisfies SpeedSourcePanelView,
+    mount(view: SpeedSourcePanelView) {
+      mountedView = view;
+      if (view.actions.value) {
+        actions.push(view.actions.value);
+      }
+      if (view.diagnostics.value) {
+        diagnostics.push(view.diagnostics.value);
+      }
+      if (view.model.value) {
+        models.push(view.model.value);
+      }
+      return {
+        focusManualSpeedInput() {
+          focusManualCalls += 1;
+        },
+        focusScanObdDevices() {
+          focusScanCalls += 1;
+        },
+        focusStaleTimeoutInput() {
+          focusStaleCalls += 1;
+        },
+        isObdConfigVisible() {
+          return mountedView?.model.value?.value.obdConfigVisible ?? false;
+        },
+      } satisfies Pick<
+        SpeedSourcePanelView,
+        "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+      >;
+    },
   };
 }
 
@@ -178,22 +187,25 @@ test.describe("createLazyUiPanels", () => {
         dashboardMounts += 1;
         return createDashboardPanels();
       },
-      loadHistoryPanel: async () => {
+      loadHistoryPanel: async (_hosts, view) => {
         historyLoads += 1;
-        return historyPanel.view;
+        historyPanel.mount(view);
       },
-      loadSettingsPanels: async () => {
+      loadSettingsPanels: async (_hosts, panels) => {
         settingsLoads += 1;
+        internetPanel.mount(panels.settings.internet);
         return {
           settingsShell: settingsShell.view,
           settings: {
-            cars: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["cars"],
-            analysis: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["analysis"],
-            internet: internetPanel.view,
-            update: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["update"],
-            sensors: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["sensors"],
-            speedSource: speedSourcePanel.view,
-            espFlash: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["espFlash"],
+            analysis: {
+              focusField() {},
+              openGuidance() {},
+            },
+            cars: {
+              focus() {},
+            },
+            internet: internetPanel.handle,
+            speedSource: speedSourcePanel.mount(panels.settings.speedSource),
           },
         };
       },
@@ -203,28 +215,30 @@ test.describe("createLazyUiPanels", () => {
     expect(historyLoads).toBe(0);
     expect(settingsLoads).toBe(0);
 
-    const historyActions = {} as Parameters<HistoryPanelView["bindActions"]>[0];
-    const historyModel = signal({}) as unknown as Parameters<HistoryPanelView["bindModel"]>[0];
-    lazyPanels.panels.history.bindModel(historyModel);
-    lazyPanels.panels.history.bindActions(historyActions);
+    const historyActions = {} as NonNullable<HistoryPanelView["actions"]["value"]>;
+    const historyModel = signal({}) as unknown as NonNullable<HistoryPanelView["model"]["value"]>;
+    lazyPanels.panels.history.model.value = historyModel;
+    lazyPanels.panels.history.actions.value = historyActions;
 
     expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("carTab");
     lazyPanels.panels.settingsShell.activateTab("updateTab");
     expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("updateTab");
 
-    const internetActions = {} as Parameters<InternetPanelView["bindActions"]>[0];
-    const internetModel = signal({}) as unknown as Parameters<InternetPanelView["bindModel"]>[0];
-    const speedSourceActions = {} as Parameters<SpeedSourcePanelView["bindActions"]>[0];
-    const speedSourceDiagnostics = signal({}) as unknown as Parameters<SpeedSourcePanelView["bindDiagnostics"]>[0];
+    const internetActions = {} as NonNullable<InternetPanelView["actions"]["value"]>;
+    const internetModel = signal({}) as unknown as NonNullable<InternetPanelView["model"]["value"]>;
+    const speedSourceActions = {} as NonNullable<SpeedSourcePanelView["actions"]["value"]>;
+    const speedSourceDiagnostics = signal({}) as unknown as NonNullable<
+      SpeedSourcePanelView["diagnostics"]["value"]
+    >;
     const speedSourceModel = signal({
       obdConfigVisible: true,
-    }) as unknown as Parameters<SpeedSourcePanelView["bindModel"]>[0];
-    lazyPanels.panels.settings.internet.bindModel(internetModel);
-    lazyPanels.panels.settings.internet.bindActions(internetActions);
+    }) as unknown as NonNullable<SpeedSourcePanelView["model"]["value"]>;
+    lazyPanels.panels.settings.internet.model.value = internetModel;
+    lazyPanels.panels.settings.internet.actions.value = internetActions;
     lazyPanels.panels.settings.internet.focusSsidInput();
-    lazyPanels.panels.settings.speedSource.bindModel(speedSourceModel);
-    lazyPanels.panels.settings.speedSource.bindActions(speedSourceActions);
-    lazyPanels.panels.settings.speedSource.bindDiagnostics(speedSourceDiagnostics);
+    lazyPanels.panels.settings.speedSource.model.value = speedSourceModel;
+    lazyPanels.panels.settings.speedSource.actions.value = speedSourceActions;
+    lazyPanels.panels.settings.speedSource.diagnostics.value = speedSourceDiagnostics;
     lazyPanels.panels.settings.speedSource.focusManualSpeedInput();
     expect(lazyPanels.panels.settings.speedSource.isObdConfigVisible()).toBe(true);
 
@@ -258,7 +272,6 @@ test.describe("createLazyUiPanels", () => {
     await lazyPanels.ensureViewPanels("settingsView");
     expect(historyLoads).toBe(1);
     expect(settingsLoads).toBe(1);
-
   });
 
   test("prefetchHiddenPanels schedules offscreen mounts through the deferred scheduler", async () => {
@@ -273,22 +286,32 @@ test.describe("createLazyUiPanels", () => {
     const lazyPanels = createLazyUiPanels({
       hosts,
       mountDashboardPanels: () => createDashboardPanels(),
-      loadHistoryPanel: async () => {
+      loadHistoryPanel: async (_hosts, view) => {
         historyLoads += 1;
-        return historyPanel.view;
+        historyPanel.mount(view);
       },
-      loadSettingsPanels: async () => {
+      loadSettingsPanels: async (_hosts, panels) => {
         settingsLoads += 1;
+        internetPanel.mount(panels.settings.internet);
         return {
           settingsShell: settingsShell.view,
           settings: {
-            cars: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["cars"],
-            analysis: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["analysis"],
-            internet: internetPanel.view,
-            update: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["update"],
-            sensors: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["sensors"],
-            speedSource: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["speedSource"],
-            espFlash: {} as ReturnType<typeof createLazyUiPanels>["panels"]["settings"]["espFlash"],
+            analysis: {
+              focusField() {},
+              openGuidance() {},
+            },
+            cars: {
+              focus() {},
+            },
+            internet: internetPanel.handle,
+            speedSource: {
+              focusManualSpeedInput() {},
+              focusScanObdDevices() {},
+              focusStaleTimeoutInput() {},
+              isObdConfigVisible() {
+                return false;
+              },
+            },
           },
         };
       },

--- a/apps/ui/tests/ui_lazy_panels.spec.ts
+++ b/apps/ui/tests/ui_lazy_panels.spec.ts
@@ -241,6 +241,8 @@ test.describe("createLazyUiPanels", () => {
     lazyPanels.panels.settings.speedSource.diagnostics.value = speedSourceDiagnostics;
     lazyPanels.panels.settings.speedSource.focusManualSpeedInput();
     expect(lazyPanels.panels.settings.speedSource.isObdConfigVisible()).toBe(true);
+    const readSpeedSourceVisibility = lazyPanels.panels.settings.speedSource.isObdConfigVisible;
+    expect(readSpeedSourceVisibility()).toBe(true);
 
     await lazyPanels.ensureViewPanels("historyView");
     expect(historyLoads).toBe(1);
@@ -258,6 +260,7 @@ test.describe("createLazyUiPanels", () => {
     expect(speedSourcePanel.diagnostics).toEqual([speedSourceDiagnostics]);
     expect(speedSourcePanel.focusManualCalls).toBe(1);
     expect(lazyPanels.panels.settings.speedSource.isObdConfigVisible()).toBe(true);
+    expect(readSpeedSourceVisibility()).toBe(true);
     expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("updateTab");
 
     lazyPanels.panels.settings.speedSource.focusScanObdDevices();

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -16,7 +16,7 @@ import {
 import { createUiShellNotificationModule } from "../src/app/runtime/ui_shell_notification_module";
 import { createUiShellPreferencesModule } from "../src/app/runtime/ui_shell_preferences_module";
 import { createUiShellStatusModule } from "../src/app/runtime/ui_shell_status_module";
-import type { ReadonlySignal } from "../src/app/ui_signals";
+import { signal, type ReadonlySignal } from "../src/app/ui_signals";
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -194,8 +194,8 @@ test.describe("UiShellController", () => {
       chrome: chrome.view,
       chromeActions: createUiShellChromeActionBridge(),
       liveOverview: {
-        bindModel() {},
-        setSpeedText() {},
+        model: signal(null),
+        speedText: signal("--"),
       },
       state,
     });
@@ -233,8 +233,8 @@ test.describe("UiShellController", () => {
       chrome: chrome.view,
       chromeActions: createUiShellChromeActionBridge(),
       liveOverview: {
-        bindModel() {},
-        setSpeedText() {},
+        model: signal(null),
+        speedText: signal("--"),
       },
       state,
     });

--- a/apps/ui/tests/update_feature_bindings.spec.ts
+++ b/apps/ui/tests/update_feature_bindings.spec.ts
@@ -8,8 +8,15 @@ import type {
 } from "../src/app/views/update_panel";
 
 test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners", () => {
-  let updateHandlers: UpdatePanelActionHandlers | null = null;
-  let internetHandlers: InternetPanelActionHandlers | null = null;
+  const updatePanel = {
+    actions: signal<UpdatePanelActionHandlers | null>(null),
+    model: signal(null),
+  };
+  const internetPanel = {
+    actions: signal<InternetPanelActionHandlers | null>(null),
+    model: signal(null),
+    focusSsidInput() {},
+  };
 
   const feature = createUpdateFeature({
     services: {
@@ -22,23 +29,14 @@ test("bindUpdateHandlers uses panel action surfaces instead of raw DOM listeners
       activeViewId: signal("settingsView"),
     },
     panels: {
-      update: {
-        bindActions(handlers: UpdatePanelActionHandlers) {
-          updateHandlers = handlers;
-        },
-        bindModel() {},
-      },
-      internet: {
-        bindActions(handlers: InternetPanelActionHandlers) {
-          internetHandlers = handlers;
-        },
-        focusSsidInput() {},
-        bindModel() {},
-      },
+      update: updatePanel,
+      internet: internetPanel,
     },
   });
 
   expect(() => feature.bindUpdateHandlers()).not.toThrow();
+  const updateHandlers = updatePanel.actions.value;
+  const internetHandlers = internetPanel.actions.value;
   expect(updateHandlers).not.toBeNull();
   expect(internetHandlers).not.toBeNull();
   expect(typeof internetHandlers?.onPasswordInput).toBe("function");


### PR DESCRIPTION
## what changed
- replace panel `bindModel()` / `bindActions()` bridges with direct signal props across dashboard, history, settings, and lazy-panel surfaces
- keep only true imperative handles on mounted views (`focus*`, `openGuidance`, cars wizard focus)
- update feature/runtime wiring to write signal props directly instead of replaying bind calls
- update focused Playwright specs, signal harnesses, and panel test doubles to match the new seam

## why
- issue wants direct signal props, not imperative mount/bind bridges
- this removes lazy replay bookkeeping without reordering app startup

## validation
- `cd apps/ui && npx playwright test tests/ui_lazy_panels.spec.ts tests/update_feature_bindings.spec.ts tests/esp_flash_feature_bindings.spec.ts tests/settings_speed_source_module_bindings.spec.ts tests/settings_cars_module.spec.ts tests/settings_analysis_module.spec.ts tests/history_feature_modules.spec.ts tests/esp_flash_feature.spec.ts tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npx tsx tests/analysis_panel_signals.ts`
- `cd apps/ui && npx tsx tests/speed_source_panel_signals.ts`
- `cd apps/ui && npx tsx tests/realtime_live_overview_signals.ts`
- `cd apps/ui && npm run test:signals`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run build`

## risk / tradeoffs
- large UI seam refactor; callers and tests moved together to avoid mixed old/new panel contracts
- startup order stays as-is on purpose; later follow-up can flatten deferred model signals further if needed

Closes #2588
