### PR TITLE
Frontend: split cars wizard and logging panel subscriptions

### DIFF
--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -4,6 +4,7 @@ import type { CarsFeatureFocusTarget } from "../features/cars_feature_workflow";
 import {
   computed,
   signal,
+  useComputed,
   type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
@@ -57,14 +58,18 @@ const DEFAULT_CARS_PANEL_MODEL: CarsListRenderModel = {
   guidance: null,
   table: null,
 };
+const DEFAULT_CARS_WIZARD_MODEL = createClosedCarsWizardRenderModel();
 
 function CarsPanel(props: {
   state: ReadonlySignal<CarsPanelBridgeState>;
   wizardFocusRequest: ReadonlySignal<CarsWizardFocusRequest | null>;
 }) {
-  const state = props.state.value;
-  const model = state.model?.value ?? DEFAULT_CARS_PANEL_MODEL;
-  const wizardModel = state.wizardModel?.value ?? createClosedCarsWizardRenderModel();
+  const listActions = useComputed(() => props.state.value.actions);
+  const listModel = useComputed(() => props.state.value.model?.value ?? DEFAULT_CARS_PANEL_MODEL);
+  const wizardActions = useComputed(() => props.state.value.wizardActions);
+  const wizardModel = useComputed(
+    () => props.state.value.wizardModel?.value ?? DEFAULT_CARS_WIZARD_MODEL,
+  );
   const { addCarButtonRef, wizardRefs } = useCarsWizardFocusManager({
     state: props.state,
     wizardFocusRequest: props.wizardFocusRequest,
@@ -73,13 +78,13 @@ function CarsPanel(props: {
   return (
     <>
       <CarsListSection
-        actions={state.actions}
+        actions={listActions.value}
         addCarButtonRef={addCarButtonRef}
-        model={model}
-        onOpenWizard={() => state.wizardActions?.onAction({ type: "open" })}
+        model={listModel.value}
+        onOpenWizard={() => wizardActions.value?.onAction({ type: "open" })}
       />
       <CarsWizardPanel
-        actions={state.wizardActions}
+        actions={wizardActions}
         refs={wizardRefs}
         wizardModel={wizardModel}
       />

--- a/apps/ui/src/app/views/cars_wizard_panel.tsx
+++ b/apps/ui/src/app/views/cars_wizard_panel.tsx
@@ -1,6 +1,10 @@
 import type { CarsFeatureFocusTarget } from "../features/cars_feature_workflow";
 import type { CarsFeatureManualInputState } from "../features/cars_manual_input";
 import { getUiText as t } from "../ui_i18n";
+import {
+  useSignalProperties,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type { CarsWizardRenderModel } from "./car_wizard_view";
 import {
   CarsWizardStepNav,
@@ -29,22 +33,45 @@ export interface CarsFeatureInteractionHandlers {
   onAction(action: CarsFeatureInteraction): void;
 }
 
+const CARS_WIZARD_PANEL_KEYS = [
+  "actionHintText",
+  "backVisible",
+  "finishEnabled",
+  "finishVisible",
+  "isOpen",
+  "progressText",
+  "specBranch",
+  "step",
+  "summary",
+] as const;
+
 export function CarsWizardPanel(props: {
-  actions: CarsFeatureInteractionHandlers | null;
+  actions: ReadonlySignal<CarsFeatureInteractionHandlers | null>;
   refs: CarsWizardElementRefs;
-  wizardModel: CarsWizardRenderModel;
+  wizardModel: ReadonlySignal<CarsWizardRenderModel>;
 }) {
-  const { actions, refs, wizardModel } = props;
+  const { refs } = props;
+  const {
+    actionHintText,
+    backVisible,
+    finishEnabled,
+    finishVisible,
+    isOpen,
+    progressText,
+    specBranch,
+    step,
+    summary,
+  } = useSignalProperties(props.wizardModel, CARS_WIZARD_PANEL_KEYS);
 
   function closeWizard(): void {
-    actions?.onAction({ type: "close" });
+    props.actions.value?.onAction({ type: "close" });
   }
 
   function emitManualInputs(
     field: keyof CarsFeatureManualInputState,
     value: string,
   ): void {
-    actions?.onAction({
+    props.actions.value?.onAction({
       type: "manual-input-changed",
       field,
       value,
@@ -60,21 +87,21 @@ export function CarsWizardPanel(props: {
   }
 
   return (
-    <div class="wizard-modal-layer" hidden={!wizardModel.isOpen}>
+    <div class="wizard-modal-layer" hidden={!isOpen.value}>
       <div
         id="wizardBackdrop"
         class="wizard-backdrop"
-        hidden={!wizardModel.isOpen}
+        hidden={!isOpen.value}
         onClick={closeWizard}
       />
       <div
         id="addCarWizard"
         class="panel card add-car-wizard"
-        hidden={!wizardModel.isOpen}
+        hidden={!isOpen.value}
         role="dialog"
         aria-modal="true"
         aria-labelledby="wizardTitle"
-        data-spec-branch={wizardModel.specBranch ?? undefined}
+        data-spec-branch={specBranch.value ?? undefined}
         tabIndex={-1}
         onKeyDown={handleWizardKeyDown}
         ref={refs.setElementRef("addCarWizard")}
@@ -84,16 +111,16 @@ export function CarsWizardPanel(props: {
             <strong id="wizardTitle">
               {t("settings.car.add_title", "Add a Car")}
             </strong>
-            <div class="subtle">
-              {t(
-                "settings.car.wizard_intro",
-                "Use the library when it fits, or branch into manual specs without losing your place.",
-              )}
-            </div>
-              <div id="wizardProgressText" class="wizard-progress-text">
-                {wizardModel.progressText}
+              <div class="subtle">
+                {t(
+                  "settings.car.wizard_intro",
+                  "Use the library when it fits, or branch into manual specs without losing your place.",
+                )}
               </div>
-          </div>
+              <div id="wizardProgressText" class="wizard-progress-text">
+                {progressText.value}
+              </div>
+            </div>
           <button
             id="wizardCloseBtn"
             class="btn btn--muted wizard-close"
@@ -104,51 +131,51 @@ export function CarsWizardPanel(props: {
             {"\u00d7"}
           </button>
         </div>
-        <div class="wizard-shell">
+          <div class="wizard-shell">
             <div class="wizard-main">
               <div class="wizard-steps">
-                <CarsWizardStepNav step={wizardModel.step} />
+                <CarsWizardStepNav step={step} />
                 <CarsWizardSteps
                   emitManualInputs={emitManualInputs}
                   refs={refs}
-                  wizardModel={wizardModel}
-                  onSelectBrand={(value) => actions?.onAction({ type: "select-brand", value })}
-                  onSelectGearbox={(index) => actions?.onAction({ type: "select-gearbox", index })}
-                  onSelectModel={(index) => actions?.onAction({ type: "select-model", index })}
-                  onSelectTire={(index) => actions?.onAction({ type: "select-tire", index })}
-                  onSelectType={(value) => actions?.onAction({ type: "select-type", value })}
-                  onSelectVariant={(index) => actions?.onAction({ type: "select-variant", index })}
+                  wizardModel={props.wizardModel}
+                  onSelectBrand={(value) => props.actions.value?.onAction({ type: "select-brand", value })}
+                  onSelectGearbox={(index) => props.actions.value?.onAction({ type: "select-gearbox", index })}
+                  onSelectModel={(index) => props.actions.value?.onAction({ type: "select-model", index })}
+                  onSelectTire={(index) => props.actions.value?.onAction({ type: "select-tire", index })}
+                  onSelectType={(value) => props.actions.value?.onAction({ type: "select-type", value })}
+                  onSelectVariant={(index) => props.actions.value?.onAction({ type: "select-variant", index })}
                   onSubmitCustomBrand={(value) =>
-                    actions?.onAction({ type: "submit-custom-brand", value })}
+                    props.actions.value?.onAction({ type: "submit-custom-brand", value })}
                   onSubmitCustomModel={(value) =>
-                    actions?.onAction({ type: "submit-custom-model", value })}
+                    props.actions.value?.onAction({ type: "submit-custom-model", value })}
                   onSubmitCustomType={(value) =>
-                    actions?.onAction({ type: "submit-custom-type", value })}
+                    props.actions.value?.onAction({ type: "submit-custom-type", value })}
                 />
               </div>
 
               <div class="wizard-nav">
-              <div id="wizardActionHint" class="subtle wizard-nav__status" aria-live="polite">
-                {wizardModel.actionHintText}
-              </div>
-              <div class="wizard-nav__actions">
-                <button
-                  id="wizardBackBtn"
-                  class="btn btn--muted"
-                  hidden={!wizardModel.backVisible}
-                  onClick={() => actions?.onAction({ type: "back" })}
-                >
-                  {t("settings.car.back", "Back")}
-                </button>
-                <button
-                  id="wizardManualAddBtn"
-                  class="btn btn--success"
-                  hidden={!wizardModel.finishVisible}
-                  disabled={!wizardModel.finishEnabled}
-                  onClick={() => actions?.onAction({ type: "finish" })}
-                  ref={refs.setElementRef("manualAddButton")}
-                >
-                  {t("settings.car.finish_add", "Add Car")}
+                <div id="wizardActionHint" class="subtle wizard-nav__status" aria-live="polite">
+                  {actionHintText.value}
+                </div>
+                <div class="wizard-nav__actions">
+                  <button
+                    id="wizardBackBtn"
+                    class="btn btn--muted"
+                    hidden={!backVisible.value}
+                    onClick={() => props.actions.value?.onAction({ type: "back" })}
+                  >
+                    {t("settings.car.back", "Back")}
+                  </button>
+                  <button
+                    id="wizardManualAddBtn"
+                    class="btn btn--success"
+                    hidden={!finishVisible.value}
+                    disabled={!finishEnabled.value}
+                    onClick={() => props.actions.value?.onAction({ type: "finish" })}
+                    ref={refs.setElementRef("manualAddButton")}
+                  >
+                    {t("settings.car.finish_add", "Add Car")}
                 </button>
               </div>
             </div>
@@ -173,11 +200,11 @@ export function CarsWizardPanel(props: {
               {t(
                 "settings.car.wizard_summary_intro",
                 "Your choices stay visible here while the profile comes together.",
-              )}
-            </div>
-            <CarsWizardSummaryPanel summary={wizardModel.summary} />
-          </aside>
-        </div>
+                )}
+              </div>
+              <CarsWizardSummaryPanel summary={summary} />
+            </aside>
+          </div>
       </div>
     </div>
   );

--- a/apps/ui/src/app/views/cars_wizard_sections.tsx
+++ b/apps/ui/src/app/views/cars_wizard_sections.tsx
@@ -3,6 +3,11 @@ import { useMemo } from "preact/hooks";
 
 import type { CarsFeatureManualInputState } from "../features/cars_manual_input";
 import { getUiText as t } from "../ui_i18n";
+import {
+  useComputed,
+  useSignalProperties,
+  type ReadonlySignal,
+} from "../ui_signals";
 import type {
   CarsWizardOptionItem,
   CarsWizardOptionsRenderModel,
@@ -16,6 +21,29 @@ const WIZARD_STEP_LABELS = [
   { key: "settings.car.step_model_short", fallback: "Model" },
   { key: "settings.car.step_variant_short", fallback: "Variant" },
   { key: "settings.car.step_specs_short", fallback: "Specs" },
+] as const;
+const CARS_WIZARD_STEPS_KEYS = [
+  "brandOptions",
+  "gearboxOptions",
+  "manualInputs",
+  "modelOptions",
+  "step",
+  "tireOptions",
+  "typeOptions",
+  "variantOptions",
+] as const;
+const WIZARD_OPTIONS_KEYS = ["attribute", "layout", "messageText", "options"] as const;
+const WIZARD_MANUAL_INPUT_KEYS = [
+  "finalDrive",
+  "rim",
+  "tireAspect",
+  "tireWidth",
+  "topGear",
+] as const;
+const WIZARD_SUMMARY_KEYS = [
+  "profileNameLabelText",
+  "profileNameValueText",
+  "rows",
 ] as const;
 
 function parseWizardOptionIndex(value: string): number | null {
@@ -90,19 +118,23 @@ function WizardOptions(props: {
   firstOptionRef?: (element: HTMLButtonElement | null) => void;
   id: string;
   onSelectOption?: (item: CarsWizardOptionItem) => void;
-  section: CarsWizardOptionsRenderModel;
+  section: ReadonlySignal<CarsWizardOptionsRenderModel>;
 }) {
-  const { firstOptionRef, id, onSelectOption, section } = props;
-  const className = section.layout === "list"
+  const { firstOptionRef, id, onSelectOption } = props;
+  const { attribute, layout, messageText, options } = useSignalProperties(
+    props.section,
+    WIZARD_OPTIONS_KEYS,
+  );
+  const className = layout.value === "list"
     ? "wizard-options wizard-options--list"
     : "wizard-options";
   return (
     <div class={className} id={id}>
-      {section.messageText ? <em>{section.messageText}</em> : null}
-      {section.options.map((item, index) => (
+      {messageText.value ? <em>{messageText.value}</em> : null}
+      {options.value.map((item, index) => (
         <WizardOptionButton
-          key={`${section.attribute}-${item.value}`}
-          attribute={section.attribute}
+          key={`${attribute.value}-${item.value}`}
+          attribute={attribute.value}
           item={item}
           onSelect={() => onSelectOption?.(item)}
           optionRef={index === 0 ? firstOptionRef : undefined}
@@ -150,10 +182,10 @@ function WizardCustomEntry(props: {
 
 function CarsManualInputForm(props: {
   emitManualInputs(field: ManualInputField, value: string): void;
+  manualInputs: ReadonlySignal<CarsWizardRenderModel["manualInputs"]>;
   refs: CarsWizardElementRefs;
-  wizardModel: CarsWizardRenderModel;
 }) {
-  const { emitManualInputs, refs, wizardModel } = props;
+  const { emitManualInputs, refs } = props;
   const inputHandlers = useMemo<Record<ManualInputField, ManualInputHandler>>(
     () => ({
       tireWidth: createManualInputHandler(emitManualInputs, "tireWidth"),
@@ -163,6 +195,10 @@ function CarsManualInputForm(props: {
       topGear: createManualInputHandler(emitManualInputs, "topGear"),
     }),
     [emitManualInputs],
+  );
+  const { finalDrive, rim, tireAspect, tireWidth, topGear } = useSignalProperties(
+    props.manualInputs,
+    WIZARD_MANUAL_INPUT_KEYS,
   );
   return (
     <div class="settings-subgrid">
@@ -175,7 +211,7 @@ function CarsManualInputForm(props: {
           type="number"
           min="100"
           step="1"
-          value={wizardModel.manualInputs.tireWidth}
+          value={tireWidth.value}
           onInput={inputHandlers.tireWidth}
           ref={refs.setElementRef("tireWidthInput")}
         />
@@ -189,7 +225,7 @@ function CarsManualInputForm(props: {
           type="number"
           min="20"
           step="1"
-          value={wizardModel.manualInputs.tireAspect}
+          value={tireAspect.value}
           onInput={inputHandlers.tireAspect}
           ref={refs.setElementRef("tireAspectInput")}
         />
@@ -203,7 +239,7 @@ function CarsManualInputForm(props: {
           type="number"
           min="10"
           step="0.5"
-          value={wizardModel.manualInputs.rim}
+          value={rim.value}
           onInput={inputHandlers.rim}
           ref={refs.setElementRef("rimInput")}
         />
@@ -217,7 +253,7 @@ function CarsManualInputForm(props: {
           type="number"
           step="0.01"
           min="0.1"
-          value={wizardModel.manualInputs.finalDrive}
+          value={finalDrive.value}
           onInput={inputHandlers.finalDrive}
           ref={refs.setElementRef("finalDriveInput")}
         />
@@ -231,7 +267,7 @@ function CarsManualInputForm(props: {
           type="number"
           step="0.01"
           min="0.1"
-          value={wizardModel.manualInputs.topGear}
+          value={topGear.value}
           onInput={inputHandlers.topGear}
           ref={refs.setElementRef("topGearInput")}
         />
@@ -241,15 +277,15 @@ function CarsManualInputForm(props: {
 }
 
 function WizardBrandStep(props: {
-  hidden: boolean;
+  hidden: ReadonlySignal<boolean>;
   refs: CarsWizardElementRefs;
-  section: CarsWizardOptionsRenderModel;
+  section: ReadonlySignal<CarsWizardOptionsRenderModel>;
   onSelectBrand(value: string): void;
   onSubmitCustomBrand(value: string): void;
 }) {
-  const { hidden, onSelectBrand, onSubmitCustomBrand, refs, section } = props;
+  const { onSelectBrand, onSubmitCustomBrand, refs, section } = props;
   return (
-    <div id="wizardStep0" class="wizard-step" hidden={hidden}>
+    <div id="wizardStep0" class="wizard-step" hidden={props.hidden.value}>
       <h3>
         {t("settings.car.step_brand", "Select Brand")}
       </h3>
@@ -274,15 +310,15 @@ function WizardBrandStep(props: {
 }
 
 function WizardTypeStep(props: {
-  hidden: boolean;
+  hidden: ReadonlySignal<boolean>;
   refs: CarsWizardElementRefs;
-  section: CarsWizardOptionsRenderModel;
+  section: ReadonlySignal<CarsWizardOptionsRenderModel>;
   onSelectType(value: string): void;
   onSubmitCustomType(value: string): void;
 }) {
-  const { hidden, onSelectType, onSubmitCustomType, refs, section } = props;
+  const { onSelectType, onSubmitCustomType, refs, section } = props;
   return (
-    <div id="wizardStep1" class="wizard-step" hidden={hidden}>
+    <div id="wizardStep1" class="wizard-step" hidden={props.hidden.value}>
       <h3>
         {t("settings.car.step_type", "Select Type")}
       </h3>
@@ -307,15 +343,15 @@ function WizardTypeStep(props: {
 }
 
 function WizardModelStep(props: {
-  hidden: boolean;
+  hidden: ReadonlySignal<boolean>;
   refs: CarsWizardElementRefs;
-  section: CarsWizardOptionsRenderModel;
+  section: ReadonlySignal<CarsWizardOptionsRenderModel>;
   onSelectModel(index: number): void;
   onSubmitCustomModel(value: string): void;
 }) {
-  const { hidden, onSelectModel, onSubmitCustomModel, refs, section } = props;
+  const { onSelectModel, onSubmitCustomModel, refs, section } = props;
   return (
-    <div id="wizardStep2" class="wizard-step" hidden={hidden}>
+    <div id="wizardStep2" class="wizard-step" hidden={props.hidden.value}>
       <h3>
         {t("settings.car.step_model", "Select Model")}
       </h3>
@@ -360,14 +396,14 @@ function WizardModelStep(props: {
 }
 
 function WizardVariantStep(props: {
-  hidden: boolean;
+  hidden: ReadonlySignal<boolean>;
   refs: CarsWizardElementRefs;
-  section: CarsWizardOptionsRenderModel;
+  section: ReadonlySignal<CarsWizardOptionsRenderModel>;
   onSelectVariant(index: number): void;
 }) {
-  const { hidden, onSelectVariant, refs, section } = props;
+  const { onSelectVariant, refs, section } = props;
   return (
-    <div id="wizardStep3" class="wizard-step" hidden={hidden}>
+    <div id="wizardStep3" class="wizard-step" hidden={props.hidden.value}>
       <h3>
         {t("settings.car.step_variant", "Select Variant")}
       </h3>
@@ -389,15 +425,24 @@ function WizardVariantStep(props: {
 
 function WizardSpecsStep(props: {
   emitManualInputs(field: keyof CarsFeatureManualInputState, value: string): void;
-  hidden: boolean;
+  gearboxOptions: ReadonlySignal<CarsWizardOptionsRenderModel>;
+  hidden: ReadonlySignal<boolean>;
+  manualInputs: ReadonlySignal<CarsWizardRenderModel["manualInputs"]>;
   refs: CarsWizardElementRefs;
-  wizardModel: CarsWizardRenderModel;
   onSelectGearbox(index: number): void;
   onSelectTire(index: number): void;
+  tireOptions: ReadonlySignal<CarsWizardOptionsRenderModel>;
 }) {
-  const { emitManualInputs, hidden, onSelectGearbox, onSelectTire, refs, wizardModel } = props;
+  const {
+    emitManualInputs,
+    gearboxOptions,
+    onSelectGearbox,
+    onSelectTire,
+    refs,
+    tireOptions,
+  } = props;
   return (
-    <div id="wizardStep4" class="wizard-step" hidden={hidden}>
+    <div id="wizardStep4" class="wizard-step" hidden={props.hidden.value}>
       <div class="wizard-branch-card wizard-branch-card--library">
         <div class="wizard-branch-card__header">
           <strong class="wizard-branch-label">
@@ -422,7 +467,7 @@ function WizardSpecsStep(props: {
           }
           onSelectTire(index);
         }}
-        section={wizardModel.tireOptions}
+        section={tireOptions}
         firstOptionRef={refs.setElementRef("tireOption")}
       />
         <h3 class="wizard-section-title">
@@ -437,7 +482,7 @@ function WizardSpecsStep(props: {
           }
           onSelectGearbox(index);
         }}
-        section={wizardModel.gearboxOptions}
+        section={gearboxOptions}
         firstOptionRef={refs.setElementRef("gearboxOption")}
       />
       </div>
@@ -460,16 +505,15 @@ function WizardSpecsStep(props: {
         </div>
         <CarsManualInputForm
           emitManualInputs={emitManualInputs}
+          manualInputs={props.manualInputs}
           refs={refs}
-          wizardModel={wizardModel}
         />
       </div>
     </div>
   );
 }
 
-export function CarsWizardStepNav(props: { step: number }) {
-  const { step } = props;
+export function CarsWizardStepNav(props: { step: ReadonlySignal<number> }) {
   return (
     <div class="wizard-step-indicators" aria-label="Add car progress">
       {WIZARD_STEP_LABELS.map((label, index) => (
@@ -477,8 +521,8 @@ export function CarsWizardStepNav(props: { step: number }) {
           key={label.key}
           class="wizard-step-dot"
           data-step={String(index)}
-          data-step-state={wizardStepState(index, step)}
-          aria-current={index === step ? "step" : undefined}
+          data-step-state={wizardStepState(index, props.step.value)}
+          aria-current={index === props.step.value ? "step" : undefined}
         >
           <span class="wizard-step-dot__number">{index + 1}</span>
           <span class="wizard-step-dot__label">
@@ -493,7 +537,7 @@ export function CarsWizardStepNav(props: { step: number }) {
 export function CarsWizardSteps(props: {
   emitManualInputs(field: keyof CarsFeatureManualInputState, value: string): void;
   refs: CarsWizardElementRefs;
-  wizardModel: CarsWizardRenderModel;
+  wizardModel: ReadonlySignal<CarsWizardRenderModel>;
   onSelectBrand(value: string): void;
   onSelectGearbox(index: number): void;
   onSelectModel(index: number): void;
@@ -516,60 +560,81 @@ export function CarsWizardSteps(props: {
     onSubmitCustomModel,
     onSubmitCustomType,
     refs,
-    wizardModel,
   } = props;
+  const {
+    brandOptions,
+    gearboxOptions,
+    manualInputs,
+    modelOptions,
+    step,
+    tireOptions,
+    typeOptions,
+    variantOptions,
+  } = useSignalProperties(props.wizardModel, CARS_WIZARD_STEPS_KEYS);
+  const brandHidden = useComputed(() => step.value !== 0);
+  const typeHidden = useComputed(() => step.value !== 1);
+  const modelHidden = useComputed(() => step.value !== 2);
+  const variantHidden = useComputed(() => step.value !== 3);
+  const specsHidden = useComputed(() => step.value !== 4);
 
   return (
     <>
       <WizardBrandStep
-        hidden={wizardModel.step !== 0}
+        hidden={brandHidden}
         refs={refs}
-        section={wizardModel.brandOptions}
+        section={brandOptions}
         onSelectBrand={onSelectBrand}
         onSubmitCustomBrand={onSubmitCustomBrand}
       />
       <WizardTypeStep
-        hidden={wizardModel.step !== 1}
+        hidden={typeHidden}
         refs={refs}
-        section={wizardModel.typeOptions}
+        section={typeOptions}
         onSelectType={onSelectType}
         onSubmitCustomType={onSubmitCustomType}
       />
       <WizardModelStep
-        hidden={wizardModel.step !== 2}
+        hidden={modelHidden}
         refs={refs}
-        section={wizardModel.modelOptions}
+        section={modelOptions}
         onSelectModel={onSelectModel}
         onSubmitCustomModel={onSubmitCustomModel}
       />
       <WizardVariantStep
-        hidden={wizardModel.step !== 3}
+        hidden={variantHidden}
         refs={refs}
-        section={wizardModel.variantOptions}
+        section={variantOptions}
         onSelectVariant={onSelectVariant}
       />
       <WizardSpecsStep
         emitManualInputs={emitManualInputs}
-        hidden={wizardModel.step !== 4}
+        gearboxOptions={gearboxOptions}
+        hidden={specsHidden}
+        manualInputs={manualInputs}
         refs={refs}
-        wizardModel={wizardModel}
         onSelectGearbox={onSelectGearbox}
         onSelectTire={onSelectTire}
+        tireOptions={tireOptions}
       />
     </>
   );
 }
 
-export function CarsWizardSummaryPanel(props: { summary: CarsWizardRenderModel["summary"] }) {
-  const { summary } = props;
+export function CarsWizardSummaryPanel(props: {
+  summary: ReadonlySignal<CarsWizardRenderModel["summary"]>;
+}) {
+  const { profileNameLabelText, profileNameValueText, rows } = useSignalProperties(
+    props.summary,
+    WIZARD_SUMMARY_KEYS,
+  );
   return (
     <div id="wizardSummaryPanel">
       <div class="wizard-summary-preview">
-        <div class="wizard-summary-preview__label">{summary.profileNameLabelText}</div>
-        <div class="wizard-summary-preview__value">{summary.profileNameValueText}</div>
+        <div class="wizard-summary-preview__label">{profileNameLabelText.value}</div>
+        <div class="wizard-summary-preview__value">{profileNameValueText.value}</div>
       </div>
       <dl class="wizard-summary-list">
-        {summary.rows.map((row) => (
+        {rows.value.map((row) => (
           <div key={row.labelText} class="wizard-summary-item">
             <dt>{row.labelText}</dt>
             <dd>{row.valueText}</dd>

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -80,33 +80,39 @@ const REALTIME_LOGGING_PANEL_MODEL_KEYS = [
   "summaryText",
 ] as const;
 
-function RealtimeLoggingSummary(props: {
-  summaryText: ReadonlySignal<string>;
-  summaryPanel: ReadonlySignal<RealtimeLoggingSummaryPanelModel | null>;
-  onAction: ((action: RealtimeLoggingSummaryAction) => void) | null;
+function RealtimeLoggingSummarySection(props: {
+  actions: ReadonlySignal<RealtimeLoggingPanelActionHandlers | null>;
+  model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
 }) {
-  const summaryAction = useComputed(() => props.summaryPanel.value?.action ?? null);
+  const { summaryPanel, summaryText } = useSignalProperties(
+    props.model,
+    ["summaryPanel", "summaryText"] as const,
+  );
+  const summaryAction = useComputed(() => summaryPanel.value?.action ?? null);
   const hidden = useComputed(() =>
-    props.summaryText.value === "" && props.summaryPanel.value === null
+    summaryText.value === "" && summaryPanel.value === null
   );
   const summaryLayout = useComputed(() =>
-    props.summaryPanel.value ? "panel" : undefined
+    summaryPanel.value ? "panel" : undefined
   );
+  const handleAction = (action: RealtimeLoggingSummaryAction) => {
+    props.actions.value?.onSummaryAction(action);
+  };
 
   return (
     <div
       id="loggingSummary"
       class="card__subtle"
-      hidden={hidden}
-      data-summary-layout={summaryLayout}
+      hidden={hidden.value}
+      data-summary-layout={summaryLayout.value}
     >
-      {props.summaryPanel.value
+      {summaryPanel.value
         ? (
           <div class={`empty-state empty-state--inline${summaryAction.value ? " empty-state--actionable" : ""}`}>
-            <strong class="empty-state__title">{props.summaryPanel.value.titleText}</strong>
-            <span class="empty-state__body">{props.summaryPanel.value.bodyText}</span>
-            {props.summaryPanel.value.detailText
-              ? <span class="empty-state__detail">{props.summaryPanel.value.detailText}</span>
+            <strong class="empty-state__title">{summaryPanel.value.titleText}</strong>
+            <span class="empty-state__body">{summaryPanel.value.bodyText}</span>
+            {summaryPanel.value.detailText
+              ? <span class="empty-state__detail">{summaryPanel.value.detailText}</span>
               : null}
             {summaryAction.value
               ? (
@@ -115,7 +121,7 @@ function RealtimeLoggingSummary(props: {
                     type="button"
                     class={inlineStateActionClass(summaryAction.value.variant)}
                     data-inline-state-action={summaryAction.value.action}
-                    onClick={() => props.onAction?.(summaryAction.value!.action)}
+                    onClick={() => handleAction(summaryAction.value!.action)}
                   >
                     {summaryAction.value.labelText}
                   </button>
@@ -124,7 +130,7 @@ function RealtimeLoggingSummary(props: {
               : null}
           </div>
         )
-        : props.summaryText}
+        : summaryText.value}
     </div>
   );
 }
@@ -135,7 +141,7 @@ function RealtimeLoggingChecklist(props: {
   const hidden = useComputed(() => props.checklist.value === null);
 
   return (
-    <div id="loggingChecklist" class="capture-readiness" hidden={hidden}>
+    <div id="loggingChecklist" class="capture-readiness" hidden={hidden.value}>
       {props.checklist.value
         ? (
           <>
@@ -162,6 +168,137 @@ function RealtimeLoggingChecklist(props: {
   );
 }
 
+function RealtimeLoggingStatusRow(props: {
+  model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
+}) {
+  const { pillText, pillVariant, runIdText, showPill } = useSignalProperties(
+    props.model,
+    ["pillText", "pillVariant", "runIdText", "showPill"] as const,
+  );
+  const loggingRowHidden = useComputed(() => !showPill.value && runIdText.value === "");
+  const pillHidden = useComputed(() => !showPill.value);
+  const runIdHidden = useComputed(() => runIdText.value === "");
+
+  return (
+    <div class="logging-row" hidden={loggingRowHidden.value}>
+      <span
+        id="loggingStatus"
+        class="pill"
+        data-variant={pillVariant.value}
+        hidden={pillHidden.value}
+        aria-live="polite"
+      >
+        {pillText.value}
+      </span>
+      <span id="loggingRunId" class="subtle" hidden={runIdHidden.value}>
+        {runIdText.value}
+      </span>
+    </div>
+  );
+}
+
+function RealtimeLoggingProgressSection(props: {
+  labels: {
+    elapsedLabel: string;
+    runPhaseLabel: string;
+    runProgressLabel: string;
+    samplesLabel: string;
+  };
+  model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
+}) {
+  const { checklist, elapsedText, phaseText, samplesText, setupMode } = useSignalProperties(
+    props.model,
+    ["checklist", "elapsedText", "phaseText", "samplesText", "setupMode"] as const,
+  );
+  const showProgressSection = useComputed(() => !setupMode.value || checklist.value !== null);
+
+  if (!showProgressSection.value) {
+    return null;
+  }
+
+  return (
+    <>
+      <div class="mini-label">
+        {props.labels.runProgressLabel}
+      </div>
+      <div class="stat-grid stat-grid--compact">
+        <div id="loggingPhase" class="stat stat--compact" hidden>
+          <div class="stat__label">
+            {props.labels.runPhaseLabel}
+          </div>
+          <div class="stat__value" data-value>
+            {phaseText.value}
+          </div>
+        </div>
+        <div id="loggingElapsed" class="stat stat--compact">
+          <div class="stat__label">
+            {props.labels.elapsedLabel}
+          </div>
+          <div class="stat__value" data-value>
+            {elapsedText.value}
+          </div>
+        </div>
+        <div id="loggingSamples" class="stat stat--compact">
+          <div class="stat__label">
+            {props.labels.samplesLabel}
+          </div>
+          <div class="stat__value" data-value>
+            {samplesText.value}
+          </div>
+        </div>
+      </div>
+      <RealtimeLoggingChecklist checklist={checklist} />
+    </>
+  );
+}
+
+function RealtimeLoggingActionRow(props: {
+  actions: ReadonlySignal<RealtimeLoggingPanelActionHandlers | null>;
+  labels: {
+    startLabel: string;
+    stopLabel: string;
+  };
+  model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
+}) {
+  const { showStart, showStop, startDisabled, stopDisabled } = useSignalProperties(
+    props.model,
+    ["showStart", "showStop", "startDisabled", "stopDisabled"] as const,
+  );
+  const startHidden = useComputed(() => !showStart.value);
+  const stopHidden = useComputed(() => !showStop.value);
+  const handleStartLogging = () => {
+    props.actions.value?.onStartLogging();
+  };
+  const handleStopLogging = () => {
+    props.actions.value?.onStopLogging();
+  };
+
+  return (
+    <div class="logging-actions">
+      <button
+        id="startLoggingBtn"
+        class="btn btn--primary"
+        type="button"
+        hidden={startHidden.value}
+        disabled={startDisabled.value}
+        onClick={handleStartLogging}
+      >
+        {props.labels.startLabel}
+      </button>
+      <button
+        id="stopLoggingBtn"
+        class="btn btn--danger-quiet"
+        type="button"
+        hidden={stopHidden.value}
+        disabled={stopDisabled.value}
+        onClick={handleStopLogging}
+      >
+        {props.labels.stopLabel}
+      </button>
+    </div>
+  );
+}
+
 function RealtimeLoggingPanel(props: {
   actions: ReadonlySignal<RealtimeLoggingPanelActionHandlers | null>;
   model: ReadonlySignal<ReadonlySignal<RealtimeLoggingPanelRenderModel> | null>;
@@ -177,129 +314,38 @@ function RealtimeLoggingPanel(props: {
     titleText: getUiText("dashboard.run_recording", "Run Recording"),
   }));
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_PANEL_MODEL);
-  const {
-    checklist,
-    elapsedText,
-    phaseText,
-    pillText,
-    pillVariant,
-    runIdText,
-    samplesText,
-    setupMode,
-    showPill,
-    showStart,
-    showStop,
-    startDisabled,
-    stopDisabled,
-    summaryPanel,
-    summaryText,
-  } = useSignalProperties(model, REALTIME_LOGGING_PANEL_MODEL_KEYS);
+  const { setupMode } = useSignalProperties(model, ["setupMode"] as const);
   const shellLayout = useComputed(() => setupMode.value ? "setup" : undefined);
-  const loggingRowHidden = useComputed(() => !showPill.value && runIdText.value === "");
-  const pillHidden = useComputed(() => !showPill.value);
-  const runIdHidden = useComputed(() => runIdText.value === "");
-  const showProgressSection = useComputed(() => !setupMode.value || checklist.value !== null);
-  const startHidden = useComputed(() => !showStart.value);
-  const stopHidden = useComputed(() => !showStop.value);
-  const handleSummaryAction = (action: RealtimeLoggingSummaryAction) => {
-    actions.value?.onSummaryAction(action);
-  };
-  const handleStartLogging = () => {
-    actions.value?.onStartLogging();
-  };
-  const handleStopLogging = () => {
-    actions.value?.onStopLogging();
-  };
   const labelTexts = labels.value;
 
   return (
-    <div class="realtime-logging-shell" data-layout={shellLayout}>
+    <div class="realtime-logging-shell" data-layout={shellLayout.value}>
       <div class="card__header card__header--stack">
         <div>
           <div class="card__title">
             {labelTexts.titleText}
           </div>
-          <RealtimeLoggingSummary
-            summaryText={summaryText}
-            summaryPanel={summaryPanel}
-            onAction={handleSummaryAction}
-          />
+          <RealtimeLoggingSummarySection actions={actions} model={model} />
         </div>
       </div>
-      <div class="logging-row" hidden={loggingRowHidden}>
-        <span
-          id="loggingStatus"
-          class="pill"
-          data-variant={pillVariant}
-          hidden={pillHidden}
-          aria-live="polite"
-        >
-          {pillText}
-        </span>
-        <span id="loggingRunId" class="subtle" hidden={runIdHidden}>
-          {runIdText}
-        </span>
-      </div>
-      {showProgressSection.value
-        ? (
-          <>
-              <div class="mini-label">
-               {labelTexts.runProgressLabel}
-              </div>
-            <div class="stat-grid stat-grid--compact">
-              <div id="loggingPhase" class="stat stat--compact" hidden>
-                <div class="stat__label">
-                  {labelTexts.runPhaseLabel}
-                </div>
-                <div class="stat__value" data-value>
-                  {phaseText}
-                </div>
-              </div>
-              <div id="loggingElapsed" class="stat stat--compact">
-                <div class="stat__label">
-                  {labelTexts.elapsedLabel}
-                </div>
-                <div class="stat__value" data-value>
-                  {elapsedText}
-                </div>
-              </div>
-              <div id="loggingSamples" class="stat stat--compact">
-                <div class="stat__label">
-                  {labelTexts.samplesLabel}
-                </div>
-                <div class="stat__value" data-value>
-                  {samplesText}
-                </div>
-              </div>
-            </div>
-            <RealtimeLoggingChecklist checklist={checklist} />
-          </>
-        )
-        : null}
-      <div class="logging-actions">
-        <button
-          id="startLoggingBtn"
-          class="btn btn--primary"
-          type="button"
-
-          hidden={startHidden}
-          disabled={startDisabled}
-          onClick={handleStartLogging}
-        >
-          {labelTexts.startLabel}
-        </button>
-        <button
-          id="stopLoggingBtn"
-          class="btn btn--danger-quiet"
-          type="button"
-
-          hidden={stopHidden}
-          disabled={stopDisabled}
-          onClick={handleStopLogging}
-        >
-          {labelTexts.stopLabel}
-        </button>
-      </div>
+      <RealtimeLoggingStatusRow model={model} />
+      <RealtimeLoggingProgressSection
+        labels={{
+          elapsedLabel: labelTexts.elapsedLabel,
+          runPhaseLabel: labelTexts.runPhaseLabel,
+          runProgressLabel: labelTexts.runProgressLabel,
+          samplesLabel: labelTexts.samplesLabel,
+        }}
+        model={model}
+      />
+      <RealtimeLoggingActionRow
+        actions={actions}
+        labels={{
+          startLabel: labelTexts.startLabel,
+          stopLabel: labelTexts.stopLabel,
+        }}
+        model={model}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- split cars wizard shell into signal-scoped step and summary subscribers
- thread signal-backed wizard bridge from cars panel instead of passing plain snapshots
- split realtime logging into summary, status, progress, checklist, and action sections
- fix child-section visibility by reading signal values directly in DOM bindings

## Why
- wizard and logging panel were re-rendering whole surfaces on step-local and section-local updates
- narrower subscriptions keep updates local without changing panel contracts or DOM ids

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/smoke.car-wizard.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.cars.spec.ts tests/realtime_logging_summary.spec.ts`

## Risk / tradeoffs
- hot-path view refactor; main risk was stale hidden or disabled state after section splits
- focused smoke/bootstrap/logging coverage caught one local visibility regression before push

Closes #2682