### PR TITLE
perf(ui): use peek for nonreactive reads

### DIFF
--- a/apps/ui/src/app/features/esp_flash_feature_workflow.ts
+++ b/apps/ui/src/app/features/esp_flash_feature_workflow.ts
@@ -175,7 +175,7 @@ export function createEspFlashFeatureWorkflow(
       const ports = payload.ports || [];
       batch(() => {
         availablePorts.value = ports;
-        if (!ports.some((port) => port.port === selectedPortValue.value)) {
+        if (!ports.some((port) => port.port === selectedPortValue.peek())) {
           selectedPortValue.value = "__auto__";
         }
       });
@@ -188,7 +188,7 @@ export function createEspFlashFeatureWorkflow(
     enabled: deps.pollingEnabled,
     poll: async () => {
       await refreshStatus();
-      return safeEspFlashState(latestStatus.value.state) === "running"
+      return safeEspFlashState(latestStatus.peek().state) === "running"
         ? ESP_FLASH_POLL_ACTIVE_MS
         : ESP_FLASH_POLL_IDLE_MS;
     },
@@ -196,14 +196,17 @@ export function createEspFlashFeatureWorkflow(
   });
 
   async function startFlash(): Promise<void> {
+    const latestState = safeEspFlashState(latestStatus.peek().state);
+    const ports = availablePorts.peek();
     if (
-      safeEspFlashState(latestStatus.value.state) === "running"
-      || availablePorts.value.length === 0
+      latestState === "running"
+      || ports.length === 0
     ) {
       return;
     }
-    const autoDetect = selectedPortValue.value === "__auto__";
-    const port = autoDetect ? null : selectedPortValue.value;
+    const selectedPort = selectedPortValue.peek();
+    const autoDetect = selectedPort === "__auto__";
+    const port = autoDetect ? null : selectedPort;
     try {
       await api.startEspFlash(port, autoDetect);
       logText.value = "";

--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -140,7 +140,7 @@ export function createRealtimeFeatureWorkflow(
   let queuedIdleCaptureReadinessSignature: string | null = null;
 
   function syncIdleCaptureReadinessSignature(): void {
-    lastIdleCaptureReadinessSignature = deps.idleCaptureReadinessSignature.value;
+    lastIdleCaptureReadinessSignature = deps.idleCaptureReadinessSignature.peek();
     queuedIdleCaptureReadinessSignature = null;
   }
 
@@ -149,17 +149,20 @@ export function createRealtimeFeatureWorkflow(
   }
 
   async function refreshIdleCaptureReadiness(signature: string): Promise<void> {
+    const handlersBound = state.handlersBound.peek();
+    const pendingLoggingAction = state.pendingLoggingAction.peek();
     if (
-      !state.handlersBound.value
+      !handlersBound
       || isDemoMode
-      || state.pendingLoggingAction.value !== null
+      || pendingLoggingAction !== null
     ) {
       return;
     }
+    const loggingStatus = realtime.loggingStatus.peek();
     if (
-      realtime.loggingStatus.value.enabled
-      || realtime.loggingStatus.value.analysis_in_progress
-      || Boolean(realtime.loggingStatus.value.last_completed_run_id)
+      loggingStatus.enabled
+      || loggingStatus.analysis_in_progress
+      || Boolean(loggingStatus.last_completed_run_id)
     ) {
       return;
     }
@@ -214,7 +217,7 @@ export function createRealtimeFeatureWorkflow(
   });
 
   function bindHandlers(): void {
-    if (state.handlersBound.value) {
+    if (state.handlersBound.peek()) {
       return;
     }
     state.handlersBound.value = true;
@@ -225,11 +228,11 @@ export function createRealtimeFeatureWorkflow(
 
   async function refreshLoggingStatus(): Promise<void> {
     syncIdleCaptureReadinessSignature();
-    if (isDemoMode && state.pendingLoggingAction.value === null) {
+    if (isDemoMode && state.pendingLoggingAction.peek() === null) {
       state.loggingError.value = null;
       return;
     }
-    const previousStatus = realtime.loggingStatus.value;
+    const previousStatus = realtime.loggingStatus.peek();
     let nextStatus: LoggingStatusPayload;
     try {
       nextStatus = await api.getLoggingStatus();
@@ -257,7 +260,7 @@ export function createRealtimeFeatureWorkflow(
   }
 
   async function startLogging(): Promise<void> {
-    if (state.pendingLoggingAction.value) return;
+    if (state.pendingLoggingAction.peek()) return;
     syncIdleCaptureReadinessSignature();
     batch(() => {
       state.pendingLoggingAction.value = "starting";
@@ -285,7 +288,7 @@ export function createRealtimeFeatureWorkflow(
   }
 
   async function stopLogging(): Promise<void> {
-    if (state.pendingLoggingAction.value) return;
+    if (state.pendingLoggingAction.peek()) return;
     syncIdleCaptureReadinessSignature();
     batch(() => {
       state.pendingLoggingAction.value = "stopping";
@@ -326,7 +329,8 @@ export function createRealtimeFeatureWorkflow(
 
   async function setClientLocation(clientId: string, locationCode: string): Promise<void> {
     if (!clientId) return;
-    const existing = realtime.clients.value.find((client) => client.id === clientId);
+    const clients = realtime.clients.peek();
+    const existing = clients.find((client) => client.id === clientId);
     const existingLocationCode = String(existing?.location_code || "").trim();
     if (existing && existingLocationCode === locationCode) return;
     try {
@@ -335,9 +339,10 @@ export function createRealtimeFeatureWorkflow(
       showError(err instanceof Error ? err.message : t("actions.set_location_failed"));
       return;
     }
-    const client = realtime.clients.value.find((row) => row.id === clientId);
+    const nextClients = realtime.clients.peek();
+    const client = nextClients.find((row) => row.id === clientId);
     if (client) {
-      realtime.clients.value = realtime.clients.value.map((row) =>
+      realtime.clients.value = nextClients.map((row) =>
         row.id === clientId ? { ...row, location_code: locationCode } : row
       );
     }
@@ -360,13 +365,13 @@ export function createRealtimeFeatureWorkflow(
       showError(err instanceof Error ? err.message : t("actions.remove_client_failed"));
       return;
     }
-    const previousSelectedClientId = realtime.selectedClientId.value;
-    realtime.clients.value = realtime.clients.value.filter((client) => client.id !== clientId);
-    if (realtime.selectedClientId.value === clientId) {
+    const previousSelectedClientId = realtime.selectedClientId.peek();
+    realtime.clients.value = realtime.clients.peek().filter((client) => client.id !== clientId);
+    if (realtime.selectedClientId.peek() === clientId) {
       realtime.selectedClientId.value = null;
     }
     syncSelectedRealtimeClient(realtime);
-    if (previousSelectedClientId !== realtime.selectedClientId.value) {
+    if (previousSelectedClientId !== realtime.selectedClientId.peek()) {
       selection.sendSelection();
     }
   }

--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -74,6 +74,9 @@ function CarsPanel(props: {
     state: props.state,
     wizardFocusRequest: props.wizardFocusRequest,
   });
+  const openWizard = () => {
+    wizardActions.peek()?.onAction({ type: "open" });
+  };
 
   return (
     <>
@@ -81,7 +84,7 @@ function CarsPanel(props: {
         actions={listActions.value}
         addCarButtonRef={addCarButtonRef}
         model={listModel.value}
-        onOpenWizard={() => wizardActions.value?.onAction({ type: "open" })}
+        onOpenWizard={openWizard}
       />
       <CarsWizardPanel
         actions={wizardActions}

--- a/apps/ui/src/app/views/cars_wizard_panel.tsx
+++ b/apps/ui/src/app/views/cars_wizard_panel.tsx
@@ -63,15 +63,19 @@ export function CarsWizardPanel(props: {
     summary,
   } = useSignalProperties(props.wizardModel, CARS_WIZARD_PANEL_KEYS);
 
+  function dispatchAction(action: CarsFeatureInteraction): void {
+    props.actions.peek()?.onAction(action);
+  }
+
   function closeWizard(): void {
-    props.actions.value?.onAction({ type: "close" });
+    dispatchAction({ type: "close" });
   }
 
   function emitManualInputs(
     field: keyof CarsFeatureManualInputState,
     value: string,
   ): void {
-    props.actions.value?.onAction({
+    dispatchAction({
       type: "manual-input-changed",
       field,
       value,
@@ -139,18 +143,18 @@ export function CarsWizardPanel(props: {
                   emitManualInputs={emitManualInputs}
                   refs={refs}
                   wizardModel={props.wizardModel}
-                  onSelectBrand={(value) => props.actions.value?.onAction({ type: "select-brand", value })}
-                  onSelectGearbox={(index) => props.actions.value?.onAction({ type: "select-gearbox", index })}
-                  onSelectModel={(index) => props.actions.value?.onAction({ type: "select-model", index })}
-                  onSelectTire={(index) => props.actions.value?.onAction({ type: "select-tire", index })}
-                  onSelectType={(value) => props.actions.value?.onAction({ type: "select-type", value })}
-                  onSelectVariant={(index) => props.actions.value?.onAction({ type: "select-variant", index })}
+                  onSelectBrand={(value) => dispatchAction({ type: "select-brand", value })}
+                  onSelectGearbox={(index) => dispatchAction({ type: "select-gearbox", index })}
+                  onSelectModel={(index) => dispatchAction({ type: "select-model", index })}
+                  onSelectTire={(index) => dispatchAction({ type: "select-tire", index })}
+                  onSelectType={(value) => dispatchAction({ type: "select-type", value })}
+                  onSelectVariant={(index) => dispatchAction({ type: "select-variant", index })}
                   onSubmitCustomBrand={(value) =>
-                    props.actions.value?.onAction({ type: "submit-custom-brand", value })}
+                    dispatchAction({ type: "submit-custom-brand", value })}
                   onSubmitCustomModel={(value) =>
-                    props.actions.value?.onAction({ type: "submit-custom-model", value })}
+                    dispatchAction({ type: "submit-custom-model", value })}
                   onSubmitCustomType={(value) =>
-                    props.actions.value?.onAction({ type: "submit-custom-type", value })}
+                    dispatchAction({ type: "submit-custom-type", value })}
                 />
               </div>
 
@@ -163,7 +167,7 @@ export function CarsWizardPanel(props: {
                     id="wizardBackBtn"
                     class="btn btn--muted"
                     hidden={!backVisible.value}
-                    onClick={() => props.actions.value?.onAction({ type: "back" })}
+                    onClick={() => dispatchAction({ type: "back" })}
                   >
                     {t("settings.car.back", "Back")}
                   </button>
@@ -172,7 +176,7 @@ export function CarsWizardPanel(props: {
                     class="btn btn--success"
                     hidden={!finishVisible.value}
                     disabled={!finishEnabled.value}
-                    onClick={() => props.actions.value?.onAction({ type: "finish" })}
+                    onClick={() => dispatchAction({ type: "finish" })}
                     ref={refs.setElementRef("manualAddButton")}
                   >
                     {t("settings.car.finish_add", "Add Car")}

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -85,10 +85,10 @@ function EspFlashPortRow(props: {
   selectedPortValue: ReadonlySignal<string>;
 }) {
   const handleSelectPort = (value: string) => {
-    props.actions.value?.onSelectPort(value);
+    props.actions.peek()?.onSelectPort(value);
   };
   const handleRefreshPorts = () => {
-    props.actions.value?.onRefreshPorts();
+    props.actions.peek()?.onRefreshPorts();
   };
   return (
     <div class="manual-speed-row">
@@ -136,10 +136,10 @@ function EspFlashActionRow(props: {
   startButtonLabelText: ReadonlySignal<string>;
 }) {
   const handleStart = () => {
-    props.actions.value?.onStart();
+    props.actions.peek()?.onStart();
   };
   const handleCancel = () => {
-    props.actions.value?.onCancel();
+    props.actions.peek()?.onCancel();
   };
   return (
     <div class="maintenance-action-row">

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -43,10 +43,10 @@ export function HistoryPanel(props: {
     HISTORY_PANEL_MODEL_KEYS,
   );
   const handleRefreshHistory = () => {
-    actions.value?.onRefreshHistory();
+    actions.peek()?.onRefreshHistory();
   };
   const handleDeleteAllRuns = () => {
-    actions.value?.onDeleteAllRuns();
+    actions.peek()?.onDeleteAllRuns();
   };
   const labelTexts = labels.value;
 

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -96,7 +96,7 @@ function RealtimeLoggingSummarySection(props: {
     summaryPanel.value ? "panel" : undefined
   );
   const handleAction = (action: RealtimeLoggingSummaryAction) => {
-    props.actions.value?.onSummaryAction(action);
+    props.actions.peek()?.onSummaryAction(action);
   };
 
   return (
@@ -267,10 +267,10 @@ function RealtimeLoggingActionRow(props: {
   const startHidden = useComputed(() => !showStart.value);
   const stopHidden = useComputed(() => !showStop.value);
   const handleStartLogging = () => {
-    props.actions.value?.onStartLogging();
+    props.actions.peek()?.onStartLogging();
   };
   const handleStopLogging = () => {
-    props.actions.value?.onStopLogging();
+    props.actions.peek()?.onStopLogging();
   };
 
   return (

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -204,7 +204,7 @@ function SpectrumPanel(props: {
               aria-expanded={bandTogglePressed}
               hidden={bandToggleHidden}
               disabled={bandToggleHidden}
-              onClick={() => props.onBandToggle.value?.()}
+              onClick={() => props.onBandToggle.peek()?.()}
             >
               {bandToggleText}
             </button>

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -462,10 +462,10 @@ function UpdateActionRow(props: {
   startButtonLabelText: ReadonlySignal<string>;
 }) {
   const handleStart = () => {
-    props.actions.value?.onStart();
+    props.actions.peek()?.onStart();
   };
   const handleCancel = () => {
-    props.actions.value?.onCancel();
+    props.actions.peek()?.onCancel();
   };
   return (
     <div class="maintenance-action-row">


### PR DESCRIPTION
## Summary
- switch imperative workflow snapshot/guard reads in realtime and ESP flash flows to `signal.peek()`
- switch view action-handler closures to `signal.peek()` in cars, ESP flash, realtime logging, update, history, and spectrum panels
- keep real reactive dependencies on `.value`; do not change the settings speed-source navigation effect because it intentionally tracks tab/view changes

## Why
- these reads only need the latest value
- `.peek()` makes that explicit and avoids accidental reactive tracking where no subscription is wanted

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/realtime_feature_workflow.spec.ts tests/esp_flash_feature_workflow.spec.ts tests/esp_flash_feature_bindings.spec.ts tests/update_feature_bindings.spec.ts tests/realtime_logging_summary.spec.ts tests/smoke.cars.spec.ts tests/smoke.update.spec.ts tests/smoke.history.spec.ts tests/smoke.spectrum.spec.ts`

## Risks / tradeoffs
- changing a real dependency to `.peek()` would suppress needed reruns, so scope stays limited to imperative guards/snapshots and action handlers
- `settings_speed_source_module.ts` stays unchanged because its effect needs live subscriptions

Closes #2686
