### PR TITLE
refactor(ui): collapse view label signals

### DIFF
--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -1,7 +1,7 @@
 import { render } from "preact";
 import { useRef } from "preact/hooks";
 
-import { useUiText } from "../ui_i18n";
+import { getUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalEffect,
@@ -42,32 +42,37 @@ function EspFlashPanel(props: {
   actions: ReadonlySignal<EspFlashPanelActionHandlers | null>;
   model: ReadonlySignal<ReadonlySignal<EspFlashPanelRenderModel> | null>;
 }) {
-  const titleText = useUiText("settings.esp_flash.title", "ESP Flash");
-  const hintText = useUiText("settings.esp_flash.hint", "Flash ESP firmware from local source on this Pi.");
-  const portLabel = useUiText("settings.esp_flash.port", "Serial Port");
-  const refreshLabel = useUiText("settings.esp_flash.refresh_ports", "Refresh");
-  const detailsTitle = useUiText("settings.esp_flash.details_title", "What happens next");
-  const detailsCaption = useUiText(
-    "settings.esp_flash.details_caption",
-    "Build, erase, and write the current firmware over USB.",
-  );
-  const preflightNote = useUiText(
-    "settings.esp_flash.preflight_note",
-    "Starting a flash builds the latest firmware on this Pi, erases the selected board, and writes the new image over USB. Keep the board powered until the staged progress reaches Done.",
-  );
-  const cancelLabel = useUiText("settings.esp_flash.cancel", "Cancel");
-  const journeyTitle = useUiText("settings.esp_flash.journey_title", "Expected stages");
-  const logsTitle = useUiText("settings.esp_flash.logs_title", "Live flash output");
-  const logsIntro = useUiText(
-    "settings.esp_flash.logs_intro",
-    "Build, erase, and upload output appears here while the toolchain runs.",
-  );
-  const historyTitle = useUiText("settings.esp_flash.history", "Recent attempts");
-  const historyIntro = useUiText(
-    "settings.esp_flash.history_intro",
-    "Recent flashes stay here so the next operator can see what happened last.",
-  );
   const actions = useComputed(() => props.actions.value);
+  const labels = useComputed(() => ({
+    cancelLabel: getUiText("settings.esp_flash.cancel", "Cancel"),
+    detailsCaption: getUiText(
+      "settings.esp_flash.details_caption",
+      "Build, erase, and write the current firmware over USB.",
+    ),
+    detailsTitle: getUiText("settings.esp_flash.details_title", "What happens next"),
+    hintText: getUiText(
+      "settings.esp_flash.hint",
+      "Flash ESP firmware from local source on this Pi.",
+    ),
+    historyIntro: getUiText(
+      "settings.esp_flash.history_intro",
+      "Recent flashes stay here so the next operator can see what happened last.",
+    ),
+    historyTitle: getUiText("settings.esp_flash.history", "Recent attempts"),
+    journeyTitle: getUiText("settings.esp_flash.journey_title", "Expected stages"),
+    logsIntro: getUiText(
+      "settings.esp_flash.logs_intro",
+      "Build, erase, and upload output appears here while the toolchain runs.",
+    ),
+    logsTitle: getUiText("settings.esp_flash.logs_title", "Live flash output"),
+    portLabel: getUiText("settings.esp_flash.port", "Serial Port"),
+    preflightNote: getUiText(
+      "settings.esp_flash.preflight_note",
+      "Starting a flash builds the latest firmware on this Pi, erases the selected board, and writes the new image over USB. Keep the board powered until the staged progress reaches Done.",
+    ),
+    refreshLabel: getUiText("settings.esp_flash.refresh_ports", "Refresh"),
+    titleText: getUiText("settings.esp_flash.title", "ESP Flash"),
+  }));
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL);
   const logEndRef = useRef<HTMLDivElement | null>(null);
   const handleSelectPort = (value: string) => {
@@ -94,6 +99,7 @@ function EspFlashPanel(props: {
     });
     return () => globalThis.cancelAnimationFrame(animationFrameId);
   });
+  const labelTexts = labels.value;
 
   return (
     <div class="panel card">
@@ -106,13 +112,13 @@ function EspFlashPanel(props: {
                   class="maintenance-card__title"
 
                 >
-                  {titleText}
+                  {labelTexts.titleText}
                 </div>
                 <div
                   class="subtle"
 
                 >
-                  {hintText}
+                  {labelTexts.hintText}
                 </div>
               </div>
               <span
@@ -129,7 +135,7 @@ function EspFlashPanel(props: {
                   htmlFor="espFlashPortSelect"
 
                 >
-                  {portLabel}
+                  {labelTexts.portLabel}
                 </label>
                 <select
                   id="espFlashPortSelect"
@@ -150,7 +156,7 @@ function EspFlashPanel(props: {
                   disabled={model.value.refreshPortsDisabled}
                   onClick={handleRefreshPorts}
                 >
-                  {refreshLabel}
+                  {labelTexts.refreshLabel}
                 </button>
               </div>
               <div
@@ -174,13 +180,13 @@ function EspFlashPanel(props: {
                       class="settings-help-disclosure__title"
 
                     >
-                      {detailsTitle}
+                      {labelTexts.detailsTitle}
                     </span>
                     <span
                       class="settings-help-disclosure__caption"
 
                     >
-                      {detailsCaption}
+                      {labelTexts.detailsCaption}
                     </span>
                   </span>
                 </summary>
@@ -189,7 +195,7 @@ function EspFlashPanel(props: {
                     class="maintenance-note"
 
                   >
-                    {preflightNote}
+                    {labelTexts.preflightNote}
                   </div>
                 </div>
               </details>
@@ -212,7 +218,7 @@ function EspFlashPanel(props: {
                   disabled={model.value.cancelButtonDisabled}
                   onClick={handleCancel}
                 >
-                  {cancelLabel}
+                  {labelTexts.cancelLabel}
                 </button>
               </div>
             </div>
@@ -226,7 +232,7 @@ function EspFlashPanel(props: {
                     class="maintenance-card__title"
 
                   >
-                    {journeyTitle}
+                    {labelTexts.journeyTitle}
                   </div>
                 </div>
               </div>
@@ -245,13 +251,13 @@ function EspFlashPanel(props: {
                     class="maintenance-card__title"
 
                   >
-                    {logsTitle}
+                    {labelTexts.logsTitle}
                   </div>
                   <div
                     class="subtle"
 
                   >
-                    {logsIntro}
+                    {labelTexts.logsIntro}
                   </div>
                 </div>
               </div>
@@ -283,12 +289,12 @@ function EspFlashPanel(props: {
                 <div
                   class="maintenance-card__title"
                 >
-                  {historyTitle}
+                  {labelTexts.historyTitle}
                 </div>
                 <div
                   class="subtle"
                 >
-                  {historyIntro}
+                  {labelTexts.historyIntro}
                 </div>
               </div>
             </div>

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -1,5 +1,5 @@
 import { render } from "preact";
-import { useUiText } from "../ui_i18n";
+import { getUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
@@ -28,13 +28,15 @@ export function HistoryPanel(props: {
   actions: ReadonlySignal<HistoryPanelActionHandlers | null>;
   model: ReadonlySignal<ReadonlySignal<HistoryPanelRenderModel> | null>;
 }) {
-  const refreshLabel = useUiText("history.refresh", "Refresh History");
-  const deleteAllLabel = useUiText("history.delete_all", "Delete All Runs");
-  const runLabel = useUiText("history.table.file", "Run");
-  const startedLabel = useUiText("history.table.updated", "Started");
-  const samplesLabel = useUiText("history.table.size", "Samples");
-  const actionsLabel = useUiText("history.table.actions", "Actions");
   const actions = useComputed(() => props.actions.value);
+  const labels = useComputed(() => ({
+    actionsLabel: getUiText("history.table.actions", "Actions"),
+    deleteAllLabel: getUiText("history.delete_all", "Delete All Runs"),
+    refreshLabel: getUiText("history.refresh", "Refresh History"),
+    runLabel: getUiText("history.table.file", "Run"),
+    samplesLabel: getUiText("history.table.size", "Samples"),
+    startedLabel: getUiText("history.table.updated", "Started"),
+  }));
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_PANEL_MODEL);
   const { deleteAllRunsDisabled, historySummaryText, table } = useSignalProperties(
     model,
@@ -46,6 +48,7 @@ export function HistoryPanel(props: {
   const handleDeleteAllRuns = () => {
     actions.value?.onDeleteAllRuns();
   };
+  const labelTexts = labels.value;
 
   return (
     <>
@@ -62,7 +65,7 @@ export function HistoryPanel(props: {
             type="button"
             onClick={handleRefreshHistory}
           >
-            {refreshLabel}
+            {labelTexts.refreshLabel}
           </button>
           <button
             id="deleteAllRunsBtn"
@@ -71,17 +74,17 @@ export function HistoryPanel(props: {
             disabled={deleteAllRunsDisabled}
             onClick={handleDeleteAllRuns}
           >
-            {deleteAllLabel}
+            {labelTexts.deleteAllLabel}
           </button>
         </div>
       </div>
       <table class="history-table">
         <thead>
           <tr>
-            <th>{runLabel}</th>
-            <th>{startedLabel}</th>
-            <th class="numeric">{samplesLabel}</th>
-            <th>{actionsLabel}</th>
+            <th>{labelTexts.runLabel}</th>
+            <th>{labelTexts.startedLabel}</th>
+            <th class="numeric">{labelTexts.samplesLabel}</th>
+            <th>{labelTexts.actionsLabel}</th>
           </tr>
         </thead>
         <tbody id="historyTableBody">

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -1,6 +1,6 @@
 import { render } from "preact";
 
-import { useUiText } from "../ui_i18n";
+import { getUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
@@ -101,7 +101,7 @@ function RealtimeLiveOverviewRunHealthPill(props: {
 
 function RealtimeLiveOverviewActiveCarStat(props: {
   activeCar: ReadonlySignal<RealtimeLiveOverviewActiveCarModel>;
-  labelText: ReadonlySignal<string>;
+  labelText: string;
 }) {
   const { text, warning } = useSignalProperties(props.activeCar, ["text", "warning"] as const);
   const variant = useComputed(() => warning.value ? "warn" : undefined);
@@ -113,9 +113,9 @@ function RealtimeLiveOverviewActiveCarStat(props: {
       class="stat"
       data-variant={variant}
     >
-      <div class="stat__label">
-        {props.labelText}
-      </div>
+        <div class="stat__label">
+          {props.labelText}
+        </div>
       <div
         class="stat__value"
         data-value
@@ -139,7 +139,7 @@ function RealtimeLiveOverviewActiveCarStat(props: {
 
 function RealtimeLiveOverviewSensorRoster(props: {
   sensorCards: ReadonlySignal<RealtimeLiveOverviewSensorCardModel[]>;
-  noSensorsText: ReadonlySignal<string>;
+  noSensorsText: string;
 }) {
   const hasSensorCards = useComputed(() => props.sensorCards.value.length > 0);
 
@@ -178,19 +178,21 @@ function RealtimeLiveOverview(props: {
   model: ReadonlySignal<ReadonlySignal<RealtimeLiveOverviewRenderModel> | null>;
   speedText: ReadonlySignal<string>;
 }) {
-  const titleText = useUiText("dashboard.live_overview", "Live overview");
-  const hintText = useUiText(
-    "dashboard.live_overview_hint",
-    "Check readiness, current run state, and the strongest sensor level before reading the chart.",
-  );
-  const connectedSensorsLabel = useUiText("dashboard.connected_sensors", "Sensors online");
-  const activeCarLabel = useUiText("dashboard.active_car", "Active car");
-  const recordingStateLabel = useUiText("dashboard.recording_state", "Run state");
-  const dataFreshnessLabel = useUiText("dashboard.data_freshness", "Feed freshness");
-  const strongestSignalLabel = useUiText("dashboard.strongest_signal", "Strongest signal");
-  const currentSpeedLabel = useUiText("dashboard.current_speed", "Current speed");
-  const sensorCoverageLabel = useUiText("dashboard.sensor_coverage", "Sensor coverage");
-  const noSensorsText = useUiText("settings.sensors.no_sensors", "No sensors yet.");
+  const labels = useComputed(() => ({
+    activeCarLabel: getUiText("dashboard.active_car", "Active car"),
+    connectedSensorsLabel: getUiText("dashboard.connected_sensors", "Sensors online"),
+    currentSpeedLabel: getUiText("dashboard.current_speed", "Current speed"),
+    dataFreshnessLabel: getUiText("dashboard.data_freshness", "Feed freshness"),
+    hintText: getUiText(
+      "dashboard.live_overview_hint",
+      "Check readiness, current run state, and the strongest sensor level before reading the chart.",
+    ),
+    noSensorsText: getUiText("settings.sensors.no_sensors", "No sensors yet."),
+    recordingStateLabel: getUiText("dashboard.recording_state", "Run state"),
+    sensorCoverageLabel: getUiText("dashboard.sensor_coverage", "Sensor coverage"),
+    strongestSignalLabel: getUiText("dashboard.strongest_signal", "Strongest signal"),
+    titleText: getUiText("dashboard.live_overview", "Live overview"),
+  }));
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_OVERVIEW_MODEL);
   const {
     activeCar,
@@ -201,58 +203,59 @@ function RealtimeLiveOverview(props: {
     sensorCards,
     strongestSignalText,
   } = useSignalProperties(model, REALTIME_LIVE_OVERVIEW_MODEL_KEYS);
+  const labelTexts = labels.value;
 
   return (
     <>
       <div class="card__header card__header--stack">
         <div>
           <div class="card__title">
-            {titleText}
+            {labelTexts.titleText}
           </div>
           <div class="card__subtle">
-            {hintText}
+            {labelTexts.hintText}
           </div>
         </div>
         <RealtimeLiveOverviewRunHealthPill runHealth={runHealth} />
       </div>
       <div class="stat-grid live-overview__stats">
         <div id="liveConnectedSensors" class="stat">
-          <div class="stat__label">
-            {connectedSensorsLabel}
-          </div>
+            <div class="stat__label">
+              {labelTexts.connectedSensorsLabel}
+            </div>
           <div class="stat__value" data-value>
             {connectedSensorsText}
           </div>
         </div>
-        <RealtimeLiveOverviewActiveCarStat activeCar={activeCar} labelText={activeCarLabel} />
+        <RealtimeLiveOverviewActiveCarStat activeCar={activeCar} labelText={labelTexts.activeCarLabel} />
         <div id="liveRecordingState" class="stat">
-          <div class="stat__label">
-            {recordingStateLabel}
-          </div>
+            <div class="stat__label">
+              {labelTexts.recordingStateLabel}
+            </div>
           <div class="stat__value" data-value>
             {recordingStateText}
           </div>
         </div>
         <div id="liveDataFreshness" class="stat">
-          <div class="stat__label">
-            {dataFreshnessLabel}
-          </div>
+            <div class="stat__label">
+              {labelTexts.dataFreshnessLabel}
+            </div>
           <div class="stat__value" data-value>
             {dataFreshnessText}
           </div>
         </div>
         <div id="liveStrongestSignal" class="stat">
-          <div class="stat__label">
-            {strongestSignalLabel}
-          </div>
+            <div class="stat__label">
+              {labelTexts.strongestSignalLabel}
+            </div>
           <div class="stat__value" data-value>
             {strongestSignalText}
           </div>
         </div>
         <div class="stat">
-          <div class="stat__label">
-            {currentSpeedLabel}
-          </div>
+            <div class="stat__label">
+              {labelTexts.currentSpeedLabel}
+            </div>
           <div id="speed" class="stat__value speed" aria-live="polite">
             {props.speedText}
           </div>
@@ -260,10 +263,13 @@ function RealtimeLiveOverview(props: {
       </div>
       <div class="live-sensor-roster__header">
         <div class="mini-label">
-          {sensorCoverageLabel}
+          {labelTexts.sensorCoverageLabel}
         </div>
       </div>
-      <RealtimeLiveOverviewSensorRoster sensorCards={sensorCards} noSensorsText={noSensorsText} />
+      <RealtimeLiveOverviewSensorRoster
+        sensorCards={sensorCards}
+        noSensorsText={labelTexts.noSensorsText}
+      />
     </>
   );
 }

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -1,6 +1,6 @@
 import { render } from "preact";
 
-import { useUiText } from "../ui_i18n";
+import { getUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
@@ -166,14 +166,16 @@ function RealtimeLoggingPanel(props: {
   actions: ReadonlySignal<RealtimeLoggingPanelActionHandlers | null>;
   model: ReadonlySignal<ReadonlySignal<RealtimeLoggingPanelRenderModel> | null>;
 }) {
-  const titleText = useUiText("dashboard.run_recording", "Run Recording");
-  const runProgressLabel = useUiText("dashboard.recording_progress", "Run progress");
-  const runPhaseLabel = useUiText("dashboard.recording_phase", "Run phase");
-  const elapsedLabel = useUiText("dashboard.recording_elapsed", "Elapsed");
-  const samplesLabel = useUiText("dashboard.recording_samples", "Samples recorded");
-  const startLabel = useUiText("dashboard.start_recording", "Start Recording");
-  const stopLabel = useUiText("dashboard.stop_recording", "Stop Recording");
   const actions = useComputed(() => props.actions.value);
+  const labels = useComputed(() => ({
+    elapsedLabel: getUiText("dashboard.recording_elapsed", "Elapsed"),
+    runPhaseLabel: getUiText("dashboard.recording_phase", "Run phase"),
+    runProgressLabel: getUiText("dashboard.recording_progress", "Run progress"),
+    samplesLabel: getUiText("dashboard.recording_samples", "Samples recorded"),
+    startLabel: getUiText("dashboard.start_recording", "Start Recording"),
+    stopLabel: getUiText("dashboard.stop_recording", "Stop Recording"),
+    titleText: getUiText("dashboard.run_recording", "Run Recording"),
+  }));
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_PANEL_MODEL);
   const {
     checklist,
@@ -208,13 +210,14 @@ function RealtimeLoggingPanel(props: {
   const handleStopLogging = () => {
     actions.value?.onStopLogging();
   };
+  const labelTexts = labels.value;
 
   return (
     <div class="realtime-logging-shell" data-layout={shellLayout}>
       <div class="card__header card__header--stack">
         <div>
           <div class="card__title">
-            {titleText}
+            {labelTexts.titleText}
           </div>
           <RealtimeLoggingSummary
             summaryText={summaryText}
@@ -240,13 +243,13 @@ function RealtimeLoggingPanel(props: {
       {showProgressSection.value
         ? (
           <>
-            <div class="mini-label">
-              {runProgressLabel}
-            </div>
+              <div class="mini-label">
+               {labelTexts.runProgressLabel}
+              </div>
             <div class="stat-grid stat-grid--compact">
               <div id="loggingPhase" class="stat stat--compact" hidden>
                 <div class="stat__label">
-                  {runPhaseLabel}
+                  {labelTexts.runPhaseLabel}
                 </div>
                 <div class="stat__value" data-value>
                   {phaseText}
@@ -254,7 +257,7 @@ function RealtimeLoggingPanel(props: {
               </div>
               <div id="loggingElapsed" class="stat stat--compact">
                 <div class="stat__label">
-                  {elapsedLabel}
+                  {labelTexts.elapsedLabel}
                 </div>
                 <div class="stat__value" data-value>
                   {elapsedText}
@@ -262,7 +265,7 @@ function RealtimeLoggingPanel(props: {
               </div>
               <div id="loggingSamples" class="stat stat--compact">
                 <div class="stat__label">
-                  {samplesLabel}
+                  {labelTexts.samplesLabel}
                 </div>
                 <div class="stat__value" data-value>
                   {samplesText}
@@ -283,7 +286,7 @@ function RealtimeLoggingPanel(props: {
           disabled={startDisabled}
           onClick={handleStartLogging}
         >
-          {startLabel}
+          {labelTexts.startLabel}
         </button>
         <button
           id="stopLoggingBtn"
@@ -294,7 +297,7 @@ function RealtimeLoggingPanel(props: {
           disabled={stopDisabled}
           onClick={handleStopLogging}
         >
-          {stopLabel}
+          {labelTexts.stopLabel}
         </button>
       </div>
     </div>

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from "preact";
 
 import { render } from "preact";
-import { useUiText } from "../ui_i18n";
+import { getUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
@@ -110,10 +110,10 @@ function SensorsTableRow(props: {
 
 function SensorsTableBody(props: {
   actions: SensorsPanelActionHandlers | null;
+  emptyText: string;
   table: RealtimeSensorTableRenderModel | null;
 }) {
-  const { actions, table } = props;
-  const emptyText = useUiText("settings.sensors.no_sensors", "No sensors detected yet.");
+  const { actions, emptyText, table } = props;
   if (table === null || table.kind === "empty") {
     return (
       <tr>
@@ -132,46 +132,54 @@ function SensorsPanel(props: {
   actions: ReadonlySignal<SensorsPanelActionHandlers | null>;
   model: ReadonlySignal<ReadonlySignal<SensorsPanelRenderModel> | null>;
 }) {
-  const titleText = useUiText("settings.sensors.title", "Sensors");
-  const hintText = useUiText(
-    "settings.sensors.hint",
-    "Manage sensor names and locations. Default name is the MAC address.",
-  );
-  const nameLabel = useUiText("settings.sensors.name", "Name");
-  const locationLabel = useUiText("settings.sensors.location", "Location");
-  const actionsLabel = useUiText("settings.sensors.actions", "Actions");
   const actions = useComputed(() => props.actions.value);
+  const labels = useComputed(() => ({
+    actionsLabel: getUiText("settings.sensors.actions", "Actions"),
+    emptyText: getUiText("settings.sensors.no_sensors", "No sensors detected yet."),
+    hintText: getUiText(
+      "settings.sensors.hint",
+      "Manage sensor names and locations. Default name is the MAC address.",
+    ),
+    locationLabel: getUiText("settings.sensors.location", "Location"),
+    nameLabel: getUiText("settings.sensors.name", "Name"),
+    titleText: getUiText("settings.sensors.title", "Sensors"),
+  }));
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_SENSORS_PANEL_MODEL);
   const { table } = useSignalProperties(model, SENSORS_PANEL_MODEL_KEYS);
+  const labelTexts = labels.value;
   return (
     <div class="panel card">
       <strong>
-        {titleText}
+        {labelTexts.titleText}
       </strong>
       <div class="subtle">
-        {hintText}
+        {labelTexts.hintText}
       </div>
       <div class="settings-table-wrap">
         <table class="clients-table settings-entity-table settings-entity-table--sensors">
           <thead>
             <tr>
-              <th>
-                {nameLabel}
-              </th>
-              <th>
-                {locationLabel}
-              </th>
-              <th>
-                {actionsLabel}
-              </th>
-            </tr>
-          </thead>
-          <tbody id="sensorsSettingsBody">
-            <SensorsTableBody actions={actions.value} table={table.value} />
-          </tbody>
-        </table>
+                <th>
+                 {labelTexts.nameLabel}
+                </th>
+                <th>
+                 {labelTexts.locationLabel}
+                </th>
+                <th>
+                 {labelTexts.actionsLabel}
+                </th>
+              </tr>
+            </thead>
+            <tbody id="sensorsSettingsBody">
+             <SensorsTableBody
+               actions={actions.value}
+               emptyText={labelTexts.emptyText}
+               table={table.value}
+             />
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
   );
 }
 

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -1,6 +1,6 @@
 import { render, type ComponentChildren } from "preact";
 
-import { useUiText } from "../ui_i18n";
+import { getUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
@@ -335,17 +335,19 @@ function UpdatePanel(props: {
   actions: ReadonlySignal<UpdatePanelActionHandlers | null>;
   model: ReadonlySignal<ReadonlySignal<UpdatePanelRenderModel> | null>;
 }) {
-  const titleText = useUiText("settings.update.title", "System Update");
-  const hintText = useUiText(
-    "settings.update.hint",
-    "Use either temporary Wi-Fi credentials or an already-connected USB internet uplink to update from GitHub. The hotspot only pauses for the Wi-Fi path.",
-  );
-  const reconnectNote = useUiText(
-    "settings.update.reconnect_note",
-    "Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.",
-  );
-  const cancelLabel = useUiText("settings.update.cancel", "Cancel Update");
   const actions = useComputed(() => props.actions.value);
+  const labels = useComputed(() => ({
+    cancelLabel: getUiText("settings.update.cancel", "Cancel Update"),
+    hintText: getUiText(
+      "settings.update.hint",
+      "Use either temporary Wi-Fi credentials or an already-connected USB internet uplink to update from GitHub. The hotspot only pauses for the Wi-Fi path.",
+    ),
+    reconnectNote: getUiText(
+      "settings.update.reconnect_note",
+      "Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.",
+    ),
+    titleText: getUiText("settings.update.title", "System Update"),
+  }));
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_UPDATE_PANEL_MODEL);
   const {
     cancelButtonDisabled,
@@ -361,23 +363,24 @@ function UpdatePanel(props: {
   const handleCancel = () => {
     actions.value?.onCancel();
   };
+  const labelTexts = labels.value;
   return (
     <div class="panel card">
       <div class="maintenance-layout maintenance-layout--compact">
         <section class="maintenance-card maintenance-card--hero">
           <div class="maintenance-card__header">
             <div>
-              <div class="maintenance-card__title">
-                {titleText}
-              </div>
-              <div class="subtle">
-                {hintText}
-              </div>
+                <div class="maintenance-card__title">
+                 {labelTexts.titleText}
+                </div>
+                <div class="subtle">
+                 {labelTexts.hintText}
+                </div>
             </div>
           </div>
           <div class="maintenance-card__body maintenance-card__body--hero">
             <div class="maintenance-note">
-              {reconnectNote}
+              {labelTexts.reconnectNote}
             </div>
             <div
               id="updateOverviewPanel"
@@ -405,7 +408,7 @@ function UpdatePanel(props: {
                 disabled={cancelButtonDisabled}
                 onClick={handleCancel}
               >
-                {cancelLabel}
+                {labelTexts.cancelLabel}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## summary
- replace per-label `useUiText()` calls with one computed label object in six label-heavy views
- keep the JSX text output unchanged while reducing translation-signal fanout in those components
- leave the single-label `settings_shell.tsx` tab button alone because it does not have the same overhead shape

## why
- `useUiText()` creates one computed signal per translated string
- these views had 4-13 static labels each, so one reactive label object per view is the tighter fit for the actual language-change trigger

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## risks / edges
- no intended behavior change
- scope stayed to label-heavy views only; model-driven text and the single-label settings tab path were left alone

Closes #2649