### PR TITLE
FE: Inline or remove view_style_types.ts — only 2 type aliases

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -24,9 +24,10 @@ import {
 import {
   createDeferredModelSignal,
 } from "../views/view_model_binding";
-import type { VisualVariant } from "../view_style_types";
 const SHELL_OWNER = "UI shell";
 const SHELL_CHROME_HOST_ID = "appShellChromeRoot";
+
+type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 export const SHELL_NAV_ITEMS = [
   {

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -45,7 +45,8 @@ import {
   SPEED_UNIT_OPTIONS,
 } from "./ui_shell_chrome";
 import type { RealtimeLiveOverviewBridge } from "../views/realtime_live_overview";
-import type { VisualVariant } from "../view_style_types";
+
+type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 type UiShellControllerDeps = {
   bindFeatureHandlers: () => void;

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -6,9 +6,10 @@ import type {
   ShellState,
   TransportState,
 } from "../ui_app_state";
-import type { VisualVariant } from "../view_style_types";
 import { computed, type ReadonlySignal } from "../ui_signals";
 import type { UiShellBadgeModel } from "./ui_shell_chrome";
+
+type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 const WS_KEY_BY_STATE: Record<string, string> = {
   connecting: "ws.connecting",

--- a/apps/ui/src/app/view_style_types.ts
+++ b/apps/ui/src/app/view_style_types.ts
@@ -1,3 +1,0 @@
-export type VisualVariant = "bad" | "muted" | "ok" | "warn";
-
-export type ChoiceCardState = "active" | "draft" | "error";

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -8,12 +8,13 @@ import {
   type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
-import type { VisualVariant } from "../view_style_types";
 import {
   MaintenanceReadinessPanel,
   type MaintenanceReadinessPanelModel,
 } from "./maintenance_readiness_view";
 import { type DeferredModelSignal } from "./view_model_binding";
+
+type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 export interface EspFlashStatusBadgeModel {
   text: string;

--- a/apps/ui/src/app/views/esp_flash_readiness_presenter.ts
+++ b/apps/ui/src/app/views/esp_flash_readiness_presenter.ts
@@ -4,13 +4,14 @@ import type {
   EspSerialPortPayload,
 } from "../../api/types";
 import { formatEpochTimestamp } from "../../format";
-import type { VisualVariant } from "../view_style_types";
 import type { MaintenanceReadinessPanelModel } from "./maintenance_readiness_view";
 import type {
   EspFlashReadinessPanelModel,
   EspFlashStatusBadgeModel,
   EspFlashStatusGridRowModel,
 } from "./esp_flash_panel";
+
+type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 const STATE_TO_VARIANT: Readonly<Record<string, VisualVariant>> = {
   failed: "bad",

--- a/apps/ui/src/app/views/internet_panel.tsx
+++ b/apps/ui/src/app/views/internet_panel.tsx
@@ -2,7 +2,6 @@ import { render, type ComponentChildren } from "preact";
 import { useRef } from "preact/hooks";
 
 import type { UpdateStartRequestPayload } from "../../api/types";
-import type { ChoiceCardState } from "../view_style_types";
 import { getUiText as t } from "../ui_i18n";
 import {
   computed,
@@ -21,6 +20,8 @@ import type {
   UpdateStatusBadgeModel,
   UpdateStatusRowModel,
 } from "./update_status_models";
+
+type ChoiceCardState = "active" | "draft" | "error";
 
 export interface UpdateTransportChoiceCardRenderModel {
   badgeText: string | null;

--- a/apps/ui/src/app/views/maintenance_readiness_view.tsx
+++ b/apps/ui/src/app/views/maintenance_readiness_view.tsx
@@ -1,6 +1,5 @@
-import type { VisualVariant } from "../view_style_types";
-
 export type MaintenanceReadinessItemState = "attention" | "blocked" | "ready";
+type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 export interface MaintenanceReadinessItem {
   label: string;

--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -1,7 +1,6 @@
 import { render } from "preact";
 
 import type { DisplayedSpeedSourceMode } from "../speed_source_state";
-import type { ChoiceCardState } from "../view_style_types";
 import {
   computed,
   effect,
@@ -16,6 +15,8 @@ import type {
   SettingsFeedbackMessage,
 } from "./settings_feedback";
 import type { DeferredModelSignal } from "./view_model_binding";
+
+type ChoiceCardState = "active" | "draft" | "error";
 
 export interface SpeedSourceChoiceCardRenderModel {
   badgeText: string | null;


### PR DESCRIPTION
## What changed
- delete `apps/ui/src/app/view_style_types.ts`
- keep `VisualVariant` local in the shell/esp-flash/readiness modules that actually use it
- keep `ChoiceCardState` local in the speed-source and internet panel views
- update imports so no module reaches through a standalone shared type file

## Why
- the old file only held two tiny unions
- live usage did not have one clean owner: `VisualVariant` spans shell runtime and multiple views, so moving it to one module would create a worse dependency edge than keeping the literal unions local

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts tests/esp_flash_feature_presenter.spec.ts tests/settings_speed_source_presenter.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts tests/smoke.settings.spec.ts`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- literal unions now live in the touched owner modules instead of one shared file
- lint remains at the same unrelated warnings in `esp_flash_journey_presenter.ts` and `history_detail_presenter.ts`

Closes #2602
