### PR TITLE
refactor(ui): split history table content

### DIFF
--- a/apps/ui/src/app/views/history_detail_expansion.tsx
+++ b/apps/ui/src/app/views/history_detail_expansion.tsx
@@ -1,0 +1,270 @@
+import type { JSX } from "preact";
+
+import { HistoryHeatmap } from "./history_heatmap_section";
+import type {
+  HistoryDetailsViewModel,
+  HistoryInsightsViewModel,
+  HistoryPrimaryFindingViewModel,
+  HistoryRowViewModel,
+  HistorySecondaryFindingViewModel,
+} from "./history_table_models";
+import type {
+  HistoryPanelActionHandlers,
+  HistoryRunAction,
+} from "./history_table_view";
+
+function HistoryPrimaryFinding(props: { primary: HistoryPrimaryFindingViewModel }) {
+  const { primary } = props;
+  return (
+    <div class="history-findings-overview">
+      <div class="history-findings-overview__header">
+        <div class="history-findings-overview__eyebrow">{primary.eyebrow}</div>
+      </div>
+      <div class={`history-diagnosis-card history-diagnosis-card--${primary.tone}`}>
+        <div class="history-diagnosis-card__header">
+          <div class="history-diagnosis-card__copy">
+            <div class="history-findings-overview__headline">{primary.headline}</div>
+            <div class="history-diagnosis-card__signature">{primary.signature}</div>
+          </div>
+          <span class={`history-diagnosis-card__confidence history-diagnosis-card__confidence--${primary.tone}`}>
+            {primary.confidence}
+          </span>
+        </div>
+        {primary.explanation ? (
+          <p class="history-findings-overview__explanation">{primary.explanation}</p>
+        ) : null}
+        <div class="history-findings-overview__chips">
+          {primary.chips.map((chip, index) => (
+            <div key={`${chip.label}:${index}`} class="history-findings-chip">
+              <span class="history-findings-chip__label">{chip.label}</span>
+              <strong>{chip.value}</strong>
+            </div>
+          ))}
+        </div>
+        {primary.nextStep && primary.nextStepLabel ? (
+          <div class="history-diagnosis-card__next-step">
+            <span class="history-diagnosis-card__next-step-label">{primary.nextStepLabel}</span>
+            <strong>{primary.nextStep}</strong>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function HistorySecondaryFindingCard(props: { finding: HistorySecondaryFindingViewModel }) {
+  const { finding } = props;
+  return (
+    <li class={`history-finding-card history-finding-card--secondary history-finding-card--${finding.tone}`}>
+      <div class="history-finding-card__header">
+        <div class="history-finding-card__title-group">
+          <strong class="history-finding-card__title">{finding.source}</strong>
+          <span class="history-finding-card__signal">{finding.signature}</span>
+        </div>
+        <span class={`history-finding-card__confidence history-finding-card__confidence--${finding.tone}`}>
+          {finding.confidence}
+        </span>
+      </div>
+      <div class="history-finding-card__meta">
+        <div class="history-finding-card__meta-item">
+          <span class="history-finding-card__label">{finding.locationLabel}</span>
+          <strong>{finding.location}</strong>
+        </div>
+        <div class="history-finding-card__meta-item">
+          <span class="history-finding-card__label">{finding.speedBandLabel}</span>
+          <strong>{finding.speedBand}</strong>
+        </div>
+      </div>
+      <p class="history-finding-card__summary">{finding.evidenceSummary}</p>
+    </li>
+  );
+}
+
+function HistoryInsightsBlock(props: { insights: HistoryInsightsViewModel }) {
+  const { insights } = props;
+
+  let body: JSX.Element;
+  if (insights.primary) {
+    body = (
+      <>
+        <HistoryPrimaryFinding primary={insights.primary} />
+        {insights.secondaryTitle ? (
+          <div class="history-secondary-findings">
+            <div class="history-secondary-findings__title">{insights.secondaryTitle}</div>
+            <ul class="history-findings-list history-findings-list--secondary">
+              {insights.visibleSecondary.map((finding, index) => (
+                <HistorySecondaryFindingCard
+                  key={`${finding.source}:${finding.signature}:${index}`}
+                  finding={finding}
+                />
+              ))}
+            </ul>
+            {insights.hiddenSecondary.length > 0 && insights.showMoreLabel ? (
+              <details class="history-secondary-findings__more">
+                <summary>{insights.showMoreLabel}</summary>
+                <ul class="history-findings-list history-findings-list--secondary">
+                  {insights.hiddenSecondary.map((finding, index) => (
+                    <HistorySecondaryFindingCard
+                      key={`${finding.source}:${finding.signature}:hidden:${index}`}
+                      finding={finding}
+                    />
+                  ))}
+                </ul>
+              </details>
+            ) : null}
+          </div>
+        ) : null}
+      </>
+    );
+  } else if (insights.emptyMessage) {
+    body = (
+      <ul class="history-findings-list history-findings-list--secondary">
+        <li class="history-finding-card history-finding-card--empty">{insights.emptyMessage}</li>
+      </ul>
+    );
+  } else {
+    body = <div class="history-panel-state">{insights.stateMessage ?? ""}</div>;
+  }
+
+  return (
+    <div class="history-insights-block">
+      <div class="history-panel-header">
+        <div class="history-panel-header__eyebrow">{insights.headerEyebrow}</div>
+      </div>
+      {body}
+    </div>
+  );
+}
+
+function HistoryWarnings(props: { warnings: HistoryDetailsViewModel["warnings"] }) {
+  const { warnings } = props;
+  if (!warnings.length) {
+    return null;
+  }
+  return (
+    <div class="history-warning-list">
+      {warnings.map((warning, index) => (
+        <div
+          key={`${warning.severity}:${warning.title}:${index}`}
+          class={`history-warning-banner history-warning-banner--${warning.severity}`}
+        >
+          <strong>{warning.title}</strong>
+          {warning.detail ? (
+            <div class="history-warning-banner__detail">{warning.detail}</div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function HistoryRunActionsPanel(props: {
+  details: HistoryDetailsViewModel;
+  historyExportUrl: (runId: string) => string;
+  onRunAction(
+    event: JSX.TargetedMouseEvent<HTMLElement>,
+    action: HistoryRunAction,
+    runId: string,
+  ): void;
+  onStopRowToggle(event: JSX.TargetedMouseEvent<HTMLElement>): void;
+  row: HistoryRowViewModel;
+}) {
+  const { details, historyExportUrl, onRunAction, onStopRowToggle, row } = props;
+  return (
+    <div class="history-details-footer">
+      <div class="history-details-footer__copy">
+        <div class="history-details-footer__eyebrow">{details.footerEyebrow}</div>
+        <div class="history-details-footer__body">{details.footerBody}</div>
+      </div>
+      <div class="history-details-footer__actions">
+        <a
+          class="btn btn--muted"
+          href={historyExportUrl(row.runId)}
+          download={`${row.runId}.zip`}
+          data-run-action="download-raw"
+          data-run={row.runId}
+          onClick={onStopRowToggle}
+        >
+          {details.exportLabel}
+        </a>
+        <button
+          class="btn btn--danger-quiet"
+          type="button"
+          data-run-action="delete-run"
+          data-run={row.runId}
+          onClick={(event) => onRunAction(event, "delete-run", row.runId)}
+        >
+          {details.deleteLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function HistoryDetailsRow(props: {
+  details: HistoryDetailsViewModel;
+  historyExportUrl: (runId: string) => string;
+  onRunAction(
+    event: JSX.TargetedMouseEvent<HTMLElement>,
+    action: HistoryRunAction,
+    runId: string,
+  ): void;
+  onStopRowToggle(event: JSX.TargetedMouseEvent<HTMLElement>): void;
+  row: HistoryRowViewModel;
+}) {
+  const { details, historyExportUrl, onRunAction, onStopRowToggle, row } = props;
+  return (
+    <tr class="history-details-row">
+      <td colSpan={4}>
+        <div class="history-details-card">
+          <div class="history-details-header">
+            <div class="history-details-header__copy">
+              <div class="history-details-header__eyebrow">{details.titleEyebrow}</div>
+              <div class="history-details-header__title">{details.title}</div>
+              {details.runSummary ? (
+                <div class="history-run-summary">{details.runSummary}</div>
+              ) : null}
+            </div>
+            <div class="history-details-header__actions">
+              {details.reloadActionLabel ? (
+                <button
+                  class="btn btn--muted"
+                  type="button"
+                  disabled={details.reloadActionDisabled}
+                  data-run-action="load-insights"
+                  data-run={row.runId}
+                  onClick={(event) => onRunAction(event, "load-insights", row.runId)}
+                >
+                  {details.reloadActionLabel}
+                </button>
+              ) : details.loadingStatusText ? (
+                <div class="history-details-header__status">{details.loadingStatusText}</div>
+              ) : null}
+              {details.insightsError ? (
+                <span class="history-inline-error">{details.insightsError}</span>
+              ) : null}
+            </div>
+          </div>
+          <HistoryWarnings warnings={details.warnings} />
+          <div class="history-results-layout">
+            <div class="history-main-column">
+              <HistoryInsightsBlock insights={details.insights} />
+              <HistoryRunActionsPanel
+                details={details}
+                historyExportUrl={historyExportUrl}
+                onRunAction={onRunAction}
+                onStopRowToggle={onStopRowToggle}
+                row={row}
+              />
+            </div>
+            <div class="history-evidence-column">
+              <div class="history-evidence-panel">
+                <HistoryHeatmap heatmap={details.heatmap} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/apps/ui/src/app/views/history_heatmap_section.tsx
+++ b/apps/ui/src/app/views/history_heatmap_section.tsx
@@ -1,0 +1,81 @@
+import type { JSX } from "preact";
+
+import type { HistoryHeatmapViewModel } from "./history_table_models";
+
+type HistoryHeatmapZoneStyle = JSX.CSSProperties & {
+  "--history-heatmap-accent"?: string;
+  "--history-heatmap-fill"?: string;
+};
+
+function heatmapZoneStyle(zone: HistoryHeatmapViewModel["zones"][number]): HistoryHeatmapZoneStyle {
+  const style: HistoryHeatmapZoneStyle = {
+    gridArea: zone.gridArea,
+  };
+  if (zone.valueLabel !== null && zone.accentColor !== null && zone.fillPercent !== null) {
+    style["--history-heatmap-accent"] = zone.accentColor;
+    style["--history-heatmap-fill"] = `${zone.fillPercent}%`;
+  }
+  return style;
+}
+
+export function HistoryHeatmap(props: { heatmap: HistoryHeatmapViewModel }) {
+  const { heatmap } = props;
+  return (
+    <div class="history-heatmap">
+      <div class="history-heatmap__header">
+        <div class="history-heatmap__title">{heatmap.title}</div>
+      </div>
+      {heatmap.stateMessage ? (
+        <p class={heatmap.stateTone === "error" ? "history-inline-error" : "subtle"}>
+          {heatmap.stateMessage}
+        </p>
+      ) : (
+        <>
+          <div class="history-heatmap__grid">
+            {heatmap.zones.map((zone) => {
+              const isEmpty =
+                zone.valueLabel === null
+                || zone.accentColor === null
+                || zone.fillPercent === null;
+              return (
+                <div
+                  key={zone.key}
+                  class={[
+                    "history-heatmap__zone",
+                    isEmpty ? "history-heatmap__zone--empty" : "",
+                    !isEmpty && zone.strongest ? "history-heatmap__zone--strongest" : "",
+                  ].filter(Boolean).join(" ")}
+                  style={heatmapZoneStyle(zone)}
+                  title={isEmpty ? zone.label : `${zone.label}: ${zone.valueLabel}`}
+                  data-location-key={zone.key}
+                >
+                  <div class="history-heatmap__zone-label">{zone.label}</div>
+                  <div
+                    class={[
+                      "history-heatmap__zone-value",
+                      isEmpty ? "history-heatmap__zone-value--empty" : "",
+                    ].filter(Boolean).join(" ")}
+                  >
+                    {zone.valueLabel ?? ""}
+                  </div>
+                  <div class="history-heatmap__zone-meter" aria-hidden="true">
+                    {!isEmpty ? <span class="history-heatmap__zone-meter-fill" /> : null}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {heatmap.extras.length ? (
+            <div class="history-heatmap__extras">
+              {heatmap.extras.map((extra, index) => (
+                <div key={`${extra}:${index}`} class="history-heatmap__extra-chip">
+                  {extra}
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/app/views/history_summary_chips.tsx
+++ b/apps/ui/src/app/views/history_summary_chips.tsx
@@ -1,0 +1,27 @@
+import type { HistoryRowViewModel, HistorySummaryChipTone } from "./history_table_models";
+
+function chipModifier(tone: HistorySummaryChipTone): string {
+  switch (tone) {
+    case "default":
+      return "";
+    case "source":
+      return " history-row__summary-chip--source";
+    default:
+      return ` history-row__summary-chip--${tone}`;
+  }
+}
+
+export function HistorySummaryChips(props: { row: HistoryRowViewModel }) {
+  return (
+    <div class="history-row__summary-chips">
+      {props.row.summaryChips.map((chip, index) => (
+        <span
+          key={`${chip.tone}:${chip.text}:${index}`}
+          class={`history-row__summary-chip${chipModifier(chip.tone)}`}
+        >
+          {chip.text}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/app/views/history_table_content.tsx
+++ b/apps/ui/src/app/views/history_table_content.tsx
@@ -2,6 +2,8 @@ import type { JSX } from "preact";
 
 import { useComputed, useSignal, type ReadonlySignal } from "../ui_signals";
 import { inlineStateActionClass } from "./dom_helpers";
+import { HistoryDetailsRow } from "./history_detail_expansion";
+import { HistorySummaryChips } from "./history_summary_chips";
 import type {
   HistoryPanelActionHandlers,
   HistoryPanelTableRenderModel,
@@ -9,41 +11,9 @@ import type {
 } from "./history_table_view";
 import type {
   HistoryDetailsViewModel,
-  HistoryHeatmapViewModel,
-  HistoryInsightsViewModel,
-  HistoryPrimaryFindingViewModel,
   HistoryRowViewModel,
-  HistorySecondaryFindingViewModel,
-  HistorySummaryChipTone,
 } from "./history_table_models";
 import { createHistoryTableRowsMemo } from "./history_table_presenters";
-
-type HistoryHeatmapZoneStyle = JSX.CSSProperties & {
-  "--history-heatmap-accent"?: string;
-  "--history-heatmap-fill"?: string;
-};
-
-function chipModifier(tone: HistorySummaryChipTone): string {
-  switch (tone) {
-    case "default":
-      return "";
-    case "source":
-      return " history-row__summary-chip--source";
-    default:
-      return ` history-row__summary-chip--${tone}`;
-  }
-}
-
-function heatmapZoneStyle(zone: HistoryHeatmapViewModel["zones"][number]): HistoryHeatmapZoneStyle {
-  const style: HistoryHeatmapZoneStyle = {
-    gridArea: zone.gridArea,
-  };
-  if (zone.valueLabel !== null && zone.accentColor !== null && zone.fillPercent !== null) {
-    style["--history-heatmap-accent"] = zone.accentColor;
-    style["--history-heatmap-fill"] = `${zone.fillPercent}%`;
-  }
-  return style;
-}
 
 function stopRowToggle(event: JSX.TargetedMouseEvent<HTMLElement>): void {
   event.stopPropagation();
@@ -106,21 +76,6 @@ function HistoryEmptyStateRow(props: {
   );
 }
 
-function HistorySummaryChips(props: { row: HistoryRowViewModel }) {
-  return (
-    <div class="history-row__summary-chips">
-      {props.row.summaryChips.map((chip, index) => (
-        <span
-          key={`${chip.tone}:${chip.text}:${index}`}
-          class={`history-row__summary-chip${chipModifier(chip.tone)}`}
-        >
-          {chip.text}
-        </span>
-      ))}
-    </div>
-  );
-}
-
 function HistoryDiagnosisSummary(props: { row: HistoryRowViewModel }) {
   const { row } = props;
   if (!row.summaryHeadline && !row.summaryMeta) {
@@ -159,313 +114,6 @@ function HistoryCollapsedRowActions(props: {
         {row.collapsedAction.pdfLabel ?? ""}
       </button>
     </div>
-  );
-}
-
-function HistoryHeatmap(props: { heatmap: HistoryHeatmapViewModel }) {
-  const { heatmap } = props;
-  return (
-    <div class="history-heatmap">
-      <div class="history-heatmap__header">
-        <div class="history-heatmap__title">{heatmap.title}</div>
-      </div>
-      {heatmap.stateMessage ? (
-        <p class={heatmap.stateTone === "error" ? "history-inline-error" : "subtle"}>
-          {heatmap.stateMessage}
-        </p>
-      ) : (
-        <>
-          <div class="history-heatmap__grid">
-            {heatmap.zones.map((zone) => {
-              const isEmpty =
-                zone.valueLabel === null
-                || zone.accentColor === null
-                || zone.fillPercent === null;
-              return (
-                <div
-                  key={zone.key}
-                  class={[
-                    "history-heatmap__zone",
-                    isEmpty ? "history-heatmap__zone--empty" : "",
-                    !isEmpty && zone.strongest ? "history-heatmap__zone--strongest" : "",
-                  ].filter(Boolean).join(" ")}
-                  style={heatmapZoneStyle(zone)}
-                  title={isEmpty ? zone.label : `${zone.label}: ${zone.valueLabel}`}
-                  data-location-key={zone.key}
-                >
-                  <div class="history-heatmap__zone-label">{zone.label}</div>
-                  <div
-                    class={[
-                      "history-heatmap__zone-value",
-                      isEmpty ? "history-heatmap__zone-value--empty" : "",
-                    ].filter(Boolean).join(" ")}
-                  >
-                    {zone.valueLabel ?? ""}
-                  </div>
-                  <div class="history-heatmap__zone-meter" aria-hidden="true">
-                    {!isEmpty ? <span class="history-heatmap__zone-meter-fill" /> : null}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-          {heatmap.extras.length ? (
-            <div class="history-heatmap__extras">
-              {heatmap.extras.map((extra, index) => (
-                <div key={`${extra}:${index}`} class="history-heatmap__extra-chip">
-                  {extra}
-                </div>
-              ))}
-            </div>
-          ) : null}
-        </>
-      )}
-    </div>
-  );
-}
-
-function HistoryPrimaryFinding(props: { primary: HistoryPrimaryFindingViewModel }) {
-  const { primary } = props;
-  return (
-    <div class="history-findings-overview">
-      <div class="history-findings-overview__header">
-        <div class="history-findings-overview__eyebrow">{primary.eyebrow}</div>
-      </div>
-      <div class={`history-diagnosis-card history-diagnosis-card--${primary.tone}`}>
-        <div class="history-diagnosis-card__header">
-          <div class="history-diagnosis-card__copy">
-            <div class="history-findings-overview__headline">{primary.headline}</div>
-            <div class="history-diagnosis-card__signature">{primary.signature}</div>
-          </div>
-          <span class={`history-diagnosis-card__confidence history-diagnosis-card__confidence--${primary.tone}`}>
-            {primary.confidence}
-          </span>
-        </div>
-        {primary.explanation ? (
-          <p class="history-findings-overview__explanation">{primary.explanation}</p>
-        ) : null}
-        <div class="history-findings-overview__chips">
-          {primary.chips.map((chip, index) => (
-            <div key={`${chip.label}:${index}`} class="history-findings-chip">
-              <span class="history-findings-chip__label">{chip.label}</span>
-              <strong>{chip.value}</strong>
-            </div>
-          ))}
-        </div>
-        {primary.nextStep && primary.nextStepLabel ? (
-          <div class="history-diagnosis-card__next-step">
-            <span class="history-diagnosis-card__next-step-label">{primary.nextStepLabel}</span>
-            <strong>{primary.nextStep}</strong>
-          </div>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-function HistorySecondaryFindingCard(props: { finding: HistorySecondaryFindingViewModel }) {
-  const { finding } = props;
-  return (
-    <li class={`history-finding-card history-finding-card--secondary history-finding-card--${finding.tone}`}>
-      <div class="history-finding-card__header">
-        <div class="history-finding-card__title-group">
-          <strong class="history-finding-card__title">{finding.source}</strong>
-          <span class="history-finding-card__signal">{finding.signature}</span>
-        </div>
-        <span class={`history-finding-card__confidence history-finding-card__confidence--${finding.tone}`}>
-          {finding.confidence}
-        </span>
-      </div>
-      <div class="history-finding-card__meta">
-        <div class="history-finding-card__meta-item">
-          <span class="history-finding-card__label">{finding.locationLabel}</span>
-          <strong>{finding.location}</strong>
-        </div>
-        <div class="history-finding-card__meta-item">
-          <span class="history-finding-card__label">{finding.speedBandLabel}</span>
-          <strong>{finding.speedBand}</strong>
-        </div>
-      </div>
-      <p class="history-finding-card__summary">{finding.evidenceSummary}</p>
-    </li>
-  );
-}
-
-function HistoryInsightsBlock(props: { insights: HistoryInsightsViewModel }) {
-  const { insights } = props;
-
-  let body: JSX.Element;
-  if (insights.primary) {
-    body = (
-      <>
-        <HistoryPrimaryFinding primary={insights.primary} />
-        {insights.secondaryTitle ? (
-          <div class="history-secondary-findings">
-            <div class="history-secondary-findings__title">{insights.secondaryTitle}</div>
-            <ul class="history-findings-list history-findings-list--secondary">
-              {insights.visibleSecondary.map((finding, index) => (
-                <HistorySecondaryFindingCard
-                  key={`${finding.source}:${finding.signature}:${index}`}
-                  finding={finding}
-                />
-              ))}
-            </ul>
-            {insights.hiddenSecondary.length > 0 && insights.showMoreLabel ? (
-              <details class="history-secondary-findings__more">
-                <summary>{insights.showMoreLabel}</summary>
-                <ul class="history-findings-list history-findings-list--secondary">
-                  {insights.hiddenSecondary.map((finding, index) => (
-                    <HistorySecondaryFindingCard
-                      key={`${finding.source}:${finding.signature}:hidden:${index}`}
-                      finding={finding}
-                    />
-                  ))}
-                </ul>
-              </details>
-            ) : null}
-          </div>
-        ) : null}
-      </>
-    );
-  } else if (insights.emptyMessage) {
-    body = (
-      <ul class="history-findings-list history-findings-list--secondary">
-        <li class="history-finding-card history-finding-card--empty">{insights.emptyMessage}</li>
-      </ul>
-    );
-  } else {
-    body = <div class="history-panel-state">{insights.stateMessage ?? ""}</div>;
-  }
-
-  return (
-    <div class="history-insights-block">
-      <div class="history-panel-header">
-        <div class="history-panel-header__eyebrow">{insights.headerEyebrow}</div>
-      </div>
-      {body}
-    </div>
-  );
-}
-
-function HistoryWarnings(props: { warnings: HistoryDetailsViewModel["warnings"] }) {
-  const { warnings } = props;
-  if (!warnings.length) {
-    return null;
-  }
-  return (
-    <div class="history-warning-list">
-      {warnings.map((warning, index) => (
-        <div
-          key={`${warning.severity}:${warning.title}:${index}`}
-          class={`history-warning-banner history-warning-banner--${warning.severity}`}
-        >
-          <strong>{warning.title}</strong>
-          {warning.detail ? (
-            <div class="history-warning-banner__detail">{warning.detail}</div>
-          ) : null}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function HistoryRunActionsPanel(props: {
-  details: HistoryDetailsViewModel;
-  handlers: HistoryPanelActionHandlers | null;
-  historyExportUrl: (runId: string) => string;
-  row: HistoryRowViewModel;
-}) {
-  const { details, handlers, historyExportUrl, row } = props;
-  return (
-    <div class="history-details-footer">
-      <div class="history-details-footer__copy">
-        <div class="history-details-footer__eyebrow">{details.footerEyebrow}</div>
-        <div class="history-details-footer__body">{details.footerBody}</div>
-      </div>
-      <div class="history-details-footer__actions">
-        <a
-          class="btn btn--muted"
-          href={historyExportUrl(row.runId)}
-          download={`${row.runId}.zip`}
-          data-run-action="download-raw"
-          data-run={row.runId}
-          onClick={stopRowToggle}
-        >
-          {details.exportLabel}
-        </a>
-        <button
-          class="btn btn--danger-quiet"
-          type="button"
-          data-run-action="delete-run"
-          data-run={row.runId}
-          onClick={(event) => handleRunAction(event, handlers, "delete-run", row.runId)}
-        >
-          {details.deleteLabel}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function HistoryDetailsRow(props: {
-  details: HistoryDetailsViewModel;
-  handlers: HistoryPanelActionHandlers | null;
-  historyExportUrl: (runId: string) => string;
-  row: HistoryRowViewModel;
-}) {
-  const { details, handlers, historyExportUrl, row } = props;
-  return (
-    <tr class="history-details-row">
-      <td colSpan={4}>
-        <div class="history-details-card">
-          <div class="history-details-header">
-            <div class="history-details-header__copy">
-              <div class="history-details-header__eyebrow">{details.titleEyebrow}</div>
-              <div class="history-details-header__title">{details.title}</div>
-              {details.runSummary ? (
-                <div class="history-run-summary">{details.runSummary}</div>
-              ) : null}
-            </div>
-            <div class="history-details-header__actions">
-              {details.reloadActionLabel ? (
-                <button
-                  class="btn btn--muted"
-                  type="button"
-                  disabled={details.reloadActionDisabled}
-                  data-run-action="load-insights"
-                  data-run={row.runId}
-                  onClick={(event) => handleRunAction(event, handlers, "load-insights", row.runId)}
-                >
-                  {details.reloadActionLabel}
-                </button>
-              ) : details.loadingStatusText ? (
-                <div class="history-details-header__status">{details.loadingStatusText}</div>
-              ) : null}
-              {details.insightsError ? (
-                <span class="history-inline-error">{details.insightsError}</span>
-              ) : null}
-            </div>
-          </div>
-          <HistoryWarnings warnings={details.warnings} />
-          <div class="history-results-layout">
-            <div class="history-main-column">
-              <HistoryInsightsBlock insights={details.insights} />
-              <HistoryRunActionsPanel
-                details={details}
-                handlers={handlers}
-                historyExportUrl={historyExportUrl}
-                row={row}
-              />
-            </div>
-            <div class="history-evidence-column">
-              <div class="history-evidence-panel">
-                <HistoryHeatmap heatmap={details.heatmap} />
-              </div>
-            </div>
-          </div>
-        </div>
-      </td>
-    </tr>
   );
 }
 
@@ -573,8 +221,9 @@ export function HistoryTableBody(props: {
           <HistoryDetailsRow
             key={`details:${row.runId}`}
             details={row.details}
-            handlers={handlers}
             historyExportUrl={currentHistoryExportUrl}
+            onRunAction={(event, action, runId) => handleRunAction(event, handlers, action, runId)}
+            onStopRowToggle={stopRowToggle}
             row={row}
           />
         ) : null,


### PR DESCRIPTION
## summary
- move expanded history row details, insights, and run actions into `history_detail_expansion.tsx`
- move heatmap rendering into `history_heatmap_section.tsx` and summary chip rendering into `history_summary_chips.tsx`
- keep `HistoryTableBody` in `history_table_content.tsx` as the table orchestrator and event-wiring owner

## why
- the history table content file had grown into another large multi-purpose view with row rendering, expanded details, insights, and visualization logic mixed together
- this split keeps the public table flow in one place while making the large detail/visual sections easier to work on in isolation

## validation
- `cd apps/ui && npm run typecheck && npm run build`

## risks / edges
- intended to be structure-only; no behavior change
- event handling still routes through `history_table_content.tsx`, so the interaction contract stays centralized
- main risk is prop drift between the new modules, covered by the frontend type/build gate