### PR TITLE
perf(ui): replace WS stale poll with timeout

### DIFF
--- a/apps/ui/src/ws.ts
+++ b/apps/ui/src/ws.ts
@@ -171,14 +171,17 @@ export function createWsClient(options: WsClientOptions): WsClient {
       ) {
         return;
       }
-      const mostRecentMessageAtMs = lastMessageAtMs.value;
-      const intervalId = window.setInterval(() => {
-        if (Date.now() - mostRecentMessageAtMs > resolvedOptions.staleAfterMs) {
-          setState("stale");
-        }
-      }, 1000);
+      const elapsedMs = Date.now() - lastMessageAtMs.value;
+      const remainingMs = resolvedOptions.staleAfterMs - elapsedMs;
+      if (remainingMs <= 0) {
+        setState("stale");
+        return;
+      }
+      const timeoutId = window.setTimeout(() => {
+        setState("stale");
+      }, remainingMs);
       return () => {
-        window.clearInterval(intervalId);
+        window.clearTimeout(timeoutId);
       };
     });
   }

--- a/apps/ui/tests/ws.spec.ts
+++ b/apps/ui/tests/ws.spec.ts
@@ -53,44 +53,19 @@ class FakeWebSocket {
   }
 }
 
-function installIntervalHarness() {
-  const originalSetInterval = globalThis.setInterval;
-  const originalClearInterval = globalThis.clearInterval;
-  let intervalHandler: (() => void) | null = null;
-
-  globalThis.setInterval = ((handler: TimerHandler) => {
-    intervalHandler = handler as () => void;
-    return 1 as unknown as ReturnType<typeof setInterval>;
-  }) as typeof setInterval;
-
-  globalThis.clearInterval = (() => {
-    intervalHandler = null;
-  }) as typeof clearInterval;
-
-  return {
-    tick(): void {
-      if (!intervalHandler) {
-        throw new Error("No interval handler installed");
-      }
-      intervalHandler();
-    },
-    restore(): void {
-      globalThis.setInterval = originalSetInterval;
-      globalThis.clearInterval = originalClearInterval;
-    },
-  };
-}
-
 function installTimeoutHarness() {
   const originalSetTimeout = globalThis.setTimeout;
   const originalClearTimeout = globalThis.clearTimeout;
   let nextId = 1;
-  const callbacks = new Map<number, () => void>();
+  const callbacks = new Map<number, { callback: () => void; delayMs: number }>();
 
-  globalThis.setTimeout = ((handler: TimerHandler) => {
+  globalThis.setTimeout = ((handler: TimerHandler, delay?: number) => {
     const timeoutId = nextId;
     nextId += 1;
-    callbacks.set(timeoutId, handler as () => void);
+    callbacks.set(timeoutId, {
+      callback: handler as () => void,
+      delayMs: Number(delay ?? 0),
+    });
     return timeoutId as unknown as ReturnType<typeof setTimeout>;
   }) as typeof setTimeout;
 
@@ -105,14 +80,17 @@ function installTimeoutHarness() {
     pendingTimeoutCount(): number {
       return callbacks.size;
     },
+    pendingDelays(): number[] {
+      return [...callbacks.values()].map((entry) => entry.delayMs);
+    },
     fireNext(): void {
       const next = callbacks.entries().next();
       if (next.done) {
         throw new Error("No timeout callback installed");
       }
-      const [timeoutId, callback] = next.value;
+      const [timeoutId, entry] = next.value;
       callbacks.delete(timeoutId);
-      callback();
+      entry.callback();
     },
     restore(): void {
       globalThis.setTimeout = originalSetTimeout;
@@ -173,7 +151,7 @@ test.describe("createWsClient", () => {
     const originalWebSocket = globalThis.WebSocket;
     const originalDateNow = Date.now;
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
-    const interval = installIntervalHarness();
+    const timeouts = installTimeoutHarness();
     let now = 1_000;
     Date.now = () => now;
     try {
@@ -196,15 +174,30 @@ test.describe("createWsClient", () => {
       });
 
       expect(client.uiState.value).toBe("connected");
+      expect(timeouts.pendingTimeoutCount()).toBe(1);
+      expect(timeouts.pendingDelays()).toEqual([10]);
+
+      now += 5;
+      socket?.emitMessage({
+        spectra: {
+          clients: {
+            "client-1": {},
+          },
+        },
+      });
+
+      expect(client.uiState.value).toBe("connected");
+      expect(timeouts.pendingTimeoutCount()).toBe(1);
+      expect(timeouts.pendingDelays()).toEqual([10]);
 
       now += 25;
-      interval.tick();
+      timeouts.fireNext();
 
       expect(client.uiState.value).toBe("stale");
       client.close();
     } finally {
       Date.now = originalDateNow;
-      interval.restore();
+      timeouts.restore();
       globalThis.WebSocket = originalWebSocket;
     }
   });


### PR DESCRIPTION
## Summary
- swap `ws.ts` stale detection from a 1s poll loop to one deadline timeout per data message
- mark stale immediately when the deadline is already overdue instead of starting another timer
- extend `ws.spec.ts` to prove one stale timeout stays pending, later messages replace it, and reconnect timeout behavior still works

## Why
- old path woke every second for a 10s stale deadline and kept polling until another state change cleaned it up
- one timeout matches the real deadline with less timer churn

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ws.spec.ts`

## Risks / tradeoffs
- stale transition happens at the exact computed deadline instead of the next 1s poll tick
- scope stays inside WS lifecycle timing; reconnect and payload handling are unchanged

Closes #2685
