### PR TITLE
refactor(ui): flatten deferred models

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_chrome.tsx
+++ b/apps/ui/src/app/runtime/ui_shell_chrome.tsx
@@ -5,12 +5,12 @@ import {
   type UiPanelHostRegistry,
 } from "../ui_panel_host_registry";
 import {
-  useComputed,
   type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
 import {
   createDeferredModelSignal,
+  useDeferredModel,
 } from "../views/view_model_binding";
 import { AppErrorBanner, ConfirmationDialogLayer } from "./shell/ui_shell_chrome_dialog";
 import { ShellViewHostsContainer } from "./shell/ui_shell_chrome_hosts";
@@ -65,10 +65,10 @@ function UiShellChrome(props: UiShellChromeProps) {
     actions,
     panelHosts,
   } = props;
-  const dialogModel = useComputed(() => props.dialogModel.value?.value ?? DEFAULT_DIALOG_MODEL);
-  const navigationModel = useComputed(() => props.navigationModel.value?.value ?? DEFAULT_NAVIGATION_MODEL);
-  const preferencesModel = useComputed(() => props.preferencesModel.value?.value ?? DEFAULT_PREFERENCES_MODEL);
-  const statusModel = useComputed(() => props.statusModel.value?.value ?? DEFAULT_STATUS_MODEL);
+  const dialogModel = useDeferredModel(props.dialogModel, DEFAULT_DIALOG_MODEL);
+  const navigationModel = useDeferredModel(props.navigationModel, DEFAULT_NAVIGATION_MODEL);
+  const preferencesModel = useDeferredModel(props.preferencesModel, DEFAULT_PREFERENCES_MODEL);
+  const statusModel = useDeferredModel(props.statusModel, DEFAULT_STATUS_MODEL);
 
   return (
     <ShellChromeFrame statusModel={statusModel}>

--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -54,6 +54,7 @@ import type {
 import {
   createDeferredModelSignal,
   createModelActionPanelBindings,
+  readDeferredModelValue,
 } from "./views/view_model_binding";
 
 const HISTORY_VIEW_ID = "historyView";
@@ -294,7 +295,7 @@ function createDeferredSpeedSourcePanelView(): {
         createDeferredModelSignal<SpeedSourceDiagnosticsRenderModel>(),
       model,
       isObdConfigVisible() {
-        return model.value?.value.obdConfigVisible ?? false;
+        return readDeferredModelValue(model)?.obdConfigVisible ?? false;
       },
       focusManualSpeedInput() {
         requestFocusTarget("manual");

--- a/apps/ui/src/app/views/analysis_panel.tsx
+++ b/apps/ui/src/app/views/analysis_panel.tsx
@@ -23,7 +23,7 @@ import {
   AnalysisGuidanceDialog,
   AnalysisSaveFeedback,
 } from "./analysis_panel_sections";
-import type { DeferredModelSignal } from "./view_model_binding";
+import { readDeferredModel, type DeferredModelSignal } from "./view_model_binding";
 
 export type {
   AnalysisPanelActionHandlers,
@@ -242,8 +242,8 @@ export function mountAnalysisPanel(
 ): Pick<AnalysisPanelView, "focusField" | "openGuidance"> {
   const bridgeState = computed<AnalysisPanelBridgeState>(() => ({
     actions: bindings.actions.value,
-    availability: bindings.carAvailability.value?.value ?? DEFAULT_ANALYSIS_CAR_AVAILABILITY,
-    model: bindings.model.value?.value ?? DEFAULT_ANALYSIS_PANEL_MODEL,
+    availability: readDeferredModel(bindings.carAvailability, DEFAULT_ANALYSIS_CAR_AVAILABILITY),
+    model: readDeferredModel(bindings.model, DEFAULT_ANALYSIS_PANEL_MODEL),
   }));
   const inputFocusRequest = signal<AnalysisFieldFocusRequest | null>(null);
   const guidanceOpenRequest = signal(0);

--- a/apps/ui/src/app/views/esp_flash_panel.tsx
+++ b/apps/ui/src/app/views/esp_flash_panel.tsx
@@ -23,6 +23,7 @@ import {
   type EspFlashStatusBadgeModel,
 } from "./esp_flash_panel_shared";
 import { EspFlashReadinessSection } from "./esp_flash_readiness_section";
+import { useDeferredModel } from "./view_model_binding";
 
 export type {
   EspFlashEmptyStateModel,
@@ -299,7 +300,7 @@ function EspFlashPanel(props: {
   );
   const refreshLabel = useUiText("settings.esp_flash.refresh_ports", "Refresh");
   const titleText = useUiText("settings.esp_flash.title", "ESP Flash");
-  const model = useComputed(() => props.model.value?.value ?? DEFAULT_ESP_FLASH_PANEL_MODEL);
+  const model = useDeferredModel(props.model, DEFAULT_ESP_FLASH_PANEL_MODEL);
   const {
     cancelButtonDisabled,
     cancelButtonHidden,

--- a/apps/ui/src/app/views/history_panel.tsx
+++ b/apps/ui/src/app/views/history_panel.tsx
@@ -11,6 +11,7 @@ import type {
   HistoryPanelView,
   HistoryPanelRenderModel,
 } from "./history_table_view";
+import { useDeferredModel } from "./view_model_binding";
 
 const DEFAULT_PANEL_MODEL: HistoryPanelRenderModel = {
   deleteAllRunsDisabled: true,
@@ -35,7 +36,7 @@ export function HistoryPanel(props: {
   const runLabel = useUiText("history.table.file", "Run");
   const samplesLabel = useUiText("history.table.size", "Samples");
   const startedLabel = useUiText("history.table.updated", "Started");
-  const model = useComputed(() => props.model.value?.value ?? DEFAULT_PANEL_MODEL);
+  const model = useDeferredModel(props.model, DEFAULT_PANEL_MODEL);
   const { deleteAllRunsDisabled, historySummaryText, table } = useSignalProperties(
     model,
     HISTORY_PANEL_MODEL_KEYS,

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -6,7 +6,7 @@ import {
   useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
-import { type DeferredModelSignal } from "./view_model_binding";
+import { type DeferredModelSignal, useDeferredModel } from "./view_model_binding";
 
 export interface RealtimeLiveOverviewActiveCarModel {
   text: string;
@@ -185,8 +185,8 @@ function RealtimeLiveOverview(props: {
   const sensorCoverageLabel = useUiText("dashboard.sensor_coverage", "Sensor coverage");
   const strongestSignalLabel = useUiText("dashboard.strongest_signal", "Strongest signal");
   const titleText = useUiText("dashboard.live_overview", "Live overview");
-  const model = useComputed(() => props.model.value?.value ?? DEFAULT_OVERVIEW_MODEL);
-  const speedText = useComputed(() => props.speedText.value?.value ?? DEFAULT_SPEED_TEXT);
+  const model = useDeferredModel(props.model, DEFAULT_OVERVIEW_MODEL);
+  const speedText = useDeferredModel(props.speedText, DEFAULT_SPEED_TEXT);
   const {
     activeCar,
     connectedSensorsText,

--- a/apps/ui/src/app/views/realtime_logging_panel.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel.tsx
@@ -8,7 +8,7 @@ import {
   type ReadonlySignal,
 } from "../ui_signals";
 import { inlineStateActionClass } from "./inline_state_panel_models";
-import { type DeferredModelSignal } from "./view_model_binding";
+import { type DeferredModelSignal, useDeferredModel } from "./view_model_binding";
 import type {
   RealtimeCaptureReadinessChecklistModel,
   RealtimeLoggingSummaryAction,
@@ -347,7 +347,7 @@ function RealtimeLoggingPanel(props: {
   const startLabel = useUiText("dashboard.start_recording", "Start Recording");
   const stopLabel = useUiText("dashboard.stop_recording", "Stop Recording");
   const titleText = useUiText("dashboard.run_recording", "Run Recording");
-  const model = useComputed(() => props.model.value?.value ?? DEFAULT_PANEL_MODEL);
+  const model = useDeferredModel(props.model, DEFAULT_PANEL_MODEL);
   const { shellLayout } = useSignalProperties(model, ["shellLayout"] as const);
 
   return (

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -15,7 +15,7 @@ import type {
   RealtimeSensorTableRenderModel,
   RealtimeSensorTableRowViewModel,
 } from "./realtime_sensor_table_view";
-import { type DeferredModelSignal } from "./view_model_binding";
+import { type DeferredModelSignal, useDeferredModel } from "./view_model_binding";
 
 export interface SensorsPanelRenderModel {
   table: RealtimeSensorTableRenderModel | null;
@@ -143,7 +143,7 @@ function SensorsPanel(props: {
   const locationLabel = useUiText("settings.sensors.location", "Location");
   const nameLabel = useUiText("settings.sensors.name", "Name");
   const titleText = useUiText("settings.sensors.title", "Sensors");
-  const model = useComputed(() => props.model.value?.value ?? DEFAULT_SENSORS_PANEL_MODEL);
+  const model = useDeferredModel(props.model, DEFAULT_SENSORS_PANEL_MODEL);
   const { table } = useSignalProperties(model, SENSORS_PANEL_MODEL_KEYS);
   return (
     <div class="panel card">

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -7,7 +7,7 @@ import {
   useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
-import { createDeferredModelSignal } from "./view_model_binding";
+import { createDeferredModelSignal, useDeferredModel } from "./view_model_binding";
 import type {
   SpectrumBandLegendModel,
   SpectrumLegendHandlers,
@@ -199,11 +199,11 @@ function SpectrumPanel(props: {
   sensorLegendModel: ReadonlySignal<ReadonlySignal<SpectrumSensorLegendModel | null> | null>;
 }) {
   const { chartDom } = props;
-  const bandLegend = useComputed(() => props.bandLegendModel.value?.value ?? DEFAULT_SPECTRUM_BAND_LEGEND_MODEL);
-  const bandToggle = useComputed(() => props.bandToggleModel.value?.value ?? DEFAULT_SPECTRUM_BAND_TOGGLE_MODEL);
+  const bandLegend = useDeferredModel(props.bandLegendModel, DEFAULT_SPECTRUM_BAND_LEGEND_MODEL);
+  const bandToggle = useDeferredModel(props.bandToggleModel, DEFAULT_SPECTRUM_BAND_TOGGLE_MODEL);
   const overlayModel = useComputed(() => props.overlayModel.value ?? DEFAULT_SPECTRUM_OVERLAY_MODEL);
-  const sensorLegend = useComputed(() => props.sensorLegendModel.value?.value ?? null);
-  const sensorLegendHandlers = useComputed(() => props.sensorLegendHandlersModel.value?.value ?? null);
+  const sensorLegend = useDeferredModel(props.sensorLegendModel, null);
+  const sensorLegendHandlers = useDeferredModel(props.sensorLegendHandlersModel, null);
   const titleText = useComputed(() => getUiText("chart.spectrum_title", props.header.value.titleText));
   const hintText = useComputed(() => getUiText("spectrum.controls_hint", props.header.value.hintText));
   const {

--- a/apps/ui/src/app/views/speed_source_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_panel.tsx
@@ -14,7 +14,7 @@ import { DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL } from "./speed_source_panel_def
 import type {
   SettingsFeedbackMessage,
 } from "./settings_feedback";
-import type { DeferredModelSignal } from "./view_model_binding";
+import { readDeferredModel, type DeferredModelSignal } from "./view_model_binding";
 
 type ChoiceCardState = "active" | "draft" | "error";
 
@@ -199,15 +199,15 @@ export function mountSpeedSourcePanel(
 > {
   const diagnosticsDisclosureOpen = signal(false);
   effect(() => {
-    if (bindings.model.value?.value.diagnosticsShouldOpen) {
+    if (readDeferredModel(bindings.model, DEFAULT_SPEED_SOURCE_PANEL_MODEL).diagnosticsShouldOpen) {
       diagnosticsDisclosureOpen.value = true;
     }
   });
   const bridgeState = computed<SpeedSourcePanelBridgeState>(() => ({
     actions: bindings.actions.value,
-    diagnostics: bindings.diagnostics.value?.value ?? DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL,
+    diagnostics: readDeferredModel(bindings.diagnostics, DEFAULT_SPEED_SOURCE_DIAGNOSTICS_MODEL),
     diagnosticsDisclosureOpen: diagnosticsDisclosureOpen.value,
-    model: bindings.model.value?.value ?? DEFAULT_SPEED_SOURCE_PANEL_MODEL,
+    model: readDeferredModel(bindings.model, DEFAULT_SPEED_SOURCE_PANEL_MODEL),
   }));
   let manualSpeedInput: HTMLInputElement | null = null;
   let scanObdDevicesBtn: HTMLButtonElement | null = null;
@@ -243,7 +243,7 @@ export function mountSpeedSourcePanel(
       staleTimeoutInput?.focus();
     },
     isObdConfigVisible(): boolean {
-      return bindings.model.value?.value.obdConfigVisible ?? false;
+      return readDeferredModel(bindings.model, DEFAULT_SPEED_SOURCE_PANEL_MODEL).obdConfigVisible;
     },
   };
 }

--- a/apps/ui/src/app/views/update_panel.tsx
+++ b/apps/ui/src/app/views/update_panel.tsx
@@ -7,7 +7,7 @@ import {
   type Signal,
   type ReadonlySignal,
 } from "../ui_signals";
-import { type DeferredModelSignal } from "./view_model_binding";
+import { type DeferredModelSignal, useDeferredModel } from "./view_model_binding";
 import type {
   UpdateCurrentStatusSectionModel,
   UpdateHealthSectionModel,
@@ -508,7 +508,7 @@ function UpdatePanel(props: {
     "Note: The page may disconnect while the hotspot is down for the Wi-Fi path. It will reconnect automatically.",
   );
   const titleText = useUiText("settings.update.title", "System Update");
-  const model = useComputed(() => props.model.value?.value ?? DEFAULT_UPDATE_PANEL_MODEL);
+  const model = useDeferredModel(props.model, DEFAULT_UPDATE_PANEL_MODEL);
   const {
     cancelButtonDisabled,
     cancelButtonHidden,

--- a/apps/ui/src/app/views/view_model_binding.ts
+++ b/apps/ui/src/app/views/view_model_binding.ts
@@ -1,5 +1,6 @@
 import {
   signal,
+  useComputed,
   type ReadonlySignal,
   type Signal,
 } from "../ui_signals";
@@ -8,6 +9,26 @@ export type DeferredModelSignal<T> = Signal<ReadonlySignal<T> | null>;
 
 export function createDeferredModelSignal<T>(): DeferredModelSignal<T> {
   return signal<ReadonlySignal<T> | null>(null);
+}
+
+export function readDeferredModelValue<T>(
+  deferred: ReadonlySignal<ReadonlySignal<T> | null>,
+): T | null {
+  return deferred.value?.value ?? null;
+}
+
+export function readDeferredModel<T>(
+  deferred: ReadonlySignal<ReadonlySignal<T> | null>,
+  defaultValue: T,
+): T {
+  return readDeferredModelValue(deferred) ?? defaultValue;
+}
+
+export function useDeferredModel<T>(
+  deferred: ReadonlySignal<ReadonlySignal<T> | null>,
+  defaultValue: T,
+): ReadonlySignal<T> {
+  return useComputed(() => readDeferredModel(deferred, defaultValue));
 }
 
 export interface ModelActionPanelBindings<TModel, TActions> {


### PR DESCRIPTION
## what change
- add `useDeferredModel()`, `readDeferredModel()`, and `readDeferredModelValue()` in `view_model_binding.ts`
- replace repeated `deferred.value?.value ?? DEFAULT` panel bindings across the mounted UI panels and shell chrome
- flatten the one related lazy-panel speed-source getter onto the same helper path

## why
- deferred panel models kept repeating the same double-unwrap pattern in every file
- readability was noisy for a mechanical binding concern
- one helper makes the binding pattern obvious and keeps future panel files consistent

## validate
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run test:visual`

## risk
- low; this is a helper refactor with no intended behavior change
- the only meaningful risk is wiring the wrong default model, which the visual suite covers across the affected panels

Closes #2704
