### PR TITLE
refactor(ui): use ui text signals

### DIFF
--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -1,7 +1,7 @@
 import { render } from "preact";
 import { useRef } from "preact/hooks";
 
-import { getUiText } from "../ui_i18n";
+import { useUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalEffect,
@@ -77,10 +77,10 @@ function EspFlashStatusBanner(props: {
 
 function EspFlashPortRow(props: {
   actions: ReadonlySignal<EspFlashPanelActionHandlers | null>;
-  portLabel: string;
+  portLabel: ReadonlySignal<string>;
   portOptions: ReadonlySignal<readonly EspFlashPortOptionModel[]>;
   portSelectDisabled: ReadonlySignal<boolean>;
-  refreshLabel: string;
+  refreshLabel: ReadonlySignal<string>;
   refreshPortsDisabled: ReadonlySignal<boolean>;
   selectedPortValue: ReadonlySignal<string>;
 }) {
@@ -130,7 +130,7 @@ function EspFlashActionRow(props: {
   actions: ReadonlySignal<EspFlashPanelActionHandlers | null>;
   cancelButtonDisabled: ReadonlySignal<boolean>;
   cancelButtonHidden: ReadonlySignal<boolean>;
-  cancelLabel: string;
+  cancelLabel: ReadonlySignal<string>;
   startButtonDisabled: ReadonlySignal<boolean>;
   startButtonHidden: ReadonlySignal<boolean>;
   startButtonLabelText: ReadonlySignal<string>;
@@ -169,7 +169,7 @@ function EspFlashActionRow(props: {
 
 function EspFlashJourneyCard(props: {
   model: ReadonlySignal<EspFlashPanelRenderModel["journey"]>;
-  titleText: string;
+  titleText: ReadonlySignal<string>;
 }) {
   return (
     <section class="maintenance-card">
@@ -192,9 +192,9 @@ function EspFlashJourneyCard(props: {
 }
 
 function EspFlashLogCard(props: {
-  introText: string;
+  introText: ReadonlySignal<string>;
   model: ReadonlySignal<EspFlashPanelRenderModel["log"]>;
-  titleText: string;
+  titleText: ReadonlySignal<string>;
 }) {
   const { emptyState, text } = useSignalProperties(props.model, ["emptyState", "text"] as const);
   const logPanelRef = useRef<HTMLDivElement | null>(null);
@@ -240,9 +240,9 @@ function EspFlashLogCard(props: {
 }
 
 function EspFlashHistoryCard(props: {
-  introText: string;
+  introText: ReadonlySignal<string>;
   model: ReadonlySignal<EspFlashPanelRenderModel["history"]>;
-  titleText: string;
+  titleText: ReadonlySignal<string>;
 }) {
   return (
     <section class="maintenance-card">
@@ -271,36 +271,34 @@ function EspFlashPanel(props: {
   model: ReadonlySignal<ReadonlySignal<EspFlashPanelRenderModel> | null>;
 }) {
   const actions = useComputed(() => props.actions.value);
-  const labels = useComputed(() => ({
-    cancelLabel: getUiText("settings.esp_flash.cancel", "Cancel"),
-    detailsCaption: getUiText(
-      "settings.esp_flash.details_caption",
-      "Build, erase, and write the current firmware over USB.",
-    ),
-    detailsTitle: getUiText("settings.esp_flash.details_title", "What happens next"),
-    hintText: getUiText(
-      "settings.esp_flash.hint",
-      "Flash ESP firmware from local source on this Pi.",
-    ),
-    historyIntro: getUiText(
-      "settings.esp_flash.history_intro",
-      "Recent flashes stay here so the next operator can see what happened last.",
-    ),
-    historyTitle: getUiText("settings.esp_flash.history", "Recent attempts"),
-    journeyTitle: getUiText("settings.esp_flash.journey_title", "Expected stages"),
-    logsIntro: getUiText(
-      "settings.esp_flash.logs_intro",
-      "Build, erase, and upload output appears here while the toolchain runs.",
-    ),
-    logsTitle: getUiText("settings.esp_flash.logs_title", "Live flash output"),
-    portLabel: getUiText("settings.esp_flash.port", "Serial Port"),
-    preflightNote: getUiText(
-      "settings.esp_flash.preflight_note",
-      "Starting a flash builds the latest firmware on this Pi, erases the selected board, and writes the new image over USB. Keep the board powered until the staged progress reaches Done.",
-    ),
-    refreshLabel: getUiText("settings.esp_flash.refresh_ports", "Refresh"),
-    titleText: getUiText("settings.esp_flash.title", "ESP Flash"),
-  }));
+  const cancelLabel = useUiText("settings.esp_flash.cancel", "Cancel");
+  const detailsCaption = useUiText(
+    "settings.esp_flash.details_caption",
+    "Build, erase, and write the current firmware over USB.",
+  );
+  const detailsTitle = useUiText("settings.esp_flash.details_title", "What happens next");
+  const hintText = useUiText(
+    "settings.esp_flash.hint",
+    "Flash ESP firmware from local source on this Pi.",
+  );
+  const historyIntro = useUiText(
+    "settings.esp_flash.history_intro",
+    "Recent flashes stay here so the next operator can see what happened last.",
+  );
+  const historyTitle = useUiText("settings.esp_flash.history", "Recent attempts");
+  const journeyTitle = useUiText("settings.esp_flash.journey_title", "Expected stages");
+  const logsIntro = useUiText(
+    "settings.esp_flash.logs_intro",
+    "Build, erase, and upload output appears here while the toolchain runs.",
+  );
+  const logsTitle = useUiText("settings.esp_flash.logs_title", "Live flash output");
+  const portLabel = useUiText("settings.esp_flash.port", "Serial Port");
+  const preflightNote = useUiText(
+    "settings.esp_flash.preflight_note",
+    "Starting a flash builds the latest firmware on this Pi, erases the selected board, and writes the new image over USB. Keep the board powered until the staged progress reaches Done.",
+  );
+  const refreshLabel = useUiText("settings.esp_flash.refresh_ports", "Refresh");
+  const titleText = useUiText("settings.esp_flash.title", "ESP Flash");
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL);
   const {
     cancelButtonDisabled,
@@ -319,8 +317,6 @@ function EspFlashPanel(props: {
     startSummary,
     statusBanner,
   } = useSignalProperties(model, ESP_FLASH_PANEL_KEYS);
-  const labelTexts = labels.value;
-
   return (
     <div class="panel card">
       <div class="maintenance-layout maintenance-layout--compact">
@@ -331,12 +327,12 @@ function EspFlashPanel(props: {
                 <div
                   class="maintenance-card__title"
                 >
-                  {labelTexts.titleText}
+                  {titleText}
                 </div>
                 <div
                   class="subtle"
                 >
-                  {labelTexts.hintText}
+                  {hintText}
                 </div>
               </div>
               <EspFlashStatusBanner badge={statusBanner} />
@@ -344,10 +340,10 @@ function EspFlashPanel(props: {
             <div class="maintenance-card__body maintenance-card__body--hero">
               <EspFlashPortRow
                 actions={actions}
-                portLabel={labelTexts.portLabel}
+                portLabel={portLabel}
                 portOptions={portOptions}
                 portSelectDisabled={portSelectDisabled}
-                refreshLabel={labelTexts.refreshLabel}
+                refreshLabel={refreshLabel}
                 refreshPortsDisabled={refreshPortsDisabled}
                 selectedPortValue={selectedPortValue}
               />
@@ -371,18 +367,18 @@ function EspFlashPanel(props: {
                     <span
                       class="settings-help-disclosure__title"
                     >
-                      {labelTexts.detailsTitle}
+                        {detailsTitle}
                     </span>
                     <span
                       class="settings-help-disclosure__caption"
                     >
-                      {labelTexts.detailsCaption}
+                        {detailsCaption}
                     </span>
                   </span>
                 </summary>
                 <div class="settings-help-disclosure__body">
                   <div class="maintenance-note">
-                    {labelTexts.preflightNote}
+                      {preflightNote}
                   </div>
                 </div>
               </details>
@@ -390,7 +386,7 @@ function EspFlashPanel(props: {
                 actions={actions}
                 cancelButtonDisabled={cancelButtonDisabled}
                 cancelButtonHidden={cancelButtonHidden}
-                cancelLabel={labelTexts.cancelLabel}
+                cancelLabel={cancelLabel}
                 startButtonDisabled={startButtonDisabled}
                 startButtonHidden={startButtonHidden}
                 startButtonLabelText={startButtonLabelText}
@@ -399,18 +395,18 @@ function EspFlashPanel(props: {
           </section>
 
           <div class="maintenance-pair-grid maintenance-pair-grid--focus">
-            <EspFlashJourneyCard model={journey} titleText={labelTexts.journeyTitle} />
+            <EspFlashJourneyCard model={journey} titleText={journeyTitle} />
             <EspFlashLogCard
-              introText={labelTexts.logsIntro}
+              introText={logsIntro}
               model={log}
-              titleText={labelTexts.logsTitle}
+              titleText={logsTitle}
             />
           </div>
 
           <EspFlashHistoryCard
-            introText={labelTexts.historyIntro}
+            introText={historyIntro}
             model={history}
-            titleText={labelTexts.historyTitle}
+            titleText={historyTitle}
           />
         </div>
       </div>

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -1,5 +1,5 @@
 import { render } from "preact";
-import { getUiText } from "../ui_i18n";
+import { useUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
@@ -29,14 +29,12 @@ export function HistoryPanel(props: {
   model: ReadonlySignal<ReadonlySignal<HistoryPanelRenderModel> | null>;
 }) {
   const actions = useComputed(() => props.actions.value);
-  const labels = useComputed(() => ({
-    actionsLabel: getUiText("history.table.actions", "Actions"),
-    deleteAllLabel: getUiText("history.delete_all", "Delete All Runs"),
-    refreshLabel: getUiText("history.refresh", "Refresh History"),
-    runLabel: getUiText("history.table.file", "Run"),
-    samplesLabel: getUiText("history.table.size", "Samples"),
-    startedLabel: getUiText("history.table.updated", "Started"),
-  }));
+  const actionsLabel = useUiText("history.table.actions", "Actions");
+  const deleteAllLabel = useUiText("history.delete_all", "Delete All Runs");
+  const refreshLabel = useUiText("history.refresh", "Refresh History");
+  const runLabel = useUiText("history.table.file", "Run");
+  const samplesLabel = useUiText("history.table.size", "Samples");
+  const startedLabel = useUiText("history.table.updated", "Started");
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_PANEL_MODEL);
   const { deleteAllRunsDisabled, historySummaryText, table } = useSignalProperties(
     model,
@@ -48,8 +46,6 @@ export function HistoryPanel(props: {
   const handleDeleteAllRuns = () => {
     actions.peek()?.onDeleteAllRuns();
   };
-  const labelTexts = labels.value;
-
   return (
     <>
       <div class="history-toolbar">
@@ -65,7 +61,7 @@ export function HistoryPanel(props: {
             type="button"
             onClick={handleRefreshHistory}
           >
-            {labelTexts.refreshLabel}
+            {refreshLabel}
           </button>
           <button
             id="deleteAllRunsBtn"
@@ -74,17 +70,17 @@ export function HistoryPanel(props: {
             disabled={deleteAllRunsDisabled}
             onClick={handleDeleteAllRuns}
           >
-            {labelTexts.deleteAllLabel}
+            {deleteAllLabel}
           </button>
         </div>
       </div>
       <table class="history-table">
         <thead>
           <tr>
-            <th>{labelTexts.runLabel}</th>
-            <th>{labelTexts.startedLabel}</th>
-            <th class="numeric">{labelTexts.samplesLabel}</th>
-            <th>{labelTexts.actionsLabel}</th>
+            <th>{runLabel}</th>
+            <th>{startedLabel}</th>
+            <th class="numeric">{samplesLabel}</th>
+            <th>{actionsLabel}</th>
           </tr>
         </thead>
         <tbody id="historyTableBody">

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -1,6 +1,6 @@
 import { render } from "preact";
 
-import { getUiText } from "../ui_i18n";
+import { useUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
@@ -94,7 +94,7 @@ function RealtimeLiveOverviewRunHealthPill(props: {
 
 function RealtimeLiveOverviewActiveCarStat(props: {
   activeCar: ReadonlySignal<RealtimeLiveOverviewActiveCarModel>;
-  labelText: string;
+  labelText: ReadonlySignal<string>;
 }) {
   const { text, warning } = useSignalProperties(props.activeCar, ["text", "warning"] as const);
   const variant = useComputed(() => warning.value ? "warn" : undefined);
@@ -132,7 +132,7 @@ function RealtimeLiveOverviewActiveCarStat(props: {
 
 function RealtimeLiveOverviewSensorRoster(props: {
   sensorCards: ReadonlySignal<RealtimeLiveOverviewSensorCardModel[]>;
-  noSensorsText: string;
+  noSensorsText: ReadonlySignal<string>;
 }) {
   const hasSensorCards = useComputed(() => props.sensorCards.value.length > 0);
 
@@ -172,21 +172,19 @@ function RealtimeLiveOverview(props: {
   model: ReadonlySignal<ReadonlySignal<RealtimeLiveOverviewRenderModel> | null>;
   speedText: ReadonlySignal<ReadonlySignal<string> | null>;
 }) {
-  const labels = useComputed(() => ({
-    activeCarLabel: getUiText("dashboard.active_car", "Active car"),
-    connectedSensorsLabel: getUiText("dashboard.connected_sensors", "Sensors online"),
-    currentSpeedLabel: getUiText("dashboard.current_speed", "Current speed"),
-    dataFreshnessLabel: getUiText("dashboard.data_freshness", "Feed freshness"),
-    hintText: getUiText(
-      "dashboard.live_overview_hint",
-      "Check readiness, current run state, and the strongest sensor level before reading the chart.",
-    ),
-    noSensorsText: getUiText("settings.sensors.no_sensors", "No sensors yet."),
-    recordingStateLabel: getUiText("dashboard.recording_state", "Run state"),
-    sensorCoverageLabel: getUiText("dashboard.sensor_coverage", "Sensor coverage"),
-    strongestSignalLabel: getUiText("dashboard.strongest_signal", "Strongest signal"),
-    titleText: getUiText("dashboard.live_overview", "Live overview"),
-  }));
+  const activeCarLabel = useUiText("dashboard.active_car", "Active car");
+  const connectedSensorsLabel = useUiText("dashboard.connected_sensors", "Sensors online");
+  const currentSpeedLabel = useUiText("dashboard.current_speed", "Current speed");
+  const dataFreshnessLabel = useUiText("dashboard.data_freshness", "Feed freshness");
+  const hintText = useUiText(
+    "dashboard.live_overview_hint",
+    "Check readiness, current run state, and the strongest sensor level before reading the chart.",
+  );
+  const noSensorsText = useUiText("settings.sensors.no_sensors", "No sensors yet.");
+  const recordingStateLabel = useUiText("dashboard.recording_state", "Run state");
+  const sensorCoverageLabel = useUiText("dashboard.sensor_coverage", "Sensor coverage");
+  const strongestSignalLabel = useUiText("dashboard.strongest_signal", "Strongest signal");
+  const titleText = useUiText("dashboard.live_overview", "Live overview");
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_OVERVIEW_MODEL);
   const speedText = useComputed(() => props.speedText.value?.value ?? DEFAULT_SPEED_TEXT);
   const {
@@ -198,17 +196,15 @@ function RealtimeLiveOverview(props: {
     sensorCards,
     strongestSignalText,
   } = useSignalProperties(model, REALTIME_LIVE_OVERVIEW_MODEL_KEYS);
-  const labelTexts = labels.value;
-
   return (
     <>
       <div class="card__header card__header--stack">
         <div>
           <div class="card__title">
-            {labelTexts.titleText}
+            {titleText}
           </div>
           <div class="card__subtle">
-            {labelTexts.hintText}
+            {hintText}
           </div>
         </div>
         <RealtimeLiveOverviewRunHealthPill runHealth={runHealth} />
@@ -216,16 +212,16 @@ function RealtimeLiveOverview(props: {
       <div class="stat-grid live-overview__stats">
         <div id="liveConnectedSensors" class="stat">
             <div class="stat__label">
-              {labelTexts.connectedSensorsLabel}
+              {connectedSensorsLabel}
             </div>
           <div class="stat__value" data-value>
             {connectedSensorsText}
           </div>
         </div>
-        <RealtimeLiveOverviewActiveCarStat activeCar={activeCar} labelText={labelTexts.activeCarLabel} />
+        <RealtimeLiveOverviewActiveCarStat activeCar={activeCar} labelText={activeCarLabel} />
         <div id="liveRecordingState" class="stat">
             <div class="stat__label">
-              {labelTexts.recordingStateLabel}
+              {recordingStateLabel}
             </div>
           <div class="stat__value" data-value>
             {recordingStateText}
@@ -233,7 +229,7 @@ function RealtimeLiveOverview(props: {
         </div>
         <div id="liveDataFreshness" class="stat">
             <div class="stat__label">
-              {labelTexts.dataFreshnessLabel}
+              {dataFreshnessLabel}
             </div>
           <div class="stat__value" data-value>
             {dataFreshnessText}
@@ -241,7 +237,7 @@ function RealtimeLiveOverview(props: {
         </div>
         <div id="liveStrongestSignal" class="stat">
             <div class="stat__label">
-              {labelTexts.strongestSignalLabel}
+              {strongestSignalLabel}
             </div>
           <div class="stat__value" data-value>
             {strongestSignalText}
@@ -249,7 +245,7 @@ function RealtimeLiveOverview(props: {
         </div>
         <div class="stat">
             <div class="stat__label">
-              {labelTexts.currentSpeedLabel}
+              {currentSpeedLabel}
             </div>
           <div id="speed" class="stat__value speed" aria-live="polite">
             {speedText}
@@ -258,12 +254,12 @@ function RealtimeLiveOverview(props: {
       </div>
       <div class="live-sensor-roster__header">
         <div class="mini-label">
-          {labelTexts.sensorCoverageLabel}
+          {sensorCoverageLabel}
         </div>
       </div>
       <RealtimeLiveOverviewSensorRoster
         sensorCards={sensorCards}
-        noSensorsText={labelTexts.noSensorsText}
+        noSensorsText={noSensorsText}
       />
     </>
   );

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -1,6 +1,6 @@
 import { render } from "preact";
 
-import { getUiText } from "../ui_i18n";
+import { useUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
@@ -238,10 +238,10 @@ function RealtimeLoggingStatusRow(props: {
 
 function RealtimeLoggingProgressSection(props: {
   labels: {
-    elapsedLabel: string;
-    runPhaseLabel: string;
-    runProgressLabel: string;
-    samplesLabel: string;
+    elapsedLabel: ReadonlySignal<string>;
+    runPhaseLabel: ReadonlySignal<string>;
+    runProgressLabel: ReadonlySignal<string>;
+    samplesLabel: ReadonlySignal<string>;
   };
   model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
 }) {
@@ -293,8 +293,8 @@ function RealtimeLoggingProgressSection(props: {
 function RealtimeLoggingActionRow(props: {
   actions: ReadonlySignal<RealtimeLoggingPanelActionHandlers | null>;
   labels: {
-    startLabel: string;
-    stopLabel: string;
+    startLabel: ReadonlySignal<string>;
+    stopLabel: ReadonlySignal<string>;
   };
   model: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
 }) {
@@ -340,25 +340,22 @@ function RealtimeLoggingPanel(props: {
   model: ReadonlySignal<ReadonlySignal<RealtimeLoggingPanelRenderModel> | null>;
 }) {
   const actions = useComputed(() => props.actions.value);
-  const labels = useComputed(() => ({
-    elapsedLabel: getUiText("dashboard.recording_elapsed", "Elapsed"),
-    runPhaseLabel: getUiText("dashboard.recording_phase", "Run phase"),
-    runProgressLabel: getUiText("dashboard.recording_progress", "Run progress"),
-    samplesLabel: getUiText("dashboard.recording_samples", "Samples recorded"),
-    startLabel: getUiText("dashboard.start_recording", "Start Recording"),
-    stopLabel: getUiText("dashboard.stop_recording", "Stop Recording"),
-    titleText: getUiText("dashboard.run_recording", "Run Recording"),
-  }));
+  const elapsedLabel = useUiText("dashboard.recording_elapsed", "Elapsed");
+  const runPhaseLabel = useUiText("dashboard.recording_phase", "Run phase");
+  const runProgressLabel = useUiText("dashboard.recording_progress", "Run progress");
+  const samplesLabel = useUiText("dashboard.recording_samples", "Samples recorded");
+  const startLabel = useUiText("dashboard.start_recording", "Start Recording");
+  const stopLabel = useUiText("dashboard.stop_recording", "Stop Recording");
+  const titleText = useUiText("dashboard.run_recording", "Run Recording");
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_PANEL_MODEL);
   const { shellLayout } = useSignalProperties(model, ["shellLayout"] as const);
-  const labelTexts = labels.value;
 
   return (
     <div class="realtime-logging-shell" data-layout={shellLayout.value}>
       <div class="card__header card__header--stack">
         <div>
           <div class="card__title">
-            {labelTexts.titleText}
+            {titleText}
           </div>
           <RealtimeLoggingSummarySection actions={actions} model={model} />
         </div>
@@ -366,18 +363,18 @@ function RealtimeLoggingPanel(props: {
       <RealtimeLoggingStatusRow model={model} />
       <RealtimeLoggingProgressSection
         labels={{
-          elapsedLabel: labelTexts.elapsedLabel,
-          runPhaseLabel: labelTexts.runPhaseLabel,
-          runProgressLabel: labelTexts.runProgressLabel,
-          samplesLabel: labelTexts.samplesLabel,
+          elapsedLabel,
+          runPhaseLabel,
+          runProgressLabel,
+          samplesLabel,
         }}
         model={model}
       />
       <RealtimeLoggingActionRow
         actions={actions}
         labels={{
-          startLabel: labelTexts.startLabel,
-          stopLabel: labelTexts.stopLabel,
+          startLabel,
+          stopLabel,
         }}
         model={model}
       />

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from "preact";
 
 import { render } from "preact";
-import { getUiText } from "../ui_i18n";
+import { useUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
@@ -110,7 +110,7 @@ function SensorsTableRow(props: {
 
 function SensorsTableBody(props: {
   actions: SensorsPanelActionHandlers | null;
-  emptyText: string;
+  emptyText: ReadonlySignal<string>;
   table: RealtimeSensorTableRenderModel | null;
 }) {
   const { actions, emptyText, table } = props;
@@ -118,7 +118,7 @@ function SensorsTableBody(props: {
     return (
       <tr>
         <td colSpan={3}>
-          {table?.emptyText ?? emptyText}
+          {table?.emptyText ?? emptyText.value}
         </td>
       </tr>
     );
@@ -133,49 +133,46 @@ function SensorsPanel(props: {
   model: ReadonlySignal<ReadonlySignal<SensorsPanelRenderModel> | null>;
 }) {
   const actions = useComputed(() => props.actions.value);
-  const labels = useComputed(() => ({
-    actionsLabel: getUiText("settings.sensors.actions", "Actions"),
-    emptyText: getUiText("settings.sensors.no_sensors", "No sensors detected yet."),
-    hintText: getUiText(
-      "settings.sensors.hint",
-      "Manage sensor names and locations. Default name is the MAC address.",
-    ),
-    locationLabel: getUiText("settings.sensors.location", "Location"),
-    nameLabel: getUiText("settings.sensors.name", "Name"),
-    titleText: getUiText("settings.sensors.title", "Sensors"),
-  }));
+  const actionsLabel = useUiText("settings.sensors.actions", "Actions");
+  const emptyText = useUiText("settings.sensors.no_sensors", "No sensors detected yet.");
+  const hintText = useUiText(
+    "settings.sensors.hint",
+    "Manage sensor names and locations. Default name is the MAC address.",
+  );
+  const locationLabel = useUiText("settings.sensors.location", "Location");
+  const nameLabel = useUiText("settings.sensors.name", "Name");
+  const titleText = useUiText("settings.sensors.title", "Sensors");
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_SENSORS_PANEL_MODEL);
   const { table } = useSignalProperties(model, SENSORS_PANEL_MODEL_KEYS);
-  const labelTexts = labels.value;
   return (
     <div class="panel card">
       <strong>
-        {labelTexts.titleText}
+        {titleText}
       </strong>
       <div class="subtle">
-        {labelTexts.hintText}
+        {hintText}
       </div>
       <div class="settings-table-wrap">
         <table class="clients-table settings-entity-table settings-entity-table--sensors">
           <thead>
             <tr>
                 <th>
-                 {labelTexts.nameLabel}
+                 {nameLabel}
                 </th>
                 <th>
-                 {labelTexts.locationLabel}
+                 {locationLabel}
                 </th>
                 <th>
-                 {labelTexts.actionsLabel}
+                 {actionsLabel}
                 </th>
               </tr>
             </thead>
             <tbody id="sensorsSettingsBody">
-             <SensorsTableBody
-               actions={actions.value}
-               emptyText={labelTexts.emptyText}
-               table={table.value}
-             />
+              <SensorsTableBody
+                actions={actions.value}
+                emptyText={emptyText}
+                table={table.value}
+              />
             </tbody>
           </table>
         </div>

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -1,6 +1,6 @@
 import { render, type ComponentChildren } from "preact";
 
-import { getUiText } from "../ui_i18n";
+import { useUiText } from "../ui_i18n";
 import {
   useComputed,
   useSignalProperties,
@@ -456,7 +456,7 @@ function UpdateActionRow(props: {
   actions: ReadonlySignal<UpdatePanelActionHandlers | null>;
   cancelButtonDisabled: ReadonlySignal<boolean>;
   cancelButtonHidden: ReadonlySignal<boolean>;
-  cancelLabel: string;
+  cancelLabel: ReadonlySignal<string>;
   startButtonDisabled: ReadonlySignal<boolean>;
   startButtonHidden: ReadonlySignal<boolean>;
   startButtonLabelText: ReadonlySignal<string>;
@@ -498,18 +498,16 @@ function UpdatePanel(props: {
   model: ReadonlySignal<ReadonlySignal<UpdatePanelRenderModel> | null>;
 }) {
   const actions = useComputed(() => props.actions.value);
-  const labels = useComputed(() => ({
-    cancelLabel: getUiText("settings.update.cancel", "Cancel Update"),
-    hintText: getUiText(
-      "settings.update.hint",
-      "Use either temporary Wi-Fi credentials or an already-connected USB internet uplink to update from GitHub. The hotspot only pauses for the Wi-Fi path.",
-    ),
-    reconnectNote: getUiText(
-      "settings.update.reconnect_note",
-      "Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.",
-    ),
-    titleText: getUiText("settings.update.title", "System Update"),
-  }));
+  const cancelLabel = useUiText("settings.update.cancel", "Cancel Update");
+  const hintText = useUiText(
+    "settings.update.hint",
+    "Use either temporary Wi-Fi credentials or an already-connected USB internet uplink to update from GitHub. The hotspot only pauses for the Wi-Fi path.",
+  );
+  const reconnectNote = useUiText(
+    "settings.update.reconnect_note",
+    "Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.",
+  );
+  const titleText = useUiText("settings.update.title", "System Update");
   const model = useComputed(() => props.model.value?.value ?? DEFAULT_UPDATE_PANEL_MODEL);
   const {
     cancelButtonDisabled,
@@ -519,7 +517,6 @@ function UpdatePanel(props: {
     startButtonLabelText,
     status,
   } = useSignalProperties(model, UPDATE_PANEL_MODEL_KEYS);
-  const labelTexts = labels.value;
   return (
     <div class="panel card">
       <div class="maintenance-layout maintenance-layout--compact">
@@ -527,16 +524,16 @@ function UpdatePanel(props: {
           <div class="maintenance-card__header">
             <div>
                 <div class="maintenance-card__title">
-                 {labelTexts.titleText}
+                 {titleText}
                 </div>
                 <div class="subtle">
-                 {labelTexts.hintText}
+                 {hintText}
                 </div>
             </div>
           </div>
           <div class="maintenance-card__body maintenance-card__body--hero">
             <div class="maintenance-note">
-              {labelTexts.reconnectNote}
+              {reconnectNote}
             </div>
             <div
               id="updateOverviewPanel"
@@ -549,7 +546,7 @@ function UpdatePanel(props: {
               actions={actions}
               cancelButtonDisabled={cancelButtonDisabled}
               cancelButtonHidden={cancelButtonHidden}
-              cancelLabel={labelTexts.cancelLabel}
+              cancelLabel={cancelLabel}
               startButtonDisabled={startButtonDisabled}
               startButtonHidden={startButtonHidden}
               startButtonLabelText={startButtonLabelText}

--- a/apps/ui/tests/realtime_live_overview_signals.ts
+++ b/apps/ui/tests/realtime_live_overview_signals.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 import { options } from "preact";
 
+import { setUiLanguage } from "../src/app/ui_i18n";
 import { computed, signal, type ReadonlySignal } from "../src/app/ui_signals";
 import type {
   RealtimeLiveOverviewBridge,
@@ -17,6 +18,7 @@ function requireElement<T extends Element = HTMLElement>(root: ParentNode, selec
 }
 
 async function runRealtimeLiveOverviewSignalProjectionTest(): Promise<void> {
+  const previousLanguage = "en";
   const connectedSensorsText = signal("2 / 4");
   const activeCarText = signal("Roadster");
   const activeCarWarning = signal(false);
@@ -71,6 +73,16 @@ async function runRealtimeLiveOverviewSignalProjectionTest(): Promise<void> {
     assert.equal(requireElement(harness.host, "#speed").textContent, "43 km/h");
     assert.equal(requireElement(harness.host, "#liveRunHealth").textContent, "Ready");
 
+    setUiLanguage("nl");
+    await harness.flush();
+
+    assert.equal(overviewRenderCount, 1);
+    assert.equal(requireElement(harness.host, ".card__title").textContent, "Live overzicht");
+    assert.equal(
+      requireElement(harness.host, ".card__subtle").textContent,
+      "Controleer de gereedheid, runstatus en het sterkste signaal voordat je de grafiek leest.",
+    );
+
     connectedSensorsText.value = "4 / 4";
     strongestSignalText.value = "82 dB";
     await harness.flush();
@@ -94,6 +106,7 @@ async function runRealtimeLiveOverviewSignalProjectionTest(): Promise<void> {
     assert.equal(harness.host.querySelectorAll("[data-strongest='true']").length, 1);
     assert.match(harness.host.textContent ?? "", /Front Left/);
   } finally {
+    setUiLanguage(previousLanguage);
     options.diffed = previousDiffed;
     harness.cleanup();
   }


### PR DESCRIPTION
## Summary
- replace the eager `useComputed(() => ({ ...getUiText()... }))` label-object pattern with direct `useUiText()` signals in six view files
- pass translated labels down as `ReadonlySignal<string>` only where child sections need them instead of flattening text in the parent
- add live-overview coverage proving language-driven label updates happen without parent rerenders

## Why
- the old pattern rebuilt a whole label object on language changes and then eagerly flattened it outside JSX
- the repo already has `useUiText()` for signal-native translation reads, so the extra wrapper was dead weight

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx tsx tests/realtime_live_overview_signals.ts`
- `cd apps/ui && npx tsx tests/esp_flash_panel_signals.ts`
- `cd apps/ui && npx playwright test tests/smoke.history.spec.ts tests/smoke.analysis-sensors.spec.ts tests/smoke.update.spec.ts tests/realtime_logging_summary.spec.ts`
- `cd apps/ui && npm run test:visual`

## Risk / tradeoffs
- scope is the eager label-object pattern only; individual `getUiText()` `useComputed()` sites like `spectrum_panel.tsx` stay out until a separate issue proves they are worth changing
- child props that consume translated labels now take `ReadonlySignal<string>` so translation reactivity stays at the render edge

Closes #2701
