### PR TITLE
refactor(ui): clean up spectrum theme listener

### DIFF
--- a/apps/ui/src/spectrum_css_vars.ts
+++ b/apps/ui/src/spectrum_css_vars.ts
@@ -1,4 +1,4 @@
-import { computed, signal } from "./app/ui_signals";
+import { computed, effect, signal } from "./app/ui_signals";
 
 export interface SpectrumCssVars {
   surface: string;
@@ -22,8 +22,8 @@ const spectrumCssVars = computed<Readonly<SpectrumCssVars>>(() => {
   spectrumCssVarsVersion.value;
   return readSpectrumCssVars();
 });
-let spectrumCssVarsThemeListenerInitialized = false;
 let cachedSpectrumCssVars: Readonly<SpectrumCssVars> | null = null;
+let stopSpectrumCssVarsThemeTracking: (() => void) | null = null;
 
 function readSpectrumCssVars(): Readonly<SpectrumCssVars> {
   const rootStyle = getComputedStyle(document.documentElement);
@@ -62,16 +62,21 @@ export function refreshSpectrumCssVars(): Readonly<SpectrumCssVars> {
 }
 
 function ensureSpectrumCssVarsThemeTracking(): void {
-  if (spectrumCssVarsThemeListenerInitialized) {
+  if (stopSpectrumCssVarsThemeTracking) {
     return;
   }
   if (typeof globalThis.matchMedia !== "function") {
     return;
   }
-  spectrumCssVarsThemeListenerInitialized = true;
-  const mediaQuery = globalThis.matchMedia(THEME_MEDIA_QUERY);
-  const refresh = () => {
-    spectrumCssVarsVersion.value += 1;
-  };
-  mediaQuery.addEventListener("change", refresh);
+  stopSpectrumCssVarsThemeTracking = effect(() => {
+    const mediaQuery = globalThis.matchMedia(THEME_MEDIA_QUERY);
+    const refresh = () => {
+      spectrumCssVarsVersion.value += 1;
+    };
+    mediaQuery.addEventListener("change", refresh);
+    return () => {
+      mediaQuery.removeEventListener("change", refresh);
+      stopSpectrumCssVarsThemeTracking = null;
+    };
+  });
 }


### PR DESCRIPTION
## Summary
- replace the module-level spectrum theme-listener latch with a stored effect disposer
- keep lazy initialization and CSS-var cache/version behavior unchanged
- leave the change scoped to `spectrum_css_vars.ts`

## Why
- old path added a `matchMedia` listener with no cleanup path
- effect cleanup matches the rest of the frontend lifecycle pattern

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/spectrum_css_vars.spec.ts tests/smoke.spectrum.spec.ts`

## Risks / tradeoffs
- scope stays local to spectrum CSS-var tracking; chart/theme behavior should stay the same
- the cache model is unchanged on purpose; this PR only fixes listener lifecycle

Closes #2687
