### PR TITLE
FE: Cache SpectrumCssVars object to avoid unnecessary allocations on theme change

### DIFF
--- a/apps/ui/src/spectrum_css_vars.ts
+++ b/apps/ui/src/spectrum_css_vars.ts
@@ -23,10 +23,11 @@ const spectrumCssVars = computed<Readonly<SpectrumCssVars>>(() => {
   return readSpectrumCssVars();
 });
 let spectrumCssVarsThemeListenerInitialized = false;
+let cachedSpectrumCssVars: Readonly<SpectrumCssVars> | null = null;
 
 function readSpectrumCssVars(): Readonly<SpectrumCssVars> {
   const rootStyle = getComputedStyle(document.documentElement);
-  return Object.freeze({
+  const next: SpectrumCssVars = {
     surface: rootStyle.getPropertyValue("--surface").trim() || DEFAULT_SPECTRUM_CSS_VARS.surface,
     muted: rootStyle.getPropertyValue("--muted").trim() || DEFAULT_SPECTRUM_CSS_VARS.muted,
     border: rootStyle.getPropertyValue("--border").trim() || DEFAULT_SPECTRUM_CSS_VARS.border,
@@ -34,7 +35,19 @@ function readSpectrumCssVars(): Readonly<SpectrumCssVars> {
       || DEFAULT_SPECTRUM_CSS_VARS.tooltipBg,
     tooltipFg: rootStyle.getPropertyValue("--tooltip-fg").trim()
       || DEFAULT_SPECTRUM_CSS_VARS.tooltipFg,
-  });
+  };
+  if (
+    cachedSpectrumCssVars
+    && cachedSpectrumCssVars.surface === next.surface
+    && cachedSpectrumCssVars.muted === next.muted
+    && cachedSpectrumCssVars.border === next.border
+    && cachedSpectrumCssVars.tooltipBg === next.tooltipBg
+    && cachedSpectrumCssVars.tooltipFg === next.tooltipFg
+  ) {
+    return cachedSpectrumCssVars;
+  }
+  cachedSpectrumCssVars = Object.freeze(next);
+  return cachedSpectrumCssVars;
 }
 
 export function getSpectrumCssVars(): Readonly<SpectrumCssVars> {

--- a/apps/ui/tests/spectrum_css_vars.spec.ts
+++ b/apps/ui/tests/spectrum_css_vars.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 import { installDocumentStub } from "./spectrum_test_support";
 
 test.describe("spectrum_css_vars", () => {
-  test("caches a plain spectrum css snapshot until refreshed", async () => {
+  test("reuses the cached spectrum css snapshot until values actually change", async () => {
     const restoreDocument = installDocumentStub();
     const styleValues: Record<string, string> = {
       "--surface": "#101820",
@@ -52,16 +52,28 @@ test.describe("spectrum_css_vars", () => {
       });
       expect(readCount).toBe(1);
 
+      const unchangedRefresh = refreshSpectrumCssVars();
+      expect(unchangedRefresh).toBe(first);
+      expect(readCount).toBe(2);
+
       styleValues["--surface"] = "#222222";
       expect(getSpectrumCssVars()).toBe(first);
       expect(getSpectrumCssVars().surface).toBe("#101820");
-      expect(readCount).toBe(1);
+      expect(readCount).toBe(2);
 
       const refreshed = refreshSpectrumCssVars();
       expect(refreshed.surface).toBe("#222222");
       expect(refreshed).not.toBe(first);
       expect(getSpectrumCssVars()).toBe(refreshed);
-      expect(readCount).toBe(2);
+      expect(readCount).toBe(3);
+
+      themeChangeHandler?.({
+        matches: true,
+        media: "(prefers-color-scheme: dark)",
+      } as MediaQueryListEvent);
+      const unchangedThemeRefresh = getSpectrumCssVars();
+      expect(unchangedThemeRefresh).toBe(refreshed);
+      expect(readCount).toBe(4);
 
       styleValues["--surface"] = "#444444";
       themeChangeHandler?.({
@@ -71,7 +83,7 @@ test.describe("spectrum_css_vars", () => {
       const autoRefreshed = getSpectrumCssVars();
       expect(autoRefreshed.surface).toBe("#444444");
       expect(autoRefreshed).not.toBe(refreshed);
-      expect(readCount).toBe(3);
+      expect(readCount).toBe(5);
     } finally {
       restoreDocument();
     }


### PR DESCRIPTION
## What changed
- cache the last frozen `SpectrumCssVars` object in `spectrum_css_vars.ts`
- reuse that object when refreshed CSS variable values are unchanged
- extend the focused spectrum CSS vars spec to prove unchanged refresh/theme invalidations keep the same reference

## Why
- stop allocating a new frozen object on every invalidation when the effective CSS values did not change
- avoid downstream recomputation churn from identity-only changes

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/spectrum_css_vars.spec.ts`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- the code still re-reads CSS vars on refresh/theme invalidation; the optimization is object reuse, not skipping the read itself
- lint still reports the same pre-existing unrelated warnings in `esp_flash_journey_presenter.ts` and `history_detail_presenter.ts`, plus the existing Biome schema-version info
