### PR TITLE
FE: Simplify loggingElapsedTickInputs effect chain in realtime_feature_view_state.ts

### DIFF
--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -181,6 +181,20 @@ export function createRealtimeFeatureViewState(
     cachedLoggingElapsedTickInputs = nextTickInputs;
     return nextTickInputs;
   });
+  const loggingElapsedShouldTick = computed(() => {
+    const {
+      handlersBound,
+      loggingEnabled,
+      loggingStartTimeUtc,
+    } = loggingElapsedTickInputs.value;
+    return handlersBound && Boolean(loggingEnabled && loggingStartTimeUtc);
+  });
+  const loggingElapsedTimerStartTime = computed(() => {
+    if (!loggingElapsedShouldTick.value) {
+      return null;
+    }
+    return loggingElapsedTickInputs.value.loggingStartTimeUtc;
+  });
   const lastCompletedElapsedText = computed(() => {
     const loggingStatus = realtime.loggingStatus.value;
     if (loggingStatus.enabled) {
@@ -201,14 +215,12 @@ export function createRealtimeFeatureViewState(
   const loggingElapsedTimer = createReplaceableInterval();
 
   effect(() => {
-    const {
-      handlersBound,
-      loggingEnabled,
-      loggingStartTimeUtc,
-    } = loggingElapsedTickInputs.value;
-    const shouldTick =
-      handlersBound && Boolean(loggingEnabled && loggingStartTimeUtc);
-    if (!shouldTick) {
+    if (!loggingElapsedShouldTick.value) {
+      loggingElapsedTimer.clear();
+      return;
+    }
+    const loggingStartTimeUtc = loggingElapsedTimerStartTime.value;
+    if (!loggingStartTimeUtc) {
       loggingElapsedTimer.clear();
       return;
     }


### PR DESCRIPTION
## What changed
- extract `loggingElapsedShouldTick` from `loggingElapsedTickInputs` in `realtime_feature_view_state.ts`
- add a computed timer-start key so the timer still re-arms when `start_time_utc` changes during an active run
- narrow the effect to timer lifecycle work instead of recomputing the pure condition inline

## Why
- the old effect mixed condition derivation with timer side effects
- the cleanup needs to preserve the existing re-arm behavior when a run restarts with a new start time, so the refactor splits the pure boolean and the timer key instead of watching the full object inline

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/realtime_feature_view_state.spec.ts tests/smoke.bootstrap.spec.ts`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- the refactor introduces one extra computed signal to preserve the existing start-time re-arm behavior
- lint remains at the same unrelated warnings in `esp_flash_journey_presenter.ts` and `history_detail_presenter.ts`

Closes #2603
