### PR TITLE
Fix duplicate WebSocket selection sends during recovery

### DIFF
--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -18,6 +18,12 @@ export class UiLiveTransportController {
 
   private readonly payloadErrorMessage: () => string;
 
+  private readySelectionCycle = 0;
+
+  private lastSentSelectionClientId: string | null | undefined = undefined;
+
+  private lastSentSelectionCycle = -1;
+
   constructor(deps: UiLiveTransportControllerDeps) {
     this.state = deps.state;
     this.payloadErrorMessage = deps.payloadErrorMessage;
@@ -26,9 +32,19 @@ export class UiLiveTransportController {
 
   sendSelection(): void {
     const ws = this.state.transport.ws.value;
-    if (ws) {
-      ws.send({ client_id: this.state.realtime.selectedClientId.value });
+    const clientId = this.state.realtime.selectedClientId.value;
+    if (
+      !ws
+      || (
+        this.lastSentSelectionCycle === this.readySelectionCycle
+        && Object.is(this.lastSentSelectionClientId, clientId)
+      )
+    ) {
+      return;
     }
+    this.lastSentSelectionCycle = this.readySelectionCycle;
+    this.lastSentSelectionClientId = clientId;
+    ws.send({ client_id: clientId });
   }
 
   private bindTransportSignalSync(): void {
@@ -52,10 +68,17 @@ export class UiLiveTransportController {
       }
     });
 
-    effectOnChange(this.state.transport.wsState, (nextWsState) => {
-      if (nextWsState === "connected" || nextWsState === "no_data") {
+    effectOnChange(this.state.transport.wsState, (nextWsState, previousWsState) => {
+      const nextReady = nextWsState === "connected" || nextWsState === "no_data";
+      const previousReady = previousWsState === "connected" || previousWsState === "no_data";
+      if (nextReady && !previousReady) {
+        this.readySelectionCycle += 1;
         untracked(() => this.sendSelection());
       }
+    });
+
+    effectOnChange(this.state.realtime.selectedClientId, () => {
+      untracked(() => this.sendSelection());
     });
   }
 
@@ -107,18 +130,14 @@ export class UiLiveTransportController {
       return;
     }
 
-    let update!: ReturnType<typeof applyLivePayloadUpdate>;
     batch(() => {
       this.state.transport.payloadError.value = null;
-      update = applyLivePayloadUpdate({
+      applyLivePayloadUpdate({
         realtime: this.state.realtime,
         spectrum: this.state.spectrum,
         adaptedPayload: adapted,
       });
     });
-    if (update.hasSelectedClientChanged) {
-      this.sendSelection();
-    }
   }
 
   private queueTransportPayload(payload: unknown): void {

--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -141,7 +141,7 @@ test.describe("UiLiveTransportController", () => {
     }
   });
 
-  test("sends the current client selection when websocket state becomes ready", async () => {
+  test("sends the current client selection once per ready cycle", async () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
     const wsUiState = signal("connecting");
@@ -165,6 +165,41 @@ test.describe("UiLiveTransportController", () => {
     wsUiState.value = "connected";
     await flushAsyncWork();
     wsUiState.value = "stale";
+    await flushAsyncWork();
+
+    expect(sentSelections).toEqual([
+      { client_id: "client-7" },
+    ]);
+  });
+
+  test("resends the current selection after leaving and re-entering a ready cycle", async () => {
+    const state = createAppState();
+    const sentSelections: Array<{ client_id: string | null }> = [];
+    const wsUiState = signal("connecting");
+    state.transport.ws.value = {
+      uiState: wsUiState,
+      close() {},
+      connect() {},
+      send(selection: { client_id: string | null }) {
+        sentSelections.push(selection);
+      },
+    } as typeof state.transport.ws.value;
+    state.realtime.selectedClientId.value = "client-7";
+
+    new UiLiveTransportController({
+      state,
+      payloadErrorMessage: () => "payload error",
+    });
+
+    wsUiState.value = "no_data";
+    await flushAsyncWork();
+    wsUiState.value = "connected";
+    await flushAsyncWork();
+    wsUiState.value = "stale";
+    await flushAsyncWork();
+    wsUiState.value = "reconnecting";
+    await flushAsyncWork();
+    wsUiState.value = "connected";
     await flushAsyncWork();
 
     expect(sentSelections).toEqual([


### PR DESCRIPTION
## What changed
- dedupe `sendSelection()` in `ui_live_transport_controller.ts` by ready-cycle and selected client
- move selection resend logic onto one reactive path: ready-state recovery + `selectedClientId` watcher
- drop the extra post-payload resend branch and add focused reconnect coverage

## Why
- `no_data -> connected` recovery could send the same `{ client_id }` twice in one reconnect cycle
- one canonical sync path is easier to reason about than watcher + imperative resend

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ui_live_transport_controller.spec.ts tests/ws.spec.ts tests/ui_spectrum_controller.spec.ts`

## Risks / edge cases
- still resends on a later real reconnect cycle
- still skips the initial already-ready websocket case
- no broader transport contract changes in this PR

Closes #2693