### PR TITLE
refactor(ui): use data attrs for state styles

### DIFF
--- a/apps/ui/src/app/runtime/shell/ui_shell_chrome_preferences.tsx
+++ b/apps/ui/src/app/runtime/shell/ui_shell_chrome_preferences.tsx
@@ -4,7 +4,7 @@ import {
   type ReadonlySignal,
 } from "../../ui_signals";
 import {
-  settingsFeedbackClassName,
+  settingsFeedbackAttrs,
   type SettingsFeedbackMessage,
 } from "../../views/settings_feedback";
 import {
@@ -113,7 +113,7 @@ function SettingsFeedbackSlot(props: {
       aria-live={ariaLive}
     >
       {message.value ? (
-        <div class={settingsFeedbackClassName(message.value)}>
+        <div {...settingsFeedbackAttrs(message.value)}>
           {message.value.title ? (
             <strong class="settings-feedback__title">{message.value.title}</strong>
           ) : null}

--- a/apps/ui/src/app/views/analysis_panel_sections.tsx
+++ b/apps/ui/src/app/views/analysis_panel_sections.tsx
@@ -2,7 +2,7 @@ import type { JSX } from "preact";
 
 import { getUiText as t } from "../ui_i18n";
 import {
-  settingsFeedbackClassName,
+  settingsFeedbackAttrs,
   type SettingsFeedbackMessage,
 } from "./settings_feedback";
 import type {
@@ -24,7 +24,7 @@ function SettingsFeedbackBlock(props: {
   const { message } = props;
   return (
     <div
-      class={settingsFeedbackClassName(message)}
+      {...settingsFeedbackAttrs(message)}
       aria-live={message.tone === "error" ? "assertive" : "polite"}
     >
       {message.title ? (

--- a/apps/ui/src/app/views/history_table_content.tsx
+++ b/apps/ui/src/app/views/history_table_content.tsx
@@ -108,7 +108,8 @@ function HistoryRow(props: {
   const { handlers, row } = props;
   return (
     <tr
-      class={`history-row${row.isExpanded ? " history-row--expanded" : ""}`}
+      class="history-row"
+      data-expanded={row.isExpanded ? "true" : undefined}
       data-run-row="1"
       data-run={row.runId}
       onClick={() => handlers?.onTableInteraction({ type: "toggle-run", runId: row.runId })}
@@ -126,7 +127,8 @@ function HistoryRow(props: {
           <div class="history-row__detail-affordance">
             <HistoryDiagnosisSummary row={row} />
             <button
-              class={`history-row__toggle${row.isExpanded ? " history-row__toggle--expanded" : ""}`}
+              class="history-row__toggle"
+              data-expanded={row.isExpanded ? "true" : undefined}
               type="button"
               aria-expanded={row.isExpanded ? "true" : "false"}
               aria-label={row.toggleTitle}

--- a/apps/ui/src/app/views/realtime_live_overview.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview.tsx
@@ -150,7 +150,8 @@ function RealtimeLiveOverviewSensorRoster(props: {
               <div class="live-sensor-card__header">
                 <strong>{card.label}</strong>
                 <span
-                  class={`live-sensor-card__status-dot live-sensor-card__status-dot--${statusClass}`}
+                  class="live-sensor-card__status-dot"
+                  data-status={statusClass}
                   role="img"
                   aria-label={card.statusText}
                   title={card.statusText}

--- a/apps/ui/src/app/views/sensors_panel.tsx
+++ b/apps/ui/src/app/views/sensors_panel.tsx
@@ -58,7 +58,9 @@ const SensorsTableRow = memo(function SensorsTableRow(props: {
         <div class="settings-sensor-row__identity">
           <div class="settings-sensor-row__heading">
             <strong>{row.displayName}</strong>
-            <span class={`status-pill settings-entity-status ${row.statusClass}`}>{row.statusText}</span>
+            <span class="status-pill settings-entity-status" data-status={row.statusClass}>
+              {row.statusText}
+            </span>
           </div>
           <div class="settings-sensor-row__meta">
             <code>{row.macAddress}</code>

--- a/apps/ui/src/app/views/settings_feedback.ts
+++ b/apps/ui/src/app/views/settings_feedback.ts
@@ -8,11 +8,17 @@ export interface SettingsFeedbackMessage {
   compact?: boolean;
 }
 
-export function settingsFeedbackClassName(message: SettingsFeedbackMessage): string {
+export interface SettingsFeedbackAttrs {
+  class: "settings-feedback";
+  "data-tone": SettingsFeedbackTone;
+  "data-compact"?: "true";
+}
+
+export function settingsFeedbackAttrs(message: SettingsFeedbackMessage): SettingsFeedbackAttrs {
   const tone = message.tone ?? "info";
-  const classNames = ["settings-feedback", `settings-feedback--${tone}`];
-  if (message.compact) {
-    classNames.push("settings-feedback--compact");
-  }
-  return classNames.join(" ");
+  return {
+    class: "settings-feedback",
+    "data-tone": tone,
+    "data-compact": message.compact ? "true" : undefined,
+  };
 }

--- a/apps/ui/src/app/views/speed_source_config_panel.tsx
+++ b/apps/ui/src/app/views/speed_source_config_panel.tsx
@@ -1,7 +1,7 @@
 import type { DisplayedSpeedSourceMode } from "../speed_source_state";
 import { getUiText as t } from "../ui_i18n";
 import {
-  settingsFeedbackClassName,
+  settingsFeedbackAttrs,
   type SettingsFeedbackMessage,
 } from "./settings_feedback";
 import type {
@@ -51,7 +51,7 @@ function SettingsFeedbackBlock(props: {
   const { message } = props;
   return (
     <div
-      class={settingsFeedbackClassName(message)}
+      {...settingsFeedbackAttrs(message)}
       aria-live={message.tone === "error" ? "assertive" : "polite"}
     >
       {message.title ? (

--- a/apps/ui/src/styles/components.css
+++ b/apps/ui/src/styles/components.css
@@ -155,9 +155,9 @@ button[hidden],
 }
 
 .pill[data-variant] { background: var(--variant-surface); color: var(--variant-text); }
-.status-pill.online,
+.status-pill[data-status="online"],
 .badge.on { background: var(--pill-ok-bg); color: var(--pill-ok-text); }
-.status-pill.offline,
+.status-pill[data-status="offline"],
 .badge.off { background: var(--pill-bad-bg); color: var(--pill-bad-text); }
 
 .card,

--- a/apps/ui/src/styles/history-table.css
+++ b/apps/ui/src/styles/history-table.css
@@ -183,7 +183,7 @@
   outline-offset: 2px;
 }
 
-.history-row__toggle--expanded {
+.history-row__toggle[data-expanded="true"] {
   color: var(--brand-800);
 }
 
@@ -210,7 +210,7 @@
   transform-origin: 35% 50%;
 }
 
-.history-row__toggle--expanded .history-row__toggle-icon {
+.history-row__toggle[data-expanded="true"] .history-row__toggle-icon {
   transform: rotate(90deg);
 }
 
@@ -257,7 +257,7 @@
   margin-top: var(--space-2);
 }
 
-.history-row--expanded td { background: var(--surface-2) !important; }
+.history-row[data-expanded="true"] td { background: var(--surface-2) !important; }
 
 .history-inline-error {
   display: inline-flex;

--- a/apps/ui/src/styles/realtime-overview.css
+++ b/apps/ui/src/styles/realtime-overview.css
@@ -83,11 +83,11 @@
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.65);
 }
 
-.live-sensor-card__status-dot--online {
+.live-sensor-card__status-dot[data-status="online"] {
   background: var(--pill-ok-text);
 }
 
-.live-sensor-card__status-dot--offline {
+.live-sensor-card__status-dot[data-status="offline"] {
   background: var(--pill-bad-text);
 }
 

--- a/apps/ui/src/styles/shell.css
+++ b/apps/ui/src/styles/shell.css
@@ -66,12 +66,12 @@
   background: var(--surface-2);
 }
 
-.settings-feedback--error {
+.settings-feedback[data-tone="error"] {
   border-color: rgba(197, 34, 31, 0.25);
   background: rgba(197, 34, 31, 0.06);
 }
 
-.settings-feedback--compact {
+.settings-feedback[data-compact="true"] {
   padding: 0;
   border: none;
   border-radius: 0;
@@ -94,13 +94,13 @@
   line-height: 1.4;
 }
 
-.settings-feedback--error .settings-feedback__title,
-.settings-feedback--error .settings-feedback__body {
+.settings-feedback[data-tone="error"] .settings-feedback__title,
+.settings-feedback[data-tone="error"] .settings-feedback__body {
   color: var(--danger-700);
 }
 
-.settings-feedback--compact .settings-feedback__body,
-.settings-feedback--compact .settings-feedback__detail {
+.settings-feedback[data-compact="true"] .settings-feedback__body,
+.settings-feedback[data-compact="true"] .settings-feedback__detail {
   font-size: 0.78rem;
 }
 

--- a/apps/ui/src/styles/theme.css
+++ b/apps/ui/src/styles/theme.css
@@ -88,7 +88,7 @@
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
   }
 
-  .history-row--expanded td { background: var(--surface-2) !important; }
+  .history-row[data-expanded="true"] td { background: var(--surface-2) !important; }
 
   .uplot .u-select { background: rgba(167, 139, 250, 0.15); }
 

--- a/apps/ui/tests/smoke.bootstrap.spec.ts
+++ b/apps/ui/tests/smoke.bootstrap.spec.ts
@@ -330,7 +330,7 @@ test("ui bootstrap smoke: tabs, ws state, recording, history", async ({ page }) 
   await expect(page.locator("#liveStrongestSignal [data-value]")).toContainText("Front Left");
   await expect(page.locator("#liveSensorRoster [data-strongest='true']")).toHaveText("Front Left Wheel");
   await expect(page.locator("#liveSensorRoster .status-pill")).toHaveCount(0);
-  await expect(page.locator("#liveSensorRoster .live-sensor-card__status-dot--online")).toHaveCount(1);
+  await expect(page.locator('#liveSensorRoster .live-sensor-card__status-dot[data-status="online"]')).toHaveCount(1);
   await expect(page.locator("#liveSensorRoster article")).toHaveText("Front Left Wheel");
   await expect(page.locator(".spectrum-controls-panel")).toContainText("Select a trace to isolate it.");
   await expect(page.locator(".spectrum-controls-panel #spectrumInspector")).toBeVisible();

--- a/apps/ui/tests/smoke.settings-alignment.spec.ts
+++ b/apps/ui/tests/smoke.settings-alignment.spec.ts
@@ -243,7 +243,7 @@ test("dashboard removes repeated ready and online status badges while keeping st
   await expect(page.locator("#liveRunHealth")).toBeHidden();
   await expect(page.locator("#loggingStatus")).toBeHidden();
   await expect(page.locator("#liveSensorRoster .status-pill")).toHaveCount(0);
-  await expect(page.locator("#liveSensorRoster .live-sensor-card__status-dot--online")).toHaveCount(1);
+  await expect(page.locator('#liveSensorRoster .live-sensor-card__status-dot[data-status="online"]')).toHaveCount(1);
 
   await page.locator("#tab-history").click();
   await expect(page.locator(".site-header__status")).toBeVisible();

--- a/apps/ui/tests/wiki_screenshots.spec.ts
+++ b/apps/ui/tests/wiki_screenshots.spec.ts
@@ -211,7 +211,7 @@ test.describe("wiki screenshots", () => {
     await expect(page.locator("#liveRunHealth")).toBeHidden();
     await expect(page.locator("#loggingStatus")).toBeHidden();
     await expect(page.locator("#liveSensorRoster .status-pill")).toHaveCount(0);
-    await expect(page.locator("#liveSensorRoster .live-sensor-card__status-dot--online")).toHaveCount(5);
+    await expect(page.locator('#liveSensorRoster .live-sensor-card__status-dot[data-status="online"]')).toHaveCount(5);
     await expect(page.locator("#liveSensorRoster article")).toHaveCount(5);
     await assertSpectrumHasData(page);
     await page.screenshot({ fullPage: true, path: screenshotPath("live-dashboard.png") });


### PR DESCRIPTION
## change
- replace shared settings feedback class-string building with stable `data-tone` and `data-compact` attrs
- move sensor status, live roster status dots, and history expansion state from modifier classes to `data-*`
- update CSS selectors and smoke/wiki selectors to the new DOM contract

## why
- remove manual class-string construction in the remaining view sites from #2705
- keep state on stable base classes instead of rebuilding modifier strings in JSX
- make the DOM contract cleaner for Preact diffing and follow-on tests

## validation
- `cd apps/ui && npx playwright test tests/smoke.bootstrap.spec.ts tests/wiki_screenshots.spec.ts tests/smoke.settings-alignment.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run test:visual`

## risk
- DOM selectors changed for settings feedback, live sensor status dots, and history expansion state
- smoke/wiki selectors that asserted old modifier classes were updated in the same change

Closes #2705