### PR TITLE
Extract a shared signal-driven timer effect helper

### DIFF
--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -10,7 +10,7 @@ import type {
   ShellState,
   SpectrumState,
 } from "../ui_app_state";
-import { createReplaceableInterval } from "../timer_cleanup";
+import { bindReplaceableTimerEffect, createReplaceableInterval } from "../timer_cleanup";
 import { computed, effect, signal, type ReadonlySignal } from "../ui_signals";
 import type { AdaptedClient } from "../../transport/live_models";
 import {
@@ -214,22 +214,20 @@ export function createRealtimeFeatureViewState(
   });
   const loggingElapsedTimer = createReplaceableInterval();
 
-  effect(() => {
+  bindReplaceableTimerEffect(loggingElapsedTimer, () => {
     if (!loggingElapsedShouldTick.value) {
-      loggingElapsedTimer.clear();
-      return;
+      return null;
     }
     const loggingStartTimeUtc = loggingElapsedTimerStartTime.value;
     if (!loggingStartTimeUtc) {
-      loggingElapsedTimer.clear();
-      return;
+      return null;
     }
-    elapsedNowMs.value = Date.now();
-    loggingElapsedTimer.replace(() => {
-      elapsedNowMs.value = Date.now();
-    }, 1_000);
-    return () => {
-      loggingElapsedTimer.clear();
+    return {
+      fireImmediately: true,
+      delayMs: 1_000,
+      callback: () => {
+        elapsedNowMs.value = Date.now();
+      },
     };
   });
 

--- a/apps/ui/src/app/timer_cleanup.ts
+++ b/apps/ui/src/app/timer_cleanup.ts
@@ -1,3 +1,5 @@
+import { effect } from "./ui_signals";
+
 type TimeoutApi = Pick<typeof globalThis, "clearTimeout" | "setTimeout">;
 type IntervalApi = Pick<typeof globalThis, "clearInterval" | "setInterval">;
 
@@ -10,6 +12,12 @@ type ScheduledHandleStore<Handle> = {
 export interface ReplaceableTimer {
   clear(): void;
   replace(callback: () => void, delayMs: number): void;
+}
+
+export interface ReplaceableTimerEffectSchedule {
+  callback: () => void;
+  delayMs: number;
+  fireImmediately?: boolean;
 }
 
 function createScheduledHandleStore<Handle>(
@@ -72,4 +80,24 @@ export function createReplaceableInterval(
       store.replace(api.setInterval(callback, delayMs));
     },
   };
+}
+
+export function bindReplaceableTimerEffect(
+  timer: ReplaceableTimer,
+  resolveSchedule: () => ReplaceableTimerEffectSchedule | null,
+): () => void {
+  return effect(() => {
+    const schedule = resolveSchedule();
+    if (schedule === null) {
+      timer.clear();
+      return;
+    }
+    if (schedule.fireImmediately) {
+      schedule.callback();
+    }
+    timer.replace(schedule.callback, schedule.delayMs);
+    return () => {
+      timer.clear();
+    };
+  });
 }

--- a/apps/ui/src/ws.ts
+++ b/apps/ui/src/ws.ts
@@ -1,5 +1,9 @@
 import type { LiveWsPayload } from "./contracts/ws_payload_types";
-import { batch, effect, signal, type ReadonlySignal } from "./app/ui_signals";
+import {
+  bindReplaceableTimerEffect,
+  createReplaceableTimeout,
+} from "./app/timer_cleanup";
+import { batch, signal, type ReadonlySignal } from "./app/ui_signals";
 
 export type WsUiState = "connecting" | "connected" | "reconnecting" | "stale" | "no_data";
 
@@ -42,7 +46,9 @@ export function createWsClient(options: WsClientOptions): WsClient {
   const manuallyClosed = signal(false);
   const reconnectAttempt = signal(0);
   const reconnectDelayMs = signal<number | null>(null);
+  const reconnectTimer = createReplaceableTimeout();
   const socketOpen = signal(false);
+  const staleTimer = createReplaceableTimeout();
 
   bindReconnectLifecycle();
   bindStaleLifecycle();
@@ -144,44 +150,44 @@ export function createWsClient(options: WsClientOptions): WsClient {
   }
 
   function bindReconnectLifecycle(): void {
-    effect(() => {
+    bindReplaceableTimerEffect(reconnectTimer, () => {
       const pendingReconnectDelayMs = reconnectDelayMs.value;
       if (pendingReconnectDelayMs === null || manuallyClosed.value) {
-        return;
+        return null;
       }
-      const timeoutId = window.setTimeout(() => {
-        batch(() => {
-          reconnectDelayMs.value = null;
-        });
-        open("reconnecting");
-      }, pendingReconnectDelayMs);
-      return () => {
-        window.clearTimeout(timeoutId);
+      return {
+        delayMs: pendingReconnectDelayMs,
+        callback: () => {
+          batch(() => {
+            reconnectDelayMs.value = null;
+          });
+          open("reconnecting");
+        },
       };
     });
   }
 
   function bindStaleLifecycle(): void {
-    effect(() => {
+    bindReplaceableTimerEffect(staleTimer, () => {
       if (
         !socketOpen.value
         || manuallyClosed.value
         || !hasReceivedData.value
         || lastMessageAtMs.value <= 0
       ) {
-        return;
+        return null;
       }
       const elapsedMs = Date.now() - lastMessageAtMs.value;
       const remainingMs = resolvedOptions.staleAfterMs - elapsedMs;
       if (remainingMs <= 0) {
         setState("stale");
-        return;
+        return null;
       }
-      const timeoutId = window.setTimeout(() => {
-        setState("stale");
-      }, remainingMs);
-      return () => {
-        window.clearTimeout(timeoutId);
+      return {
+        delayMs: remainingMs,
+        callback: () => {
+          setState("stale");
+        },
       };
     });
   }

--- a/apps/ui/tests/timer_cleanup.spec.ts
+++ b/apps/ui/tests/timer_cleanup.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "@playwright/test";
 
-import { createReplaceableInterval, createReplaceableTimeout } from "../src/app/timer_cleanup";
+import { signal } from "../src/app/ui_signals";
+import {
+  bindReplaceableTimerEffect,
+  createReplaceableInterval,
+  createReplaceableTimeout,
+} from "../src/app/timer_cleanup";
 
 test.describe("timer cleanup utilities", () => {
   test("replaceable timeout clears the previous timeout before scheduling a new one", () => {
@@ -69,5 +74,54 @@ test.describe("timer cleanup utilities", () => {
 
     expect(activeHandles.size).toBe(0);
     expect(clearedHandles).toEqual([1, 2]);
+  });
+
+  test("timer effect binds and clears a replaceable interval from signal state", () => {
+    let nextHandle = 1;
+    const activeHandles = new Set<number>();
+    const clearedHandles: number[] = [];
+    const enabled = signal(false);
+    const tickLog: string[] = [];
+    const interval = createReplaceableInterval({
+      clearInterval: ((handle?: ReturnType<typeof setInterval>) => {
+        if (typeof handle !== "number") {
+          return;
+        }
+        activeHandles.delete(handle);
+        clearedHandles.push(handle);
+      }) as typeof clearInterval,
+      setInterval: ((callback: TimerHandler, delay?: number) => {
+        void callback;
+        void delay;
+        const handle = nextHandle;
+        nextHandle += 1;
+        activeHandles.add(handle);
+        return handle as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval,
+    });
+
+    bindReplaceableTimerEffect(interval, () => {
+      if (!enabled.value) {
+        return null;
+      }
+      return {
+        fireImmediately: true,
+        delayMs: 1_000,
+        callback: () => {
+          tickLog.push("tick");
+        },
+      };
+    });
+
+    expect(activeHandles.size).toBe(0);
+    expect(tickLog).toEqual([]);
+
+    enabled.value = true;
+    expect(tickLog).toEqual(["tick"]);
+    expect(Array.from(activeHandles)).toEqual([1]);
+
+    enabled.value = false;
+    expect(activeHandles.size).toBe(0);
+    expect(clearedHandles).toEqual([1]);
   });
 });


### PR DESCRIPTION
## What changed
- add `bindReplaceableTimerEffect()` in `app/timer_cleanup.ts` to bind a replaceable timer from signal state with shared cleanup
- move the matching timeout/interval effect patterns in `ws.ts` and `realtime_feature_view_state.ts` onto that helper
- add focused helper coverage and keep polling controller coverage green without forcing it onto the new abstraction

## Why
- `ws.ts` reconnect/stale timeouts and realtime elapsed ticking were repeating the same effect-driven timer lifecycle
- one helper keeps the timer cleanup shape consistent without changing the generation-based polling controller contract

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/timer_cleanup.spec.ts tests/ws.spec.ts tests/realtime_feature_view_state.spec.ts tests/polling_controller.spec.ts`

## Risks / edge cases
- polling controller intentionally stays on its existing generation-aware timer flow
- stale-state immediate transitions in `ws.ts` still bypass scheduling and set state directly
- no timer API surface changes outside the new helper export

Closes #2696