### PR TITLE
perf(ui): replace Ajv ws validator

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@preact/signals": "^2.9.0",
-        "ajv": "^8.18.0",
         "preact": "^10.29.1",
         "uplot": "^1.6.31"
       },
@@ -1552,21 +1551,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -1912,22 +1896,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ]
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2108,7 +2078,8 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -2665,6 +2636,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@preact/signals": "^2.9.0",
-    "ajv": "^8.18.0",
     "preact": "^10.29.1",
     "uplot": "^1.6.31"
   },

--- a/apps/ui/src/ws_payload_validator.ts
+++ b/apps/ui/src/ws_payload_validator.ts
@@ -1,32 +1,413 @@
-import Ajv2020, { type ErrorObject } from "ajv/dist/2020.js";
-import type { ValidateFunction } from "ajv";
-import wsPayloadSchema from "./contracts/ws_payload_schema.generated";
-import type { LiveWsPayload } from "./contracts/ws_payload_types";
+import type {
+  LiveWsPayload,
+  StrengthMetricPeak,
+  StrengthMetricsPayload,
+  WsClientInfo,
+  WsRotationalSpeeds,
+  WsRotationalSpeedValue,
+  WsSpectraPayload,
+  WsSpectrumSeries,
+} from "./contracts/ws_payload_types";
 
-const ajv = new Ajv2020({
-  allErrors: true,
-  strict: false,
-});
+type JsonRecord = Record<string, unknown>;
 
-const liveWsPayloadValidator = ajv.compile(wsPayloadSchema) as ValidateFunction<LiveWsPayload>;
-const MAX_FORMATTED_VALIDATION_ERRORS = 3;
+function invalidPayload(path: string, message: string): never {
+  throw new Error(`Invalid websocket payload: ${path} ${message}`);
+}
 
-function formatValidationErrorSummary(errors: readonly ErrorObject[] | null | undefined): string {
-  if (!errors?.length) {
-    return "unknown schema violation";
+function requireRecord(value: unknown, path: string): JsonRecord {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    invalidPayload(path, "must be an object");
   }
-  return errors
-    .slice(0, MAX_FORMATTED_VALIDATION_ERRORS)
-    .map((error) => {
-      const path = error.instancePath || "/";
-      return `${path} ${error.message ?? "is invalid"}`;
-    })
-    .join("; ");
+  return value as JsonRecord;
+}
+
+function requireProperty(
+  record: JsonRecord,
+  key: string,
+  path: string,
+): unknown {
+  if (!(key in record)) {
+    invalidPayload(path, "is required");
+  }
+  return record[key];
+}
+
+function requireString(value: unknown, path: string): string {
+  if (typeof value !== "string") {
+    invalidPayload(path, "must be a string");
+  }
+  return value;
+}
+
+function requireBoolean(value: unknown, path: string): boolean {
+  if (typeof value !== "boolean") {
+    invalidPayload(path, "must be a boolean");
+  }
+  return value;
+}
+
+function requireFiniteNumber(value: unknown, path: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    invalidPayload(path, "must be a finite number");
+  }
+  return value;
+}
+
+function requireInteger(value: unknown, path: string): number {
+  const numberValue = requireFiniteNumber(value, path);
+  if (!Number.isInteger(numberValue)) {
+    invalidPayload(path, "must be an integer");
+  }
+  return numberValue;
+}
+
+function requireNullableString(value: unknown, path: string): string | null {
+  if (value === null) {
+    return null;
+  }
+  return requireString(value, path);
+}
+
+function requireNullableNumber(value: unknown, path: string): number | null {
+  if (value === null) {
+    return null;
+  }
+  return requireFiniteNumber(value, path);
+}
+
+function requireNullableInteger(value: unknown, path: string): number | null {
+  if (value === null) {
+    return null;
+  }
+  return requireInteger(value, path);
+}
+
+function requireArray(value: unknown, path: string): unknown[] {
+  if (!Array.isArray(value)) {
+    invalidPayload(path, "must be an array");
+  }
+  return value;
+}
+
+function validateNumberArray(value: unknown, path: string): number[] {
+  const array = requireArray(value, path);
+  for (let index = 0; index < array.length; index += 1) {
+    requireFiniteNumber(array[index], `${path}/${index}`);
+  }
+  return array as number[];
+}
+
+function validateStringArray(value: unknown, path: string): string[] {
+  const array = requireArray(value, path);
+  for (let index = 0; index < array.length; index += 1) {
+    requireString(array[index], `${path}/${index}`);
+  }
+  return array as string[];
+}
+
+function validateStrengthPeak(
+  value: unknown,
+  path: string,
+): StrengthMetricPeak {
+  const record = requireRecord(value, path);
+  requireFiniteNumber(
+    requireProperty(record, "hz", `${path}/hz`),
+    `${path}/hz`,
+  );
+  requireFiniteNumber(
+    requireProperty(record, "amp", `${path}/amp`),
+    `${path}/amp`,
+  );
+  requireFiniteNumber(
+    requireProperty(
+      record,
+      "vibration_strength_db",
+      `${path}/vibration_strength_db`,
+    ),
+    `${path}/vibration_strength_db`,
+  );
+  requireNullableString(
+    requireProperty(record, "strength_bucket", `${path}/strength_bucket`),
+    `${path}/strength_bucket`,
+  );
+  return value as StrengthMetricPeak;
+}
+
+function validateStrengthMetrics(
+  value: unknown,
+  path: string,
+): StrengthMetricsPayload {
+  const record = requireRecord(value, path);
+  requireFiniteNumber(
+    requireProperty(
+      record,
+      "vibration_strength_db",
+      `${path}/vibration_strength_db`,
+    ),
+    `${path}/vibration_strength_db`,
+  );
+  requireFiniteNumber(
+    requireProperty(record, "peak_amp_g", `${path}/peak_amp_g`),
+    `${path}/peak_amp_g`,
+  );
+  requireFiniteNumber(
+    requireProperty(record, "noise_floor_amp_g", `${path}/noise_floor_amp_g`),
+    `${path}/noise_floor_amp_g`,
+  );
+  requireNullableString(
+    requireProperty(record, "strength_bucket", `${path}/strength_bucket`),
+    `${path}/strength_bucket`,
+  );
+  const topPeaks = requireArray(
+    requireProperty(record, "top_peaks", `${path}/top_peaks`),
+    `${path}/top_peaks`,
+  );
+  for (let index = 0; index < topPeaks.length; index += 1) {
+    validateStrengthPeak(topPeaks[index], `${path}/top_peaks/${index}`);
+  }
+  return value as StrengthMetricsPayload;
+}
+
+function validateWsClient(value: unknown, path: string): WsClientInfo {
+  const record = requireRecord(value, path);
+  requireString(requireProperty(record, "id", `${path}/id`), `${path}/id`);
+  requireString(
+    requireProperty(record, "mac_address", `${path}/mac_address`),
+    `${path}/mac_address`,
+  );
+  requireString(
+    requireProperty(record, "name", `${path}/name`),
+    `${path}/name`,
+  );
+  requireBoolean(
+    requireProperty(record, "connected", `${path}/connected`),
+    `${path}/connected`,
+  );
+  requireString(
+    requireProperty(record, "location_code", `${path}/location_code`),
+    `${path}/location_code`,
+  );
+  requireString(
+    requireProperty(record, "firmware_version", `${path}/firmware_version`),
+    `${path}/firmware_version`,
+  );
+  requireInteger(
+    requireProperty(record, "sample_rate_hz", `${path}/sample_rate_hz`),
+    `${path}/sample_rate_hz`,
+  );
+  requireNullableInteger(
+    requireProperty(record, "last_seen_age_ms", `${path}/last_seen_age_ms`),
+    `${path}/last_seen_age_ms`,
+  );
+  requireInteger(
+    requireProperty(record, "frames_total", `${path}/frames_total`),
+    `${path}/frames_total`,
+  );
+  requireInteger(
+    requireProperty(record, "dropped_frames", `${path}/dropped_frames`),
+    `${path}/dropped_frames`,
+  );
+  return value as WsClientInfo;
+}
+
+function validateRotationalSpeedValue(
+  value: unknown,
+  path: string,
+): WsRotationalSpeedValue {
+  const record = requireRecord(value, path);
+  requireNullableNumber(
+    requireProperty(record, "rpm", `${path}/rpm`),
+    `${path}/rpm`,
+  );
+  requireNullableString(
+    requireProperty(record, "mode", `${path}/mode`),
+    `${path}/mode`,
+  );
+  requireNullableString(
+    requireProperty(record, "reason", `${path}/reason`),
+    `${path}/reason`,
+  );
+  return value as WsRotationalSpeedValue;
+}
+
+function validateOrderBand(value: unknown, path: string): void {
+  const record = requireRecord(value, path);
+  requireString(requireProperty(record, "key", `${path}/key`), `${path}/key`);
+  requireFiniteNumber(
+    requireProperty(record, "center_hz", `${path}/center_hz`),
+    `${path}/center_hz`,
+  );
+  requireFiniteNumber(
+    requireProperty(record, "tolerance", `${path}/tolerance`),
+    `${path}/tolerance`,
+  );
+}
+
+function validateRotationalSpeeds(
+  value: unknown,
+  path: string,
+): WsRotationalSpeeds {
+  const record = requireRecord(value, path);
+  requireNullableString(
+    requireProperty(record, "basis_speed_source", `${path}/basis_speed_source`),
+    `${path}/basis_speed_source`,
+  );
+  validateRotationalSpeedValue(
+    requireProperty(record, "wheel", `${path}/wheel`),
+    `${path}/wheel`,
+  );
+  validateRotationalSpeedValue(
+    requireProperty(record, "driveshaft", `${path}/driveshaft`),
+    `${path}/driveshaft`,
+  );
+  validateRotationalSpeedValue(
+    requireProperty(record, "engine", `${path}/engine`),
+    `${path}/engine`,
+  );
+  const orderBands = requireProperty(
+    record,
+    "order_bands",
+    `${path}/order_bands`,
+  );
+  if (orderBands !== null) {
+    const bands = requireArray(orderBands, `${path}/order_bands`);
+    for (let index = 0; index < bands.length; index += 1) {
+      validateOrderBand(bands[index], `${path}/order_bands/${index}`);
+    }
+  }
+  return value as WsRotationalSpeeds;
+}
+
+function validateSpectrumSeries(
+  value: unknown,
+  path: string,
+): WsSpectrumSeries {
+  const record = requireRecord(value, path);
+  if ("freq" in record && record.freq !== undefined) {
+    validateNumberArray(record.freq, `${path}/freq`);
+  }
+  if (
+    "combined_spectrum_amp_g" in record &&
+    record.combined_spectrum_amp_g !== undefined
+  ) {
+    validateNumberArray(
+      record.combined_spectrum_amp_g,
+      `${path}/combined_spectrum_amp_g`,
+    );
+  }
+  if ("strength_metrics" in record && record.strength_metrics !== undefined) {
+    validateStrengthMetrics(
+      record.strength_metrics,
+      `${path}/strength_metrics`,
+    );
+  }
+  return value as WsSpectrumSeries;
+}
+
+function validateSpectra(value: unknown, path: string): WsSpectraPayload {
+  const record = requireRecord(value, path);
+  if ("freq" in record && record.freq !== undefined) {
+    validateNumberArray(record.freq, `${path}/freq`);
+  }
+  if ("clients" in record && record.clients !== undefined) {
+    const clients = requireRecord(record.clients, `${path}/clients`);
+    for (const [clientId, series] of Object.entries(clients)) {
+      validateSpectrumSeries(series, `${path}/clients/${clientId}`);
+    }
+  }
+  if ("warning" in record && record.warning !== undefined) {
+    const warning = requireRecord(record.warning, `${path}/warning`);
+    requireString(
+      requireProperty(warning, "code", `${path}/warning/code`),
+      `${path}/warning/code`,
+    );
+    requireString(
+      requireProperty(warning, "message", `${path}/warning/message`),
+      `${path}/warning/message`,
+    );
+    validateStringArray(
+      requireProperty(warning, "client_ids", `${path}/warning/client_ids`),
+      `${path}/warning/client_ids`,
+    );
+  }
+  if ("alignment" in record && record.alignment !== undefined) {
+    const alignment = requireRecord(record.alignment, `${path}/alignment`);
+    requireBoolean(
+      requireProperty(alignment, "aligned", `${path}/alignment/aligned`),
+      `${path}/alignment/aligned`,
+    );
+    requireBoolean(
+      requireProperty(
+        alignment,
+        "clock_synced",
+        `${path}/alignment/clock_synced`,
+      ),
+      `${path}/alignment/clock_synced`,
+    );
+    requireFiniteNumber(
+      requireProperty(
+        alignment,
+        "overlap_ratio",
+        `${path}/alignment/overlap_ratio`,
+      ),
+      `${path}/alignment/overlap_ratio`,
+    );
+    requireInteger(
+      requireProperty(
+        alignment,
+        "sensor_count",
+        `${path}/alignment/sensor_count`,
+      ),
+      `${path}/alignment/sensor_count`,
+    );
+    requireFiniteNumber(
+      requireProperty(
+        alignment,
+        "shared_window_s",
+        `${path}/alignment/shared_window_s`,
+      ),
+      `${path}/alignment/shared_window_s`,
+    );
+  }
+  return value as WsSpectraPayload;
 }
 
 export function validateLiveWsPayload(payload: unknown): LiveWsPayload {
-  if (liveWsPayloadValidator(payload)) {
-    return payload;
+  const record = requireRecord(payload, "/");
+  requireString(
+    requireProperty(record, "schema_version", "/schema_version"),
+    "/schema_version",
+  );
+  requireString(
+    requireProperty(record, "server_time", "/server_time"),
+    "/server_time",
+  );
+  requireNullableNumber(
+    requireProperty(record, "speed_mps", "/speed_mps"),
+    "/speed_mps",
+  );
+  const clients = requireArray(
+    requireProperty(record, "clients", "/clients"),
+    "/clients",
+  );
+  for (let index = 0; index < clients.length; index += 1) {
+    validateWsClient(clients[index], `/clients/${index}`);
   }
-  throw new Error(`Invalid websocket payload: ${formatValidationErrorSummary(liveWsPayloadValidator.errors)}`);
+  requireNullableString(
+    requireProperty(record, "selected_client_id", "/selected_client_id"),
+    "/selected_client_id",
+  );
+  const rotationalSpeeds = requireProperty(
+    record,
+    "rotational_speeds",
+    "/rotational_speeds",
+  );
+  if (rotationalSpeeds !== null) {
+    validateRotationalSpeeds(rotationalSpeeds, "/rotational_speeds");
+  }
+  if ("spectra" in record && record.spectra !== undefined) {
+    validateSpectra(record.spectra, "/spectra");
+  }
+  return payload as LiveWsPayload;
 }

--- a/apps/ui/tests/ws_contract.spec.ts
+++ b/apps/ui/tests/ws_contract.spec.ts
@@ -10,7 +10,10 @@
 
 import { expect, test } from "@playwright/test";
 import { adaptServerPayload } from "../src/server_payload";
-import { EXPECTED_SCHEMA_VERSION, type StrengthMetricsPayload } from "../src/contracts/ws_payload_types";
+import {
+  EXPECTED_SCHEMA_VERSION,
+  type StrengthMetricsPayload,
+} from "../src/contracts/ws_payload_types";
 
 function makeStrengthMetrics(
   overrides: Partial<StrengthMetricsPayload> = {},
@@ -35,7 +38,9 @@ const basePayload = {
 };
 
 function expectInvalidPayload(payload: unknown): void {
-  expect(() => adaptServerPayload(payload)).toThrow(/Invalid websocket payload/);
+  expect(() => adaptServerPayload(payload)).toThrow(
+    /Invalid websocket payload/,
+  );
 }
 
 function requireSpectra(adapted: ReturnType<typeof adaptServerPayload>) {
@@ -67,7 +72,7 @@ test.describe("schema_version handling", () => {
     expect(adapted).toBeDefined();
   });
 
-  test("rejects invalid field types via AJV validation", () => {
+  test("rejects invalid field types via runtime validation", () => {
     expectInvalidPayload({
       ...basePayload,
       speed_mps: "10",
@@ -106,7 +111,9 @@ test.describe("shared freq optimization", () => {
         clients: {
           sensor1: {
             combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-            strength_metrics: makeStrengthMetrics({ vibration_strength_db: 12 }),
+            strength_metrics: makeStrengthMetrics({
+              vibration_strength_db: 12,
+            }),
           },
           sensor2: {
             combined_spectrum_amp_g: [0.04, 0.05, 0.06],
@@ -132,7 +139,9 @@ test.describe("shared freq optimization", () => {
           sensor1: {
             freq: [15, 25, 35],
             combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-            strength_metrics: makeStrengthMetrics({ vibration_strength_db: 12 }),
+            strength_metrics: makeStrengthMetrics({
+              vibration_strength_db: 12,
+            }),
           },
         },
       },
@@ -151,7 +160,9 @@ test.describe("shared freq optimization", () => {
           sensor1: {
             freq: [10, 20, 30],
             combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-            strength_metrics: makeStrengthMetrics({ vibration_strength_db: 12 }),
+            strength_metrics: makeStrengthMetrics({
+              vibration_strength_db: 12,
+            }),
           },
         },
       },
@@ -168,7 +179,9 @@ test.describe("shared freq optimization", () => {
         clients: {
           sensor1: {
             combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-            strength_metrics: makeStrengthMetrics({ vibration_strength_db: 12 }),
+            strength_metrics: makeStrengthMetrics({
+              vibration_strength_db: 12,
+            }),
           },
         },
       },
@@ -186,7 +199,9 @@ test.describe("shared freq optimization", () => {
           sensor1: {
             freq: [10, "bad", 30],
             combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-            strength_metrics: makeStrengthMetrics({ vibration_strength_db: 12 }),
+            strength_metrics: makeStrengthMetrics({
+              vibration_strength_db: 12,
+            }),
           },
         },
       },
@@ -201,7 +216,9 @@ test.describe("shared freq optimization", () => {
           sensor1: {
             freq: [10, 20],
             combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-            strength_metrics: makeStrengthMetrics({ vibration_strength_db: 12 }),
+            strength_metrics: makeStrengthMetrics({
+              vibration_strength_db: 12,
+            }),
           },
         },
       },
@@ -218,7 +235,9 @@ test.describe("shared freq optimization", () => {
         clients: {
           sensor1: {
             combined_spectrum_amp_g: [0.01, 0.02, 0.03],
-            strength_metrics: makeStrengthMetrics({ vibration_strength_db: 12 }),
+            strength_metrics: makeStrengthMetrics({
+              vibration_strength_db: 12,
+            }),
           },
           sensor2: {
             freq: [15, 25, 35],
@@ -249,7 +268,12 @@ test.describe("shared freq optimization", () => {
               noise_floor_amp_g: 0.01,
               strength_bucket: null,
               top_peaks: [
-                { hz: 10, amp: 0.1, vibration_strength_db: 12, strength_bucket: "l2" },
+                {
+                  hz: 10,
+                  amp: 0.1,
+                  vibration_strength_db: 12,
+                  strength_bucket: "l2",
+                },
                 { hz: 20, amp: 0.2 },
               ],
             },
@@ -278,9 +302,7 @@ test.describe("shared freq optimization", () => {
       wheel: { rpm: 738, mode: "calculated", reason: null },
       driveshaft: { rpm: 1476, mode: "calculated", reason: null },
       engine: { rpm: 2208, mode: "calculated", reason: null },
-      order_bands: [
-        { key: "wheel_1x", center_hz: 12.3, tolerance: 0.08 },
-      ],
+      order_bands: [{ key: "wheel_1x", center_hz: 12.3, tolerance: 0.08 }],
     };
 
     const adapted = adaptServerPayload({


### PR DESCRIPTION
## Summary
- replace the Ajv-based websocket payload validator with a hand-written runtime validator
- keep explicit checks for required top-level fields, client rows, rotational speeds, spectra arrays, strength metrics, and peak rows
- drop `ajv` from the UI runtime deps

## Why
- Ajv only guarded this one hot websocket path
- accepted payloads must keep original object refs for the downstream hot path
- build comparison: `origin/main` vendor chunk `149.66 kB` / `46.03 kB` gzip -> this branch `26.93 kB` / `10.22 kB` gzip

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ws_contract.spec.ts tests/ws.spec.ts tests/ui_live_payload_application.spec.ts tests/spectrum_canvas_renderer.spec.ts`

## Risks / tradeoffs
- validator is narrower than full JSON Schema coverage
- kept strict checks for the shapes the UI actually consumes; optional unused fields stay permissive
- existing contract tests still lock the rejection cases we care about

Closes #2697