### PR TITLE
refactor(ui): unify deferred panel replay

### DIFF
--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -7,7 +7,7 @@ import {
   type UiMountedLazyPanelHandles,
   type UiMountedPanels,
 } from "./ui_panel_bootstrap";
-import { effect, signal } from "./ui_signals";
+import { effect, signal, type ReadonlySignal } from "./ui_signals";
 import type {
   AnalysisPanelActionHandlers,
   AnalysisPanelCarAvailability,
@@ -70,8 +70,13 @@ export interface UiLazyPanels {
 
 export interface CreateUiLazyPanelsDeps {
   hosts: UiPanelHostRegistry;
-  mountDashboardPanels?: (hosts: UiPanelHostRegistry) => UiMountedDashboardPanels;
-  loadHistoryPanel?: (hosts: UiPanelHostRegistry, view: HistoryPanelView) => Promise<void>;
+  mountDashboardPanels?: (
+    hosts: UiPanelHostRegistry,
+  ) => UiMountedDashboardPanels;
+  loadHistoryPanel?: (
+    hosts: UiPanelHostRegistry,
+    view: HistoryPanelView,
+  ) => Promise<void>;
   loadSettingsPanels?: (
     hosts: UiPanelHostRegistry,
     panels: Pick<UiMountedPanels, "settings">,
@@ -87,6 +92,56 @@ function scheduleDeferredWork(task: () => void): void {
     return;
   }
   setTimeout(task, 0);
+}
+
+function createDeferredTargetAction<TView, TTarget>(
+  realView: ReadonlySignal<TView | null>,
+  run: (view: TView, target: TTarget) => void,
+): (target: TTarget) => void {
+  const pendingTarget = signal<TTarget | null>(null);
+  effect(() => {
+    const view = realView.value;
+    const target = pendingTarget.value;
+    if (view === null || target === null) {
+      return;
+    }
+    run(view, target);
+    pendingTarget.value = null;
+  });
+  return (target) => {
+    pendingTarget.value = target;
+  };
+}
+
+function createDeferredAction<TView>(
+  realView: ReadonlySignal<TView | null>,
+  run: (view: TView) => void,
+): () => void {
+  const pending = signal(false);
+  effect(() => {
+    const view = realView.value;
+    if (view === null || !pending.value) {
+      return;
+    }
+    run(view);
+    pending.value = false;
+  });
+  return () => {
+    pending.value = true;
+  };
+}
+
+function createDeferredViewAttachment<TView>(): {
+  attach(nextRealView: TView): void;
+  realView: ReadonlySignal<TView | null>;
+} {
+  const realView = signal<TView | null>(null);
+  return {
+    attach(nextRealView) {
+      realView.value = nextRealView;
+    },
+    realView,
+  };
 }
 
 function createDeferredSettingsShellView(): {
@@ -122,24 +177,26 @@ function createDeferredCarsPanelView(): {
   view: CarsPanelView;
 } {
   type CarsWizardFocusTarget = Parameters<CarsPanelView["wizard"]["focus"]>[0];
+  const realWizard =
+    createDeferredViewAttachment<Pick<CarsPanelView["wizard"], "focus">>();
   const list = createModelActionPanelBindings<
     CarsListRenderModel,
-    { onAction(action: import("./views/settings_car_list_view").CarsListAction): void }
+    {
+      onAction(
+        action: import("./views/settings_car_list_view").CarsListAction,
+      ): void;
+    }
   >();
   const wizard = createModelActionPanelBindings<
     import("./views/car_wizard_view").CarsWizardRenderModel,
     CarsFeatureInteractionHandlers
   >();
-  const realWizard = signal<Pick<CarsPanelView["wizard"], "focus"> | null>(null);
-  const wizardFocusTarget = signal<CarsWizardFocusTarget | null>(null);
-  effect(() => {
-    const view = realWizard.value;
-    const target = wizardFocusTarget.value;
-    if (view !== null && target !== null) {
+  const requestWizardFocus = createDeferredTargetAction(
+    realWizard.realView,
+    (view, target: CarsWizardFocusTarget) => {
       view.focus(target);
-      wizardFocusTarget.value = null;
-    }
-  });
+    },
+  );
 
   return {
     view: {
@@ -148,55 +205,52 @@ function createDeferredCarsPanelView(): {
         actions: wizard.actions,
         model: wizard.model,
         focus(target) {
-          wizardFocusTarget.value = target;
+          requestWizardFocus(target);
         },
       },
     },
-    attach(nextRealView) {
-      realWizard.value = nextRealView;
-    },
+    attach: realWizard.attach,
   };
 }
 
 function createDeferredAnalysisPanelView(): {
-  attach(realView: Pick<AnalysisPanelView, "focusField" | "openGuidance">): void;
+  attach(
+    realView: Pick<AnalysisPanelView, "focusField" | "openGuidance">,
+  ): void;
   view: AnalysisPanelView;
 } {
   type AnalysisFocusField = Parameters<AnalysisPanelView["focusField"]>[0];
-  const realView = signal<Pick<AnalysisPanelView, "focusField" | "openGuidance"> | null>(null);
-  const focusField = signal<AnalysisFocusField | null>(null);
-  const guidanceOpenRequested = signal(false);
-  effect(() => {
-    const view = realView.value;
-    if (view === null) {
-      return;
-    }
-    if (guidanceOpenRequested.value) {
+  const realView =
+    createDeferredViewAttachment<
+      Pick<AnalysisPanelView, "focusField" | "openGuidance">
+    >();
+  const requestGuidanceOpen = createDeferredAction(
+    realView.realView,
+    (view) => {
       view.openGuidance();
-      guidanceOpenRequested.value = false;
-    }
-    const nextFocusField = focusField.value;
-    if (nextFocusField !== null) {
+    },
+  );
+  const requestFocusField = createDeferredTargetAction(
+    realView.realView,
+    (view, nextFocusField: AnalysisFocusField) => {
       view.focusField(nextFocusField);
-      focusField.value = null;
-    }
-  });
+    },
+  );
 
   return {
     view: {
       actions: signal<AnalysisPanelActionHandlers | null>(null),
-      carAvailability: createDeferredModelSignal<AnalysisPanelCarAvailability>(),
+      carAvailability:
+        createDeferredModelSignal<AnalysisPanelCarAvailability>(),
       model: createDeferredModelSignal<AnalysisPanelRenderModel>(),
       openGuidance() {
-        guidanceOpenRequested.value = true;
+        requestGuidanceOpen();
       },
       focusField(nextFocusField) {
-        focusField.value = nextFocusField;
+        requestFocusField(nextFocusField);
       },
     },
-    attach(nextRealView) {
-      realView.value = nextRealView;
-    },
+    attach: realView.attach,
   };
 }
 
@@ -210,49 +264,49 @@ function createDeferredSpeedSourcePanelView(): {
   view: SpeedSourcePanelView;
 } {
   type PendingFocusTarget = "manual" | "scan" | "stale";
-  const realView = signal<Pick<
-    SpeedSourcePanelView,
-    "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput"
-  > | null>(null);
+  const realView =
+    createDeferredViewAttachment<
+      Pick<
+        SpeedSourcePanelView,
+        | "focusManualSpeedInput"
+        | "focusScanObdDevices"
+        | "focusStaleTimeoutInput"
+      >
+    >();
   const model = createDeferredModelSignal<SpeedSourcePanelRenderModel>();
-  const pendingFocusTarget = signal<PendingFocusTarget | null>(null);
-  effect(() => {
-    const view = realView.value;
-    const target = pendingFocusTarget.value;
-    if (view === null || target === null) {
-      return;
-    }
-    if (target === "manual") {
-      view.focusManualSpeedInput();
-    } else if (target === "scan") {
-      view.focusScanObdDevices();
-    } else {
-      view.focusStaleTimeoutInput();
-    }
-    pendingFocusTarget.value = null;
-  });
+  const requestFocusTarget = createDeferredTargetAction(
+    realView.realView,
+    (view, target: PendingFocusTarget) => {
+      if (target === "manual") {
+        view.focusManualSpeedInput();
+      } else if (target === "scan") {
+        view.focusScanObdDevices();
+      } else {
+        view.focusStaleTimeoutInput();
+      }
+    },
+  );
 
   return {
     view: {
       actions: signal<SpeedSourcePanelActionHandlers | null>(null),
-      diagnostics: createDeferredModelSignal<SpeedSourceDiagnosticsRenderModel>(),
+      diagnostics:
+        createDeferredModelSignal<SpeedSourceDiagnosticsRenderModel>(),
       model,
       isObdConfigVisible() {
         return model.value?.value.obdConfigVisible ?? false;
       },
       focusManualSpeedInput() {
-        pendingFocusTarget.value = "manual";
+        requestFocusTarget("manual");
       },
       focusScanObdDevices() {
-        pendingFocusTarget.value = "scan";
+        requestFocusTarget("scan");
       },
       focusStaleTimeoutInput() {
-        pendingFocusTarget.value = "stale";
+        requestFocusTarget("stale");
       },
     },
-    attach(nextRealView) {
-      realView.value = nextRealView;
-    },
+    attach: realView.attach,
   };
 }
 
@@ -260,14 +314,10 @@ function createDeferredInternetPanelView(): {
   attach(realView: Pick<InternetPanelView, "focusSsidInput">): void;
   view: InternetPanelView;
 } {
-  const realView = signal<Pick<InternetPanelView, "focusSsidInput"> | null>(null);
-  const focusSsidRequested = signal(false);
-  effect(() => {
-    const view = realView.value;
-    if (view !== null && focusSsidRequested.value) {
-      view.focusSsidInput();
-      focusSsidRequested.value = false;
-    }
+  const realView =
+    createDeferredViewAttachment<Pick<InternetPanelView, "focusSsidInput">>();
+  const requestSsidFocus = createDeferredAction(realView.realView, (view) => {
+    view.focusSsidInput();
   });
 
   return {
@@ -275,12 +325,10 @@ function createDeferredInternetPanelView(): {
       actions: signal<InternetPanelActionHandlers | null>(null),
       model: createDeferredModelSignal<InternetPanelRenderModel>(),
       focusSsidInput() {
-        focusSsidRequested.value = true;
+        requestSsidFocus();
       },
     },
-    attach(nextRealView) {
-      realView.value = nextRealView;
-    },
+    attach: realView.attach,
   };
 }
 
@@ -321,7 +369,9 @@ export function createLazyUiPanels(deps: CreateUiLazyPanelsDeps): UiLazyPanels {
   let historyMountPromise: Promise<void> | null = null;
   let settingsMountPromise: Promise<void> | null = null;
 
-  const attachSettingsPanels = (mountedPanels: UiMountedLazyPanelHandles): void => {
+  const attachSettingsPanels = (
+    mountedPanels: UiMountedLazyPanelHandles,
+  ): void => {
     settingsShell.attach(mountedPanels.settingsShell);
     settings.cars.attach(mountedPanels.settings.cars);
     settings.analysis.attach(mountedPanels.settings.analysis);
@@ -331,29 +381,31 @@ export function createLazyUiPanels(deps: CreateUiLazyPanelsDeps): UiLazyPanels {
 
   const ensureHistoryMounted = (): Promise<void> => {
     if (historyMountPromise === null) {
-      historyMountPromise = (deps.loadHistoryPanel ?? mountHistoryPanelLazy)(hosts, history.view);
+      historyMountPromise = (deps.loadHistoryPanel ?? mountHistoryPanelLazy)(
+        hosts,
+        history.view,
+      );
     }
     return historyMountPromise;
   };
 
   const ensureSettingsMounted = (): Promise<void> => {
     if (settingsMountPromise === null) {
-        settingsMountPromise = (deps.loadSettingsPanels ?? mountSettingsPanelsLazy)(
-          hosts,
-          {
-            settings: {
-              analysis: settings.analysis.view,
-              cars: settings.cars.view,
-              espFlash: settings.espFlash.view,
-              internet: settings.internet.view,
-              sensors: settings.sensors.view,
-              speedSource: settings.speedSource.view,
-              update: settings.update.view,
-            },
-          },
-        ).then((mountedPanels) => {
-          attachSettingsPanels(mountedPanels);
-        });
+      settingsMountPromise = (
+        deps.loadSettingsPanels ?? mountSettingsPanelsLazy
+      )(hosts, {
+        settings: {
+          analysis: settings.analysis.view,
+          cars: settings.cars.view,
+          espFlash: settings.espFlash.view,
+          internet: settings.internet.view,
+          sensors: settings.sensors.view,
+          speedSource: settings.speedSource.view,
+          update: settings.update.view,
+        },
+      }).then((mountedPanels) => {
+        attachSettingsPanels(mountedPanels);
+      });
     }
     return settingsMountPromise;
   };

--- a/apps/ui/tests/ui_lazy_panels.spec.ts
+++ b/apps/ui/tests/ui_lazy_panels.spec.ts
@@ -4,6 +4,8 @@ import { createLazyUiPanels } from "../src/app/ui_lazy_panels";
 import type { UiMountedDashboardPanels } from "../src/app/ui_panel_bootstrap";
 import type { UiPanelHostRegistry } from "../src/app/ui_panel_host_registry";
 import { signal } from "../src/app/ui_signals";
+import type { AnalysisPanelView } from "../src/app/views/analysis_panel";
+import type { CarsPanelView } from "../src/app/views/cars_panel";
 import type { HistoryPanelView } from "../src/app/views/history_table_view";
 import type { InternetPanelView } from "../src/app/views/internet_panel";
 import type { SettingsShellView } from "../src/app/views/settings_shell";
@@ -79,6 +81,40 @@ function createSettingsShellSpy() {
   };
 }
 
+function createAnalysisPanelSpy() {
+  const focusFields: Array<Parameters<AnalysisPanelView["focusField"]>[0]> = [];
+  let guidanceOpens = 0;
+
+  return {
+    focusFields,
+    get guidanceOpens() {
+      return guidanceOpens;
+    },
+    handle: {
+      focusField(field) {
+        focusFields.push(field);
+      },
+      openGuidance() {
+        guidanceOpens += 1;
+      },
+    } satisfies Pick<AnalysisPanelView, "focusField" | "openGuidance">,
+  };
+}
+
+function createCarsPanelSpy() {
+  const focusTargets: Array<Parameters<CarsPanelView["wizard"]["focus"]>[0]> =
+    [];
+
+  return {
+    focusTargets,
+    handle: {
+      focus(target) {
+        focusTargets.push(target);
+      },
+    } satisfies Pick<CarsPanelView["wizard"], "focus">,
+  };
+}
+
 function createInternetPanelSpy() {
   type InternetActions = NonNullable<InternetPanelView["actions"]["value"]>;
   type InternetModel = NonNullable<InternetPanelView["model"]["value"]>;
@@ -110,8 +146,12 @@ function createInternetPanelSpy() {
 }
 
 function createSpeedSourcePanelSpy() {
-  type SpeedSourceActions = NonNullable<SpeedSourcePanelView["actions"]["value"]>;
-  type SpeedSourceDiagnostics = NonNullable<SpeedSourcePanelView["diagnostics"]["value"]>;
+  type SpeedSourceActions = NonNullable<
+    SpeedSourcePanelView["actions"]["value"]
+  >;
+  type SpeedSourceDiagnostics = NonNullable<
+    SpeedSourcePanelView["diagnostics"]["value"]
+  >;
   type SpeedSourceModel = NonNullable<SpeedSourcePanelView["model"]["value"]>;
 
   const actions: SpeedSourceActions[] = [];
@@ -164,7 +204,10 @@ function createSpeedSourcePanelSpy() {
         },
       } satisfies Pick<
         SpeedSourcePanelView,
-        "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput" | "isObdConfigVisible"
+        | "focusManualSpeedInput"
+        | "focusScanObdDevices"
+        | "focusStaleTimeoutInput"
+        | "isObdConfigVisible"
       >;
     },
   };
@@ -173,6 +216,8 @@ function createSpeedSourcePanelSpy() {
 test.describe("createLazyUiPanels", () => {
   test("mounts dashboard immediately and replays deferred history/settings bindings", async () => {
     const hosts = createFakeHosts();
+    const analysisPanel = createAnalysisPanelSpy();
+    const carsPanel = createCarsPanelSpy();
     const historyPanel = createHistoryPanelSpy();
     const internetPanel = createInternetPanelSpy();
     const settingsShell = createSettingsShellSpy();
@@ -197,13 +242,8 @@ test.describe("createLazyUiPanels", () => {
         return {
           settingsShell: settingsShell.view,
           settings: {
-            analysis: {
-              focusField() {},
-              openGuidance() {},
-            },
-            cars: {
-              focus() {},
-            },
+            analysis: analysisPanel.handle,
+            cars: carsPanel.handle,
             internet: internetPanel.handle,
             speedSource: speedSourcePanel.mount(panels.settings.speedSource),
           },
@@ -215,8 +255,12 @@ test.describe("createLazyUiPanels", () => {
     expect(historyLoads).toBe(0);
     expect(settingsLoads).toBe(0);
 
-    const historyActions = {} as NonNullable<HistoryPanelView["actions"]["value"]>;
-    const historyModel = signal({}) as unknown as NonNullable<HistoryPanelView["model"]["value"]>;
+    const historyActions = {} as NonNullable<
+      HistoryPanelView["actions"]["value"]
+    >;
+    const historyModel = signal({}) as unknown as NonNullable<
+      HistoryPanelView["model"]["value"]
+    >;
     lazyPanels.panels.history.model.value = historyModel;
     lazyPanels.panels.history.actions.value = historyActions;
 
@@ -224,9 +268,15 @@ test.describe("createLazyUiPanels", () => {
     lazyPanels.panels.settingsShell.activateTab("updateTab");
     expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("updateTab");
 
-    const internetActions = {} as NonNullable<InternetPanelView["actions"]["value"]>;
-    const internetModel = signal({}) as unknown as NonNullable<InternetPanelView["model"]["value"]>;
-    const speedSourceActions = {} as NonNullable<SpeedSourcePanelView["actions"]["value"]>;
+    const internetActions = {} as NonNullable<
+      InternetPanelView["actions"]["value"]
+    >;
+    const internetModel = signal({}) as unknown as NonNullable<
+      InternetPanelView["model"]["value"]
+    >;
+    const speedSourceActions = {} as NonNullable<
+      SpeedSourcePanelView["actions"]["value"]
+    >;
     const speedSourceDiagnostics = signal({}) as unknown as NonNullable<
       SpeedSourcePanelView["diagnostics"]["value"]
     >;
@@ -236,12 +286,19 @@ test.describe("createLazyUiPanels", () => {
     lazyPanels.panels.settings.internet.model.value = internetModel;
     lazyPanels.panels.settings.internet.actions.value = internetActions;
     lazyPanels.panels.settings.internet.focusSsidInput();
+    lazyPanels.panels.settings.analysis.openGuidance();
+    lazyPanels.panels.settings.analysis.focusField("wheel_bandwidth_pct");
+    lazyPanels.panels.settings.cars.wizard.focus("finish");
     lazyPanels.panels.settings.speedSource.model.value = speedSourceModel;
     lazyPanels.panels.settings.speedSource.actions.value = speedSourceActions;
-    lazyPanels.panels.settings.speedSource.diagnostics.value = speedSourceDiagnostics;
+    lazyPanels.panels.settings.speedSource.diagnostics.value =
+      speedSourceDiagnostics;
     lazyPanels.panels.settings.speedSource.focusManualSpeedInput();
-    expect(lazyPanels.panels.settings.speedSource.isObdConfigVisible()).toBe(true);
-    const readSpeedSourceVisibility = lazyPanels.panels.settings.speedSource.isObdConfigVisible;
+    expect(lazyPanels.panels.settings.speedSource.isObdConfigVisible()).toBe(
+      true,
+    );
+    const readSpeedSourceVisibility =
+      lazyPanels.panels.settings.speedSource.isObdConfigVisible;
     expect(readSpeedSourceVisibility()).toBe(true);
 
     await lazyPanels.ensureViewPanels("historyView");
@@ -252,6 +309,9 @@ test.describe("createLazyUiPanels", () => {
     await lazyPanels.ensureViewPanels("settingsView");
     expect(settingsLoads).toBe(1);
     expect(settingsShell.activations).toEqual(["updateTab"]);
+    expect(analysisPanel.guidanceOpens).toBe(1);
+    expect(analysisPanel.focusFields).toEqual(["wheel_bandwidth_pct"]);
+    expect(carsPanel.focusTargets).toEqual(["finish"]);
     expect(internetPanel.models).toEqual([internetModel]);
     expect(internetPanel.actions).toEqual([internetActions]);
     expect(internetPanel.focusCalls).toBe(1);
@@ -259,17 +319,30 @@ test.describe("createLazyUiPanels", () => {
     expect(speedSourcePanel.actions).toEqual([speedSourceActions]);
     expect(speedSourcePanel.diagnostics).toEqual([speedSourceDiagnostics]);
     expect(speedSourcePanel.focusManualCalls).toBe(1);
-    expect(lazyPanels.panels.settings.speedSource.isObdConfigVisible()).toBe(true);
+    expect(lazyPanels.panels.settings.speedSource.isObdConfigVisible()).toBe(
+      true,
+    );
     expect(readSpeedSourceVisibility()).toBe(true);
     expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("updateTab");
 
     lazyPanels.panels.settings.speedSource.focusScanObdDevices();
     lazyPanels.panels.settings.speedSource.focusStaleTimeoutInput();
+    lazyPanels.panels.settings.analysis.openGuidance();
+    lazyPanels.panels.settings.analysis.focusField("speed_uncertainty_pct");
+    lazyPanels.panels.settings.cars.wizard.focus("close");
+    expect(analysisPanel.guidanceOpens).toBe(2);
+    expect(analysisPanel.focusFields).toEqual([
+      "wheel_bandwidth_pct",
+      "speed_uncertainty_pct",
+    ]);
+    expect(carsPanel.focusTargets).toEqual(["finish", "close"]);
     expect(speedSourcePanel.focusScanCalls).toBe(1);
     expect(speedSourcePanel.focusStaleCalls).toBe(1);
 
     settingsShell.emit("internetTab");
-    expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("internetTab");
+    expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe(
+      "internetTab",
+    );
 
     await lazyPanels.ensureViewPanels("historyView");
     await lazyPanels.ensureViewPanels("settingsView");


### PR DESCRIPTION
## Summary
- extract shared helpers in `ui_lazy_panels.ts` for attached-view storage, no-arg replay, and target-arg replay
- rewire the cars, analysis, speed-source, and internet deferred panel factories onto those helpers
- keep the settings-shell tab sync path bespoke
- add regression coverage for cars and analysis deferred replay before and after attach

## Why
- four deferred panel factories were repeating the same attach-plus-replay effect pattern
- the shared helper removes that duplication without changing the existing panel view contracts
- settings shell still owns extra tab-state sync, so forcing it through the same helper would be noise

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ui_lazy_panels.spec.ts`

## Risks / tradeoffs
- the helper preserves the existing collapse semantics: repeated pending requests still coalesce to the latest request before attach
- kept the helper local to `ui_lazy_panels.ts` until a second consumer exists outside this module

Closes #2698