### PR TITLE
refactor(ui): use effectOnChange watchers

### DIFF
--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -18,7 +18,8 @@ import {
 } from "../ui_app_state";
 import {
   batch,
-  effect,
+  computed,
+  effectOnChange,
   signal,
   type ReadonlySignal,
   type Signal,
@@ -138,6 +139,16 @@ export function createRealtimeFeatureWorkflow(
   let idleCaptureReadinessRefreshInFlight = false;
   let lastIdleCaptureReadinessSignature: string | null = null;
   let queuedIdleCaptureReadinessSignature: string | null = null;
+  const idleCaptureReadinessTrigger = computed(() =>
+    [
+      deps.idleCaptureReadinessSignature.value,
+      state.handlersBound.value ? "1" : "0",
+      state.pendingLoggingAction.value ?? "",
+      realtime.loggingStatus.value.enabled ? "1" : "0",
+      realtime.loggingStatus.value.analysis_in_progress ? "1" : "0",
+      Boolean(realtime.loggingStatus.value.last_completed_run_id) ? "1" : "0",
+    ].join("::")
+  );
 
   function syncIdleCaptureReadinessSignature(): void {
     lastIdleCaptureReadinessSignature = deps.idleCaptureReadinessSignature.peek();
@@ -187,23 +198,8 @@ export function createRealtimeFeatureWorkflow(
     }
   }
 
-  effect(() => {
-    const signature = deps.idleCaptureReadinessSignature.value;
-    if (
-      !state.handlersBound.value
-      || isDemoMode
-      || state.pendingLoggingAction.value !== null
-    ) {
-      return;
-    }
-    if (
-      realtime.loggingStatus.value.enabled
-      || realtime.loggingStatus.value.analysis_in_progress
-      || Boolean(realtime.loggingStatus.value.last_completed_run_id)
-    ) {
-      return;
-    }
-    void refreshIdleCaptureReadiness(signature);
+  effectOnChange(idleCaptureReadinessTrigger, () => {
+    void refreshIdleCaptureReadiness(deps.idleCaptureReadinessSignature.peek());
   });
 
   const loggingStatusPolling = createPolling({

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -7,7 +7,7 @@ import type { SpeedSourcePanelView } from "../views/speed_source_panel";
 import type { SettingsState } from "../ui_app_state";
 import {
   computed,
-  effect,
+  effectOnChange,
   untracked,
   type ReadonlySignal,
 } from "../ui_signals";
@@ -66,6 +66,9 @@ export function createSettingsSpeedSourceModule(
   const panelModel = computed(() =>
     buildSettingsSpeedSourcePanelModel(workflow.renderState.value, presenterDeps)
   );
+  const navigationContextKey = computed(
+    () => `${ctx.ports.activeViewId.value}::${ctx.ports.activeSettingsTabId.value}`,
+  );
   ctx.panel.model.value = panelModel;
   let handlersBound = false;
 
@@ -74,14 +77,7 @@ export function createSettingsSpeedSourceModule(
       return;
     }
     handlersBound = true;
-    let hasSeenInitialContext = false;
-    effect(() => {
-      ctx.ports.activeViewId.value;
-      ctx.ports.activeSettingsTabId.value;
-      if (!hasSeenInitialContext) {
-        hasSeenInitialContext = true;
-        return;
-      }
+    effectOnChange(navigationContextKey, () => {
       untracked(() => {
         workflow.handleNavigateContext();
       });

--- a/apps/ui/src/app/views/update_feature_presenter.ts
+++ b/apps/ui/src/app/views/update_feature_presenter.ts
@@ -25,7 +25,7 @@ import {
 import {
   batch,
   computed,
-  effect,
+  effectOnChange,
   signal,
   untracked,
   type ReadonlySignal,
@@ -356,8 +356,7 @@ export function createUpdateFeaturePresenter(
   const ssidInputValue = signal("");
   let hasHydratedPersistedWifiSettings = false;
 
-  effect(() => {
-    const state = renderState.value;
+  function syncDerivedFormState(state: UpdateFeatureRenderState): void {
     const currentSelectedTransport = untracked(() => selectedTransportInput.value);
     const currentSsid = untracked(() => ssidInputValue.value);
     let nextSelectedTransport: UpdateStartRequestPayload["transport"] | null = null;
@@ -388,6 +387,11 @@ export function createUpdateFeaturePresenter(
         }
       });
     }
+  }
+
+  syncDerivedFormState(renderState.peek());
+  effectOnChange(renderState, (state) => {
+    syncDerivedFormState(state);
   });
 
   const actionSummaryModel = computed(() =>

--- a/apps/ui/tests/update_feature_presenter.spec.ts
+++ b/apps/ui/tests/update_feature_presenter.spec.ts
@@ -315,6 +315,35 @@ test.describe("buildUpdateFeaturePanelModels", () => {
 });
 
 test.describe("createUpdateFeaturePresenter", () => {
+  test("hydrates Wi-Fi inputs from initial render state once", () => {
+    const renderState = signal({
+      internetStatus: makeInternet(),
+      healthStatus: makeHealth(),
+      updateStatus: makeStatus({
+        transport: "wifi",
+        ssid: "persisted-ssid",
+      }),
+      updateState: "idle" as const,
+      updateTransport: "wifi" as const,
+    });
+    const presenter = createUpdateFeaturePresenter({
+      renderState,
+      t,
+    });
+
+    expect(presenter.internetPanelModel.value.ssidInputValue).toBe("persisted-ssid");
+
+    renderState.value = {
+      ...renderState.value,
+      updateStatus: makeStatus({
+        transport: "wifi",
+        ssid: "next-ssid",
+      }),
+    };
+
+    expect(presenter.internetPanelModel.value.ssidInputValue).toBe("persisted-ssid");
+  });
+
   test("reads and clears presenter-owned form state instead of DOM values", () => {
     const renderState = signal({
       internetStatus: makeInternet({


### PR DESCRIPTION
## what changed
- replace the speed-source navigation context watcher with a computed key + `effectOnChange()`
- replace the realtime idle-capture readiness watcher with a combined computed trigger + `effectOnChange()`
- replace the update presenter render-state watcher with an explicit sync function + `effectOnChange()`
- add regression coverage for initial Wi-Fi hydration in the update presenter

## why
- these flows are change reactions, not generic imperative effects
- `effectOnChange()` makes the no-initial-fire behavior explicit and removes manual first-run tracking
- the presenter keeps one explicit initial sync because it still needs first-render hydration

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/settings_speed_source_module_bindings.spec.ts tests/realtime_feature_workflow.spec.ts tests/update_feature_presenter.spec.ts`

## risks / tradeoffs
- realtime still uses a combined trigger key because idle-capture refresh depends on more than one gate
- `effectOnChange()` skips the first run by design, so the presenter performs one eager sync before subscribing

Closes #2690