### PR TITLE
Frontend: extract createApiLoader for matching fetch flows

### DIFF
--- a/apps/ui/src/app/features/api_loader.ts
+++ b/apps/ui/src/app/features/api_loader.ts
@@ -1,0 +1,37 @@
+import { signal, type ReadonlySignal } from "../ui_signals";
+
+export interface ApiLoader<TValue> {
+  readonly loading: ReadonlySignal<boolean>;
+  load(): Promise<TValue | null>;
+}
+
+export interface CreateApiLoaderOptions<TValue> {
+  beforeLoad?: () => void;
+  load: () => Promise<TValue>;
+  apply: (value: TValue) => void;
+  onError?: (error: unknown) => void;
+}
+
+export function createApiLoader<TValue>(
+  options: CreateApiLoaderOptions<TValue>,
+): ApiLoader<TValue> {
+  const loading = signal(false);
+
+  return {
+    loading,
+    async load(): Promise<TValue | null> {
+      loading.value = true;
+      options.beforeLoad?.();
+      try {
+        const value = await options.load();
+        options.apply(value);
+        return value;
+      } catch (error) {
+        options.onError?.(error);
+        return null;
+      } finally {
+        loading.value = false;
+      }
+    },
+  };
+}

--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -34,6 +34,7 @@ import {
   createCarsFeatureTransport,
   type CarsFeatureTransport,
 } from "./cars_feature_transport";
+import { createApiLoader } from "./api_loader";
 import {
   batch,
   computed,
@@ -334,39 +335,61 @@ export function createCarsFeatureWorkflow(
     });
   }
 
-  async function loadBrandStep(): Promise<void> {
-    brandOptions.value = createLoadingOptionsState(deps.t("settings.wizard.loading"));
-    try {
-      brandOptions.value = createReadyOptionsState(await transport.loadBrands());
+  const brandStepLoader = createApiLoader({
+    beforeLoad: () => {
+      brandOptions.value = createLoadingOptionsState(deps.t("settings.wizard.loading"));
+    },
+    load: () => transport.loadBrands(),
+    apply: (brands) => {
+      brandOptions.value = createReadyOptionsState(brands);
       deps.view.focus("brand-option");
-    } catch (_err) {
+    },
+    onError: () => {
       brandOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_brands"));
       deps.view.focus("custom-brand");
-    }
+    },
+  });
+
+  const typeStepLoader = createApiLoader({
+    beforeLoad: () => {
+      typeOptions.value = createLoadingOptionsState(deps.t("settings.wizard.loading"));
+    },
+    load: () => transport.loadTypes(wizardState.value.brand),
+    apply: (types) => {
+      typeOptions.value = createReadyOptionsState(types);
+      deps.view.focus("type-option");
+    },
+    onError: () => {
+      typeOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_types"));
+      deps.view.focus("custom-type");
+    },
+  });
+
+  const modelStepLoader = createApiLoader({
+    beforeLoad: () => {
+      modelOptions.value = createLoadingOptionsState(deps.t("settings.wizard.loading"));
+    },
+    load: () => transport.loadModels(wizardState.value.brand, wizardState.value.carType),
+    apply: (models) => {
+      modelOptions.value = createReadyOptionsState(models);
+      deps.view.focus("model-option");
+    },
+    onError: () => {
+      modelOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_models"));
+      deps.view.focus("custom-model");
+    },
+  });
+
+  async function loadBrandStep(): Promise<void> {
+    await brandStepLoader.load();
   }
 
   async function loadTypeStep(): Promise<void> {
-    typeOptions.value = createLoadingOptionsState(deps.t("settings.wizard.loading"));
-    try {
-      typeOptions.value = createReadyOptionsState(await transport.loadTypes(wizardState.value.brand));
-      deps.view.focus("type-option");
-    } catch (_err) {
-      typeOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_types"));
-      deps.view.focus("custom-type");
-    }
+    await typeStepLoader.load();
   }
 
   async function loadModelStep(): Promise<void> {
-    modelOptions.value = createLoadingOptionsState(deps.t("settings.wizard.loading"));
-    try {
-      modelOptions.value = createReadyOptionsState(
-        await transport.loadModels(wizardState.value.brand, wizardState.value.carType),
-      );
-      deps.view.focus("model-option");
-    } catch (_err) {
-      modelOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_models"));
-      deps.view.focus("custom-model");
-    }
+    await modelStepLoader.load();
   }
 
   function loadVariantStep(): void {

--- a/apps/ui/src/app/features/esp_flash_feature_workflow.ts
+++ b/apps/ui/src/app/features/esp_flash_feature_workflow.ts
@@ -29,6 +29,7 @@ import {
   type PollingController,
   type PollingControllerOptions,
 } from "./polling_controller";
+import { createApiLoader } from "./api_loader";
 
 export interface EspFlashFeatureWorkflowApi {
   cancelEspFlash(): Promise<unknown>;
@@ -127,13 +128,28 @@ export function createEspFlashFeatureWorkflow(
     }
   }
 
-  async function refreshHistory(): Promise<void> {
-    try {
-      const payload = await api.getEspFlashHistory();
+  const historyLoader = createApiLoader({
+    load: () => api.getEspFlashHistory(),
+    apply: (payload) => {
       latestAttempts.value = payload.attempts || [];
-    } catch {
-      /* keep existing history on transient error */
-    }
+    },
+  });
+
+  const portsLoader = createApiLoader({
+    load: () => api.getEspFlashPorts(),
+    apply: (payload) => {
+      const ports = payload.ports || [];
+      batch(() => {
+        availablePorts.value = ports;
+        if (!ports.some((port) => port.port === selectedPortValue.peek())) {
+          selectedPortValue.value = "__auto__";
+        }
+      });
+    },
+  });
+
+  async function refreshHistory(): Promise<void> {
+    await historyLoader.load();
   }
 
   async function refreshLogs(status: EspFlashStatusPayload): Promise<void> {
@@ -170,18 +186,7 @@ export function createEspFlashFeatureWorkflow(
   }
 
   async function refreshPorts(): Promise<void> {
-    try {
-      const payload = await api.getEspFlashPorts();
-      const ports = payload.ports || [];
-      batch(() => {
-        availablePorts.value = ports;
-        if (!ports.some((port) => port.port === selectedPortValue.peek())) {
-          selectedPortValue.value = "__auto__";
-        }
-      });
-    } catch {
-      /* keep existing options on transient error */
-    }
+    await portsLoader.load();
   }
 
   const polling = createPolling({

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -27,6 +27,7 @@ import {
   createSettingsCarsTransport,
   type SettingsCarsTransport,
 } from "./settings_cars_transport";
+import { createApiLoader } from "./api_loader";
 
 interface SettingsCarsModulePanels {
   analysisPanel: Pick<AnalysisPanelView, "carAvailability">;
@@ -164,13 +165,16 @@ export function createSettingsCarsModule(
     }
   }
 
-  async function loadCarsFromServer(): Promise<void> {
-    try {
-      syncCarsPayload(await transport.loadCars());
+  const carsLoader = createApiLoader({
+    load: () => transport.loadCars(),
+    apply: (payload) => {
+      syncCarsPayload(payload);
       syncActiveCarToInputs();
-    } catch (_err) {
-      return;
-    }
+    },
+  });
+
+  async function loadCarsFromServer(): Promise<void> {
+    await carsLoader.load();
   }
 
   async function handleActivateCar(carId: string): Promise<void> {

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -28,6 +28,7 @@ import {
   createSettingsSpeedSourceTransport,
   type SettingsSpeedSourceTransport,
 } from "./settings_speed_source_transport";
+import { createApiLoader } from "./api_loader";
 
 const OBD_BACKGROUND_RESCAN_DELAY_MS = 2_000;
 
@@ -317,13 +318,13 @@ export function createSettingsSpeedSourceWorkflow(
     deps.renderSpeedReadout();
   }
 
+  const speedSourceLoader = createApiLoader({
+    load: () => transport.loadSpeedSource(),
+    apply: applyPayload,
+  });
+
   async function loadSpeedSourceFromServer(): Promise<void> {
-    try {
-      const payload = await transport.loadSpeedSource();
-      applyPayload(payload);
-    } catch {
-      /* keep the current UI state on transient load errors */
-    }
+    await speedSourceLoader.load();
   }
 
   function handleSpeedSourceChanged(mode: DisplayedSpeedSourceMode): void {

--- a/apps/ui/tests/api_loader.spec.ts
+++ b/apps/ui/tests/api_loader.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+import { effect } from "../src/app/ui_signals";
+import { createApiLoader } from "../src/app/features/api_loader";
+
+test.describe("createApiLoader", () => {
+  test("runs lifecycle hooks and toggles loading on success", async () => {
+    const events: string[] = [];
+    const loader = createApiLoader({
+      beforeLoad: () => {
+        events.push("before");
+      },
+      load: async () => {
+        events.push("load");
+        return "ready";
+      },
+      apply: (value) => {
+        events.push(`apply:${value}`);
+      },
+    });
+    const loadingStates: boolean[] = [];
+    const dispose = effect(() => {
+      loadingStates.push(loader.loading.value);
+    });
+
+    expect(loadingStates).toEqual([false]);
+    await expect(loader.load()).resolves.toBe("ready");
+    expect(events).toEqual(["before", "load", "apply:ready"]);
+    expect(loadingStates).toEqual([false, true, false]);
+
+    dispose();
+  });
+
+  test("returns null and calls onError when the load fails", async () => {
+    const events: string[] = [];
+    const loader = createApiLoader({
+      load: async () => {
+        throw new Error("offline");
+      },
+      apply: () => {
+        events.push("apply");
+      },
+      onError: (error) => {
+        events.push(error instanceof Error ? error.message : String(error));
+      },
+    });
+
+    await expect(loader.load()).resolves.toBeNull();
+    expect(events).toEqual(["offline"]);
+    expect(loader.loading.value).toBe(false);
+  });
+});

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -119,3 +119,82 @@ test("settings cars module dismisses transient creation feedback through typed t
   expect(dismissedByView.table.rows[0].isHighlighted).toBe(false);
   expect(dismissedByView.table.rows[0].highlightedStatusText).toBeNull();
 });
+
+test("settings cars module loads cars through the shared async loader and syncs active-car inputs", async () => {
+  const state = createAppState().settings;
+  const renders: CarsListRenderModel[] = [];
+  let syncAnalysisInputsCalls = 0;
+
+  const panel: CarsListPanelView = {
+    actions: signal(null),
+    model: signal(null),
+  };
+  effect(() => {
+    const model = panel.model.value;
+    if (model === null) {
+      return;
+    }
+    renders.push(model.value);
+  });
+
+  const module = createSettingsCarsModule({
+    settings: state,
+    panels: {
+      analysisPanel: {
+        carAvailability: signal(null),
+      },
+      panel,
+    },
+    ports: {
+      activeViewId: signal("settingsView"),
+      activeSettingsTabId: signal("carTab"),
+      openAnalysisTab: () => undefined,
+      openCarWizard: () => undefined,
+      renderSpectrum: () => undefined,
+      syncAnalysisInputs: () => {
+        syncAnalysisInputsCalls += 1;
+      },
+    },
+    services: {
+      t: (key) => key,
+      requestConfirmation: async () => true,
+      showError: () => undefined,
+    },
+    formatting: {
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+    },
+    transport: {
+      async loadCars() {
+        return {
+          active_car_id: "car-1",
+          cars: [{
+            id: "car-1",
+            name: "Track Demo",
+            type: "Coupe",
+            variant: null,
+            aspects: {
+              tire_width_mm: 245,
+              tire_aspect_pct: 40,
+              rim_in: 19,
+              final_drive_ratio: 3.23,
+              current_gear_ratio: 0.72,
+            },
+          }],
+        };
+      },
+    },
+  });
+
+  await module.loadCarsFromServer();
+
+  expect(state.activeCarId.value).toBe("car-1");
+  expect(state.vehicleSettings.value).toMatchObject({
+    current_gear_ratio: 0.72,
+    final_drive_ratio: 3.23,
+    rim_in: 19,
+    tire_aspect_pct: 40,
+    tire_width_mm: 245,
+  });
+  expect(syncAnalysisInputsCalls).toBe(1);
+  expect(lastRender(renders).table?.kind).toBe("rows");
+});

--- a/apps/ui/tests/settings_speed_source_workflow.spec.ts
+++ b/apps/ui/tests/settings_speed_source_workflow.spec.ts
@@ -10,17 +10,17 @@ import type {
   SpeedSourceRequest,
 } from "../src/api/types";
 import { createAppState } from "../src/app/ui_app_state";
-import { effect } from "../src/app/ui_signals";
+import { effect, signal, type Signal } from "../src/app/ui_signals";
 
 type WorkflowHarness = {
-  contextVisible: boolean;
+  obdConfigVisible: Signal<boolean>;
   errors: string[];
   focuses: string[];
 };
 
 function createHarness(): WorkflowHarness {
   return {
-    contextVisible: false,
+    obdConfigVisible: signal(false),
     errors: [],
     focuses: [],
   };
@@ -38,9 +38,6 @@ function createViewPorts(
     },
     focusStaleTimeoutInput(): void {
       harness.focuses.push("stale-timeout");
-    },
-    isObdConfigVisible(): boolean {
-      return harness.contextVisible;
     },
   };
 }
@@ -89,6 +86,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     const harness = createHarness();
     const appState = createAppState();
     const workflow = createSettingsSpeedSourceWorkflow({
+      obdConfigVisible: harness.obdConfigVisible,
       renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
@@ -144,6 +142,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     let savedPayload: SpeedSourceRequest | null = null;
 
     const workflow = createSettingsSpeedSourceWorkflow({
+      obdConfigVisible: harness.obdConfigVisible,
       renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
@@ -184,6 +183,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     const harness = createHarness();
     const appState = createAppState();
     const workflow = createSettingsSpeedSourceWorkflow({
+      obdConfigVisible: harness.obdConfigVisible,
       renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
@@ -214,6 +214,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     const harness = createHarness();
     const appState = createAppState();
     const workflow = createSettingsSpeedSourceWorkflow({
+      obdConfigVisible: harness.obdConfigVisible,
       renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
@@ -291,10 +292,11 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
           };
         },
       },
+      obdConfigVisible: harness.obdConfigVisible,
       view: createViewPorts(harness),
     });
 
-    harness.contextVisible = true;
+    harness.obdConfigVisible.value = true;
     workflow.handleSpeedSourceChanged("obd2");
     await workflow.scanObdDevices();
     await workflow.pairObdDevice(scannedDevice.mac_address);
@@ -342,21 +344,22 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
           };
         },
       },
+      obdConfigVisible: harness.obdConfigVisible,
       view: createViewPorts(harness),
     });
 
-    harness.contextVisible = true;
+    harness.obdConfigVisible.value = true;
     workflow.handleSpeedSourceChanged("obd2");
     await workflow.scanObdDevices();
 
     expect(pollingStarts).toBeGreaterThan(0);
 
-    harness.contextVisible = false;
+    harness.obdConfigVisible.value = false;
     workflow.handleNavigateContext();
 
     expect(pollingStops).toBeGreaterThan(0);
 
-    harness.contextVisible = true;
+    harness.obdConfigVisible.value = true;
     workflow.handleNavigateContext();
 
     expect(pollingStarts).toBeGreaterThan(1);
@@ -372,6 +375,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
         start() {},
         stop() {},
       }),
+      obdConfigVisible: harness.obdConfigVisible,
       renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
@@ -398,6 +402,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
         start() {},
         stop() {},
       }),
+      obdConfigVisible: harness.obdConfigVisible,
       renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
@@ -435,6 +440,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
         start() {},
         stop() {},
       }),
+      obdConfigVisible: harness.obdConfigVisible,
       renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {


### PR DESCRIPTION
## What changed
- add `createApiLoader` with `beforeLoad`, `load`, `apply`, `onError`, and a shared `loading` signal
- switch only the matching callers: cars wizard option loads, settings cars load, settings speed-source load, and ESP flash history/ports refresh
- add helper coverage plus focused caller coverage; align the speed-source test harness with the real `obdConfigVisible` signal contract

## Why
- these paths repeated the same async load/apply/error shape
- the issue sketch with owned `data` and `error` signals did not match real state ownership in these features
- callback hooks remove duplication without pulling feature state into a new parallel abstraction

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/api_loader.spec.ts tests/cars_feature_workflow.spec.ts tests/esp_flash_feature_workflow.spec.ts tests/settings_cars_module.spec.ts tests/settings_speed_source_workflow.spec.ts tests/app_feature_ports.spec.ts tests/ui_startup_coordinator.spec.ts`

## Risks / tradeoffs
- helper intentionally does not own `data` or `error` signals; callers keep their existing state shape
- helper still returns `null` on load failure, so it only fits flows that already treat transient fetch errors as non-fatal
- left `update_feature_workflow.ts` and `settings_analysis_module.ts` alone because forcing them into the helper would blur their error/ownership model

Closes #2688