### PR TITLE
Frontend: split ESP flash and update panels into signal-isolated sub-components

### DIFF
--- a/apps/ui/src/app/views/esp_flash_history_section.tsx
+++ b/apps/ui/src/app/views/esp_flash_history_section.tsx
@@ -4,17 +4,20 @@ import {
   StatusBadge,
   type EspFlashHistoryPanelModel,
 } from "./esp_flash_panel_shared";
+import { useSignalProperties, type ReadonlySignal } from "../ui_signals";
+
+const ESP_FLASH_HISTORY_KEYS = ["attempts", "emptyState"] as const;
 
 export function EspFlashHistoryContent(props: {
-  model: EspFlashHistoryPanelModel;
+  model: ReadonlySignal<EspFlashHistoryPanelModel>;
 }) {
-  const { model } = props;
-  if (model.emptyState) {
-    return <InlineEmptyState model={model.emptyState} />;
+  const { attempts, emptyState } = useSignalProperties(props.model, ESP_FLASH_HISTORY_KEYS);
+  if (emptyState.value) {
+    return <InlineEmptyState model={emptyState.value} />;
   }
   return (
     <ul class="maintenance-attempt-list">
-      {model.attempts.map((attempt, index) => (
+      {attempts.value.map((attempt, index) => (
         <li class="maintenance-attempt" key={`${attempt.portText}:${index}`}>
           <div class="maintenance-attempt__header">
             <StatusBadge badge={attempt.badge} />

--- a/apps/ui/src/app/views/esp_flash_journey_section.tsx
+++ b/apps/ui/src/app/views/esp_flash_journey_section.tsx
@@ -3,6 +3,9 @@ import {
   type EspFlashJourneyPanelModel,
   type EspFlashJourneyStageModel,
 } from "./esp_flash_panel_shared";
+import { useSignalProperties, type ReadonlySignal } from "../ui_signals";
+
+const ESP_FLASH_JOURNEY_KEYS = ["stages", "terminalNoteText"] as const;
 
 function JourneyStageItem(props: {
   stage: EspFlashJourneyStageModel;
@@ -26,16 +29,19 @@ function JourneyStageItem(props: {
 }
 
 export function EspFlashJourneySection(props: {
-  model: EspFlashJourneyPanelModel;
+  model: ReadonlySignal<EspFlashJourneyPanelModel>;
 }) {
-  const { model } = props;
+  const { stages, terminalNoteText } = useSignalProperties(
+    props.model,
+    ESP_FLASH_JOURNEY_KEYS,
+  );
   return (
     <div class="maintenance-journey">
-      {model.terminalNoteText ? (
-        <MaintenanceNote text={model.terminalNoteText} variant="bad" />
+      {terminalNoteText.value ? (
+        <MaintenanceNote text={terminalNoteText.value} variant="bad" />
       ) : null}
       <ol class="maintenance-stage-list">
-        {model.stages.map((stage) => (
+        {stages.value.map((stage) => (
           <JourneyStageItem key={stage.phase} stage={stage} />
         ))}
       </ol>

--- a/apps/ui/src/app/views/esp_flash_log_section.tsx
+++ b/apps/ui/src/app/views/esp_flash_log_section.tsx
@@ -2,13 +2,16 @@ import {
   InlineEmptyState,
   type EspFlashLogPanelModel,
 } from "./esp_flash_panel_shared";
+import { useSignalProperties, type ReadonlySignal } from "../ui_signals";
+
+const ESP_FLASH_LOG_KEYS = ["emptyState", "text"] as const;
 
 export function EspFlashLogContent(props: {
-  model: EspFlashLogPanelModel;
+  model: ReadonlySignal<EspFlashLogPanelModel>;
 }) {
-  const { model } = props;
-  if (model.emptyState) {
-    return <InlineEmptyState model={model.emptyState} />;
+  const { emptyState, text } = useSignalProperties(props.model, ESP_FLASH_LOG_KEYS);
+  if (emptyState.value) {
+    return <InlineEmptyState model={emptyState.value} />;
   }
-  return <pre class="log-pre log-pre--contained">{model.text}</pre>;
+  return <pre class="log-pre log-pre--contained">{text.value}</pre>;
 }

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -5,6 +5,7 @@ import { getUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalEffect,
+  useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
 import {
@@ -18,6 +19,8 @@ import {
   type EspFlashPanelActionHandlers,
   type EspFlashPanelRenderModel,
   type EspFlashPanelView,
+  type EspFlashPortOptionModel,
+  type EspFlashStatusBadgeModel,
 } from "./esp_flash_panel_shared";
 import { EspFlashReadinessSection } from "./esp_flash_readiness_section";
 
@@ -37,6 +40,231 @@ export type {
   EspFlashStatusBadgeModel,
   EspFlashStatusGridRowModel,
 } from "./esp_flash_panel_shared";
+
+const ESP_FLASH_PANEL_KEYS = [
+  "cancelButtonDisabled",
+  "cancelButtonHidden",
+  "history",
+  "journey",
+  "log",
+  "portOptions",
+  "portSelectDisabled",
+  "readiness",
+  "refreshPortsDisabled",
+  "selectedPortValue",
+  "startButtonDisabled",
+  "startButtonHidden",
+  "startButtonLabelText",
+  "startSummary",
+  "statusBanner",
+] as const;
+
+const ESP_FLASH_STATUS_BANNER_KEYS = ["text", "variant"] as const;
+
+function EspFlashStatusBanner(props: {
+  badge: ReadonlySignal<EspFlashStatusBadgeModel>;
+}) {
+  const { text, variant } = useSignalProperties(
+    props.badge,
+    ESP_FLASH_STATUS_BANNER_KEYS,
+  );
+  return (
+    <span id="espFlashStatusBanner" class="pill" data-variant={variant.value}>
+      {text.value}
+    </span>
+  );
+}
+
+function EspFlashPortRow(props: {
+  actions: ReadonlySignal<EspFlashPanelActionHandlers | null>;
+  portLabel: string;
+  portOptions: ReadonlySignal<readonly EspFlashPortOptionModel[]>;
+  portSelectDisabled: ReadonlySignal<boolean>;
+  refreshLabel: string;
+  refreshPortsDisabled: ReadonlySignal<boolean>;
+  selectedPortValue: ReadonlySignal<string>;
+}) {
+  const handleSelectPort = (value: string) => {
+    props.actions.value?.onSelectPort(value);
+  };
+  const handleRefreshPorts = () => {
+    props.actions.value?.onRefreshPorts();
+  };
+  return (
+    <div class="manual-speed-row">
+      <label htmlFor="espFlashPortSelect">
+        {props.portLabel}
+      </label>
+      <select
+        id="espFlashPortSelect"
+        disabled={props.portSelectDisabled.value}
+        value={props.selectedPortValue.value}
+        onChange={(event) => handleSelectPort(event.currentTarget.value)}
+      >
+        {props.portOptions.value.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.labelText}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        id="espFlashRefreshPortsBtn"
+        class="btn btn--muted"
+        disabled={props.refreshPortsDisabled.value}
+        onClick={handleRefreshPorts}
+      >
+        {props.refreshLabel}
+      </button>
+    </div>
+  );
+}
+
+function EspFlashStartSummarySection(props: {
+  model: ReadonlySignal<EspFlashPanelRenderModel["startSummary"]>;
+}) {
+  return <MaintenanceReadinessPanel model={props.model.value} />;
+}
+
+function EspFlashActionRow(props: {
+  actions: ReadonlySignal<EspFlashPanelActionHandlers | null>;
+  cancelButtonDisabled: ReadonlySignal<boolean>;
+  cancelButtonHidden: ReadonlySignal<boolean>;
+  cancelLabel: string;
+  startButtonDisabled: ReadonlySignal<boolean>;
+  startButtonHidden: ReadonlySignal<boolean>;
+  startButtonLabelText: ReadonlySignal<string>;
+}) {
+  const handleStart = () => {
+    props.actions.value?.onStart();
+  };
+  const handleCancel = () => {
+    props.actions.value?.onCancel();
+  };
+  return (
+    <div class="maintenance-action-row">
+      <button
+        type="button"
+        id="espFlashStartBtn"
+        class="btn btn--success"
+        hidden={props.startButtonHidden.value}
+        disabled={props.startButtonDisabled.value}
+        onClick={handleStart}
+      >
+        {props.startButtonLabelText.value}
+      </button>
+      <button
+        type="button"
+        id="espFlashCancelBtn"
+        class="btn btn--danger"
+        hidden={props.cancelButtonHidden.value}
+        disabled={props.cancelButtonDisabled.value}
+        onClick={handleCancel}
+      >
+        {props.cancelLabel}
+      </button>
+    </div>
+  );
+}
+
+function EspFlashJourneyCard(props: {
+  model: ReadonlySignal<EspFlashPanelRenderModel["journey"]>;
+  titleText: string;
+}) {
+  return (
+    <section class="maintenance-card">
+      <div class="maintenance-card__header">
+        <div>
+          <div class="maintenance-card__title">
+            {props.titleText}
+          </div>
+        </div>
+      </div>
+      <div
+        id="espFlashJourneyPanel"
+        class="maintenance-stack maintenance-stack--tight"
+        aria-live="polite"
+      >
+        <EspFlashJourneySection model={props.model} />
+      </div>
+    </section>
+  );
+}
+
+function EspFlashLogCard(props: {
+  introText: string;
+  model: ReadonlySignal<EspFlashPanelRenderModel["log"]>;
+  titleText: string;
+}) {
+  const { emptyState, text } = useSignalProperties(props.model, ["emptyState", "text"] as const);
+  const logPanelRef = useRef<HTMLDivElement | null>(null);
+
+  useSignalEffect(() => {
+    const logPanel = logPanelRef.current;
+    if (!logPanel || emptyState.value !== null) {
+      return;
+    }
+    text.value;
+    const animationFrameId = globalThis.requestAnimationFrame(() => {
+      logPanel.scrollTop = logPanel.scrollHeight;
+    });
+    return () => globalThis.cancelAnimationFrame(animationFrameId);
+  });
+
+  return (
+    <section class="maintenance-card">
+      <div class="maintenance-card__header">
+        <div>
+          <div class="maintenance-card__title">
+            {props.titleText}
+          </div>
+          <div class="subtle">
+            {props.introText}
+          </div>
+        </div>
+      </div>
+      <div
+        ref={logPanelRef}
+        id="espFlashLogPanel"
+        class={
+          emptyState.value
+            ? "maintenance-log-slot"
+            : "maintenance-log-slot maintenance-log-panel"
+        }
+        aria-live="polite"
+      >
+        <EspFlashLogContent model={props.model} />
+      </div>
+    </section>
+  );
+}
+
+function EspFlashHistoryCard(props: {
+  introText: string;
+  model: ReadonlySignal<EspFlashPanelRenderModel["history"]>;
+  titleText: string;
+}) {
+  return (
+    <section class="maintenance-card">
+      <div class="maintenance-card__header">
+        <div>
+          <div class="maintenance-card__title">
+            {props.titleText}
+          </div>
+          <div class="subtle">
+            {props.introText}
+          </div>
+        </div>
+      </div>
+      <div
+        id="espFlashHistoryPanel"
+        class="maintenance-stack maintenance-stack--tight"
+      >
+        <EspFlashHistoryContent model={props.model} />
+      </div>
+    </section>
+  );
+}
 
 function EspFlashPanel(props: {
   actions: ReadonlySignal<EspFlashPanelActionHandlers | null>;
@@ -74,31 +302,23 @@ function EspFlashPanel(props: {
     titleText: getUiText("settings.esp_flash.title", "ESP Flash"),
   }));
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL);
-  const logEndRef = useRef<HTMLDivElement | null>(null);
-  const handleSelectPort = (value: string) => {
-    actions.value?.onSelectPort(value);
-  };
-  const handleRefreshPorts = () => {
-    actions.value?.onRefreshPorts();
-  };
-  const handleStart = () => {
-    actions.value?.onStart();
-  };
-  const handleCancel = () => {
-    actions.value?.onCancel();
-  };
-
-  useSignalEffect(() => {
-    const log = model.value.log;
-    const logEnd = logEndRef.current;
-    if (!logEnd || log.emptyState !== null) {
-      return;
-    }
-    const animationFrameId = globalThis.requestAnimationFrame(() => {
-      logEnd.scrollIntoView({ block: "end", inline: "nearest" });
-    });
-    return () => globalThis.cancelAnimationFrame(animationFrameId);
-  });
+  const {
+    cancelButtonDisabled,
+    cancelButtonHidden,
+    history,
+    journey,
+    log,
+    portOptions,
+    portSelectDisabled,
+    readiness,
+    refreshPortsDisabled,
+    selectedPortValue,
+    startButtonDisabled,
+    startButtonHidden,
+    startButtonLabelText,
+    startSummary,
+    statusBanner,
+  } = useSignalProperties(model, ESP_FLASH_PANEL_KEYS);
   const labelTexts = labels.value;
 
   return (
@@ -110,201 +330,88 @@ function EspFlashPanel(props: {
               <div>
                 <div
                   class="maintenance-card__title"
-
                 >
                   {labelTexts.titleText}
                 </div>
                 <div
                   class="subtle"
-
                 >
                   {labelTexts.hintText}
                 </div>
               </div>
-              <span
-                id="espFlashStatusBanner"
-                class="pill"
-                data-variant={model.value.statusBanner.variant}
-              >
-                {model.value.statusBanner.text}
-              </span>
+              <EspFlashStatusBanner badge={statusBanner} />
             </div>
             <div class="maintenance-card__body maintenance-card__body--hero">
-              <div class="manual-speed-row">
-                <label
-                  htmlFor="espFlashPortSelect"
-
-                >
-                  {labelTexts.portLabel}
-                </label>
-                <select
-                  id="espFlashPortSelect"
-                  disabled={model.value.portSelectDisabled}
-                  value={model.value.selectedPortValue}
-                  onChange={(event) => handleSelectPort(event.currentTarget.value)}
-                >
-                  {model.value.portOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.labelText}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  id="espFlashRefreshPortsBtn"
-                  class="btn btn--muted"
-                  disabled={model.value.refreshPortsDisabled}
-                  onClick={handleRefreshPorts}
-                >
-                  {labelTexts.refreshLabel}
-                </button>
-              </div>
+              <EspFlashPortRow
+                actions={actions}
+                portLabel={labelTexts.portLabel}
+                portOptions={portOptions}
+                portSelectDisabled={portSelectDisabled}
+                refreshLabel={labelTexts.refreshLabel}
+                refreshPortsDisabled={refreshPortsDisabled}
+                selectedPortValue={selectedPortValue}
+              />
               <div
                 id="espFlashStartSummary"
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
               >
-                <MaintenanceReadinessPanel model={model.value.startSummary} />
+                <EspFlashStartSummarySection model={startSummary} />
               </div>
               <div
                 id="espFlashReadinessPanel"
                 class="maintenance-stack maintenance-stack--tight"
                 aria-live="polite"
               >
-                <EspFlashReadinessSection model={model.value.readiness} />
+                <EspFlashReadinessSection model={readiness} />
               </div>
               <details class="settings-help-disclosure settings-help-disclosure--inline">
                 <summary class="settings-help-disclosure__summary">
                   <span class="settings-help-disclosure__heading">
                     <span
                       class="settings-help-disclosure__title"
-
                     >
                       {labelTexts.detailsTitle}
                     </span>
                     <span
                       class="settings-help-disclosure__caption"
-
                     >
                       {labelTexts.detailsCaption}
                     </span>
                   </span>
                 </summary>
                 <div class="settings-help-disclosure__body">
-                  <div
-                    class="maintenance-note"
-
-                  >
+                  <div class="maintenance-note">
                     {labelTexts.preflightNote}
                   </div>
                 </div>
               </details>
-              <div class="maintenance-action-row">
-                <button
-                  type="button"
-                  id="espFlashStartBtn"
-                  class="btn btn--success"
-                  hidden={model.value.startButtonHidden}
-                  disabled={model.value.startButtonDisabled}
-                  onClick={handleStart}
-                >
-                  {model.value.startButtonLabelText}
-                </button>
-                <button
-                  type="button"
-                  id="espFlashCancelBtn"
-                  class="btn btn--danger"
-                  hidden={model.value.cancelButtonHidden}
-                  disabled={model.value.cancelButtonDisabled}
-                  onClick={handleCancel}
-                >
-                  {labelTexts.cancelLabel}
-                </button>
-              </div>
+              <EspFlashActionRow
+                actions={actions}
+                cancelButtonDisabled={cancelButtonDisabled}
+                cancelButtonHidden={cancelButtonHidden}
+                cancelLabel={labelTexts.cancelLabel}
+                startButtonDisabled={startButtonDisabled}
+                startButtonHidden={startButtonHidden}
+                startButtonLabelText={startButtonLabelText}
+              />
             </div>
           </section>
 
           <div class="maintenance-pair-grid maintenance-pair-grid--focus">
-            <section class="maintenance-card">
-              <div class="maintenance-card__header">
-                <div>
-                  <div
-                    class="maintenance-card__title"
-
-                  >
-                    {labelTexts.journeyTitle}
-                  </div>
-                </div>
-              </div>
-              <div
-                id="espFlashJourneyPanel"
-                class="maintenance-stack maintenance-stack--tight"
-                aria-live="polite"
-              >
-                <EspFlashJourneySection model={model.value.journey} />
-              </div>
-            </section>
-            <section class="maintenance-card">
-              <div class="maintenance-card__header">
-                <div>
-                  <div
-                    class="maintenance-card__title"
-
-                  >
-                    {labelTexts.logsTitle}
-                  </div>
-                  <div
-                    class="subtle"
-
-                  >
-                    {labelTexts.logsIntro}
-                  </div>
-                </div>
-              </div>
-              <div
-                id="espFlashLogPanel"
-                class={
-                  model.value.log.emptyState
-                    ? "maintenance-log-slot"
-                    : "maintenance-log-slot maintenance-log-panel"
-                }
-                aria-live="polite"
-              >
-                <EspFlashLogContent model={model.value.log} />
-                {model.value.log.emptyState === null ? (
-                  <div
-                    ref={logEndRef}
-                    class="maintenance-log-anchor"
-                    data-log-end="true"
-                    aria-hidden="true"
-                  />
-                ) : null}
-              </div>
-            </section>
+            <EspFlashJourneyCard model={journey} titleText={labelTexts.journeyTitle} />
+            <EspFlashLogCard
+              introText={labelTexts.logsIntro}
+              model={log}
+              titleText={labelTexts.logsTitle}
+            />
           </div>
 
-          <section class="maintenance-card">
-            <div class="maintenance-card__header">
-              <div>
-                <div
-                  class="maintenance-card__title"
-                >
-                  {labelTexts.historyTitle}
-                </div>
-                <div
-                  class="subtle"
-                >
-                  {labelTexts.historyIntro}
-                </div>
-              </div>
-            </div>
-            <div
-              id="espFlashHistoryPanel"
-              class="maintenance-stack maintenance-stack--tight"
-            >
-              <EspFlashHistoryContent model={model.value.history} />
-            </div>
-          </section>
+          <EspFlashHistoryCard
+            introText={labelTexts.historyIntro}
+            model={history}
+            titleText={labelTexts.historyTitle}
+          />
         </div>
       </div>
     </div>

--- a/apps/ui/src/app/views/esp_flash_readiness_section.tsx
+++ b/apps/ui/src/app/views/esp_flash_readiness_section.tsx
@@ -3,17 +3,23 @@ import {
   StatusGrid,
   type EspFlashReadinessPanelModel,
 } from "./esp_flash_panel_shared";
+import { useSignalProperties, type ReadonlySignal } from "../ui_signals";
+
+const ESP_FLASH_READINESS_KEYS = ["errorText", "rows", "summaryText"] as const;
 
 export function EspFlashReadinessSection(props: {
-  model: EspFlashReadinessPanelModel;
+  model: ReadonlySignal<EspFlashReadinessPanelModel>;
 }) {
-  const { model } = props;
+  const { errorText, rows, summaryText } = useSignalProperties(
+    props.model,
+    ESP_FLASH_READINESS_KEYS,
+  );
   return (
     <div class="maintenance-stack maintenance-stack--tight">
-      <div class="subtle">{model.summaryText}</div>
-      {model.rows.length > 0 ? <StatusGrid rows={model.rows} /> : null}
-      {model.errorText ? (
-        <MaintenanceNote text={model.errorText} variant="bad" />
+      <div class="subtle">{summaryText.value}</div>
+      {rows.value.length > 0 ? <StatusGrid rows={rows.value} /> : null}
+      {errorText.value ? (
+        <MaintenanceNote text={errorText.value} variant="bad" />
       ) : null}
     </div>
   );

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -45,6 +45,25 @@ const UPDATE_PANEL_MODEL_KEYS = [
   "startButtonLabelText",
   "status",
 ] as const;
+const UPDATE_STATUS_BADGE_KEYS = ["text", "variant"] as const;
+const UPDATE_CURRENT_STATUS_KEYS = [
+  "badge",
+  "emptyText",
+  "rows",
+  "summaryText",
+  "titleText",
+] as const;
+const UPDATE_JOURNEY_KEYS = ["failureNote", "stages", "subtitleText", "titleText"] as const;
+const UPDATE_ISSUES_KEYS = ["items", "subtitleText", "titleText"] as const;
+const UPDATE_LATEST_ATTEMPT_KEYS = [
+  "badge",
+  "failureNote",
+  "rows",
+  "subtitleText",
+  "titleText",
+] as const;
+const UPDATE_HEALTH_KEYS = ["badge", "rows", "summaryText", "titleText"] as const;
+const UPDATE_LOG_KEYS = ["emptyState", "lines", "noteText", "subtitleText", "titleText"] as const;
 
 export interface UpdatePanelView {
   actions: Signal<UpdatePanelActionHandlers | null>;
@@ -60,11 +79,60 @@ const DEFAULT_UPDATE_PANEL_MODEL: UpdatePanelRenderModel = {
   status: null,
 };
 
-function UpdateBadge(props: { badge: UpdateStatusBadgeModel }) {
-  const { badge } = props;
+const DEFAULT_UPDATE_BADGE_MODEL: UpdateStatusBadgeModel = {
+  text: "",
+  variant: "muted",
+};
+
+const DEFAULT_UPDATE_CURRENT_STATUS_SECTION_MODEL: UpdateCurrentStatusSectionModel = {
+  badge: DEFAULT_UPDATE_BADGE_MODEL,
+  emptyText: null,
+  rows: [],
+  summaryText: "",
+  titleText: "",
+};
+
+const DEFAULT_UPDATE_JOURNEY_SECTION_MODEL: UpdateJourneySectionModel = {
+  failureNote: null,
+  stages: [],
+  subtitleText: "",
+  titleText: "",
+};
+
+const DEFAULT_UPDATE_ISSUES_SECTION_MODEL: UpdateIssuesSectionModel = {
+  items: [],
+  subtitleText: "",
+  titleText: "",
+};
+
+const DEFAULT_UPDATE_LATEST_ATTEMPT_SECTION_MODEL: UpdateLatestAttemptSectionModel = {
+  badge: DEFAULT_UPDATE_BADGE_MODEL,
+  failureNote: null,
+  rows: [],
+  subtitleText: "",
+  titleText: "",
+};
+
+const DEFAULT_UPDATE_HEALTH_SECTION_MODEL: UpdateHealthSectionModel = {
+  badge: DEFAULT_UPDATE_BADGE_MODEL,
+  rows: [],
+  summaryText: "",
+  titleText: "",
+};
+
+const DEFAULT_UPDATE_LOG_SECTION_MODEL: UpdateLogSectionModel = {
+  emptyState: null,
+  lines: [],
+  noteText: null,
+  subtitleText: "",
+  titleText: "",
+};
+
+function UpdateBadge(props: { badge: ReadonlySignal<UpdateStatusBadgeModel> }) {
+  const { text, variant } = useSignalProperties(props.badge, UPDATE_STATUS_BADGE_KEYS);
   return (
-    <span class="pill" data-variant={badge.variant}>
-      {badge.text}
+    <span class="pill" data-variant={variant.value}>
+      {text.value}
     </span>
   );
 }
@@ -110,12 +178,12 @@ function InlineEmptyState(props: {
 }
 
 function MaintenanceCard(props: {
-  badge?: UpdateStatusBadgeModel | null;
+  badge?: ComponentChildren;
   children: ComponentChildren;
   subtitleText: string;
   titleText: string;
 }) {
-  const { badge, children, subtitleText, titleText } = props;
+  const { children, subtitleText, titleText } = props;
   return (
     <section class="maintenance-card">
       <div class="maintenance-card__header">
@@ -123,7 +191,7 @@ function MaintenanceCard(props: {
           <div class="maintenance-card__title">{titleText}</div>
           <div class="subtle">{subtitleText}</div>
         </div>
-        {badge ? <UpdateBadge badge={badge} /> : null}
+        {props.badge ?? null}
       </div>
       <div class="maintenance-card__body">{children}</div>
     </section>
@@ -131,19 +199,29 @@ function MaintenanceCard(props: {
 }
 
 function UpdateCurrentStatusCard(props: {
-  model: UpdateCurrentStatusSectionModel;
+  model: ReadonlySignal<UpdateCurrentStatusSectionModel | null>;
 }) {
-  const { model } = props;
+  const hasModel = useComputed(() => props.model.value !== null);
+  const model = useComputed(
+    () => props.model.value ?? DEFAULT_UPDATE_CURRENT_STATUS_SECTION_MODEL,
+  );
+  const { badge, emptyText, rows, summaryText, titleText } = useSignalProperties(
+    model,
+    UPDATE_CURRENT_STATUS_KEYS,
+  );
+  if (!hasModel.value) {
+    return null;
+  }
   return (
     <MaintenanceCard
-      badge={model.badge}
-      subtitleText={model.summaryText}
-      titleText={model.titleText}
+      badge={<UpdateBadge badge={badge} />}
+      subtitleText={summaryText.value}
+      titleText={titleText.value}
     >
-      {model.rows.length > 0 ? (
-        <StatusGrid rows={model.rows} />
+      {rows.value.length > 0 ? (
+        <StatusGrid rows={rows.value} />
       ) : (
-        <MaintenanceNote text={model.emptyText ?? ""} />
+        <MaintenanceNote text={emptyText.value ?? ""} />
       )}
     </MaintenanceCard>
   );
@@ -189,20 +267,28 @@ function JourneyStageItem(props: {
 }
 
 function UpdateJourneyCard(props: {
-  model: UpdateJourneySectionModel;
+  model: ReadonlySignal<UpdateJourneySectionModel | null>;
 }) {
-  const { model } = props;
+  const hasModel = useComputed(() => props.model.value !== null);
+  const model = useComputed(() => props.model.value ?? DEFAULT_UPDATE_JOURNEY_SECTION_MODEL);
+  const { failureNote, stages, subtitleText, titleText } = useSignalProperties(
+    model,
+    UPDATE_JOURNEY_KEYS,
+  );
+  if (!hasModel.value) {
+    return null;
+  }
   return (
     <MaintenanceCard
-      subtitleText={model.subtitleText}
-      titleText={model.titleText}
+      subtitleText={subtitleText.value}
+      titleText={titleText.value}
     >
       <div class="maintenance-journey">
-        {model.failureNote ? (
-          <JourneyFailureStack failure={model.failureNote} />
+        {failureNote.value ? (
+          <JourneyFailureStack failure={failureNote.value} />
         ) : null}
         <ol class="maintenance-stage-list">
-          {model.stages.map((stage) => (
+          {stages.value.map((stage) => (
             <JourneyStageItem key={stage.phase} stage={stage} />
           ))}
         </ol>
@@ -212,16 +298,21 @@ function UpdateJourneyCard(props: {
 }
 
 function UpdateIssuesCard(props: {
-  model: UpdateIssuesSectionModel;
+  model: ReadonlySignal<UpdateIssuesSectionModel | null>;
 }) {
-  const { model } = props;
+  const hasModel = useComputed(() => props.model.value !== null);
+  const model = useComputed(() => props.model.value ?? DEFAULT_UPDATE_ISSUES_SECTION_MODEL);
+  const { items, subtitleText, titleText } = useSignalProperties(model, UPDATE_ISSUES_KEYS);
+  if (!hasModel.value) {
+    return null;
+  }
   return (
     <MaintenanceCard
-      subtitleText={model.subtitleText}
-      titleText={model.titleText}
+      subtitleText={subtitleText.value}
+      titleText={titleText.value}
     >
       <ul class="issue-list">
-        {model.items.map((item, index) => (
+        {items.value.map((item, index) => (
           <li class="issue-item" key={`${item.phaseText}:${index}`}>
             <div class="issue-phase">{item.phaseText}</div>
             <div>
@@ -236,21 +327,31 @@ function UpdateIssuesCard(props: {
 }
 
 function UpdateLatestAttemptCard(props: {
-  model: UpdateLatestAttemptSectionModel;
+  model: ReadonlySignal<UpdateLatestAttemptSectionModel | null>;
 }) {
-  const { model } = props;
+  const hasModel = useComputed(() => props.model.value !== null);
+  const model = useComputed(
+    () => props.model.value ?? DEFAULT_UPDATE_LATEST_ATTEMPT_SECTION_MODEL,
+  );
+  const { badge, failureNote, rows, subtitleText, titleText } = useSignalProperties(
+    model,
+    UPDATE_LATEST_ATTEMPT_KEYS,
+  );
+  if (!hasModel.value) {
+    return null;
+  }
   return (
     <MaintenanceCard
-      badge={model.badge}
-      subtitleText={model.subtitleText}
-      titleText={model.titleText}
+      badge={<UpdateBadge badge={badge} />}
+      subtitleText={subtitleText.value}
+      titleText={titleText.value}
     >
-      <StatusGrid rows={model.rows} />
-      {model.failureNote ? (
+      <StatusGrid rows={rows.value} />
+      {failureNote.value ? (
         <div class="maintenance-note maintenance-note--bad">
-          <strong>{model.failureNote.summaryText}</strong>
-          {model.failureNote.detailText ? (
-            <IssueDetail text={model.failureNote.detailText} />
+          <strong>{failureNote.value.summaryText}</strong>
+          {failureNote.value.detailText ? (
+            <IssueDetail text={failureNote.value.detailText} />
           ) : null}
         </div>
       ) : null}
@@ -259,36 +360,52 @@ function UpdateLatestAttemptCard(props: {
 }
 
 function UpdateHealthCard(props: {
-  model: UpdateHealthSectionModel;
+  model: ReadonlySignal<UpdateHealthSectionModel | null>;
 }) {
-  const { model } = props;
+  const hasModel = useComputed(() => props.model.value !== null);
+  const model = useComputed(() => props.model.value ?? DEFAULT_UPDATE_HEALTH_SECTION_MODEL);
+  const { badge, rows, summaryText, titleText } = useSignalProperties(
+    model,
+    UPDATE_HEALTH_KEYS,
+  );
+  if (!hasModel.value) {
+    return null;
+  }
   return (
     <MaintenanceCard
-      badge={model.badge}
-      subtitleText={model.summaryText}
-      titleText={model.titleText}
+      badge={<UpdateBadge badge={badge} />}
+      subtitleText={summaryText.value}
+      titleText={titleText.value}
     >
-      <StatusGrid rows={model.rows} />
+      <StatusGrid rows={rows.value} />
     </MaintenanceCard>
   );
 }
 
 function UpdateLogCard(props: {
-  model: UpdateLogSectionModel;
+  model: ReadonlySignal<UpdateLogSectionModel | null>;
 }) {
-  const { model } = props;
-  const logBody = model.lines.map((line) => `${line}\n`).join("");
+  const hasModel = useComputed(() => props.model.value !== null);
+  const model = useComputed(() => props.model.value ?? DEFAULT_UPDATE_LOG_SECTION_MODEL);
+  const { emptyState, lines, noteText, subtitleText, titleText } = useSignalProperties(
+    model,
+    UPDATE_LOG_KEYS,
+  );
+  const logBody = useComputed(() => lines.value.map((line) => `${line}\n`).join(""));
+  if (!hasModel.value) {
+    return null;
+  }
   return (
     <MaintenanceCard
-      subtitleText={model.subtitleText}
-      titleText={model.titleText}
+      subtitleText={subtitleText.value}
+      titleText={titleText.value}
     >
-      {model.emptyState ? (
-        <InlineEmptyState emptyState={model.emptyState} />
+      {emptyState.value ? (
+        <InlineEmptyState emptyState={emptyState.value} />
       ) : (
         <>
-          {model.noteText ? <MaintenanceNote text={model.noteText} /> : null}
-          <pre class="log-pre">{logBody}</pre>
+          {noteText.value ? <MaintenanceNote text={noteText.value} /> : null}
+          <pre class="log-pre">{logBody.value}</pre>
         </>
       )}
     </MaintenanceCard>
@@ -296,38 +413,83 @@ function UpdateLogCard(props: {
 }
 
 function UpdateOverviewContent(props: {
-  status: UpdateStatusPanelViewModel | null;
+  status: ReadonlySignal<UpdateStatusPanelViewModel | null>;
 }) {
-  const { status } = props;
-  if (!status) {
+  const hasStatus = useComputed(() => props.status.value !== null);
+  const currentStatus = useComputed(() => props.status.value?.currentStatus ?? null);
+  const health = useComputed(() => props.status.value?.health ?? null);
+  if (!hasStatus.value) {
     return null;
   }
   return (
     <div class="maintenance-pair-grid maintenance-pair-grid--summary">
-      <UpdateCurrentStatusCard model={status.currentStatus} />
-      <UpdateHealthCard model={status.health} />
+      <UpdateCurrentStatusCard model={currentStatus} />
+      <UpdateHealthCard model={health} />
     </div>
   );
 }
 
 function UpdateStatusContent(props: {
-  status: UpdateStatusPanelViewModel | null;
+  status: ReadonlySignal<UpdateStatusPanelViewModel | null>;
 }) {
-  const { status } = props;
-  if (!status) {
+  const hasStatus = useComputed(() => props.status.value !== null);
+  const journey = useComputed(() => props.status.value?.journey ?? null);
+  const log = useComputed(() => props.status.value?.log ?? null);
+  const latestAttempt = useComputed(() => props.status.value?.latestAttempt ?? null);
+  const issues = useComputed(() => props.status.value?.issues ?? null);
+  if (!hasStatus.value) {
     return null;
   }
   return (
     <>
       <div class="maintenance-pair-grid maintenance-pair-grid--focus">
-        <UpdateJourneyCard model={status.journey} />
-        <UpdateLogCard model={status.log} />
+        <UpdateJourneyCard model={journey} />
+        <UpdateLogCard model={log} />
       </div>
-      {status.latestAttempt ? (
-        <UpdateLatestAttemptCard model={status.latestAttempt} />
-      ) : null}
-      {status.issues ? <UpdateIssuesCard model={status.issues} /> : null}
+      <UpdateLatestAttemptCard model={latestAttempt} />
+      <UpdateIssuesCard model={issues} />
     </>
+  );
+}
+
+function UpdateActionRow(props: {
+  actions: ReadonlySignal<UpdatePanelActionHandlers | null>;
+  cancelButtonDisabled: ReadonlySignal<boolean>;
+  cancelButtonHidden: ReadonlySignal<boolean>;
+  cancelLabel: string;
+  startButtonDisabled: ReadonlySignal<boolean>;
+  startButtonHidden: ReadonlySignal<boolean>;
+  startButtonLabelText: ReadonlySignal<string>;
+}) {
+  const handleStart = () => {
+    props.actions.value?.onStart();
+  };
+  const handleCancel = () => {
+    props.actions.value?.onCancel();
+  };
+  return (
+    <div class="maintenance-action-row">
+      <button
+        type="button"
+        id="updateStartBtn"
+        class="btn btn--success"
+        hidden={props.startButtonHidden.value}
+        disabled={props.startButtonDisabled.value}
+        onClick={handleStart}
+      >
+        {props.startButtonLabelText.value}
+      </button>
+      <button
+        type="button"
+        id="updateCancelBtn"
+        class="btn btn--danger"
+        hidden={props.cancelButtonHidden.value}
+        disabled={props.cancelButtonDisabled.value}
+        onClick={handleCancel}
+      >
+        {props.cancelLabel}
+      </button>
+    </div>
   );
 }
 
@@ -357,12 +519,6 @@ function UpdatePanel(props: {
     startButtonLabelText,
     status,
   } = useSignalProperties(model, UPDATE_PANEL_MODEL_KEYS);
-  const handleStart = () => {
-    actions.value?.onStart();
-  };
-  const handleCancel = () => {
-    actions.value?.onCancel();
-  };
   const labelTexts = labels.value;
   return (
     <div class="panel card">
@@ -387,30 +543,17 @@ function UpdatePanel(props: {
               class="maintenance-stack maintenance-stack--tight"
               aria-live="polite"
             >
-              <UpdateOverviewContent status={status.value} />
+              <UpdateOverviewContent status={status} />
             </div>
-            <div class="maintenance-action-row">
-              <button
-                type="button"
-                id="updateStartBtn"
-                class="btn btn--success"
-                hidden={startButtonHidden}
-                disabled={startButtonDisabled}
-                onClick={handleStart}
-              >
-                {startButtonLabelText}
-              </button>
-              <button
-                type="button"
-                id="updateCancelBtn"
-                class="btn btn--danger"
-                hidden={cancelButtonHidden}
-                disabled={cancelButtonDisabled}
-                onClick={handleCancel}
-              >
-                {labelTexts.cancelLabel}
-              </button>
-            </div>
+            <UpdateActionRow
+              actions={actions}
+              cancelButtonDisabled={cancelButtonDisabled}
+              cancelButtonHidden={cancelButtonHidden}
+              cancelLabel={labelTexts.cancelLabel}
+              startButtonDisabled={startButtonDisabled}
+              startButtonHidden={startButtonHidden}
+              startButtonLabelText={startButtonLabelText}
+            />
           </div>
         </section>
 
@@ -419,7 +562,7 @@ function UpdatePanel(props: {
           class="maintenance-stack maintenance-stack--tight"
           aria-live="polite"
         >
-          <UpdateStatusContent status={status.value} />
+          <UpdateStatusContent status={status} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What changed
- Split ESP flash shell from status badge, readiness, journey, log, and history sections.
- Convert ESP flash section components to subscribe only to signal props they render.
- Split update panel into signal-scoped overview, journey, log, latest-attempt/issues, and action-row sections.
- Keep DOM ids, button wiring, layout, and flash log lifecycle behavior stable.

## Why
- Old parent panels subscribed wide.
- Small model change re-rendered whole tree.
- New section signals keep re-renders local.

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/smoke.esp-flash.spec.ts tests/smoke.update.spec.ts`

## Risks / tradeoffs
- Full `npm run test:visual` still hits unrelated `settings_speed_source_workflow` failures outside touched files.
- Local `python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-smoke` stopped during bootstrap pip upgrade before UI jobs started.

## Post-merge Investigation (2026-04-18)
- Confirmed that this PR did improve render isolation inside the ESP flash and update surfaces: the current code is split into smaller section components that subscribe only to the signals they render.
- Current sources for that are `apps/ui/src/app/views/esp_flash_panel.tsx:44-240`, `apps/ui/src/app/views/update_panel.tsx:40-260`, and `apps/ui/src/app/views/update_feature_presenter.ts:64-258`.
- This PR did not change the higher-level runtime/lifecycle/ownership concerns tracked separately in `#2706`, `#2707`, `#2709`, and `#2711`. Polling and other side effects still live in feature workflows, and the top-level app lifecycle is still imperative.

Closes #2681
