### PR TITLE
UI: remove dead live model type exports

### DIFF
--- a/apps/ui/src/transport/live_models.ts
+++ b/apps/ui/src/transport/live_models.ts
@@ -2,8 +2,6 @@ import {
   EXPECTED_SCHEMA_VERSION,
   type StrengthMetricsPayload,
   type WsClientInfo,
-  type WsOrderBand,
-  type WsRotationalSpeedValue,
   type WsRotationalSpeeds,
 } from "../contracts/ws_payload_types";
 
@@ -32,11 +30,7 @@ export type AdaptedClient = Pick<
   | "firmware_version"
 >;
 
-export type RotationalSpeedValue = WsRotationalSpeedValue;
-
 export type RotationalSpeeds = WsRotationalSpeeds;
-
-export type OrderBand = WsOrderBand;
 
 export interface AdaptedPayload {
   clients: AdaptedClient[];


### PR DESCRIPTION
## Summary
Small dead-code cleanup. Two unused type re-exports gone.

## What changed
- remove `RotationalSpeedValue` and `OrderBand` re-exports from `apps/ui/src/transport/live_models.ts`
- remove the matching unused `WsRotationalSpeedValue` and `WsOrderBand` imports
- keep all remaining live model exports unchanged

## Why
- repo search shows no imports for either alias
- keeps `live_models.ts` focused on types the UI still uses
- matches issue scope exactly

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoffs
- low risk; dead type-only exports
- no runtime behavior change
- out of scope: any future transport type reshaping

Closes #2633