### PR TITLE
Use a single-pass min/max loop in heatmap presenter

### DIFF
--- a/apps/ui/src/app/views/history_heatmap_presenter.ts
+++ b/apps/ui/src/app/views/history_heatmap_presenter.ts
@@ -77,11 +77,18 @@ export function buildHistoryHeatmapViewModel(
       labelByLocation[key] = label;
     }
   }
-  const values = Object.values(metricByLocation).filter((value) => typeof value === "number");
-  const min = values.length ? Math.min(...values) : null;
-  const max = values.length ? Math.max(...values) : null;
+  let min: number | null = null;
+  let max: number | null = null;
+  for (const value of Object.values(metricByLocation)) {
+    if (min === null || value < min) {
+      min = value;
+    }
+    if (max === null || value > max) {
+      max = value;
+    }
+  }
   const knownPositionKeys = new Set<string>(HISTORY_HEATMAP_POSITIONS.map((point) => point.key));
-  const strongestValue = values.length ? Math.max(...values) : null;
+  const strongestValue = max;
   const zones: HistoryHeatmapZoneViewModel[] = HISTORY_HEATMAP_POSITIONS.map((point) => {
     const value = metricByLocation[point.key];
     const label = labelByLocation[point.key] || humanizeHeatmapLocationKey(point.key);

--- a/apps/ui/tests/history_heatmap_presenter.spec.ts
+++ b/apps/ui/tests/history_heatmap_presenter.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+import type { HistoryInsightsPayload } from "../src/api/types";
+import { buildHistoryHeatmapViewModel } from "../src/app/views/history_heatmap_presenter";
+
+function makeSummary(rows: HistoryInsightsPayload["sensor_intensity_by_location"]): HistoryInsightsPayload {
+  return {
+    run_id: "run-001",
+    status: "complete",
+    start_time_utc: "2026-01-01T00:00:00Z",
+    duration_s: 12,
+    sensor_count_used: rows.length,
+    findings: [],
+    warnings: [],
+    sensor_intensity_by_location: rows,
+  };
+}
+
+test("buildHistoryHeatmapViewModel uses the final normalized location values for strongest and extras", () => {
+  const heatmap = buildHistoryHeatmapViewModel(
+    makeSummary([
+      {
+        location: "Front Left Wheel",
+        p50_intensity_db: 8,
+        p95_intensity_db: 30,
+        max_intensity_db: 32,
+        dropped_frames_delta: 0,
+        queue_overflow_drops_delta: 0,
+        sample_count: 20,
+      },
+      {
+        location: "front_left_wheel",
+        p50_intensity_db: 8,
+        p95_intensity_db: 10,
+        max_intensity_db: 12,
+        dropped_frames_delta: 0,
+        queue_overflow_drops_delta: 0,
+        sample_count: 20,
+      },
+      {
+        location: "Front Right Wheel",
+        p50_intensity_db: 8,
+        p95_intensity_db: 24,
+        max_intensity_db: 26,
+        dropped_frames_delta: 0,
+        queue_overflow_drops_delta: 0,
+        sample_count: 20,
+      },
+      {
+        location: "Custom Tunnel Mount",
+        p50_intensity_db: 8,
+        p95_intensity_db: 16,
+        max_intensity_db: 18,
+        dropped_frames_delta: 0,
+        queue_overflow_drops_delta: 0,
+        sample_count: 20,
+      },
+    ]),
+    {
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      t: (key) => key,
+    },
+  );
+
+  expect(heatmap.zones.find((zone) => zone.key === "front-left wheel")).toMatchObject({
+    label: "front_left_wheel",
+    strongest: false,
+    valueLabel: "10.0 dB",
+  });
+  expect(heatmap.zones.find((zone) => zone.key === "front-right wheel")).toMatchObject({
+    label: "Front Right Wheel",
+    strongest: true,
+    valueLabel: "24.0 dB",
+  });
+  expect(heatmap.extras).toEqual(["Custom Tunnel Mount · 16.0 dB"]);
+});


### PR DESCRIPTION
## What changed
- replace spread-based `Math.min(...values)` / `Math.max(...values)` in `history_heatmap_presenter.ts` with one loop over the finalized metric map
- reuse that same max value for `strongestValue` instead of computing `Math.max()` twice
- add focused presenter coverage for duplicate normalized location keys and extras output

## Why
- spread-based min/max does extra work and can blow up on large arrays
- the presenter only needs one pass over the final values, and strongest-value reuse falls out naturally

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/history_heatmap_presenter.spec.ts tests/history_feature_modules.spec.ts tests/smoke.history.spec.ts`

## Risks / edge cases
- duplicate raw rows that normalize to the same location still use the final overwritten metric, same as before
- no visible heatmap contract changes outside the min/max computation path

Closes #2695