### PR TITLE
refactor(ui): drop simple class toggles

### DIFF
--- a/apps/ui/src/app/runtime/shell/ui_shell_chrome_navigation.tsx
+++ b/apps/ui/src/app/runtime/shell/ui_shell_chrome_navigation.tsx
@@ -95,7 +95,6 @@ function ShellNavigationTabButton(props: {
 }) {
   const { index, item, onActivateView } = props;
   const isActive = useComputed(() => item.viewId === props.activeViewId.value);
-  const buttonClass = useComputed(() => isActive.value ? "menu-btn active" : "menu-btn");
   const ariaSelected = useComputed(() => isActive.value ? "true" : "false");
   const tabIndex = useComputed(() => isActive.value ? 0 : -1);
 
@@ -103,7 +102,7 @@ function ShellNavigationTabButton(props: {
     <button
       ref={props.onRef}
       type="button"
-      class={buttonClass}
+      class="menu-btn"
       data-view={item.viewId}
       id={item.tabId}
       role="tab"

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -151,7 +151,8 @@ function RealtimeLiveOverviewSensorRoster(props: {
           return (
             <article
               key={card.id}
-              class={card.strongest ? "live-sensor-card live-sensor-card--strongest" : "live-sensor-card"}
+              class="live-sensor-card"
+              data-strongest={card.strongest ? "true" : undefined}
             >
               <div class="live-sensor-card__header">
                 <strong>{card.label}</strong>

--- a/apps/ui/src/app/views/settings_shell.tsx
+++ b/apps/ui/src/app/views/settings_shell.tsx
@@ -91,7 +91,6 @@ function SettingsShellTabButton(props: {
   const { index, onActivateTab, tab } = props;
   const isActive = useComputed(() => tab.id === props.activeTabId.value);
   const labelText = useUiText(tab.labelKey, tab.fallbackLabel);
-  const tabClass = useComputed(() => isActive.value ? "settings-tab active" : "settings-tab");
   const ariaSelected = useComputed(() => isActive.value ? "true" : "false");
   const tabIndex = useComputed(() => isActive.value ? 0 : -1);
 
@@ -112,7 +111,7 @@ function SettingsShellTabButton(props: {
     <button
       ref={props.onRef}
       type="button"
-      class={tabClass}
+      class="settings-tab"
       data-settings-tab={tab.id}
       role="tab"
       aria-controls={tab.id}
@@ -132,13 +131,12 @@ function SettingsShellTabPanel(props: {
   tab: (typeof SETTINGS_TABS)[number];
 }) {
   const isActive = useComputed(() => props.tab.id === props.activeTabId.value);
-  const panelClass = useComputed(() => isActive.value ? "settings-tab-panel active" : "settings-tab-panel");
   const hidden = useComputed(() => !isActive.value);
 
   return (
     <div
       id={props.tab.id}
-      class={panelClass}
+      class="settings-tab-panel"
       role="tabpanel"
       hidden={hidden}
     >

--- a/apps/ui/src/styles/realtime-overview.css
+++ b/apps/ui/src/styles/realtime-overview.css
@@ -91,12 +91,12 @@
   background: var(--pill-bad-text);
 }
 
-.live-sensor-card--strongest {
+.live-sensor-card[data-strongest="true"] {
   border-color: rgba(124, 58, 237, 0.35);
   background: linear-gradient(180deg, rgba(139, 92, 246, 0.08), var(--surface-2));
 }
 
-.live-sensor-card--strongest::before {
+.live-sensor-card[data-strongest="true"]::before {
   content: "";
   position: absolute;
   inset: 0 auto 0 0;
@@ -105,7 +105,7 @@
   background: var(--brand-500);
 }
 
-.live-sensor-card--strongest .live-sensor-card__header strong {
+.live-sensor-card[data-strongest="true"] .live-sensor-card__header strong {
   color: var(--brand-700);
 }
 

--- a/apps/ui/tests/realtime_live_overview_signals.ts
+++ b/apps/ui/tests/realtime_live_overview_signals.ts
@@ -90,7 +90,7 @@ async function runRealtimeLiveOverviewSignalProjectionTest(): Promise<void> {
     await harness.flush();
 
     assert.equal(overviewRenderCount, 1);
-    assert.equal(harness.host.querySelectorAll(".live-sensor-card--strongest").length, 1);
+    assert.equal(harness.host.querySelectorAll("[data-strongest='true']").length, 1);
     assert.match(harness.host.textContent ?? "", /Front Left/);
   } finally {
     options.diffed = previousDiffed;

--- a/apps/ui/tests/signal_view_reference_tests.ts
+++ b/apps/ui/tests/signal_view_reference_tests.ts
@@ -178,7 +178,7 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
       requireElement(harness.host, "#liveActiveCar [data-value]").getAttribute("data-variant"),
       "warn",
     );
-    assert.equal(harness.host.querySelectorAll(".live-sensor-card--strongest").length, 1);
+    assert.equal(harness.host.querySelectorAll("[data-strongest='true']").length, 1);
     assert.match(harness.host.textContent ?? "", /Front Left/);
     assert.doesNotMatch(harness.host.textContent ?? "", /No sensors/i);
 

--- a/apps/ui/tests/smoke.bootstrap.spec.ts
+++ b/apps/ui/tests/smoke.bootstrap.spec.ts
@@ -328,7 +328,7 @@ test("ui bootstrap smoke: tabs, ws state, recording, history", async ({ page }) 
   await expect(page.locator("#liveStrongestSignal")).not.toHaveClass(/stat--spotlight/);
   await expect(page.locator("#liveStrongestSignal .stat__label")).toHaveText("Strongest signal");
   await expect(page.locator("#liveStrongestSignal [data-value]")).toContainText("Front Left");
-  await expect(page.locator("#liveSensorRoster .live-sensor-card--strongest")).toHaveText("Front Left Wheel");
+  await expect(page.locator("#liveSensorRoster [data-strongest='true']")).toHaveText("Front Left Wheel");
   await expect(page.locator("#liveSensorRoster .status-pill")).toHaveCount(0);
   await expect(page.locator("#liveSensorRoster .live-sensor-card__status-dot--online")).toHaveCount(1);
   await expect(page.locator("#liveSensorRoster article")).toHaveText("Front Left Wheel");


### PR DESCRIPTION
## summary
- remove the computed `"… active"` class strings from shell navigation and settings tabs/panels
- keep those surfaces on stable classes plus their existing `aria-selected`/`hidden` state
- switch the live overview strongest sensor card from a modifier class to `data-strongest` and update the selector assertions

## why
- these toggles were simple boolean state switches that did not need derived class-string allocations
- the shell and settings styles already key off `aria-selected`, and the live overview card state fits the existing `data-*` selector pattern the issue asks for

## validation
- `cd apps/ui && npm run test:signals`
- `cd apps/ui && npx tsx tests/realtime_live_overview_signals.ts`
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/smoke.cars.spec.ts --workers=1`
- `cd apps/ui && npm run typecheck && npm run build`

## risks / edges
- no intended behavior change
- scope stayed to simple active/strongest toggles; the live sensor online/offline status classes were left unchanged

Closes #2656