### PR TITLE
FE: Extract reusable effectOnChange() helper for skip-first-run effects

### DIFF
--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -11,7 +11,7 @@ import type {
   RunDetail,
   ShellState,
 } from "../ui_app_state";
-import { computed, effect, untracked } from "../ui_signals";
+import { computed, effectOnChange, untracked } from "../ui_signals";
 import type {
   HistoryPanelRenderModel,
   HistoryPanelView,
@@ -233,19 +233,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
   }
 
   function bindReactiveLanguageSync(): void {
-    let initialized = false;
-    let previousLanguage = shell.lang.value;
-    effect(() => {
-      const currentLanguage = shell.lang.value;
-      if (!initialized) {
-        initialized = true;
-        previousLanguage = currentLanguage;
-        return;
-      }
-      if (currentLanguage === previousLanguage) {
-        return;
-      }
-      previousLanguage = currentLanguage;
+    effectOnChange(shell.lang, () => {
       untracked(() => {
         reloadExpandedRunOnLanguageChange();
       });

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -1,7 +1,7 @@
 import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import { createCarSelectionDerivedState } from "../car_selection_state";
 import type { SettingsState, ShellState } from "../ui_app_state";
-import { effect, untracked, type ReadonlySignal } from "../ui_signals";
+import { effectOnChange, untracked, type ReadonlySignal } from "../ui_signals";
 import type { CarsPayload } from "../../api/types";
 import {
   createSettingsAnalysisModule,
@@ -144,18 +144,7 @@ export function createSettingsFeature(
     formatting,
   });
 
-  let initializedLanguage = false;
-  let previousLanguage = ctx.state.shell.lang.value;
-  effect(() => {
-    const currentLanguage = ctx.state.shell.lang.value;
-    if (!initializedLanguage) {
-      initializedLanguage = true;
-      previousLanguage = currentLanguage;
-    } else if (currentLanguage === previousLanguage) {
-      return;
-    } else {
-      previousLanguage = currentLanguage;
-    }
+  effectOnChange(ctx.state.shell.lang, () => {
     untracked(() => {
       analysisModule.syncSettingsInputs();
     });

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -7,7 +7,7 @@ import {
   batchAppStateUpdates,
   type AppState,
 } from "../ui_app_state";
-import { effect, untracked } from "../ui_signals";
+import { effect, effectOnChange, untracked } from "../ui_signals";
 
 type UiLiveTransportControllerDeps = {
   state: AppState;
@@ -47,25 +47,13 @@ export class UiLiveTransportController {
       });
     });
 
-    let previousPendingPayload = this.state.transport.pendingPayload.value;
-    effect(() => {
-      const nextPendingPayload = this.state.transport.pendingPayload.value;
-      if (nextPendingPayload === previousPendingPayload) {
-        return;
-      }
-      previousPendingPayload = nextPendingPayload;
+    effectOnChange(this.state.transport.pendingPayload, (nextPendingPayload) => {
       if (nextPendingPayload !== null) {
         untracked(() => this.queueRender());
       }
     });
 
-    let previousWsState = this.state.transport.wsState.value;
-    effect(() => {
-      const nextWsState = this.state.transport.wsState.value;
-      if (nextWsState === previousWsState) {
-        return;
-      }
-      previousWsState = nextWsState;
+    effectOnChange(this.state.transport.wsState, (nextWsState) => {
       if (nextWsState === "connected" || nextWsState === "no_data") {
         untracked(() => this.sendSelection());
       }

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -5,6 +5,7 @@ import type { AppState } from "../ui_app_state";
 import {
   computed,
   effect,
+  effectOnChange,
   signal,
   untracked,
   type Signal,
@@ -191,18 +192,7 @@ export class UiShellController {
   }
 
   private bindReactiveLanguageSync(): void {
-    let initialized = false;
-    let previousLanguage = this.state.shell.lang.value;
-    effect(() => {
-      const currentLanguage = this.state.shell.lang.value;
-      if (!initialized) {
-        initialized = true;
-        previousLanguage = currentLanguage;
-      } else if (currentLanguage === previousLanguage) {
-        return;
-      } else {
-        previousLanguage = currentLanguage;
-      }
+    effectOnChange(this.state.shell.lang, (currentLanguage) => {
       untracked(() => {
         setUiLanguage(currentLanguage);
       });

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -1,5 +1,5 @@
 import type { AppState } from "../ui_app_state";
-import { effect, untracked } from "../ui_signals";
+import { effect, effectOnChange, untracked } from "../ui_signals";
 import {
   createSpectrumCanvasRenderer,
   type SpectrumCanvasRenderer,
@@ -127,19 +127,7 @@ export class UiSpectrumController {
   }
 
   private bindReactiveLanguageSync(): void {
-    let initialized = false;
-    let previousLanguage = this.state.shell.lang.value;
-    effect(() => {
-      const currentLanguage = this.state.shell.lang.value;
-      if (!initialized) {
-        initialized = true;
-        previousLanguage = currentLanguage;
-        return;
-      }
-      if (currentLanguage === previousLanguage) {
-        return;
-      }
-      previousLanguage = currentLanguage;
+    effectOnChange(this.state.shell.lang, () => {
       untracked(() => {
         this.renderSpectrumHeader();
         this.updateSpectrumOverlay();

--- a/apps/ui/src/app/ui_signals.ts
+++ b/apps/ui/src/app/ui_signals.ts
@@ -69,3 +69,19 @@ export function useSignalProperties<
 >(source: ReadonlySignal<T>, keys: K): SignalPropertyMap<T, K> {
   return getOrCreateSignalPropertyMap(source, keys);
 }
+
+export function effectOnChange<T>(
+  source: ReadonlySignal<T>,
+  callback: (value: T, previousValue: T) => void,
+): () => void {
+  let previousValue = source.peek();
+  return effect(() => {
+    const nextValue = source.value;
+    if (Object.is(nextValue, previousValue)) {
+      return;
+    }
+    const oldValue = previousValue;
+    previousValue = nextValue;
+    callback(nextValue, oldValue);
+  });
+}

--- a/apps/ui/tests/signal_view_reference_tests.ts
+++ b/apps/ui/tests/signal_view_reference_tests.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { computed, effect, signal, useSignalProperties } from "../src/app/ui_signals";
+import { computed, effect, effectOnChange, signal, useSignalProperties } from "../src/app/ui_signals";
 import type {
   RealtimeLiveOverviewBridge,
   RealtimeLiveOverviewRenderModel,
@@ -212,6 +212,28 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
   }
 }
 
+async function runEffectOnChangeReferenceTest(): Promise<void> {
+  const source = signal("idle");
+  const observed: Array<[string, string]> = [];
+  const dispose = effectOnChange(source, (value, previousValue) => {
+    observed.push([previousValue, value]);
+  });
+
+  try {
+    source.value = "idle";
+    source.value = "running";
+    source.value = "running";
+    source.value = "done";
+
+    assert.deepEqual(observed, [
+      ["idle", "running"],
+      ["running", "done"],
+    ]);
+  } finally {
+    dispose();
+  }
+}
+
 async function runSignalPropertiesHelperReferenceTest(): Promise<void> {
   const badgeText = signal("Idle");
   const hidden = signal(true);
@@ -327,6 +349,10 @@ const referenceTests = [
   {
     name: "realtime live overview computed-driven output",
     run: runRealtimeLiveOverviewReferenceTest,
+  },
+  {
+    name: "effectOnChange skips initial and unchanged values",
+    run: runEffectOnChangeReferenceTest,
   },
   {
     name: "useSignalProperties returns direct binding signals",


### PR DESCRIPTION
## What changed
- add `effectOnChange()` to `ui_signals.ts`
- replace hand-rolled skip-first-run effect bookkeeping in live transport plus shell/settings/history/spectrum language-sync callers
- add a direct helper reference test in `tests/signal_view_reference_tests.ts`

## Why
- same pattern kept repeating: seed previous value, skip first run, ignore unchanged values
- one shared helper keeps side-effect code small and makes the first-run contract explicit
- issue body caller list was stale, so the refactor follows the live remaining sites instead

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run test:signals`
- `cd apps/ui && npx playwright test tests/ui_live_transport_controller.spec.ts tests/history_feature_modules.spec.ts tests/ui_spectrum_controller.spec.ts tests/ui_shell_runtime_modules.spec.ts tests/app_feature_ports.spec.ts`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- helper only fits single-source change detection; the multi-signal spectrum transport sync still stays custom
- lint remains at the same unrelated warnings in `esp_flash_journey_presenter.ts` and `history_detail_presenter.ts`

Closes #2600
