### PR TITLE
refactor(ui): tighten sensor legend signals

### DIFF
--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -41,6 +41,7 @@ const DEFAULT_SPECTRUM_BAND_LEGEND_MODEL: SpectrumBandLegendModel = {
   items: [],
   emptyText: "No reference band",
 };
+const EMPTY_SPECTRUM_SENSOR_LEGEND_ITEMS: SpectrumSensorLegendModel["items"] = [];
 type SpectrumCssVariableStyle = JSX.CSSProperties & {
   "--band-color"?: string;
   "--swatch-color"?: string;
@@ -115,52 +116,74 @@ const SpectrumSensorLegend = memo(function SpectrumSensorLegend(props: {
 }) {
   const hasLegend = useComputed(() => {
     const legend = props.sensorLegend.value;
-    return legend !== null && legend.items.length > 0 && props.sensorLegendHandlers.value !== null;
+    return (
+      legend !== null
+      && legend.items.length > 0
+      && props.sensorLegendHandlers.value !== null
+    );
   });
-  if (!hasLegend.value) {
-    return null;
-  }
-
-  const sensorLegend = props.sensorLegend.value;
-  const sensorLegendHandlers = props.sensorLegendHandlers.value;
-  if (sensorLegend === null || sensorLegendHandlers === null) {
-    return null;
-  }
 
   return (
-    <>
-      <button
-        type="button"
-        class="legend-item legend-item--interactive legend-item--reset"
-        aria-pressed={sensorLegend.reset.ariaPressed ? "true" : "false"}
-        title={sensorLegend.reset.titleText}
-        aria-label={sensorLegend.reset.ariaLabel}
-        data-legend-state={sensorLegend.reset.active ? "active" : undefined}
-        onClick={() => sensorLegendHandlers.onReset()}
-      >
-        <span class="legend-item__label">{sensorLegend.reset.labelText}</span>
-      </button>
-      {sensorLegend.items.map((item) => (
-        <button
-          key={item.id}
-          type="button"
-          class="legend-item legend-item--interactive"
-          aria-pressed={item.ariaPressed ? "true" : "false"}
-          title={item.titleText}
-          aria-label={item.ariaLabel}
-          data-legend-state={item.active ? "active" : item.muted ? "muted" : undefined}
-          onClick={() => sensorLegendHandlers.onSelect(item.id)}
-        >
-          <span class="swatch" style={swatchColorStyle(item.color)} />
-          <span class="legend-item__text-group">
-            <span class="legend-item__label">{item.labelText}</span>
-            {item.detailText
-              ? <span class="legend-item__meta">{item.detailText}</span>
-              : null}
-          </span>
-        </button>
-      ))}
-    </>
+    hasLegend.value
+      ? (
+        <SpectrumSensorLegendContent
+          sensorLegend={props.sensorLegend}
+          sensorLegendHandlers={props.sensorLegendHandlers}
+        />
+      )
+      : null
+  );
+});
+
+const SpectrumSensorLegendContent = memo(function SpectrumSensorLegendContent(
+  props: {
+    sensorLegend: ReadonlySignal<SpectrumSensorLegendModel | null>;
+    sensorLegendHandlers: ReadonlySignal<SpectrumLegendHandlers | null>;
+  },
+) {
+  const items = useComputed(
+    () => props.sensorLegend.value?.items ?? EMPTY_SPECTRUM_SENSOR_LEGEND_ITEMS,
+  );
+  const reset = useComputed(() => props.sensorLegend.value?.reset ?? null);
+
+  return (
+    reset.value !== null && props.sensorLegendHandlers.value !== null
+      ? (
+        <>
+          <button
+            type="button"
+            class="legend-item legend-item--interactive legend-item--reset"
+            aria-pressed={reset.value.ariaPressed ? "true" : "false"}
+            title={reset.value.titleText}
+            aria-label={reset.value.ariaLabel}
+            data-legend-state={reset.value.active ? "active" : undefined}
+            onClick={() => props.sensorLegendHandlers.peek()?.onReset()}
+          >
+            <span class="legend-item__label">{reset.value.labelText}</span>
+          </button>
+          {items.value.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              class="legend-item legend-item--interactive"
+              aria-pressed={item.ariaPressed ? "true" : "false"}
+              title={item.titleText}
+              aria-label={item.ariaLabel}
+              data-legend-state={item.active ? "active" : item.muted ? "muted" : undefined}
+              onClick={() => props.sensorLegendHandlers.peek()?.onSelect(item.id)}
+            >
+              <span class="swatch" style={swatchColorStyle(item.color)} />
+              <span class="legend-item__text-group">
+                <span class="legend-item__label">{item.labelText}</span>
+                {item.detailText
+                  ? <span class="legend-item__meta">{item.detailText}</span>
+                  : null}
+              </span>
+            </button>
+          ))}
+        </>
+      )
+      : null
   );
 });
 

--- a/apps/ui/tests/spectrum_panel_signals.ts
+++ b/apps/ui/tests/spectrum_panel_signals.ts
@@ -11,7 +11,10 @@ import type {
 } from "../src/app/runtime/spectrum_panel_view";
 import { mountSignalView } from "./dom_render_test_support";
 
-function requireElement<T extends Element = HTMLElement>(root: ParentNode, selector: string): T {
+function requireElement<T extends Element = HTMLElement>(
+  root: ParentNode,
+  selector: string,
+): T {
   const element = root.querySelector<T>(selector);
   assert.ok(element, `Expected element matching ${selector}`);
   return element;
@@ -23,134 +26,201 @@ async function runSpectrumPanelSignalProjectionTest(): Promise<void> {
   let bandLegendRenderCount = 0;
   let sensorLegendRenderCount = 0;
   options.diffed = (vnode) => {
-    if (typeof vnode.type === "function" && vnode.type.name === "SpectrumPanel") {
+    if (
+      typeof vnode.type === "function" &&
+      vnode.type.name === "SpectrumPanel"
+    ) {
       spectrumPanelRenderCount += 1;
     }
-    if (typeof vnode.type === "function" && vnode.type.displayName === "Memo(SpectrumBandLegend)") {
+    if (
+      typeof vnode.type === "function" &&
+      vnode.type.displayName === "Memo(SpectrumBandLegend)"
+    ) {
       bandLegendRenderCount += 1;
     }
-    if (typeof vnode.type === "function" && vnode.type.displayName === "Memo(SpectrumSensorLegend)") {
+    if (
+      typeof vnode.type === "function" &&
+      vnode.type.displayName === "Memo(SpectrumSensorLegend)"
+    ) {
       sensorLegendRenderCount += 1;
     }
     previousDiffed?.(vnode);
   };
 
   const harness = await mountSignalView(async () => {
-    const { mountSpectrumPanel } = await import("../src/app/views/spectrum_panel");
+    const { mountSpectrumPanel } = await import(
+      "../src/app/views/spectrum_panel"
+    );
     return mountSpectrumPanel;
   });
 
-    try {
-      await harness.flush();
-      assert.equal(spectrumPanelRenderCount, 1);
+  try {
+    await harness.flush();
+    assert.equal(spectrumPanelRenderCount, 1);
 
-      const bandToggleModel = signal<SpectrumPanelBandToggleModel>({
-        bandsVisible: true,
-        disabled: false,
-        hasBands: true,
-        hidden: false,
-        pressed: "true",
-        text: "Hide reference bands",
-      });
-      harness.view.bindBandToggleModel(bandToggleModel);
-      await harness.flush();
+    const bandToggleModel = signal<SpectrumPanelBandToggleModel>({
+      bandsVisible: true,
+      disabled: false,
+      hasBands: true,
+      hidden: false,
+      pressed: "true",
+      text: "Hide reference bands",
+    });
+    harness.view.bindBandToggleModel(bandToggleModel);
+    await harness.flush();
 
-      const bandToggleBaseline = spectrumPanelRenderCount;
-      assert.equal(requireElement<HTMLButtonElement>(harness.host, "#spectrumBandToggle").textContent, "Hide reference bands");
+    const bandToggleBaseline = spectrumPanelRenderCount;
+    assert.equal(
+      requireElement<HTMLButtonElement>(harness.host, "#spectrumBandToggle")
+        .textContent,
+      "Hide reference bands",
+    );
 
-      const bandLegendModel = signal<SpectrumBandLegendModel>({
-        visible: true,
-        items: [{ color: "#f59e0b", labelText: "Wheel 1x" }],
-        emptyText: "No reference band",
-      });
-      harness.view.bindBandLegendModel(bandLegendModel);
-      await harness.flush();
+    const bandLegendModel = signal<SpectrumBandLegendModel>({
+      visible: true,
+      items: [{ color: "#f59e0b", labelText: "Wheel 1x" }],
+      emptyText: "No reference band",
+    });
+    harness.view.bindBandLegendModel(bandLegendModel);
+    await harness.flush();
 
-      assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
-      assert.equal(bandLegendRenderCount, 1);
-      assert.match(requireElement(harness.host, "#bandLegend").textContent ?? "", /Wheel 1x/);
+    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+    assert.equal(bandLegendRenderCount, 1);
+    assert.match(
+      requireElement(harness.host, "#bandLegend").textContent ?? "",
+      /Wheel 1x/,
+    );
 
-      let resetClicks = 0;
-      const selectedIds: string[] = [];
-      const sensorLegendModel = signal<SpectrumSensorLegendModel | null>({
-        reset: {
-          labelText: "All sensor traces",
-          titleText: "Show all traces",
+    let resetClicks = 0;
+    const selectedIds: string[] = [];
+    const sensorLegendModel = signal<SpectrumSensorLegendModel | null>({
+      reset: {
+        labelText: "All sensor traces",
+        titleText: "Show all traces",
         ariaLabel: "Show all sensor traces",
         ariaPressed: true,
         active: true,
       },
-      items: [{
-        id: "front-left",
-        labelText: "Front Left",
-        color: "#2563eb",
-        detailText: "12.0 dB",
-        titleText: "Focus Front Left",
-        ariaLabel: "Focus Front Left",
-        ariaPressed: false,
-        active: false,
+      items: [
+        {
+          id: "front-left",
+          labelText: "Front Left",
+          color: "#2563eb",
+          detailText: "12.0 dB",
+          titleText: "Focus Front Left",
+          ariaLabel: "Focus Front Left",
+          ariaPressed: false,
+          active: false,
           muted: false,
-        }],
-      });
-      const sensorLegendHandlers = signal<SpectrumLegendHandlers | null>({
-        onReset: () => {
-          resetClicks += 1;
         },
-        onSelect: (entryId) => {
-          selectedIds.push(entryId);
-        },
-      });
-      harness.view.bindSensorLegendModel(sensorLegendModel, sensorLegendHandlers);
-      await harness.flush();
+      ],
+    });
+    const sensorLegendHandlers = signal<SpectrumLegendHandlers | null>({
+      onReset: () => {
+        resetClicks += 1;
+      },
+      onSelect: (entryId) => {
+        selectedIds.push(entryId);
+      },
+    });
+    harness.view.bindSensorLegendModel(sensorLegendModel, sensorLegendHandlers);
+    await harness.flush();
 
-      assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
-      assert.equal(sensorLegendRenderCount, 1);
-      assert.match(requireElement(harness.host, "#legend").textContent ?? "", /Front Left/);
-      assert.match(requireElement(harness.host, "#legend").textContent ?? "", /12.0 dB/);
+    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+    assert.equal(sensorLegendRenderCount, 1);
+    assert.match(
+      requireElement(harness.host, "#legend").textContent ?? "",
+      /Front Left/,
+    );
+    assert.match(
+      requireElement(harness.host, "#legend").textContent ?? "",
+      /12.0 dB/,
+    );
 
-      requireElement<HTMLButtonElement>(harness.host, ".legend-item--reset").click();
-      requireElement<HTMLButtonElement>(harness.host, '[aria-label="Focus Front Left"]').click();
-      assert.equal(resetClicks, 1);
-      assert.deepEqual(selectedIds, ["front-left"]);
+    requireElement<HTMLButtonElement>(
+      harness.host,
+      ".legend-item--reset",
+    ).click();
+    requireElement<HTMLButtonElement>(
+      harness.host,
+      '[aria-label="Focus Front Left"]',
+    ).click();
+    assert.equal(resetClicks, 1);
+    assert.deepEqual(selectedIds, ["front-left"]);
 
-      const bandLegendSignalBaseline = bandLegendRenderCount;
-      const sensorLegendSignalBaseline = sensorLegendRenderCount;
-      sensorLegendModel.value = {
-        ...sensorLegendModel.value!,
-        items: [{
+    const bandLegendSignalBaseline = bandLegendRenderCount;
+    const sensorLegendSignalBaseline = sensorLegendRenderCount;
+    sensorLegendModel.value = {
+      ...sensorLegendModel.value!,
+      items: [
+        {
           ...sensorLegendModel.value!.items[0],
           detailText: "13.0 dB",
           active: true,
           ariaPressed: true,
-        }],
-      };
-      await harness.flush();
+        },
+      ],
+    };
+    await harness.flush();
 
-      assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
-      assert.equal(sensorLegendRenderCount, sensorLegendSignalBaseline);
-      assert.match(requireElement(harness.host, "#legend").textContent ?? "", /13.0 dB/);
+    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+    assert.equal(sensorLegendRenderCount, sensorLegendSignalBaseline);
+    assert.match(
+      requireElement(harness.host, "#legend").textContent ?? "",
+      /13.0 dB/,
+    );
 
-      bandLegendModel.value = {
-        ...bandLegendModel.value,
-        items: [{ color: "#22c55e", labelText: "Wheel 2x" }],
-      };
-      await harness.flush();
+    sensorLegendHandlers.value = null;
+    await harness.flush();
 
-      assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
-      assert.equal(bandLegendRenderCount, bandLegendSignalBaseline);
-      assert.match(requireElement(harness.host, "#bandLegend").textContent ?? "", /Wheel 2x/);
+    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+    assert.equal(sensorLegendRenderCount, sensorLegendSignalBaseline);
+    assert.equal(
+      (requireElement(harness.host, "#legend").textContent ?? "").trim(),
+      "",
+    );
 
-      const bandLegendParentBaseline = bandLegendRenderCount;
-      const sensorLegendParentBaseline = sensorLegendRenderCount;
-      harness.view.renderHeader({
-        titleText: "Updated title",
-        hintText: "Updated hint",
-      });
-      await harness.flush();
+    sensorLegendHandlers.value = {
+      onReset: () => {
+        resetClicks += 1;
+      },
+      onSelect: (entryId) => {
+        selectedIds.push(entryId);
+      },
+    };
+    await harness.flush();
 
-      assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
-      assert.equal(bandLegendRenderCount, bandLegendParentBaseline);
-      assert.equal(sensorLegendRenderCount, sensorLegendParentBaseline);
+    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+    assert.equal(sensorLegendRenderCount, sensorLegendSignalBaseline);
+    assert.match(
+      requireElement(harness.host, "#legend").textContent ?? "",
+      /13.0 dB/,
+    );
+
+    bandLegendModel.value = {
+      ...bandLegendModel.value,
+      items: [{ color: "#22c55e", labelText: "Wheel 2x" }],
+    };
+    await harness.flush();
+
+    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+    assert.equal(bandLegendRenderCount, bandLegendSignalBaseline);
+    assert.match(
+      requireElement(harness.host, "#bandLegend").textContent ?? "",
+      /Wheel 2x/,
+    );
+
+    const bandLegendParentBaseline = bandLegendRenderCount;
+    const sensorLegendParentBaseline = sensorLegendRenderCount;
+    harness.view.renderHeader({
+      titleText: "Updated title",
+      hintText: "Updated hint",
+    });
+    await harness.flush();
+
+    assert.equal(spectrumPanelRenderCount, bandToggleBaseline);
+    assert.equal(bandLegendRenderCount, bandLegendParentBaseline);
+    assert.equal(sensorLegendRenderCount, sensorLegendParentBaseline);
   } finally {
     options.diffed = previousDiffed;
     harness.cleanup();


### PR DESCRIPTION
## Summary
- keep `SpectrumSensorLegend` as a visibility gate and move the actual legend model reads into render-time content
- switch legend click handlers to `.peek()` access instead of eager signal reads
- extend `tests/spectrum_panel_signals.ts` to cover handler-null hide/show transitions as well as detail-text updates

## Why
- the old legend component still read `sensorLegend.value` and `sensorLegendHandlers.value` imperatively before the JSX return
- this keeps the signal reads inside the rendered tree without changing the panel contract
- the new signal test proves legend visibility and content updates still avoid panel rerenders

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx tsx tests/spectrum_panel_signals.ts`
- `cd apps/ui && npm run test:visual`

## Risks / tradeoffs
- this is a render-structure cleanup, not a legend contract change
- kept the reset/item list semantics unchanged; only the signal read points moved

Closes #2699