### PR TITLE
FE: Audit CSS for unused selectors in large stylesheet files

### DIFF
--- a/apps/ui/src/styles/adaptive.css
+++ b/apps/ui/src/styles/adaptive.css
@@ -54,7 +54,6 @@
     align-items: flex-start;
     flex-direction: column;
   }
-  .history-details-preview { grid-template-columns: 1fr; }
   .history-toolbar {
     align-items: flex-start;
   }

--- a/apps/ui/src/styles/settings-common.css
+++ b/apps/ui/src/styles/settings-common.css
@@ -106,20 +106,6 @@
   line-height: 1.45;
 }
 
-.settings-field-guidance__stack {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem 0.75rem;
-}
-
-.settings-field-guidance__line {
-  font-size: 0.8rem;
-  color: var(--muted);
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 0.2rem;
-}
-
 .settings-field-guidance__label {
   color: var(--pill-muted-text);
   font-weight: 700;


### PR DESCRIPTION
## size
tiny

## what changed
- remove the dead `.history-details-preview` responsive override from `adaptive.css`
- remove stale `.settings-field-guidance__stack` and `.settings-field-guidance__line` rules from `settings-common.css`

## why
- these selectors have no current owner in the UI markup
- the audit pass verified the nearby dynamic history tone classes, settings feedback tone classes, and uPlot selectors are still live, so only the genuinely dead rules were cut

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/smoke.history-layout.spec.ts tests/smoke.settings-alignment.spec.ts`
- `cd apps/ui && npm run lint`

## risks
- low; selectors were removed only after source-owner verification and adjacent history/settings smoke coverage
