### PR TITLE
refactor(ui): use object styles in spectrum

### DIFF
--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -1,4 +1,4 @@
-import { render } from "preact";
+import { render, type JSX } from "preact";
 import { memo } from "preact/compat";
 import { getUiText } from "../ui_i18n";
 import {
@@ -41,6 +41,19 @@ const DEFAULT_SPECTRUM_BAND_LEGEND_MODEL: SpectrumBandLegendModel = {
   items: [],
   emptyText: "No reference band",
 };
+type SpectrumCssVariableStyle = JSX.CSSProperties & {
+  "--band-color"?: string;
+  "--swatch-color"?: string;
+};
+
+function bandColorStyle(color: string): SpectrumCssVariableStyle {
+  return { "--band-color": color };
+}
+
+function swatchColorStyle(color: string): SpectrumCssVariableStyle {
+  return { "--swatch-color": color };
+}
+
 const SPECTRUM_BAND_TOGGLE_KEYS = [
   "bandsVisible",
   "disabled",
@@ -80,9 +93,9 @@ const SpectrumBandLegend = memo(function SpectrumBandLegend(props: {
               key={item.labelText}
               class="legend-item legend-item--band"
               data-band-state="active"
-              style={`--band-color: ${item.color}`}
+              style={bandColorStyle(item.color)}
             >
-              <span class="swatch" style={`--swatch-color: ${item.color}`} />
+              <span class="swatch" style={swatchColorStyle(item.color)} />
               <span>{item.labelText}</span>
             </div>
           ))
@@ -138,7 +151,7 @@ const SpectrumSensorLegend = memo(function SpectrumSensorLegend(props: {
           data-legend-state={item.active ? "active" : item.muted ? "muted" : undefined}
           onClick={() => sensorLegendHandlers.onSelect(item.id)}
         >
-          <span class="swatch" style={`--swatch-color: ${item.color}`} />
+          <span class="swatch" style={swatchColorStyle(item.color)} />
           <span class="legend-item__text-group">
             <span class="legend-item__label">{item.labelText}</span>
             {item.detailText


### PR DESCRIPTION
## what changed
- replace the remaining three string-built inline style props in `spectrum_panel.tsx` with typed object style props
- keep the custom CSS-variable bindings explicit through a small local `JSX.CSSProperties` helper

## why
- the live issue body was stale: `history_heatmap_section.tsx` already uses object styles, and the repo search showed the only remaining JSX style strings were the spectrum band/swatch color bindings
- object styles keep the custom-property bindings type-safe and remove the last template-literal style strings from the frontend JSX surface

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx tsx tests/spectrum_panel_signals.ts`
- `cd apps/ui && npm run test:visual`

## risks / tradeoffs
- tiny surface only: one view file, no intended behavior change
- the issue body also mentioned class-string cleanup, but that is a different cleanup axis than inline style construction and was left out intentionally

Closes #2692