### PR TITLE
refactor(ui): replace DOM-walking OBD visibility

### DIFF
--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -40,12 +40,19 @@ export function createSettingsSpeedSourceModule(
   ctx: SettingsSpeedSourceModuleDeps,
 ): SettingsSpeedSourceModule {
   const { settings, services } = ctx;
+  let workflow!: ReturnType<typeof createSettingsSpeedSourceWorkflow>;
   const presenterDeps: SettingsSpeedSourcePresenterDeps = {
     fmt: ctx.formatting.fmt,
     getSpeedUnit: ctx.getSpeedUnit,
     t: services.t,
   };
-  const workflow = createSettingsSpeedSourceWorkflow({
+  const obdConfigVisible = computed(() =>
+    ctx.ports.activeViewId.value === "settingsView"
+    && ctx.ports.activeSettingsTabId.value === "speedSourceTab"
+    && buildSettingsSpeedSourcePanelModel(workflow.renderState.value, presenterDeps).obdConfigVisible
+  );
+  workflow = createSettingsSpeedSourceWorkflow({
+    obdConfigVisible,
     renderSpeedReadout: ctx.ports.renderSpeedReadout,
     settings,
     showError: services.showError,
@@ -54,7 +61,6 @@ export function createSettingsSpeedSourceModule(
       focusManualSpeedInput: ctx.panel.focusManualSpeedInput,
       focusScanObdDevices: ctx.panel.focusScanObdDevices,
       focusStaleTimeoutInput: ctx.panel.focusStaleTimeoutInput,
-      isObdConfigVisible: ctx.panel.isObdConfigVisible,
     },
   });
   const panelModel = computed(() =>

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -35,11 +35,11 @@ export interface SettingsSpeedSourceWorkflowViewPorts {
   focusManualSpeedInput(): void;
   focusScanObdDevices(): void;
   focusStaleTimeoutInput(): void;
-  isObdConfigVisible(): boolean;
 }
 
 export interface SettingsSpeedSourceWorkflowDeps {
   createPollingController?: (options: PollingControllerOptions) => PollingController;
+  obdConfigVisible: ReadonlySignal<boolean>;
   renderSpeedReadout: () => void;
   settings: SettingsState;
   showError: (message: string) => void;
@@ -218,7 +218,7 @@ export function createSettingsSpeedSourceWorkflow(
   }
 
   function syncContextVisibility(): void {
-    speedSourceContextVisible = deps.view.isObdConfigVisible();
+    speedSourceContextVisible = deps.obdConfigVisible.value;
     syncBackgroundRescan();
   }
 

--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -220,7 +220,7 @@ function createDeferredSpeedSourcePanelView(): {
   attach(
     realView: Pick<
       SpeedSourcePanelView,
-      "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+      "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput"
     >,
   ): void;
   view: SpeedSourcePanelView;
@@ -228,7 +228,7 @@ function createDeferredSpeedSourcePanelView(): {
   type PendingFocusTarget = "manual" | "scan" | "stale";
   const realView = signal<Pick<
     SpeedSourcePanelView,
-    "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+    "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput"
   > | null>(null);
   const model = createDeferredModelSignal<SpeedSourcePanelRenderModel>();
   const pendingFocusTarget = signal<PendingFocusTarget | null>(null);
@@ -261,13 +261,6 @@ function createDeferredSpeedSourcePanelView(): {
       },
       focusStaleTimeoutInput() {
         pendingFocusTarget.value = "stale";
-      },
-      isObdConfigVisible() {
-        const attachedView = realView.value;
-        if (attachedView !== null) {
-          return attachedView.isObdConfigVisible();
-        }
-        return model.value?.value.obdConfigVisible ?? false;
       },
     },
     attach(nextRealView) {

--- a/apps/ui/src/app/ui_panel_bootstrap.tsx
+++ b/apps/ui/src/app/ui_panel_bootstrap.tsx
@@ -63,7 +63,7 @@ export interface UiMountedLazyPanelHandles {
     internet: Pick<InternetPanelView, "focusSsidInput">;
     speedSource: Pick<
       SpeedSourcePanelView,
-      "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+      "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput"
     >;
   };
 }

--- a/apps/ui/src/app/views/settings_lazy_view.tsx
+++ b/apps/ui/src/app/views/settings_lazy_view.tsx
@@ -56,7 +56,7 @@ interface SettingsLazyViewReadyHandles {
     internet: Pick<InternetPanelView, "focusSsidInput">;
     speedSource: Pick<
       SpeedSourcePanelView,
-      "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+      "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput"
     >;
   };
 }

--- a/apps/ui/src/app/views/speed_source_config_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_config_panel.tsx
@@ -283,14 +283,12 @@ function SpeedSourceObdDeviceRow(props: {
 function ObdConfigSection(props: {
   actions: SpeedSourcePanelActionHandlers | null;
   model: SpeedSourcePanelRenderModel;
-  obdConfigRef: (element: HTMLElement | null) => void;
   scanButtonRef: (element: HTMLButtonElement | null) => void;
 }) {
-  const { actions, model, obdConfigRef, scanButtonRef } = props;
+  const { actions, model, scanButtonRef } = props;
   return (
     <div
       id="obdSpeedConfig"
-      ref={obdConfigRef}
       class="speed-source-config"
       hidden={!model.obdConfigVisible}
     >
@@ -422,7 +420,6 @@ export function SpeedSourceConfigPanel(props: {
   actions: SpeedSourcePanelActionHandlers | null;
   manualInputRef: (element: HTMLInputElement | null) => void;
   model: SpeedSourcePanelRenderModel;
-  obdConfigRef: (element: HTMLElement | null) => void;
   scanButtonRef: (element: HTMLButtonElement | null) => void;
   staleTimeoutInputRef: (element: HTMLInputElement | null) => void;
 }) {
@@ -430,7 +427,6 @@ export function SpeedSourceConfigPanel(props: {
     actions,
     manualInputRef,
     model,
-    obdConfigRef,
     scanButtonRef,
     staleTimeoutInputRef,
   } = props;
@@ -449,7 +445,6 @@ export function SpeedSourceConfigPanel(props: {
       <ObdConfigSection
         actions={actions}
         model={model}
-        obdConfigRef={obdConfigRef}
         scanButtonRef={scanButtonRef}
       />
       <GpsFallbackSection

--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -119,7 +119,6 @@ export interface SpeedSourcePanelView extends SpeedSourcePanelBindings {
   focusManualSpeedInput(): void;
   focusScanObdDevices(): void;
   focusStaleTimeoutInput(): void;
-  isObdConfigVisible(): boolean;
 }
 
 type SpeedSourcePanelBridgeState = {
@@ -159,7 +158,6 @@ const DEFAULT_SPEED_SOURCE_PANEL_MODEL: SpeedSourcePanelRenderModel = {
 
 function SpeedSourcePanel(props: {
   manualInputRef: (element: HTMLInputElement | null) => void;
-  obdConfigRef: (element: HTMLElement | null) => void;
   onDiagnosticsToggle: (event: Event) => void;
   scanButtonRef: (element: HTMLButtonElement | null) => void;
   staleTimeoutInputRef: (element: HTMLInputElement | null) => void;
@@ -167,7 +165,6 @@ function SpeedSourcePanel(props: {
 }) {
   const {
     manualInputRef,
-    obdConfigRef,
     onDiagnosticsToggle,
     scanButtonRef,
     staleTimeoutInputRef,
@@ -180,7 +177,6 @@ function SpeedSourcePanel(props: {
         actions={state.actions}
         manualInputRef={manualInputRef}
         model={state.model}
-        obdConfigRef={obdConfigRef}
         scanButtonRef={scanButtonRef}
         staleTimeoutInputRef={staleTimeoutInputRef}
       />
@@ -198,7 +194,7 @@ export function mountSpeedSourcePanel(
   bindings: SpeedSourcePanelBindings,
 ): Pick<
   SpeedSourcePanelView,
-  "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+  "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput"
 > {
   const diagnosticsDisclosureOpen = signal(false);
   effect(() => {
@@ -213,16 +209,12 @@ export function mountSpeedSourcePanel(
     model: bindings.model.value?.value ?? DEFAULT_SPEED_SOURCE_PANEL_MODEL,
   }));
   let manualSpeedInput: HTMLInputElement | null = null;
-  let obdConfig: HTMLElement | null = null;
   let scanObdDevicesBtn: HTMLButtonElement | null = null;
   let staleTimeoutInput: HTMLInputElement | null = null;
   render(
     <SpeedSourcePanel
       manualInputRef={(element) => {
         manualSpeedInput = element;
-      }}
-      obdConfigRef={(element) => {
-        obdConfig = element;
       }}
       onDiagnosticsToggle={(event) => {
         diagnosticsDisclosureOpen.value =
@@ -248,17 +240,6 @@ export function mountSpeedSourcePanel(
     },
     focusStaleTimeoutInput(): void {
       staleTimeoutInput?.focus();
-    },
-    isObdConfigVisible(): boolean {
-      if (!obdConfig || obdConfig.hidden) {
-        return false;
-      }
-      const activePanel = obdConfig.closest<HTMLElement>(".settings-tab-panel");
-      if (!activePanel || activePanel.hidden) {
-        return false;
-      }
-      const activeView = activePanel.closest<HTMLElement>(".view");
-      return activeView == null || !activeView.hidden;
     },
   };
 }


### PR DESCRIPTION
## what changed
- derive OBD config visibility from reactive state in the speed-source workflow
- remove `isObdConfigVisible()` DOM walking from the mounted panel view
- delete dead `obdConfigRef` and lazy-panel pass-through plumbing tied to that method

## why
- visibility already comes from active view, active tab, and panel model state
- DOM traversal bypassed the reactive model and kept extra imperative bridge code alive

## validation
- `cd apps/ui && npm run typecheck && npm run build`

## risks / edges
- no intended behavior change
- workflow visibility now depends on the same rendered model flag plus active settings context, so hidden tabs/views stop background visibility the same way without querying the DOM