### PR TITLE
UI: batch GPS status poll updates

### DIFF
--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -3,6 +3,7 @@ import { GPS_POLL_FAST_MS, GPS_POLL_SLOW_MS } from "../../config";
 import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
 import type { SettingsState } from "../ui_app_state";
 import {
+  batch,
   computed,
   signal,
   type ReadonlySignal,
@@ -70,10 +71,16 @@ export function createSettingsGpsStatusModule(
         getSpeedSourceStatus(),
         shouldLoadObdStatus ? getSettingsObdStatus() : Promise.resolve(null),
       ]);
-      settings.gpsFallbackActive.value = status.fallback_active;
-      settings.gpsEffectiveSpeedKph.value = status.effective_speed_kmh;
-      settings.resolvedSpeedSource.value = status.speed_source;
-      diagnosticsModel.value = buildSpeedSourceDiagnosticsRenderModel(status, obdStatus, presenterDeps);
+      batch(() => {
+        settings.gpsFallbackActive.value = status.fallback_active;
+        settings.gpsEffectiveSpeedKph.value = status.effective_speed_kmh;
+        settings.resolvedSpeedSource.value = status.speed_source;
+        diagnosticsModel.value = buildSpeedSourceDiagnosticsRenderModel(
+          status,
+          obdStatus,
+          presenterDeps,
+        );
+      });
       ctx.ports.syncSpeedSourceSelectionUi();
       ctx.ports.renderSpeedReadout();
       return status.connection_state === "connected"


### PR DESCRIPTION
## Summary
Small performance cleanup. GPS poll writes batch together.

## What changed
- wrap the four signal writes in `settings_gps_status_module.ts` poll callback with `batch()`
- keep `syncSpeedSourceSelectionUi()` and `renderSpeedReadout()` outside the batch
- leave polling cadence and fetched data unchanged

## Why
- the callback was emitting separate reactive notifications for each write
- the two imperative follow-up calls need to read the fresh batched state after writes land
- matches issue scope exactly

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoffs
- low risk; same values, fewer reactive flushes
- no visible behavior change intended
- out of scope: broader speed-source polling refactors

Closes #2635