### PR TITLE
UI: extract shared VisualVariant type

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -16,6 +16,7 @@ import {
   type ReadonlySignal,
   useSignalEffect,
 } from "../ui_signals";
+import type { VisualVariant } from "../visual_variant";
 import type { UiConfirmationDialogModel } from "./ui_confirmation_module";
 import {
   settingsFeedbackClassName,
@@ -26,8 +27,6 @@ import {
 } from "../views/view_model_binding";
 const SHELL_OWNER = "UI shell";
 const SHELL_CHROME_HOST_ID = "appShellChromeRoot";
-
-type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 export const SHELL_NAV_ITEMS = [
   {

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -11,6 +11,7 @@ import {
   type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
+import type { VisualVariant } from "../visual_variant";
 import {
   createUiConfirmationModule,
   type UiConfirmationModule,
@@ -45,8 +46,6 @@ import {
   SPEED_UNIT_OPTIONS,
 } from "./ui_shell_chrome";
 import type { RealtimeLiveOverviewBridge } from "../views/realtime_live_overview";
-
-type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 type UiShellControllerDeps = {
   bindFeatureHandlers: () => void;

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -7,9 +7,8 @@ import type {
   TransportState,
 } from "../ui_app_state";
 import { computed, type ReadonlySignal } from "../ui_signals";
+import type { VisualVariant } from "../visual_variant";
 import type { UiShellBadgeModel } from "./ui_shell_chrome";
-
-type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 const WS_KEY_BY_STATE: Record<string, string> = {
   connecting: "ws.connecting",

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -8,13 +8,12 @@ import {
   type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
+import type { VisualVariant } from "../visual_variant";
 import {
   MaintenanceReadinessPanel,
   type MaintenanceReadinessPanelModel,
 } from "./maintenance_readiness_view";
 import { type DeferredModelSignal } from "./view_model_binding";
-
-type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 export interface EspFlashStatusBadgeModel {
   text: string;

--- a/apps/ui/src/app/views/esp_flash_readiness_presenter.ts
+++ b/apps/ui/src/app/views/esp_flash_readiness_presenter.ts
@@ -4,14 +4,13 @@ import type {
   EspSerialPortPayload,
 } from "../../api/types";
 import { formatEpochTimestamp } from "../../format";
+import type { VisualVariant } from "../visual_variant";
 import type { MaintenanceReadinessPanelModel } from "./maintenance_readiness_view";
 import type {
   EspFlashReadinessPanelModel,
   EspFlashStatusBadgeModel,
   EspFlashStatusGridRowModel,
 } from "./esp_flash_panel";
-
-type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 const STATE_TO_VARIANT: Readonly<Record<string, VisualVariant>> = {
   failed: "bad",

--- a/apps/ui/src/app/views/maintenance_readiness_view.tsx
+++ b/apps/ui/src/app/views/maintenance_readiness_view.tsx
@@ -1,5 +1,6 @@
+import type { VisualVariant } from "../visual_variant";
+
 export type MaintenanceReadinessItemState = "attention" | "blocked" | "ready";
-type VisualVariant = "bad" | "muted" | "ok" | "warn";
 
 export interface MaintenanceReadinessItem {
   label: string;

--- a/apps/ui/src/app/visual_variant.ts
+++ b/apps/ui/src/app/visual_variant.ts
@@ -1,0 +1,1 @@
+export type VisualVariant = "bad" | "muted" | "ok" | "warn";


### PR DESCRIPTION
## Summary
Small type-only cleanup. One owner. Six imports.

## What changed
- add `apps/ui/src/app/visual_variant.ts` as the canonical `VisualVariant` export
- replace 6 local duplicate aliases with type-only imports
- keep runtime behavior and data flow unchanged

## Why
- one type shape, one owner
- no drift between runtime and view modules
- matches issue scope exactly

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoffs
- low risk; type-only module
- no runtime behavior change
- out of scope: other variant unions not named `VisualVariant`

Closes #2632