### PR TITLE
refactor(ui): memo stable signal sections

### DIFF
--- a/apps/ui/src/app/views/esp_flash_history_section.tsx
+++ b/apps/ui/src/app/views/esp_flash_history_section.tsx
@@ -1,3 +1,4 @@
+import { memo } from "preact/compat";
 import {
   InlineEmptyState,
   MaintenanceNote,
@@ -8,7 +9,7 @@ import { useSignalProperties, type ReadonlySignal } from "../ui_signals";
 
 const ESP_FLASH_HISTORY_KEYS = ["attempts", "emptyState"] as const;
 
-export function EspFlashHistoryContent(props: {
+export const EspFlashHistoryContent = memo(function EspFlashHistoryContent(props: {
   model: ReadonlySignal<EspFlashHistoryPanelModel>;
 }) {
   const { attempts, emptyState } = useSignalProperties(props.model, ESP_FLASH_HISTORY_KEYS);
@@ -31,4 +32,4 @@ export function EspFlashHistoryContent(props: {
       ))}
     </ul>
   );
-}
+});

--- a/apps/ui/src/app/views/esp_flash_journey_section.tsx
+++ b/apps/ui/src/app/views/esp_flash_journey_section.tsx
@@ -1,3 +1,4 @@
+import { memo } from "preact/compat";
 import {
   MaintenanceNote,
   type EspFlashJourneyPanelModel,
@@ -28,7 +29,7 @@ function JourneyStageItem(props: {
   );
 }
 
-export function EspFlashJourneySection(props: {
+export const EspFlashJourneySection = memo(function EspFlashJourneySection(props: {
   model: ReadonlySignal<EspFlashJourneyPanelModel>;
 }) {
   const { stages, terminalNoteText } = useSignalProperties(
@@ -47,4 +48,4 @@ export function EspFlashJourneySection(props: {
       </ol>
     </div>
   );
-}
+});

--- a/apps/ui/src/app/views/esp_flash_log_section.tsx
+++ b/apps/ui/src/app/views/esp_flash_log_section.tsx
@@ -1,3 +1,4 @@
+import { memo } from "preact/compat";
 import {
   InlineEmptyState,
   type EspFlashLogPanelModel,
@@ -6,7 +7,7 @@ import { useSignalProperties, type ReadonlySignal } from "../ui_signals";
 
 const ESP_FLASH_LOG_KEYS = ["emptyState", "text"] as const;
 
-export function EspFlashLogContent(props: {
+export const EspFlashLogContent = memo(function EspFlashLogContent(props: {
   model: ReadonlySignal<EspFlashLogPanelModel>;
 }) {
   const { emptyState, text } = useSignalProperties(props.model, ESP_FLASH_LOG_KEYS);
@@ -14,4 +15,4 @@ export function EspFlashLogContent(props: {
     return <InlineEmptyState model={emptyState.value} />;
   }
   return <pre class="log-pre log-pre--contained">{text.value}</pre>;
-}
+});

--- a/apps/ui/src/app/views/esp_flash_readiness_section.tsx
+++ b/apps/ui/src/app/views/esp_flash_readiness_section.tsx
@@ -1,3 +1,4 @@
+import { memo } from "preact/compat";
 import {
   MaintenanceNote,
   StatusGrid,
@@ -7,7 +8,7 @@ import { useSignalProperties, type ReadonlySignal } from "../ui_signals";
 
 const ESP_FLASH_READINESS_KEYS = ["errorText", "rows", "summaryText"] as const;
 
-export function EspFlashReadinessSection(props: {
+export const EspFlashReadinessSection = memo(function EspFlashReadinessSection(props: {
   model: ReadonlySignal<EspFlashReadinessPanelModel>;
 }) {
   const { errorText, rows, summaryText } = useSignalProperties(
@@ -23,4 +24,4 @@ export function EspFlashReadinessSection(props: {
       ) : null}
     </div>
   );
-}
+});

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -1,4 +1,5 @@
 import { render } from "preact";
+import { memo } from "preact/compat";
 import { getUiText } from "../ui_i18n";
 import {
   signal,
@@ -60,7 +61,7 @@ function requireSpectrumElement<T extends HTMLElement>(
   throw new Error(`Spectrum UI requires ${target}`);
 }
 
-function SpectrumBandLegend(props: {
+const SpectrumBandLegend = memo(function SpectrumBandLegend(props: {
   bandLegend: ReadonlySignal<SpectrumBandLegendModel>;
 }) {
   const {
@@ -93,9 +94,9 @@ function SpectrumBandLegend(props: {
         : null}
     </div>
   );
-}
+});
 
-function SpectrumSensorLegend(props: {
+const SpectrumSensorLegend = memo(function SpectrumSensorLegend(props: {
   sensorLegend: ReadonlySignal<SpectrumSensorLegendModel | null>;
   sensorLegendHandlers: ReadonlySignal<SpectrumLegendHandlers | null>;
 }) {
@@ -148,7 +149,7 @@ function SpectrumSensorLegend(props: {
       ))}
     </>
   );
-}
+});
 
 function SpectrumPanel(props: {
   bandLegendModel: ReadonlySignal<ReadonlySignal<SpectrumBandLegendModel> | null>;

--- a/apps/ui/tests/esp_flash_panel_signals.ts
+++ b/apps/ui/tests/esp_flash_panel_signals.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+
+import { options } from "preact";
+
+import { setUiLanguage } from "../src/app/ui_i18n";
+import { signal } from "../src/app/ui_signals";
+import type {
+  EspFlashPanelActionHandlers,
+  EspFlashPanelRenderModel,
+  EspFlashPanelView,
+} from "../src/app/views/esp_flash_panel";
+import { mountSignalView } from "./dom_render_test_support";
+
+function requireElement<T extends Element = HTMLElement>(root: ParentNode, selector: string): T {
+  const element = root.querySelector<T>(selector);
+  assert.ok(element, `Expected element matching ${selector}`);
+  return element;
+}
+
+async function runEspFlashPanelSignalMemoTest(): Promise<void> {
+  const previousDiffed = options.diffed;
+  const previousLanguage = "en";
+  let panelRenderCount = 0;
+  let readinessRenderCount = 0;
+  let journeyRenderCount = 0;
+  let logRenderCount = 0;
+  let historyRenderCount = 0;
+  options.diffed = (vnode) => {
+    if (typeof vnode.type === "function" && vnode.type.name === "EspFlashPanel") {
+      panelRenderCount += 1;
+    }
+    if (typeof vnode.type === "function" && vnode.type.displayName === "Memo(EspFlashReadinessSection)") {
+      readinessRenderCount += 1;
+    }
+    if (typeof vnode.type === "function" && vnode.type.displayName === "Memo(EspFlashJourneySection)") {
+      journeyRenderCount += 1;
+    }
+    if (typeof vnode.type === "function" && vnode.type.displayName === "Memo(EspFlashLogContent)") {
+      logRenderCount += 1;
+    }
+    if (typeof vnode.type === "function" && vnode.type.displayName === "Memo(EspFlashHistoryContent)") {
+      historyRenderCount += 1;
+    }
+    previousDiffed?.(vnode);
+  };
+
+  const harness = await mountSignalView(
+    async () => {
+      const { mountEspFlashPanel } = await import("../src/app/views/esp_flash_panel");
+      return mountEspFlashPanel;
+    },
+    () => ({
+      actions: signal<EspFlashPanelActionHandlers | null>(null),
+      model: signal(null),
+    } satisfies EspFlashPanelView),
+  );
+
+  try {
+    await harness.flush();
+    assert.equal(panelRenderCount, 1);
+
+    const panelModel = signal<EspFlashPanelRenderModel>({
+      cancelButtonDisabled: true,
+      cancelButtonHidden: true,
+      history: {
+        attempts: [{
+          badge: { text: "Done", variant: "ok" },
+          errorText: null,
+          metaText: "latest flash",
+          portText: "/dev/ttyUSB0",
+        }],
+        emptyState: null,
+      },
+      journey: {
+        stages: [{
+          current: true,
+          detailText: "Build firmware",
+          markerText: "1",
+          phase: "build",
+          state: "active",
+          stateText: "Running",
+          titleText: "Build",
+        }],
+        terminalNoteText: null,
+      },
+      log: {
+        emptyState: null,
+        text: "first line",
+      },
+      portOptions: [{ labelText: "Auto-detect", value: "__auto__" }],
+      portSelectDisabled: false,
+      readiness: {
+        errorText: null,
+        rows: [{ labelText: "Board", valueText: "Ready" }],
+        summaryText: "Ready to flash",
+      },
+      refreshPortsDisabled: false,
+      selectedPortValue: "__auto__",
+      startButtonDisabled: false,
+      startButtonHidden: false,
+      startButtonLabelText: "Flash latest",
+      startSummary: {
+        items: [],
+        stateLabel: "Ready",
+        stateVariant: "ok",
+        summary: "Can start now",
+        title: "Summary",
+      },
+      statusBanner: {
+        text: "Idle",
+        variant: "muted",
+      },
+    });
+    harness.view.model.value = panelModel;
+    await harness.flush();
+
+    assert.equal(panelRenderCount, 1);
+    assert.equal(readinessRenderCount, 1);
+    assert.equal(journeyRenderCount, 1);
+    assert.equal(logRenderCount, 1);
+    assert.equal(historyRenderCount, 1);
+    assert.match(requireElement(harness.host, "#espFlashReadinessPanel").textContent ?? "", /Ready to flash/);
+    assert.match(requireElement(harness.host, "#espFlashLogPanel").textContent ?? "", /first line/);
+    assert.match(requireElement(harness.host, "#espFlashHistoryPanel").textContent ?? "", /latest flash/);
+
+    const readinessBaseline = readinessRenderCount;
+    const journeyBaseline = journeyRenderCount;
+    const logBaseline = logRenderCount;
+    const historyBaseline = historyRenderCount;
+    panelModel.value = {
+      ...panelModel.value,
+      log: {
+        ...panelModel.value.log,
+        text: "first line\nsecond line",
+      },
+    };
+    await harness.flush();
+
+    assert.equal(panelRenderCount, 1);
+    assert.equal(readinessRenderCount, readinessBaseline);
+    assert.equal(journeyRenderCount, journeyBaseline);
+    assert.equal(logRenderCount, logBaseline);
+    assert.equal(historyRenderCount, historyBaseline);
+
+    const parentReadinessBaseline = readinessRenderCount;
+    const parentJourneyBaseline = journeyRenderCount;
+    const parentLogBaseline = logRenderCount;
+    const parentHistoryBaseline = historyRenderCount;
+    setUiLanguage("de");
+    await harness.flush();
+
+    assert.equal(panelRenderCount, 1);
+    assert.equal(readinessRenderCount, parentReadinessBaseline);
+    assert.equal(journeyRenderCount, parentJourneyBaseline);
+    assert.equal(logRenderCount, parentLogBaseline);
+    assert.equal(historyRenderCount, parentHistoryBaseline);
+  } finally {
+    setUiLanguage(previousLanguage);
+    options.diffed = previousDiffed;
+    harness.cleanup();
+  }
+}
+
+await runEspFlashPanelSignalMemoTest();
+console.log("PASS esp flash memoized signal sections avoid parent rerender");

--- a/apps/ui/tests/spectrum_panel_signals.ts
+++ b/apps/ui/tests/spectrum_panel_signals.ts
@@ -20,9 +20,17 @@ function requireElement<T extends Element = HTMLElement>(root: ParentNode, selec
 async function runSpectrumPanelSignalProjectionTest(): Promise<void> {
   const previousDiffed = options.diffed;
   let spectrumPanelRenderCount = 0;
+  let bandLegendRenderCount = 0;
+  let sensorLegendRenderCount = 0;
   options.diffed = (vnode) => {
     if (typeof vnode.type === "function" && vnode.type.name === "SpectrumPanel") {
       spectrumPanelRenderCount += 1;
+    }
+    if (typeof vnode.type === "function" && vnode.type.displayName === "Memo(SpectrumBandLegend)") {
+      bandLegendRenderCount += 1;
+    }
+    if (typeof vnode.type === "function" && vnode.type.displayName === "Memo(SpectrumSensorLegend)") {
+      sensorLegendRenderCount += 1;
     }
     previousDiffed?.(vnode);
   };
@@ -59,6 +67,7 @@ async function runSpectrumPanelSignalProjectionTest(): Promise<void> {
       await harness.flush();
 
       assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+      assert.equal(bandLegendRenderCount, 1);
       assert.match(requireElement(harness.host, "#bandLegend").textContent ?? "", /Wheel 1x/);
 
       let resetClicks = 0;
@@ -95,14 +104,17 @@ async function runSpectrumPanelSignalProjectionTest(): Promise<void> {
       await harness.flush();
 
       assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
-    assert.match(requireElement(harness.host, "#legend").textContent ?? "", /Front Left/);
-    assert.match(requireElement(harness.host, "#legend").textContent ?? "", /12.0 dB/);
+      assert.equal(sensorLegendRenderCount, 1);
+      assert.match(requireElement(harness.host, "#legend").textContent ?? "", /Front Left/);
+      assert.match(requireElement(harness.host, "#legend").textContent ?? "", /12.0 dB/);
 
-     requireElement<HTMLButtonElement>(harness.host, ".legend-item--reset").click();
+      requireElement<HTMLButtonElement>(harness.host, ".legend-item--reset").click();
       requireElement<HTMLButtonElement>(harness.host, '[aria-label="Focus Front Left"]').click();
       assert.equal(resetClicks, 1);
       assert.deepEqual(selectedIds, ["front-left"]);
 
+      const bandLegendSignalBaseline = bandLegendRenderCount;
+      const sensorLegendSignalBaseline = sensorLegendRenderCount;
       sensorLegendModel.value = {
         ...sensorLegendModel.value!,
         items: [{
@@ -115,7 +127,30 @@ async function runSpectrumPanelSignalProjectionTest(): Promise<void> {
       await harness.flush();
 
       assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
-    assert.match(requireElement(harness.host, "#legend").textContent ?? "", /13.0 dB/);
+      assert.equal(sensorLegendRenderCount, sensorLegendSignalBaseline);
+      assert.match(requireElement(harness.host, "#legend").textContent ?? "", /13.0 dB/);
+
+      bandLegendModel.value = {
+        ...bandLegendModel.value,
+        items: [{ color: "#22c55e", labelText: "Wheel 2x" }],
+      };
+      await harness.flush();
+
+      assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+      assert.equal(bandLegendRenderCount, bandLegendSignalBaseline);
+      assert.match(requireElement(harness.host, "#bandLegend").textContent ?? "", /Wheel 2x/);
+
+      const bandLegendParentBaseline = bandLegendRenderCount;
+      const sensorLegendParentBaseline = sensorLegendRenderCount;
+      harness.view.renderHeader({
+        titleText: "Updated title",
+        hintText: "Updated hint",
+      });
+      await harness.flush();
+
+      assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+      assert.equal(bandLegendRenderCount, bandLegendParentBaseline);
+      assert.equal(sensorLegendRenderCount, sensorLegendParentBaseline);
   } finally {
     options.diffed = previousDiffed;
     harness.cleanup();

--- a/apps/ui/tests/visual.spec.ts
+++ b/apps/ui/tests/visual.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from "@playwright/test";
 async function assertSpectrumHasData(
   page: import("@playwright/test").Page,
 ): Promise<void> {
-  const hasData = await page.evaluate(() => {
+  await expect.poll(async () => page.evaluate(() => {
     const canvas =
       document.querySelector<HTMLCanvasElement>("#specChart canvas");
     if (!canvas) return false;
@@ -33,8 +33,10 @@ async function assertSpectrumHasData(
         return true;
     }
     return false;
-  });
-  expect(hasData, "Spectrum chart must contain visible graph data").toBe(true);
+  }), {
+    message: "Spectrum chart must contain visible graph data",
+    timeout: 5_000,
+  }).toBe(true);
 }
 
 test.describe("Live view", () => {

--- a/apps/ui/tests/wiki_screenshots.spec.ts
+++ b/apps/ui/tests/wiki_screenshots.spec.ts
@@ -29,7 +29,7 @@ function screenshotPath(fileName: string): string {
 }
 
 async function assertSpectrumHasData(page: Page): Promise<void> {
-  const hasData = await page.evaluate(() => {
+  await expect.poll(async () => page.evaluate(() => {
     const canvas = document.querySelector<HTMLCanvasElement>("#specChart canvas");
     if (!canvas) return false;
     const ctx = canvas.getContext("2d");
@@ -51,8 +51,10 @@ async function assertSpectrumHasData(page: Page): Promise<void> {
       }
     }
     return false;
-  });
-  expect(hasData, "Spectrum chart must contain visible graph data").toBe(true);
+  }), {
+    message: "Spectrum chart must contain visible graph data",
+    timeout: 5_000,
+  }).toBe(true);
 }
 
 async function installWikiRoutes(page: Page): Promise<void> {


### PR DESCRIPTION
## what changed
- wrap the stable-signal spectrum legend leaves in `memo()`: `SpectrumBandLegend` and `SpectrumSensorLegend`
- wrap the stable-signal ESP flash content sections in `memo()`: readiness, journey, log, and history
- add render-count seam coverage for spectrum and ESP flash so these leaves stay flat across signal updates and unrelated global UI updates
- fix the live-dashboard screenshot helper to poll for visible spectrum pixels instead of sampling the canvas once before the chart paint lands

## why
- these leaves already consume stable `ReadonlySignal` props and own the expensive DOM trees in their sections
- `memo()` gives them a cheap guard if parent rerenders happen later
- the plain-model candidates from the issue body were left out on purpose because they do not match the stable-signal-prop premise
- broader visual validation exposed a chart-paint race in the screenshot suites; polling keeps the assertion strict without turning it into a sleep

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx tsx tests/spectrum_panel_signals.ts`
- `cd apps/ui && npx tsx tests/esp_flash_panel_signals.ts`
- `cd apps/ui && npx playwright test tests/esp_flash_feature_bindings.spec.ts tests/ui_spectrum_controller.spec.ts tests/spectrum_interaction_controller.spec.ts`
- `cd apps/ui && npm run test:visual`

## risks / tradeoffs
- today the mounted signal views already keep render counts flat for the exercised updates; the memo wrappers are a small defensive leaf optimization more than a dramatic hot-path rewrite
- screenshot checks now wait up to 5s for real chart pixels, so failures stay real but no longer race the first paint

Closes #2691