### PR TITLE
refactor(ui): inline lazy panel bindings

### DIFF
--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -83,17 +83,6 @@ function scheduleDeferredWork(task: () => void): void {
   setTimeout(task, 0);
 }
 
-function createDeferredHistoryPanelView(): {
-  view: HistoryPanelView;
-} {
-  return {
-    view: createModelActionPanelBindings<
-      HistoryPanelRenderModel,
-      HistoryPanelActionHandlers
-    >(),
-  };
-}
-
 function createDeferredSettingsShellView(): {
   attach(realView: SettingsShellView): void;
   view: SettingsShellView;
@@ -205,17 +194,6 @@ function createDeferredAnalysisPanelView(): {
   };
 }
 
-function createDeferredSensorsPanelView(): {
-  view: SensorsPanelView;
-} {
-  return {
-    view: createModelActionPanelBindings<
-      SensorsPanelRenderModel,
-      SensorsPanelActionHandlers
-    >(),
-  };
-}
-
 function createDeferredSpeedSourcePanelView(): {
   attach(
     realView: Pick<
@@ -253,6 +231,9 @@ function createDeferredSpeedSourcePanelView(): {
       actions: signal<SpeedSourcePanelActionHandlers | null>(null),
       diagnostics: createDeferredModelSignal<SpeedSourceDiagnosticsRenderModel>(),
       model,
+      isObdConfigVisible() {
+        return model.value?.value.obdConfigVisible ?? false;
+      },
       focusManualSpeedInput() {
         pendingFocusTarget.value = "manual";
       },
@@ -266,17 +247,6 @@ function createDeferredSpeedSourcePanelView(): {
     attach(nextRealView) {
       realView.value = nextRealView;
     },
-  };
-}
-
-function createDeferredUpdatePanelView(): {
-  view: UpdatePanelView;
-} {
-  return {
-    view: createModelActionPanelBindings<
-      UpdatePanelRenderModel,
-      UpdatePanelActionHandlers
-    >(),
   };
 }
 
@@ -308,30 +278,39 @@ function createDeferredInternetPanelView(): {
   };
 }
 
-function createDeferredEspFlashPanelView(): {
-  view: EspFlashPanelView;
-} {
-  return {
-    view: createModelActionPanelBindings<
-      EspFlashPanelRenderModel,
-      EspFlashPanelActionHandlers
-    >(),
-  };
-}
-
 export function createLazyUiPanels(deps: CreateUiLazyPanelsDeps): UiLazyPanels {
   const { hosts } = deps;
   const dashboard = (deps.mountDashboardPanels ?? mountDashboardPanels)(hosts);
-  const history = createDeferredHistoryPanelView();
+  const history = {
+    view: createModelActionPanelBindings<
+      HistoryPanelRenderModel,
+      HistoryPanelActionHandlers
+    >(),
+  };
   const settingsShell = createDeferredSettingsShellView();
   const settings = {
     analysis: createDeferredAnalysisPanelView(),
     cars: createDeferredCarsPanelView(),
-    espFlash: createDeferredEspFlashPanelView(),
+    espFlash: {
+      view: createModelActionPanelBindings<
+        EspFlashPanelRenderModel,
+        EspFlashPanelActionHandlers
+      >(),
+    },
     internet: createDeferredInternetPanelView(),
-    sensors: createDeferredSensorsPanelView(),
+    sensors: {
+      view: createModelActionPanelBindings<
+        SensorsPanelRenderModel,
+        SensorsPanelActionHandlers
+      >(),
+    },
     speedSource: createDeferredSpeedSourcePanelView(),
-    update: createDeferredUpdatePanelView(),
+    update: {
+      view: createModelActionPanelBindings<
+        UpdatePanelRenderModel,
+        UpdatePanelActionHandlers
+      >(),
+    },
   };
   let historyMountPromise: Promise<void> | null = null;
   let settingsMountPromise: Promise<void> | null = null;

--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -119,6 +119,7 @@ export interface SpeedSourcePanelView extends SpeedSourcePanelBindings {
   focusManualSpeedInput(): void;
   focusScanObdDevices(): void;
   focusStaleTimeoutInput(): void;
+  isObdConfigVisible(): boolean;
 }
 
 type SpeedSourcePanelBridgeState = {
@@ -194,7 +195,7 @@ export function mountSpeedSourcePanel(
   bindings: SpeedSourcePanelBindings,
 ): Pick<
   SpeedSourcePanelView,
-  "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput"
+  "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
 > {
   const diagnosticsDisclosureOpen = signal(false);
   effect(() => {
@@ -240,6 +241,9 @@ export function mountSpeedSourcePanel(
     },
     focusStaleTimeoutInput(): void {
       staleTimeoutInput?.focus();
+    },
+    isObdConfigVisible(): boolean {
+      return bindings.model.value?.value.obdConfigVisible ?? false;
     },
   };
 }


### PR DESCRIPTION
## summary
- inline the trivial History, Sensors, Update, and ESP flash deferred panel bindings inside `createLazyUiPanels()`
- delete the four zero-logic `createDeferred*PanelView()` wrappers those bindings previously flowed through
- expose `isObdConfigVisible()` on the deferred speed-source panel bridge so the lazy panel seam matches the focused spec contract

## why
- the removed factories only wrapped `createModelActionPanelBindings()` and added no state or behavior
- keeping the creation inline leaves the real deferred factories alone and makes the remaining special cases easier to see
- the speed-source visibility bridge is tightly coupled to the same lazy panel surface and was already required by the focused lazy-panel behavior test

## validation
- `cd apps/ui && npx playwright test tests/ui_lazy_panels.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## risks / edges
- no intended behavior change
- only the trivial factories were inlined; Cars, Analysis, Speed Source, and Internet still own real deferred focus/guidance behavior

Closes #2651