### PR TITLE
UI: simplify spectrum transport sync

### DIFF
--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -1,5 +1,5 @@
 import type { AppState } from "../ui_app_state";
-import { effect, effectOnChange, untracked } from "../ui_signals";
+import { computed, effectOnChange, untracked } from "../ui_signals";
 import {
   createSpectrumCanvasRenderer,
   type SpectrumCanvasRenderer,
@@ -136,39 +136,16 @@ export class UiSpectrumController {
   }
 
   private bindReactiveTransportSync(): void {
-    let previousSpectra = this.state.spectrum.spectra.value;
-    let previousWsState = this.state.transport.wsState.value;
-    let previousPayloadError = this.state.transport.payloadError.value;
-    let previousHasReceivedPayload = this.state.transport.hasReceivedPayload.value;
-    let initialized = false;
-    effect(() => {
-      const nextSpectra = this.state.spectrum.spectra.value;
-      const nextWsState = this.state.transport.wsState.value;
-      const nextPayloadError = this.state.transport.payloadError.value;
-      const nextHasReceivedPayload = this.state.transport.hasReceivedPayload.value;
-      if (!initialized) {
-        initialized = true;
-        previousSpectra = nextSpectra;
-        previousWsState = nextWsState;
-        previousPayloadError = nextPayloadError;
-        previousHasReceivedPayload = nextHasReceivedPayload;
-        return;
-      }
-      const spectraChanged = nextSpectra !== previousSpectra;
-      const transportChanged =
-        nextWsState !== previousWsState
-        || nextPayloadError !== previousPayloadError
-        || nextHasReceivedPayload !== previousHasReceivedPayload;
-      previousSpectra = nextSpectra;
-      previousWsState = nextWsState;
-      previousPayloadError = nextPayloadError;
-      previousHasReceivedPayload = nextHasReceivedPayload;
-      if (spectraChanged) {
-        untracked(() => this.renderSpectrum());
-      }
-      if (transportChanged) {
-        untracked(() => this.updateSpectrumOverlay());
-      }
+    effectOnChange(this.state.spectrum.spectra, () => {
+      untracked(() => this.renderSpectrum());
+    });
+    const transportOverlayState = computed(() => ({
+      hasReceivedPayload: this.state.transport.hasReceivedPayload.value,
+      payloadError: this.state.transport.payloadError.value,
+      wsState: this.state.transport.wsState.value,
+    }));
+    effectOnChange(transportOverlayState, () => {
+      untracked(() => this.updateSpectrumOverlay());
     });
   }
 }


### PR DESCRIPTION
## Summary
Small code-quality cleanup. Spectrum transport sync uses targeted change effects now.

## What changed
- replace the manual init flag and previous-value tracking in `ui_spectrum_controller.ts`
- use one `effectOnChange()` for `spectrum.spectra`
- use one `effectOnChange()` on a computed transport overlay state for websocket/payload overlay refreshes

## Why
- removes brittle hand-rolled change tracking
- uses the shared helper the repo already relies on elsewhere
- matches issue scope exactly

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoffs
- low risk; same reactive triggers, simpler wiring
- no behavior change intended
- out of scope: broader spectrum controller refactors

Closes #2637