### PR TITLE
FE: Remove AbortSignal composition polyfill — use AbortSignal.any()

### DIFF
--- a/apps/ui/src/api/http.ts
+++ b/apps/ui/src/api/http.ts
@@ -1,31 +1,13 @@
 const DEFAULT_TIMEOUT_MS = 10000;
-const NOOP = () => {};
 const WHITESPACE_RE = /\s+/g;
 const DEFAULT_TIMEOUT_MESSAGE = "Request timed out.";
 
 function composeSignal(
   timeoutSignal: AbortSignal,
   externalSignal?: AbortSignal,
-): { signal: AbortSignal; cleanup: () => void } {
-  if (!externalSignal) return { signal: timeoutSignal, cleanup: NOOP };
-  if ("any" in AbortSignal) {
-    return { signal: AbortSignal.any([timeoutSignal, externalSignal]), cleanup: NOOP };
-  }
-
-  const controller = new AbortController();
-  const abortFromExternal = () => controller.abort(externalSignal.reason);
-  const abortFromTimeout = () => controller.abort(timeoutSignal.reason);
-  externalSignal.addEventListener("abort", abortFromExternal, { once: true });
-  timeoutSignal.addEventListener("abort", abortFromTimeout, { once: true });
-  if (externalSignal.aborted) abortFromExternal();
-  if (timeoutSignal.aborted) abortFromTimeout();
-  return {
-    signal: controller.signal,
-    cleanup: () => {
-      externalSignal.removeEventListener("abort", abortFromExternal);
-      timeoutSignal.removeEventListener("abort", abortFromTimeout);
-    },
-  };
+): AbortSignal {
+  if (!externalSignal) return timeoutSignal;
+  return AbortSignal.any([timeoutSignal, externalSignal]);
 }
 
 function formatBodySnippet(text: string): string {
@@ -52,10 +34,9 @@ export async function apiJsonResponse<T = unknown>(
     () => timeoutController.abort(new DOMException(DEFAULT_TIMEOUT_MESSAGE, "AbortError")),
     timeoutMs,
   );
-  const { signal, cleanup } = composeSignal(timeoutController.signal, externalSignal ?? undefined);
+  const signal = composeSignal(timeoutController.signal, externalSignal ?? undefined);
   const response = await fetch(path, { ...requestInit, signal }).finally(() => {
     window.clearTimeout(timeoutId);
-    cleanup();
   });
   const bodyText = await response.text();
   if (!response.ok) {


### PR DESCRIPTION
## What changed
- remove the old controller/listener fallback from `apps/ui/src/api/http.ts`
- make `composeSignal()` return either the timeout signal or `AbortSignal.any([timeoutSignal, externalSignal])`
- drop the no-op cleanup plumbing that only existed for the removed fallback

## Why
- the code already preferred `AbortSignal.any()`
- supported browsers already have native `AbortSignal.any()`, so the fallback path was dead complexity

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/api_http.spec.ts`
- `cd apps/ui && npm run lint`

## Risks / tradeoffs
- this removes compatibility with runtimes that lack `AbortSignal.any()`
- lint remains at the same unrelated warnings in `esp_flash_journey_presenter.ts` and `history_detail_presenter.ts`

Closes #2604
