### PR TITLE
perf(ui): remove ws state batch

### DIFF
--- a/apps/ui/src/ws.ts
+++ b/apps/ui/src/ws.ts
@@ -184,9 +184,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
   }
 
   function setState(next: WsUiState): void {
-    batch(() => {
-      commitState(next);
-    });
+    commitState(next);
   }
 
   function commitState(next: WsUiState): void {


### PR DESCRIPTION
## summary
- remove the `batch()` wrapper from `setState()` in `ws.ts`
- keep `commitState()` as the single guarded websocket UI-state write path
- leave the other grouped websocket transitions untouched

## why
- `setState()` only forwarded to `commitState()`
- `commitState()` only performs one guarded `uiState.value` assignment, so the extra batch added overhead without grouping any additional writes

## validation
- `cd apps/ui && npx playwright test tests/ws.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## risks / edges
- no intended behavior change
- only the stale-state helper changed; the other websocket lifecycle paths still keep their existing grouped writes

Closes #2645