### PR TITLE
Use idle scheduling for panel and history prefetch

### DIFF
--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -44,6 +44,7 @@ export interface HistoryFeature {
 
 export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
   const { history, panel, shell, services, formatting } = ctx;
+  const COLLAPSED_RUN_PREVIEW_PREFETCH_CONCURRENCY = 3;
   let handlersBound = false;
   let previewPrefetchToken = 0;
   const rowsMemo = createHistoryTableRowsMemo();
@@ -248,14 +249,20 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
   function prefetchCollapsedRunContext(): void {
     const token = ++previewPrefetchToken;
     void (async () => {
-      for (const run of history.runs.value) {
+      const completedRuns = history.runs.value.filter((run) => run.status === "complete");
+      for (
+        let index = 0;
+        index < completedRuns.length;
+        index += COLLAPSED_RUN_PREVIEW_PREFETCH_CONCURRENCY
+      ) {
         if (token !== previewPrefetchToken) {
           return;
         }
-        if (run.status !== "complete") {
-          continue;
-        }
-        await loadRunPreview(run.run_id);
+        const batch = completedRuns.slice(
+          index,
+          index + COLLAPSED_RUN_PREVIEW_PREFETCH_CONCURRENCY,
+        );
+        await Promise.all(batch.map((run) => loadRunPreview(run.run_id)));
       }
     })();
   }

--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -80,6 +80,12 @@ export interface CreateUiLazyPanelsDeps {
 }
 
 function scheduleDeferredWork(task: () => void): void {
+  if (typeof globalThis.requestIdleCallback === "function") {
+    globalThis.requestIdleCallback(() => {
+      task();
+    });
+    return;
+  }
   setTimeout(task, 0);
 }
 

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -487,6 +487,64 @@ test("history feature preloads collapsed row context for completed runs", async 
   ]);
 });
 
+test("history feature prefetches collapsed run previews in parallel batches", async () => {
+  const state = createAppState();
+  const { feature } = createFeatureHarness(state);
+  const originalFetch = globalThis.fetch;
+  const previewRequests: string[] = [];
+  const previewResolvers = new Map<string, (response: Response) => void>();
+
+  globalThis.fetch = (async (input: string | URL | RequestInfo) => {
+    const url = String(typeof input === "string" ? input : input instanceof URL ? input : input.url);
+    if (url === "/api/history") {
+      return jsonResponse({
+        runs: [
+          historyListRun("run-001"),
+          historyListRun("run-002"),
+          historyListRun("run-003"),
+          historyListRun("run-004"),
+        ],
+      });
+    }
+    if (url.startsWith("/api/history/run-") && url.endsWith("/insights?lang=en")) {
+      previewRequests.push(url);
+      return await new Promise<Response>((resolve) => {
+        previewResolvers.set(url, resolve);
+      });
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    await feature.refreshHistory();
+    await expect.poll(() => previewRequests.length).toBe(3);
+
+    previewResolvers.get("/api/history/run-001/insights?lang=en")
+      ?.call(null, jsonResponse(historyInsightsWithFindingsPayload("run-001", 2)));
+    previewResolvers.get("/api/history/run-002/insights?lang=en")
+      ?.call(null, jsonResponse(historyInsightsWithFindingsPayload("run-002", 2)));
+    previewResolvers.get("/api/history/run-003/insights?lang=en")
+      ?.call(null, jsonResponse(historyInsightsWithFindingsPayload("run-003", 2)));
+
+    await expect.poll(() => previewRequests.length).toBe(4);
+
+    previewResolvers.get("/api/history/run-004/insights?lang=en")
+      ?.call(null, jsonResponse(historyInsightsWithFindingsPayload("run-004", 2)));
+
+    await expect.poll(() => state.history.runDetailsById.value["run-004"]?.preview?.sensor_count_used ?? null)
+      .toBe(2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  expect(previewRequests).toEqual([
+    "/api/history/run-001/insights?lang=en",
+    "/api/history/run-002/insights?lang=en",
+    "/api/history/run-003/insights?lang=en",
+    "/api/history/run-004/insights?lang=en",
+  ]);
+});
+
 
 test("history feature reports partial delete failures without splitting render ownership", async () => {
   const state = createAppState();

--- a/apps/ui/tests/ui_lazy_panels.spec.ts
+++ b/apps/ui/tests/ui_lazy_panels.spec.ts
@@ -340,4 +340,71 @@ test.describe("createLazyUiPanels", () => {
     expect(historyLoads).toBe(1);
     expect(settingsLoads).toBe(1);
   });
+
+  test("prefetchHiddenPanels prefers requestIdleCallback when available", async () => {
+    const hosts = createFakeHosts();
+    let historyLoads = 0;
+    let idleTask: IdleRequestCallback | null = null;
+    let settingsLoads = 0;
+    const originalRequestIdleCallback = globalThis.requestIdleCallback;
+    const originalSetTimeout = globalThis.setTimeout;
+    let timeoutCalls = 0;
+
+    globalThis.requestIdleCallback = ((callback: IdleRequestCallback) => {
+      idleTask = callback;
+      return 1;
+    }) as typeof requestIdleCallback;
+    globalThis.setTimeout = ((...args: Parameters<typeof setTimeout>) => {
+      timeoutCalls += 1;
+      return originalSetTimeout(...args);
+    }) as typeof setTimeout;
+
+    try {
+      const lazyPanels = createLazyUiPanels({
+        hosts,
+        mountDashboardPanels: () => createDashboardPanels(),
+        loadHistoryPanel: async () => {
+          historyLoads += 1;
+        },
+        loadSettingsPanels: async () => {
+          settingsLoads += 1;
+          return {
+            settingsShell: createSettingsShellSpy().view,
+            settings: {
+              analysis: {
+                focusField() {},
+                openGuidance() {},
+              },
+              cars: {
+                focus() {},
+              },
+              internet: createInternetPanelSpy().handle,
+              speedSource: {
+                focusManualSpeedInput() {},
+                focusScanObdDevices() {},
+                focusStaleTimeoutInput() {},
+              },
+            },
+          };
+        },
+      });
+
+      lazyPanels.prefetchHiddenPanels();
+      expect(idleTask).not.toBeNull();
+      expect(timeoutCalls).toBe(0);
+      idleTask?.({
+        didTimeout: false,
+        timeRemaining() {
+          return 50;
+        },
+      });
+      await Promise.resolve();
+    } finally {
+      globalThis.requestIdleCallback = originalRequestIdleCallback;
+      globalThis.setTimeout = originalSetTimeout;
+    }
+
+    expect(historyLoads).toBe(1);
+    expect(settingsLoads).toBe(1);
+  });
 });


### PR DESCRIPTION
## What changed
- make hidden panel prefetch prefer `requestIdleCallback`, with the old `setTimeout(0)` path kept as fallback
- batch collapsed history preview warmup in groups of three instead of awaiting every run serially
- add focused coverage for idle scheduling and parallel preview batching

## Why
- hidden panel mounts are non-critical work and should yield to active user work when the browser has idle time
- sequential history preview warmup leaves obvious latency on the table once multiple completed runs exist

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ui_lazy_panels.spec.ts tests/history_feature_modules.spec.ts tests/smoke.history.spec.ts`

## Risks / edge cases
- `requestIdleCallback` is browser-dependent, so fallback stays in place
- history preview batching stays bounded at three concurrent loads instead of fan-out-all-at-once
- no changes to visible history/detail contracts outside prefetch timing

Closes #2694