### PR TITLE
refactor(ui): move document lang sync

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -8,7 +8,6 @@ import {
   useComputed,
   type Signal,
   type ReadonlySignal,
-  useSignalEffect,
 } from "../ui_signals";
 import {
   createDeferredModelSignal,
@@ -61,20 +60,6 @@ type UiShellChromeProps = {
   statusModel: ReadonlySignal<ReadonlySignal<UiShellChromeStatusModel> | null>;
 };
 
-function DocumentLanguageSync(props: {
-  preferencesModel: ReadonlySignal<UiShellChromePreferencesModel>;
-}) {
-  const { preferencesModel } = props;
-
-  useSignalEffect(() => {
-    const lang = preferencesModel.value.selectedLanguage;
-    const documentElement = globalThis.document?.documentElement;
-    if (documentElement) documentElement.lang = lang;
-  });
-
-  return null;
-}
-
 function UiShellChrome(props: UiShellChromeProps) {
   const {
     actions,
@@ -87,7 +72,6 @@ function UiShellChrome(props: UiShellChromeProps) {
 
   return (
     <ShellChromeFrame statusModel={statusModel}>
-      <DocumentLanguageSync preferencesModel={preferencesModel} />
       <header class="site-header">
         <div class="site-header__main">
           <ShellNavigation actions={actions} navigationModel={navigationModel} />

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -141,6 +141,7 @@ export class UiShellController {
     this.statusRenderModel = this.createStatusRenderModel();
     this.dialogRenderModel = this.createDialogRenderModel();
     this.bindChromeModelSignals();
+    this.bindDocumentLanguageSync();
     this.bindReactiveLanguageSync();
     this.bindReactiveSpeedReadoutSync();
   }
@@ -195,6 +196,18 @@ export class UiShellController {
     effectOnChange(this.state.shell.lang, (currentLanguage) => {
       untracked(() => {
         setUiLanguage(currentLanguage);
+      });
+    });
+  }
+
+  private bindDocumentLanguageSync(): void {
+    effect(() => {
+      const currentLanguage = this.state.shell.lang.value;
+      untracked(() => {
+        const documentElement = globalThis.document?.documentElement;
+        if (documentElement) {
+          documentElement.lang = currentLanguage;
+        }
       });
     });
   }

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -18,6 +18,7 @@ import { createUiShellNotificationModule } from "../src/app/runtime/ui_shell_not
 import { createUiShellPreferencesModule } from "../src/app/runtime/ui_shell_preferences_module";
 import { createUiShellStatusModule } from "../src/app/runtime/ui_shell_status_module";
 import { signal, type ReadonlySignal } from "../src/app/ui_signals";
+import { installDocumentStub } from "./spectrum_test_support";
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -204,6 +205,32 @@ test.describe("UiShellController", () => {
 
     chromeActions.value.activateView("historyView");
     expect(state.shell.activeViewId.value).toBe("historyView");
+  });
+
+  test("syncs the document language from shell state without a chrome component", () => {
+    const restoreDocument = installDocumentStub();
+    const state = createAppState();
+    const chrome = createChromeViewRecorder();
+    try {
+      new UiShellController({
+        bindFeatureHandlers: () => undefined,
+        chrome: chrome.view,
+        chromeActions: signal<UiShellChromeActions>({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS }),
+        liveOverview: {
+          model: signal(null),
+          speedText: signal("--"),
+        },
+        state,
+      });
+
+      expect(globalThis.document.documentElement.lang).toBe("en");
+
+      state.shell.lang.value = "nl";
+
+      expect(globalThis.document.documentElement.lang).toBe("nl");
+    } finally {
+      restoreDocument();
+    }
   });
 
   test("routes live status updates through the status model only", () => {


### PR DESCRIPTION
## summary
- remove the null-rendering `DocumentLanguageSync` component from `ui_shell_chrome.tsx`
- move `document.documentElement.lang` syncing into `UiShellController` as a plain runtime effect
- cover the controller-owned sync with a focused shell runtime test

## why
- the old component existed only to run a side effect and return `null`
- shell language sync already belongs to the controller runtime, so the document `lang` bridge fits there without adding another view-layer node

## validation
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## risks / edges
- no intended behavior change
- the sync now follows `state.shell.lang` directly, so the shell controller remains the single owner of language side effects

Closes #2647