### PR TITLE
refactor(ui): share variant CSS tokens

### DIFF
--- a/apps/ui/src/styles/components.css
+++ b/apps/ui/src/styles/components.css
@@ -154,12 +154,9 @@ button[hidden],
   display: none !important;
 }
 
-.pill[data-variant="muted"] { background: var(--pill-muted-bg); color: var(--pill-muted-text); }
-.pill[data-variant="ok"],
+.pill[data-variant] { background: var(--variant-surface); color: var(--variant-text); }
 .status-pill.online,
 .badge.on { background: var(--pill-ok-bg); color: var(--pill-ok-text); }
-.pill[data-variant="warn"] { background: var(--pill-warn-bg); color: var(--pill-warn-text); }
-.pill[data-variant="bad"],
 .status-pill.offline,
 .badge.off { background: var(--pill-bad-bg); color: var(--pill-bad-text); }
 
@@ -257,7 +254,7 @@ button[hidden],
 .stat { min-height: 72px; }
 .stat__label { font-size: 0.76rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted); }
 .stat__value { margin-top: var(--space-1); font-size: 1.1rem; font-weight: 700; overflow-wrap: anywhere; }
-.stat__value[data-variant="warn"] { color: var(--warning-text); }
+.stat__value[data-variant] { color: var(--variant-text); }
 .stat__value[data-has-icon="true"] {
   display: inline-flex;
   align-items: flex-start;
@@ -276,10 +273,10 @@ button[hidden],
   line-height: 1;
   margin-top: 2px;
 }
-.stat__value-icon[data-variant="warn"] {
-  border: 1px solid var(--warning-border);
-  background: var(--pill-warn-bg);
-  color: var(--pill-warn-text);
+.stat__value-icon[data-variant] {
+  border: 1px solid var(--variant-border);
+  background: var(--variant-surface);
+  color: var(--variant-text);
 }
 
 .app-modal-layer {

--- a/apps/ui/src/styles/maintenance-readiness.css
+++ b/apps/ui/src/styles/maintenance-readiness.css
@@ -85,44 +85,16 @@
   line-height: 1.45;
 }
 
-.maintenance-readiness__item[data-readiness-state="ready"] {
-  border-color: rgba(11, 122, 68, 0.18);
-  background: var(--pill-ok-bg);
+.maintenance-readiness__item[data-readiness-state] {
+  border-color: var(--readiness-border);
+  background: var(--readiness-surface);
 }
 
-.maintenance-readiness__item[data-readiness-state="ready"] .maintenance-readiness__marker {
-  background: var(--success);
-  color: var(--on-fill);
+.maintenance-readiness__item[data-readiness-state] .maintenance-readiness__marker {
+  background: var(--readiness-marker-surface);
+  color: var(--readiness-marker-text);
 }
 
-.maintenance-readiness__item[data-readiness-state="ready"] .maintenance-readiness__label {
-  color: var(--pill-ok-text);
-}
-
-.maintenance-readiness__item[data-readiness-state="attention"] {
-  border-color: rgba(170, 108, 26, 0.28);
-  background: var(--pill-warn-bg);
-}
-
-.maintenance-readiness__item[data-readiness-state="attention"] .maintenance-readiness__marker {
-  background: var(--warning);
-  color: var(--text);
-}
-
-.maintenance-readiness__item[data-readiness-state="attention"] .maintenance-readiness__label {
-  color: var(--pill-warn-text);
-}
-
-.maintenance-readiness__item[data-readiness-state="blocked"] {
-  border-color: #f0c4c4;
-  background: var(--pill-bad-bg);
-}
-
-.maintenance-readiness__item[data-readiness-state="blocked"] .maintenance-readiness__marker {
-  background: var(--danger);
-  color: var(--on-fill);
-}
-
-.maintenance-readiness__item[data-readiness-state="blocked"] .maintenance-readiness__label {
-  color: var(--pill-bad-text);
+.maintenance-readiness__item[data-readiness-state] .maintenance-readiness__label {
+  color: var(--readiness-text);
 }

--- a/apps/ui/src/styles/realtime-overview.css
+++ b/apps/ui/src/styles/realtime-overview.css
@@ -24,15 +24,15 @@
   line-height: 1.25;
 }
 
-.stat[data-variant="warn"] {
-  border: 1px solid var(--warning-border);
+.stat[data-variant] {
+  border: 1px solid var(--variant-border);
   border-radius: var(--radius-sm);
-  background: var(--warning-surface);
+  background: var(--variant-surface);
   padding-inline: var(--space-3);
 }
 
-.stat[data-variant="warn"] .stat__label {
-  color: var(--warning-text);
+.stat[data-variant] .stat__label {
+  color: var(--variant-text);
 }
 
 .live-sensor-roster__header {

--- a/apps/ui/src/styles/shell.css
+++ b/apps/ui/src/styles/shell.css
@@ -161,22 +161,10 @@
 
 .connection-banner[hidden] { display: none; }
 
-.connection-banner[data-variant="warn"] {
-  background: var(--warning-surface);
-  color: var(--warning-text);
-  border-bottom-color: var(--warning-border);
-}
-
-.connection-banner[data-variant="bad"] {
-  background: var(--pill-bad-bg);
-  color: var(--pill-bad-text);
-  border-bottom-color: #f0c4c4;
-}
-
-.connection-banner[data-variant="muted"] {
-  background: var(--pill-muted-bg);
-  color: var(--pill-muted-text);
-  border-bottom-color: var(--border);
+.connection-banner[data-variant] {
+  background: var(--variant-banner-surface);
+  color: var(--variant-text);
+  border-bottom-color: var(--variant-border);
 }
 
 .app-error-banner {

--- a/apps/ui/src/styles/tokens.css
+++ b/apps/ui/src/styles/tokens.css
@@ -97,3 +97,70 @@ body {
   color: var(--text);
   font-size: 15px;
 }
+
+[data-variant] {
+  --variant-surface: transparent;
+  --variant-banner-surface: var(--variant-surface);
+  --variant-text: inherit;
+  --variant-border: transparent;
+}
+
+[data-variant="muted"] {
+  --variant-surface: var(--pill-muted-bg);
+  --variant-banner-surface: var(--pill-muted-bg);
+  --variant-text: var(--pill-muted-text);
+  --variant-border: var(--border);
+}
+
+[data-variant="ok"] {
+  --variant-surface: var(--pill-ok-bg);
+  --variant-banner-surface: var(--pill-ok-bg);
+  --variant-text: var(--pill-ok-text);
+  --variant-border: transparent;
+}
+
+[data-variant="warn"] {
+  --variant-surface: var(--pill-warn-bg);
+  --variant-banner-surface: var(--warning-surface);
+  --variant-text: var(--pill-warn-text);
+  --variant-border: var(--warning-border);
+}
+
+[data-variant="bad"] {
+  --variant-surface: var(--pill-bad-bg);
+  --variant-banner-surface: var(--pill-bad-bg);
+  --variant-text: var(--pill-bad-text);
+  --variant-border: #f0c4c4;
+}
+
+[data-readiness-state] {
+  --readiness-surface: var(--surface-2);
+  --readiness-text: var(--text);
+  --readiness-border: var(--border);
+  --readiness-marker-surface: var(--pill-muted-bg);
+  --readiness-marker-text: var(--pill-muted-text);
+}
+
+[data-readiness-state="ready"] {
+  --readiness-surface: var(--pill-ok-bg);
+  --readiness-text: var(--pill-ok-text);
+  --readiness-border: rgba(11, 122, 68, 0.18);
+  --readiness-marker-surface: var(--success);
+  --readiness-marker-text: var(--on-fill);
+}
+
+[data-readiness-state="attention"] {
+  --readiness-surface: var(--pill-warn-bg);
+  --readiness-text: var(--pill-warn-text);
+  --readiness-border: rgba(170, 108, 26, 0.28);
+  --readiness-marker-surface: var(--warning);
+  --readiness-marker-text: var(--text);
+}
+
+[data-readiness-state="blocked"] {
+  --readiness-surface: var(--pill-bad-bg);
+  --readiness-text: var(--pill-bad-text);
+  --readiness-border: #f0c4c4;
+  --readiness-marker-surface: var(--danger);
+  --readiness-marker-text: var(--on-fill);
+}


### PR DESCRIPTION
## summary
- centralize shared `data-variant` and `data-readiness-state` color wiring in `tokens.css`
- repoint the pill, connection banner, live overview stat, and maintenance readiness styles to those shared custom properties
- keep the existing warn/bad/muted surfaces and borders while removing the repeated local state-to-color mappings

## why
- the token values already lived in one place, but several stylesheets still repeated the semantic mapping from state names to local colors
- one shared mapping keeps the UI surfaces consistent and cuts CSS duplication in the exact files this issue calls out

## validation
- `cd apps/ui && npm run typecheck && npm run build`
- `cd apps/ui && npx playwright test tests/smoke.cars.spec.ts --workers=1`
- `cd apps/ui && npm run test:visual` *(known non-green on current `main`: unrelated `tests/settings_speed_source_workflow.spec.ts` failures, and the focused `tests/visual.spec.ts -g "renders the live overview dashboard"` spectrum-canvas assertion is already red/flaky on clean `main`; I confirmed that baseline by stashing this CSS patch and rerunning the focused visual test)*

## risks / edges
- no intended behavior change
- shared selectors now own the semantic state mapping, so any new `data-variant` or `data-readiness-state` consumer will inherit the same colors by default

Closes #2655