### PR TITLE
FE: Consolidate Proxy-based reactive state slices into explicit signals

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -123,7 +123,7 @@ export function createAppFeatureBundle(
   });
 
   const carCreation = createUiCarCreationCommand({
-    getVehicleSettings: () => state.settings.vehicleSettings,
+    getVehicleSettings: () => state.settings.vehicleSettings.value,
     syncCarsPayload: (payload) => settings.syncCarsPayload(payload),
     syncActiveCarToInputs: () => settings.syncActiveCarToInputs(),
     showCarCreationSuccess: (carId, carName) =>

--- a/apps/ui/src/app/car_selection_state.ts
+++ b/apps/ui/src/app/car_selection_state.ts
@@ -1,6 +1,5 @@
 import type { CarRecord } from "../api/types";
 import type { SettingsState } from "./ui_app_state";
-import { trackAppStateSlice } from "./ui_app_state";
 import { computed, type ReadonlySignal } from "./ui_signals";
 
 const REQUIRED_CAR_ASPECT_KEYS = [
@@ -41,17 +40,17 @@ function isConfiguredAspectValue(value: unknown): value is number {
 }
 
 function resolveActiveCar(settings: CarSelectionStateSource): CarRecord | null {
-  if (!settings.activeCarId) {
+  if (!settings.activeCarId.value) {
     return null;
   }
-  return settings.cars.find((car) => car.id === settings.activeCarId) ?? null;
+  return settings.cars.value.find((car) => car.id === settings.activeCarId.value) ?? null;
 }
 
 function deriveCarSelectionState(settings: CarSelectionStateSource): CarSelectionState {
-  if (!settings.carsLoaded) {
+  if (!settings.carsLoaded.value) {
     return { kind: "loading" };
   }
-  if (!settings.cars.length) {
+  if (!settings.cars.value.length) {
     return { kind: "no_cars" };
   }
   const activeCar = resolveActiveCar(settings);
@@ -68,16 +67,12 @@ export function hasResolvedActiveCar(settings: CarSelectionStateSource): boolean
 export function createCarSelectionDerivedState(
   settings: CarSelectionStateSource,
 ): CarSelectionDerivedState {
-  const activeCar = computed(() => {
-    trackAppStateSlice(settings);
-    return resolveActiveCar(settings);
-  });
+  const activeCar = computed(() => resolveActiveCar(settings));
   const selection = computed<CarSelectionState>(() => {
-    trackAppStateSlice(settings);
-    if (!settings.carsLoaded) {
+    if (!settings.carsLoaded.value) {
       return { kind: "loading" };
     }
-    if (!settings.cars.length) {
+    if (!settings.cars.value.length) {
       return { kind: "no_cars" };
     }
     const resolvedCar = activeCar.value;

--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -178,17 +178,17 @@ export function runDemoMode(deps: DemoDeps): void {
   };
 
   batchAppStateUpdates(() => {
-    state.settings.carsLoaded = true;
-    state.settings.cars = [
+    state.settings.carsLoaded.value = true;
+    state.settings.cars.value = [
       {
         id: "demo-car-1",
         name: "Demo Hatch",
         type: "Simulated setup",
         variant: "Audit baseline",
-        aspects: { ...state.settings.vehicleSettings },
+        aspects: { ...state.settings.vehicleSettings.value },
       },
     ];
-    state.settings.activeCarId = "demo-car-1";
+    state.settings.activeCarId.value = "demo-car-1";
   });
   deps.queueTransportPayload(demoPayload);
 

--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -6,11 +6,10 @@ import {
   historyReportPdfUrl,
 } from "../../api";
 import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
-import {
-  trackAppStateSlice,
-  type HistoryState,
-  type RunDetail,
-  type ShellState,
+import type {
+  HistoryState,
+  RunDetail,
+  ShellState,
 } from "../ui_app_state";
 import { computed, effect, untracked } from "../ui_signals";
 import type {
@@ -49,36 +48,61 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
   }
 
   function ensureRunDetail(runId: string): RunDetail {
-    if (!history.runDetailsById[runId]) {
-      history.runDetailsById[runId] = {
-        preview: null,
-        previewLoading: false,
-        previewError: "",
-        insights: null,
-        insightsLoading: false,
-        insightsError: "",
-        pdfLoading: false,
-        pdfError: "",
-      };
+    const existing = history.runDetailsById.value[runId];
+    if (existing) {
+      return existing;
     }
-    return history.runDetailsById[runId];
+    const nextDetail: RunDetail = {
+      preview: null,
+      previewLoading: false,
+      previewError: "",
+      insights: null,
+      insightsLoading: false,
+      insightsError: "",
+      pdfLoading: false,
+      pdfError: "",
+    };
+    history.runDetailsById.value = {
+      ...history.runDetailsById.value,
+      [runId]: nextDetail,
+    };
+    return nextDetail;
+  }
+
+  function updateRunDetail(
+    runId: string,
+    updater: (detail: RunDetail) => RunDetail,
+  ): RunDetail {
+    const nextDetail = updater(ensureRunDetail(runId));
+    history.runDetailsById.value = {
+      ...history.runDetailsById.value,
+      [runId]: nextDetail,
+    };
+    return nextDetail;
+  }
+
+  function removeRunDetail(runId: string): void {
+    const { [runId]: _removed, ...rest } = history.runDetailsById.value;
+    history.runDetailsById.value = rest;
   }
 
   function collapseExpandedRun(): void {
-    const previous = history.expandedRunId;
-    history.expandedRunId = null;
+    const previous = history.expandedRunId.value;
+    history.expandedRunId.value = null;
     if (previous) {
-      delete history.runDetailsById[previous];
+      removeRunDetail(previous);
     }
   }
 
   function buildPanelRenderModel(): HistoryPanelRenderModel {
-    const deleteAllRunsDisabled = history.deleteAllRunsInFlight || history.runs.length === 0;
-    const expandedRunId = history.expandedRunId
-      && history.runs.some((row) => row.run_id === history.expandedRunId)
-      ? history.expandedRunId
+    const runs = history.runs.value;
+    const deleteAllRunsDisabled =
+      history.deleteAllRunsInFlight.value || runs.length === 0;
+    const expandedRunId = history.expandedRunId.value
+      && runs.some((row) => row.run_id === history.expandedRunId.value)
+      ? history.expandedRunId.value
       : null;
-    if (!history.runs.length) {
+    if (!runs.length) {
       return {
         historySummaryText: services.t("history.none"),
         deleteAllRunsDisabled,
@@ -90,28 +114,26 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     }
     return {
       historySummaryText: services.t("history.available_count", {
-        count: history.runs.length,
+        count: runs.length,
       }),
       deleteAllRunsDisabled,
-        table: {
-          kind: "rows",
-          params: {
-            runs: history.runs,
-            expandedRunId,
-            runDetailsById: history.runDetailsById,
-            t: services.t,
-            fmt: formatting.fmt,
+      table: {
+        kind: "rows",
+        params: {
+          runs,
+          expandedRunId,
+          runDetailsById: history.runDetailsById.value,
+          t: services.t,
+          fmt: formatting.fmt,
           fmtTs: formatting.fmtTs,
           formatInt: formatting.formatInt,
           historyExportUrl,
         },
       },
-      };
+    };
   }
-  const panelModel = computed(() => {
-    trackAppStateSlice(history);
-    return buildPanelRenderModel();
-  });
+
+  const panelModel = computed(buildPanelRenderModel);
   panel.model.value = panelModel;
 
   async function loadRunPreview(runId: string, force = false): Promise<void> {
@@ -122,17 +144,29 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     if (!force && (detail.previewLoading || detail.preview)) {
       return;
     }
-    detail.previewLoading = true;
-    detail.previewError = "";
+    updateRunDetail(runId, (current) => ({
+      ...current,
+      previewLoading: true,
+      previewError: "",
+    }));
     try {
-      const response = await getHistoryInsights(runId, shell.lang);
-      detail.preview = response.status === "complete" ? response : null;
+      const response = await getHistoryInsights(runId, shell.lang.value);
+      updateRunDetail(runId, (current) => ({
+        ...current,
+        preview: response.status === "complete" ? response : null,
+      }));
     } catch (err) {
-      detail.previewError = err instanceof Error
-        ? err.message
-        : services.t("report.unable_load_insights");
+      updateRunDetail(runId, (current) => ({
+        ...current,
+        previewError: err instanceof Error
+          ? err.message
+          : services.t("report.unable_load_insights"),
+      }));
     } finally {
-      detail.previewLoading = false;
+      updateRunDetail(runId, (current) => ({
+        ...current,
+        previewLoading: false,
+      }));
     }
   }
 
@@ -144,17 +178,29 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     if (!force && detail.insightsLoading) {
       return;
     }
-    detail.insightsLoading = true;
-    detail.insightsError = "";
+    updateRunDetail(runId, (current) => ({
+      ...current,
+      insightsLoading: true,
+      insightsError: "",
+    }));
     try {
-      const response = await getHistoryInsights(runId, shell.lang);
-      detail.insights = response.status === "complete" ? response : null;
+      const response = await getHistoryInsights(runId, shell.lang.value);
+      updateRunDetail(runId, (current) => ({
+        ...current,
+        insights: response.status === "complete" ? response : null,
+      }));
     } catch (err) {
-      detail.insightsError = err instanceof Error
-        ? err.message
-        : services.t("report.unable_load_insights");
+      updateRunDetail(runId, (current) => ({
+        ...current,
+        insightsError: err instanceof Error
+          ? err.message
+          : services.t("report.unable_load_insights"),
+      }));
     } finally {
-      detail.insightsLoading = false;
+      updateRunDetail(runId, (current) => ({
+        ...current,
+        insightsLoading: false,
+      }));
     }
   }
 
@@ -162,23 +208,23 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     if (!runId) {
       return;
     }
-    if (history.expandedRunId === runId) {
+    if (history.expandedRunId.value === runId) {
       collapseExpandedRun();
       return;
     }
     collapseExpandedRun();
-    history.expandedRunId = runId;
+    history.expandedRunId.value = runId;
     void loadRunPreview(runId);
   }
 
   function reloadExpandedRunOnLanguageChange(): void {
-    if (!history.expandedRunId) {
+    if (!history.expandedRunId.value) {
       return;
     }
-    const runId = history.expandedRunId;
-    const detail = history.runDetailsById[runId];
+    const runId = history.expandedRunId.value;
+    const detail = history.runDetailsById.value[runId];
     const shouldReloadInsights = Boolean(detail?.insights);
-    delete history.runDetailsById[runId];
+    removeRunDetail(runId);
     void loadRunPreview(runId, true).then(() => {
       if (shouldReloadInsights) {
         void loadRunInsights(runId, true);
@@ -188,9 +234,9 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
 
   function bindReactiveLanguageSync(): void {
     let initialized = false;
-    let previousLanguage = shell.lang;
+    let previousLanguage = shell.lang.value;
     effect(() => {
-      const currentLanguage = shell.lang;
+      const currentLanguage = shell.lang.value;
       if (!initialized) {
         initialized = true;
         previousLanguage = currentLanguage;
@@ -209,7 +255,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
   function prefetchCollapsedRunContext(): void {
     const token = ++previewPrefetchToken;
     void (async () => {
-      for (const run of history.runs) {
+      for (const run of history.runs.value) {
         if (token !== previewPrefetchToken) {
           return;
         }
@@ -224,7 +270,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
   async function refreshHistory(): Promise<void> {
     try {
       const payload = await getHistory();
-      history.runs = payload.runs ?? [];
+      history.runs.value = payload.runs ?? [];
     } catch (_err) {
       return;
     }
@@ -249,14 +295,14 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       );
       return;
     }
-    if (history.expandedRunId === runId) {
+    if (history.expandedRunId.value === runId) {
       collapseExpandedRun();
     }
     await refreshHistory();
   }
 
   async function deleteAllRuns(): Promise<void> {
-    const names = history.runs.map((row) => row.run_id).filter(Boolean);
+    const names = history.runs.value.map((row) => row.run_id).filter(Boolean);
     if (!names.length) {
       return;
     }
@@ -267,7 +313,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       return;
     }
 
-    history.deleteAllRunsInFlight = true;
+    history.deleteAllRunsInFlight.value = true;
     let deleted = 0;
     let failed = 0;
     let firstError = "";
@@ -275,8 +321,8 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       try {
         await deleteHistoryRunApi(name);
         deleted += 1;
-        delete history.runDetailsById[name];
-        if (history.expandedRunId === name) {
+        removeRunDetail(name);
+        if (history.expandedRunId.value === name) {
           collapseExpandedRun();
         }
       } catch (err) {
@@ -288,7 +334,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
         }
       }
     }
-    history.deleteAllRunsInFlight = false;
+    history.deleteAllRunsInFlight.value = false;
     await refreshHistory();
     if (failed > 0) {
       const summary = services.t("history.delete_all_partial", {
@@ -305,19 +351,28 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     if (detail.pdfLoading) {
       return;
     }
-    detail.pdfLoading = true;
-    detail.pdfError = "";
+    updateRunDetail(runId, (current) => ({
+      ...current,
+      pdfLoading: true,
+      pdfError: "",
+    }));
     try {
       await downloadBlobFile(
-        historyReportPdfUrl(runId, shell.lang),
+        historyReportPdfUrl(runId, shell.lang.value),
         `${runId}_report.pdf`,
       );
     } catch (err) {
-      detail.pdfError = err instanceof Error
-        ? err.message
-        : services.t("history.pdf_failed");
+      updateRunDetail(runId, (current) => ({
+        ...current,
+        pdfError: err instanceof Error
+          ? err.message
+          : services.t("history.pdf_failed"),
+      }));
     } finally {
-      detail.pdfLoading = false;
+      updateRunDetail(runId, (current) => ({
+        ...current,
+        pdfLoading: false,
+      }));
     }
   }
 
@@ -361,7 +416,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
         if (action.type === "run-action") {
           void onHistoryTableAction(
             action.action,
-            action.runId ?? history.expandedRunId ?? "",
+            action.runId ?? history.expandedRunId.value ?? "",
           );
           return;
         }

--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -11,7 +11,6 @@ import type {
   SpectrumState,
 } from "../ui_app_state";
 import { createReplaceableInterval } from "../timer_cleanup";
-import { trackAppStateSlice } from "../ui_app_state";
 import { computed, effect, signal, type ReadonlySignal } from "../ui_signals";
 import type { AdaptedClient } from "../../transport/live_models";
 import {
@@ -166,16 +165,15 @@ export function createRealtimeFeatureViewState(
   let cachedLastCompletedElapsedText = "--";
   let cachedLoggingElapsedTickInputs: LoggingElapsedTickInputs = {
     handlersBound: workflow.handlersBound.value,
-    loggingEnabled: realtime.loggingStatus.enabled,
-    loggingStartTimeUtc: realtime.loggingStatus.start_time_utc ?? null,
+    loggingEnabled: realtime.loggingStatus.value.enabled,
+    loggingStartTimeUtc: realtime.loggingStatus.value.start_time_utc ?? null,
   };
   const loggingElapsedTickInputs = computed<LoggingElapsedTickInputs>(() => {
     const handlersBound = workflow.handlersBound.value;
-    trackAppStateSlice(realtime);
     const nextTickInputs = {
       handlersBound,
-      loggingEnabled: realtime.loggingStatus.enabled,
-      loggingStartTimeUtc: realtime.loggingStatus.start_time_utc ?? null,
+      loggingEnabled: realtime.loggingStatus.value.enabled,
+      loggingStartTimeUtc: realtime.loggingStatus.value.start_time_utc ?? null,
     } satisfies LoggingElapsedTickInputs;
     if (sameLoggingElapsedTickInputs(cachedLoggingElapsedTickInputs, nextTickInputs)) {
       return cachedLoggingElapsedTickInputs;
@@ -184,17 +182,17 @@ export function createRealtimeFeatureViewState(
     return nextTickInputs;
   });
   const lastCompletedElapsedText = computed(() => {
-    trackAppStateSlice(realtime);
-    if (realtime.loggingStatus.enabled) {
+    const loggingStatus = realtime.loggingStatus.value;
+    if (loggingStatus.enabled) {
       cachedLastCompletedElapsedText = formatElapsed(
-        realtime.loggingStatus.start_time_utc,
+        loggingStatus.start_time_utc,
         elapsedNowMs.value,
       );
       return cachedLastCompletedElapsedText;
     }
     if (
-      !realtime.loggingStatus.analysis_in_progress
-      && !realtime.loggingStatus.last_completed_run_id
+      !loggingStatus.analysis_in_progress
+      && !loggingStatus.last_completed_run_id
     ) {
       cachedLastCompletedElapsedText = "--";
     }
@@ -231,7 +229,7 @@ export function createRealtimeFeatureViewState(
     return selection.kind === "no_cars" ? "no_cars" : "no_active";
   }
 
-  function recordingRunIdText(status = realtime.loggingStatus): string {
+  function recordingRunIdText(status = realtime.loggingStatus.value): string {
     if (status.enabled && status.run_id) {
       return t("dashboard.logging.run_id", { runId: status.run_id });
     }
@@ -253,7 +251,7 @@ export function createRealtimeFeatureViewState(
     if (!ages.length) {
       return t("dashboard.data_freshness_none");
     }
-    const captureReadiness = realtime.loggingStatus.capture_readiness ?? null;
+    const captureReadiness = realtime.loggingStatus.value.capture_readiness ?? null;
     const referenceCheck = captureReadinessCheck(
       captureReadiness,
       "reference_ready",
@@ -298,8 +296,7 @@ export function createRealtimeFeatureViewState(
   }
 
   const loggingPanelBaseModel = computed(() => {
-    trackAppStateSlice(realtime);
-    const loggingStatus = realtime.loggingStatus;
+    const loggingStatus = realtime.loggingStatus.value;
     const pendingLoggingAction = workflow.pendingLoggingAction.value;
     const liveHealth = sensorState.liveHealth.value;
     const connectedClients = sensorState.connectedClients.value;
@@ -325,7 +322,6 @@ export function createRealtimeFeatureViewState(
   });
 
   const liveOverviewModel = computed<RealtimeLiveOverviewRenderModel>(() => {
-    trackAppStateSlice(realtime);
     const connectedClients = sensorState.connectedClients.value;
     const strongestSignal = sensorState.strongestSignal.value;
     const strongestSignalText = sensorState.strongestSignalText.value;
@@ -334,7 +330,7 @@ export function createRealtimeFeatureViewState(
     const setupBlock = selectionBlockReason();
     const recordingStateText = loggingPanelBaseModel.value.phaseText;
     return {
-      connectedSensorsText: `${formatInt(connectedClients.length)} / ${formatInt(realtime.clients.length)}`,
+      connectedSensorsText: `${formatInt(connectedClients.length)} / ${formatInt(realtime.clients.value.length)}`,
       activeCar: {
         text: activeCar.text,
         warning: setupBlock === null && activeCar.isWarning,
@@ -347,7 +343,7 @@ export function createRealtimeFeatureViewState(
         text: liveHealth.text,
         variant: liveHealth.variant,
       },
-      sensorCards: realtime.clients.map((client) => ({
+      sensorCards: realtime.clients.value.map((client) => ({
         id: client.id,
         label: liveSensorOverviewLabel(client),
         connected: Boolean(client.connected),
@@ -367,10 +363,9 @@ export function createRealtimeFeatureViewState(
   });
 
   const sensorsPanelModel = computed<SensorsPanelRenderModel>(() => {
-    trackAppStateSlice(realtime);
     return {
       table: buildRealtimeSensorTableRenderModel({
-        clients: realtime.clients,
+        clients: realtime.clients.value,
         locationOptions: sensorState.locationOptions.value,
         t,
       }),
@@ -378,9 +373,7 @@ export function createRealtimeFeatureViewState(
   });
 
   const idleCaptureReadinessSignature = computed(() => {
-    trackAppStateSlice(realtime);
-    trackAppStateSlice(settings);
-    const clientsSignature = realtime.clients
+    const clientsSignature = realtime.clients.value
       .map((client) =>
         [
           client.id,
@@ -390,7 +383,7 @@ export function createRealtimeFeatureViewState(
       )
       .sort()
       .join("|");
-    return `${settings.activeCarId ?? ""}##${clientsSignature}`;
+    return `${settings.activeCarId.value ?? ""}##${clientsSignature}`;
   });
 
   return {

--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -13,7 +13,6 @@ import type {
   LoggingStatusPayload,
 } from "../../api/types";
 import {
-  trackAppStateSlice,
   syncSelectedRealtimeClient,
   type RealtimeState,
 } from "../ui_app_state";
@@ -146,7 +145,7 @@ export function createRealtimeFeatureWorkflow(
   }
 
   function applyLocationCodes(codes: string[]): void {
-    realtime.locationCodes = codes.length ? codes : defaultLocationCodes.slice();
+    realtime.locationCodes.value = codes.length ? codes : defaultLocationCodes.slice();
   }
 
   async function refreshIdleCaptureReadiness(signature: string): Promise<void> {
@@ -158,9 +157,9 @@ export function createRealtimeFeatureWorkflow(
       return;
     }
     if (
-      realtime.loggingStatus.enabled
-      || realtime.loggingStatus.analysis_in_progress
-      || Boolean(realtime.loggingStatus.last_completed_run_id)
+      realtime.loggingStatus.value.enabled
+      || realtime.loggingStatus.value.analysis_in_progress
+      || Boolean(realtime.loggingStatus.value.last_completed_run_id)
     ) {
       return;
     }
@@ -186,7 +185,6 @@ export function createRealtimeFeatureWorkflow(
   }
 
   effect(() => {
-    trackAppStateSlice(realtime);
     const signature = deps.idleCaptureReadinessSignature.value;
     if (
       !state.handlersBound.value
@@ -196,9 +194,9 @@ export function createRealtimeFeatureWorkflow(
       return;
     }
     if (
-      realtime.loggingStatus.enabled
-      || realtime.loggingStatus.analysis_in_progress
-      || Boolean(realtime.loggingStatus.last_completed_run_id)
+      realtime.loggingStatus.value.enabled
+      || realtime.loggingStatus.value.analysis_in_progress
+      || Boolean(realtime.loggingStatus.value.last_completed_run_id)
     ) {
       return;
     }
@@ -208,7 +206,7 @@ export function createRealtimeFeatureWorkflow(
   const loggingStatusPolling = createPolling({
     poll: async () => {
       await refreshLoggingStatus();
-      return realtime.loggingStatus.enabled || realtime.loggingStatus.analysis_in_progress
+      return realtime.loggingStatus.value.enabled || realtime.loggingStatus.value.analysis_in_progress
         ? LOGGING_STATUS_ACTIVE_POLL_MS
         : LOGGING_STATUS_IDLE_POLL_MS;
     },
@@ -231,7 +229,7 @@ export function createRealtimeFeatureWorkflow(
       state.loggingError.value = null;
       return;
     }
-    const previousStatus = realtime.loggingStatus;
+    const previousStatus = realtime.loggingStatus.value;
     let nextStatus: LoggingStatusPayload;
     try {
       nextStatus = await api.getLoggingStatus();
@@ -245,7 +243,7 @@ export function createRealtimeFeatureWorkflow(
       });
       return;
     }
-    realtime.loggingStatus = nextStatus;
+    realtime.loggingStatus.value = nextStatus;
     state.loggingError.value = null;
     if (!didHistoryAffectingStatusChange(previousStatus, nextStatus)) {
       return;
@@ -266,7 +264,7 @@ export function createRealtimeFeatureWorkflow(
       state.loggingError.value = null;
     });
     try {
-      realtime.loggingStatus = await api.startLoggingRun();
+      realtime.loggingStatus.value = await api.startLoggingRun();
       await recording.onRecordingStatusChanged();
       loggingStatusPolling.restart();
     } catch (err) {
@@ -294,7 +292,7 @@ export function createRealtimeFeatureWorkflow(
       state.loggingError.value = null;
     });
     try {
-      realtime.loggingStatus = await api.stopLoggingRun();
+      realtime.loggingStatus.value = await api.stopLoggingRun();
       await recording.onRecordingStatusChanged();
       loggingStatusPolling.restart();
     } catch (err) {
@@ -328,7 +326,7 @@ export function createRealtimeFeatureWorkflow(
 
   async function setClientLocation(clientId: string, locationCode: string): Promise<void> {
     if (!clientId) return;
-    const existing = realtime.clients.find((client) => client.id === clientId);
+    const existing = realtime.clients.value.find((client) => client.id === clientId);
     const existingLocationCode = String(existing?.location_code || "").trim();
     if (existing && existingLocationCode === locationCode) return;
     try {
@@ -337,9 +335,11 @@ export function createRealtimeFeatureWorkflow(
       showError(err instanceof Error ? err.message : t("actions.set_location_failed"));
       return;
     }
-    const client = realtime.clients.find((row) => row.id === clientId);
+    const client = realtime.clients.value.find((row) => row.id === clientId);
     if (client) {
-      client.location_code = locationCode;
+      realtime.clients.value = realtime.clients.value.map((row) =>
+        row.id === clientId ? { ...row, location_code: locationCode } : row
+      );
     }
   }
 
@@ -360,13 +360,13 @@ export function createRealtimeFeatureWorkflow(
       showError(err instanceof Error ? err.message : t("actions.remove_client_failed"));
       return;
     }
-    const previousSelectedClientId = realtime.selectedClientId;
-    realtime.clients = realtime.clients.filter((client) => client.id !== clientId);
-    if (realtime.selectedClientId === clientId) {
-      realtime.selectedClientId = null;
+    const previousSelectedClientId = realtime.selectedClientId.value;
+    realtime.clients.value = realtime.clients.value.filter((client) => client.id !== clientId);
+    if (realtime.selectedClientId.value === clientId) {
+      realtime.selectedClientId.value = null;
     }
     syncSelectedRealtimeClient(realtime);
-    if (previousSelectedClientId !== realtime.selectedClientId) {
+    if (previousSelectedClientId !== realtime.selectedClientId.value) {
       selection.sendSelection();
     }
   }

--- a/apps/ui/src/app/features/realtime_sensor_state.ts
+++ b/apps/ui/src/app/features/realtime_sensor_state.ts
@@ -11,7 +11,6 @@ import type {
   ShellState,
   SpectrumState,
 } from "../ui_app_state";
-import { trackAppStateSlice } from "../ui_app_state";
 import { computed, type ReadonlySignal } from "../ui_signals";
 
 export type ActiveCarDisplayState = {
@@ -70,7 +69,7 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
   }
 
   function locationLabel(code: string): string {
-    return locationLabelForLang(shell.lang, code);
+    return locationLabelForLang(shell.lang.value, code);
   }
 
   function buildLocationOptions(codes: readonly string[]): LocationOption[] {
@@ -78,20 +77,19 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
   }
 
   const locationOptions = computed<LocationOption[]>(() => {
-    trackAppStateSlice(realtime);
-    return buildLocationOptions(realtime.locationCodes);
+    return buildLocationOptions(realtime.locationCodes.value);
   });
 
   function locationCodeForClient(client: AdaptedClient): string {
     const explicitCode = String(client.location_code || "").trim();
-    if (explicitCode && realtime.locationCodes.includes(explicitCode)) return explicitCode;
+    if (explicitCode && realtime.locationCodes.value.includes(explicitCode)) return explicitCode;
     const name = String(client.name || "").trim();
     if (!name) return "";
     const normalizedName = name.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
     for (const [token, code] of Object.entries(SHORTHAND_LOCATION_MAP)) {
-      if (normalizedName.includes(token) && realtime.locationCodes.includes(code)) return code;
+      if (normalizedName.includes(token) && realtime.locationCodes.value.includes(code)) return code;
     }
-    for (const code of realtime.locationCodes) {
+    for (const code of realtime.locationCodes.value) {
       const labels = I18N.getForAllLangs(`location.${code}`);
       if (labels.some((label) => label === name)) return code;
     }
@@ -113,22 +111,18 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
   }
 
   const connectedClients = computed<AdaptedClient[]>(() => {
-    trackAppStateSlice(realtime);
-    return realtime.clients.filter((client) => Boolean(client.connected));
+    return realtime.clients.value.filter((client) => Boolean(client.connected));
   });
 
   const assignedClientCount = computed(() => {
-    trackAppStateSlice(realtime);
-    return realtime.clients.filter((client) => locationCodeForClient(client)).length;
+    return realtime.clients.value.filter((client) => locationCodeForClient(client)).length;
   });
 
   const strongestSignal = computed<{ client: AdaptedClient; db: number } | null>(() => {
-    trackAppStateSlice(realtime);
-    trackAppStateSlice(spectrum);
     let bestClient: AdaptedClient | null = null;
     let bestDb = Number.NEGATIVE_INFINITY;
     for (const client of connectedClients.value) {
-      const db = spectrum.spectra.clients[client.id]?.strength_metrics?.vibration_strength_db;
+      const db = spectrum.spectra.value.clients[client.id]?.strength_metrics?.vibration_strength_db;
       if (typeof db !== "number" || !Number.isFinite(db)) continue;
       if (db > bestDb) {
         bestDb = db;
@@ -145,7 +139,6 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
   });
 
   const strongestSignalText = computed(() => {
-    trackAppStateSlice(realtime);
     const signal = strongestSignal.value;
     if (!signal) {
       return t("dashboard.strongest_signal_none");
@@ -183,12 +176,12 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
   );
 
   const liveHealth = computed<LiveHealth>(() => {
-    trackAppStateSlice(realtime);
-    if (realtime.loggingStatus.write_error) {
+    const loggingStatus = realtime.loggingStatus.value;
+    if (loggingStatus.write_error) {
       return {
         variant: "bad",
         text: t("dashboard.health.write_error"),
-        summary: realtime.loggingStatus.write_error,
+        summary: loggingStatus.write_error,
         showOverviewPill: true,
       };
     }
@@ -227,7 +220,7 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
         showOverviewPill: true,
       };
     }
-    const offlineCount = realtime.clients.filter((client) => !client.connected).length;
+    const offlineCount = realtime.clients.value.filter((client) => !client.connected).length;
     if (offlineCount > 0) {
       return {
         variant: "warn",
@@ -238,7 +231,7 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
     }
     const connectedCount = formatInt(connected.length);
     const assignedCount = formatInt(assignedClientCount.value);
-    if (realtime.loggingStatus.enabled) {
+    if (loggingStatus.enabled) {
       return {
         variant: "ok",
         text: t("dashboard.health.recording"),
@@ -246,7 +239,7 @@ export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): Realtim
         showOverviewPill: false,
       };
     }
-    const captureReadiness = realtime.loggingStatus.capture_readiness ?? null;
+    const captureReadiness = loggingStatus.capture_readiness ?? null;
     if (captureReadiness && !captureReadiness.is_ready) {
       return {
         variant: "warn",

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -183,23 +183,24 @@ function analysisFieldConfig(key: AnalysisPanelFieldKey): AnalysisFieldConfig {
 }
 
 function buildDraftValues(settings: SettingsState): EditableAnalysisDrafts {
+  const vehicleSettings = settings.vehicleSettings.value;
   return {
-    wheel_bandwidth_pct: formatSettingValue(settings.vehicleSettings.wheel_bandwidth_pct),
+    wheel_bandwidth_pct: formatSettingValue(vehicleSettings.wheel_bandwidth_pct),
     driveshaft_bandwidth_pct: formatSettingValue(
-      settings.vehicleSettings.driveshaft_bandwidth_pct,
+      vehicleSettings.driveshaft_bandwidth_pct,
     ),
-    engine_bandwidth_pct: formatSettingValue(settings.vehicleSettings.engine_bandwidth_pct),
-    speed_uncertainty_pct: formatSettingValue(settings.vehicleSettings.speed_uncertainty_pct),
+    engine_bandwidth_pct: formatSettingValue(vehicleSettings.engine_bandwidth_pct),
+    speed_uncertainty_pct: formatSettingValue(vehicleSettings.speed_uncertainty_pct),
     tire_diameter_uncertainty_pct: formatSettingValue(
-      settings.vehicleSettings.tire_diameter_uncertainty_pct,
+      vehicleSettings.tire_diameter_uncertainty_pct,
     ),
     final_drive_uncertainty_pct: formatSettingValue(
-      settings.vehicleSettings.final_drive_uncertainty_pct,
+      vehicleSettings.final_drive_uncertainty_pct,
     ),
-    gear_uncertainty_pct: formatSettingValue(settings.vehicleSettings.gear_uncertainty_pct),
-    min_abs_band_hz: formatSettingValue(settings.vehicleSettings.min_abs_band_hz),
+    gear_uncertainty_pct: formatSettingValue(vehicleSettings.gear_uncertainty_pct),
+    min_abs_band_hz: formatSettingValue(vehicleSettings.min_abs_band_hz),
     max_band_half_width_pct: formatSettingValue(
-      settings.vehicleSettings.max_band_half_width_pct,
+      vehicleSettings.max_band_half_width_pct,
     ),
   };
 }
@@ -351,15 +352,25 @@ export function createSettingsAnalysisModule(
     saveFeedback.value = null;
   }
 
+  function updateVehicleSettings(
+    updater: (current: VehicleSettings) => VehicleSettings,
+  ): void {
+    settings.vehicleSettings.value = updater(settings.vehicleSettings.value);
+  }
+
   function applyAnalysisSettingsPayload(
     serverSettings: AnalysisSettingsPayload,
   ): void {
-    for (const key of ANALYSIS_SETTING_KEYS) {
-      const value = serverSettings[key];
-      if (typeof value === "number") {
-        settings.vehicleSettings[key] = value;
+    updateVehicleSettings((current) => {
+      const next = { ...current };
+      for (const key of ANALYSIS_SETTING_KEYS) {
+        const value = serverSettings[key];
+        if (typeof value === "number") {
+          next[key] = value;
+        }
       }
-    }
+      return next;
+    });
     syncSettingsInputs();
     ctx.renderSpectrum();
   }
@@ -465,9 +476,10 @@ export function createSettingsAnalysisModule(
       }
     }
     const payload = buildEditableAnalysisPayload(fieldStates);
+    const vehicleSettings = settings.vehicleSettings.value;
     for (const key of ANALYSIS_SETTING_KEYS) {
       if (!(key in payload)) {
-        payload[key] = settings.vehicleSettings[key];
+        payload[key] = vehicleSettings[key];
       }
     }
     void syncAnalysisSettingsToServer(payload);

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -68,12 +68,13 @@ function copyActiveCarAspects(
   if (!car?.aspects || typeof car.aspects !== "object") {
     return;
   }
+  const nextVehicleSettings = { ...settings.vehicleSettings.value };
   for (const [key, value] of Object.entries(car.aspects)) {
-    if (typeof value === "number" && key in settings.vehicleSettings) {
-      settings.vehicleSettings[key as keyof SettingsState["vehicleSettings"]] =
-        value;
+    if (typeof value === "number" && key in nextVehicleSettings) {
+      nextVehicleSettings[key as keyof typeof nextVehicleSettings] = value;
     }
   }
+  settings.vehicleSettings.value = nextVehicleSettings;
 }
 
 export function createSettingsCarsModule(
@@ -111,8 +112,8 @@ export function createSettingsCarsModule(
       table: carSelectionState.kind === "loading"
         ? null
         : buildSettingsCarListRenderModel({
-          activeCarId: settings.activeCarId,
-          cars: settings.cars,
+          activeCarId: settings.activeCarId.value,
+          cars: settings.cars.value,
           highlightedCarId: highlightedCar.value?.carId ?? null,
           fmt: formatting.fmt,
           t,
@@ -137,23 +138,23 @@ export function createSettingsCarsModule(
   }
 
   function syncCarsPayload(payload: CarsPayload): void {
-    settings.cars = payload.cars;
-    settings.carsLoaded = true;
+    settings.cars.value = payload.cars;
+    settings.carsLoaded.value = true;
     const requestedActiveCarId = payload.active_car_id;
     const hasRequestedActive = requestedActiveCarId
-      ? settings.cars.some((car) => car.id === requestedActiveCarId)
+      ? settings.cars.value.some((car) => car.id === requestedActiveCarId)
       : false;
-    settings.activeCarId = hasRequestedActive ? requestedActiveCarId : null;
+    settings.activeCarId.value = hasRequestedActive ? requestedActiveCarId : null;
     if (
       highlightedCar.value
-      && !settings.cars.some((car) => car.id === highlightedCar.value?.carId)
+      && !settings.cars.value.some((car) => car.id === highlightedCar.value?.carId)
     ) {
       highlightedCar.value = null;
     }
   }
 
   function findCar(carId: string): CarRecord | null {
-    return settings.cars.find((entry) => entry.id === carId) ?? null;
+    return settings.cars.value.find((entry) => entry.id === carId) ?? null;
   }
 
   function syncActiveCarToInputs(): void {
@@ -203,7 +204,7 @@ export function createSettingsCarsModule(
       return;
     }
     try {
-      if (car.id !== settings.activeCarId) {
+      if (car.id !== settings.activeCarId.value) {
         syncCarsPayload(await transport.activateCar(carId));
         syncActiveCarToInputs();
         ctx.ports.renderSpectrum();

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -103,7 +103,7 @@ export function createSettingsFeature(
       settings,
       services,
       formatting,
-      getSpeedUnit: () => ctx.state.shell.speedUnit,
+      getSpeedUnit: () => ctx.state.shell.speedUnit.value,
       ports: {
         activeViewId: ctx.ports.activeViewId,
         activeSettingsTabId: ctx.panels.settingsShell.activeTabId,
@@ -118,7 +118,7 @@ export function createSettingsFeature(
         t: services.t,
       },
       formatting,
-      getSpeedUnit: () => ctx.state.shell.speedUnit,
+      getSpeedUnit: () => ctx.state.shell.speedUnit.value,
       ports: {
         activeViewId: ctx.ports.activeViewId,
         activeSettingsTabId: ctx.panels.settingsShell.activeTabId,
@@ -145,9 +145,9 @@ export function createSettingsFeature(
   });
 
   let initializedLanguage = false;
-  let previousLanguage = ctx.state.shell.lang;
+  let previousLanguage = ctx.state.shell.lang.value;
   effect(() => {
-    const currentLanguage = ctx.state.shell.lang;
+    const currentLanguage = ctx.state.shell.lang.value;
     if (!initializedLanguage) {
       initializedLanguage = true;
       previousLanguage = currentLanguage;

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -65,14 +65,14 @@ export function createSettingsGpsStatusModule(
     enabled: pollingEnabled,
     poll: async () => {
       const shouldLoadObdStatus =
-        settings.speedSource === "obd2" || settings.obdDeviceMac != null;
+        settings.speedSource.value === "obd2" || settings.obdDeviceMac.value != null;
       const [status, obdStatus] = await Promise.all([
         getSpeedSourceStatus(),
         shouldLoadObdStatus ? getSettingsObdStatus() : Promise.resolve(null),
       ]);
-      settings.gpsFallbackActive = status.fallback_active;
-      settings.gpsEffectiveSpeedKph = status.effective_speed_kmh;
-      settings.resolvedSpeedSource = status.speed_source;
+      settings.gpsFallbackActive.value = status.fallback_active;
+      settings.gpsEffectiveSpeedKph.value = status.effective_speed_kmh;
+      settings.resolvedSpeedSource.value = status.speed_source;
       diagnosticsModel.value = buildSpeedSourceDiagnosticsRenderModel(status, obdStatus, presenterDeps);
       ctx.ports.syncSpeedSourceSelectionUi();
       ctx.ports.renderSpeedReadout();

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -8,10 +8,10 @@ import {
   createSpeedSourceDerivedState,
   resolveEffectiveSpeedSource,
   type DisplayedSpeedSourceMode,
+  type SpeedSourceStateSnapshot,
 } from "../speed_source_state";
 import {
   batchAppStateUpdates,
-  trackAppStateSlice,
   type SettingsState,
 } from "../ui_app_state";
 import {
@@ -74,7 +74,11 @@ function activeSourceLabel(
   settings: SettingsState,
   t: SettingsSpeedSourceWorkflowDeps["t"],
 ): string {
-  const effectiveSource = resolveEffectiveSpeedSource(settings);
+  const effectiveSource = resolveEffectiveSpeedSource({
+    speedSource: settings.speedSource.value,
+    manualSpeedKph: settings.manualSpeedKph.value,
+    resolvedSpeedSource: settings.resolvedSpeedSource.value,
+  });
   if (effectiveSource === "fallback_manual") {
     return t("settings.speed.current_source_fallback_manual");
   }
@@ -147,8 +151,9 @@ export function createSettingsSpeedSourceWorkflow(
     if (draft != null) {
       return draft;
     }
-    trackAppStateSlice(deps.settings);
-    return deps.settings.manualSpeedKph != null ? String(deps.settings.manualSpeedKph) : "";
+    return deps.settings.manualSpeedKph.value != null
+      ? String(deps.settings.manualSpeedKph.value)
+      : "";
   });
   const staleTimeoutInputValue = signal("");
   let speedSourceContextVisible = false;
@@ -163,7 +168,20 @@ export function createSettingsSpeedSourceWorkflow(
   const obdSelectionError = signal(false);
   const diagnosticsOpen = signal(false);
   const renderState = computed<SettingsSpeedSourceRenderState>(() => {
-    const trackedSettings = trackAppStateSlice(deps.settings);
+    const settingsSnapshot: SpeedSourceStateSnapshot & {
+      gpsFallbackActive: boolean;
+      gpsEffectiveSpeedKph: number | null;
+      obdDeviceMac: string | null;
+      obdDeviceName: string | null;
+    } = {
+      gpsFallbackActive: deps.settings.gpsFallbackActive.value,
+      gpsEffectiveSpeedKph: deps.settings.gpsEffectiveSpeedKph.value,
+      manualSpeedKph: deps.settings.manualSpeedKph.value,
+      obdDeviceMac: deps.settings.obdDeviceMac.value,
+      obdDeviceName: deps.settings.obdDeviceName.value,
+      resolvedSpeedSource: deps.settings.resolvedSpeedSource.value,
+      speedSource: deps.settings.speedSource.value,
+    };
     return {
       diagnosticsOpen: diagnosticsOpen.value,
       draftDirty: selectedModeDraft.value !== null,
@@ -176,15 +194,7 @@ export function createSettingsSpeedSourceWorkflow(
       scannedDevices: [...scannedDevices.value],
       scanInFlight: scanInFlight.value,
       selectedMode: selectedMode.value,
-      settings: {
-        gpsFallbackActive: trackedSettings.gpsFallbackActive,
-        gpsEffectiveSpeedKph: trackedSettings.gpsEffectiveSpeedKph,
-        manualSpeedKph: trackedSettings.manualSpeedKph,
-        obdDeviceMac: trackedSettings.obdDeviceMac,
-        obdDeviceName: trackedSettings.obdDeviceName,
-        resolvedSpeedSource: trackedSettings.resolvedSpeedSource,
-        speedSource: trackedSettings.speedSource,
-      },
+      settings: settingsSnapshot,
       staleTimeoutFeedback: cloneFeedback(staleTimeoutFeedback.value),
       staleTimeoutInputValue: staleTimeoutInputValue.value,
     };
@@ -300,11 +310,11 @@ export function createSettingsSpeedSourceWorkflow(
   function applyPayload(payload: SpeedSourcePayload): void {
     batch(() => {
       batchAppStateUpdates(() => {
-        deps.settings.speedSource = payload.speed_source;
-        deps.settings.manualSpeedKph = payload.manual_speed_kph;
-        deps.settings.obdDeviceMac = payload.obd_device_mac ?? null;
-        deps.settings.obdDeviceName = payload.obd_device_name ?? null;
-        deps.settings.resolvedSpeedSource = null;
+        deps.settings.speedSource.value = payload.speed_source;
+        deps.settings.manualSpeedKph.value = payload.manual_speed_kph;
+        deps.settings.obdDeviceMac.value = payload.obd_device_mac ?? null;
+        deps.settings.obdDeviceName.value = payload.obd_device_name ?? null;
+        deps.settings.resolvedSpeedSource.value = null;
       });
       staleTimeoutInputValue.value = String(payload.stale_timeout_s);
       syncInputsFromSettings();
@@ -347,7 +357,7 @@ export function createSettingsSpeedSourceWorkflow(
     clearAllFeedback();
 
     const source: SpeedSourceKind =
-      selectedModeDraft.value ?? deps.settings.speedSource;
+      selectedModeDraft.value ?? deps.settings.speedSource.value;
     const manualInputValue = manualSpeedInputValue.value.trim();
     const manualSpeedKph = parseManualSpeedKph(Number(manualInputValue));
     const staleValueRaw = staleTimeoutInputValue.value.trim();
@@ -395,7 +405,7 @@ export function createSettingsSpeedSourceWorkflow(
       return;
     }
 
-    if (source === "obd2" && !deps.settings.obdDeviceMac) {
+    if (source === "obd2" && !deps.settings.obdDeviceMac.value) {
       batch(() => {
         obdSelectionError.value = true;
         showSaveFeedback(
@@ -474,8 +484,8 @@ export function createSettingsSpeedSourceWorkflow(
       const payload = await transport.pairObdDevice(macAddress);
       batch(() => {
         batchAppStateUpdates(() => {
-          deps.settings.obdDeviceMac = payload.configured_device_mac ?? null;
-          deps.settings.obdDeviceName = payload.configured_device_name ?? null;
+          deps.settings.obdDeviceMac.value = payload.configured_device_mac ?? null;
+          deps.settings.obdDeviceName.value = payload.configured_device_name ?? null;
         });
         mergeScannedDevices([{
           connected: payload.connected,

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -121,11 +121,11 @@ export function createSpectrumCanvasRenderer(
     const entries: SpectrumSeriesEntry[] = [];
     let targetFreq: number[] = [];
 
-    for (const [index, client] of deps.state.realtime.clients.entries()) {
+    for (const [index, client] of deps.state.realtime.clients.value.entries()) {
       if (!client?.connected) {
         continue;
       }
-      const spectrum = deps.state.spectrum.spectra.clients?.[client.id];
+      const spectrum = deps.state.spectrum.spectra.value.clients?.[client.id];
       if (!spectrum || !Array.isArray(spectrum.combined)) {
         continue;
       }
@@ -230,7 +230,7 @@ export function createSpectrumCanvasRenderer(
     tweenFromFrame.value = spectrumLastFrame.value;
     tweenToFrame.value = nextFrame;
     tweenTarget.value = null; // cancel any in-flight animation
-    const canTween = deps.state.transport.wsState === "connected"
+    const canTween = deps.state.transport.wsState.value === "connected"
       && tweenState.canTween.value;
     if (!canTween || !spectrumLastFrame.value) {
       setSpectrumDataFromFrame(nextFrame);
@@ -254,7 +254,7 @@ export function createSpectrumCanvasRenderer(
   }
 
   function setSeriesIsolation(seriesIndex: number | null): void {
-    deps.state.spectrum.spectrumPlot?.setSeriesIsolation(seriesIndex);
+    deps.state.spectrum.spectrumPlot.value?.setSeriesIsolation(seriesIndex);
   }
 
   function colorForClient(index: number): string {
@@ -262,7 +262,7 @@ export function createSpectrumCanvasRenderer(
   }
 
   function setSpectrumDataFromFrame(frame: SpectrumHeavyFrame): void {
-    if (!deps.state.spectrum.spectrumPlot) {
+    if (!deps.state.spectrum.spectrumPlot.value) {
       return;
     }
     currentFreqAxis.value = frame.freq;
@@ -271,7 +271,7 @@ export function createSpectrumCanvasRenderer(
   }
 
   function calculateBandsFromBackend(): ChartBand[] | null {
-    const bands = deps.state.realtime.rotationalSpeeds?.order_bands;
+    const bands = deps.state.realtime.rotationalSpeeds.value?.order_bands;
     if (!Array.isArray(bands) || !bands.length) {
       return null;
     }
@@ -380,11 +380,11 @@ export function createSpectrumCanvasRenderer(
   function createSpectrumPlot(loadedChartModule: SpectrumChartModule): void {
     tweenTarget.value = null;
     spectrumLastFrame.value = null;
-    if (deps.state.spectrum.spectrumPlot) {
-      deps.state.spectrum.spectrumPlot.destroy();
-      deps.state.spectrum.spectrumPlot = null;
+    if (deps.state.spectrum.spectrumPlot.value) {
+      deps.state.spectrum.spectrumPlot.value.destroy();
+      deps.state.spectrum.spectrumPlot.value = null;
     }
-    deps.state.spectrum.spectrumPlot = loadedChartModule.createSpectrumChart({
+    deps.state.spectrum.spectrumPlot.value = loadedChartModule.createSpectrumChart({
       hostEl: deps.dom.specChart,
       measureEl: deps.dom.specChartWrap,
       height: chartHeight,
@@ -396,22 +396,22 @@ export function createSpectrumCanvasRenderer(
   }
 
   function ensureSpectrumPlot(): boolean {
-    if (deps.state.spectrum.spectrumPlot) {
-      deps.state.spectrum.chartLoadErrorDetail = null;
+    if (deps.state.spectrum.spectrumPlot.value) {
+      deps.state.spectrum.chartLoadErrorDetail.value = null;
       return true;
     }
     if (chartModule.value) {
-      deps.state.spectrum.chartLoading = false;
-      deps.state.spectrum.chartLoadErrorDetail = null;
+      deps.state.spectrum.chartLoading.value = false;
+      deps.state.spectrum.chartLoadErrorDetail.value = null;
       createSpectrumPlot(chartModule.value);
-      return deps.state.spectrum.spectrumPlot !== null;
+      return deps.state.spectrum.spectrumPlot.value !== null;
     }
     if (chartLoadPromise) {
       return false;
     }
 
-    deps.state.spectrum.chartLoading = true;
-    deps.state.spectrum.chartLoadErrorDetail = null;
+    deps.state.spectrum.chartLoading.value = true;
+    deps.state.spectrum.chartLoadErrorDetail.value = null;
     chartLoadPromise = loadChartModule()
       .then((module) => {
         chartModule.value = module;
@@ -425,10 +425,10 @@ export function createSpectrumCanvasRenderer(
         renderPreparedFrame(rerender);
       })
       .catch((error: unknown) => {
-        deps.state.spectrum.chartLoadErrorDetail = getChartLoadErrorDetail(error);
+        deps.state.spectrum.chartLoadErrorDetail.value = getChartLoadErrorDetail(error);
       })
       .finally(() => {
-        deps.state.spectrum.chartLoading = false;
+        deps.state.spectrum.chartLoading.value = false;
         chartLoadPromise = null;
         onAsyncChartUpdate();
       });

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -5,9 +5,7 @@ import { createWsClient } from "../../ws";
 import {
   applyLivePayloadUpdate,
   batchAppStateUpdates,
-  trackAppStateSlice,
   type AppState,
-  unwrapAppStateValue,
 } from "../ui_app_state";
 import { effect, untracked } from "../ui_signals";
 
@@ -28,32 +26,31 @@ export class UiLiveTransportController {
   }
 
   sendSelection(): void {
-    if (this.state.transport.ws) {
-      this.state.transport.ws.send({ client_id: this.state.realtime.selectedClientId });
+    const ws = this.state.transport.ws.value;
+    if (ws) {
+      ws.send({ client_id: this.state.realtime.selectedClientId.value });
     }
   }
 
   private bindTransportSignalSync(): void {
     effect(() => {
-      trackAppStateSlice(this.state.transport);
-      const ws = this.state.transport.ws;
+      const ws = this.state.transport.ws.value;
       if (!ws) {
         return;
       }
       const nextWsState = ws.uiState.value;
-      if (this.state.transport.wsState === nextWsState) {
+      if (this.state.transport.wsState.value === nextWsState) {
         return;
       }
       batchAppStateUpdates(() => {
-        this.state.transport.wsState = nextWsState;
+        this.state.transport.wsState.value = nextWsState;
       });
     });
 
-    let previousPendingPayload = unwrapAppStateValue(this.state.transport.pendingPayload);
+    let previousPendingPayload = this.state.transport.pendingPayload.value;
     let pendingPayloadInitialized = false;
     effect(() => {
-      trackAppStateSlice(this.state.transport);
-      const nextPendingPayload = unwrapAppStateValue(this.state.transport.pendingPayload);
+      const nextPendingPayload = this.state.transport.pendingPayload.value;
       if (!pendingPayloadInitialized) {
         pendingPayloadInitialized = true;
         previousPendingPayload = nextPendingPayload;
@@ -68,11 +65,10 @@ export class UiLiveTransportController {
       }
     });
 
-    let previousWsState = this.state.transport.wsState;
+    let previousWsState = this.state.transport.wsState.value;
     let wsStateInitialized = false;
     effect(() => {
-      trackAppStateSlice(this.state.transport);
-      const nextWsState = this.state.transport.wsState;
+      const nextWsState = this.state.transport.wsState.value;
       if (!wsStateInitialized) {
         wsStateInitialized = true;
         previousWsState = nextWsState;
@@ -101,20 +97,23 @@ export class UiLiveTransportController {
   }
 
   private queueRender(): void {
-    if (this.state.transport.renderQueued) return;
-    this.state.transport.renderQueued = true;
+    if (this.state.transport.renderQueued.value) return;
+    this.state.transport.renderQueued.value = true;
     window.requestAnimationFrame(() => {
-      this.state.transport.renderQueued = false;
+      this.state.transport.renderQueued.value = false;
       const now = Date.now();
-      if (now - this.state.transport.lastRenderTsMs < this.state.transport.minRenderIntervalMs) {
+      if (
+        now - this.state.transport.lastRenderTsMs.value
+        < this.state.transport.minRenderIntervalMs.value
+      ) {
         this.queueRender();
         return;
       }
-      const payload = unwrapAppStateValue(this.state.transport.pendingPayload);
+      const payload = this.state.transport.pendingPayload.value;
       if (!payload) return;
       batchAppStateUpdates(() => {
-        this.state.transport.pendingPayload = null;
-        this.state.transport.lastRenderTsMs = now;
+        this.state.transport.pendingPayload.value = null;
+        this.state.transport.lastRenderTsMs.value = now;
       });
       this.applyPayload(payload);
     });
@@ -126,15 +125,15 @@ export class UiLiveTransportController {
       adapted = adaptServerPayload(payload);
     } catch (error) {
       batchAppStateUpdates(() => {
-        this.state.transport.payloadError =
+        this.state.transport.payloadError.value =
           error instanceof Error ? error.message : this.payloadErrorMessage();
-        this.state.spectrum.hasSpectrumData = false;
+        this.state.spectrum.hasSpectrumData.value = false;
       });
       return;
     }
 
     const update = batchAppStateUpdates(() => {
-      this.state.transport.payloadError = null;
+      this.state.transport.payloadError.value = null;
       return applyLivePayloadUpdate({
         realtime: this.state.realtime,
         spectrum: this.state.spectrum,
@@ -148,21 +147,21 @@ export class UiLiveTransportController {
 
   private queueTransportPayload(payload: unknown): void {
     batchAppStateUpdates(() => {
-      this.state.transport.wsState = "connected";
-      this.state.transport.hasReceivedPayload = true;
-      this.state.transport.pendingPayload = payload;
+      this.state.transport.wsState.value = "connected";
+      this.state.transport.hasReceivedPayload.value = true;
+      this.state.transport.pendingPayload.value = payload;
     });
   }
 
   private connectWs(): void {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    this.state.transport.ws = createWsClient({
+    this.state.transport.ws.value = createWsClient({
       url: `${protocol}//${window.location.host}/ws`,
       onMessage: (payload) => {
-        this.state.transport.hasReceivedPayload = true;
-        this.state.transport.pendingPayload = payload;
+        this.state.transport.hasReceivedPayload.value = true;
+        this.state.transport.pendingPayload.value = payload;
       },
     });
-    this.state.transport.ws.connect();
+    this.state.transport.ws.value.connect();
   }
 }

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -109,7 +109,7 @@ export class UiShellController {
         this.notifications.showError(this.t("status.view_load_failed"));
       },
       onDashboardViewActivated: () => {
-        this.state.spectrum.spectrumPlot?.resize();
+        this.state.spectrum.spectrumPlot.value?.resize();
       },
     });
     this.status = createUiShellStatusModule({
@@ -144,11 +144,11 @@ export class UiShellController {
   }
 
   t(key: string, vars?: Record<string, unknown>): string {
-    return I18N.get(this.state.shell.lang, key, vars);
+    return I18N.get(this.state.shell.lang.value, key, vars);
   }
 
   localFormatInt(value: number): string {
-    return formatIntLocale(value, this.state.shell.lang);
+    return formatIntLocale(value, this.state.shell.lang.value);
   }
 
   showError(message: string): void {
@@ -191,9 +191,9 @@ export class UiShellController {
 
   private bindReactiveLanguageSync(): void {
     let initialized = false;
-    let previousLanguage = this.state.shell.lang;
+    let previousLanguage = this.state.shell.lang.value;
     effect(() => {
-      const currentLanguage = this.state.shell.lang;
+      const currentLanguage = this.state.shell.lang.value;
       if (!initialized) {
         initialized = true;
         previousLanguage = currentLanguage;

--- a/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_navigation_module.ts
@@ -23,13 +23,15 @@ function normalizeActiveViewId(viewId: string, viewIds: readonly string[]): stri
 export function createUiShellNavigationModule(
   deps: UiShellNavigationDeps,
 ): UiShellNavigationModule {
-  const activeViewId = signal(normalizeActiveViewId(deps.shell.activeViewId, deps.viewIds));
+  const activeViewId = signal(
+    normalizeActiveViewId(deps.shell.activeViewId.value, deps.viewIds),
+  );
   let pendingActivationToken = 0;
-  deps.shell.activeViewId = activeViewId.value;
+  deps.shell.activeViewId.value = activeViewId.value;
 
   const applyActiveView = (nextViewId: string): void => {
     activeViewId.value = nextViewId;
-    deps.shell.activeViewId = nextViewId;
+    deps.shell.activeViewId.value = nextViewId;
     if (nextViewId === DEFAULT_SHELL_VIEW_ID) {
       deps.onDashboardViewActivated?.();
     }

--- a/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
@@ -30,8 +30,8 @@ export function createUiShellPreferencesModule(
 ): UiShellPreferencesModule {
   const languageFeedback = signal<SettingsFeedbackMessage | null>(null);
   const speedUnitFeedback = signal<SettingsFeedbackMessage | null>(null);
-  const selectedLanguage = signal(deps.shell.lang);
-  const selectedSpeedUnit = signal(deps.shell.speedUnit);
+  const selectedLanguage = signal(deps.shell.lang.value);
+  const selectedSpeedUnit = signal(deps.shell.speedUnit.value);
 
   function speedUnitLabel(value: string): string {
     return deps.t(value === "mps" ? "speed.unit.mps" : "speed.unit.kmh");
@@ -46,13 +46,13 @@ export function createUiShellPreferencesModule(
   }
 
   function applyLanguageValue(rawLanguage: string): void {
-    deps.shell.lang = deps.normalizeLanguage(rawLanguage);
-    selectedLanguage.value = deps.shell.lang;
+    deps.shell.lang.value = deps.normalizeLanguage(rawLanguage);
+    selectedLanguage.value = deps.shell.lang.value;
   }
 
   function applySpeedUnitValue(rawUnit: string): void {
-    deps.shell.speedUnit = normalizeSpeedUnit(rawUnit);
-    selectedSpeedUnit.value = deps.shell.speedUnit;
+    deps.shell.speedUnit.value = normalizeSpeedUnit(rawUnit);
+    selectedSpeedUnit.value = deps.shell.speedUnit.value;
   }
 
   function buildSaveFailureFeedback(
@@ -100,7 +100,7 @@ export function createUiShellPreferencesModule(
     },
     async saveLanguage(lang) {
       const nextLanguage = deps.normalizeLanguage(lang);
-      const previousLanguage = deps.shell.lang;
+      const previousLanguage = deps.shell.lang.value;
       languageFeedback.value = null;
       selectedLanguage.value = nextLanguage;
       try {
@@ -117,7 +117,7 @@ export function createUiShellPreferencesModule(
     },
     async saveSpeedUnit(unit) {
       const nextUnit = normalizeSpeedUnit(unit);
-      const previousUnit = deps.shell.speedUnit;
+      const previousUnit = deps.shell.speedUnit.value;
       speedUnitFeedback.value = null;
       selectedSpeedUnit.value = nextUnit;
       try {

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -6,7 +6,6 @@ import type {
   ShellState,
   TransportState,
 } from "../ui_app_state";
-import { trackAppStateSlice } from "../ui_app_state";
 import type { VisualVariant } from "../view_style_types";
 import { computed, type ReadonlySignal } from "../ui_signals";
 import type { UiShellBadgeModel } from "./ui_shell_chrome";
@@ -45,18 +44,17 @@ export function createUiShellStatusModule(
   deps: UiShellStatusDeps,
 ): UiShellStatusModule {
   function speedValueInSelectedUnit(speedMps: number): number {
-    return deps.shell.speedUnit === "mps" ? speedMps : speedMps * 3.6;
+    return deps.shell.speedUnit.value === "mps" ? speedMps : speedMps * 3.6;
   }
 
   function selectedSpeedUnitLabel(): string {
-    return deps.shell.speedUnit === "mps"
+    return deps.shell.speedUnit.value === "mps"
       ? deps.t("speed.unit.mps")
       : deps.t("speed.unit.kmh");
   }
 
   const runtimeSpeedSource = computed(() => {
-    trackAppStateSlice(deps.realtime);
-    return deps.realtime.rotationalSpeeds?.basis_speed_source ?? null;
+    return deps.realtime.rotationalSpeeds.value?.basis_speed_source ?? null;
   });
   const speedSourceState = createSpeedSourceDerivedState(
     deps.settings,
@@ -64,14 +62,13 @@ export function createUiShellStatusModule(
   );
 
   const wsLinkState = computed<UiShellBadgeModel>(() => {
-    trackAppStateSlice(deps.transport);
-    if (deps.transport.payloadError) {
+    if (deps.transport.payloadError.value) {
       return {
         text: deps.t("ws.payload_error_pill"),
         variant: "bad",
       };
     }
-    const wsState = deps.transport.wsState;
+    const wsState = deps.transport.wsState.value;
     return {
       text: deps.t(WS_KEY_BY_STATE[wsState] || "ws.connecting"),
       variant: WS_VARIANT_BY_STATE[wsState] || "muted",
@@ -79,13 +76,12 @@ export function createUiShellStatusModule(
   });
 
   const speedReadoutText = computed(() => {
-    trackAppStateSlice(deps.realtime);
     const unitLabel = selectedSpeedUnitLabel();
     if (
-      typeof deps.realtime.speedMps === "number" &&
-      Number.isFinite(deps.realtime.speedMps)
+      typeof deps.realtime.speedMps.value === "number" &&
+      Number.isFinite(deps.realtime.speedMps.value)
     ) {
-      const value = speedValueInSelectedUnit(deps.realtime.speedMps);
+      const value = speedValueInSelectedUnit(deps.realtime.speedMps.value);
       const labelKey = speedSourceState.speedReadoutLabelKey.value;
       return deps.t(labelKey, {
         unit: unitLabel,
@@ -96,11 +92,10 @@ export function createUiShellStatusModule(
   });
 
   const connectionState = computed(() => {
-    trackAppStateSlice(deps.transport);
     const degraded =
-      deps.transport.payloadError !== null ||
-      deps.transport.wsState === "reconnecting" ||
-      deps.transport.wsState === "stale";
+      deps.transport.payloadError.value !== null ||
+      deps.transport.wsState.value === "reconnecting" ||
+      deps.transport.wsState.value === "stale";
     return degraded ? "degraded" : "live";
   });
 

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -1,4 +1,4 @@
-import { trackAppStateSlice, type AppState } from "../ui_app_state";
+import type { AppState } from "../ui_app_state";
 import { effect, untracked } from "../ui_signals";
 import {
   createSpectrumCanvasRenderer,
@@ -41,10 +41,10 @@ export class UiSpectrumController {
       panel: this.panel,
       t: this.t,
       getStrengthDb: (entryId) =>
-        this.state.spectrum.spectra.clients[entryId]?.strength_metrics?.vibration_strength_db
+        this.state.spectrum.spectra.value.clients[entryId]?.strength_metrics?.vibration_strength_db
         ?? null,
       getTopPeakHz: (entryId) =>
-        this.state.spectrum.spectra.clients[entryId]?.strength_metrics?.top_peaks?.[0]?.hz
+        this.state.spectrum.spectra.value.clients[entryId]?.strength_metrics?.top_peaks?.[0]?.hz
         ?? null,
       setSeriesIsolation: (seriesIndex) => this.canvas.setSeriesIsolation(seriesIndex),
       requestPlotRefresh: () => this.canvas.refreshDecorations(),
@@ -77,8 +77,8 @@ export class UiSpectrumController {
   renderSpectrum(): void {
     this.renderSpectrumHeader();
     const prepared = this.canvas.prepareFrame();
-    this.state.spectrum.chartBands = prepared.chartBands;
-    this.state.spectrum.hasSpectrumData = prepared.hasData;
+    this.state.spectrum.chartBands.value = prepared.chartBands;
+    this.state.spectrum.hasSpectrumData.value = prepared.hasData;
     this.interaction.sync({
       entries: prepared.entries,
       freqAxis: prepared.freqAxis,
@@ -90,30 +90,33 @@ export class UiSpectrumController {
   }
 
   private spectrumOverlayMessage(): string | null {
-    if (this.state.spectrum.chartLoadErrorDetail) {
+    if (this.state.spectrum.chartLoadErrorDetail.value) {
       return this.t("spectrum.chart_load_error", {
-        message: this.state.spectrum.chartLoadErrorDetail,
+        message: this.state.spectrum.chartLoadErrorDetail.value,
       });
     }
-    if (this.state.transport.payloadError) {
-      return this.state.transport.payloadError;
+    if (this.state.transport.payloadError.value) {
+      return this.state.transport.payloadError.value;
     }
-    if (!this.state.transport.hasReceivedPayload && this.state.transport.wsState === "connecting") {
+    if (
+      !this.state.transport.hasReceivedPayload.value
+      && this.state.transport.wsState.value === "connecting"
+    ) {
       return this.t("spectrum.loading");
     }
     if (
-      this.state.transport.wsState === "connecting"
-      || this.state.transport.wsState === "reconnecting"
+      this.state.transport.wsState.value === "connecting"
+      || this.state.transport.wsState.value === "reconnecting"
     ) {
       return this.t("ws.connecting");
     }
-    if (this.state.transport.wsState === "stale") {
+    if (this.state.transport.wsState.value === "stale") {
       return this.t("spectrum.stale");
     }
-    if (this.state.spectrum.chartLoading && this.state.spectrum.hasSpectrumData) {
+    if (this.state.spectrum.chartLoading.value && this.state.spectrum.hasSpectrumData.value) {
       return this.t("spectrum.loading");
     }
-    if (!this.state.spectrum.hasSpectrumData) {
+    if (!this.state.spectrum.hasSpectrumData.value) {
       return this.t("spectrum.empty");
     }
     return null;
@@ -125,9 +128,9 @@ export class UiSpectrumController {
 
   private bindReactiveLanguageSync(): void {
     let initialized = false;
-    let previousLanguage = this.state.shell.lang;
+    let previousLanguage = this.state.shell.lang.value;
     effect(() => {
-      const currentLanguage = this.state.shell.lang;
+      const currentLanguage = this.state.shell.lang.value;
       if (!initialized) {
         initialized = true;
         previousLanguage = currentLanguage;
@@ -145,18 +148,16 @@ export class UiSpectrumController {
   }
 
   private bindReactiveTransportSync(): void {
-    let previousSpectra = this.state.spectrum.spectra;
-    let previousWsState = this.state.transport.wsState;
-    let previousPayloadError = this.state.transport.payloadError;
-    let previousHasReceivedPayload = this.state.transport.hasReceivedPayload;
+    let previousSpectra = this.state.spectrum.spectra.value;
+    let previousWsState = this.state.transport.wsState.value;
+    let previousPayloadError = this.state.transport.payloadError.value;
+    let previousHasReceivedPayload = this.state.transport.hasReceivedPayload.value;
     let initialized = false;
     effect(() => {
-      trackAppStateSlice(this.state.spectrum);
-      trackAppStateSlice(this.state.transport);
-      const nextSpectra = this.state.spectrum.spectra;
-      const nextWsState = this.state.transport.wsState;
-      const nextPayloadError = this.state.transport.payloadError;
-      const nextHasReceivedPayload = this.state.transport.hasReceivedPayload;
+      const nextSpectra = this.state.spectrum.spectra.value;
+      const nextWsState = this.state.transport.wsState.value;
+      const nextPayloadError = this.state.transport.payloadError.value;
+      const nextHasReceivedPayload = this.state.transport.hasReceivedPayload.value;
       if (!initialized) {
         initialized = true;
         previousSpectra = nextSpectra;

--- a/apps/ui/src/app/speed_source_state.ts
+++ b/apps/ui/src/app/speed_source_state.ts
@@ -1,11 +1,16 @@
-import type { SettingsState } from "./ui_app_state";
-import { trackAppStateSlice } from "./ui_app_state";
+import type { SpeedSourceKind, SpeedSourceStatusPayload } from "../api/types";
 import { computed, type ReadonlySignal } from "./ui_signals";
 
+export interface SpeedSourceStateSnapshot {
+  speedSource: SpeedSourceKind;
+  manualSpeedKph: number | null;
+  resolvedSpeedSource: SpeedSourceStatusPayload["speed_source"] | null;
+}
+
 export interface SpeedSourceStateSource {
-  speedSource: SettingsState["speedSource"];
-  manualSpeedKph: SettingsState["manualSpeedKph"];
-  resolvedSpeedSource: SettingsState["resolvedSpeedSource"];
+  speedSource: ReadonlySignal<SpeedSourceKind>;
+  manualSpeedKph: ReadonlySignal<number | null>;
+  resolvedSpeedSource: ReadonlySignal<SpeedSourceStatusPayload["speed_source"] | null>;
 }
 
 export type DisplayedSpeedSourceMode = "gps" | "manual" | "obd2";
@@ -23,7 +28,7 @@ export function isManualLikeSpeedSource(source: string | null | undefined): bool
 }
 
 export function deriveDisplayedSpeedSourceMode(
-  settings: SpeedSourceStateSource,
+  settings: SpeedSourceStateSnapshot,
 ): DisplayedSpeedSourceMode {
   const effectiveSource = resolveEffectiveSpeedSource(settings);
   if (effectiveSource === "obd2") {
@@ -36,7 +41,7 @@ export function deriveDisplayedSpeedSourceMode(
 }
 
 export function resolveEffectiveSpeedSource(
-  settings: SpeedSourceStateSource,
+  settings: SpeedSourceStateSnapshot,
   runtimeSpeedSource?: string | null,
 ): string | null {
   if (settings.resolvedSpeedSource) {
@@ -49,14 +54,14 @@ export function resolveEffectiveSpeedSource(
 }
 
 export function isManualEffectiveSpeedSource(
-  settings: SpeedSourceStateSource,
+  settings: SpeedSourceStateSnapshot,
   runtimeSpeedSource?: string | null,
 ): boolean {
   return isManualLikeSpeedSource(resolveEffectiveSpeedSource(settings, runtimeSpeedSource));
 }
 
 export function deriveSpeedReadoutLabelKey(
-  settings: SpeedSourceStateSource,
+  settings: SpeedSourceStateSnapshot,
   runtimeSpeedSource?: string | null,
 ): SpeedReadoutLabelKey {
   const effectiveSource = resolveEffectiveSpeedSource(settings, runtimeSpeedSource);
@@ -70,12 +75,15 @@ export function createSpeedSourceDerivedState(
   settings: SpeedSourceStateSource,
   runtimeSpeedSource?: ReadonlySignal<string | null>,
 ): SpeedSourceDerivedState {
-  const effectiveSource = computed(() => {
-    trackAppStateSlice(settings);
-    return resolveEffectiveSpeedSource(settings, runtimeSpeedSource?.value);
+  const snapshot = (): SpeedSourceStateSnapshot => ({
+    speedSource: settings.speedSource.value,
+    manualSpeedKph: settings.manualSpeedKph.value,
+    resolvedSpeedSource: settings.resolvedSpeedSource.value,
   });
+  const effectiveSource = computed(() =>
+    resolveEffectiveSpeedSource(snapshot(), runtimeSpeedSource?.value)
+  );
   const displayedMode = computed<DisplayedSpeedSourceMode>(() => {
-    trackAppStateSlice(settings);
     const resolvedSource = effectiveSource.value;
     if (resolvedSource === "obd2") {
       return "obd2";
@@ -83,7 +91,7 @@ export function createSpeedSourceDerivedState(
     if (isManualLikeSpeedSource(resolvedSource)) {
       return "manual";
     }
-    return settings.speedSource;
+    return settings.speedSource.value;
   });
   const isManualEffective = computed(() =>
     isManualLikeSpeedSource(effectiveSource.value),

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -15,124 +15,7 @@ import type {
   SpeedSourceKind,
   SpeedSourceStatusPayload,
 } from "../api/types";
-import { batch, signal, type ReadonlySignal, type Signal } from "./ui_signals";
-
-const reactiveTargetProxies = new WeakMap<object, WeakMap<Signal<number>, object>>();
-const reactiveProxyTargets = new WeakMap<object, object>();
-const reactiveSliceSignals = new WeakMap<object, Signal<number>>();
-
-type SignalStateScalar = boolean | null | number | string | undefined;
-
-function isProxyableObject(value: unknown): value is object {
-  if (value === null || typeof value !== "object") {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    return true;
-  }
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
-}
-
-function unwrapReactiveValue<T>(value: T): T {
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-  return (reactiveProxyTargets.get(value) as T | undefined) ?? value;
-}
-
-function createReactiveProxy<T extends object>(target: T, rootSignal: Signal<number>): T {
-  let proxiesBySignal = reactiveTargetProxies.get(target);
-  if (!proxiesBySignal) {
-    proxiesBySignal = new WeakMap<Signal<number>, object>();
-    reactiveTargetProxies.set(target, proxiesBySignal);
-  }
-  const existingProxy = proxiesBySignal.get(rootSignal);
-  if (existingProxy) {
-    return existingProxy as T;
-  }
-
-  const proxy = new Proxy(target, {
-    get(current, property) {
-      const value = Reflect.get(current, property);
-      if (isProxyableObject(value)) {
-        return createReactiveProxy(unwrapReactiveValue(value), rootSignal);
-      }
-      return value;
-    },
-    set(current, property, nextValue) {
-      const rawNextValue = unwrapReactiveValue(nextValue);
-      const previousValue = unwrapReactiveValue(Reflect.get(current, property));
-      if (Object.is(previousValue, rawNextValue)) {
-        return true;
-      }
-      const didSet = Reflect.set(current, property, rawNextValue);
-      if (didSet) {
-        rootSignal.value += 1;
-      }
-      return didSet;
-    },
-    deleteProperty(current, property) {
-      if (!Reflect.has(current, property)) {
-        return true;
-      }
-      const didDelete = Reflect.deleteProperty(current, property);
-      if (didDelete) {
-        rootSignal.value += 1;
-      }
-      return didDelete;
-    },
-  });
-
-  proxiesBySignal.set(rootSignal, proxy);
-  reactiveProxyTargets.set(proxy, target);
-  reactiveSliceSignals.set(proxy, rootSignal);
-  return proxy as T;
-}
-
-function createReactiveStateSlice<T extends object>(value: T): T {
-  return createReactiveProxy(value, signal(0));
-}
-
-function createSignalStateSlice<T extends Record<string, SignalStateScalar>>(value: T): T {
-  const sliceSignal = signal(0);
-  const slice = {} as T;
-  for (const [key, initialValue] of Object.entries(value) as [keyof T, T[keyof T]][]) {
-    const propertySignal = signal(initialValue);
-    Object.defineProperty(slice, key, {
-      enumerable: true,
-      get() {
-        return propertySignal.value;
-      },
-      set(nextValue: T[keyof T]) {
-        if (Object.is(propertySignal.value, nextValue)) {
-          return;
-        }
-        propertySignal.value = nextValue;
-        sliceSignal.value += 1;
-      },
-    });
-  }
-  reactiveSliceSignals.set(slice as object, sliceSignal);
-  return slice;
-}
-
-function requireReactiveSliceSignal<T extends object>(slice: T): Signal<number> {
-  const sliceSignal = reactiveSliceSignals.get(slice as object);
-  if (!sliceSignal) {
-    throw new Error("AppState slice signal is unavailable outside createAppState()");
-  }
-  return sliceSignal;
-}
-
-export function getAppStateSliceSignal<T extends object>(slice: T): ReadonlySignal<number> {
-  return requireReactiveSliceSignal(slice);
-}
-
-export function trackAppStateSlice<T extends object>(slice: T): T {
-  requireReactiveSliceSignal(slice).value;
-  return slice;
-}
+import { batch, signal, type Signal } from "./ui_signals";
 
 export function batchAppStateUpdates<T>(callback: () => T): T {
   let result!: T;
@@ -140,10 +23,6 @@ export function batchAppStateUpdates<T>(callback: () => T): T {
     result = callback();
   });
   return result;
-}
-
-export function unwrapAppStateValue<T>(value: T): T {
-  return unwrapReactiveValue(value);
 }
 
 export interface VehicleSettings {
@@ -242,18 +121,19 @@ export function applySpectrumTick(
 }
 
 export function syncSelectedRealtimeClient(realtime: RealtimeState): void {
-  const firstConnected = realtime.clients.find((client) => Boolean(client.connected));
-  if (!realtime.selectedClientId && realtime.clients.length > 0) {
-    realtime.selectedClientId = firstConnected ? firstConnected.id : realtime.clients[0]?.id ?? null;
+  const clients = realtime.clients.value;
+  const firstConnected = clients.find((client) => Boolean(client.connected));
+  if (!realtime.selectedClientId.value && clients.length > 0) {
+    realtime.selectedClientId.value = firstConnected ? firstConnected.id : clients[0]?.id ?? null;
   }
   if (
-    realtime.selectedClientId
-    && !realtime.clients.some((client) => client.id === realtime.selectedClientId)
+    realtime.selectedClientId.value
+    && !clients.some((client) => client.id === realtime.selectedClientId.value)
   ) {
-    realtime.selectedClientId = firstConnected
+    realtime.selectedClientId.value = firstConnected
       ? firstConnected.id
-      : realtime.clients.length
-        ? realtime.clients[0]?.id ?? null
+      : clients.length
+        ? clients[0]?.id ?? null
         : null;
   }
 }
@@ -261,33 +141,39 @@ export function syncSelectedRealtimeClient(realtime: RealtimeState): void {
 export function applyLivePayloadUpdate(deps: LivePayloadUpdateDeps): LivePayloadUpdateResult {
   return batchAppStateUpdates(() => {
     const { realtime, spectrum, adaptedPayload } = deps;
-    const previousSelectedClientId = realtime.selectedClientId;
-    realtime.clients = adaptedPayload.clients;
+    const previousSelectedClientId = realtime.selectedClientId.value;
+    realtime.clients.value = adaptedPayload.clients;
     const spectrumTick = applySpectrumTick(
-      spectrum.spectra,
-      spectrum.hasSpectrumData,
+      spectrum.spectra.value,
+      spectrum.hasSpectrumData.value,
       adaptedPayload.spectra,
     );
-    spectrum.spectra = spectrumTick.spectra;
+    spectrum.spectra.value = spectrumTick.spectra;
     syncSelectedRealtimeClient(realtime);
-    realtime.speedMps = adaptedPayload.speed_mps;
-    realtime.rotationalSpeeds = adaptedPayload.rotational_speeds;
-    spectrum.hasSpectrumData = spectrumTick.hasSpectrumData;
+    realtime.speedMps.value = adaptedPayload.speed_mps;
+    realtime.rotationalSpeeds.value = adaptedPayload.rotational_speeds;
+    spectrum.hasSpectrumData.value = spectrumTick.hasSpectrumData;
     return {
-      hasSelectedClientChanged: previousSelectedClientId !== realtime.selectedClientId,
-      selectedClient: realtime.clients.find((client) => client.id === realtime.selectedClientId),
+      hasSelectedClientChanged: previousSelectedClientId !== realtime.selectedClientId.value,
+      selectedClient: realtime.clients.value.find(
+        (client) => client.id === realtime.selectedClientId.value,
+      ),
       hasNewSpectrumFrame: spectrumTick.hasNewSpectrumFrame,
     };
   });
 }
 
-export interface ShellState {
+export type SignalState<T extends object> = {
+  [K in keyof T]: Signal<T[K]>;
+};
+
+export interface ShellStateValue {
   lang: string;
   speedUnit: string;
   activeViewId: string;
 }
 
-export interface TransportState {
+export interface TransportStateValue {
   ws: WsClient | null;
   wsState: WsUiState;
   pendingPayload: unknown | null;
@@ -298,7 +184,7 @@ export interface TransportState {
   payloadError: string | null;
 }
 
-export interface RealtimeState {
+export interface RealtimeStateValue {
   clients: AdaptedClient[];
   selectedClientId: string | null;
   speedMps: number | null;
@@ -307,14 +193,14 @@ export interface RealtimeState {
   locationCodes: string[];
 }
 
-export interface HistoryState {
+export interface HistoryStateValue {
   runs: HistoryEntry[];
   deleteAllRunsInFlight: boolean;
   expandedRunId: string | null;
   runDetailsById: Record<string, RunDetail>;
 }
 
-export interface SettingsState {
+export interface SettingsStateValue {
   vehicleSettings: VehicleSettings;
   cars: CarRecord[];
   carsLoaded: boolean;
@@ -328,7 +214,7 @@ export interface SettingsState {
   gpsEffectiveSpeedKph: number | null;
 }
 
-export interface SpectrumState {
+export interface SpectrumStateValue {
   spectrumPlot: SpectrumChart | null;
   spectra: { clients: Record<string, SpectrumClientData> };
   chartBands: ChartBand[];
@@ -336,6 +222,13 @@ export interface SpectrumState {
   chartLoading: boolean;
   chartLoadErrorDetail: string | null;
 }
+
+export type ShellState = SignalState<ShellStateValue>;
+export type TransportState = SignalState<TransportStateValue>;
+export type RealtimeState = SignalState<RealtimeStateValue>;
+export type HistoryState = SignalState<HistoryStateValue>;
+export type SettingsState = SignalState<SettingsStateValue>;
+export type SpectrumState = SignalState<SpectrumStateValue>;
 
 export interface AppState {
   shell: ShellState;
@@ -348,27 +241,27 @@ export interface AppState {
 
 export function createAppState(): AppState {
   return {
-    shell: createSignalStateSlice({
-      lang: "en",
-      speedUnit: "kmh",
-      activeViewId: "dashboardView",
-    }),
-    transport: createReactiveStateSlice({
-      ws: null,
-      wsState: "connecting",
-      pendingPayload: null,
-      renderQueued: false,
-      lastRenderTsMs: 0,
-      minRenderIntervalMs: 100,
-      hasReceivedPayload: false,
-      payloadError: null,
-    }),
-    realtime: createReactiveStateSlice({
-      clients: [],
-      selectedClientId: null,
-      speedMps: null,
-      rotationalSpeeds: null,
-      loggingStatus: {
+    shell: {
+      lang: signal("en"),
+      speedUnit: signal("kmh"),
+      activeViewId: signal("dashboardView"),
+    },
+    transport: {
+      ws: signal<WsClient | null>(null),
+      wsState: signal<WsUiState>("connecting"),
+      pendingPayload: signal<unknown | null>(null),
+      renderQueued: signal(false),
+      lastRenderTsMs: signal(0),
+      minRenderIntervalMs: signal(100),
+      hasReceivedPayload: signal(false),
+      payloadError: signal<string | null>(null),
+    },
+    realtime: {
+      clients: signal<AdaptedClient[]>([]),
+      selectedClientId: signal<string | null>(null),
+      speedMps: signal<number | null>(null),
+      rotationalSpeeds: signal<RotationalSpeeds | null>(null),
+      loggingStatus: signal<LoggingStatusPayload>({
         enabled: false,
         run_id: null,
         write_error: null,
@@ -379,35 +272,35 @@ export function createAppState(): AppState {
         last_completed_run_id: null,
         last_completed_run_error: null,
         capture_readiness: null,
-      },
-      locationCodes: defaultLocationCodes.slice(),
-    }),
-    history: createReactiveStateSlice({
-      runs: [],
-      deleteAllRunsInFlight: false,
-      expandedRunId: null,
-      runDetailsById: {},
-    }),
-    settings: createReactiveStateSlice({
-      vehicleSettings: { ...defaultVehicleSettings },
-      cars: [],
-      carsLoaded: false,
-      activeCarId: null,
-      speedSource: "gps",
-      manualSpeedKph: null,
-      obdDeviceMac: null,
-      obdDeviceName: null,
-      resolvedSpeedSource: null,
-      gpsFallbackActive: false,
-      gpsEffectiveSpeedKph: null,
-    }),
-    spectrum: createReactiveStateSlice({
-      spectrumPlot: null,
-      spectra: { clients: {} },
-      chartBands: [],
-      hasSpectrumData: false,
-      chartLoading: false,
-      chartLoadErrorDetail: null,
-    }),
+      }),
+      locationCodes: signal(defaultLocationCodes.slice()),
+    },
+    history: {
+      runs: signal<HistoryEntry[]>([]),
+      deleteAllRunsInFlight: signal(false),
+      expandedRunId: signal<string | null>(null),
+      runDetailsById: signal<Record<string, RunDetail>>({}),
+    },
+    settings: {
+      vehicleSettings: signal<VehicleSettings>({ ...defaultVehicleSettings }),
+      cars: signal<CarRecord[]>([]),
+      carsLoaded: signal(false),
+      activeCarId: signal<string | null>(null),
+      speedSource: signal<SpeedSourceKind>("gps"),
+      manualSpeedKph: signal<number | null>(null),
+      obdDeviceMac: signal<string | null>(null),
+      obdDeviceName: signal<string | null>(null),
+      resolvedSpeedSource: signal<SpeedSourceStatusPayload["speed_source"] | null>(null),
+      gpsFallbackActive: signal(false),
+      gpsEffectiveSpeedKph: signal<number | null>(null),
+    },
+    spectrum: {
+      spectrumPlot: signal<SpectrumChart | null>(null),
+      spectra: signal<{ clients: Record<string, SpectrumClientData> }>({ clients: {} }),
+      chartBands: signal<ChartBand[]>([]),
+      hasSpectrumData: signal(false),
+      chartLoading: signal(false),
+      chartLoadErrorDetail: signal<string | null>(null),
+    },
   };
 }

--- a/apps/ui/src/app/views/settings_speed_source_presenter.ts
+++ b/apps/ui/src/app/views/settings_speed_source_presenter.ts
@@ -8,7 +8,7 @@ import {
   isManualLikeSpeedSource,
   resolveEffectiveSpeedSource,
   type DisplayedSpeedSourceMode,
-  type SpeedSourceStateSource,
+  type SpeedSourceStateSnapshot,
 } from "../speed_source_state";
 import type {
   SpeedSourceChoiceCardRenderModel,
@@ -20,7 +20,7 @@ import type {
 import type { SettingsFeedbackMessage } from "./settings_feedback";
 
 export interface SettingsSpeedSourceSettingsSnapshot
-  extends SpeedSourceStateSource {
+  extends SpeedSourceStateSnapshot {
   gpsFallbackActive: boolean;
   gpsEffectiveSpeedKph: number | null;
   obdDeviceMac: string | null;

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -175,19 +175,22 @@ function testTranslation(key: string, vars?: Record<string, unknown>): string {
 }
 
 function ensureRunDetail(state: ReturnType<typeof createAppState>, runId: string): RunDetail {
-  if (!state.history.runDetailsById[runId]) {
-    state.history.runDetailsById[runId] = {
-      preview: null,
-      previewLoading: false,
-      previewError: "",
-      insights: null,
-      insightsLoading: false,
-      insightsError: "",
-      pdfLoading: false,
-      pdfError: "",
+  if (!state.history.runDetailsById.value[runId]) {
+    state.history.runDetailsById.value = {
+      ...state.history.runDetailsById.value,
+      [runId]: {
+        preview: null,
+        previewLoading: false,
+        previewError: "",
+        insights: null,
+        insightsLoading: false,
+        insightsError: "",
+        pdfLoading: false,
+        pdfError: "",
+      },
     };
   }
-  return state.history.runDetailsById[runId];
+  return state.history.runDetailsById.value[runId];
 }
 
 function latestRowModels(panel: { getLatestModel(): HistoryPanelRenderModel | null }) {
@@ -253,7 +256,7 @@ test.beforeEach(() => {
 
 test("history feature skips deletion when confirmation is declined", async () => {
   const state = createAppState();
-  state.history.runs = [historyListRun("run-42")];
+  state.history.runs.value = [historyListRun("run-42")];
   const confirmationMessages: string[] = [];
   const { feature } = createFeatureHarness(state, {
     requestConfirmation: async (message) => {
@@ -267,7 +270,7 @@ test("history feature skips deletion when confirmation is declined", async () =>
   expect(confirmationMessages).toEqual([
     'history.delete_confirm:{"name":"run-42"}',
   ]);
-  expect(state.history.runs.map((run) => run.run_id)).toEqual(["run-42"]);
+  expect(state.history.runs.value.map((run) => run.run_id)).toEqual(["run-42"]);
 });
 
 test("history feature refreshes runs and renders an empty-state model when no runs exist", async () => {
@@ -316,7 +319,7 @@ test("history feature refreshes runs and renders table state through one owner",
     globalThis.fetch = originalFetch;
   }
 
-  expect(state.history.runs).toHaveLength(1);
+  expect(state.history.runs.value).toHaveLength(1);
   expect(historySummary.textContent).toContain("history.available_count");
   expect(getLatestModel()?.table?.kind).toBe("rows");
   const row = latestRowModels({ getLatestModel })[0];
@@ -344,7 +347,7 @@ test("history feature binds panel actions through the shared owner", () => {
 
 test("history feature reloads the expanded run when the language changes", async () => {
   const state = createAppState();
-  state.history.runs = [historyListRun("run-001")];
+  state.history.runs.value = [historyListRun("run-001")];
   const { feature, getRenderCount } = createFeatureHarness(state);
   const originalFetch = globalThis.fetch;
   const requests: string[] = [];
@@ -362,13 +365,13 @@ test("history feature reloads the expanded run when the language changes", async
 
   try {
     feature.toggleRunDetails("run-001");
-    await expect.poll(() => state.history.runDetailsById["run-001"]?.preview?.sensor_count_used ?? null).toBe(1);
+    await expect.poll(() => state.history.runDetailsById.value["run-001"]?.preview?.sensor_count_used ?? null).toBe(1);
     await feature.onHistoryTableAction("load-insights", "run-001");
-    expect(state.history.runDetailsById["run-001"]?.insights?.sensor_count_used).toBe(1);
+    expect(state.history.runDetailsById.value["run-001"]?.insights?.sensor_count_used).toBe(1);
 
-    state.shell.lang = "nl";
-    await expect.poll(() => state.history.runDetailsById["run-001"]?.preview?.sensor_count_used ?? null).toBe(2);
-    await expect.poll(() => state.history.runDetailsById["run-001"]?.insights?.sensor_count_used ?? null).toBe(2);
+    state.shell.lang.value = "nl";
+    await expect.poll(() => state.history.runDetailsById.value["run-001"]?.preview?.sensor_count_used ?? null).toBe(2);
+    await expect.poll(() => state.history.runDetailsById.value["run-001"]?.insights?.sensor_count_used ?? null).toBe(2);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -384,7 +387,7 @@ test("history feature reloads the expanded run when the language changes", async
 
 test("history feature treats analyzing insights responses as not-yet-available", async () => {
   const state = createAppState();
-  state.history.runs = [historyListRun("run-001")];
+  state.history.runs.value = [historyListRun("run-001")];
   const { feature, getRenderCount } = createFeatureHarness(state);
   const originalFetch = globalThis.fetch;
   const requests: string[] = [];
@@ -399,16 +402,16 @@ test("history feature treats analyzing insights responses as not-yet-available",
 
   try {
     feature.toggleRunDetails("run-001");
-    await expect.poll(() => state.history.runDetailsById["run-001"]?.previewLoading ?? false).toBe(false);
+    await expect.poll(() => state.history.runDetailsById.value["run-001"]?.previewLoading ?? false).toBe(false);
     await feature.onHistoryTableAction("load-insights", "run-001");
   } finally {
     globalThis.fetch = originalFetch;
   }
 
-  expect(state.history.runDetailsById["run-001"]?.preview).toBeNull();
-  expect(state.history.runDetailsById["run-001"]?.previewError).toBe("");
-  expect(state.history.runDetailsById["run-001"]?.insights).toBeNull();
-  expect(state.history.runDetailsById["run-001"]?.insightsError).toBe("");
+  expect(state.history.runDetailsById.value["run-001"]?.preview).toBeNull();
+  expect(state.history.runDetailsById.value["run-001"]?.previewError).toBe("");
+  expect(state.history.runDetailsById.value["run-001"]?.insights).toBeNull();
+  expect(state.history.runDetailsById.value["run-001"]?.insightsError).toBe("");
   expect(getRenderCount()).toBeGreaterThanOrEqual(4);
   expect(requests.filter((url) => url.startsWith("/api/history/"))).toEqual([
     "/api/history/run-001/insights?lang=en",
@@ -418,17 +421,20 @@ test("history feature treats analyzing insights responses as not-yet-available",
 
 test("history feature rendering promotes loaded findings ahead of supporting statistics", () => {
   const state = createAppState();
-  state.history.runs = [historyListRun("run-001")];
-  state.history.expandedRunId = "run-001";
-  state.history.runDetailsById["run-001"] = {
-    preview: historyInsightsWithFindingsPayload("run-001", 2) as RunDetail["preview"],
-    previewLoading: false,
-    previewError: "",
+  state.history.runs.value = [historyListRun("run-001")];
+  state.history.expandedRunId.value = "run-001";
+  state.history.runDetailsById.value = {
+    ...state.history.runDetailsById.value,
+    "run-001": {
+      preview: historyInsightsWithFindingsPayload("run-001", 2) as RunDetail["preview"],
+      previewLoading: false,
+      previewError: "",
     insights: historyInsightsWithFindingsPayload("run-001", 2) as RunDetail["insights"],
     insightsLoading: false,
     insightsError: "",
     pdfLoading: false,
-    pdfError: "",
+      pdfError: "",
+    },
   };
   const { getLatestModel } = createFeatureHarness(state);
 
@@ -467,7 +473,7 @@ test("history feature preloads collapsed row context for completed runs", async 
 
   try {
     await feature.refreshHistory();
-    await expect.poll(() => state.history.runDetailsById["run-001"]?.preview?.sensor_count_used ?? null).toBe(2);
+    await expect.poll(() => state.history.runDetailsById.value["run-001"]?.preview?.sensor_count_used ?? null).toBe(2);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -485,11 +491,11 @@ test("history feature preloads collapsed row context for completed runs", async 
 
 test("history feature reports partial delete failures without splitting render ownership", async () => {
   const state = createAppState();
-  state.history.runs = [
+  state.history.runs.value = [
     historyListRun("run-001"),
     historyListRun("run-002"),
   ];
-  state.history.expandedRunId = "run-001";
+  state.history.expandedRunId.value = "run-001";
   ensureRunDetail(state, "run-001");
   ensureRunDetail(state, "run-002");
 
@@ -522,8 +528,8 @@ test("history feature reports partial delete failures without splitting render o
   }
 
   expect(deleteRequests).toEqual(["/api/history/run-001", "/api/history/run-002"]);
-  expect(state.history.deleteAllRunsInFlight).toBe(false);
-  expect(state.history.expandedRunId).toBeNull();
+  expect(state.history.deleteAllRunsInFlight.value).toBe(false);
+  expect(state.history.expandedRunId.value).toBeNull();
   expect(getRenderCount()).toBeGreaterThanOrEqual(2);
   expect(errors).toHaveLength(1);
   expect(errors[0]).toContain("history.delete_all_partial");

--- a/apps/ui/tests/realtime_feature_view_state.spec.ts
+++ b/apps/ui/tests/realtime_feature_view_state.spec.ts
@@ -50,26 +50,35 @@ test("realtime view state only re-arms its elapsed timer when logging tick input
     expect(activeTimerIds.size).toBe(0);
 
     workflow.handlersBound.value = true;
-    state.realtime.loggingStatus.enabled = true;
-    state.realtime.loggingStatus.start_time_utc = "2026-04-16T00:00:00Z";
+    state.realtime.loggingStatus.value = {
+      ...state.realtime.loggingStatus.value,
+      enabled: true,
+      start_time_utc: "2026-04-16T00:00:00Z",
+    };
 
     expect(createdTimerIds).toHaveLength(1);
     expect(Array.from(activeTimerIds)).toEqual([createdTimerIds[0]]);
     expect(clearedTimerIds).toEqual([]);
 
-    state.realtime.selectedClientId = "sensor-1";
+    state.realtime.selectedClientId.value = "sensor-1";
 
     expect(createdTimerIds).toHaveLength(1);
     expect(Array.from(activeTimerIds)).toEqual([createdTimerIds[0]]);
     expect(clearedTimerIds).toEqual([]);
 
-    state.realtime.loggingStatus.start_time_utc = "2026-04-16T00:00:05Z";
+    state.realtime.loggingStatus.value = {
+      ...state.realtime.loggingStatus.value,
+      start_time_utc: "2026-04-16T00:00:05Z",
+    };
 
     expect(createdTimerIds).toHaveLength(2);
     expect(Array.from(activeTimerIds)).toEqual([createdTimerIds[1]]);
     expect(clearedTimerIds).toEqual([createdTimerIds[0]]);
 
-    state.realtime.loggingStatus.enabled = false;
+    state.realtime.loggingStatus.value = {
+      ...state.realtime.loggingStatus.value,
+      enabled: false,
+    };
 
     expect(activeTimerIds.size).toBe(0);
     expect(clearedTimerIds).toEqual([createdTimerIds[0], createdTimerIds[1]]);
@@ -118,8 +127,8 @@ test("realtime view state preserves the last completed elapsed text through proc
     });
 
     workflow.handlersBound.value = true;
-    state.realtime.loggingStatus = {
-      ...state.realtime.loggingStatus,
+    state.realtime.loggingStatus.value = {
+      ...state.realtime.loggingStatus.value,
       enabled: true,
       start_time_utc: "2026-04-16T00:00:00Z",
       last_completed_run_id: null,
@@ -127,8 +136,8 @@ test("realtime view state preserves the last completed elapsed text through proc
 
     expect(viewState.loggingPanelModel.value.elapsedText).toBe("1:23");
 
-    state.realtime.loggingStatus = {
-      ...state.realtime.loggingStatus,
+    state.realtime.loggingStatus.value = {
+      ...state.realtime.loggingStatus.value,
       enabled: false,
       analysis_in_progress: true,
       start_time_utc: null,
@@ -137,15 +146,15 @@ test("realtime view state preserves the last completed elapsed text through proc
 
     expect(viewState.loggingPanelModel.value.elapsedText).toBe("1:23");
 
-    state.realtime.loggingStatus = {
-      ...state.realtime.loggingStatus,
+    state.realtime.loggingStatus.value = {
+      ...state.realtime.loggingStatus.value,
       analysis_in_progress: false,
     };
 
     expect(viewState.loggingPanelModel.value.elapsedText).toBe("1:23");
 
-    state.realtime.loggingStatus = {
-      ...state.realtime.loggingStatus,
+    state.realtime.loggingStatus.value = {
+      ...state.realtime.loggingStatus.value,
       last_completed_run_id: null,
     };
 

--- a/apps/ui/tests/realtime_feature_workflow.spec.ts
+++ b/apps/ui/tests/realtime_feature_workflow.spec.ts
@@ -52,12 +52,12 @@ function createHarness(): WorkflowHarness {
 test.describe("createRealtimeFeatureWorkflow", () => {
   test("starts logging through signal-backed workflow state and restarts polling", async () => {
     const harness = createHarness();
-    harness.state.realtime.loggingStatus = {
-      ...harness.state.realtime.loggingStatus,
+    harness.state.realtime.loggingStatus.value = {
+      ...harness.state.realtime.loggingStatus.value,
       last_completed_run_id: "previous-run",
     };
     const nextStatus: LoggingStatusPayload = {
-      ...harness.state.realtime.loggingStatus,
+      ...harness.state.realtime.loggingStatus.value,
       enabled: true,
       run_id: "run-42",
       start_time_utc: "2026-04-05T09:00:00Z",
@@ -116,7 +116,7 @@ test.describe("createRealtimeFeatureWorkflow", () => {
     expect(pendingTransitions).toEqual([null, "starting", null]);
     expect(workflow.signals.handlersBound.value).toBe(true);
     expect(workflow.signals.loggingError.value).toBeNull();
-    expect(harness.state.realtime.loggingStatus).toEqual(nextStatus);
+    expect(harness.state.realtime.loggingStatus.value).toEqual(nextStatus);
   });
 
   test("refreshes idle capture readiness from the signature signal instead of view render calls", async () => {
@@ -144,7 +144,7 @@ test.describe("createRealtimeFeatureWorkflow", () => {
       api: {
         async getLoggingStatus() {
           harness.apiCalls.push(`getLoggingStatus:${idleCaptureReadinessSignature.value}`);
-          return harness.state.realtime.loggingStatus;
+          return harness.state.realtime.loggingStatus.value;
         },
       },
       createPollingController: () => ({
@@ -173,7 +173,7 @@ test.describe("createRealtimeFeatureWorkflow", () => {
 
   test("falls back to default location codes when refreshing locations fails", async () => {
     const harness = createHarness();
-    harness.state.realtime.locationCodes = ["custom-code"];
+    harness.state.realtime.locationCodes.value = ["custom-code"];
     const workflow = createRealtimeFeatureWorkflow({
       realtime: harness.state.realtime,
       t: (key) => key,
@@ -202,18 +202,18 @@ test.describe("createRealtimeFeatureWorkflow", () => {
 
     await workflow.refreshLocationOptions();
 
-    expect(harness.state.realtime.locationCodes).toEqual(defaultLocationCodes);
+    expect(harness.state.realtime.locationCodes.value).toEqual(defaultLocationCodes);
   });
 
   test("refreshes history once when polling observes analysis completion", async () => {
     const harness = createHarness();
-    harness.state.realtime.loggingStatus = {
-      ...harness.state.realtime.loggingStatus,
+    harness.state.realtime.loggingStatus.value = {
+      ...harness.state.realtime.loggingStatus.value,
       analysis_in_progress: true,
       last_completed_run_id: null,
     };
     const completedStatus: LoggingStatusPayload = {
-      ...harness.state.realtime.loggingStatus,
+      ...harness.state.realtime.loggingStatus.value,
       analysis_in_progress: false,
       last_completed_run_id: "run-42",
     };
@@ -251,18 +251,18 @@ test.describe("createRealtimeFeatureWorkflow", () => {
     await workflow.refreshLoggingStatus();
     await workflow.refreshLoggingStatus();
 
-    expect(harness.state.realtime.loggingStatus).toEqual(completedStatus);
+    expect(harness.state.realtime.loggingStatus.value).toEqual(completedStatus);
     expect(harness.recordingCalls).toEqual(["onRecordingStatusChanged"]);
     expect(workflow.signals.loggingError.value).toBeNull();
   });
 
   test("removes the selected client and emits a new selection without DOM fixtures", async () => {
     const harness = createHarness();
-    harness.state.realtime.clients = [
+    harness.state.realtime.clients.value = [
       makeClient("client-a", { connected: true }),
       makeClient("client-b", { connected: true }),
     ];
-    harness.state.realtime.selectedClientId = "client-a";
+    harness.state.realtime.selectedClientId.value = "client-a";
     const workflow = createRealtimeFeatureWorkflow({
       realtime: harness.state.realtime,
       t: (key, vars) => `${key}:${String(vars?.id ?? "")}`,
@@ -296,18 +296,18 @@ test.describe("createRealtimeFeatureWorkflow", () => {
 
     expect(harness.confirmMessages).toEqual(["actions.remove_client_confirm:client-a"]);
     expect(harness.apiCalls).toEqual(["removeClient:client-a"]);
-    expect(harness.state.realtime.clients.map((client) => client.id)).toEqual(["client-b"]);
-    expect(harness.state.realtime.selectedClientId).toBe("client-b");
+    expect(harness.state.realtime.clients.value.map((client) => client.id)).toEqual(["client-b"]);
+    expect(harness.state.realtime.selectedClientId.value).toBe("client-b");
     expect(harness.selectionCalls).toEqual(["sendSelection"]);
   });
 
   test("does not remove a client when confirmation is declined", async () => {
     const harness = createHarness();
-    harness.state.realtime.clients = [
+    harness.state.realtime.clients.value = [
       makeClient("client-a", { connected: true }),
       makeClient("client-b", { connected: true }),
     ];
-    harness.state.realtime.selectedClientId = "client-a";
+    harness.state.realtime.selectedClientId.value = "client-a";
     const workflow = createRealtimeFeatureWorkflow({
       realtime: harness.state.realtime,
       t: (key, vars) => `${key}:${String(vars?.id ?? "")}`,
@@ -341,11 +341,11 @@ test.describe("createRealtimeFeatureWorkflow", () => {
 
     expect(harness.confirmMessages).toEqual(["actions.remove_client_confirm:client-a"]);
     expect(harness.apiCalls).toEqual([]);
-    expect(harness.state.realtime.clients.map((client) => client.id)).toEqual([
+    expect(harness.state.realtime.clients.value.map((client) => client.id)).toEqual([
       "client-a",
       "client-b",
     ]);
-    expect(harness.state.realtime.selectedClientId).toBe("client-a");
+    expect(harness.state.realtime.selectedClientId.value).toBe("client-a");
     expect(harness.selectionCalls).toEqual([]);
   });
 });

--- a/apps/ui/tests/settings_speed_source_workflow.spec.ts
+++ b/apps/ui/tests/settings_speed_source_workflow.spec.ts
@@ -137,10 +137,10 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
   test("keeps the configured GPS source when saving fallback-manual edits without a radio change", async () => {
     const harness = createHarness();
     const appState = createAppState();
-    appState.settings.speedSource = "gps";
-    appState.settings.manualSpeedKph = 80;
-    appState.settings.resolvedSpeedSource = "fallback_manual";
-    appState.settings.gpsEffectiveSpeedKph = 80;
+    appState.settings.speedSource.value = "gps";
+    appState.settings.manualSpeedKph.value = 80;
+    appState.settings.resolvedSpeedSource.value = "fallback_manual";
+    appState.settings.gpsEffectiveSpeedKph.value = 80;
     let savedPayload: SpeedSourceRequest | null = null;
 
     const workflow = createSettingsSpeedSourceWorkflow({
@@ -174,8 +174,8 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
       stale_timeout_s: 5,
     });
     expect(workflow.getRenderState().selectedMode).toBe("gps");
-    expect(appState.settings.speedSource).toBe("gps");
-    expect(appState.settings.manualSpeedKph).toBe(90);
+    expect(appState.settings.speedSource.value).toBe("gps");
+    expect(appState.settings.manualSpeedKph.value).toBe(90);
     expect(harness.focuses).toEqual([]);
     expect(harness.errors).toEqual([]);
   });
@@ -306,8 +306,8 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
       rfcomm_channel: 1,
       trusted: true,
     }]);
-    expect(appState.settings.obdDeviceMac).toBe(scannedDevice.mac_address);
-    expect(appState.settings.obdDeviceName).toBe("OBDLink CX");
+    expect(appState.settings.obdDeviceMac.value).toBe(scannedDevice.mac_address);
+    expect(appState.settings.obdDeviceName.value).toBe("OBDLink CX");
     expect(harness.errors).toEqual([]);
   });
 
@@ -381,9 +381,9 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
       view: createViewPorts(harness),
     });
 
-    appState.settings.speedSource = "obd2";
-    appState.settings.resolvedSpeedSource = "obd2";
-    appState.settings.gpsEffectiveSpeedKph = 81;
+    appState.settings.speedSource.value = "obd2";
+    appState.settings.resolvedSpeedSource.value = "obd2";
+    appState.settings.gpsEffectiveSpeedKph.value = 81;
 
     expect(workflow.getRenderState().settings.gpsEffectiveSpeedKph).toBe(81);
     expect(harness.errors).toEqual([]);
@@ -412,9 +412,9 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
       selectedMode: "gps",
     });
 
-    appState.settings.manualSpeedKph = 88;
-    appState.settings.speedSource = "manual";
-    appState.settings.resolvedSpeedSource = "manual";
+    appState.settings.manualSpeedKph.value = 88;
+    appState.settings.speedSource.value = "manual";
+    appState.settings.resolvedSpeedSource.value = "manual";
 
     expect(workflow.getRenderState()).toMatchObject({
       manualSpeedInputValue: "88",
@@ -426,8 +426,8 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
   test("keeps local manual input draft when settings change externally", () => {
     const harness = createHarness();
     const appState = createAppState();
-    appState.settings.speedSource = "gps";
-    appState.settings.manualSpeedKph = 80;
+    appState.settings.speedSource.value = "gps";
+    appState.settings.manualSpeedKph.value = 80;
 
     const workflow = createSettingsSpeedSourceWorkflow({
       createPollingController: () => ({
@@ -445,7 +445,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     });
 
     workflow.handleManualSpeedInput("90");
-    appState.settings.manualSpeedKph = 70;
+    appState.settings.manualSpeedKph.value = 70;
     workflow.syncFromSettings();
 
     expect(workflow.getRenderState()).toMatchObject({

--- a/apps/ui/tests/spectrum_canvas_renderer.spec.ts
+++ b/apps/ui/tests/spectrum_canvas_renderer.spec.ts
@@ -36,12 +36,15 @@ test.describe("createSpectrumCanvasRenderer", () => {
         "../src/app/runtime/spectrum_canvas_renderer"
       );
       const state = createAppState();
-      state.realtime.clients = [
+      state.realtime.clients.value = [
         makeClient("sensor-a", "Front Right Wheel"),
         makeClient("sensor-b", "Rear Left Wheel"),
       ];
-      state.spectrum.spectra.clients = {
-        "sensor-a": {
+      state.spectrum.spectra.value = {
+        ...state.spectrum.spectra.value,
+        clients: {
+          ...state.spectrum.spectra.value.clients,
+          "sensor-a": {
           freq: [10, 15, 20],
           combined: [1, 0.75, 0.5],
           strength_metrics: {
@@ -57,7 +60,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
             vibration_strength_db: 12,
           },
         },
-        "sensor-b": {
+          "sensor-b": {
           freq: [10, 20],
           combined: [0.8, 0.4],
           strength_metrics: {
@@ -71,6 +74,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
               vibration_strength_db: 9,
             }],
             vibration_strength_db: 9,
+          },
           },
         },
       };
@@ -108,10 +112,13 @@ test.describe("createSpectrumCanvasRenderer", () => {
         "../src/app/runtime/spectrum_canvas_renderer"
       );
       const state = createAppState();
-      state.transport.wsState = "connected";
-      state.realtime.clients = [makeClient("sensor-a", "Front Right Wheel")];
-      state.spectrum.spectra.clients = {
-        "sensor-a": {
+      state.transport.wsState.value = "connected";
+      state.realtime.clients.value = [makeClient("sensor-a", "Front Right Wheel")];
+      state.spectrum.spectra.value = {
+        ...state.spectrum.spectra.value,
+        clients: {
+          ...state.spectrum.spectra.value.clients,
+          "sensor-a": {
           freq: [10, 15, 20],
           combined: [1, 0.75, 0.5],
           strength_metrics: {
@@ -125,6 +132,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
               vibration_strength_db: 12,
             }],
             vibration_strength_db: 12,
+          },
           },
         },
       };
@@ -172,8 +180,8 @@ test.describe("createSpectrumCanvasRenderer", () => {
       const prepared = renderer.prepareFrame();
       renderer.renderPreparedFrame(prepared);
 
-      expect(state.spectrum.chartLoading).toBe(true);
-      expect(state.spectrum.spectrumPlot).toBeNull();
+      expect(state.spectrum.chartLoading.value).toBe(true);
+      expect(state.spectrum.spectrumPlot.value).toBeNull();
       expect(createdCharts).toHaveLength(0);
 
       chartModule.resolve({
@@ -181,10 +189,10 @@ test.describe("createSpectrumCanvasRenderer", () => {
       });
       await flushSignalUpdates();
 
-      expect(state.spectrum.chartLoading).toBe(false);
-      expect(state.spectrum.chartLoadErrorDetail).toBeNull();
+      expect(state.spectrum.chartLoading.value).toBe(false);
+      expect(state.spectrum.chartLoadErrorDetail.value).toBeNull();
       expect(createdCharts).toHaveLength(1);
-      expect(state.spectrum.spectrumPlot).not.toBeNull();
+      expect(state.spectrum.spectrumPlot.value).not.toBeNull();
       expect(createdCharts[0].dataSnapshots.at(-1)?.[0]).toEqual([10, 15, 20]);
       expect(createdCharts[0].seriesCount).toBe(2);
     } finally {
@@ -199,9 +207,12 @@ test.describe("createSpectrumCanvasRenderer", () => {
         "../src/app/runtime/spectrum_canvas_renderer"
       );
       const state = createAppState();
-      state.realtime.clients = [makeClient("sensor-a", "Front Right Wheel")];
-      state.spectrum.spectra.clients = {
-        "sensor-a": {
+      state.realtime.clients.value = [makeClient("sensor-a", "Front Right Wheel")];
+      state.spectrum.spectra.value = {
+        ...state.spectrum.spectra.value,
+        clients: {
+          ...state.spectrum.spectra.value.clients,
+          "sensor-a": {
           freq: [10, 15, 20],
           combined: [1, 0.75, 0.5],
           strength_metrics: {
@@ -216,6 +227,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
             }],
             vibration_strength_db: 12,
           },
+          },
         },
       };
       const axisTexts: string[] = [];
@@ -227,7 +239,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
           specChart: createElementStub("div"),
           specChartWrap: createElementStub("div"),
         } as unknown as SpectrumPanelChartDom,
-        t: (key) => `${state.shell.lang}:${key}`,
+        t: (key) => `${state.shell.lang.value}:${key}`,
         getBandsVisible: () => false,
         getChartBands: () => [],
         getFocusMarker: () => null,
@@ -253,7 +265,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
       renderer.renderPreparedFrame(prepared);
       await flushSignalUpdates();
 
-      state.shell.lang = "nl";
+      state.shell.lang.value = "nl";
       await flushSignalUpdates();
 
       expect(createCalls).toBe(1);

--- a/apps/ui/tests/speed_source_state.spec.ts
+++ b/apps/ui/tests/speed_source_state.spec.ts
@@ -93,7 +93,7 @@ test.describe("speed source state helpers", () => {
     expect(derived.speedReadoutLabelKey.value).toBe("speed.override");
     expect(derived.isManualEffective.value).toBe(true);
 
-    state.settings.resolvedSpeedSource = "obd2";
+    state.settings.resolvedSpeedSource.value = "obd2";
     expect(derived.effectiveSource.value).toBe("obd2");
     expect(derived.displayedMode.value).toBe("obd2");
     expect(derived.speedReadoutLabelKey.value).toBe("speed.obd2");

--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -83,14 +83,14 @@ test.describe("UiLiveTransportController", () => {
   test("applies queued transport payloads through shared state without transport ports", async () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
-    state.transport.ws = {
+    state.transport.ws.value = {
       uiState: signal("connecting"),
       close() {},
       connect() {},
       send(selection: { client_id: string | null }) {
         sentSelections.push(selection);
       },
-    } as unknown as typeof state.transport.ws;
+    } as typeof state.transport.ws.value;
 
     new UiLiveTransportController({
       state,
@@ -99,7 +99,7 @@ test.describe("UiLiveTransportController", () => {
 
     const raf = installRafHarness();
     try {
-      state.transport.pendingPayload = makeLivePayload({
+      state.transport.pendingPayload.value = makeLivePayload({
         clients: [makeClient("client-1")],
         speed_mps: 12,
       });
@@ -107,10 +107,10 @@ test.describe("UiLiveTransportController", () => {
       raf.flushNext();
       await flushAsyncWork();
 
-      expect(state.transport.pendingPayload).toBeNull();
-      expect(state.realtime.clients.map((client) => client.id)).toEqual(["client-1"]);
-      expect(state.realtime.selectedClientId).toBe("client-1");
-      expect(state.realtime.speedMps).toBe(12);
+      expect(state.transport.pendingPayload.value).toBeNull();
+      expect(state.realtime.clients.value.map((client) => client.id)).toEqual(["client-1"]);
+      expect(state.realtime.selectedClientId.value).toBe("client-1");
+      expect(state.realtime.speedMps.value).toBe(12);
       expect(sentSelections).toEqual([{ client_id: "client-1" }]);
     } finally {
       raf.restore();
@@ -121,15 +121,15 @@ test.describe("UiLiveTransportController", () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
     const wsUiState = signal("connecting");
-    state.transport.ws = {
+    state.transport.ws.value = {
       uiState: wsUiState,
       close() {},
       connect() {},
       send(selection: { client_id: string | null }) {
         sentSelections.push(selection);
       },
-    } as unknown as typeof state.transport.ws;
-    state.realtime.selectedClientId = "client-7";
+    } as typeof state.transport.ws.value;
+    state.realtime.selectedClientId.value = "client-7";
 
     new UiLiveTransportController({
       state,
@@ -152,12 +152,12 @@ test.describe("UiLiveTransportController", () => {
   test("mirrors ws client uiState into the transport slice", async () => {
     const state = createAppState();
     const wsUiState = signal("connecting");
-    state.transport.ws = {
+    state.transport.ws.value = {
       uiState: wsUiState,
       close() {},
       connect() {},
       send() {},
-    } as unknown as typeof state.transport.ws;
+    } as typeof state.transport.ws.value;
 
     new UiLiveTransportController({
       state,
@@ -166,11 +166,11 @@ test.describe("UiLiveTransportController", () => {
 
     wsUiState.value = "no_data";
     await flushAsyncWork();
-    expect(state.transport.wsState).toBe("no_data");
+    expect(state.transport.wsState.value).toBe("no_data");
 
     wsUiState.value = "connected";
     await flushAsyncWork();
-    expect(state.transport.wsState).toBe("connected");
+    expect(state.transport.wsState.value).toBe("connected");
   });
 
   test("applies payloads without requiring feature-port attachment", () => {
@@ -181,7 +181,7 @@ test.describe("UiLiveTransportController", () => {
     });
 
     expect(() => applyPayload(controller, makeLivePayload())).not.toThrow();
-    expect(state.realtime.speedMps).toBe(10);
+    expect(state.realtime.speedMps.value).toBe(10);
   });
 
   test("routes demo mode through the shared queued transport pipeline", async () => {
@@ -196,18 +196,18 @@ test.describe("UiLiveTransportController", () => {
       controller.startTransportMode();
       await flushAsyncWork();
 
-      expect(state.transport.wsState).toBe("connected");
-      expect(state.transport.hasReceivedPayload).toBe(true);
-      expect(state.transport.pendingPayload).not.toBeNull();
+      expect(state.transport.wsState.value).toBe("connected");
+      expect(state.transport.hasReceivedPayload.value).toBe(true);
+      expect(state.transport.pendingPayload.value).not.toBeNull();
 
       raf.flushNext();
       await flushAsyncWork();
 
-      expect(state.transport.pendingPayload).toBeNull();
-      expect(state.realtime.clients).toHaveLength(5);
-      expect(state.realtime.selectedClientId).toBe("aabbcc001122");
-      expect(state.realtime.speedMps).toBe(22.2);
-      expect(state.spectrum.hasSpectrumData).toBe(true);
+      expect(state.transport.pendingPayload.value).toBeNull();
+      expect(state.realtime.clients.value).toHaveLength(5);
+      expect(state.realtime.selectedClientId.value).toBe("aabbcc001122");
+      expect(state.realtime.speedMps.value).toBe(22.2);
+      expect(state.spectrum.hasSpectrumData.value).toBe(true);
     } finally {
       restoreLocation();
       raf.restore();

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -116,13 +116,13 @@ test.describe("createUiShellNavigationModule", () => {
     });
 
     module.setActiveView("historyView");
-    expect(state.shell.activeViewId).toBe("historyView");
+    expect(state.shell.activeViewId.value).toBe("historyView");
     expect(module.activeViewId.value).toBe("historyView");
     expect(activatedViews).toEqual(["historyView"]);
     expect(resizeCalls).toBe(0);
 
     module.setActiveView("missingView");
-    expect(state.shell.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(state.shell.activeViewId.value).toBe(DEFAULT_SHELL_VIEW_ID);
     expect(module.activeViewId.value).toBe(DEFAULT_SHELL_VIEW_ID);
     expect(activatedViews).toEqual(["historyView"]);
     expect(resizeCalls).toBe(1);
@@ -144,13 +144,13 @@ test.describe("createUiShellNavigationModule", () => {
     });
 
     module.setActiveView("settingsView");
-    expect(state.shell.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(state.shell.activeViewId.value).toBe(DEFAULT_SHELL_VIEW_ID);
     expect(module.activeViewId.value).toBe(DEFAULT_SHELL_VIEW_ID);
 
     resolveActivation?.();
     await Promise.resolve();
 
-    expect(state.shell.activeViewId).toBe("settingsView");
+    expect(state.shell.activeViewId.value).toBe("settingsView");
     expect(module.activeViewId.value).toBe("settingsView");
   });
 
@@ -175,7 +175,7 @@ test.describe("createUiShellNavigationModule", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(state.shell.activeViewId).toBe(DEFAULT_SHELL_VIEW_ID);
+    expect(state.shell.activeViewId.value).toBe(DEFAULT_SHELL_VIEW_ID);
     expect(module.activeViewId.value).toBe(DEFAULT_SHELL_VIEW_ID);
     expect(activationErrors).toEqual(["settingsView:chunk failed"]);
   });
@@ -305,8 +305,8 @@ test.describe("createUiShellPreferencesModule", () => {
       "/api/settings/language",
       "/api/settings/speed-unit",
     ]);
-    expect(state.shell.lang).toBe("nl");
-    expect(state.shell.speedUnit).toBe("mps");
+    expect(state.shell.lang.value).toBe("nl");
+    expect(state.shell.speedUnit.value).toBe("mps");
     expect(module.selectedLanguage.value).toBe("nl");
     expect(module.selectedSpeedUnit.value).toBe("mps");
   });
@@ -329,13 +329,13 @@ test.describe("createUiShellPreferencesModule", () => {
       async () => {
         const savePromise = module.saveLanguage("nl");
         expect(module.selectedLanguage.value).toBe("nl");
-        expect(state.shell.lang).toBe("en");
+        expect(state.shell.lang.value).toBe("en");
         resolveResponse?.(jsonResponse({ language: "nl" }));
         await savePromise;
       },
     );
 
-    expect(state.shell.lang).toBe("nl");
+    expect(state.shell.lang.value).toBe("nl");
     expect(module.selectedLanguage.value).toBe("nl");
   });
 
@@ -357,7 +357,7 @@ test.describe("createUiShellPreferencesModule", () => {
       },
     );
 
-    expect(state.shell.speedUnit).toBe("kmh");
+    expect(state.shell.speedUnit.value).toBe("kmh");
     expect(module.selectedSpeedUnit.value).toBe("kmh");
     expect(module.speedUnitFeedback.value?.detail).toBe("save failed");
   });
@@ -396,7 +396,7 @@ test.describe("createUiShellNotificationModule", () => {
 test.describe("createUiShellStatusModule", () => {
   test("builds websocket badge state and degraded shell status signals without bootstrap wiring", () => {
     const state = createAppState();
-    state.transport.wsState = "stale";
+    state.transport.wsState.value = "stale";
 
     const module = createUiShellStatusModule({
       realtime: state.realtime,
@@ -428,13 +428,13 @@ test.describe("createUiShellStatusModule", () => {
       variant: "muted",
     });
 
-    state.transport.wsState = "stale";
+    state.transport.wsState.value = "stale";
     expect(module.wsLinkState.value).toEqual({
       text: "ws.stale",
       variant: "bad",
     });
 
-    state.transport.payloadError = "bad frame";
+    state.transport.payloadError.value = "bad frame";
     expect(module.wsLinkState.value).toEqual({
       text: "ws.payload_error_pill",
       variant: "bad",
@@ -447,7 +447,7 @@ test.describe("createUiShellStatusModule", () => {
       realtime: state.realtime,
       settings: state.settings,
       shell: state.shell,
-      t: (key) => `${state.shell.lang}:${key}`,
+      t: (key) => `${state.shell.lang.value}:${key}`,
       transport: state.transport,
     });
 
@@ -456,7 +456,7 @@ test.describe("createUiShellStatusModule", () => {
       variant: "muted",
     });
 
-    state.shell.lang = "nl";
+    state.shell.lang.value = "nl";
 
     expect(module.wsLinkState.value).toEqual({
       text: "nl:ws.connecting",
@@ -466,13 +466,13 @@ test.describe("createUiShellStatusModule", () => {
 
   test("renders speed override after car bootstrap resolves", () => {
     const state = createAppState();
-    state.realtime.speedMps = 12;
-    state.settings.speedSource = "manual";
-    state.settings.manualSpeedKph = 43.2;
-    state.shell.speedUnit = "kmh";
-    state.settings.carsLoaded = true;
-    state.settings.cars = [];
-    state.settings.activeCarId = null;
+    state.realtime.speedMps.value = 12;
+    state.settings.speedSource.value = "manual";
+    state.settings.manualSpeedKph.value = 43.2;
+    state.shell.speedUnit.value = "kmh";
+    state.settings.carsLoaded.value = true;
+    state.settings.cars.value = [];
+    state.settings.activeCarId.value = null;
 
     const module = createUiShellStatusModule({
       realtime: state.realtime,
@@ -488,10 +488,10 @@ test.describe("createUiShellStatusModule", () => {
 
   test("renders OBD2 when OBD2 is the resolved speed source", () => {
     const state = createAppState();
-    state.realtime.speedMps = 22.5;
-    state.settings.speedSource = "obd2";
-    state.settings.resolvedSpeedSource = "obd2";
-    state.shell.speedUnit = "kmh";
+    state.realtime.speedMps.value = 22.5;
+    state.settings.speedSource.value = "obd2";
+    state.settings.resolvedSpeedSource.value = "obd2";
+    state.shell.speedUnit.value = "kmh";
 
     const module = createUiShellStatusModule({
       realtime: state.realtime,

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -55,8 +55,8 @@ test.describe("UiSpectrumController", () => {
     try {
       const UiSpectrumController = await importUiSpectrumController();
       const state = createAppState();
-      state.transport.wsState = "connecting";
-      state.transport.hasReceivedPayload = false;
+      state.transport.wsState.value = "connecting";
+      state.transport.hasReceivedPayload.value = false;
       const panel = createPanelStub();
 
       new UiSpectrumController({
@@ -76,8 +76,8 @@ test.describe("UiSpectrumController", () => {
     try {
       const UiSpectrumController = await importUiSpectrumController();
       const state = createAppState();
-      state.transport.wsState = "connecting";
-      state.transport.hasReceivedPayload = false;
+      state.transport.wsState.value = "connecting";
+      state.transport.hasReceivedPayload.value = false;
       const panel = createPanelStub();
 
       new UiSpectrumController({
@@ -86,7 +86,7 @@ test.describe("UiSpectrumController", () => {
         t: (key) => key,
       });
 
-      state.transport.wsState = "stale";
+      state.transport.wsState.value = "stale";
 
       expect(panel.lastOverlayMessage).toBe("spectrum.stale");
     } finally {
@@ -116,8 +116,8 @@ test.describe("UiSpectrumController", () => {
       };
 
       batch(() => {
-        state.spectrum.spectra = { ...state.spectrum.spectra };
-        state.transport.wsState = "stale";
+        state.spectrum.spectra.value = { ...state.spectrum.spectra.value };
+        state.transport.wsState.value = "stale";
       });
 
       expect(renderCalls).toBe(1);
@@ -132,10 +132,10 @@ test.describe("UiSpectrumController", () => {
     try {
       const UiSpectrumController = await importUiSpectrumController();
       const state = createAppState();
-      state.transport.wsState = "connected";
-      state.transport.hasReceivedPayload = true;
-      state.spectrum.hasSpectrumData = true;
-      state.spectrum.chartLoading = true;
+      state.transport.wsState.value = "connected";
+      state.transport.hasReceivedPayload.value = true;
+      state.spectrum.hasSpectrumData.value = true;
+      state.spectrum.chartLoading.value = true;
       const panel = createPanelStub();
 
       new UiSpectrumController({
@@ -155,10 +155,10 @@ test.describe("UiSpectrumController", () => {
     try {
       const UiSpectrumController = await importUiSpectrumController();
       const state = createAppState();
-      state.transport.wsState = "connected";
-      state.transport.hasReceivedPayload = true;
-      state.spectrum.hasSpectrumData = true;
-      state.spectrum.chartLoadErrorDetail = "chunk timeout";
+      state.transport.wsState.value = "connected";
+      state.transport.hasReceivedPayload.value = true;
+      state.spectrum.hasSpectrumData.value = true;
+      state.spectrum.chartLoadErrorDetail.value = "chunk timeout";
       const panel = createPanelStub();
 
       new UiSpectrumController({
@@ -183,13 +183,13 @@ test.describe("UiSpectrumController", () => {
     try {
       const UiSpectrumController = await importUiSpectrumController();
       const state = createAppState();
-      state.transport.wsState = "stale";
+      state.transport.wsState.value = "stale";
       const panel = createPanelStub();
 
       new UiSpectrumController({
         state,
         panel: panel.panel,
-        t: (key) => `${state.shell.lang}:${key}`,
+        t: (key) => `${state.shell.lang.value}:${key}`,
       });
 
       expect(panel.lastHeaderModel).toEqual({
@@ -198,7 +198,7 @@ test.describe("UiSpectrumController", () => {
       });
       expect(panel.lastOverlayMessage).toBe("en:spectrum.stale");
 
-      state.shell.lang = "nl";
+      state.shell.lang.value = "nl";
 
       expect(panel.lastHeaderModel).toEqual({
         titleText: "nl:chart.spectrum_title",


### PR DESCRIPTION
## What changed
- remove proxy-backed app-state slices from `ui_app_state.ts`
- make slice fields explicit Preact signals
- delete `trackAppStateSlice()`, `unwrapAppStateValue()`, `getAppStateSliceSignal()`
- migrate runtime, feature, presenter, and derived-state consumers to direct `.value` reads/writes
- keep nested object-heavy fields as signal-of-object slices and switch their updates to immutable reassignment
- update focused frontend tests to the explicit-signal contract

## Why
- old state layer hid reactivity behind proxies and helper APIs
- consumer code had to remember special tracking/unwrapping rules
- explicit signals make dependencies obvious and remove custom state machinery

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run lint` *(same pre-existing warnings in `esp_flash_journey_presenter.ts` and `history_detail_presenter.ts`; no new issue-specific warnings)*
- focused Playwright:
  - `tests/settings_speed_source_workflow.spec.ts`
  - `tests/settings_speed_source_presenter.spec.ts`
  - `tests/speed_source_state.spec.ts`
  - `tests/ui_spectrum_controller.spec.ts`
  - `tests/spectrum_canvas_renderer.spec.ts`
  - `tests/ui_live_transport_controller.spec.ts`
  - `tests/realtime_feature_workflow.spec.ts`
  - `tests/realtime_feature_view_state.spec.ts`
  - `tests/history_feature_modules.spec.ts`
  - `tests/ui_shell_runtime_modules.spec.ts`
- broader smoke:
  - `tests/smoke.bootstrap.spec.ts`
  - `tests/smoke.settings.spec.ts`
  - `tests/smoke.history.spec.ts`
  - `tests/smoke.spectrum.spec.ts`

## Risks / tradeoffs
- broad caller churn: many state consumers now depend on explicit `.value` access, so missed call sites would break quickly
- nested object slices stay grouped instead of fully flattened to keep the refactor bounded; they still need immutable replacement to trigger updates
- lint still shows two unrelated pre-existing unused-import warnings outside this change

## Follow-up
- none in this PR; issue scope is the state-layer refactor only
