### PR TITLE
FE: Reduce UiPanelHostRegistry / refs indirection

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -2,9 +2,7 @@ import { render, type ComponentChildren, type JSX } from "preact";
 import { useRef } from "preact/hooks";
 
 import {
-  createUiPanelHostRefs,
   resolveUiPanelHosts,
-  type UiPanelHostRefs,
   type UiPanelHostRegistry,
 } from "../ui_panel_host_registry";
 import {
@@ -148,7 +146,7 @@ type UiShellChromeProps = {
   bridge: UiShellChromeActionBridge;
   dialogModel: ReadonlySignal<ReadonlySignal<UiShellChromeDialogModel> | null>;
   navigationModel: ReadonlySignal<ReadonlySignal<UiShellChromeNavigationModel> | null>;
-  panelHostRefs: UiPanelHostRefs;
+  panelHosts: PendingUiPanelHosts;
   preferencesModel: ReadonlySignal<ReadonlySignal<UiShellChromePreferencesModel> | null>;
   statusModel: ReadonlySignal<ReadonlySignal<UiShellChromeStatusModel> | null>;
 };
@@ -203,8 +201,22 @@ const DEFAULT_DIALOG_MODEL: UiShellChromeDialogModel = {
   confirmationDialog: null,
 };
 
+type PendingUiPanelHosts = Parameters<typeof resolveUiPanelHosts>[0];
+
 function noop(): void {
   return;
+}
+
+function createPendingUiPanelHosts(): PendingUiPanelHosts {
+  return {
+    dashboard: {
+      spectrum: null,
+      liveOverview: null,
+      logging: null,
+    },
+    history: null,
+    settingsShell: null,
+  };
 }
 
 function SettingsFeedbackSlot(props: {
@@ -303,24 +315,36 @@ function ConfirmationDialog(props: {
 }
 
 function DashboardViewHosts(props: {
-  panelHostRefs: UiPanelHostRefs["dashboard"];
+  panelHosts: PendingUiPanelHosts["dashboard"];
 }) {
-  const { panelHostRefs } = props;
+  const { panelHosts } = props;
+  const liveOverviewHostRef = useRef<HTMLDivElement | null>(null);
+  const spectrumHostRef = useRef<HTMLDivElement | null>(null);
+  const loggingHostRef = useRef<HTMLDivElement | null>(null);
   return (
     <div class="dashboard-grid">
       <div
         id="liveOverviewRoot"
-        ref={panelHostRefs.liveOverview}
+        ref={(element) => {
+          liveOverviewHostRef.current = element;
+          panelHosts.liveOverview = element;
+        }}
         class="panel card dashboard-grid__overview"
       ></div>
       <div
         id="spectrumPanelRoot"
-        ref={panelHostRefs.spectrum}
+        ref={(element) => {
+          spectrumHostRef.current = element;
+          panelHosts.spectrum = element;
+        }}
         class="panel card dashboard-grid__main"
       ></div>
       <div
         id="loggingPanelRoot"
-        ref={panelHostRefs.logging}
+        ref={(element) => {
+          loggingHostRef.current = element;
+          panelHosts.logging = element;
+        }}
         class="panel card dashboard-grid__controls"
       ></div>
     </div>
@@ -328,15 +352,34 @@ function DashboardViewHosts(props: {
 }
 
 function HistoryViewHosts(props: {
-  hostRef: UiPanelHostRefs["history"];
+  panelHosts: PendingUiPanelHosts;
 }) {
-  return <div id="historyPanelRoot" ref={props.hostRef} class="panel card"></div>;
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <div
+      id="historyPanelRoot"
+      ref={(element) => {
+        hostRef.current = element;
+        props.panelHosts.history = element;
+      }}
+      class="panel card"
+    ></div>
+  );
 }
 
 function SettingsViewHosts(props: {
-  hostRef: UiPanelHostRefs["settingsShell"];
+  panelHosts: PendingUiPanelHosts;
 }) {
-  return <div id="settingsShellRoot" ref={props.hostRef}></div>;
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  return (
+    <div
+      id="settingsShellRoot"
+      ref={(element) => {
+        hostRef.current = element;
+        props.panelHosts.settingsShell = element;
+      }}
+    ></div>
+  );
 }
 
 function ShellViewSection(props: ShellViewSectionProps) {
@@ -628,9 +671,9 @@ function AppErrorBanner(props: {
 
 function ShellViewHostsContainer(props: {
   navigationModel: ReadonlySignal<UiShellChromeNavigationModel>;
-  panelHostRefs: UiPanelHostRefs;
+  panelHosts: PendingUiPanelHosts;
 }) {
-  const { navigationModel, panelHostRefs } = props;
+  const { navigationModel, panelHosts } = props;
   const { activeViewId } = useSignalProperties(navigationModel, SHELL_ACTIVE_VIEW_KEY);
 
   return (
@@ -640,7 +683,7 @@ function ShellViewHostsContainer(props: {
         ariaLabelledBy="tab-dashboard"
         viewId="dashboardView"
       >
-        <DashboardViewHosts panelHostRefs={panelHostRefs.dashboard} />
+        <DashboardViewHosts panelHosts={panelHosts.dashboard} />
       </ShellViewSection>
 
       <ShellViewSection
@@ -648,7 +691,7 @@ function ShellViewHostsContainer(props: {
         ariaLabelledBy="tab-history"
         viewId="historyView"
       >
-        <HistoryViewHosts hostRef={panelHostRefs.history} />
+        <HistoryViewHosts panelHosts={panelHosts} />
       </ShellViewSection>
 
       <ShellViewSection
@@ -656,7 +699,7 @@ function ShellViewHostsContainer(props: {
         ariaLabelledBy="tab-settings"
         viewId="settingsView"
       >
-        <SettingsViewHosts hostRef={panelHostRefs.settingsShell} />
+        <SettingsViewHosts panelHosts={panelHosts} />
       </ShellViewSection>
     </>
   );
@@ -676,7 +719,7 @@ function ConfirmationDialogLayer(props: {
 function UiShellChrome(props: UiShellChromeProps) {
   const {
     bridge,
-    panelHostRefs,
+    panelHosts,
   } = props;
   const dialogModel = useDeferredViewModel(props.dialogModel, DEFAULT_DIALOG_MODEL);
   const navigationModel = useDeferredViewModel(props.navigationModel, DEFAULT_NAVIGATION_MODEL);
@@ -695,7 +738,7 @@ function UiShellChrome(props: UiShellChromeProps) {
       </header>
 
       <AppErrorBanner dialogModel={dialogModel} />
-      <ShellViewHostsContainer navigationModel={navigationModel} panelHostRefs={panelHostRefs} />
+      <ShellViewHostsContainer navigationModel={navigationModel} panelHosts={panelHosts} />
       <ConfirmationDialogLayer bridge={bridge} dialogModel={dialogModel} />
     </ShellChromeFrame>
   );
@@ -735,7 +778,7 @@ export function mountUiShellChrome(
 ): UiShellChromeView & { panelHosts: UiPanelHostRegistry } {
   const dialogModel = createDeferredViewModel<UiShellChromeDialogModel>();
   const navigationModel = createDeferredViewModel<UiShellChromeNavigationModel>();
-  const panelHostRefs = createUiPanelHostRefs();
+  const panelHosts = createPendingUiPanelHosts();
   const preferencesModel = createDeferredViewModel<UiShellChromePreferencesModel>();
   const statusModel = createDeferredViewModel<UiShellChromeStatusModel>();
   render(
@@ -743,16 +786,16 @@ export function mountUiShellChrome(
       bridge={bridge}
       dialogModel={dialogModel.model}
       navigationModel={navigationModel.model}
-      panelHostRefs={panelHostRefs}
+      panelHosts={panelHosts}
       preferencesModel={preferencesModel.model}
       statusModel={statusModel.model}
     />,
     host,
   );
-  const panelHosts = resolveUiPanelHosts(panelHostRefs);
+  const resolvedPanelHosts = resolveUiPanelHosts(panelHosts);
 
   return {
-    panelHosts,
+    panelHosts: resolvedPanelHosts,
     bindDialogModel(model) {
       dialogModel.bind(model);
     },

--- a/apps/ui/src/app/ui_panel_host_registry.ts
+++ b/apps/ui/src/app/ui_panel_host_registry.ts
@@ -1,64 +1,3 @@
-type PanelHostSpec = {
-  id: string;
-  owner: string;
-};
-
-const PANEL_HOST_SPECS = {
-  dashboard: {
-    spectrum: {
-      id: "spectrumPanelRoot",
-      owner: "Spectrum UI",
-    },
-    liveOverview: {
-      id: "liveOverviewRoot",
-      owner: "Realtime feature",
-    },
-    logging: {
-      id: "loggingPanelRoot",
-      owner: "Realtime feature",
-    },
-  },
-  history: {
-    id: "historyPanelRoot",
-    owner: "History feature",
-  },
-  settingsShell: {
-    id: "settingsShellRoot",
-    owner: "Settings shell",
-  },
-} as const;
-
-const SETTINGS_PANEL_HOST_SPECS = {
-  cars: {
-    id: "carsPanelRoot",
-    owner: "Cars feature",
-  },
-  analysis: {
-    id: "analysisPanelRoot",
-    owner: "Analysis feature",
-  },
-  internet: {
-    id: "internetPanelRoot",
-    owner: "Internet settings",
-  },
-  update: {
-    id: "updatePanelRoot",
-    owner: "Update feature",
-  },
-  sensors: {
-    id: "sensorsPanelRoot",
-    owner: "Sensors feature",
-  },
-  speedSource: {
-    id: "speedSourcePanelRoot",
-    owner: "Speed source feature",
-  },
-  espFlash: {
-    id: "espFlashPanelRoot",
-    owner: "ESP flash feature",
-  },
-} as const;
-
 export interface UiPanelHostRegistry {
   dashboard: {
     spectrum: HTMLElement;
@@ -68,6 +7,16 @@ export interface UiPanelHostRegistry {
   history: HTMLElement;
   settingsShell: HTMLElement;
 }
+
+type UiPendingPanelHostRegistry = {
+  dashboard: {
+    spectrum: HTMLDivElement | null;
+    liveOverview: HTMLDivElement | null;
+    logging: HTMLDivElement | null;
+  };
+  history: HTMLDivElement | null;
+  settingsShell: HTMLDivElement | null;
+};
 
 export interface UiSettingsPanelHostRegistry {
   cars: HTMLElement;
@@ -79,81 +28,57 @@ export interface UiSettingsPanelHostRegistry {
   espFlash: HTMLElement;
 }
 
-type PanelHostRef<T extends HTMLElement = HTMLElement> = {
+type UiSettingsPanelHostRef<T extends HTMLElement = HTMLElement> = {
   current: T | null;
 };
 
-export interface UiPanelHostRefs {
-  dashboard: {
-    spectrum: PanelHostRef<HTMLDivElement>;
-    liveOverview: PanelHostRef<HTMLDivElement>;
-    logging: PanelHostRef<HTMLDivElement>;
-  };
-  history: PanelHostRef<HTMLDivElement>;
-  settingsShell: PanelHostRef<HTMLDivElement>;
-}
-
 export interface UiSettingsPanelHostRefs {
-  cars: PanelHostRef<HTMLDivElement>;
-  analysis: PanelHostRef<HTMLDivElement>;
-  internet: PanelHostRef<HTMLDivElement>;
-  update: PanelHostRef<HTMLDivElement>;
-  sensors: PanelHostRef<HTMLDivElement>;
-  speedSource: PanelHostRef<HTMLDivElement>;
-  espFlash: PanelHostRef<HTMLDivElement>;
+  cars: UiSettingsPanelHostRef<HTMLDivElement>;
+  analysis: UiSettingsPanelHostRef<HTMLDivElement>;
+  internet: UiSettingsPanelHostRef<HTMLDivElement>;
+  update: UiSettingsPanelHostRef<HTMLDivElement>;
+  sensors: UiSettingsPanelHostRef<HTMLDivElement>;
+  speedSource: UiSettingsPanelHostRef<HTMLDivElement>;
+  espFlash: UiSettingsPanelHostRef<HTMLDivElement>;
 }
 
-function createPanelHostRef<T extends HTMLElement = HTMLDivElement>(): PanelHostRef<T> {
-  return { current: null };
+function missingElement(message: string): never {
+  throw new Error(message);
 }
 
-function missingElement(owner: string, target: string): never {
-  throw new Error(`${owner} requires ${target}`);
-}
-
-function resolvePanelHost<T extends HTMLElement>(
-  ref: PanelHostRef<T>,
-  spec: PanelHostSpec,
-): T {
-  return ref.current ?? missingElement(spec.owner, `#${spec.id}`);
-}
-
-export function createUiPanelHostRefs(): UiPanelHostRefs {
+export function resolveUiPanelHosts(
+  panelHosts: UiPendingPanelHostRegistry,
+): UiPanelHostRegistry {
   return {
     dashboard: {
-      spectrum: createPanelHostRef(),
-      liveOverview: createPanelHostRef(),
-      logging: createPanelHostRef(),
+      spectrum:
+        panelHosts.dashboard.spectrum ??
+        missingElement("Spectrum UI requires #spectrumPanelRoot"),
+      liveOverview:
+        panelHosts.dashboard.liveOverview ??
+        missingElement("Realtime feature requires #liveOverviewRoot"),
+      logging:
+        panelHosts.dashboard.logging ??
+        missingElement("Realtime feature requires #loggingPanelRoot"),
     },
-    history: createPanelHostRef(),
-    settingsShell: createPanelHostRef(),
+    history:
+      panelHosts.history ??
+      missingElement("History feature requires #historyPanelRoot"),
+    settingsShell:
+      panelHosts.settingsShell ??
+      missingElement("Settings shell requires #settingsShellRoot"),
   };
 }
 
 export function createUiSettingsPanelHostRefs(): UiSettingsPanelHostRefs {
   return {
-    cars: createPanelHostRef(),
-    analysis: createPanelHostRef(),
-    internet: createPanelHostRef(),
-    update: createPanelHostRef(),
-    sensors: createPanelHostRef(),
-    speedSource: createPanelHostRef(),
-    espFlash: createPanelHostRef(),
-  };
-}
-
-export function resolveUiPanelHosts(panelHostRefs: UiPanelHostRefs): UiPanelHostRegistry {
-  return {
-    dashboard: {
-      spectrum: resolvePanelHost(panelHostRefs.dashboard.spectrum, PANEL_HOST_SPECS.dashboard.spectrum),
-      liveOverview: resolvePanelHost(
-        panelHostRefs.dashboard.liveOverview,
-        PANEL_HOST_SPECS.dashboard.liveOverview,
-      ),
-      logging: resolvePanelHost(panelHostRefs.dashboard.logging, PANEL_HOST_SPECS.dashboard.logging),
-    },
-    history: resolvePanelHost(panelHostRefs.history, PANEL_HOST_SPECS.history),
-    settingsShell: resolvePanelHost(panelHostRefs.settingsShell, PANEL_HOST_SPECS.settingsShell),
+    cars: { current: null },
+    analysis: { current: null },
+    internet: { current: null },
+    update: { current: null },
+    sensors: { current: null },
+    speedSource: { current: null },
+    espFlash: { current: null },
   };
 }
 
@@ -161,12 +86,26 @@ export function resolveUiSettingsPanelHosts(
   panelHostRefs: UiSettingsPanelHostRefs,
 ): UiSettingsPanelHostRegistry {
   return {
-    cars: resolvePanelHost(panelHostRefs.cars, SETTINGS_PANEL_HOST_SPECS.cars),
-    analysis: resolvePanelHost(panelHostRefs.analysis, SETTINGS_PANEL_HOST_SPECS.analysis),
-    internet: resolvePanelHost(panelHostRefs.internet, SETTINGS_PANEL_HOST_SPECS.internet),
-    update: resolvePanelHost(panelHostRefs.update, SETTINGS_PANEL_HOST_SPECS.update),
-    sensors: resolvePanelHost(panelHostRefs.sensors, SETTINGS_PANEL_HOST_SPECS.sensors),
-    speedSource: resolvePanelHost(panelHostRefs.speedSource, SETTINGS_PANEL_HOST_SPECS.speedSource),
-    espFlash: resolvePanelHost(panelHostRefs.espFlash, SETTINGS_PANEL_HOST_SPECS.espFlash),
+    cars:
+      panelHostRefs.cars.current ??
+      missingElement("Cars feature requires #carsPanelRoot"),
+    analysis:
+      panelHostRefs.analysis.current ??
+      missingElement("Analysis feature requires #analysisPanelRoot"),
+    internet:
+      panelHostRefs.internet.current ??
+      missingElement("Internet settings requires #internetPanelRoot"),
+    update:
+      panelHostRefs.update.current ??
+      missingElement("Update feature requires #updatePanelRoot"),
+    sensors:
+      panelHostRefs.sensors.current ??
+      missingElement("Sensors feature requires #sensorsPanelRoot"),
+    speedSource:
+      panelHostRefs.speedSource.current ??
+      missingElement("Speed source feature requires #speedSourcePanelRoot"),
+    espFlash:
+      panelHostRefs.espFlash.current ??
+      missingElement("ESP flash feature requires #espFlashPanelRoot"),
   };
 }

--- a/apps/ui/tests/ui_runtime_dom.spec.ts
+++ b/apps/ui/tests/ui_runtime_dom.spec.ts
@@ -2,11 +2,9 @@ import { expect, test } from "@playwright/test";
 
 import { getUiShellChromeHost } from "../src/app/runtime/ui_shell_chrome";
 import {
-  createUiPanelHostRefs,
   createUiSettingsPanelHostRefs,
   resolveUiPanelHosts,
   resolveUiSettingsPanelHosts,
-  type UiPanelHostRefs,
   type UiSettingsPanelHostRefs,
 } from "../src/app/ui_panel_host_registry";
 
@@ -26,7 +24,9 @@ function stubElement(id = ""): HTMLElement {
 
 function installDomFixture(overrides: { missingId?: string } = {}): () => void {
   const originalDocument = globalThis.document;
-  const ids = new Map([["appShellChromeRoot", stubElement("appShellChromeRoot")]]);
+  const ids = new Map([
+    ["appShellChromeRoot", stubElement("appShellChromeRoot")],
+  ]);
 
   if (overrides.missingId) {
     ids.delete(overrides.missingId);
@@ -43,24 +43,42 @@ function installDomFixture(overrides: { missingId?: string } = {}): () => void {
   };
 }
 
-function createPanelHostRefs(overrides: { missingId?: string } = {}): UiPanelHostRefs {
-  const panelHostRefs = createUiPanelHostRefs();
+function createPanelHosts(
+  overrides: { missingId?: string } = {},
+): Parameters<typeof resolveUiPanelHosts>[0] {
+  const panelHosts: Parameters<typeof resolveUiPanelHosts>[0] = {
+    dashboard: {
+      spectrum: null,
+      liveOverview: null,
+      logging: null,
+    },
+    history: null,
+    settingsShell: null,
+  };
   if (overrides.missingId !== "spectrumPanelRoot") {
-    panelHostRefs.dashboard.spectrum.current = stubElement("spectrumPanelRoot") as HTMLDivElement;
+    panelHosts.dashboard.spectrum = stubElement(
+      "spectrumPanelRoot",
+    ) as HTMLDivElement;
   }
   if (overrides.missingId !== "liveOverviewRoot") {
-    panelHostRefs.dashboard.liveOverview.current = stubElement("liveOverviewRoot") as HTMLDivElement;
+    panelHosts.dashboard.liveOverview = stubElement(
+      "liveOverviewRoot",
+    ) as HTMLDivElement;
   }
   if (overrides.missingId !== "loggingPanelRoot") {
-    panelHostRefs.dashboard.logging.current = stubElement("loggingPanelRoot") as HTMLDivElement;
+    panelHosts.dashboard.logging = stubElement(
+      "loggingPanelRoot",
+    ) as HTMLDivElement;
   }
   if (overrides.missingId !== "historyPanelRoot") {
-    panelHostRefs.history.current = stubElement("historyPanelRoot") as HTMLDivElement;
+    panelHosts.history = stubElement("historyPanelRoot") as HTMLDivElement;
   }
   if (overrides.missingId !== "settingsShellRoot") {
-    panelHostRefs.settingsShell.current = stubElement("settingsShellRoot") as HTMLDivElement;
+    panelHosts.settingsShell = stubElement(
+      "settingsShellRoot",
+    ) as HTMLDivElement;
   }
-  return panelHostRefs;
+  return panelHosts;
 }
 
 function createSettingsPanelHostRefs(
@@ -71,22 +89,34 @@ function createSettingsPanelHostRefs(
     panelHostRefs.cars.current = stubElement("carsPanelRoot") as HTMLDivElement;
   }
   if (overrides.missingId !== "analysisPanelRoot") {
-    panelHostRefs.analysis.current = stubElement("analysisPanelRoot") as HTMLDivElement;
+    panelHostRefs.analysis.current = stubElement(
+      "analysisPanelRoot",
+    ) as HTMLDivElement;
   }
   if (overrides.missingId !== "internetPanelRoot") {
-    panelHostRefs.internet.current = stubElement("internetPanelRoot") as HTMLDivElement;
+    panelHostRefs.internet.current = stubElement(
+      "internetPanelRoot",
+    ) as HTMLDivElement;
   }
   if (overrides.missingId !== "updatePanelRoot") {
-    panelHostRefs.update.current = stubElement("updatePanelRoot") as HTMLDivElement;
+    panelHostRefs.update.current = stubElement(
+      "updatePanelRoot",
+    ) as HTMLDivElement;
   }
   if (overrides.missingId !== "espFlashPanelRoot") {
-    panelHostRefs.espFlash.current = stubElement("espFlashPanelRoot") as HTMLDivElement;
+    panelHostRefs.espFlash.current = stubElement(
+      "espFlashPanelRoot",
+    ) as HTMLDivElement;
   }
   if (overrides.missingId !== "sensorsPanelRoot") {
-    panelHostRefs.sensors.current = stubElement("sensorsPanelRoot") as HTMLDivElement;
+    panelHostRefs.sensors.current = stubElement(
+      "sensorsPanelRoot",
+    ) as HTMLDivElement;
   }
   if (overrides.missingId !== "speedSourcePanelRoot") {
-    panelHostRefs.speedSource.current = stubElement("speedSourcePanelRoot") as HTMLDivElement;
+    panelHostRefs.speedSource.current = stubElement(
+      "speedSourcePanelRoot",
+    ) as HTMLDivElement;
   }
   return panelHostRefs;
 }
@@ -106,20 +136,25 @@ const missingSettingsPanelHostCases = [
   ["updatePanelRoot", "Update feature requires #updatePanelRoot"],
   ["espFlashPanelRoot", "ESP flash feature requires #espFlashPanelRoot"],
   ["sensorsPanelRoot", "Sensors feature requires #sensorsPanelRoot"],
-  ["speedSourcePanelRoot", "Speed source feature requires #speedSourcePanelRoot"],
+  [
+    "speedSourcePanelRoot",
+    "Speed source feature requires #speedSourcePanelRoot",
+  ],
 ] as const;
 
 test("shell chrome host and panel registry resolve the startup anchors", () => {
   const restore = installDomFixture();
   try {
     expect(getUiShellChromeHost().id).toBe("appShellChromeRoot");
-    const hosts = resolveUiPanelHosts(createPanelHostRefs());
+    const hosts = resolveUiPanelHosts(createPanelHosts());
     expect(hosts.dashboard.spectrum.id).toBe("spectrumPanelRoot");
     expect(hosts.dashboard.liveOverview.id).toBe("liveOverviewRoot");
     expect(hosts.dashboard.logging.id).toBe("loggingPanelRoot");
     expect(hosts.history.id).toBe("historyPanelRoot");
     expect(hosts.settingsShell.id).toBe("settingsShellRoot");
-    const settingsHosts = resolveUiSettingsPanelHosts(createSettingsPanelHostRefs());
+    const settingsHosts = resolveUiSettingsPanelHosts(
+      createSettingsPanelHostRefs(),
+    );
     expect(settingsHosts.cars.id).toBe("carsPanelRoot");
     expect(settingsHosts.analysis.id).toBe("analysisPanelRoot");
     expect(settingsHosts.internet.id).toBe("internetPanelRoot");
@@ -148,7 +183,9 @@ test.describe("runtime locator missing required feature anchors", () => {
     test(`fails when ${missingId} is missing from the top-level panel registry`, () => {
       const restore = installDomFixture();
       try {
-        expect(() => resolveUiPanelHosts(createPanelHostRefs({ missingId }))).toThrow(message);
+        expect(() =>
+          resolveUiPanelHosts(createPanelHosts({ missingId })),
+        ).toThrow(message);
       } finally {
         restore();
       }
@@ -159,9 +196,11 @@ test.describe("runtime locator missing required feature anchors", () => {
     test(`fails when ${missingId} is missing from the settings panel registry`, () => {
       const restore = installDomFixture();
       try {
-        expect(() => resolveUiSettingsPanelHosts(createSettingsPanelHostRefs({ missingId }))).toThrow(
-          message,
-        );
+        expect(() =>
+          resolveUiSettingsPanelHosts(
+            createSettingsPanelHostRefs({ missingId }),
+          ),
+        ).toThrow(message);
       } finally {
         restore();
       }


### PR DESCRIPTION
## size
small

## what changed
- remove exported top-level `UiPanelHostRefs` scaffolding from `ui_panel_host_registry.ts`
- drop top-level host-spec lookup tables and generic host ref/resolve helpers
- keep `UiPanelHostRegistry` as the mounted downstream contract
- have `ui_shell_chrome.tsx` capture shell panel hosts directly during render and resolve them after mount
- update `ui_runtime_dom.spec.ts` to cover the new top-level host resolution path

## why
- top-level shell hosts only needed a render-time bridge from ref callbacks to mounted elements
- the extra refs hierarchy and lookup tables were pure indirection around five known anchors
- direct capture keeps the contract stable for bootstrap code and cuts boilerplate

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ui_runtime_dom.spec.ts`
- `cd apps/ui && npm run lint`

## risks
- shell chrome still depends on the initial render completing synchronously before host resolution
- nested settings-shell host mounting stays on its existing path in this PR

## follow-ups
- none
