### PR TITLE
refactor(ui): signal-drive spectrum panel

### DIFF
--- a/apps/ui/src/app/runtime/spectrum_interaction_controller.ts
+++ b/apps/ui/src/app/runtime/spectrum_interaction_controller.ts
@@ -1,10 +1,13 @@
-import { batch, effect, signal } from "../ui_signals";
+import { batch, computed, effect, signal, type ReadonlySignal } from "../ui_signals";
 import type { ChartBand } from "../ui_app_state";
 import type { SpectrumFocusMarker, SpectrumSeriesEntry } from "./spectrum_shared";
 import { closestFrequencyIndex } from "./spectrum_shared";
 import type {
+  SpectrumBandLegendModel,
   SpectrumLegendItemModel,
+  SpectrumLegendHandlers,
   SpectrumLegendState,
+  SpectrumPanelBandToggleModel,
   SpectrumPanelView,
   SpectrumSensorLegendModel,
 } from "./spectrum_panel_view";
@@ -41,32 +44,36 @@ export class SpectrumInteractionController {
 
   private readonly bandsVisible = signal(false);
 
+  readonly bandToggleModel: ReadonlySignal<SpectrumPanelBandToggleModel>;
+
+  readonly sensorLegendModel: ReadonlySignal<SpectrumSensorLegendModel | null>;
+
+  readonly sensorLegendHandlersModel: ReadonlySignal<SpectrumLegendHandlers | null>;
+
+  readonly bandLegendModel: ReadonlySignal<SpectrumBandLegendModel>;
+
   constructor(
     private readonly deps: SpectrumInteractionControllerDeps,
   ) {
-    this.deps.panel.bindBandToggle(() => this.toggleBands());
-
-    effect(() => {
+    this.bandToggleModel = computed(() => {
       const bands = this.currentBands.value;
       const entries = this.currentEntries.value;
       const visible = this.bandsVisible.value;
-      const hasBands = bands.length > 0 && entries.length > 0;
-      this.deps.panel.renderBandToggle({
-        hasBands,
+      return {
+        hasBands: bands.length > 0 && entries.length > 0,
         bandsVisible: visible,
         text: this.deps.t(visible ? "spectrum.bands.hide" : "spectrum.bands.show"),
-      });
+      };
     });
 
-    effect(() => {
+    this.sensorLegendModel = computed(() => {
       const entries = this.currentEntries.value;
       const pinnedId = this.pinnedSeriesId.value;
       if (!entries.length) {
-        this.deps.panel.renderSensorLegend(null);
-        return;
+        return null;
       }
       const allActive = pinnedId === null;
-      const model: SpectrumSensorLegendModel = {
+      return {
         reset: {
           labelText: this.deps.t("spectrum.legend.all_series"),
           titleText: this.deps.t("spectrum.legend.clear_focus"),
@@ -113,31 +120,41 @@ export class SpectrumInteractionController {
             muted,
           } satisfies SpectrumLegendItemModel;
         }),
-      };
-      this.deps.panel.renderSensorLegend(model, {
-        onReset: () => {
-          this.pinnedSeriesId.value = null;
-          this.applyPlotSelection();
-        },
-        onSelect: (entryId) => {
-          this.pinnedSeriesId.value = this.pinnedSeriesId.value === entryId ? null : entryId;
-          this.applyPlotSelection();
-        },
-      });
+      } satisfies SpectrumSensorLegendModel;
     });
 
-    effect(() => {
+    this.sensorLegendHandlersModel = computed(() =>
+      this.sensorLegendModel.value === null
+        ? null
+        : {
+          onReset: () => {
+            this.pinnedSeriesId.value = null;
+            this.applyPlotSelection();
+          },
+          onSelect: (entryId: string) => {
+            this.pinnedSeriesId.value = this.pinnedSeriesId.value === entryId ? null : entryId;
+            this.applyPlotSelection();
+          },
+        } satisfies SpectrumLegendHandlers
+    );
+
+    this.bandLegendModel = computed(() => {
       const activeFreq = this.activeFrequency();
       const activeBands = activeFreq === null ? [] : this.activeBandsForFrequency(activeFreq);
-      this.deps.panel.renderBandLegend({
+      return {
         visible: this.bandsVisible.value && this.currentBands.value.length > 0 && this.currentEntries.value.length > 0,
         items: activeBands.map((band) => ({
           labelText: band.label,
           color: band.color,
         })),
         emptyText: this.deps.t("spectrum.bands.none"),
-      });
+      };
+    });
 
+    this.deps.panel.bindBandToggle(() => this.toggleBands());
+    effect(() => {
+      const activeFreq = this.activeFrequency();
+      const activeBands = activeFreq === null ? [] : this.activeBandsForFrequency(activeFreq);
       const focusEntry = this.focusEntry();
       if (!focusEntry) {
         this.deps.panel.renderInspectorText(this.deps.t("spectrum.inspector_idle"));

--- a/apps/ui/src/app/runtime/spectrum_panel_view.ts
+++ b/apps/ui/src/app/runtime/spectrum_panel_view.ts
@@ -1,3 +1,5 @@
+import type { ReadonlySignal } from "../ui_signals";
+
 export type SpectrumLegendState = "all-visible" | "visible" | "isolated" | "inactive";
 
 export interface SpectrumPanelHeaderModel {
@@ -52,19 +54,21 @@ export interface SpectrumPanelBandToggleModel {
   text: string;
 }
 
+export interface SpectrumLegendHandlers {
+  onReset: () => void;
+  onSelect: (entryId: string) => void;
+}
+
 export interface SpectrumPanelView {
   readonly chartDom: SpectrumPanelChartDom;
   bindBandToggle(onToggle: () => void): void;
+  bindBandToggleModel(model: ReadonlySignal<SpectrumPanelBandToggleModel>): void;
+  bindSensorLegendModel(
+    model: ReadonlySignal<SpectrumSensorLegendModel | null>,
+    handlers: ReadonlySignal<SpectrumLegendHandlers | null>,
+  ): void;
+  bindBandLegendModel(model: ReadonlySignal<SpectrumBandLegendModel>): void;
   renderHeader(model: SpectrumPanelHeaderModel): void;
   renderOverlay(message: string | null): void;
-  renderBandToggle(model: SpectrumPanelBandToggleModel): void;
-  renderSensorLegend(
-    model: SpectrumSensorLegendModel | null,
-    handlers?: {
-      onReset: () => void;
-      onSelect: (entryId: string) => void;
-    },
-  ): void;
-  renderBandLegend(model: SpectrumBandLegendModel): void;
   renderInspectorText(text: string): void;
 }

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -49,6 +49,7 @@ export class UiSpectrumController {
       setSeriesIsolation: (seriesIndex) => this.canvas.setSeriesIsolation(seriesIndex),
       requestPlotRefresh: () => this.canvas.refreshDecorations(),
     });
+    this.bindInteractionModelSignals();
     this.renderSpectrumHeader();
     this.updateSpectrumOverlay();
     this.bindReactiveTransportSync();
@@ -124,6 +125,15 @@ export class UiSpectrumController {
 
   private setSpectrumOverlay(message: string | null): void {
     this.panel.renderOverlay(message);
+  }
+
+  private bindInteractionModelSignals(): void {
+    this.panel.bindBandToggleModel(this.interaction.bandToggleModel);
+    this.panel.bindSensorLegendModel(
+      this.interaction.sensorLegendModel,
+      this.interaction.sensorLegendHandlersModel,
+    );
+    this.panel.bindBandLegendModel(this.interaction.bandLegendModel);
   }
 
   private bindReactiveLanguageSync(): void {

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -6,8 +6,10 @@ import {
   useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
+import { createDeferredModelSignal } from "./view_model_binding";
 import type {
   SpectrumBandLegendModel,
+  SpectrumLegendHandlers,
   SpectrumPanelBandToggleModel,
   SpectrumPanelChartDom,
   SpectrumPanelHeaderModel,
@@ -15,16 +17,21 @@ import type {
   SpectrumSensorLegendModel,
 } from "../runtime/spectrum_panel_view";
 
-type SpectrumLegendHandlers = {
-  onReset: () => void;
-  onSelect: (entryId: string) => void;
-};
-
 type MutableSpectrumPanelChartDom = {
   specChartWrap: HTMLElement | null;
   specChart: HTMLElement | null;
 };
 
+const DEFAULT_SPECTRUM_BAND_TOGGLE_MODEL: SpectrumPanelBandToggleModel = {
+  hasBands: false,
+  bandsVisible: false,
+  text: "Show reference bands",
+};
+const DEFAULT_SPECTRUM_BAND_LEGEND_MODEL: SpectrumBandLegendModel = {
+  visible: false,
+  items: [],
+  emptyText: "No reference band",
+};
 const SPECTRUM_BAND_TOGGLE_KEYS = ["bandsVisible", "hasBands", "text"] as const;
 const SPECTRUM_BAND_LEGEND_KEYS = ["emptyText", "items", "visible"] as const;
 
@@ -129,17 +136,21 @@ function SpectrumSensorLegend(props: {
 }
 
 function SpectrumPanel(props: {
-  bandLegend: ReadonlySignal<SpectrumBandLegendModel>;
-  bandToggle: ReadonlySignal<SpectrumPanelBandToggleModel>;
+  bandLegendModel: ReadonlySignal<ReadonlySignal<SpectrumBandLegendModel> | null>;
+  bandToggleModel: ReadonlySignal<ReadonlySignal<SpectrumPanelBandToggleModel> | null>;
   chartDom: MutableSpectrumPanelChartDom;
   header: ReadonlySignal<SpectrumPanelHeaderModel>;
   inspectorText: ReadonlySignal<string>;
   onBandToggle: ReadonlySignal<(() => void) | null>;
   overlayMessage: ReadonlySignal<string | null>;
-  sensorLegend: ReadonlySignal<SpectrumSensorLegendModel | null>;
-  sensorLegendHandlers: ReadonlySignal<SpectrumLegendHandlers | null>;
+  sensorLegendHandlersModel: ReadonlySignal<ReadonlySignal<SpectrumLegendHandlers | null> | null>;
+  sensorLegendModel: ReadonlySignal<ReadonlySignal<SpectrumSensorLegendModel | null> | null>;
 }) {
   const { chartDom } = props;
+  const bandLegend = useComputed(() => props.bandLegendModel.value?.value ?? DEFAULT_SPECTRUM_BAND_LEGEND_MODEL);
+  const bandToggle = useComputed(() => props.bandToggleModel.value?.value ?? DEFAULT_SPECTRUM_BAND_TOGGLE_MODEL);
+  const sensorLegend = useComputed(() => props.sensorLegendModel.value?.value ?? null);
+  const sensorLegendHandlers = useComputed(() => props.sensorLegendHandlersModel.value?.value ?? null);
   const titleText = useComputed(() => getUiText("chart.spectrum_title", props.header.value.titleText));
   const hintText = useComputed(() => getUiText("spectrum.controls_hint", props.header.value.hintText));
   const overlayHidden = useComputed(() => props.overlayMessage.value === null);
@@ -148,9 +159,9 @@ function SpectrumPanel(props: {
     bandsVisible: bandToggleBandsVisible,
     hasBands: bandToggleHasBands,
     text: bandToggleText,
-  } = useSignalProperties(props.bandToggle, SPECTRUM_BAND_TOGGLE_KEYS);
+  } = useSignalProperties(bandToggle, SPECTRUM_BAND_TOGGLE_KEYS);
   const bandTogglePressed = useComputed(() =>
-    bandToggleHasBands.value && bandToggleBandsVisible.value ? "true" : "false"
+      bandToggleHasBands.value && bandToggleBandsVisible.value ? "true" : "false"
   );
   const bandToggleHidden = useComputed(() => !bandToggleHasBands.value);
 
@@ -197,7 +208,7 @@ function SpectrumPanel(props: {
             >
               {bandToggleText}
             </button>
-            <SpectrumBandLegend bandLegend={props.bandLegend} />
+            <SpectrumBandLegend bandLegend={bandLegend} />
           </div>
         </div>
         <div id="spectrumInspector" class="spectrum-inspector" aria-live="polite">
@@ -205,8 +216,8 @@ function SpectrumPanel(props: {
         </div>
         <div id="legend" class="legend">
           <SpectrumSensorLegend
-            sensorLegend={props.sensorLegend}
-            sensorLegendHandlers={props.sensorLegendHandlers}
+            sensorLegend={sensorLegend}
+            sensorLegendHandlers={sensorLegendHandlers}
           />
         </div>
       </div>
@@ -220,18 +231,10 @@ export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
     hintText: "Use the trace chips to isolate one sensor at a time. Turn on reference bands when you need order context.",
   });
   const overlayMessage = signal<string | null>(null);
-  const bandToggle = signal<SpectrumPanelBandToggleModel>({
-    hasBands: false,
-    bandsVisible: false,
-    text: "Show reference bands",
-  });
-  const sensorLegend = signal<SpectrumSensorLegendModel | null>(null);
-  const sensorLegendHandlers = signal<SpectrumLegendHandlers | null>(null);
-  const bandLegend = signal<SpectrumBandLegendModel>({
-    visible: false,
-    items: [],
-    emptyText: "No reference band",
-  });
+  const bandToggleModel = createDeferredModelSignal<SpectrumPanelBandToggleModel>();
+  const sensorLegendModel = createDeferredModelSignal<SpectrumSensorLegendModel | null>();
+  const sensorLegendHandlersModel = createDeferredModelSignal<SpectrumLegendHandlers | null>();
+  const bandLegendModel = createDeferredModelSignal<SpectrumBandLegendModel>();
   const inspectorText = signal("Use the trace chips or hover the chart to inspect the current peak.");
   const onBandToggle = signal<(() => void) | null>(null);
   const chartDom: MutableSpectrumPanelChartDom = {
@@ -240,15 +243,15 @@ export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
   };
   render(
     <SpectrumPanel
-      bandLegend={bandLegend}
-      bandToggle={bandToggle}
+      bandLegendModel={bandLegendModel}
+      bandToggleModel={bandToggleModel}
       chartDom={chartDom}
       header={header}
       inspectorText={inspectorText}
       onBandToggle={onBandToggle}
       overlayMessage={overlayMessage}
-      sensorLegend={sensorLegend}
-      sensorLegendHandlers={sensorLegendHandlers}
+      sensorLegendHandlersModel={sensorLegendHandlersModel}
+      sensorLegendModel={sensorLegendModel}
     />,
     host,
   );
@@ -265,24 +268,24 @@ export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
     bindBandToggle(onToggle: () => void): void {
       onBandToggle.value = onToggle;
     },
+    bindBandToggleModel(model: ReadonlySignal<SpectrumPanelBandToggleModel>): void {
+      bandToggleModel.value = model;
+    },
+    bindSensorLegendModel(
+      model: ReadonlySignal<SpectrumSensorLegendModel | null>,
+      handlers: ReadonlySignal<SpectrumLegendHandlers | null>,
+    ): void {
+      sensorLegendModel.value = model;
+      sensorLegendHandlersModel.value = handlers;
+    },
+    bindBandLegendModel(model: ReadonlySignal<SpectrumBandLegendModel>): void {
+      bandLegendModel.value = model;
+    },
     renderHeader(model: SpectrumPanelHeaderModel): void {
       header.value = model;
     },
     renderOverlay(message: string | null): void {
       overlayMessage.value = message;
-    },
-    renderBandToggle(model: SpectrumPanelBandToggleModel): void {
-      bandToggle.value = model;
-    },
-    renderSensorLegend(
-      model: SpectrumSensorLegendModel | null,
-      handlers?: SpectrumLegendHandlers,
-    ): void {
-      sensorLegend.value = model;
-      sensorLegendHandlers.value = model && handlers ? handlers : null;
-    },
-    renderBandLegend(model: SpectrumBandLegendModel): void {
-      bandLegend.value = model;
     },
     renderInspectorText(text: string): void {
       inspectorText.value = text;

--- a/apps/ui/tests/spectrum_interaction_controller.spec.ts
+++ b/apps/ui/tests/spectrum_interaction_controller.spec.ts
@@ -2,75 +2,41 @@ import { expect, test } from "@playwright/test";
 
 import { SpectrumInteractionController } from "../src/app/runtime/spectrum_interaction_controller";
 import type {
-  SpectrumBandLegendModel,
   SpectrumPanelView,
-  SpectrumSensorLegendModel,
 } from "../src/app/runtime/spectrum_panel_view";
 import { createElementStub } from "./spectrum_test_support";
 
 function createPanelStub(): {
   panel: SpectrumPanelView;
-  bandToggleModel: { hasBands: boolean; bandsVisible: boolean; text: string } | null;
-  sensorLegend: {
-    model: SpectrumSensorLegendModel | null;
-    handlers: {
-      onReset: () => void;
-      onSelect: (entryId: string) => void;
-    } | null;
-  };
-  bandLegendModel: SpectrumBandLegendModel | null;
+  onBandToggle: (() => void) | null;
   inspectorText: string;
 } {
-  let bandToggleModel: { hasBands: boolean; bandsVisible: boolean; text: string } | null = null;
-  let sensorLegend: {
-    model: SpectrumSensorLegendModel | null;
-    handlers: {
-      onReset: () => void;
-      onSelect: (entryId: string) => void;
-    } | null;
-  } = {
-    model: null,
-    handlers: null,
-  };
-  let bandLegendModel: SpectrumBandLegendModel | null = null;
+  let onBandToggle: (() => void) | null = null;
   let inspectorText = "";
 
   return {
     panel: {
-      chartDom: {
-        specChartWrap: createElementStub("div"),
-        specChart: createElementStub("div"),
+        chartDom: {
+          specChartWrap: createElementStub("div"),
+          specChart: createElementStub("div"),
+        },
+        bindBandToggle(handler) {
+          onBandToggle = handler;
+        },
+        bindBandToggleModel() {},
+        bindSensorLegendModel() {},
+        bindBandLegendModel() {},
+        renderHeader() {},
+        renderOverlay() {},
+        renderInspectorText(text) {
+          inspectorText = text;
+        },
       },
-      bindBandToggle() {},
-      renderHeader() {},
-      renderOverlay() {},
-      renderBandToggle(model) {
-        bandToggleModel = model;
+      get onBandToggle() {
+        return onBandToggle;
       },
-      renderSensorLegend(model, handlers) {
-        sensorLegend = {
-          model,
-          handlers: handlers ?? null,
-        };
-      },
-      renderBandLegend(model) {
-        bandLegendModel = model;
-      },
-      renderInspectorText(text) {
-        inspectorText = text;
-      },
-    },
-    get bandToggleModel() {
-      return bandToggleModel;
-    },
-    get sensorLegend() {
-      return sensorLegend;
-    },
-    get bandLegendModel() {
-      return bandLegendModel;
-    },
-    get inspectorText() {
-      return inspectorText;
+      get inspectorText() {
+        return inspectorText;
     },
   };
 }
@@ -124,22 +90,22 @@ test.describe("SpectrumInteractionController", () => {
       chartBands: [],
     });
 
-    expect(panel.bandToggleModel).toEqual({
+    expect(controller.bandToggleModel.value).toEqual({
       hasBands: false,
       bandsVisible: false,
       text: "Show reference bands",
     });
-    expect(panel.sensorLegend.model?.items[0]?.detailText).toBe("12.0 dB");
-    expect(panel.sensorLegend.model?.items[0]?.ariaPressed).toBe(false);
-    expect(panel.sensorLegend.model?.items[1]?.detailText).toBe("8.0 dB");
+    expect(controller.sensorLegendModel.value?.items[0]?.detailText).toBe("12.0 dB");
+    expect(controller.sensorLegendModel.value?.items[0]?.ariaPressed).toBe(false);
+    expect(controller.sensorLegendModel.value?.items[1]?.detailText).toBe("8.0 dB");
     expect(isolatedSeries).toBeNull();
 
-    panel.sensorLegend.handlers?.onSelect("sensor-a");
-    expect(panel.sensorLegend.model?.items[0]?.detailText).toBe("12.0 dB");
-    expect(panel.sensorLegend.model?.items[0]?.ariaPressed).toBe(true);
-    expect(panel.sensorLegend.model?.items[0]?.active).toBe(true);
-    expect(panel.sensorLegend.model?.items[1]?.detailText).toBe("8.0 dB");
-    expect(panel.sensorLegend.model?.items[1]?.muted).toBe(true);
+    controller.sensorLegendHandlersModel.value?.onSelect("sensor-a");
+    expect(controller.sensorLegendModel.value?.items[0]?.detailText).toBe("12.0 dB");
+    expect(controller.sensorLegendModel.value?.items[0]?.ariaPressed).toBe(true);
+    expect(controller.sensorLegendModel.value?.items[0]?.active).toBe(true);
+    expect(controller.sensorLegendModel.value?.items[1]?.detailText).toBe("8.0 dB");
+    expect(controller.sensorLegendModel.value?.items[1]?.muted).toBe(true);
     expect(isolatedSeries).toBe(1);
 
     strengthDbById.set("sensor-a", 13);
@@ -152,15 +118,17 @@ test.describe("SpectrumInteractionController", () => {
       chartBands: [],
     });
 
-    expect(panel.sensorLegend.model?.items[0]?.detailText).toBe("13.0 dB");
-    expect(panel.sensorLegend.model?.items[0]?.ariaPressed).toBe(true);
+    expect(controller.sensorLegendModel.value?.items[0]?.detailText).toBe("13.0 dB");
+    expect(controller.sensorLegendModel.value?.items[0]?.ariaPressed).toBe(true);
 
-    panel.sensorLegend.handlers?.onSelect("sensor-a");
-    expect(panel.sensorLegend.model?.items[0]?.detailText).toBe("13.0 dB");
-    expect(panel.sensorLegend.model?.items[0]?.ariaPressed).toBe(false);
-    expect(panel.sensorLegend.model?.items[0]?.active).toBe(false);
-    expect(panel.sensorLegend.model?.items[1]?.detailText).toBe("8.0 dB");
-    expect(panel.sensorLegend.model?.items[1]?.muted).toBe(false);
+    controller.sensorLegendHandlersModel.value?.onSelect("sensor-a");
+    expect(controller.sensorLegendModel.value?.items[0]?.detailText).toBe("13.0 dB");
+    expect(controller.sensorLegendModel.value?.items[0]?.ariaPressed).toBe(false);
+    expect(controller.sensorLegendModel.value?.items[0]?.active).toBe(false);
+    expect(controller.sensorLegendModel.value?.items[1]?.detailText).toBe("8.0 dB");
+    expect(controller.sensorLegendModel.value?.items[1]?.muted).toBe(false);
     expect(isolatedSeries).toBeNull();
+
+    expect(panel.onBandToggle).not.toBeNull();
   });
 });

--- a/apps/ui/tests/spectrum_panel_signals.ts
+++ b/apps/ui/tests/spectrum_panel_signals.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 
 import { options } from "preact";
+import { signal } from "../src/app/ui_signals";
 
 import type {
   SpectrumBandLegendModel,
+  SpectrumLegendHandlers,
   SpectrumPanelBandToggleModel,
   SpectrumSensorLegendModel,
 } from "../src/app/runtime/spectrum_panel_view";
@@ -30,38 +32,38 @@ async function runSpectrumPanelSignalProjectionTest(): Promise<void> {
     return mountSpectrumPanel;
   });
 
-  try {
-    await harness.flush();
-    assert.equal(spectrumPanelRenderCount, 1);
+    try {
+      await harness.flush();
+      assert.equal(spectrumPanelRenderCount, 1);
 
-    const bandToggleModel: SpectrumPanelBandToggleModel = {
-      bandsVisible: true,
-      hasBands: true,
-      text: "Hide reference bands",
-    };
-    harness.view.renderBandToggle(bandToggleModel);
-    await harness.flush();
+      const bandToggleModel = signal<SpectrumPanelBandToggleModel>({
+        bandsVisible: true,
+        hasBands: true,
+        text: "Hide reference bands",
+      });
+      harness.view.bindBandToggleModel(bandToggleModel);
+      await harness.flush();
 
-    const bandToggleBaseline = spectrumPanelRenderCount;
-    assert.equal(requireElement<HTMLButtonElement>(harness.host, "#spectrumBandToggle").textContent, "Hide reference bands");
+      const bandToggleBaseline = spectrumPanelRenderCount;
+      assert.equal(requireElement<HTMLButtonElement>(harness.host, "#spectrumBandToggle").textContent, "Hide reference bands");
 
-    const bandLegendModel: SpectrumBandLegendModel = {
-      visible: true,
-      items: [{ color: "#f59e0b", labelText: "Wheel 1x" }],
-      emptyText: "No reference band",
-    };
-    harness.view.renderBandLegend(bandLegendModel);
-    await harness.flush();
+      const bandLegendModel = signal<SpectrumBandLegendModel>({
+        visible: true,
+        items: [{ color: "#f59e0b", labelText: "Wheel 1x" }],
+        emptyText: "No reference band",
+      });
+      harness.view.bindBandLegendModel(bandLegendModel);
+      await harness.flush();
 
-    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
-    assert.match(requireElement(harness.host, "#bandLegend").textContent ?? "", /Wheel 1x/);
+      assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+      assert.match(requireElement(harness.host, "#bandLegend").textContent ?? "", /Wheel 1x/);
 
-    let resetClicks = 0;
-    const selectedIds: string[] = [];
-    const sensorLegendModel: SpectrumSensorLegendModel = {
-      reset: {
-        labelText: "All sensor traces",
-        titleText: "Show all traces",
+      let resetClicks = 0;
+      const selectedIds: string[] = [];
+      const sensorLegendModel = signal<SpectrumSensorLegendModel | null>({
+        reset: {
+          labelText: "All sensor traces",
+          titleText: "Show all traces",
         ariaLabel: "Show all sensor traces",
         ariaPressed: true,
         active: true,
@@ -75,47 +77,41 @@ async function runSpectrumPanelSignalProjectionTest(): Promise<void> {
         ariaLabel: "Focus Front Left",
         ariaPressed: false,
         active: false,
-        muted: false,
-      }],
-    };
-    harness.view.renderSensorLegend(sensorLegendModel, {
-      onReset: () => {
-        resetClicks += 1;
-      },
-      onSelect: (entryId) => {
-        selectedIds.push(entryId);
-      },
-    });
-    await harness.flush();
+          muted: false,
+        }],
+      });
+      const sensorLegendHandlers = signal<SpectrumLegendHandlers | null>({
+        onReset: () => {
+          resetClicks += 1;
+        },
+        onSelect: (entryId) => {
+          selectedIds.push(entryId);
+        },
+      });
+      harness.view.bindSensorLegendModel(sensorLegendModel, sensorLegendHandlers);
+      await harness.flush();
 
-    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+      assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
     assert.match(requireElement(harness.host, "#legend").textContent ?? "", /Front Left/);
     assert.match(requireElement(harness.host, "#legend").textContent ?? "", /12.0 dB/);
 
-    requireElement<HTMLButtonElement>(harness.host, ".legend-item--reset").click();
-    requireElement<HTMLButtonElement>(harness.host, '[aria-label="Focus Front Left"]').click();
-    assert.equal(resetClicks, 1);
-    assert.deepEqual(selectedIds, ["front-left"]);
+     requireElement<HTMLButtonElement>(harness.host, ".legend-item--reset").click();
+      requireElement<HTMLButtonElement>(harness.host, '[aria-label="Focus Front Left"]').click();
+      assert.equal(resetClicks, 1);
+      assert.deepEqual(selectedIds, ["front-left"]);
 
-    harness.view.renderSensorLegend({
-      ...sensorLegendModel,
-      items: [{
-        ...sensorLegendModel.items[0],
-        detailText: "13.0 dB",
-        active: true,
-        ariaPressed: true,
-      }],
-    }, {
-      onReset: () => {
-        resetClicks += 1;
-      },
-      onSelect: (entryId) => {
-        selectedIds.push(entryId);
-      },
-    });
-    await harness.flush();
+      sensorLegendModel.value = {
+        ...sensorLegendModel.value!,
+        items: [{
+          ...sensorLegendModel.value!.items[0],
+          detailText: "13.0 dB",
+          active: true,
+          ariaPressed: true,
+        }],
+      };
+      await harness.flush();
 
-    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+      assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
     assert.match(requireElement(harness.host, "#legend").textContent ?? "", /13.0 dB/);
   } finally {
     options.diffed = previousDiffed;

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -19,23 +19,23 @@ function createPanelStub(): {
   let lastOverlayMessage: string | null = null;
 
   return {
-    panel: {
-      chartDom: {
-        specChartWrap: createElementStub("div"),
-        specChart: createElementStub("div"),
+      panel: {
+        chartDom: {
+          specChartWrap: createElementStub("div"),
+          specChart: createElementStub("div"),
+        },
+        bindBandToggle() {},
+        bindBandToggleModel() {},
+        bindSensorLegendModel() {},
+        bindBandLegendModel() {},
+        renderHeader(model) {
+          lastHeaderModel = model;
+        },
+        renderOverlay(message: string | null) {
+          lastOverlayMessage = message;
+        },
+        renderInspectorText() {},
       },
-      bindBandToggle() {},
-      renderHeader(model) {
-        lastHeaderModel = model;
-      },
-      renderOverlay(message: string | null) {
-        lastOverlayMessage = message;
-      },
-      renderBandToggle() {},
-      renderSensorLegend() {},
-      renderBandLegend() {},
-      renderInspectorText() {},
-    },
     get lastHeaderModel() {
       return lastHeaderModel;
     },


### PR DESCRIPTION
## summary
- move the spectrum band toggle, sensor legend, and band legend off imperative `render*()` calls and onto controller-owned computed signals
- bind those signals into `spectrum_panel.tsx` once through the existing deferred-model pattern instead of pushing new models through view methods every update
- keep the chart DOM, inspector text, header, and overlay surfaces on the existing panel bridge so the refactor stays scoped
- update the focused spectrum seam tests to assert the new signal path instead of the removed imperative legend/toggle methods

## why
- the spectrum panel still had a leftover imperative render surface even though the Preact view already owned those sections
- pushing legend and toggle state through computed signals completes that migration and keeps updates inside the existing reactive VDOM path
- the narrower bind-once bridge follows the same pattern already used elsewhere in the UI runtime

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx tsx tests/spectrum_panel_signals.ts`
- `cd apps/ui && npx playwright test tests/spectrum_interaction_controller.spec.ts tests/ui_spectrum_controller.spec.ts --workers=1`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts --project=laptop-light tests/smoke.spectrum.spec.ts`

## risks / edges
- no intended behavior change; this rewires update flow, not the rendered spectrum UI
- header, overlay, and inspector text still use the existing panel bridge on purpose so the refactor only removes the leftover imperative legend/toggle path
- the panel now depends on deferred model bindings for those sections, so future runtime work should extend the bound signals instead of reintroducing `renderBandToggle`/`renderSensorLegend`/`renderBandLegend` methods

Closes #2644