### PR TITLE
fix(ui): stabilize history chip keys

### DIFF
--- a/apps/ui/src/app/views/history_summary_chips.tsx
+++ b/apps/ui/src/app/views/history_summary_chips.tsx
@@ -14,9 +14,9 @@ function chipModifier(tone: HistorySummaryChipTone): string {
 export function HistorySummaryChips(props: { row: HistoryRowViewModel }) {
   return (
     <div class="history-row__summary-chips">
-      {props.row.summaryChips.map((chip, index) => (
+      {props.row.summaryChips.map((chip) => (
         <span
-          key={`${chip.tone}:${chip.text}:${index}`}
+          key={chip.key}
           class={`history-row__summary-chip${chipModifier(chip.tone)}`}
         >
           {chip.text}

--- a/apps/ui/src/app/views/history_table_models.ts
+++ b/apps/ui/src/app/views/history_table_models.ts
@@ -2,6 +2,7 @@ export type HistorySummaryChipTone = "ok" | "warn" | "bad" | "muted" | "source" 
 export type HistoryFindingTone = "success" | "warn" | "neutral";
 
 export interface HistorySummaryChipViewModel {
+  key: string;
   text: string;
   tone: HistorySummaryChipTone;
 }

--- a/apps/ui/src/app/views/history_table_presenters.ts
+++ b/apps/ui/src/app/views/history_table_presenters.ts
@@ -28,10 +28,10 @@ function buildSummaryChips(
   const { t } = params;
   const statusBadge = historyRowStatusBadge(run, detail, t);
   const chips: HistorySummaryChipViewModel[] = [
-    { text: statusBadge.label, tone: statusBadge.tone },
+    { key: "status", text: statusBadge.label, tone: statusBadge.tone },
   ];
   if (run.status === "error" && run.error_message) {
-    chips.push({ text: run.error_message, tone: "muted" });
+    chips.push({ key: "error-message", text: run.error_message, tone: "muted" });
   }
   return chips;
 }

--- a/apps/ui/tests/history_summary_chip_keys.spec.ts
+++ b/apps/ui/tests/history_summary_chip_keys.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test";
+
+import type { HistoryEntry } from "../src/api/types";
+import { buildHistoryTableRowsViewModel } from "../src/app/views/history_table_presenters";
+import type { RunDetail } from "../src/app/ui_app_state";
+
+function testTranslation(key: string, vars?: Record<string, unknown>): string {
+  return vars ? `${key}:${JSON.stringify(vars)}` : key;
+}
+
+function defaultDetail(detail: Partial<RunDetail> = {}): RunDetail {
+  return {
+    preview: null,
+    previewLoading: false,
+    previewError: "",
+    insights: null,
+    insightsLoading: false,
+    insightsError: "",
+    pdfLoading: false,
+    pdfError: "",
+    ...detail,
+  };
+}
+
+function historyListRun(runId: string, overrides: Partial<HistoryEntry> = {}): HistoryEntry {
+  return {
+    run_id: runId,
+    start_time_utc: "2026-01-01T00:00:00Z",
+    end_time_utc: "2026-01-01T00:00:12Z",
+    sample_count: 2048,
+    status: "complete",
+    car_name: "Track Car",
+    error_message: null,
+    ...overrides,
+  } as HistoryEntry;
+}
+
+test("history summary chips expose stable presenter-owned keys", () => {
+  const rows = buildHistoryTableRowsViewModel({
+    runs: [
+      historyListRun("run-001"),
+      historyListRun("run-002", {
+        status: "error",
+        error_message: "history.error.capture_failed",
+      }),
+    ],
+    expandedRunId: null,
+    runDetailsById: {
+      "run-001": defaultDetail(),
+      "run-002": defaultDetail(),
+    },
+    t: testTranslation,
+    fmt: (value, digits = 0) => Number(value).toFixed(digits),
+    fmtTs: (iso) => iso,
+    formatInt: (value) => String(value),
+  });
+
+  expect(rows[0].summaryChips.map((chip) => chip.key)).toEqual(["status"]);
+  expect(rows[1].summaryChips.map((chip) => chip.key)).toEqual(["status", "error-message"]);
+});


### PR DESCRIPTION
## summary
- add a stable presenter-owned `key` field to `HistorySummaryChipViewModel`
- assign fixed chip ids in `buildSummaryChips()` and render `HistorySummaryChips` with `key={chip.key}`
- cover the stable key slots with a focused history presenter test

## why
- the old renderer key mixed presentation text with the array index
- summary chip identity is a presenter concern, so the stable id belongs in the chip model instead of being rebuilt from render order

## validation
- `cd apps/ui && npx playwright test tests/history_summary_chip_keys.spec.ts tests/history_table_presenters.spec.ts tests/history_table_view.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## risks / edges
- no intended behavior change
- current chip slots are `status` and optional `error-message`; future chips should add their own stable presenter ids instead of falling back to positional keys

Closes #2650