### PR TITLE
refactor(ui): bind live speed readout

### DIFF
--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -52,7 +52,6 @@ export interface SettingsFeatureDeps {
 
 export interface SettingsFeatureViewPorts {
   renderSpectrum: () => void;
-  renderSpeedReadout: () => void;
 }
 
 export interface SettingsFeature {
@@ -107,7 +106,6 @@ export function createSettingsFeature(
       ports: {
         activeViewId: ctx.ports.activeViewId,
         activeSettingsTabId: ctx.panels.settingsShell.activeTabId,
-        renderSpeedReadout: ctx.ports.view.renderSpeedReadout,
       },
     });
   const gpsStatusModule: SettingsGpsStatusModule =
@@ -123,7 +121,6 @@ export function createSettingsFeature(
         activeViewId: ctx.ports.activeViewId,
         activeSettingsTabId: ctx.panels.settingsShell.activeTabId,
         syncSpeedSourceSelectionUi: speedSourceModule.syncSpeedSourceSelectionUi,
-        renderSpeedReadout: ctx.ports.view.renderSpeedReadout,
       },
     });
   carsModule = createSettingsCarsModule({

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -20,7 +20,6 @@ interface SettingsGpsStatusModulePorts {
   activeViewId: ReadonlySignal<string>;
   activeSettingsTabId: ReadonlySignal<string>;
   syncSpeedSourceSelectionUi: () => void;
-  renderSpeedReadout: () => void;
 }
 
 export interface SettingsGpsStatusModuleDeps {
@@ -82,7 +81,6 @@ export function createSettingsGpsStatusModule(
         );
       });
       ctx.ports.syncSpeedSourceSelectionUi();
-      ctx.ports.renderSpeedReadout();
       return status.connection_state === "connected"
         ? GPS_POLL_FAST_MS
         : GPS_POLL_SLOW_MS;

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -16,7 +16,6 @@ import { createSettingsSpeedSourceWorkflow } from "./settings_speed_source_workf
 interface SettingsSpeedSourceModulePorts {
   activeViewId: ReadonlySignal<string>;
   activeSettingsTabId: ReadonlySignal<string>;
-  renderSpeedReadout: () => void;
 }
 
 export interface SettingsSpeedSourceModuleDeps {
@@ -53,7 +52,6 @@ export function createSettingsSpeedSourceModule(
   );
   workflow = createSettingsSpeedSourceWorkflow({
     obdConfigVisible,
-    renderSpeedReadout: ctx.ports.renderSpeedReadout,
     settings,
     showError: services.showError,
     t: services.t,

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -41,7 +41,6 @@ export interface SettingsSpeedSourceWorkflowViewPorts {
 export interface SettingsSpeedSourceWorkflowDeps {
   createPollingController?: (options: PollingControllerOptions) => PollingController;
   obdConfigVisible: ReadonlySignal<boolean>;
-  renderSpeedReadout: () => void;
   settings: SettingsState;
   showError: (message: string) => void;
   t: (key: string, vars?: Record<string, unknown>) => string;
@@ -315,7 +314,6 @@ export function createSettingsSpeedSourceWorkflow(
       staleTimeoutInputValue.value = String(payload.stale_timeout_s);
       syncInputsFromSettings();
     });
-    deps.renderSpeedReadout();
   }
 
   const speedSourceLoader = createApiLoader({

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -67,8 +67,6 @@ export class UiShellController {
 
   private readonly chrome: UiShellChromeView;
 
-  private readonly liveOverview: RealtimeLiveOverviewBridge;
-
   private readonly navigation: UiShellNavigationModule;
 
   private readonly notifications: UiShellNotificationModule;
@@ -97,7 +95,6 @@ export class UiShellController {
   constructor(deps: UiShellControllerDeps) {
     this.state = deps.state;
     this.chrome = deps.chrome;
-    this.liveOverview = deps.liveOverview;
     this.bindFeatureHandlers = deps.bindFeatureHandlers;
     this.notifications = createUiShellNotificationModule({
       window,
@@ -140,10 +137,10 @@ export class UiShellController {
     this.preferencesRenderModel = this.createPreferencesRenderModel();
     this.statusRenderModel = this.createStatusRenderModel();
     this.dialogRenderModel = this.createDialogRenderModel();
+    deps.liveOverview.speedText.value = this.status.speedReadoutText;
     this.bindChromeModelSignals();
     this.bindDocumentLanguageSync();
     this.bindReactiveLanguageSync();
-    this.bindReactiveSpeedReadoutSync();
   }
 
   t(key: string, vars?: Record<string, unknown>): string {
@@ -160,12 +157,6 @@ export class UiShellController {
 
   requestConfirmation(message: string): Promise<boolean> {
     return this.confirmation.requestConfirmation(message);
-  }
-
-  renderSpeedReadout(): void {
-    untracked(() => {
-      this.liveOverview.speedText.value = this.status.speedReadoutText.value;
-    });
   }
 
   setLiveStatus(variant: string, text: string): void {
@@ -217,15 +208,6 @@ export class UiShellController {
     this.chrome.bindPreferencesModel(this.preferencesRenderModel);
     this.chrome.bindStatusModel(this.statusRenderModel);
     this.chrome.bindDialogModel(this.dialogRenderModel);
-  }
-
-  private bindReactiveSpeedReadoutSync(): void {
-    effect(() => {
-      const speedText = this.status.speedReadoutText.value;
-      untracked(() => {
-        this.liveOverview.speedText.value = speedText;
-      });
-    });
   }
 
   private createNavigationRenderModel(): ReadonlySignal<UiShellChromeNavigationModel> {

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -76,7 +76,6 @@ function createUiAppFeatureRuntimePorts(deps: {
     },
     view: {
       renderSpectrum: () => spectrum.renderSpectrum(),
-      renderSpeedReadout: () => shell.renderSpeedReadout(),
     },
     transport: {
       sendSelection: () => transport.sendSelection(),

--- a/apps/ui/src/app/ui_panel_bootstrap.tsx
+++ b/apps/ui/src/app/ui_panel_bootstrap.tsx
@@ -1,7 +1,6 @@
 import { Suspense, lazy } from "preact/compat";
 
 import { render } from "preact";
-import { signal } from "./ui_signals";
 import {
   createDeferredModelSignal,
   createModelActionPanelBindings,
@@ -84,7 +83,7 @@ export function mountDashboardPanels(
 ): UiMountedDashboardPanels {
   const liveOverview: RealtimeLiveOverviewBridge = {
     model: createDeferredModelSignal<RealtimeLiveOverviewRenderModel>(),
-    speedText: signal("--"),
+    speedText: createDeferredModelSignal<string>(),
   };
   const logging: RealtimeLoggingPanelBridge = createModelActionPanelBindings<
     RealtimeLoggingPanelRenderModel,

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -4,7 +4,6 @@ import { getUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
-  type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
 import { type DeferredModelSignal } from "./view_model_binding";
@@ -38,13 +37,9 @@ export interface RealtimeLiveOverviewRenderModel {
   sensorCards: RealtimeLiveOverviewSensorCardModel[];
 }
 
-interface RealtimeLiveOverviewBridgeState {
-  speedText: string;
-}
-
 export interface RealtimeLiveOverviewBridge {
   model: DeferredModelSignal<RealtimeLiveOverviewRenderModel>;
-  speedText: Signal<string>;
+  speedText: DeferredModelSignal<string>;
 }
 
 const DEFAULT_OVERVIEW_MODEL: RealtimeLiveOverviewRenderModel = {
@@ -64,9 +59,7 @@ const DEFAULT_OVERVIEW_MODEL: RealtimeLiveOverviewRenderModel = {
   sensorCards: [],
 };
 
-const DEFAULT_OVERVIEW_STATE: RealtimeLiveOverviewBridgeState = {
-  speedText: "--",
-};
+const DEFAULT_SPEED_TEXT = "--";
 
 const REALTIME_LIVE_OVERVIEW_MODEL_KEYS = [
   "activeCar",
@@ -177,7 +170,7 @@ function RealtimeLiveOverviewSensorRoster(props: {
 
 function RealtimeLiveOverview(props: {
   model: ReadonlySignal<ReadonlySignal<RealtimeLiveOverviewRenderModel> | null>;
-  speedText: ReadonlySignal<string>;
+  speedText: ReadonlySignal<ReadonlySignal<string> | null>;
 }) {
   const labels = useComputed(() => ({
     activeCarLabel: getUiText("dashboard.active_car", "Active car"),
@@ -195,6 +188,7 @@ function RealtimeLiveOverview(props: {
     titleText: getUiText("dashboard.live_overview", "Live overview"),
   }));
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_OVERVIEW_MODEL);
+  const speedText = useComputed(() => props.speedText.value?.value ?? DEFAULT_SPEED_TEXT);
   const {
     activeCar,
     connectedSensorsText,
@@ -258,7 +252,7 @@ function RealtimeLiveOverview(props: {
               {labelTexts.currentSpeedLabel}
             </div>
           <div id="speed" class="stat__value speed" aria-live="polite">
-            {props.speedText}
+            {speedText}
           </div>
         </div>
       </div>

--- a/apps/ui/tests/realtime_live_overview_signals.ts
+++ b/apps/ui/tests/realtime_live_overview_signals.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 
 import { options } from "preact";
 
-import { computed, signal } from "../src/app/ui_signals";
+import { computed, signal, type ReadonlySignal } from "../src/app/ui_signals";
 import type {
   RealtimeLiveOverviewBridge,
   RealtimeLiveOverviewRenderModel,
@@ -56,12 +56,13 @@ async function runRealtimeLiveOverviewSignalProjectionTest(): Promise<void> {
     return mountRealtimeLiveOverview;
   }, (): RealtimeLiveOverviewBridge => ({
     model: signal(null),
-    speedText: signal("--"),
+    speedText: signal<ReadonlySignal<string> | null>(null),
   }));
+  const speedText = signal("43 km/h");
 
   try {
     harness.view.model.value = model;
-    harness.view.speedText.value = "43 km/h";
+    harness.view.speedText.value = speedText;
     await harness.flush();
 
     assert.equal(overviewRenderCount, 1);

--- a/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
+++ b/apps/ui/tests/settings_speed_source_module_bindings.spec.ts
@@ -35,7 +35,6 @@ test("bindHandlers uses typed panel actions and navigation subscriptions", () =>
     ports: {
       activeViewId,
       activeSettingsTabId,
-      renderSpeedReadout() {},
     },
   });
 

--- a/apps/ui/tests/settings_speed_source_workflow.spec.ts
+++ b/apps/ui/tests/settings_speed_source_workflow.spec.ts
@@ -87,7 +87,6 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     const appState = createAppState();
     const workflow = createSettingsSpeedSourceWorkflow({
       obdConfigVisible: harness.obdConfigVisible,
-      renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
         harness.errors.push(message);
@@ -143,7 +142,6 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
 
     const workflow = createSettingsSpeedSourceWorkflow({
       obdConfigVisible: harness.obdConfigVisible,
-      renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
         harness.errors.push(message);
@@ -184,7 +182,6 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     const appState = createAppState();
     const workflow = createSettingsSpeedSourceWorkflow({
       obdConfigVisible: harness.obdConfigVisible,
-      renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
         harness.errors.push(message);
@@ -215,7 +212,6 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     const appState = createAppState();
     const workflow = createSettingsSpeedSourceWorkflow({
       obdConfigVisible: harness.obdConfigVisible,
-      renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
         harness.errors.push(message);
@@ -269,7 +265,6 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
           /* no-op */
         },
       }),
-      renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
         harness.errors.push(message);
@@ -331,7 +326,6 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
           pollingStops += 1;
         },
       }),
-      renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
         harness.errors.push(message);
@@ -376,7 +370,6 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
         stop() {},
       }),
       obdConfigVisible: harness.obdConfigVisible,
-      renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
         harness.errors.push(message);
@@ -403,7 +396,6 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
         stop() {},
       }),
       obdConfigVisible: harness.obdConfigVisible,
-      renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
         harness.errors.push(message);
@@ -441,7 +433,6 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
         stop() {},
       }),
       obdConfigVisible: harness.obdConfigVisible,
-      renderSpeedReadout: () => undefined,
       settings: appState.settings,
       showError: (message) => {
         harness.errors.push(message);

--- a/apps/ui/tests/signal_view_reference_tests.ts
+++ b/apps/ui/tests/signal_view_reference_tests.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 
-import { computed, effect, effectOnChange, signal, useSignalProperties } from "../src/app/ui_signals";
+import {
+  computed,
+  effect,
+  effectOnChange,
+  signal,
+  useSignalProperties,
+  type ReadonlySignal,
+} from "../src/app/ui_signals";
 import type {
   RealtimeLiveOverviewBridge,
   RealtimeLiveOverviewRenderModel,
@@ -130,12 +137,13 @@ async function runRealtimeLiveOverviewReferenceTest(): Promise<void> {
     return mountRealtimeLiveOverview;
   }, (): RealtimeLiveOverviewBridge => ({
     model: signal(null),
-    speedText: signal("--"),
+    speedText: signal<ReadonlySignal<string> | null>(null),
   }));
+  const speedText = signal("43 km/h");
 
   try {
     harness.view.model.value = model;
-    harness.view.speedText.value = "43 km/h";
+    harness.view.speedText.value = speedText;
     await harness.flush();
 
     assert.equal(requireElement(harness.host, "#liveConnectedSensors [data-value]").textContent, "2 / 4");

--- a/apps/ui/tests/ui_lazy_panels.spec.ts
+++ b/apps/ui/tests/ui_lazy_panels.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 import { createLazyUiPanels } from "../src/app/ui_lazy_panels";
 import type { UiMountedDashboardPanels } from "../src/app/ui_panel_bootstrap";
 import type { UiPanelHostRegistry } from "../src/app/ui_panel_host_registry";
-import { signal } from "../src/app/ui_signals";
+import { signal, type ReadonlySignal } from "../src/app/ui_signals";
 import type { AnalysisPanelView } from "../src/app/views/analysis_panel";
 import type { CarsPanelView } from "../src/app/views/cars_panel";
 import type { HistoryPanelView } from "../src/app/views/history_table_view";
@@ -32,7 +32,7 @@ function createDashboardPanels(): UiMountedDashboardPanels {
     spectrum: {} as UiMountedDashboardPanels["spectrum"],
     liveOverview: {
       model: signal(null),
-      speedText: signal("--"),
+      speedText: signal<ReadonlySignal<string> | null>(null),
     } as UiMountedDashboardPanels["liveOverview"],
     logging: {
       actions: signal(null),

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -198,13 +198,42 @@ test.describe("UiShellController", () => {
       chromeActions,
       liveOverview: {
         model: signal(null),
-        speedText: signal("--"),
+        speedText: signal<ReadonlySignal<string> | null>(null),
       },
       state,
     });
 
     chromeActions.value.activateView("historyView");
     expect(state.shell.activeViewId.value).toBe("historyView");
+  });
+
+  test("binds live overview speed text to the shell status signal", () => {
+    const state = createAppState();
+    const chrome = createChromeViewRecorder();
+    const liveOverview = {
+      model: signal(null),
+      speedText: signal<ReadonlySignal<string> | null>(null),
+    };
+
+    state.realtime.speedMps.value = 12.3;
+    new UiShellController({
+      bindFeatureHandlers: () => undefined,
+      chrome: chrome.view,
+      chromeActions: signal<UiShellChromeActions>({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS }),
+      liveOverview,
+      state,
+    });
+
+    const speedText = liveOverview.speedText.value;
+    expect(speedText).not.toBeNull();
+    expect(speedText?.value).toBe("44.3 km/h · GPS");
+
+    state.shell.speedUnit.value = "mps";
+    expect(liveOverview.speedText.value).toBe(speedText);
+    expect(speedText?.value).toBe("12.3 m/s · GPS");
+
+    state.settings.resolvedSpeedSource.value = "obd2";
+    expect(speedText?.value).toBe("12.3 m/s · OBD2");
   });
 
   test("syncs the document language from shell state without a chrome component", () => {
@@ -218,7 +247,7 @@ test.describe("UiShellController", () => {
         chromeActions: signal<UiShellChromeActions>({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS }),
         liveOverview: {
           model: signal(null),
-          speedText: signal("--"),
+          speedText: signal<ReadonlySignal<string> | null>(null),
         },
         state,
       });
@@ -242,7 +271,7 @@ test.describe("UiShellController", () => {
       chromeActions: signal<UiShellChromeActions>({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS }),
       liveOverview: {
         model: signal(null),
-        speedText: signal("--"),
+        speedText: signal<ReadonlySignal<string> | null>(null),
       },
       state,
     });
@@ -281,7 +310,7 @@ test.describe("UiShellController", () => {
       chromeActions: signal<UiShellChromeActions>({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS }),
       liveOverview: {
         model: signal(null),
-        speedText: signal("--"),
+        speedText: signal<ReadonlySignal<string> | null>(null),
       },
       state,
     });


### PR DESCRIPTION
## Summary
- bind the live overview speed text to the shell status computed signal through the existing deferred bridge pattern
- remove `renderSpeedReadout()` / `bindReactiveSpeedReadoutSync()` and delete the dead settings refresh port
- update the affected tests to the nested signal shape and add a shell regression for unit/source-driven speed text updates

## Why
- the shell status module already owns the canonical speed readout
- the push path duplicated that state with an effect plus manual refresh calls

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ui_shell_runtime_modules.spec.ts tests/settings_speed_source_workflow.spec.ts tests/settings_speed_source_module_bindings.spec.ts tests/ui_lazy_panels.spec.ts`
- `cd apps/ui && npx tsx tests/realtime_live_overview_signals.ts`
- `cd apps/ui && npx tsx tests/signal_view_reference_tests.ts`

## Risk / tradeoffs
- the live overview speed bridge now carries an inner read-only signal instead of a writable string value, so bridge fixtures/tests had to move with it
- scope stays tight to the speed readout chain; this does not add a broader deferred-model helper cleanup

Closes #2700
