### PR TITLE
FE: use Preact lazy() + Suspense for settings/history

### DIFF
--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -5,14 +5,12 @@ import {
   mountSettingsPanelsLazy,
   type UiMountedDashboardPanels,
   type UiMountedLazyPanelHandles,
-  type UiMountedLazyPanels,
   type UiMountedPanels,
 } from "./ui_panel_bootstrap";
 import { effect, signal } from "./ui_signals";
 import type {
   AnalysisPanelActionHandlers,
   AnalysisPanelCarAvailability,
-  AnalysisPanelFieldKey,
   AnalysisPanelRenderModel,
   AnalysisPanelView,
 } from "./views/analysis_panel";
@@ -76,7 +74,7 @@ export interface CreateUiLazyPanelsDeps {
   loadHistoryPanel?: (hosts: UiPanelHostRegistry, view: HistoryPanelView) => Promise<void>;
   loadSettingsPanels?: (
     hosts: UiPanelHostRegistry,
-    panels: UiMountedLazyPanels,
+    panels: Pick<UiMountedPanels, "settings">,
   ) => Promise<UiMountedLazyPanelHandles>;
   scheduleDeferredWork?: DeferredWorkScheduler;
 }
@@ -362,21 +360,20 @@ export function createLazyUiPanels(deps: CreateUiLazyPanelsDeps): UiLazyPanels {
 
   const ensureSettingsMounted = (): Promise<void> => {
     if (settingsMountPromise === null) {
-      settingsMountPromise = (deps.loadSettingsPanels ?? mountSettingsPanelsLazy)(
-        hosts,
-        {
-          settingsShell: settingsShell.view,
-          settings: {
-            analysis: settings.analysis.view,
-            cars: settings.cars.view,
-            espFlash: settings.espFlash.view,
-            internet: settings.internet.view,
-            sensors: settings.sensors.view,
-            speedSource: settings.speedSource.view,
-            update: settings.update.view,
+        settingsMountPromise = (deps.loadSettingsPanels ?? mountSettingsPanelsLazy)(
+          hosts,
+          {
+            settings: {
+              analysis: settings.analysis.view,
+              cars: settings.cars.view,
+              espFlash: settings.espFlash.view,
+              internet: settings.internet.view,
+              sensors: settings.sensors.view,
+              speedSource: settings.speedSource.view,
+              update: settings.update.view,
+            },
           },
-        },
-      ).then((mountedPanels) => {
+        ).then((mountedPanels) => {
           attachSettingsPanels(mountedPanels);
         });
     }

--- a/apps/ui/src/app/ui_panel_bootstrap.tsx
+++ b/apps/ui/src/app/ui_panel_bootstrap.tsx
@@ -1,3 +1,6 @@
+import { Suspense, lazy } from "preact/compat";
+
+import { render } from "preact";
 import { signal } from "./ui_signals";
 import {
   createDeferredModelSignal,
@@ -7,11 +10,11 @@ import type { SpectrumPanelView } from "./runtime/spectrum_panel_view";
 import {
   type UiPanelHostRegistry,
 } from "./ui_panel_host_registry";
-import { mountAnalysisPanel, type AnalysisPanelView } from "./views/analysis_panel";
-import { mountCarsPanel, type CarsPanelView } from "./views/cars_panel";
-import { mountEspFlashPanel, type EspFlashPanelView } from "./views/esp_flash_panel";
+import type { AnalysisPanelView } from "./views/analysis_panel";
+import type { CarsPanelView } from "./views/cars_panel";
+import type { EspFlashPanelView } from "./views/esp_flash_panel";
 import type { HistoryPanelView } from "./views/history_table_view";
-import { mountInternetPanel, type InternetPanelView } from "./views/internet_panel";
+import type { InternetPanelView } from "./views/internet_panel";
 import {
   mountRealtimeLoggingPanel,
   type RealtimeLoggingPanelActionHandlers,
@@ -23,11 +26,11 @@ import {
   type RealtimeLiveOverviewBridge,
   type RealtimeLiveOverviewRenderModel,
 } from "./views/realtime_live_overview";
-import { mountSensorsPanel, type SensorsPanelView } from "./views/sensors_panel";
+import type { SensorsPanelView } from "./views/sensors_panel";
 import type { SettingsShellView } from "./views/settings_shell";
-import { mountSpeedSourcePanel, type SpeedSourcePanelView } from "./views/speed_source_panel";
+import type { SpeedSourcePanelView } from "./views/speed_source_panel";
 import { mountSpectrumPanel } from "./views/spectrum_panel";
-import { mountUpdatePanel, type UpdatePanelView } from "./views/update_panel";
+import type { UpdatePanelView } from "./views/update_panel";
 
 export interface UiMountedDashboardPanels {
   spectrum: SpectrumPanelView;
@@ -52,8 +55,6 @@ export interface UiMountedPanels {
   settings: UiMountedSettingsPanels;
 }
 
-export type UiMountedLazyPanels = Pick<UiMountedPanels, "settingsShell" | "settings">;
-
 export interface UiMountedLazyPanelHandles {
   settingsShell: SettingsShellView;
   settings: {
@@ -65,6 +66,17 @@ export interface UiMountedLazyPanelHandles {
       "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
     >;
   };
+}
+
+const HistoryLazyView = lazy(() => import("./views/history_lazy_view"));
+const SettingsLazyView = lazy(() => import("./views/settings_lazy_view"));
+
+function LazyPanelFallback(props: { text: string }) {
+  return (
+    <div class="subtle" aria-busy="true">
+      {props.text}
+    </div>
+  );
 }
 
 export function mountDashboardPanels(
@@ -91,51 +103,26 @@ export async function mountHistoryPanelLazy(
   hosts: UiPanelHostRegistry,
   view: HistoryPanelView,
 ): Promise<void> {
-  const { mountHistoryPanel } = await import("./views/history_panel");
-  mountHistoryPanel(hosts.history, view);
+  return new Promise((resolve) => {
+    render(
+      <Suspense fallback={<LazyPanelFallback text="Loading history..." />}>
+        <HistoryLazyView onReady={resolve} view={view} />
+      </Suspense>,
+      hosts.history,
+    );
+  });
 }
 
 export async function mountSettingsPanelsLazy(
   hosts: UiPanelHostRegistry,
-  panels: UiMountedLazyPanels,
+  panels: Pick<UiMountedPanels, "settings">,
 ): Promise<UiMountedLazyPanelHandles> {
-  const settingsShellModulePromise = import("./views/settings_shell");
-  const settingsPanelModulesPromise = Promise.all([
-    import("./views/cars_panel"),
-    import("./views/analysis_panel"),
-    import("./views/internet_panel"),
-    import("./views/update_panel"),
-    import("./views/sensors_panel"),
-    import("./views/speed_source_panel"),
-    import("./views/esp_flash_panel"),
-  ]);
-  const { mountSettingsShell } = await settingsShellModulePromise;
-  const settingsShellMount = mountSettingsShell(hosts.settingsShell);
-  const settingsShell = settingsShellMount.view;
-  const settingsHosts = settingsShellMount.panelHosts;
-  const [
-    { mountCarsPanel },
-    { mountAnalysisPanel },
-    { mountInternetPanel },
-    { mountUpdatePanel },
-    { mountSensorsPanel },
-    { mountSpeedSourcePanel },
-    { mountEspFlashPanel },
-  ] = await settingsPanelModulesPromise;
-  const cars = mountCarsPanel(settingsHosts.cars, panels.settings.cars);
-  const analysis = mountAnalysisPanel(settingsHosts.analysis, panels.settings.analysis);
-  const internet = mountInternetPanel(settingsHosts.internet, panels.settings.internet);
-  mountUpdatePanel(settingsHosts.update, panels.settings.update);
-  mountSensorsPanel(settingsHosts.sensors, panels.settings.sensors);
-  const speedSource = mountSpeedSourcePanel(settingsHosts.speedSource, panels.settings.speedSource);
-  mountEspFlashPanel(settingsHosts.espFlash, panels.settings.espFlash);
-  return {
-    settingsShell,
-    settings: {
-      cars,
-      analysis,
-      internet,
-      speedSource,
-    },
-  };
+  return new Promise((resolve) => {
+    render(
+      <Suspense fallback={<LazyPanelFallback text="Loading settings..." />}>
+        <SettingsLazyView onReady={resolve} panels={panels} />
+      </Suspense>,
+      hosts.settingsShell,
+    );
+  });
 }

--- a/apps/ui/src/app/views/history_lazy_view.tsx
+++ b/apps/ui/src/app/views/history_lazy_view.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "preact/hooks";
+
+import { HistoryPanel } from "./history_panel";
+import type { HistoryPanelView } from "./history_table_view";
+
+export interface HistoryLazyViewProps {
+  onReady?(): void;
+  view: HistoryPanelView;
+}
+
+export default function HistoryLazyView(props: HistoryLazyViewProps) {
+  useEffect(() => {
+    props.onReady?.();
+  }, [props.onReady]);
+
+  return <HistoryPanel actions={props.view.actions} model={props.view.model} />;
+}

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -25,7 +25,7 @@ const HISTORY_PANEL_MODEL_KEYS = [
   "table",
 ] as const;
 
-function HistoryPanel(props: {
+export function HistoryPanel(props: {
   actions: ReadonlySignal<HistoryPanelActionHandlers | null>;
   model: ReadonlySignal<ReadonlySignal<HistoryPanelRenderModel> | null>;
 }) {

--- a/apps/ui/src/app/views/settings_lazy_view.tsx
+++ b/apps/ui/src/app/views/settings_lazy_view.tsx
@@ -1,0 +1,103 @@
+import { render } from "preact";
+import { useEffect, useRef } from "preact/hooks";
+
+import {
+  mountAnalysisPanel,
+  type AnalysisPanelView,
+} from "./analysis_panel";
+import {
+  mountCarsPanel,
+  type CarsPanelView,
+} from "./cars_panel";
+import {
+  mountEspFlashPanel,
+  type EspFlashPanelView,
+} from "./esp_flash_panel";
+import {
+  mountInternetPanel,
+  type InternetPanelView,
+} from "./internet_panel";
+import {
+  mountSensorsPanel,
+  type SensorsPanelView,
+} from "./sensors_panel";
+import {
+  mountSettingsShell,
+  type SettingsShellView,
+} from "./settings_shell";
+import {
+  mountSpeedSourcePanel,
+  type SpeedSourcePanelView,
+} from "./speed_source_panel";
+import {
+  mountUpdatePanel,
+  type UpdatePanelView,
+} from "./update_panel";
+
+interface SettingsLazyViewReadyHandles {
+  settingsShell: SettingsShellView;
+  settings: {
+    analysis: Pick<AnalysisPanelView, "focusField" | "openGuidance">;
+    cars: Pick<CarsPanelView["wizard"], "focus">;
+    internet: Pick<InternetPanelView, "focusSsidInput">;
+    speedSource: Pick<
+      SpeedSourcePanelView,
+      "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+    >;
+  };
+}
+
+export interface SettingsLazyViewProps {
+  onReady(handles: SettingsLazyViewReadyHandles): void;
+  panels: {
+    settings: {
+      analysis: AnalysisPanelView;
+      cars: CarsPanelView;
+      espFlash: EspFlashPanelView;
+      internet: InternetPanelView;
+      sensors: SensorsPanelView;
+      speedSource: SpeedSourcePanelView;
+      update: UpdatePanelView;
+    };
+  };
+}
+
+export default function SettingsLazyView(props: SettingsLazyViewProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) {
+      return;
+    }
+
+    const settingsShellMount = mountSettingsShell(host);
+    const settingsShell = settingsShellMount.view;
+    const settingsHosts = settingsShellMount.panelHosts;
+    const cars = mountCarsPanel(settingsHosts.cars, props.panels.settings.cars);
+    const analysis = mountAnalysisPanel(settingsHosts.analysis, props.panels.settings.analysis);
+    const internet = mountInternetPanel(settingsHosts.internet, props.panels.settings.internet);
+    mountUpdatePanel(settingsHosts.update, props.panels.settings.update);
+    mountSensorsPanel(settingsHosts.sensors, props.panels.settings.sensors);
+    const speedSource = mountSpeedSourcePanel(
+      settingsHosts.speedSource,
+      props.panels.settings.speedSource,
+    );
+    mountEspFlashPanel(settingsHosts.espFlash, props.panels.settings.espFlash);
+    props.onReady({
+      settingsShell,
+      settings: {
+        analysis,
+        cars,
+        internet,
+        speedSource,
+      },
+    });
+
+    return () => {
+      render(null, host);
+    };
+  }, [props.onReady, props.panels]);
+
+  return <div ref={hostRef} />;
+}


### PR DESCRIPTION
## what changed
- move `ui_panel_bootstrap` to TSX and replace manual `Promise.all(import(...))` loading with `preact/compat` `lazy()` + `Suspense` for history and settings
- add `history_lazy_view.tsx` and `settings_lazy_view.tsx` so the existing deferred panel bridges mount inside lazy host components
- export `HistoryPanel` for direct lazy rendering and drop the dedicated `UiMountedLazyPanels` coordination type

## why
- issue `#2589` asks for Preact-native code splitting instead of custom promise choreography
- keeps the direct-signal and deferred-handle contracts from `#2588` while deleting bootstrap-only lazy-loading glue

## validation
- `npm run typecheck`
- `npx playwright test tests/ui_lazy_panels.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.history.spec.ts tests/smoke.update.spec.ts --project=laptop-light --workers=1`
- `npm run build`

## risks / tradeoffs
- history and settings now show simple Suspense fallback copy while their chunks load
- settings still mounts the existing imperative inner panel handles after the lazy shell loads; full pure-component composition stays out of scope here

## out of scope
- existing unrelated lint warnings in `src/app/views/esp_flash_journey_presenter.ts` and `src/app/views/history_detail_presenter.ts`
