### PR TITLE
FE: Flatten DeferredViewModel into direct signal-of-signal pattern

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -21,8 +21,7 @@ import {
   type SettingsFeedbackMessage,
 } from "../views/settings_feedback";
 import {
-  createDeferredViewModel,
-  useDeferredViewModel,
+  createDeferredModelSignal,
 } from "../views/view_model_binding";
 import type { VisualVariant } from "../view_style_types";
 const SHELL_OWNER = "UI shell";
@@ -721,10 +720,10 @@ function UiShellChrome(props: UiShellChromeProps) {
     bridge,
     panelHosts,
   } = props;
-  const dialogModel = useDeferredViewModel(props.dialogModel, DEFAULT_DIALOG_MODEL);
-  const navigationModel = useDeferredViewModel(props.navigationModel, DEFAULT_NAVIGATION_MODEL);
-  const preferencesModel = useDeferredViewModel(props.preferencesModel, DEFAULT_PREFERENCES_MODEL);
-  const statusModel = useDeferredViewModel(props.statusModel, DEFAULT_STATUS_MODEL);
+  const dialogModel = useComputed(() => props.dialogModel.value?.value ?? DEFAULT_DIALOG_MODEL);
+  const navigationModel = useComputed(() => props.navigationModel.value?.value ?? DEFAULT_NAVIGATION_MODEL);
+  const preferencesModel = useComputed(() => props.preferencesModel.value?.value ?? DEFAULT_PREFERENCES_MODEL);
+  const statusModel = useComputed(() => props.statusModel.value?.value ?? DEFAULT_STATUS_MODEL);
 
   return (
     <ShellChromeFrame statusModel={statusModel}>
@@ -776,19 +775,19 @@ export function mountUiShellChrome(
   host: HTMLElement,
   bridge: UiShellChromeActionBridge,
 ): UiShellChromeView & { panelHosts: UiPanelHostRegistry } {
-  const dialogModel = createDeferredViewModel<UiShellChromeDialogModel>();
-  const navigationModel = createDeferredViewModel<UiShellChromeNavigationModel>();
+  const dialogModel = createDeferredModelSignal<UiShellChromeDialogModel>();
+  const navigationModel = createDeferredModelSignal<UiShellChromeNavigationModel>();
   const panelHosts = createPendingUiPanelHosts();
-  const preferencesModel = createDeferredViewModel<UiShellChromePreferencesModel>();
-  const statusModel = createDeferredViewModel<UiShellChromeStatusModel>();
+  const preferencesModel = createDeferredModelSignal<UiShellChromePreferencesModel>();
+  const statusModel = createDeferredModelSignal<UiShellChromeStatusModel>();
   render(
     <UiShellChrome
       bridge={bridge}
-      dialogModel={dialogModel.model}
-      navigationModel={navigationModel.model}
+      dialogModel={dialogModel}
+      navigationModel={navigationModel}
       panelHosts={panelHosts}
-      preferencesModel={preferencesModel.model}
-      statusModel={statusModel.model}
+      preferencesModel={preferencesModel}
+      statusModel={statusModel}
     />,
     host,
   );
@@ -797,16 +796,16 @@ export function mountUiShellChrome(
   return {
     panelHosts: resolvedPanelHosts,
     bindDialogModel(model) {
-      dialogModel.bind(model);
+      dialogModel.value = model;
     },
     bindNavigationModel(model) {
-      navigationModel.bind(model);
+      navigationModel.value = model;
     },
     bindPreferencesModel(model) {
-      preferencesModel.bind(model);
+      preferencesModel.value = model;
     },
     bindStatusModel(model) {
-      statusModel.bind(model);
+      statusModel.value = model;
     },
   };
 }

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -13,10 +13,7 @@ import {
   MaintenanceReadinessPanel,
   type MaintenanceReadinessPanelModel,
 } from "./maintenance_readiness_view";
-import {
-  type DeferredModelSignal,
-  useDeferredViewModel,
-} from "./view_model_binding";
+import { type DeferredModelSignal } from "./view_model_binding";
 
 export interface EspFlashStatusBadgeModel {
   text: string;
@@ -338,7 +335,7 @@ function EspFlashPanel(props: {
     "Recent flashes stay here so the next operator can see what happened last.",
   );
   const actions = useComputed(() => props.actions.value);
-  const model = useDeferredViewModel(props.model, DEFAULT_ESP_FLASH_PANEL_MODEL);
+  const model = useComputed(() => props.model.value?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL);
   const logPanelRef = useRef<HTMLDivElement | null>(null);
   const handleSelectPort = (value: string) => {
     actions.value?.onSelectPort(value);

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -6,7 +6,6 @@ import {
   type ReadonlySignal,
 } from "../ui_signals";
 import { HistoryTableBody } from "./history_table_content";
-import { useDeferredViewModel } from "./view_model_binding";
 import type {
   HistoryPanelActionHandlers,
   HistoryPanelView,
@@ -36,7 +35,7 @@ export function HistoryPanel(props: {
   const samplesLabel = useUiText("history.table.size", "Samples");
   const actionsLabel = useUiText("history.table.actions", "Actions");
   const actions = useComputed(() => props.actions.value);
-  const model = useDeferredViewModel(props.model, DEFAULT_PANEL_MODEL);
+  const model = useComputed(() => props.model.value?.value ?? DEFAULT_PANEL_MODEL);
   const { deleteAllRunsDisabled, historySummaryText, table } = useSignalProperties(
     model,
     HISTORY_PANEL_MODEL_KEYS,

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -7,10 +7,7 @@ import {
   type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
-import {
-  type DeferredModelSignal,
-  useDeferredViewModel,
-} from "./view_model_binding";
+import { type DeferredModelSignal } from "./view_model_binding";
 
 export interface RealtimeLiveOverviewActiveCarModel {
   text: string;
@@ -194,7 +191,7 @@ function RealtimeLiveOverview(props: {
   const currentSpeedLabel = useUiText("dashboard.current_speed", "Current speed");
   const sensorCoverageLabel = useUiText("dashboard.sensor_coverage", "Sensor coverage");
   const noSensorsText = useUiText("settings.sensors.no_sensors", "No sensors yet.");
-  const model = useDeferredViewModel(props.model, DEFAULT_OVERVIEW_MODEL);
+  const model = useComputed(() => props.model.value?.value ?? DEFAULT_OVERVIEW_MODEL);
   const {
     activeCar,
     connectedSensorsText,

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -8,10 +8,7 @@ import {
   type ReadonlySignal,
 } from "../ui_signals";
 import { inlineStateActionClass } from "./dom_helpers";
-import {
-  type DeferredModelSignal,
-  useDeferredViewModel,
-} from "./view_model_binding";
+import { type DeferredModelSignal } from "./view_model_binding";
 import type {
   RealtimeCaptureReadinessChecklistModel,
   RealtimeLoggingSummaryAction,
@@ -177,7 +174,7 @@ function RealtimeLoggingPanel(props: {
   const startLabel = useUiText("dashboard.start_recording", "Start Recording");
   const stopLabel = useUiText("dashboard.stop_recording", "Stop Recording");
   const actions = useComputed(() => props.actions.value);
-  const model = useDeferredViewModel(props.model, DEFAULT_PANEL_MODEL);
+  const model = useComputed(() => props.model.value?.value ?? DEFAULT_PANEL_MODEL);
   const {
     checklist,
     elapsedText,

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -14,10 +14,7 @@ import type {
   RealtimeSensorTableRenderModel,
   RealtimeSensorTableRowViewModel,
 } from "./realtime_sensor_table_view";
-import {
-  type DeferredModelSignal,
-  useDeferredViewModel,
-} from "./view_model_binding";
+import { type DeferredModelSignal } from "./view_model_binding";
 
 export interface SensorsPanelRenderModel {
   table: RealtimeSensorTableRenderModel | null;
@@ -144,7 +141,7 @@ function SensorsPanel(props: {
   const locationLabel = useUiText("settings.sensors.location", "Location");
   const actionsLabel = useUiText("settings.sensors.actions", "Actions");
   const actions = useComputed(() => props.actions.value);
-  const model = useDeferredViewModel(props.model, DEFAULT_SENSORS_PANEL_MODEL);
+  const model = useComputed(() => props.model.value?.value ?? DEFAULT_SENSORS_PANEL_MODEL);
   const { table } = useSignalProperties(model, SENSORS_PANEL_MODEL_KEYS);
   return (
     <div class="panel card">

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -7,10 +7,7 @@ import {
   type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
-import {
-  type DeferredModelSignal,
-  useDeferredViewModel,
-} from "./view_model_binding";
+import { type DeferredModelSignal } from "./view_model_binding";
 import type {
   UpdateCurrentStatusSectionModel,
   UpdateHealthSectionModel,
@@ -349,7 +346,7 @@ function UpdatePanel(props: {
   );
   const cancelLabel = useUiText("settings.update.cancel", "Cancel Update");
   const actions = useComputed(() => props.actions.value);
-  const model = useDeferredViewModel(props.model, DEFAULT_UPDATE_PANEL_MODEL);
+  const model = useComputed(() => props.model.value?.value ?? DEFAULT_UPDATE_PANEL_MODEL);
   const {
     cancelButtonDisabled,
     cancelButtonHidden,

--- a/apps/ui/src/app/views/view_model_binding.ts
+++ b/apps/ui/src/app/views/view_model_binding.ts
@@ -1,16 +1,10 @@
 import {
   signal,
-  useComputed,
   type ReadonlySignal,
   type Signal,
 } from "../ui_signals";
 
 export type DeferredModelSignal<T> = Signal<ReadonlySignal<T> | null>;
-
-export interface DeferredViewModel<T> {
-  readonly model: DeferredModelSignal<T>;
-  bind(source: ReadonlySignal<T>): void;
-}
 
 export function createDeferredModelSignal<T>(): DeferredModelSignal<T> {
   return signal<ReadonlySignal<T> | null>(null);
@@ -26,21 +20,4 @@ export function createModelActionPanelBindings<TModel, TActions>(): ModelActionP
     actions: signal<TActions | null>(null),
     model: createDeferredModelSignal<TModel>(),
   };
-}
-
-export function createDeferredViewModel<T>(): DeferredViewModel<T> {
-  const model = createDeferredModelSignal<T>();
-  return {
-    model,
-    bind(source) {
-      model.value = source;
-    },
-  };
-}
-
-export function useDeferredViewModel<T>(
-  source: ReadonlySignal<ReadonlySignal<T> | null>,
-  initialValue: T,
-): ReadonlySignal<T> {
-  return useComputed(() => source.value?.value ?? initialValue);
 }

--- a/apps/ui/tests/view_model_binding_signals.ts
+++ b/apps/ui/tests/view_model_binding_signals.ts
@@ -8,11 +8,10 @@ import {
   useComputed,
   type ReadonlySignal,
 } from "../src/app/ui_signals";
-import {
-  createDeferredViewModel,
-  useDeferredViewModel,
-} from "../src/app/views/view_model_binding";
+import { createDeferredModelSignal } from "../src/app/views/view_model_binding";
 import { mountSignalView } from "./dom_render_test_support";
+
+const DEFAULT_MODEL = { text: "Loading" };
 
 function requireElement<T extends Element = HTMLElement>(root: ParentNode, selector: string): T {
   const element = root.querySelector<T>(selector);
@@ -25,7 +24,7 @@ async function runDeferredViewModelSignalTest(): Promise<void> {
   const secondText = signal("Ready");
   const firstModel = computed(() => ({ text: firstText.value }));
   const secondModel = computed(() => ({ text: secondText.value }));
-  const binding = createDeferredViewModel<{ text: string }>();
+  const binding = createDeferredModelSignal<{ text: string }>();
   const previousDiffed = options.diffed;
   let renderCount = 0;
   options.diffed = (vnode) => {
@@ -41,12 +40,12 @@ async function runDeferredViewModelSignalTest(): Promise<void> {
       function DeferredViewModelProbe(props: {
         model: ReadonlySignal<ReadonlySignal<{ text: string }> | null>;
       }) {
-        const model = useDeferredViewModel(props.model, { text: "Loading" });
+        const model = useComputed(() => props.model.value?.value ?? DEFAULT_MODEL);
         const text = useComputed(() => model.value.text);
         return h("span", { id: "bindingProbe" }, text);
       }
 
-      render(h(DeferredViewModelProbe, { model: binding.model }), host);
+      render(h(DeferredViewModelProbe, { model: binding }), host);
       return {};
     };
   });
@@ -56,7 +55,7 @@ async function runDeferredViewModelSignalTest(): Promise<void> {
     assert.equal(renderCount, 1);
     assert.equal(requireElement(harness.host, "#bindingProbe").textContent, "Loading");
 
-    binding.bind(firstModel);
+    binding.value = firstModel;
     await harness.flush();
     assert.equal(renderCount, 1);
     assert.equal(requireElement(harness.host, "#bindingProbe").textContent, "Idle");
@@ -66,7 +65,7 @@ async function runDeferredViewModelSignalTest(): Promise<void> {
     assert.equal(renderCount, 1);
     assert.equal(requireElement(harness.host, "#bindingProbe").textContent, "Running");
 
-    binding.bind(secondModel);
+    binding.value = secondModel;
     await harness.flush();
     assert.equal(renderCount, 1);
     assert.equal(requireElement(harness.host, "#bindingProbe").textContent, "Ready");


### PR DESCRIPTION
## what changed
- remove `createDeferredViewModel()` and `useDeferredViewModel()` from `view_model_binding.ts`
- flatten deferred model signals directly in history, realtime, update, sensors, ESP flash, and shell chrome consumers
- bind shell chrome deferred models with `createDeferredModelSignal()` plus direct signal assignment
- update the focused deferred-model signal test to cover the direct signal-of-signal path

## why
- the deleted wrapper added no behavior beyond `useComputed(() => source.value?.value ?? fallback)`
- direct signal-of-signal bindings keep the same behavior with less indirection

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/view_model_binding_signals.ts tests/ui_shell_runtime_modules.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.history.spec.ts tests/smoke.settings.spec.ts tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts`
- `cd apps/ui && npm run lint`

## risk / tradeoffs
- touches several panel entrypoints and shell chrome in one PR because the wrapper still had live callers across all of them
- keeps `DeferredModelSignal`, `createDeferredModelSignal()`, and `createModelActionPanelBindings()` because they still carry real shared value; only the dead wrapper layer is removed

Closes #2597
