### PR TITLE
Only run ci on main and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,8 @@ name: CodeQL
 
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/apps/server/tests/hygiene/test_ui_smoke_contract.py
+++ b/apps/server/tests/hygiene/test_ui_smoke_contract.py
@@ -27,15 +27,18 @@ def test_ui_smoke_script_defers_test_selection_to_smoke_config() -> None:
     package_json = json.loads(_UI_PACKAGE_JSON.read_text())
     scripts = package_json["scripts"]
     script = str(scripts["test:smoke"])
+    config_text = _SMOKE_CONFIG.read_text()
 
     assert scripts["pretest:smoke"] == "npm run sync:generated-contracts"
     assert "--config=playwright.smoke.config.ts" in script
     assert "--project=laptop-light" in script
-    assert "--workers=1" in script
+    assert "--workers=" not in script
     assert "tests/" not in script, (
         "Smoke file selection should live in playwright.smoke.config.ts, "
         "not as hard-coded paths in package.json."
     )
+    assert "PLAYWRIGHT_SMOKE_WORKERS" in config_text
+    assert '?? "1"' in config_text
 
 
 def test_ui_smoke_config_uses_split_smoke_glob() -> None:


### PR DESCRIPTION
## what changed
- scope `pull_request.branches` to `main` in `.github/workflows/ci.yml`
- scope `pull_request.branches` to `main` in `.github/workflows/codeql.yml`
- keep the existing `push.branches: [main]` behavior unchanged
- update the stale backend hygiene smoke-contract test so it matches the current config-owned worker setting

## why
- stop CI-related workflows from running for PRs that do not target `main`
- keep the repo on the requested policy: run on `main` and on pull requests to `main`
- keep the branch green after the workflow change exercised the full backend matrix and exposed the outdated smoke-contract assertion

## validation
- `python3` + `yaml.BaseLoader` parse check for both workflow files
- confirmed both files resolve `pull_request.branches=['main']` and `push.branches=['main']`
- `pytest -q apps/server/tests/hygiene/test_ui_smoke_contract.py`

## risk / tradeoffs
- PRs targeting non-`main` branches no longer get these workflows automatically
- no job logic changed; only trigger scope changed

Closes #2624