### PR TITLE
FE: Simplify UiShellChromeActionBridge to direct signal

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -12,6 +12,7 @@ import {
 import {
   useComputed,
   useSignalProperties,
+  type Signal,
   type ReadonlySignal,
   useSignalEffect,
 } from "../ui_signals";
@@ -80,10 +81,13 @@ export interface UiShellChromeActions {
   saveSpeedUnit(unit: string): Promise<void> | void;
 }
 
-export interface UiShellChromeActionBridge {
-  readonly current: UiShellChromeActions;
-  attach(actions: UiShellChromeActions): void;
-}
+export const DEFAULT_UI_SHELL_CHROME_ACTIONS: UiShellChromeActions = {
+  activateView: noop,
+  cancelConfirmation: noop,
+  confirmConfirmation: noop,
+  saveLanguage: noop,
+  saveSpeedUnit: noop,
+};
 
 export interface UiShellBadgeModel {
   text: string;
@@ -142,7 +146,7 @@ export interface UiShellChromeView {
 }
 
 type UiShellChromeProps = {
-  bridge: UiShellChromeActionBridge;
+  actions: ReadonlySignal<UiShellChromeActions>;
   dialogModel: ReadonlySignal<ReadonlySignal<UiShellChromeDialogModel> | null>;
   navigationModel: ReadonlySignal<ReadonlySignal<UiShellChromeNavigationModel> | null>;
   panelHosts: PendingUiPanelHosts;
@@ -251,10 +255,10 @@ function SettingsFeedbackSlot(props: {
 }
 
 function ConfirmationDialog(props: {
-  bridge: UiShellChromeActionBridge;
+  actions: ReadonlySignal<UiShellChromeActions>;
   model: UiConfirmationDialogModel;
 }) {
-  const { bridge, model } = props;
+  const { actions, model } = props;
   const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
 
   useSignalEffect(() => {
@@ -265,11 +269,11 @@ function ConfirmationDialog(props: {
 
   return (
     <div class="app-modal-layer">
-      <div
-        class="app-modal-backdrop"
-        aria-hidden="true"
-        onClick={() => bridge.current.cancelConfirmation()}
-      />
+        <div
+          class="app-modal-backdrop"
+          aria-hidden="true"
+          onClick={() => actions.value.cancelConfirmation()}
+        />
       <div
         class="panel card confirmation-dialog"
         role="alertdialog"
@@ -279,7 +283,7 @@ function ConfirmationDialog(props: {
         onKeyDown={(event) => {
           if (event.key === "Escape") {
             event.preventDefault();
-            bridge.current.cancelConfirmation();
+            actions.value.cancelConfirmation();
           }
         }}
       >
@@ -295,14 +299,14 @@ function ConfirmationDialog(props: {
           <button
             type="button"
             class="btn"
-            onClick={() => bridge.current.cancelConfirmation()}
+            onClick={() => actions.value.cancelConfirmation()}
           >
             {model.cancelButtonText}
           </button>
           <button
             type="button"
             class="btn btn--danger"
-            onClick={() => bridge.current.confirmConfirmation()}
+            onClick={() => actions.value.confirmConfirmation()}
             ref={confirmButtonRef}
           >
             {model.confirmButtonText}
@@ -429,10 +433,10 @@ function ShellChromeFrame(props: {
 }
 
 function ShellNavigation(props: {
-  bridge: UiShellChromeActionBridge;
+  actions: ReadonlySignal<UiShellChromeActions>;
   navigationModel: ReadonlySignal<UiShellChromeNavigationModel>;
 }) {
-  const { bridge, navigationModel } = props;
+  const { actions, navigationModel } = props;
   const { activeViewId, navItems } = useSignalProperties(
     navigationModel,
     SHELL_NAVIGATION_MODEL_KEYS,
@@ -440,7 +444,7 @@ function ShellNavigation(props: {
   const menuButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   function activateView(viewId: string): void {
-    bridge.current.activateView(viewId);
+    actions.value.activateView(viewId);
   }
 
   function focusMenuButton(nextIndex: number): void {
@@ -528,10 +532,10 @@ function ShellNavigationTabButton(props: {
 }
 
 function ShellPreferences(props: {
-  bridge: UiShellChromeActionBridge;
+  actions: ReadonlySignal<UiShellChromeActions>;
   preferencesModel: ReadonlySignal<UiShellChromePreferencesModel>;
 }) {
-  const { bridge, preferencesModel } = props;
+  const { actions, preferencesModel } = props;
   const {
     languageFeedback,
     languageLabelText,
@@ -566,7 +570,7 @@ function ShellPreferences(props: {
           aria-invalid={speedUnitAriaInvalid}
           value={selectedSpeedUnit}
           onChange={(event) => {
-            void bridge.current.saveSpeedUnit(event.currentTarget.value);
+            void actions.value.saveSpeedUnit(event.currentTarget.value);
           }}
         >
           {SPEED_UNIT_OPTIONS.map((option) => (
@@ -590,7 +594,7 @@ function ShellPreferences(props: {
           aria-invalid={languageAriaInvalid}
           value={selectedLanguage}
           onChange={(event) => {
-            void bridge.current.saveLanguage(event.currentTarget.value);
+            void actions.value.saveLanguage(event.currentTarget.value);
           }}
         >
           {LANGUAGE_OPTIONS.map((option) => (
@@ -705,19 +709,19 @@ function ShellViewHostsContainer(props: {
 }
 
 function ConfirmationDialogLayer(props: {
-  bridge: UiShellChromeActionBridge;
+  actions: ReadonlySignal<UiShellChromeActions>;
   dialogModel: ReadonlySignal<UiShellChromeDialogModel>;
 }) {
-  const { bridge, dialogModel } = props;
+  const { actions, dialogModel } = props;
   const confirmationDialog = dialogModel.value.confirmationDialog;
   return confirmationDialog
-    ? <ConfirmationDialog bridge={bridge} model={confirmationDialog} />
+    ? <ConfirmationDialog actions={actions} model={confirmationDialog} />
     : null;
 }
 
 function UiShellChrome(props: UiShellChromeProps) {
   const {
-    bridge,
+    actions,
     panelHosts,
   } = props;
   const dialogModel = useComputed(() => props.dialogModel.value?.value ?? DEFAULT_DIALOG_MODEL);
@@ -730,37 +734,17 @@ function UiShellChrome(props: UiShellChromeProps) {
       <DocumentLanguageSync preferencesModel={preferencesModel} />
       <header class="site-header">
         <div class="site-header__main">
-          <ShellNavigation bridge={bridge} navigationModel={navigationModel} />
-          <ShellPreferences bridge={bridge} preferencesModel={preferencesModel} />
+          <ShellNavigation actions={actions} navigationModel={navigationModel} />
+          <ShellPreferences actions={actions} preferencesModel={preferencesModel} />
         </div>
         <ShellStatus navigationModel={navigationModel} statusModel={statusModel} />
       </header>
 
       <AppErrorBanner dialogModel={dialogModel} />
       <ShellViewHostsContainer navigationModel={navigationModel} panelHosts={panelHosts} />
-      <ConfirmationDialogLayer bridge={bridge} dialogModel={dialogModel} />
+      <ConfirmationDialogLayer actions={actions} dialogModel={dialogModel} />
     </ShellChromeFrame>
   );
-}
-
-export function createUiShellChromeActionBridge(): UiShellChromeActionBridge {
-  const current: UiShellChromeActions = {
-    activateView: noop,
-    cancelConfirmation: noop,
-    confirmConfirmation: noop,
-    saveLanguage: noop,
-    saveSpeedUnit: noop,
-  };
-  return {
-    current,
-    attach(actions: UiShellChromeActions): void {
-      current.activateView = actions.activateView;
-      current.cancelConfirmation = actions.cancelConfirmation;
-      current.confirmConfirmation = actions.confirmConfirmation;
-      current.saveLanguage = actions.saveLanguage;
-      current.saveSpeedUnit = actions.saveSpeedUnit;
-    },
-  };
 }
 
 export function getUiShellChromeHost(): HTMLElement {
@@ -773,7 +757,7 @@ export function getUiShellChromeHost(): HTMLElement {
 
 export function mountUiShellChrome(
   host: HTMLElement,
-  bridge: UiShellChromeActionBridge,
+  actions: Signal<UiShellChromeActions>,
 ): UiShellChromeView & { panelHosts: UiPanelHostRegistry } {
   const dialogModel = createDeferredModelSignal<UiShellChromeDialogModel>();
   const navigationModel = createDeferredModelSignal<UiShellChromeNavigationModel>();
@@ -782,7 +766,7 @@ export function mountUiShellChrome(
   const statusModel = createDeferredModelSignal<UiShellChromeStatusModel>();
   render(
     <UiShellChrome
-      bridge={bridge}
+      actions={actions}
       dialogModel={dialogModel}
       navigationModel={navigationModel}
       panelHosts={panelHosts}

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -7,6 +7,7 @@ import {
   effect,
   signal,
   untracked,
+  type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
 import {
@@ -31,7 +32,7 @@ import {
 } from "./ui_shell_status_module";
 import type {
   UiShellBadgeModel,
-  UiShellChromeActionBridge,
+  UiShellChromeActions,
   UiShellChromeDialogModel,
   UiShellChromeNavigationModel,
   UiShellChromePreferencesModel,
@@ -48,7 +49,7 @@ import type { VisualVariant } from "../view_style_types";
 type UiShellControllerDeps = {
   bindFeatureHandlers: () => void;
   chrome: UiShellChromeView;
-  chromeActions: UiShellChromeActionBridge;
+  chromeActions: Signal<UiShellChromeActions>;
   liveOverview: RealtimeLiveOverviewBridge;
   onViewActivated?: (viewId: string) => Promise<void> | void;
   state: AppState;
@@ -127,13 +128,13 @@ export class UiShellController {
       t: (key, vars) => this.t(key, vars),
       normalizeLanguage: (lang) => I18N.normalizeLang(lang ?? ""),
     });
-    deps.chromeActions.attach({
+    deps.chromeActions.value = {
       activateView: (viewId) => this.setActiveView(viewId),
       cancelConfirmation: () => this.confirmation.cancel(),
       confirmConfirmation: () => this.confirmation.confirm(),
       saveLanguage: (lang) => this.preferences.saveLanguage(lang),
       saveSpeedUnit: (unit) => this.preferences.saveSpeedUnit(unit),
-    });
+    };
     this.navigationRenderModel = this.createNavigationRenderModel();
     this.preferencesRenderModel = this.createPreferencesRenderModel();
     this.statusRenderModel = this.createStatusRenderModel();

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -3,14 +3,15 @@ import { createAppState } from "./ui_app_state";
 import { UiAppRuntime } from "./ui_app_runtime";
 import { createLazyUiPanels } from "./ui_lazy_panels";
 import {
-  createUiShellChromeActionBridge,
+  DEFAULT_UI_SHELL_CHROME_ACTIONS,
   getUiShellChromeHost,
   mountUiShellChrome,
 } from "./runtime/ui_shell_chrome";
+import { signal } from "./ui_signals";
 
 export function startUiApp(): void {
   const state = createAppState();
-  const shellChromeActions = createUiShellChromeActionBridge();
+  const shellChromeActions = signal({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS });
   const shellChrome = mountUiShellChrome(getUiShellChromeHost(), shellChromeActions);
   const lazyPanels = createLazyUiPanels({ hosts: shellChrome.panelHosts });
   new UiAppRuntime({

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -9,8 +9,8 @@ import type { AppState } from "./ui_app_state";
 import { createAppState } from "./ui_app_state";
 import { UiLiveTransportController } from "./runtime/ui_live_transport_controller";
 import {
-  createUiShellChromeActionBridge,
-  type UiShellChromeActionBridge,
+  DEFAULT_UI_SHELL_CHROME_ACTIONS,
+  type UiShellChromeActions,
   type UiShellChromeView,
 } from "./runtime/ui_shell_chrome";
 import { DEFAULT_SHELL_VIEW_ID } from "./runtime/ui_shell_navigation_module";
@@ -18,13 +18,14 @@ import { UiShellController } from "./runtime/ui_shell_controller";
 import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
 import { UiStartupCoordinator } from "./runtime/ui_startup_coordinator";
 import type { UiMountedPanels } from "./ui_panel_bootstrap";
+import { signal, type Signal } from "./ui_signals";
 
 export interface UiAppRuntimeDeps {
   shellChrome: UiShellChromeView;
   panels: UiMountedPanels;
   ensureViewPanels?: (viewId: string) => Promise<void> | void;
   state?: AppState;
-  shellChromeActions?: UiShellChromeActionBridge;
+  shellChromeActions?: Signal<UiShellChromeActions>;
 }
 
 function requireUiRuntimeDependency<T>(value: T | null, name: string): T {
@@ -89,7 +90,7 @@ export class UiAppRuntime {
   constructor(deps: UiAppRuntimeDeps) {
     const state = deps.state ?? createAppState();
     const shellChromeActions =
-      deps.shellChromeActions ?? createUiShellChromeActionBridge();
+      deps.shellChromeActions ?? signal<UiShellChromeActions>({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS });
     let spectrum: UiSpectrumController | null = null;
     let shellBindings: AppFeatureBundle["shell"] | null = null;
     const shell = new UiShellController({

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -3,7 +3,8 @@ import { expect, test } from "@playwright/test";
 import { createAppState } from "../src/app/ui_app_state";
 import { UiShellController } from "../src/app/runtime/ui_shell_controller";
 import {
-  createUiShellChromeActionBridge,
+  DEFAULT_UI_SHELL_CHROME_ACTIONS,
+  type UiShellChromeActions,
   type UiShellChromeDialogModel,
   type UiShellChromeNavigationModel,
   type UiShellChromePreferencesModel,
@@ -186,13 +187,32 @@ test.describe("UiShellController", () => {
     installWindowStub();
   });
 
+  test("publishes live shell actions through the provided signal", () => {
+    const state = createAppState();
+    const chrome = createChromeViewRecorder();
+    const chromeActions = signal<UiShellChromeActions>({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS });
+    new UiShellController({
+      bindFeatureHandlers: () => undefined,
+      chrome: chrome.view,
+      chromeActions,
+      liveOverview: {
+        model: signal(null),
+        speedText: signal("--"),
+      },
+      state,
+    });
+
+    chromeActions.value.activateView("historyView");
+    expect(state.shell.activeViewId.value).toBe("historyView");
+  });
+
   test("routes live status updates through the status model only", () => {
     const state = createAppState();
     const chrome = createChromeViewRecorder();
     const controller = new UiShellController({
       bindFeatureHandlers: () => undefined,
       chrome: chrome.view,
-      chromeActions: createUiShellChromeActionBridge(),
+      chromeActions: signal<UiShellChromeActions>({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS }),
       liveOverview: {
         model: signal(null),
         speedText: signal("--"),
@@ -231,7 +251,7 @@ test.describe("UiShellController", () => {
     const controller = new UiShellController({
       bindFeatureHandlers: () => undefined,
       chrome: chrome.view,
-      chromeActions: createUiShellChromeActionBridge(),
+      chromeActions: signal<UiShellChromeActions>({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS }),
       liveOverview: {
         model: signal(null),
         speedText: signal("--"),


### PR DESCRIPTION
## What changed
- remove `UiShellChromeActionBridge` and `createUiShellChromeActionBridge()`
- thread a plain `Signal<UiShellChromeActions>` through shell chrome, runtime, and controller wiring
- update shell runtime tests to prove the controller publishes live handlers into the provided action signal

## Why
- old bridge was manual ref state: `.current` plus `attach()`
- direct signal keeps one canonical action surface and cuts wrapper code

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts tests/smoke.bootstrap.spec.ts`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- startup still begins with no-op shell actions until the controller binds real handlers; this preserves the existing initialization behavior
- change is internal shell wiring only; no external contract or schema shift

Closes #2599
