### PR TITLE
FE: Remove initialization-skip flags in transport controller effects

### DIFF
--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -48,14 +48,8 @@ export class UiLiveTransportController {
     });
 
     let previousPendingPayload = this.state.transport.pendingPayload.value;
-    let pendingPayloadInitialized = false;
     effect(() => {
       const nextPendingPayload = this.state.transport.pendingPayload.value;
-      if (!pendingPayloadInitialized) {
-        pendingPayloadInitialized = true;
-        previousPendingPayload = nextPendingPayload;
-        return;
-      }
       if (nextPendingPayload === previousPendingPayload) {
         return;
       }
@@ -66,14 +60,8 @@ export class UiLiveTransportController {
     });
 
     let previousWsState = this.state.transport.wsState.value;
-    let wsStateInitialized = false;
     effect(() => {
       const nextWsState = this.state.transport.wsState.value;
-      if (!wsStateInitialized) {
-        wsStateInitialized = true;
-        previousWsState = nextWsState;
-        return;
-      }
       if (nextWsState === previousWsState) {
         return;
       }

--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -117,6 +117,30 @@ test.describe("UiLiveTransportController", () => {
     }
   });
 
+  test("does not queue an initial payload that already exists before effects bind", async () => {
+    const state = createAppState();
+    state.transport.pendingPayload.value = makeLivePayload({
+      clients: [makeClient("client-1")],
+      speed_mps: 12,
+    });
+
+    const raf = installRafHarness();
+    try {
+      new UiLiveTransportController({
+        state,
+        payloadErrorMessage: () => "payload error",
+      });
+      await flushAsyncWork();
+
+      expect(state.transport.renderQueued.value).toBe(false);
+      expect(state.realtime.clients.value).toEqual([]);
+      expect(state.realtime.selectedClientId.value).toBeNull();
+      expect(state.realtime.speedMps.value).toBeNull();
+    } finally {
+      raf.restore();
+    }
+  });
+
   test("sends the current client selection when websocket state becomes ready", async () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
@@ -147,6 +171,28 @@ test.describe("UiLiveTransportController", () => {
       { client_id: "client-7" },
       { client_id: "client-7" },
     ]);
+  });
+
+  test("does not send the current selection for an initial ready websocket state", async () => {
+    const state = createAppState();
+    const sentSelections: Array<{ client_id: string | null }> = [];
+    state.transport.ws.value = {
+      uiState: signal("connected"),
+      close() {},
+      connect() {},
+      send(selection: { client_id: string | null }) {
+        sentSelections.push(selection);
+      },
+    } as typeof state.transport.ws.value;
+    state.realtime.selectedClientId.value = "client-7";
+
+    new UiLiveTransportController({
+      state,
+      payloadErrorMessage: () => "payload error",
+    });
+    await flushAsyncWork();
+
+    expect(sentSelections).toEqual([]);
   });
 
   test("mirrors ws client uiState into the transport slice", async () => {


### PR DESCRIPTION
## What changed
- drop `pendingPayloadInitialized` and `wsStateInitialized` from `ui_live_transport_controller.ts`
- use seeded `previousPendingPayload` and `previousWsState` equality checks to keep the first effect pass quiet
- add focused regressions for an initial pending payload and an initial ready websocket state

## Why
- remove the effect first-run skip anti-pattern
- keep transport behavior the same: no work on bind, work only on real state changes

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ui_live_transport_controller.spec.ts`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- behavior still depends on identity equality for pending payload objects and transport state strings
- lint still reports the same pre-existing unrelated warnings in `esp_flash_journey_presenter.ts` and `history_detail_presenter.ts`, plus the existing Biome schema-version info
