### PR TITLE
UI: use effectOnChange for ESP flash

### DIFF
--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -1,6 +1,6 @@
 import {
   computed,
-  effect,
+  effectOnChange,
   signal,
   type ReadonlySignal,
 } from "../ui_signals";
@@ -50,13 +50,10 @@ export function createEspFlashFeature(
   });
   panel.model.value = presenter.model;
 
-  let wasPollingEnabled = false;
-  effect(() => {
-    const enabled = pollingEnabled.value;
-    if (enabled && !wasPollingEnabled) {
+  effectOnChange(pollingEnabled, (enabled) => {
+    if (enabled) {
       void workflow.refreshPorts();
     }
-    wasPollingEnabled = enabled;
   });
 
   function bindHandlers(): void {


### PR DESCRIPTION
## Summary
Small code-quality cleanup. ESP flash polling transition uses the shared helper now.

## What changed
- replace the manual `wasPollingEnabled` tracking in `esp_flash_feature.ts` with `effectOnChange(pollingEnabled, ...)`
- keep the same behavior: refresh ports only when polling becomes enabled
- leave the workflow, presenter, and polling signal shape unchanged

## Why
- the repo already has `effectOnChange()` for this exact transition-detection pattern
- removes local mutable state that duplicated the helper
- matches issue scope exactly

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoffs
- low risk; same transition behavior through the shared helper
- no behavior change intended
- out of scope: any broader ESP flash workflow changes

Closes #2636