### PR TITLE
FE: Eliminate batchAppStateUpdates() wrapper — use batch() directly

### DIFF
--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -1,6 +1,6 @@
 import { EXPECTED_LIVE_PAYLOAD_SCHEMA_VERSION } from "../transport/live_models";
-import { batchAppStateUpdates } from "./ui_app_state";
 import type { AppState } from "./ui_app_state";
+import { batch } from "./ui_signals";
 
 type DemoDeps = {
   queueTransportPayload(payload: unknown): void;
@@ -177,7 +177,7 @@ export function runDemoMode(deps: DemoDeps): void {
     spectra: { clients: demoSpectra },
   };
 
-  batchAppStateUpdates(() => {
+  batch(() => {
     state.settings.carsLoaded.value = true;
     state.settings.cars.value = [
       {

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -10,10 +10,7 @@ import {
   type DisplayedSpeedSourceMode,
   type SpeedSourceStateSnapshot,
 } from "../speed_source_state";
-import {
-  batchAppStateUpdates,
-  type SettingsState,
-} from "../ui_app_state";
+import type { SettingsState } from "../ui_app_state";
 import {
   batch,
   computed,
@@ -309,13 +306,11 @@ export function createSettingsSpeedSourceWorkflow(
 
   function applyPayload(payload: SpeedSourcePayload): void {
     batch(() => {
-      batchAppStateUpdates(() => {
-        deps.settings.speedSource.value = payload.speed_source;
-        deps.settings.manualSpeedKph.value = payload.manual_speed_kph;
-        deps.settings.obdDeviceMac.value = payload.obd_device_mac ?? null;
-        deps.settings.obdDeviceName.value = payload.obd_device_name ?? null;
-        deps.settings.resolvedSpeedSource.value = null;
-      });
+      deps.settings.speedSource.value = payload.speed_source;
+      deps.settings.manualSpeedKph.value = payload.manual_speed_kph;
+      deps.settings.obdDeviceMac.value = payload.obd_device_mac ?? null;
+      deps.settings.obdDeviceName.value = payload.obd_device_name ?? null;
+      deps.settings.resolvedSpeedSource.value = null;
       staleTimeoutInputValue.value = String(payload.stale_timeout_s);
       syncInputsFromSettings();
     });
@@ -483,10 +478,8 @@ export function createSettingsSpeedSourceWorkflow(
     try {
       const payload = await transport.pairObdDevice(macAddress);
       batch(() => {
-        batchAppStateUpdates(() => {
-          deps.settings.obdDeviceMac.value = payload.configured_device_mac ?? null;
-          deps.settings.obdDeviceName.value = payload.configured_device_name ?? null;
-        });
+        deps.settings.obdDeviceMac.value = payload.configured_device_mac ?? null;
+        deps.settings.obdDeviceName.value = payload.configured_device_name ?? null;
         mergeScannedDevices([{
           connected: payload.connected,
           mac_address: payload.configured_device_mac ?? macAddress,

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -4,10 +4,9 @@ import { runDemoMode } from "../demo_mode";
 import { createWsClient } from "../../ws";
 import {
   applyLivePayloadUpdate,
-  batchAppStateUpdates,
   type AppState,
 } from "../ui_app_state";
-import { effect, effectOnChange, untracked } from "../ui_signals";
+import { batch, effect, effectOnChange, untracked } from "../ui_signals";
 
 type UiLiveTransportControllerDeps = {
   state: AppState;
@@ -42,7 +41,7 @@ export class UiLiveTransportController {
       if (this.state.transport.wsState.value === nextWsState) {
         return;
       }
-      batchAppStateUpdates(() => {
+      batch(() => {
         this.state.transport.wsState.value = nextWsState;
       });
     });
@@ -87,7 +86,7 @@ export class UiLiveTransportController {
       }
       const payload = this.state.transport.pendingPayload.value;
       if (!payload) return;
-      batchAppStateUpdates(() => {
+      batch(() => {
         this.state.transport.pendingPayload.value = null;
         this.state.transport.lastRenderTsMs.value = now;
       });
@@ -100,7 +99,7 @@ export class UiLiveTransportController {
     try {
       adapted = adaptServerPayload(payload);
     } catch (error) {
-      batchAppStateUpdates(() => {
+      batch(() => {
         this.state.transport.payloadError.value =
           error instanceof Error ? error.message : this.payloadErrorMessage();
         this.state.spectrum.hasSpectrumData.value = false;
@@ -108,9 +107,10 @@ export class UiLiveTransportController {
       return;
     }
 
-    const update = batchAppStateUpdates(() => {
+    let update!: ReturnType<typeof applyLivePayloadUpdate>;
+    batch(() => {
       this.state.transport.payloadError.value = null;
-      return applyLivePayloadUpdate({
+      update = applyLivePayloadUpdate({
         realtime: this.state.realtime,
         spectrum: this.state.spectrum,
         adaptedPayload: adapted,
@@ -122,7 +122,7 @@ export class UiLiveTransportController {
   }
 
   private queueTransportPayload(payload: unknown): void {
-    batchAppStateUpdates(() => {
+    batch(() => {
       this.state.transport.wsState.value = "connected";
       this.state.transport.hasReceivedPayload.value = true;
       this.state.transport.pendingPayload.value = payload;

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -17,14 +17,6 @@ import type {
 } from "../api/types";
 import { batch, signal, type Signal } from "./ui_signals";
 
-export function batchAppStateUpdates<T>(callback: () => T): T {
-  let result!: T;
-  batch(() => {
-    result = callback();
-  });
-  return result;
-}
-
 export interface VehicleSettings {
   tire_width_mm: number;
   tire_aspect_pct: number;
@@ -139,7 +131,8 @@ export function syncSelectedRealtimeClient(realtime: RealtimeState): void {
 }
 
 export function applyLivePayloadUpdate(deps: LivePayloadUpdateDeps): LivePayloadUpdateResult {
-  return batchAppStateUpdates(() => {
+  let update!: LivePayloadUpdateResult;
+  batch(() => {
     const { realtime, spectrum, adaptedPayload } = deps;
     const previousSelectedClientId = realtime.selectedClientId.value;
     realtime.clients.value = adaptedPayload.clients;
@@ -153,7 +146,7 @@ export function applyLivePayloadUpdate(deps: LivePayloadUpdateDeps): LivePayload
     realtime.speedMps.value = adaptedPayload.speed_mps;
     realtime.rotationalSpeeds.value = adaptedPayload.rotational_speeds;
     spectrum.hasSpectrumData.value = spectrumTick.hasSpectrumData;
-    return {
+    update = {
       hasSelectedClientChanged: previousSelectedClientId !== realtime.selectedClientId.value,
       selectedClient: realtime.clients.value.find(
         (client) => client.id === realtime.selectedClientId.value,
@@ -161,6 +154,7 @@ export function applyLivePayloadUpdate(deps: LivePayloadUpdateDeps): LivePayload
       hasNewSpectrumFrame: spectrumTick.hasNewSpectrumFrame,
     };
   });
+  return update;
 }
 
 export type SignalState<T extends object> = {

--- a/apps/ui/src/ws.ts
+++ b/apps/ui/src/ws.ts
@@ -1,6 +1,5 @@
 import type { LiveWsPayload } from "./contracts/ws_payload_types";
-import { batchAppStateUpdates } from "./app/ui_app_state";
-import { effect, signal, type ReadonlySignal } from "./app/ui_signals";
+import { batch, effect, signal, type ReadonlySignal } from "./app/ui_signals";
 
 export type WsUiState = "connecting" | "connected" | "reconnecting" | "stale" | "no_data";
 
@@ -56,7 +55,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
   };
 
   function connect(): void {
-    batchAppStateUpdates(() => {
+    batch(() => {
       manuallyClosed.value = false;
       reconnectDelayMs.value = null;
     });
@@ -64,7 +63,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
   }
 
   function close(): void {
-    batchAppStateUpdates(() => {
+    batch(() => {
       manuallyClosed.value = true;
       reconnectDelayMs.value = null;
       socketOpen.value = false;
@@ -82,7 +81,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
   }
 
   function open(initialState: WsUiState): void {
-    batchAppStateUpdates(() => {
+    batch(() => {
       commitState(initialState);
       hasReceivedData.value = false;
       lastMessageAtMs.value = 0;
@@ -91,7 +90,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
     ws = new WebSocket(resolvedOptions.url);
 
     ws.onopen = () => {
-      batchAppStateUpdates(() => {
+      batch(() => {
         socketOpen.value = true;
         commitState("no_data");
       });
@@ -105,7 +104,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
         return;
       }
       const receivedAt = Date.now();
-      batchAppStateUpdates(() => {
+      batch(() => {
         reconnectAttempt.value = 0;
         lastMessageAtMs.value = receivedAt;
         hasReceivedData.value = hasReceivedData.value || resolvedOptions.hasData(payload);
@@ -115,7 +114,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
     };
 
     ws.onclose = () => {
-      batchAppStateUpdates(() => {
+      batch(() => {
         ws = null;
         socketOpen.value = false;
         if (manuallyClosed.value) {
@@ -151,7 +150,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
         return;
       }
       const timeoutId = window.setTimeout(() => {
-        batchAppStateUpdates(() => {
+        batch(() => {
           reconnectDelayMs.value = null;
         });
         open("reconnecting");
@@ -185,7 +184,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
   }
 
   function setState(next: WsUiState): void {
-    batchAppStateUpdates(() => {
+    batch(() => {
       commitState(next);
     });
   }

--- a/apps/ui/tests/ui_app_state.spec.ts
+++ b/apps/ui/tests/ui_app_state.spec.ts
@@ -1,10 +1,9 @@
 import { expect, test } from "@playwright/test";
 
 import {
-  batchAppStateUpdates,
   createAppState,
 } from "../src/app/ui_app_state";
-import { effect } from "../src/app/ui_signals";
+import { batch, effect } from "../src/app/ui_signals";
 
 test.describe("ui_app_state reactivity", () => {
   test("tracks shell writes directly through field signals without slice tracking", () => {
@@ -19,7 +18,7 @@ test.describe("ui_app_state reactivity", () => {
 
     expect(seenShellState).toEqual(["en:kmh:dashboardView"]);
 
-    batchAppStateUpdates(() => {
+    batch(() => {
       state.shell.lang.value = "nl";
       state.shell.speedUnit.value = "mps";
       state.shell.activeViewId.value = "historyView";
@@ -116,7 +115,7 @@ test.describe("ui_app_state reactivity", () => {
 
     expect(seenSnapshots).toEqual(["connecting:false:null"]);
 
-    batchAppStateUpdates(() => {
+    batch(() => {
       state.transport.wsState.value = "connected";
       state.transport.hasReceivedPayload.value = true;
       state.transport.payloadError.value = "frame-error";

--- a/apps/ui/tests/ws.spec.ts
+++ b/apps/ui/tests/ws.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
-import { batchAppStateUpdates, createAppState } from "../src/app/ui_app_state";
+import { createAppState } from "../src/app/ui_app_state";
+import { batch } from "../src/app/ui_signals";
 import { createWsClient } from "../src/ws";
 import { installWindowGlobal } from "./async_test_helpers";
 
@@ -134,7 +135,7 @@ test.describe("createWsClient", () => {
       const client = createWsClient({
         url: "ws://example.test/ws",
         onMessage: (payload) => {
-          batchAppStateUpdates(() => {
+          batch(() => {
             state.transport.hasReceivedPayload.value = true;
             state.transport.pendingPayload.value = payload;
           });


### PR DESCRIPTION
## What changed
- remove `batchAppStateUpdates()` from `ui_app_state.ts`
- switch live void callers to direct `batch()` in demo mode, websocket runtime, transport runtime, and speed-source workflow
- keep the one real return-value case in `applyLivePayloadUpdate()` with a local result variable around `batch()`
- update focused ws/app-state tests to use `batch()` directly

## Why
- wrapper only mirrored `batch()` and hid where batching actually matters
- live caller list was broader than the issue body, so the refactor follows the full current blast radius and deletes the helper completely

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ws.spec.ts tests/ui_app_state.spec.ts tests/ui_live_transport_controller.spec.ts tests/settings_speed_source_workflow.spec.ts tests/smoke.bootstrap.spec.ts`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- only `applyLivePayloadUpdate()` still needs the local result pattern because it computes and returns batched derived data
- lint remains at the same unrelated warnings in `esp_flash_journey_presenter.ts` and `history_detail_presenter.ts`

Closes #2601
