### PR TITLE
Frontend: move derived view state into models

### DIFF
--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -17,6 +17,10 @@ import type {
   HistoryPanelView,
   HistoryRunAction,
 } from "../views/history_table_view";
+import {
+  buildHistoryRowsTableRenderModel,
+  createHistoryTableRowsMemo,
+} from "../views/history_table_presenters";
 import { downloadBlobFile } from "./history_download";
 
 export interface HistoryFeatureDeps {
@@ -42,6 +46,7 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
   const { history, panel, shell, services, formatting } = ctx;
   let handlersBound = false;
   let previewPrefetchToken = 0;
+  const rowsMemo = createHistoryTableRowsMemo();
 
   function activatePrimaryView(viewId: string): void {
     ctx.navigation.activatePrimaryView(viewId);
@@ -117,9 +122,8 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
         count: runs.length,
       }),
       deleteAllRunsDisabled,
-      table: {
-        kind: "rows",
-        params: {
+      table: (() => {
+        const params = {
           runs,
           expandedRunId,
           runDetailsById: history.runDetailsById.value,
@@ -128,8 +132,9 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
           fmtTs: formatting.fmtTs,
           formatInt: formatting.formatInt,
           historyExportUrl,
-        },
-      },
+        };
+        return buildHistoryRowsTableRenderModel(params, rowsMemo(params));
+      })(),
     };
   }
 

--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -79,23 +79,8 @@ function formatElapsed(
 }
 
 function buildLoggingRenderModel(model: ReturnType<typeof buildRealtimeLoggingPanelViewModel>) {
-  return {
-    pillVariant: model.pillVariant,
-    pillText: model.pillText,
-    showPill: model.showPill,
-    summaryText: model.summaryText,
-    summaryPanel: model.summaryPanel,
-    runIdText: model.runIdText,
-    phaseText: model.phaseText,
-    elapsedText: model.elapsedText,
-    samplesText: model.samplesText,
-    checklist: model.checklist,
-    showStart: model.showStart,
-    showStop: model.showStop,
-    startDisabled: model.startDisabled,
-    stopDisabled: model.stopDisabled,
-    setupMode: model.setupMode,
-  } satisfies RealtimeLoggingPanelRenderModel;
+  const { nextLastCompletedElapsedText: _nextLastCompletedElapsedText, ...renderModel } = model;
+  return renderModel satisfies RealtimeLoggingPanelRenderModel;
 }
 
 function buildLoggingUnavailableModel(
@@ -107,16 +92,27 @@ function buildLoggingUnavailableModel(
     showPill: true,
     summaryText: t("status.unavailable"),
     summaryPanel: null,
+    summaryAction: null,
+    summaryHidden: false,
+    summaryLayout: undefined,
     runIdText: "",
+    runIdHidden: true,
+    loggingRowHidden: false,
     phaseText: t("status.unavailable"),
     elapsedText: "--",
     samplesText: "--",
     checklist: null,
+    checklistHidden: true,
+    showProgressSection: true,
     showStart: true,
+    startHidden: false,
     showStop: false,
+    stopHidden: true,
     startDisabled: true,
     stopDisabled: true,
     setupMode: false,
+    pillHidden: false,
+    shellLayout: undefined,
   };
 }
 
@@ -134,8 +130,12 @@ function buildLoggingErrorModel(
     pillVariant: "bad",
     pillText: errorText,
     showPill: true,
+    pillHidden: false,
     summaryText: errorText,
     summaryPanel: null,
+    summaryAction: null,
+    summaryHidden: false,
+    summaryLayout: undefined,
   };
 }
 

--- a/apps/ui/src/app/runtime/spectrum_interaction_controller.ts
+++ b/apps/ui/src/app/runtime/spectrum_interaction_controller.ts
@@ -59,9 +59,14 @@ export class SpectrumInteractionController {
       const bands = this.currentBands.value;
       const entries = this.currentEntries.value;
       const visible = this.bandsVisible.value;
+      const hasBands = bands.length > 0 && entries.length > 0;
+      const pressed = hasBands && visible ? "true" : "false";
       return {
-        hasBands: bands.length > 0 && entries.length > 0,
+        hasBands,
         bandsVisible: visible,
+        disabled: !hasBands,
+        hidden: !hasBands,
+        pressed,
         text: this.deps.t(visible ? "spectrum.bands.hide" : "spectrum.bands.show"),
       };
     });

--- a/apps/ui/src/app/runtime/spectrum_panel_view.ts
+++ b/apps/ui/src/app/runtime/spectrum_panel_view.ts
@@ -51,6 +51,14 @@ export interface SpectrumPanelChartDom {
 export interface SpectrumPanelBandToggleModel {
   hasBands: boolean;
   bandsVisible: boolean;
+  disabled: boolean;
+  hidden: boolean;
+  pressed: "true" | "false";
+  text: string;
+}
+
+export interface SpectrumPanelOverlayModel {
+  hidden: boolean;
   text: string;
 }
 
@@ -69,6 +77,6 @@ export interface SpectrumPanelView {
   ): void;
   bindBandLegendModel(model: ReadonlySignal<SpectrumBandLegendModel>): void;
   renderHeader(model: SpectrumPanelHeaderModel): void;
-  renderOverlay(message: string | null): void;
+  renderOverlay(model: SpectrumPanelOverlayModel): void;
   renderInspectorText(text: string): void;
 }

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -65,7 +65,7 @@ export class UiSpectrumController {
   }
 
   updateSpectrumOverlay(): void {
-    this.setSpectrumOverlay(this.spectrumOverlayMessage());
+    this.setSpectrumOverlay(this.spectrumOverlayModel());
   }
 
   private renderSpectrumHeader(): void {
@@ -90,41 +90,39 @@ export class UiSpectrumController {
     this.updateSpectrumOverlay();
   }
 
-  private spectrumOverlayMessage(): string | null {
+  private spectrumOverlayModel(): { hidden: boolean; text: string } {
+    let message: string | null = null;
     if (this.state.spectrum.chartLoadErrorDetail.value) {
-      return this.t("spectrum.chart_load_error", {
+      message = this.t("spectrum.chart_load_error", {
         message: this.state.spectrum.chartLoadErrorDetail.value,
       });
-    }
-    if (this.state.transport.payloadError.value) {
-      return this.state.transport.payloadError.value;
-    }
-    if (
+    } else if (this.state.transport.payloadError.value) {
+      message = this.state.transport.payloadError.value;
+    } else if (
       !this.state.transport.hasReceivedPayload.value
       && this.state.transport.wsState.value === "connecting"
     ) {
-      return this.t("spectrum.loading");
-    }
-    if (
+      message = this.t("spectrum.loading");
+    } else if (
       this.state.transport.wsState.value === "connecting"
       || this.state.transport.wsState.value === "reconnecting"
     ) {
-      return this.t("ws.connecting");
+      message = this.t("ws.connecting");
+    } else if (this.state.transport.wsState.value === "stale") {
+      message = this.t("spectrum.stale");
+    } else if (this.state.spectrum.chartLoading.value && this.state.spectrum.hasSpectrumData.value) {
+      message = this.t("spectrum.loading");
+    } else if (!this.state.spectrum.hasSpectrumData.value) {
+      message = this.t("spectrum.empty");
     }
-    if (this.state.transport.wsState.value === "stale") {
-      return this.t("spectrum.stale");
-    }
-    if (this.state.spectrum.chartLoading.value && this.state.spectrum.hasSpectrumData.value) {
-      return this.t("spectrum.loading");
-    }
-    if (!this.state.spectrum.hasSpectrumData.value) {
-      return this.t("spectrum.empty");
-    }
-    return null;
+    return {
+      hidden: message === null,
+      text: message ?? "Waiting for sensor data...",
+    };
   }
 
-  private setSpectrumOverlay(message: string | null): void {
-    this.panel.renderOverlay(message);
+  private setSpectrumOverlay(model: { hidden: boolean; text: string }): void {
+    this.panel.renderOverlay(model);
   }
 
   private bindInteractionModelSignals(): void {

--- a/apps/ui/src/app/views/history_table_content.tsx
+++ b/apps/ui/src/app/views/history_table_content.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "preact";
 
-import { useComputed, useSignal, type ReadonlySignal } from "../ui_signals";
+import type { ReadonlySignal } from "../ui_signals";
 import { inlineStateActionClass } from "./inline_state_panel_models";
 import { HistoryDetailsRow } from "./history_detail_expansion";
 import { HistorySummaryChips } from "./history_summary_chips";
@@ -10,10 +10,8 @@ import type {
   HistoryRunAction,
 } from "./history_table_view";
 import type {
-  HistoryDetailsViewModel,
   HistoryRowViewModel,
 } from "./history_table_models";
-import { createHistoryTableRowsMemo } from "./history_table_presenters";
 
 function stopRowToggle(event: JSX.TargetedMouseEvent<HTMLElement>): void {
   event.stopPropagation();
@@ -31,20 +29,6 @@ function handleRunAction(
     type: "run-action",
     action,
     runId,
-  });
-}
-
-function useHistoryTableRows(
-  table: ReadonlySignal<HistoryPanelTableRenderModel | null>,
-): ReadonlySignal<HistoryRowViewModel[] | null> {
-  const rowsMemo = useSignal(createHistoryTableRowsMemo());
-
-  return useComputed(() => {
-    const nextTable = table.value;
-    if (nextTable === null || nextTable.kind !== "rows") {
-      return null;
-    }
-    return rowsMemo.value(nextTable.params);
   });
 }
 
@@ -184,44 +168,28 @@ export function HistoryTableBody(props: {
   table: ReadonlySignal<HistoryPanelTableRenderModel | null>;
 }) {
   const { handlers } = props;
-  const tableKind = useComputed(() => props.table.value?.kind ?? null);
-  const emptyStateTranslate = useComputed(() =>
-    props.table.value?.kind === "empty" ? props.table.value.t : null
-  );
-  const historyExportUrl = useComputed(() =>
-    props.table.value?.kind === "rows" ? props.table.value.params.historyExportUrl : null
-  );
-  const rows = useHistoryTableRows(props.table);
+  const table = props.table.value;
 
-  if (tableKind.value === null) {
+  if (table === null) {
     return (
       <tr>
         <td colSpan={4}>No runs found.</td>
       </tr>
     );
   }
-  if (tableKind.value === "empty") {
-    const translate = emptyStateTranslate.value;
-    if (translate === null) {
-      throw new Error("History empty-state translation missing");
-    }
-    return <HistoryEmptyStateRow handlers={handlers} t={translate} />;
+  if (table.kind === "empty") {
+    return <HistoryEmptyStateRow handlers={handlers} t={table.t} />;
   }
 
-  const currentRows = rows.value;
-  const currentHistoryExportUrl = historyExportUrl.value;
-  if (currentRows === null || currentHistoryExportUrl === null) {
-    throw new Error("History row params missing");
-  }
   return (
     <>
-      {currentRows.flatMap((row) => [
+      {table.rows.flatMap((row) => [
         <HistoryRow key={`row:${row.runId}`} handlers={handlers} row={row} />,
         row.details ? (
           <HistoryDetailsRow
             key={`details:${row.runId}`}
             details={row.details}
-            historyExportUrl={currentHistoryExportUrl}
+            historyExportUrl={table.historyExportUrl}
             onRunAction={(event, action, runId) => handleRunAction(event, handlers, action, runId)}
             onStopRowToggle={stopRowToggle}
             row={row}

--- a/apps/ui/src/app/views/history_table_presenters.ts
+++ b/apps/ui/src/app/views/history_table_presenters.ts
@@ -19,6 +19,7 @@ import type {
   HistoryRowViewModel,
   HistorySummaryChipViewModel,
 } from "./history_table_models";
+import type { HistoryPanelTableRenderModel, HistoryTableViewParams } from "./history_table_view";
 
 function buildSummaryChips(
   run: HistoryEntry,
@@ -129,6 +130,17 @@ export function buildHistoryTableRowsViewModel(params: PresenterParams): History
   return params.runs.map((run) =>
     buildRowViewModel(run, params.runDetailsById[run.run_id] ?? EMPTY_RUN_DETAIL, params),
   );
+}
+
+export function buildHistoryRowsTableRenderModel(
+  params: HistoryTableViewParams,
+  rows: HistoryRowViewModel[],
+): HistoryPanelTableRenderModel {
+  return {
+    kind: "rows",
+    historyExportUrl: params.historyExportUrl,
+    rows,
+  };
 }
 
 type HistoryRowsMemoKey = Pick<

--- a/apps/ui/src/app/views/history_table_view.ts
+++ b/apps/ui/src/app/views/history_table_view.ts
@@ -1,6 +1,7 @@
 import type { HistoryEntry } from "../../api/types";
 import type { RunDetail } from "../ui_app_state";
 import type { Signal } from "../ui_signals";
+import type { HistoryRowViewModel } from "./history_table_models";
 import type { DeferredModelSignal } from "./view_model_binding";
 
 export interface HistoryTableViewParams {
@@ -35,7 +36,8 @@ export type HistoryPanelTableRenderModel =
     }
   | {
       kind: "rows";
-      params: HistoryTableViewParams;
+      historyExportUrl: (runId: string) => string;
+      rows: HistoryRowViewModel[];
     };
 
 export interface HistoryPanelRenderModel {

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -19,18 +19,29 @@ export interface RealtimeLoggingPanelRenderModel {
   pillVariant: "muted" | "ok" | "warn" | "bad";
   pillText: string;
   showPill: boolean;
+  pillHidden: boolean;
   summaryText: string;
   summaryPanel: RealtimeLoggingSummaryPanelModel | null;
+  summaryAction: RealtimeLoggingSummaryPanelModel["action"] | null;
+  summaryHidden: boolean;
+  summaryLayout: "panel" | undefined;
   runIdText: string;
+  runIdHidden: boolean;
+  loggingRowHidden: boolean;
   phaseText: string;
   elapsedText: string;
   samplesText: string;
   checklist: RealtimeCaptureReadinessChecklistModel | null;
+  checklistHidden: boolean;
+  showProgressSection: boolean;
   showStart: boolean;
+  startHidden: boolean;
   showStop: boolean;
+  stopHidden: boolean;
   startDisabled: boolean;
   stopDisabled: boolean;
   setupMode: boolean;
+  shellLayout: "setup" | undefined;
 }
 
 export interface RealtimeLoggingPanelActionHandlers {
@@ -48,34 +59,56 @@ const DEFAULT_PANEL_MODEL: RealtimeLoggingPanelRenderModel = {
   pillVariant: "muted",
   pillText: "Stopped",
   showPill: true,
+  pillHidden: false,
   summaryText: "Connect sensors to begin a trustworthy run.",
   summaryPanel: null,
+  summaryAction: null,
+  summaryHidden: false,
+  summaryLayout: undefined,
   runIdText: "",
+  runIdHidden: true,
+  loggingRowHidden: false,
   phaseText: "--",
   elapsedText: "--",
   samplesText: "0",
   checklist: null,
+  checklistHidden: true,
+  showProgressSection: true,
   showStart: true,
+  startHidden: false,
   showStop: false,
+  stopHidden: true,
   startDisabled: false,
   stopDisabled: true,
   setupMode: false,
+  shellLayout: undefined,
 };
 
 const REALTIME_LOGGING_PANEL_MODEL_KEYS = [
   "checklist",
+  "checklistHidden",
   "elapsedText",
+  "loggingRowHidden",
   "phaseText",
+  "pillHidden",
   "pillText",
   "pillVariant",
+  "runIdHidden",
   "runIdText",
   "samplesText",
+  "shellLayout",
   "setupMode",
+  "showProgressSection",
   "showPill",
   "showStart",
   "showStop",
   "startDisabled",
+  "startHidden",
+  "stopHidden",
   "stopDisabled",
+  "summaryAction",
+  "summaryHidden",
+  "summaryLayout",
   "summaryPanel",
   "summaryText",
 ] as const;
@@ -84,16 +117,15 @@ function RealtimeLoggingSummarySection(props: {
   actions: ReadonlySignal<RealtimeLoggingPanelActionHandlers | null>;
   model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
 }) {
-  const { summaryPanel, summaryText } = useSignalProperties(
+  const {
+    summaryAction,
+    summaryHidden,
+    summaryLayout,
+    summaryPanel,
+    summaryText,
+  } = useSignalProperties(
     props.model,
-    ["summaryPanel", "summaryText"] as const,
-  );
-  const summaryAction = useComputed(() => summaryPanel.value?.action ?? null);
-  const hidden = useComputed(() =>
-    summaryText.value === "" && summaryPanel.value === null
-  );
-  const summaryLayout = useComputed(() =>
-    summaryPanel.value ? "panel" : undefined
+    ["summaryAction", "summaryHidden", "summaryLayout", "summaryPanel", "summaryText"] as const,
   );
   const handleAction = (action: RealtimeLoggingSummaryAction) => {
     props.actions.peek()?.onSummaryAction(action);
@@ -103,7 +135,7 @@ function RealtimeLoggingSummarySection(props: {
     <div
       id="loggingSummary"
       class="card__subtle"
-      hidden={hidden.value}
+      hidden={summaryHidden.value}
       data-summary-layout={summaryLayout.value}
     >
       {summaryPanel.value
@@ -136,18 +168,21 @@ function RealtimeLoggingSummarySection(props: {
 }
 
 function RealtimeLoggingChecklist(props: {
-  checklist: ReadonlySignal<RealtimeCaptureReadinessChecklistModel | null>;
+  model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
 }) {
-  const hidden = useComputed(() => props.checklist.value === null);
+  const { checklist, checklistHidden } = useSignalProperties(
+    props.model,
+    ["checklist", "checklistHidden"] as const,
+  );
 
   return (
-    <div id="loggingChecklist" class="capture-readiness" hidden={hidden.value}>
-      {props.checklist.value
+    <div id="loggingChecklist" class="capture-readiness" hidden={checklistHidden.value}>
+      {checklist.value
         ? (
           <>
-            <div class="capture-readiness__title">{props.checklist.value.titleText}</div>
+            <div class="capture-readiness__title">{checklist.value.titleText}</div>
             <div class="capture-readiness__list">
-              {props.checklist.value.items.map((item) => (
+              {checklist.value.items.map((item) => (
                 <div
                   key={item.checkKey}
                   class="capture-readiness__item"
@@ -171,13 +206,17 @@ function RealtimeLoggingChecklist(props: {
 function RealtimeLoggingStatusRow(props: {
   model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
 }) {
-  const { pillText, pillVariant, runIdText, showPill } = useSignalProperties(
+  const {
+    loggingRowHidden,
+    pillHidden,
+    pillText,
+    pillVariant,
+    runIdHidden,
+    runIdText,
+  } = useSignalProperties(
     props.model,
-    ["pillText", "pillVariant", "runIdText", "showPill"] as const,
+    ["loggingRowHidden", "pillHidden", "pillText", "pillVariant", "runIdHidden", "runIdText"] as const,
   );
-  const loggingRowHidden = useComputed(() => !showPill.value && runIdText.value === "");
-  const pillHidden = useComputed(() => !showPill.value);
-  const runIdHidden = useComputed(() => runIdText.value === "");
 
   return (
     <div class="logging-row" hidden={loggingRowHidden.value}>
@@ -206,11 +245,10 @@ function RealtimeLoggingProgressSection(props: {
   };
   model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
 }) {
-  const { checklist, elapsedText, phaseText, samplesText, setupMode } = useSignalProperties(
+  const { elapsedText, phaseText, samplesText, showProgressSection } = useSignalProperties(
     props.model,
-    ["checklist", "elapsedText", "phaseText", "samplesText", "setupMode"] as const,
+    ["elapsedText", "phaseText", "samplesText", "showProgressSection"] as const,
   );
-  const showProgressSection = useComputed(() => !setupMode.value || checklist.value !== null);
 
   if (!showProgressSection.value) {
     return null;
@@ -247,7 +285,7 @@ function RealtimeLoggingProgressSection(props: {
           </div>
         </div>
       </div>
-      <RealtimeLoggingChecklist checklist={checklist} />
+      <RealtimeLoggingChecklist model={props.model} />
     </>
   );
 }
@@ -260,12 +298,10 @@ function RealtimeLoggingActionRow(props: {
   };
   model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
 }) {
-  const { showStart, showStop, startDisabled, stopDisabled } = useSignalProperties(
+  const { startDisabled, startHidden, stopDisabled, stopHidden } = useSignalProperties(
     props.model,
-    ["showStart", "showStop", "startDisabled", "stopDisabled"] as const,
+    ["startDisabled", "startHidden", "stopDisabled", "stopHidden"] as const,
   );
-  const startHidden = useComputed(() => !showStart.value);
-  const stopHidden = useComputed(() => !showStop.value);
   const handleStartLogging = () => {
     props.actions.peek()?.onStartLogging();
   };
@@ -314,8 +350,7 @@ function RealtimeLoggingPanel(props: {
     titleText: getUiText("dashboard.run_recording", "Run Recording"),
   }));
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_PANEL_MODEL);
-  const { setupMode } = useSignalProperties(model, ["setupMode"] as const);
-  const shellLayout = useComputed(() => setupMode.value ? "setup" : undefined);
+  const { shellLayout } = useSignalProperties(model, ["shellLayout"] as const);
   const labelTexts = labels.value;
 
   return (

--- a/apps/ui/src/app/views/realtime_logging_view_models.ts
+++ b/apps/ui/src/app/views/realtime_logging_view_models.ts
@@ -36,16 +36,27 @@ export interface RealtimeLoggingPanelViewModel {
   phaseText: string;
   summaryText: string;
   summaryPanel: RealtimeLoggingSummaryPanelModel | null;
+  summaryAction: RealtimeLoggingSummaryPanelModel["action"] | null;
+  summaryHidden: boolean;
+  summaryLayout: "panel" | undefined;
   runIdText: string;
+  runIdHidden: boolean;
   elapsedText: string;
   samplesText: string;
   showStart: boolean;
+  startHidden: boolean;
   showStop: boolean;
+  stopHidden: boolean;
   startDisabled: boolean;
   stopDisabled: boolean;
   showPill: boolean;
+  pillHidden: boolean;
+  loggingRowHidden: boolean;
   checklist: RealtimeCaptureReadinessChecklistModel | null;
+  checklistHidden: boolean;
   setupMode: boolean;
+  showProgressSection: boolean;
+  shellLayout: "setup" | undefined;
   nextLastCompletedElapsedText: string;
 }
 
@@ -82,6 +93,50 @@ export function buildRealtimeLoggingPanelViewModel(
   const captureReadiness = status.capture_readiness ?? null;
   const recordingReady = Boolean(captureReadiness?.is_ready);
   const readinessSummary = captureReadinessSummaryText(captureReadiness, { t, formatInt });
+  function finalize(model: {
+    pillVariant: "muted" | "ok" | "warn" | "bad";
+    pillText: string;
+    phaseText: string;
+    summaryText: string;
+    summaryPanel: RealtimeLoggingSummaryPanelModel | null;
+    runIdText: string;
+    elapsedText: string;
+    samplesText: string;
+    showStart: boolean;
+    showStop: boolean;
+    startDisabled: boolean;
+    stopDisabled: boolean;
+    showPill: boolean;
+    checklist: RealtimeCaptureReadinessChecklistModel | null;
+    setupMode: boolean;
+    nextLastCompletedElapsedText: string;
+  }): RealtimeLoggingPanelViewModel {
+    const summaryAction = model.summaryPanel?.action ?? null;
+    const summaryHidden = model.summaryText === "" && model.summaryPanel === null;
+    const summaryLayout = model.summaryPanel ? "panel" : undefined;
+    const runIdHidden = model.runIdText === "";
+    const startHidden = !model.showStart;
+    const stopHidden = !model.showStop;
+    const pillHidden = !model.showPill;
+    const loggingRowHidden = pillHidden && runIdHidden;
+    const checklistHidden = model.checklist === null;
+    const showProgressSection = !model.setupMode || model.checklist !== null;
+    const shellLayout = model.setupMode ? "setup" : undefined;
+    return {
+      ...model,
+      summaryAction,
+      summaryHidden,
+      summaryLayout,
+      runIdHidden,
+      startHidden,
+      stopHidden,
+      pillHidden,
+      loggingRowHidden,
+      checklistHidden,
+      showProgressSection,
+      shellLayout,
+    };
+  }
   let nextLastCompletedElapsedText = params.lastCompletedElapsedText;
 
   if (status.enabled) {
@@ -91,7 +146,7 @@ export function buildRealtimeLoggingPanelViewModel(
   }
 
   if (pendingLoggingAction === "starting") {
-    return {
+    return finalize({
       pillVariant: "muted",
       pillText: t("dashboard.recording_phase.starting"),
       phaseText: t("dashboard.recording_phase.starting"),
@@ -108,11 +163,11 @@ export function buildRealtimeLoggingPanelViewModel(
       checklist: null,
       setupMode: false,
       nextLastCompletedElapsedText,
-    };
+    });
   }
 
   if (pendingLoggingAction === "stopping") {
-    return {
+    return finalize({
       pillVariant: "warn",
       pillText: t("dashboard.recording_phase.stopping"),
       phaseText: t("dashboard.recording_phase.stopping"),
@@ -129,11 +184,11 @@ export function buildRealtimeLoggingPanelViewModel(
       checklist: null,
       setupMode: false,
       nextLastCompletedElapsedText,
-    };
+    });
   }
 
   if (status.enabled) {
-    return {
+    return finalize({
       pillVariant: status.write_error ? "bad" : "ok",
       pillText: status.write_error || t("dashboard.recording_phase.recording"),
       phaseText: status.write_error ? t("dashboard.health.attention") : t("dashboard.recording_phase.recording"),
@@ -152,12 +207,12 @@ export function buildRealtimeLoggingPanelViewModel(
       checklist: null,
       setupMode: false,
       nextLastCompletedElapsedText,
-    };
+    });
   }
 
   if (status.analysis_in_progress) {
     const runId = status.last_completed_run_id ?? t("status.unavailable");
-    return {
+    return finalize({
       pillVariant: "warn",
       pillText: t("dashboard.recording_phase.processing"),
       phaseText: t("dashboard.recording_phase.processing"),
@@ -174,11 +229,11 @@ export function buildRealtimeLoggingPanelViewModel(
       checklist: null,
       setupMode: false,
       nextLastCompletedElapsedText,
-    };
+    });
   }
 
   if (status.last_completed_run_id) {
-    return {
+    return finalize({
       pillVariant: "ok",
       pillText: t("dashboard.recording_phase.saved"),
       phaseText: t("dashboard.recording_phase.saved"),
@@ -195,11 +250,11 @@ export function buildRealtimeLoggingPanelViewModel(
       checklist: null,
       setupMode: false,
       nextLastCompletedElapsedText,
-    };
+    });
   }
 
   if (selectionBlockReason) {
-    return {
+    return finalize({
       pillVariant: "warn",
       pillText: t("dashboard.recording_phase.blocked"),
       phaseText: t("dashboard.recording_phase.blocked"),
@@ -216,11 +271,11 @@ export function buildRealtimeLoggingPanelViewModel(
       checklist: null,
       setupMode: true,
       nextLastCompletedElapsedText,
-    };
+    });
   }
 
   const waitingOnReadiness = captureReadiness !== null && !captureReadiness.is_ready;
-  return {
+  return finalize({
     pillVariant: waitingOnReadiness ? "muted" : "ok",
     pillText: waitingOnReadiness
       ? t("dashboard.recording_phase.preparing")
@@ -245,5 +300,5 @@ export function buildRealtimeLoggingPanelViewModel(
     }),
     setupMode: waitingOnReadiness,
     nextLastCompletedElapsedText,
-  };
+  });
 }

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -13,6 +13,7 @@ import type {
   SpectrumPanelBandToggleModel,
   SpectrumPanelChartDom,
   SpectrumPanelHeaderModel,
+  SpectrumPanelOverlayModel,
   SpectrumPanelView,
   SpectrumSensorLegendModel,
 } from "../runtime/spectrum_panel_view";
@@ -23,16 +24,30 @@ type MutableSpectrumPanelChartDom = {
 };
 
 const DEFAULT_SPECTRUM_BAND_TOGGLE_MODEL: SpectrumPanelBandToggleModel = {
+  disabled: true,
   hasBands: false,
   bandsVisible: false,
+  hidden: true,
+  pressed: "false",
   text: "Show reference bands",
+};
+const DEFAULT_SPECTRUM_OVERLAY_MODEL: SpectrumPanelOverlayModel = {
+  hidden: true,
+  text: "Waiting for sensor data...",
 };
 const DEFAULT_SPECTRUM_BAND_LEGEND_MODEL: SpectrumBandLegendModel = {
   visible: false,
   items: [],
   emptyText: "No reference band",
 };
-const SPECTRUM_BAND_TOGGLE_KEYS = ["bandsVisible", "hasBands", "text"] as const;
+const SPECTRUM_BAND_TOGGLE_KEYS = [
+  "bandsVisible",
+  "disabled",
+  "hasBands",
+  "hidden",
+  "pressed",
+  "text",
+] as const;
 const SPECTRUM_BAND_LEGEND_KEYS = ["emptyText", "items", "visible"] as const;
 
 function requireSpectrumElement<T extends HTMLElement>(
@@ -142,28 +157,24 @@ function SpectrumPanel(props: {
   header: ReadonlySignal<SpectrumPanelHeaderModel>;
   inspectorText: ReadonlySignal<string>;
   onBandToggle: ReadonlySignal<(() => void) | null>;
-  overlayMessage: ReadonlySignal<string | null>;
+  overlayModel: ReadonlySignal<SpectrumPanelOverlayModel>;
   sensorLegendHandlersModel: ReadonlySignal<ReadonlySignal<SpectrumLegendHandlers | null> | null>;
   sensorLegendModel: ReadonlySignal<ReadonlySignal<SpectrumSensorLegendModel | null> | null>;
 }) {
   const { chartDom } = props;
   const bandLegend = useComputed(() => props.bandLegendModel.value?.value ?? DEFAULT_SPECTRUM_BAND_LEGEND_MODEL);
   const bandToggle = useComputed(() => props.bandToggleModel.value?.value ?? DEFAULT_SPECTRUM_BAND_TOGGLE_MODEL);
+  const overlayModel = useComputed(() => props.overlayModel.value ?? DEFAULT_SPECTRUM_OVERLAY_MODEL);
   const sensorLegend = useComputed(() => props.sensorLegendModel.value?.value ?? null);
   const sensorLegendHandlers = useComputed(() => props.sensorLegendHandlersModel.value?.value ?? null);
   const titleText = useComputed(() => getUiText("chart.spectrum_title", props.header.value.titleText));
   const hintText = useComputed(() => getUiText("spectrum.controls_hint", props.header.value.hintText));
-  const overlayHidden = useComputed(() => props.overlayMessage.value === null);
-  const overlayText = useComputed(() => props.overlayMessage.value ?? "Waiting for sensor data...");
   const {
-    bandsVisible: bandToggleBandsVisible,
-    hasBands: bandToggleHasBands,
+    disabled: bandToggleDisabled,
+    hidden: bandToggleHidden,
+    pressed: bandTogglePressed,
     text: bandToggleText,
   } = useSignalProperties(bandToggle, SPECTRUM_BAND_TOGGLE_KEYS);
-  const bandTogglePressed = useComputed(() =>
-      bandToggleHasBands.value && bandToggleBandsVisible.value ? "true" : "false"
-  );
-  const bandToggleHidden = useComputed(() => !bandToggleHasBands.value);
 
   return (
     <>
@@ -185,8 +196,8 @@ function SpectrumPanel(props: {
             chartDom.specChart = element;
           }}
         />
-        <div id="spectrumOverlay" class="empty-state" hidden={overlayHidden}>
-          {overlayText}
+        <div id="spectrumOverlay" class="empty-state" hidden={overlayModel.value.hidden}>
+          {overlayModel.value.text}
         </div>
       </div>
       <div class="spectrum-controls-panel">
@@ -203,7 +214,7 @@ function SpectrumPanel(props: {
               aria-pressed={bandTogglePressed}
               aria-expanded={bandTogglePressed}
               hidden={bandToggleHidden}
-              disabled={bandToggleHidden}
+              disabled={bandToggleDisabled}
               onClick={() => props.onBandToggle.peek()?.()}
             >
               {bandToggleText}
@@ -230,7 +241,7 @@ export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
     titleText: "Multi-Sensor Blended Spectrum",
     hintText: "Use the trace chips to isolate one sensor at a time. Turn on reference bands when you need order context.",
   });
-  const overlayMessage = signal<string | null>(null);
+  const overlayModel = signal<SpectrumPanelOverlayModel>(DEFAULT_SPECTRUM_OVERLAY_MODEL);
   const bandToggleModel = createDeferredModelSignal<SpectrumPanelBandToggleModel>();
   const sensorLegendModel = createDeferredModelSignal<SpectrumSensorLegendModel | null>();
   const sensorLegendHandlersModel = createDeferredModelSignal<SpectrumLegendHandlers | null>();
@@ -249,7 +260,7 @@ export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
       header={header}
       inspectorText={inspectorText}
       onBandToggle={onBandToggle}
-      overlayMessage={overlayMessage}
+      overlayModel={overlayModel}
       sensorLegendHandlersModel={sensorLegendHandlersModel}
       sensorLegendModel={sensorLegendModel}
     />,
@@ -284,8 +295,8 @@ export function mountSpectrumPanel(host: HTMLElement): SpectrumPanelView {
     renderHeader(model: SpectrumPanelHeaderModel): void {
       header.value = model;
     },
-    renderOverlay(message: string | null): void {
-      overlayMessage.value = message;
+    renderOverlay(model: SpectrumPanelOverlayModel): void {
+      overlayModel.value = model;
     },
     renderInspectorText(text: string): void {
       inspectorText.value = text;

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -8,7 +8,6 @@ import type {
   HistoryPanelRenderModel,
   HistoryPanelView,
 } from "../src/app/views/history_table_view";
-import { buildHistoryTableRowsViewModel } from "../src/app/views/history_table_presenters";
 import { installWindowGlobal, jsonResponse } from "./async_test_helpers";
 
 type ButtonStub = HTMLButtonElement & {
@@ -199,7 +198,7 @@ function latestRowModels(panel: { getLatestModel(): HistoryPanelRenderModel | nu
   if (!model?.table || model.table.kind !== "rows") {
     throw new Error("Expected rendered history rows");
   }
-  return buildHistoryTableRowsViewModel(model.table.params);
+  return model.table.rows;
 }
 
 function createFeatureHarness(

--- a/apps/ui/tests/realtime_logging_view_models.spec.ts
+++ b/apps/ui/tests/realtime_logging_view_models.spec.ts
@@ -107,6 +107,10 @@ test.describe("realtime logging view models", () => {
       },
     });
     expect(model.checklist).toBeNull();
+    expect(model.summaryAction?.action).toBe("open-add-car");
+    expect(model.summaryHidden).toBe(false);
+    expect(model.shellLayout).toBe("setup");
+    expect(model.showProgressSection).toBe(false);
     expect(model.setupMode).toBe(true);
     expect(model.startDisabled).toBe(true);
   });
@@ -154,6 +158,9 @@ test.describe("realtime logging view models", () => {
       "reference_ready",
       "speed_stable",
     ]);
+    expect(model.summaryLayout).toBe("panel");
+    expect(model.checklistHidden).toBe(false);
+    expect(model.showProgressSection).toBe(true);
   });
 
   test("preserves the last completed elapsed value when processing begins", () => {
@@ -191,5 +198,8 @@ test.describe("realtime logging view models", () => {
       },
     });
     expect(model.nextLastCompletedElapsedText).toBe("1:23");
+    expect(model.loggingRowHidden).toBe(false);
+    expect(model.pillHidden).toBe(true);
+    expect(model.runIdHidden).toBe(false);
   });
 });

--- a/apps/ui/tests/spectrum_interaction_controller.spec.ts
+++ b/apps/ui/tests/spectrum_interaction_controller.spec.ts
@@ -91,8 +91,11 @@ test.describe("SpectrumInteractionController", () => {
     });
 
     expect(controller.bandToggleModel.value).toEqual({
+      disabled: true,
       hasBands: false,
       bandsVisible: false,
+      hidden: true,
+      pressed: "false",
       text: "Show reference bands",
     });
     expect(controller.sensorLegendModel.value?.items[0]?.detailText).toBe("12.0 dB");

--- a/apps/ui/tests/spectrum_panel_signals.ts
+++ b/apps/ui/tests/spectrum_panel_signals.ts
@@ -38,7 +38,10 @@ async function runSpectrumPanelSignalProjectionTest(): Promise<void> {
 
       const bandToggleModel = signal<SpectrumPanelBandToggleModel>({
         bandsVisible: true,
+        disabled: false,
         hasBands: true,
+        hidden: false,
+        pressed: "true",
         text: "Hide reference bands",
       });
       harness.view.bindBandToggleModel(bandToggleModel);

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -13,10 +13,10 @@ async function importUiSpectrumController() {
 function createPanelStub(): {
   panel: SpectrumPanelView;
   lastHeaderModel: { hintText: string; titleText: string } | null;
-  lastOverlayMessage: string | null;
+  lastOverlayModel: { hidden: boolean; text: string } | null;
 } {
   let lastHeaderModel: { hintText: string; titleText: string } | null = null;
-  let lastOverlayMessage: string | null = null;
+  let lastOverlayModel: { hidden: boolean; text: string } | null = null;
 
   return {
       panel: {
@@ -31,16 +31,16 @@ function createPanelStub(): {
         renderHeader(model) {
           lastHeaderModel = model;
         },
-        renderOverlay(message: string | null) {
-          lastOverlayMessage = message;
+        renderOverlay(model) {
+          lastOverlayModel = model;
         },
         renderInspectorText() {},
       },
     get lastHeaderModel() {
       return lastHeaderModel;
     },
-    get lastOverlayMessage() {
-      return lastOverlayMessage;
+    get lastOverlayModel() {
+      return lastOverlayModel;
     },
   };
 }
@@ -65,7 +65,10 @@ test.describe("UiSpectrumController", () => {
         t: (key) => key,
       });
 
-      expect(panel.lastOverlayMessage).toBe("spectrum.loading");
+      expect(panel.lastOverlayModel).toEqual({
+        hidden: false,
+        text: "spectrum.loading",
+      });
     } finally {
       restoreDocument();
     }
@@ -88,7 +91,10 @@ test.describe("UiSpectrumController", () => {
 
       state.transport.wsState.value = "stale";
 
-      expect(panel.lastOverlayMessage).toBe("spectrum.stale");
+      expect(panel.lastOverlayModel).toEqual({
+        hidden: false,
+        text: "spectrum.stale",
+      });
     } finally {
       restoreDocument();
     }
@@ -144,7 +150,10 @@ test.describe("UiSpectrumController", () => {
         t: (key) => key,
       });
 
-      expect(panel.lastOverlayMessage).toBe("spectrum.loading");
+      expect(panel.lastOverlayModel).toEqual({
+        hidden: false,
+        text: "spectrum.loading",
+      });
     } finally {
       restoreDocument();
     }
@@ -172,7 +181,10 @@ test.describe("UiSpectrumController", () => {
         },
       });
 
-      expect(panel.lastOverlayMessage).toBe("chart load failed: chunk timeout");
+      expect(panel.lastOverlayModel).toEqual({
+        hidden: false,
+        text: "chart load failed: chunk timeout",
+      });
     } finally {
       restoreDocument();
     }
@@ -196,7 +208,10 @@ test.describe("UiSpectrumController", () => {
         titleText: "en:chart.spectrum_title",
         hintText: "en:spectrum.controls_hint",
       });
-      expect(panel.lastOverlayMessage).toBe("en:spectrum.stale");
+      expect(panel.lastOverlayModel).toEqual({
+        hidden: false,
+        text: "en:spectrum.stale",
+      });
 
       state.shell.lang.value = "nl";
 
@@ -204,7 +219,10 @@ test.describe("UiSpectrumController", () => {
         titleText: "nl:chart.spectrum_title",
         hintText: "nl:spectrum.controls_hint",
       });
-      expect(panel.lastOverlayMessage).toBe("nl:spectrum.stale");
+      expect(panel.lastOverlayModel).toEqual({
+        hidden: false,
+        text: "nl:spectrum.stale",
+      });
     } finally {
       restoreDocument();
     }


### PR DESCRIPTION
## What changed
- move realtime logging visibility, layout, and summary-action flags into the logging view model instead of deriving them in `realtime_logging_panel.tsx`
- move spectrum overlay and band-toggle derived state into controller-owned models instead of deriving them in `spectrum_panel.tsx`
- prebuild the history rows table render model in the feature/presenter layer so `history_table_content.tsx` stops memoizing rows and deriving table shape locally

## Why
- these views still owned pure derived state through local `useComputed()` hooks
- moving that state into render-model or presenter-owned computed signals keeps the views data-in / DOM-out and makes the derivations reusable and testable
- the history path is cleaner when the feature hands the view an already-shaped rows table model instead of raw table params

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/realtime_feature_view_state.spec.ts tests/realtime_logging_view_models.spec.ts tests/history_feature_modules.spec.ts tests/history_table_view.spec.ts tests/spectrum_interaction_controller.spec.ts tests/ui_spectrum_controller.spec.ts tests/smoke.history.spec.ts tests/smoke.spectrum.spec.ts`
- `cd apps/ui && npx tsx tests/history_table_body_signals.ts && npx tsx tests/spectrum_panel_signals.ts`

## Risks / tradeoffs
- history row-model identity is now owned by the feature/presenter layer instead of the body view
- spectrum overlay rendering now consumes a typed overlay model instead of `message | null`
- left unrelated i18n/view cleanup out of scope; this PR only moves pure derived state ownership

Closes #2689