### PR TITLE
perf(ui): memoize sensor and car table rows

### DIFF
--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -20,7 +20,7 @@ import {
 } from "../views/realtime_logging_view_models";
 import type { RealtimeLiveOverviewRenderModel } from "../views/realtime_live_overview";
 import type { RealtimeLoggingPanelRenderModel } from "../views/realtime_logging_panel";
-import { buildRealtimeSensorTableRenderModel } from "../views/realtime_sensor_table_view";
+import { createRealtimeSensorTableRenderModelMemo } from "../views/realtime_sensor_table_view";
 import type { SensorsPanelRenderModel } from "../views/sensors_panel";
 
 interface RealtimeFeatureViewStateDeps {
@@ -161,6 +161,7 @@ export function createRealtimeFeatureViewState(
     t,
     formatInt,
   });
+  const buildSensorsTableRenderModel = createRealtimeSensorTableRenderModelMemo();
   const elapsedNowMs = signal(Date.now());
   let cachedLastCompletedElapsedText = "--";
   let cachedLoggingElapsedTickInputs: LoggingElapsedTickInputs = {
@@ -374,7 +375,7 @@ export function createRealtimeFeatureViewState(
 
   const sensorsPanelModel = computed<SensorsPanelRenderModel>(() => {
     return {
-      table: buildRealtimeSensorTableRenderModel({
+      table: buildSensorsTableRenderModel({
         clients: realtime.clients.value,
         locationOptions: sensorState.locationOptions.value,
         t,

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -20,7 +20,7 @@ import {
 } from "../ui_signals";
 import {
   buildCarsGuidanceRenderModel,
-  buildSettingsCarListRenderModel,
+  createSettingsCarListRenderModelMemo,
   type CarsListHighlightedFeedback,
 } from "../views/settings_car_list_view";
 import {
@@ -92,6 +92,7 @@ export function createSettingsCarsModule(
       ctx.ports.activeViewId.value === "settingsView"
       && ctx.ports.activeSettingsTabId.value === "carTab",
   );
+  const buildCarListRenderModel = createSettingsCarListRenderModelMemo();
 
   function hasValidActiveCar(): boolean {
     return carSelection.hasResolvedActiveCar.value;
@@ -112,7 +113,7 @@ export function createSettingsCarsModule(
       }),
       table: carSelectionState.kind === "loading"
         ? null
-        : buildSettingsCarListRenderModel({
+        : buildCarListRenderModel({
           activeCarId: settings.activeCarId.value,
           cars: settings.cars.value,
           highlightedCarId: highlightedCar.value?.carId ?? null,

--- a/apps/ui/src/app/views/cars_list_section.tsx
+++ b/apps/ui/src/app/views/cars_list_section.tsx
@@ -1,3 +1,4 @@
+import { memo } from "preact/compat";
 import { getUiText as t } from "../ui_i18n";
 import { inlineStateActionClass } from "./inline_state_panel_models";
 import type {
@@ -58,7 +59,7 @@ function CarsInlineStatePanel(props: {
   );
 }
 
-function CarsTableRow(props: {
+const CarsTableRow = memo(function CarsTableRow(props: {
   actions: CarsListPanelActionHandlers | null;
   row: CarsListRowViewModel;
 }) {
@@ -150,7 +151,7 @@ function CarsTableRow(props: {
       </td>
     </tr>
   );
-}
+});
 
 function CarsTableBody(props: {
   actions: CarsListPanelActionHandlers | null;

--- a/apps/ui/src/app/views/realtime_sensor_table_view.ts
+++ b/apps/ui/src/app/views/realtime_sensor_table_view.ts
@@ -46,6 +46,45 @@ export type RealtimeSensorTableRenderModel =
       rows: RealtimeSensorTableRowViewModel[];
     };
 
+function sameLocationOption(
+  left: RealtimeSensorTableLocationOptionViewModel,
+  right: RealtimeSensorTableLocationOptionViewModel,
+): boolean {
+  return left.code === right.code && left.label === right.label;
+}
+
+function sameLocationOptions(
+  left: readonly RealtimeSensorTableLocationOptionViewModel[],
+  right: readonly RealtimeSensorTableLocationOptionViewModel[],
+): boolean {
+  return left.length === right.length
+    && left.every((option, index) => sameLocationOption(option, right[index]));
+}
+
+function sameSensorRow(
+  left: RealtimeSensorTableRowViewModel,
+  right: RealtimeSensorTableRowViewModel,
+): boolean {
+  return left.clientId === right.clientId
+    && left.displayName === right.displayName
+    && left.statusText === right.statusText
+    && left.statusClass === right.statusClass
+    && left.macAddress === right.macAddress
+    && left.selectedLocationCode === right.selectedLocationCode
+    && left.locationSelectLabel === right.locationSelectLabel
+    && sameLocationOptions(left.locationOptions, right.locationOptions)
+    && left.identifyLabel === right.identifyLabel
+    && left.identifyDisabled === right.identifyDisabled
+    && left.removeLabel === right.removeLabel;
+}
+
+function sameRowReferences(
+  left: readonly RealtimeSensorTableRowViewModel[],
+  right: readonly RealtimeSensorTableRowViewModel[],
+): boolean {
+  return left.length === right.length && left.every((row, index) => row === right[index]);
+}
+
 export function buildRealtimeSensorTableRenderModel(
   params: RealtimeSensorTableViewParams,
 ): RealtimeSensorTableRenderModel {
@@ -78,5 +117,39 @@ export function buildRealtimeSensorTableRenderModel(
         removeLabel: t("actions.remove"),
       };
     }),
+  };
+}
+
+export function createRealtimeSensorTableRenderModelMemo(): (
+  params: RealtimeSensorTableViewParams,
+) => RealtimeSensorTableRenderModel {
+  let previousModel: RealtimeSensorTableRenderModel | null = null;
+  let previousRowsById = new Map<string, RealtimeSensorTableRowViewModel>();
+
+  return (params: RealtimeSensorTableViewParams): RealtimeSensorTableRenderModel => {
+    const nextModel = buildRealtimeSensorTableRenderModel(params);
+    if (nextModel.kind === "empty") {
+      previousRowsById = new Map();
+      if (previousModel?.kind === "empty" && previousModel.emptyText === nextModel.emptyText) {
+        return previousModel;
+      }
+      previousModel = nextModel;
+      return nextModel;
+    }
+
+    const nextRows = nextModel.rows.map((row) => {
+      const previousRow = previousRowsById.get(row.clientId);
+      return previousRow && sameSensorRow(previousRow, row) ? previousRow : row;
+    });
+    previousRowsById = new Map(nextRows.map((row) => [row.clientId, row]));
+    if (previousModel?.kind === "rows" && sameRowReferences(previousModel.rows, nextRows)) {
+      return previousModel;
+    }
+
+    previousModel = {
+      kind: "rows",
+      rows: nextRows,
+    };
+    return previousModel;
   };
 }

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "preact";
 
 import { render } from "preact";
+import { memo } from "preact/compat";
 import { useUiText } from "../ui_i18n";
 import {
   useComputed,
@@ -46,7 +47,7 @@ function handleSensorAction(
   actions?.onSensorTableAction({ type: action, clientId });
 }
 
-function SensorsTableRow(props: {
+const SensorsTableRow = memo(function SensorsTableRow(props: {
   actions: SensorsPanelActionHandlers | null;
   row: RealtimeSensorTableRowViewModel;
 }) {
@@ -106,7 +107,7 @@ function SensorsTableRow(props: {
       </td>
     </tr>
   );
-}
+});
 
 function SensorsTableBody(props: {
   actions: SensorsPanelActionHandlers | null;

--- a/apps/ui/src/app/views/settings_car_list_view.ts
+++ b/apps/ui/src/app/views/settings_car_list_view.ts
@@ -73,6 +73,80 @@ export type SettingsCarListTableRenderModel =
       rows: readonly CarsListRowViewModel[];
     };
 
+function sameInlineAction(
+  left: CarsInlineActionViewModel | undefined,
+  right: CarsInlineActionViewModel | undefined,
+): boolean {
+  return left?.labelText === right?.labelText
+    && left?.type === right?.type
+    && left?.variant === right?.variant;
+}
+
+function sameInlineState(
+  left: CarsInlineStateViewModel,
+  right: CarsInlineStateViewModel,
+): boolean {
+  return left.bodyText === right.bodyText
+    && left.detailText === right.detailText
+    && left.titleText === right.titleText
+    && left.tone === right.tone
+    && sameInlineAction(left.action, right.action);
+}
+
+function sameRowAction(
+  left: CarsListRowActionViewModel | null,
+  right: CarsListRowActionViewModel | null,
+): boolean {
+  return left?.className === right?.className
+    && left?.labelText === right?.labelText
+    && left?.type === right?.type;
+}
+
+function sameRowMetric(
+  left: CarsListRowMetricViewModel,
+  right: CarsListRowMetricViewModel,
+): boolean {
+  return left.isCode === right.isCode
+    && left.labelText === right.labelText
+    && left.valueText === right.valueText;
+}
+
+function sameRowMetrics(
+  left: readonly CarsListRowMetricViewModel[],
+  right: readonly CarsListRowMetricViewModel[],
+): boolean {
+  return left.length === right.length
+    && left.every((metric, index) => sameRowMetric(metric, right[index]));
+}
+
+function sameCarRow(
+  left: CarsListRowViewModel,
+  right: CarsListRowViewModel,
+): boolean {
+  return left.activeState === right.activeState
+    && left.activeStatusText === right.activeStatusText
+    && left.carId === right.carId
+    && left.completionDetailText === right.completionDetailText
+    && left.deleteLabelText === right.deleteLabelText
+    && left.displayName === right.displayName
+    && left.highlightedStatusText === right.highlightedStatusText
+    && left.isComplete === right.isComplete
+    && left.isHighlighted === right.isHighlighted
+    && left.metaTypeText === right.metaTypeText
+    && left.metaVariantText === right.metaVariantText
+    && sameRowAction(left.primaryAction, right.primaryAction)
+    && left.readinessState === right.readinessState
+    && left.readinessStatusText === right.readinessStatusText
+    && sameRowMetrics(left.setupMetrics, right.setupMetrics);
+}
+
+function sameRowReferences(
+  left: readonly CarsListRowViewModel[],
+  right: readonly CarsListRowViewModel[],
+): boolean {
+  return left.length === right.length && left.every((row, index) => row === right[index]);
+}
+
 function hasConfiguredNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
@@ -227,5 +301,39 @@ export function buildSettingsCarListRenderModel(
         ],
       };
     }),
+  };
+}
+
+export function createSettingsCarListRenderModelMemo(): (
+  params: SettingsCarListViewParams,
+) => SettingsCarListTableRenderModel {
+  let previousModel: SettingsCarListTableRenderModel | null = null;
+  let previousRowsById = new Map<string, CarsListRowViewModel>();
+
+  return (params: SettingsCarListViewParams): SettingsCarListTableRenderModel => {
+    const nextModel = buildSettingsCarListRenderModel(params);
+    if (nextModel.kind === "empty") {
+      previousRowsById = new Map();
+      if (previousModel?.kind === "empty" && sameInlineState(previousModel.emptyState, nextModel.emptyState)) {
+        return previousModel;
+      }
+      previousModel = nextModel;
+      return nextModel;
+    }
+
+    const nextRows = nextModel.rows.map((row) => {
+      const previousRow = previousRowsById.get(row.carId);
+      return previousRow && sameCarRow(previousRow, row) ? previousRow : row;
+    });
+    previousRowsById = new Map(nextRows.map((row) => [row.carId, row]));
+    if (previousModel?.kind === "rows" && sameRowReferences(previousModel.rows, nextRows)) {
+      return previousModel;
+    }
+
+    previousModel = {
+      kind: "rows",
+      rows: nextRows,
+    };
+    return previousModel;
   };
 }

--- a/apps/ui/tests/car_list_state.spec.ts
+++ b/apps/ui/tests/car_list_state.spec.ts
@@ -4,6 +4,7 @@ import { getCarCompleteness } from "../src/app/car_selection_state";
 import {
   buildCarsGuidanceRenderModel,
   buildSettingsCarListRenderModel,
+  createSettingsCarListRenderModelMemo,
 } from "../src/app/views/settings_car_list_view";
 import type { CarRecord } from "../src/api/types";
 
@@ -191,6 +192,67 @@ test("buildSettingsCarListRenderModel produces the actionable empty state when n
       titleText: "Add the first car profile.",
     },
   });
+});
+
+test("createSettingsCarListRenderModelMemo preserves unchanged row references", () => {
+  const buildMemoizedModel = createSettingsCarListRenderModelMemo();
+  const readyCar = makeCar({
+    id: "car-ready",
+    name: "Ready Car",
+    aspects: {
+      tire_width_mm: 245,
+      tire_aspect_pct: 40,
+      rim_in: 18,
+      final_drive_ratio: 3.91,
+      current_gear_ratio: 0.82,
+    },
+  });
+  const incompleteCar = makeCar({
+    id: "car-new",
+    name: "Needs Work",
+    variant: "Project",
+    aspects: {
+      tire_width_mm: 245,
+    },
+  });
+
+  const firstModel = buildMemoizedModel({
+    cars: [readyCar, incompleteCar],
+    activeCarId: "car-ready",
+    highlightedCarId: null,
+    t,
+    fmt,
+  });
+
+  expect(firstModel.kind).toBe("rows");
+  if (firstModel.kind !== "rows") {
+    throw new Error("Expected car rows");
+  }
+
+  const secondModel = buildMemoizedModel({
+    cars: [
+      makeCar({
+        ...readyCar,
+        aspects: { ...readyCar.aspects },
+      }),
+      makeCar({
+        ...incompleteCar,
+        aspects: { ...incompleteCar.aspects },
+      }),
+    ],
+    activeCarId: "car-ready",
+    highlightedCarId: "car-new",
+    t,
+    fmt,
+  });
+
+  expect(secondModel.kind).toBe("rows");
+  if (secondModel.kind !== "rows") {
+    throw new Error("Expected car rows");
+  }
+
+  expect(secondModel.rows[0]).toBe(firstModel.rows[0]);
+  expect(secondModel.rows[1]).not.toBe(firstModel.rows[1]);
 });
 
 test("buildCarsGuidanceRenderModel returns success, guidance, or hidden states based on selection", () => {

--- a/apps/ui/tests/realtime_sensor_table_view.spec.ts
+++ b/apps/ui/tests/realtime_sensor_table_view.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { buildRealtimeSensorTableRenderModel } from "../src/app/views/realtime_sensor_table_view";
+import {
+  buildRealtimeSensorTableRenderModel,
+  createRealtimeSensorTableRenderModelMemo,
+} from "../src/app/views/realtime_sensor_table_view";
 import type { AdaptedClient } from "../src/transport/live_models";
 
 const labels: Record<string, string> = {
@@ -73,4 +76,57 @@ test("buildRealtimeSensorTableRenderModel uses the compact three-column empty st
     kind: "empty",
     emptyText: "No sensors detected yet.",
   });
+});
+
+test("createRealtimeSensorTableRenderModelMemo preserves unchanged row references", () => {
+  const buildMemoizedModel = createRealtimeSensorTableRenderModelMemo();
+  const firstModel = buildMemoizedModel({
+    clients: [
+      makeClient({
+        id: "sensor-1",
+        mac_address: "001122334455",
+        name: "Chassis Sensor A",
+      }),
+      makeClient({
+        connected: false,
+        id: "sensor-2",
+        mac_address: "66778899AABB",
+        name: "Chassis Sensor B",
+      }),
+    ],
+    locationOptions: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
+    t,
+  });
+
+  expect(firstModel.kind).toBe("rows");
+  if (firstModel.kind !== "rows") {
+    throw new Error("Expected sensor rows");
+  }
+
+  const secondModel = buildMemoizedModel({
+    clients: [
+      makeClient({
+        id: "sensor-1",
+        last_seen_age_ms: 250,
+        mac_address: "001122334455",
+        name: "Chassis Sensor A",
+      }),
+      makeClient({
+        connected: true,
+        id: "sensor-2",
+        mac_address: "66778899AABB",
+        name: "Chassis Sensor B",
+      }),
+    ],
+    locationOptions: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
+    t,
+  });
+
+  expect(secondModel.kind).toBe("rows");
+  if (secondModel.kind !== "rows") {
+    throw new Error("Expected sensor rows");
+  }
+
+  expect(secondModel.rows[0]).toBe(firstModel.rows[0]);
+  expect(secondModel.rows[1]).not.toBe(firstModel.rows[1]);
 });


### PR DESCRIPTION
## what change
- memo sensor and car table row components so stable row props skip rerender
- add render-model memo builders keyed by clientId and carId in the sensor and car table builders
- keep those memo builders alive in the realtime and settings feature callers and add row-reference regressions

## why
- the table signal swaps in a fresh render-model object on each update
- unchanged rows were rerendering even when only one sensor or car row changed
- history table already uses the same stable-reference pattern

## validate
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/realtime_sensor_table_view.spec.ts tests/car_list_state.spec.ts tests/settings_cars_module.spec.ts`
- `cd apps/ui && npx playwright test tests/smoke.cars.spec.ts tests/smoke.analysis-sensors.spec.ts`
- `cd apps/ui && npm run test:visual`

## risk
- row reuse depends on the equality helpers staying aligned with rendered row fields
- if a new rendered row field is added later, the row comparison helper must include it

Closes #2702
