### PR TITLE
perf(ui): use declarative ESP flash log scroll

### DIFF
--- a/apps/ui/src/app/views/esp_flash_log_section.tsx
+++ b/apps/ui/src/app/views/esp_flash_log_section.tsx
@@ -10,5 +10,5 @@ export function EspFlashLogContent(props: {
   if (model.emptyState) {
     return <InlineEmptyState model={model.emptyState} />;
   }
-  return <pre class="log-pre">{model.text}</pre>;
+  return <pre class="log-pre log-pre--contained">{model.text}</pre>;
 }

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -69,7 +69,7 @@ function EspFlashPanel(props: {
   );
   const actions = useComputed(() => props.actions.value);
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL);
-  const logPanelRef = useRef<HTMLDivElement | null>(null);
+  const logEndRef = useRef<HTMLDivElement | null>(null);
   const handleSelectPort = (value: string) => {
     actions.value?.onSelectPort(value);
   };
@@ -84,12 +84,12 @@ function EspFlashPanel(props: {
   };
 
   useSignalEffect(() => {
-    const logPanel = logPanelRef.current;
     const log = model.value.log;
-    if (!logPanel || log.emptyState !== null) {
+    const logEnd = logEndRef.current;
+    if (!logEnd || log.emptyState !== null) {
       return;
     }
-    logPanel.scrollTop = logPanel.scrollHeight;
+    logEnd.scrollIntoView({ block: "end" });
   });
 
   return (
@@ -254,7 +254,6 @@ function EspFlashPanel(props: {
               </div>
               <div
                 id="espFlashLogPanel"
-                ref={logPanelRef}
                 class={
                   model.value.log.emptyState
                     ? "maintenance-log-slot"
@@ -263,6 +262,7 @@ function EspFlashPanel(props: {
                 aria-live="polite"
               >
                 <EspFlashLogContent model={model.value.log} />
+                {model.value.log.emptyState === null ? <div ref={logEndRef} aria-hidden="true" /> : null}
               </div>
             </section>
           </div>

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -89,7 +89,10 @@ function EspFlashPanel(props: {
     if (!logEnd || log.emptyState !== null) {
       return;
     }
-    logEnd.scrollIntoView({ block: "end" });
+    const animationFrameId = globalThis.requestAnimationFrame(() => {
+      logEnd.scrollIntoView({ block: "end", inline: "nearest" });
+    });
+    return () => globalThis.cancelAnimationFrame(animationFrameId);
   });
 
   return (
@@ -262,7 +265,14 @@ function EspFlashPanel(props: {
                 aria-live="polite"
               >
                 <EspFlashLogContent model={model.value.log} />
-                {model.value.log.emptyState === null ? <div ref={logEndRef} aria-hidden="true" /> : null}
+                {model.value.log.emptyState === null ? (
+                  <div
+                    ref={logEndRef}
+                    class="maintenance-log-anchor"
+                    data-log-end="true"
+                    aria-hidden="true"
+                  />
+                ) : null}
               </div>
             </section>
           </div>

--- a/apps/ui/src/styles/maintenance-details.css
+++ b/apps/ui/src/styles/maintenance-details.css
@@ -14,6 +14,10 @@
   padding: var(--space-3);
 }
 
+.maintenance-log-anchor {
+  transform: translateY(calc(var(--space-3) - 1px));
+}
+
 .log-pre {
   margin: 0;
   max-height: 15rem;
@@ -26,6 +30,15 @@
   background: var(--surface);
   padding: var(--space-3);
   white-space: pre-wrap;
+}
+
+.log-pre--contained {
+  max-height: none;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
 }
 
 .issue-list,


### PR DESCRIPTION
## summary
- replace the ESP flash log `scrollTop = scrollHeight` write with a bottom sentinel and `scrollIntoView()`
- make the outer ESP flash log panel the only scroll owner so the sentinel targets the real container
- add a small anchor offset so the padded panel still reaches its true bottom and keeps the smoke contract green

## why
- direct `scrollTop` writes were imperative and tied the effect to manual scroll math
- the first sentinel-only version stopped short in the padded outer panel and failed the existing smoke check
- flattening the nested log scroll keeps the declarative path and preserves current UX

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts --project=laptop-light tests/smoke.esp-flash.spec.ts`

## risks / edges
- no intended UX change beyond preserving full-bottom autoscroll
- the anchor offset follows the existing spacing token, so keep it aligned if maintenance log padding changes later