### PR TITLE
UI: remove dead shell render type

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -132,12 +132,6 @@ export interface UiShellChromeDialogModel {
   confirmationDialog: UiConfirmationDialogModel | null;
 }
 
-export type UiShellChromeRenderModel =
-  & UiShellChromeNavigationModel
-  & UiShellChromePreferencesModel
-  & UiShellChromeStatusModel
-  & UiShellChromeDialogModel;
-
 export interface UiShellChromeView {
   bindDialogModel(model: ReadonlySignal<UiShellChromeDialogModel>): void;
   bindNavigationModel(model: ReadonlySignal<UiShellChromeNavigationModel>): void;


### PR DESCRIPTION
## Summary
Small dead-code cleanup. One unused intersection type gone.

## What changed
- remove the exported `UiShellChromeRenderModel` alias from `apps/ui/src/app/runtime/ui_shell_chrome.tsx`
- keep the individual shell chrome model interfaces and `bind*Model()` API unchanged

## Why
- repo search shows the alias is never imported
- shell chrome already works against the individual model types
- matches issue scope exactly

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoffs
- low risk; dead type-only alias
- no runtime behavior change
- out of scope: any broader shell chrome type reshaping

Closes #2634