### PR TITLE
FE: Replace manual read() aggregation with computed() in cars_manual_input.ts

### DIFF
--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -224,7 +224,7 @@ export function createCarsFeatureWorkflow(
     variantOptions: variantOptions.value,
   }));
 
-  const manualInputRenderState = computed<CarsFeatureManualInputState>(() => manualInputs.read());
+  const manualInputRenderState = manualInputs.state;
 
   const wizardMetaRenderState = computed<CarsFeatureWizardMetaRenderState>(() => {
     const state = wizardState.value;
@@ -384,7 +384,7 @@ export function createCarsFeatureWorkflow(
 
   function loadSpecsStep(): void {
     const state = wizardState.value;
-    const currentManualInputs = manualInputs.read();
+    const currentManualInputs = manualInputs.state.value;
     const nextTireOptions = resolveTireOptions(state.selectedModel, state.selectedVariant);
     const nextGearboxOptions = resolveGearboxes(state.selectedModel, state.selectedVariant);
     const nextSelectedTire = nextTireOptions.length > 0
@@ -450,7 +450,7 @@ export function createCarsFeatureWorkflow(
 
     async finishWizard(): Promise<boolean> {
       const state = wizardState.value;
-      const inputs = manualInputs.read();
+      const inputs = manualInputs.state.value;
       const resolvedBranch = getResolvedWizardSpecBranch(state);
       if (resolvedBranch === "library") {
         const tire = state.selectedTire;
@@ -523,7 +523,7 @@ export function createCarsFeatureWorkflow(
     ): void {
       batch(() => {
         manualInputs.write({
-          ...manualInputs.read(),
+          ...manualInputs.state.value,
           [field]: value,
         });
         if (isOpen.value && wizardState.value.step === 4) {
@@ -597,7 +597,7 @@ export function createCarsFeatureWorkflow(
         updateWizardState((state) => {
           state.selectedTire = selectedTire;
         });
-        manualInputs.write(tireInputsFromOption(selectedTire, manualInputs.read()));
+        manualInputs.write(tireInputsFromOption(selectedTire, manualInputs.state.value));
       });
     },
 

--- a/apps/ui/src/app/features/cars_manual_input.ts
+++ b/apps/ui/src/app/features/cars_manual_input.ts
@@ -25,12 +25,12 @@ export interface CarsFeatureManualInputState {
 export interface CarsFeatureManualInputStore {
   readonly finalDrive: Signal<string>;
   readonly rim: Signal<string>;
+  readonly state: ReadonlySignal<CarsFeatureManualInputState>;
   readonly tireAspect: Signal<string>;
   readonly tireWidth: Signal<string>;
   readonly topGear: Signal<string>;
   readonly manualGearbox: ReadonlySignal<ManualGearboxValues | null>;
   readonly manualTire: ReadonlySignal<ManualTireValues | null>;
-  read(): CarsFeatureManualInputState;
   write(inputs: CarsFeatureManualInputState): void;
 }
 
@@ -80,16 +80,13 @@ export function createCarsManualInputStore(
   const tireAspect = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.tireAspect);
   const tireWidth = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.tireWidth);
   const topGear = signal<string>(DEFAULT_CARS_WIZARD_MANUAL_INPUTS.topGear);
-
-  function read(): CarsFeatureManualInputState {
-    return {
-      finalDrive: finalDrive.value,
-      rim: rim.value,
-      tireAspect: tireAspect.value,
-      tireWidth: tireWidth.value,
-      topGear: topGear.value,
-    };
-  }
+  const state = computed<CarsFeatureManualInputState>(() => ({
+    finalDrive: finalDrive.value,
+    rim: rim.value,
+    tireAspect: tireAspect.value,
+    tireWidth: tireWidth.value,
+    topGear: topGear.value,
+  }));
 
   function write(inputs: CarsFeatureManualInputState): void {
     batch(() => {
@@ -104,6 +101,7 @@ export function createCarsManualInputStore(
   return {
     finalDrive,
     rim,
+    state,
     tireAspect,
     tireWidth,
     topGear,
@@ -120,7 +118,6 @@ export function createCarsManualInputStore(
         width: tireWidth.value,
       })
     ),
-    read,
     write,
   };
 }

--- a/apps/ui/tests/cars_manual_input.spec.ts
+++ b/apps/ui/tests/cars_manual_input.spec.ts
@@ -23,7 +23,7 @@ test.describe("createCarsManualInputStore", () => {
     const seenSnapshots: string[] = [];
 
     const dispose = effect(() => {
-      seenSnapshots.push(formatManualInputs(store.read()));
+      seenSnapshots.push(formatManualInputs(store.state.value));
     });
 
     expect(seenSnapshots).toEqual(["3.08:18:45:225:0.64"]);


### PR DESCRIPTION
## What changed
- replace the manual `read()` snapshot helper in `cars_manual_input.ts` with a computed aggregate `state` signal
- update the cars workflow to consume `manualInputs.state.value` directly for render state, manual edits, and tire autofill
- keep the focused cars manual-input invalidation test on the new signal path

## Why
- remove a parallel non-reactive aggregation path
- make the manual-input snapshot reactive and directly composable downstream

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/cars_manual_input.spec.ts tests/cars_feature_workflow.spec.ts`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- the aggregate `state` signal still allocates a new object when any manual input changes; that is intentional because the goal is one canonical reactive snapshot
- lint still reports the same pre-existing unrelated warnings in `esp_flash_journey_presenter.ts` and `history_detail_presenter.ts`, plus the existing Biome schema-version info
