### PR TITLE
refactor(ui): coalesce analysis lazy effect

### DIFF
--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -162,15 +162,15 @@ function createDeferredAnalysisPanelView(): {
   const guidanceOpenRequested = signal(false);
   effect(() => {
     const view = realView.value;
-    if (view !== null && guidanceOpenRequested.value) {
+    if (view === null) {
+      return;
+    }
+    if (guidanceOpenRequested.value) {
       view.openGuidance();
       guidanceOpenRequested.value = false;
     }
-  });
-  effect(() => {
-    const view = realView.value;
     const nextFocusField = focusField.value;
-    if (view !== null && nextFocusField !== null) {
+    if (nextFocusField !== null) {
       view.focusField(nextFocusField);
       focusField.value = null;
     }


### PR DESCRIPTION
## summary
- merge the two deferred analysis-panel forwarding effects in `ui_lazy_panels.ts` into one effect
- keep the same `openGuidance()` and `focusField()` reset behavior while removing the duplicate `realView` subscription
- leave the other lazy panel bridges unchanged

## why
- both old effects subscribed to the same `realView` signal and only split the guidance and focus forwarding branches
- one effect is enough for this bridge and keeps the deferred analysis wiring easier to scan

## validation
- `cd apps/ui && npx playwright test tests/ui_lazy_panels.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## risks / edges
- no intended behavior change
- guidance forwarding still runs before deferred focus forwarding inside the shared effect, matching the previous branch order

Closes #2652