### PR TITLE
refactor(ui): add runtime disposal path

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -104,12 +104,13 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | File | Purpose |
 |------|---------|
 | `main.ts` | Thin Vite entry that boots the UI runtime |
-| `app/start_ui_app.ts` | CSS-aware startup entry that renders one `UiAppRoot`, then starts the runtime and hidden-view prefetch |
+| `app/start_ui_app.ts` | CSS-aware public startup entry that mounts one `UiAppRoot` and returns a disposable app handle |
+| `app/ui_app_mount.ts` | Pure mount helper that creates the runtime, renders the root tree, and composes teardown for tests and startup callers |
 | `app/ui_app_root.tsx` | Single rendered app tree that owns the shell frame plus the dashboard/history/settings sections |
 | `app/ui_panel_host_registry.ts` | Ref-backed settings-shell host registry for the per-tab settings panels mounted inside the settings subtree |
 | `app/ui_lazy_panels.ts` | Typed panel binding factory that gives the runtime full dashboard/history/settings contracts up front, then attaches the real settings shell handles when that subtree mounts |
 | `app/dom/` | Focused DOM-only utilities for download and RAF lifecycles after removing the shared global query helper |
-| `app/ui_app_runtime.ts` | Thin UI composition root that creates the shell, spectrum, transport, feature bundle, and startup coordinator from local helper wiring instead of deferred attachment seams |
+| `app/ui_app_runtime.ts` | Thin UI composition root that creates the shell, spectrum, transport, feature bundle, and startup coordinator, then exposes one composed runtime `dispose()` |
 | `app/ui_app_state.ts` | Canonical AppState shape plus reactive slice helpers that keep object-style reads/writes working while shared shell/transport/realtime/history/settings/spectrum state becomes signal-observable |
 | `app/ui_signals.ts` | Canonical re-export surface for shared `signal`, `computed`, and `effect` usage across runtime, features, and views |
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, app-level error banner, and the top-level dashboard/history/settings view containers plus the typed shell bridge |
@@ -223,8 +224,10 @@ the concrete features, wires explicit cross-feature ports, and returns only the
 shell, transport, and startup contracts the runtime needs, while
 `ui_startup_coordinator.ts` runs the startup-only load/refresh ports from a
 small declarative sync/async plan instead of a handwritten boot call chain.
-Long-lived update, ESP flash, and GPS-status polling still start and stop from
-feature-owned reactive context.
+`startUiApp()` now returns a public dispose handle, and that top-level teardown
+flows through `ui_app_runtime.ts` to stop long-lived effects, polling loops,
+WebSocket reconnect/stale timers, spectrum RAF work, and deferred settings
+panel bindings from one place.
 
 The live UI architecture is now fully Preact for the top-level shell and
 primary page composition. `app/runtime/ui_shell_chrome.tsx` owns the primary

--- a/apps/ui/src/app/app_feature_bundle_ports.ts
+++ b/apps/ui/src/app/app_feature_bundle_ports.ts
@@ -11,29 +11,32 @@ export interface AppShellFeatureBindings {
 }
 
 export interface AppFeatureBundle {
+  dispose(): void;
   shell: AppShellFeatureBindings;
   startup: UiStartupFeaturePorts;
 }
 
 interface AppFeatureBundlePortSources {
-  history: Pick<HistoryFeature, "bindHandlers" | "refreshHistory">;
+  history: Pick<HistoryFeature, "bindHandlers" | "dispose" | "refreshHistory">;
   realtime: Pick<
     RealtimeFeature,
     | "bindHandlers"
+    | "dispose"
     | "refreshLocationOptions"
     | "refreshLoggingStatus"
   >;
   settings: Pick<
     SettingsFeature,
     | "bindHandlers"
+    | "dispose"
     | "syncSettingsInputs"
     | "loadSpeedSourceFromServer"
     | "loadAnalysisSettingsFromServer"
     | "loadCarsFromServer"
   >;
-  cars: Pick<CarsFeature, "bindWizardHandlers">;
-  update: Pick<UpdateFeature, "bindUpdateHandlers">;
-  espFlash: Pick<EspFlashFeature, "bindHandlers">;
+  cars: Pick<CarsFeature, "bindWizardHandlers" | "dispose">;
+  update: Pick<UpdateFeature, "bindUpdateHandlers" | "dispose">;
+  espFlash: Pick<EspFlashFeature, "bindHandlers" | "dispose">;
 }
 
 export function createRealtimeFeatureRecordingPorts(
@@ -48,6 +51,14 @@ export function createAppFeatureBundlePorts(
   features: AppFeatureBundlePortSources,
 ): AppFeatureBundle {
   return {
+    dispose: () => {
+      features.espFlash.dispose();
+      features.update.dispose();
+      features.history.dispose();
+      features.realtime.dispose();
+      features.settings.dispose();
+      features.cars.dispose();
+    },
     shell: {
       bindHandlers: () => {
         features.settings.bindHandlers();

--- a/apps/ui/src/app/features/cars_feature.ts
+++ b/apps/ui/src/app/features/cars_feature.ts
@@ -21,6 +21,7 @@ export interface CarsFeatureDeps {
 
 export interface CarsFeature {
   bindWizardHandlers(): void;
+  dispose(): void;
   openWizard(): void;
 }
 
@@ -116,6 +117,7 @@ export function createCarsFeature(ctx: CarsFeatureDeps): CarsFeature {
         },
       };
     },
+    dispose(): void {},
     openWizard,
   };
 }

--- a/apps/ui/src/app/features/esp_flash_feature.ts
+++ b/apps/ui/src/app/features/esp_flash_feature.ts
@@ -22,6 +22,7 @@ export interface EspFlashFeatureDeps {
 
 export interface EspFlashFeature {
   bindHandlers(): void;
+  dispose(): void;
   startPolling(): void;
   stopPolling(): void;
 }
@@ -50,7 +51,7 @@ export function createEspFlashFeature(
   });
   panel.model.value = presenter.model;
 
-  effectOnChange(pollingEnabled, (enabled) => {
+  const disposePollingContextSync = effectOnChange(pollingEnabled, (enabled) => {
     if (enabled) {
       void workflow.refreshPorts();
     }
@@ -79,6 +80,10 @@ export function createEspFlashFeature(
 
   return {
     bindHandlers,
+    dispose(): void {
+      disposePollingContextSync();
+      workflow.dispose();
+    },
     startPolling: () => workflow.startPolling(),
     stopPolling: () => workflow.stopPolling(),
   };

--- a/apps/ui/src/app/features/esp_flash_feature_workflow.ts
+++ b/apps/ui/src/app/features/esp_flash_feature_workflow.ts
@@ -50,6 +50,7 @@ export interface EspFlashFeatureWorkflowDeps {
 
 export interface EspFlashFeatureWorkflow {
   cancelFlash(): Promise<void>;
+  dispose(): void;
   getRenderState(): EspFlashFeatureRenderState;
   readonly renderState: ReadonlySignal<EspFlashFeatureRenderState>;
   refreshPorts(): Promise<void>;
@@ -235,6 +236,9 @@ export function createEspFlashFeatureWorkflow(
 
   return {
     cancelFlash,
+    dispose(): void {
+      polling.dispose();
+    },
     getRenderState,
     renderState,
     refreshPorts,

--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -36,6 +36,7 @@ export interface HistoryFeatureDeps {
 
 export interface HistoryFeature {
   bindHandlers(): void;
+  dispose(): void;
   refreshHistory(): Promise<void>;
   deleteAllRuns(): Promise<void>;
   onHistoryTableAction(action: HistoryRunAction, runId: string): Promise<void>;
@@ -238,8 +239,8 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     });
   }
 
-  function bindReactiveLanguageSync(): void {
-    effectOnChange(shell.lang, () => {
+  function bindReactiveLanguageSync(): () => void {
+    return effectOnChange(shell.lang, () => {
       untracked(() => {
         reloadExpandedRunOnLanguageChange();
       });
@@ -425,10 +426,14 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     };
   }
 
-  bindReactiveLanguageSync();
+  const disposeLanguageSync = bindReactiveLanguageSync();
 
   return {
     bindHandlers,
+    dispose(): void {
+      previewPrefetchToken += 1;
+      disposeLanguageSync();
+    },
     refreshHistory,
     deleteAllRuns,
     onHistoryTableAction,

--- a/apps/ui/src/app/features/polling_controller.ts
+++ b/apps/ui/src/app/features/polling_controller.ts
@@ -2,6 +2,7 @@ import { effect, signal, type ReadonlySignal } from "../ui_signals";
 import { createReplaceableTimeout } from "../timer_cleanup";
 
 export interface PollingController {
+  dispose(): void;
   start(): void;
   stop(): void;
   restart(): void;
@@ -21,15 +22,20 @@ export function createPollingController(
   const pollTimer = createReplaceableTimeout();
   let pollGeneration = 0;
   const pollingActive = signal(false);
+  let disposeEnabledSync: (() => void) | null = null;
+  let disposed = false;
 
   function schedulePoll(delayMs: number, generation: number): void {
-    if (!pollingActive.value || generation !== pollGeneration) return;
+    if (disposed || !pollingActive.value || generation !== pollGeneration) return;
     pollTimer.replace(() => {
       void runPoll(generation);
     }, delayMs);
   }
 
   async function runPoll(generation: number = pollGeneration): Promise<void> {
+    if (disposed) {
+      return;
+    }
     try {
       const delayMs = await poll();
       schedulePoll(delayMs, generation);
@@ -39,14 +45,14 @@ export function createPollingController(
   }
 
   function restart(): void {
-    if (!pollingActive.value) return;
+    if (disposed || !pollingActive.value) return;
     pollGeneration += 1;
     pollTimer.clear();
     void runPoll(pollGeneration);
   }
 
   function start(): void {
-    if (pollingActive.value) return;
+    if (disposed || pollingActive.value) return;
     pollingActive.value = true;
     restart();
   }
@@ -58,8 +64,18 @@ export function createPollingController(
     pollTimer.clear();
   }
 
+  function dispose(): void {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    stop();
+    disposeEnabledSync?.();
+    disposeEnabledSync = null;
+  }
+
   if (enabled) {
-    effect(() => {
+    disposeEnabledSync = effect(() => {
       if (enabled.value) {
         start();
         return;
@@ -69,6 +85,7 @@ export function createPollingController(
   }
 
   return {
+    dispose,
     start,
     stop,
     restart,

--- a/apps/ui/src/app/features/realtime_feature.ts
+++ b/apps/ui/src/app/features/realtime_feature.ts
@@ -63,6 +63,7 @@ export interface RealtimeFeatureRecordingPorts {
 
 export interface RealtimeFeature {
   bindHandlers(): void;
+  dispose(): void;
   refreshLoggingStatus(): Promise<void>;
   refreshLocationOptions(): Promise<void>;
 }
@@ -117,7 +118,7 @@ export function createRealtimeFeature(
     activateSettingsTab(tabId);
   }
 
-  effect(() => {
+  const disposeLiveStatusSync = effect(() => {
     const model = viewState.liveOverviewModel.value;
     untracked(() => {
       ports.chrome.setShellLiveStatus(model.runHealth.variant, model.runHealth.text);
@@ -174,6 +175,11 @@ export function createRealtimeFeature(
 
   return {
     bindHandlers,
+    dispose(): void {
+      disposeLiveStatusSync();
+      workflow.dispose();
+      viewState.dispose();
+    },
     refreshLoggingStatus: () => workflow.refreshLoggingStatus(),
     refreshLocationOptions: () => workflow.refreshLocationOptions(),
   };

--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -40,6 +40,7 @@ interface RealtimeFeatureViewStateDeps {
 }
 
 export interface RealtimeFeatureViewState {
+  dispose(): void;
   readonly idleCaptureReadinessSignature: ReadonlySignal<string>;
   readonly liveOverviewModel: ReadonlySignal<RealtimeLiveOverviewRenderModel>;
   readonly loggingPanelModel: ReadonlySignal<RealtimeLoggingPanelRenderModel>;
@@ -215,7 +216,7 @@ export function createRealtimeFeatureViewState(
   });
   const loggingElapsedTimer = createReplaceableInterval();
 
-  bindReplaceableTimerEffect(loggingElapsedTimer, () => {
+  const disposeLoggingElapsedTimer = bindReplaceableTimerEffect(loggingElapsedTimer, () => {
     if (!loggingElapsedShouldTick.value) {
       return null;
     }
@@ -398,6 +399,10 @@ export function createRealtimeFeatureViewState(
   });
 
   return {
+    dispose(): void {
+      disposeLoggingElapsedTimer();
+      loggingElapsedTimer.clear();
+    },
     idleCaptureReadinessSignature,
     liveOverviewModel,
     loggingPanelModel,

--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -87,6 +87,7 @@ export interface RealtimeFeatureWorkflowDeps {
 export interface RealtimeFeatureWorkflow {
   readonly signals: RealtimeFeatureWorkflowSignals;
   bindHandlers(): void;
+  dispose(): void;
   refreshLoggingStatus(): Promise<void>;
   startLogging(): Promise<void>;
   stopLogging(): Promise<void>;
@@ -198,7 +199,7 @@ export function createRealtimeFeatureWorkflow(
     }
   }
 
-  effectOnChange(idleCaptureReadinessTrigger, () => {
+  const disposeIdleCaptureReadinessSync = effectOnChange(idleCaptureReadinessTrigger, () => {
     void refreshIdleCaptureReadiness(deps.idleCaptureReadinessSignature.peek());
   });
 
@@ -373,6 +374,10 @@ export function createRealtimeFeatureWorkflow(
   }
 
   return {
+    dispose(): void {
+      loggingStatusPolling.dispose();
+      disposeIdleCaptureReadinessSync();
+    },
     signals: state,
     bindHandlers,
     refreshLoggingStatus,

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -54,6 +54,7 @@ export interface SettingsCarsModuleDeps {
 
 export interface SettingsCarsModule {
   bindHandlers(): void;
+  dispose(): void;
   hasValidActiveCar(): boolean;
   loadCarsFromServer(): Promise<void>;
   renderCarList(): void;
@@ -86,6 +87,7 @@ export function createSettingsCarsModule(
   const transport = createSettingsCarsTransport(ctx.transport);
   const carSelection = createCarSelectionDerivedState(settings);
   let handlersBound = false;
+  let disposeHighlightedCarSync: (() => void) | null = null;
   const highlightedCar = signal<CarsListHighlightedFeedback | null>(null);
   const carsContextVisible = computed(
     () =>
@@ -247,7 +249,7 @@ export function createSettingsCarsModule(
       return;
     }
     handlersBound = true;
-    effect(() => {
+    disposeHighlightedCarSync = effect(() => {
       if (highlightedCar.value && !carsContextVisible.value) {
         untracked(clearHighlightedCarFeedback);
       }
@@ -279,6 +281,10 @@ export function createSettingsCarsModule(
 
   return {
     bindHandlers,
+    dispose(): void {
+      disposeHighlightedCarSync?.();
+      disposeHighlightedCarSync = null;
+    },
     hasValidActiveCar,
     loadCarsFromServer,
     renderCarList,

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -56,6 +56,7 @@ export interface SettingsFeatureViewPorts {
 
 export interface SettingsFeature {
   bindHandlers(): void;
+  dispose(): void;
   syncSettingsInputs(): void;
   loadSpeedSourceFromServer(): Promise<void>;
   loadAnalysisSettingsFromServer(): Promise<void>;
@@ -141,7 +142,7 @@ export function createSettingsFeature(
     formatting,
   });
 
-  effectOnChange(ctx.state.shell.lang, () => {
+  const disposeLanguageSync = effectOnChange(ctx.state.shell.lang, () => {
     untracked(() => {
       analysisModule.syncSettingsInputs();
     });
@@ -168,6 +169,12 @@ export function createSettingsFeature(
 
   return {
     bindHandlers,
+    dispose(): void {
+      disposeLanguageSync();
+      gpsStatusModule.dispose();
+      speedSourceModule.dispose();
+      carsModule.dispose();
+    },
     syncSettingsInputs: analysisModule.syncSettingsInputs,
     loadSpeedSourceFromServer,
     loadAnalysisSettingsFromServer:

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -33,6 +33,7 @@ export interface SettingsGpsStatusModuleDeps {
 
 export interface SettingsGpsStatusModule {
   bindHandlers(): void;
+  dispose(): void;
   markStartupReady(): void;
 }
 
@@ -61,7 +62,7 @@ export function createSettingsGpsStatusModule(
     )
   );
 
-  createPollingController({
+  const polling = createPollingController({
     enabled: pollingEnabled,
     poll: async () => {
       const shouldLoadObdStatus =
@@ -91,6 +92,9 @@ export function createSettingsGpsStatusModule(
   return {
     bindHandlers(): void {
       handlersBound.value = true;
+    },
+    dispose(): void {
+      polling.dispose();
     },
     markStartupReady(): void {
       startupReady.value = true;

--- a/apps/ui/src/app/features/settings_speed_source_module.ts
+++ b/apps/ui/src/app/features/settings_speed_source_module.ts
@@ -29,6 +29,7 @@ export interface SettingsSpeedSourceModuleDeps {
 
 export interface SettingsSpeedSourceModule {
   bindHandlers(): void;
+  dispose(): void;
   syncSpeedSourceSelectionUi(): void;
   syncSpeedSourceInputs(): void;
   loadSpeedSourceFromServer(): Promise<void>;
@@ -69,13 +70,14 @@ export function createSettingsSpeedSourceModule(
   );
   ctx.panel.model.value = panelModel;
   let handlersBound = false;
+  let disposeNavigationContextSync: (() => void) | null = null;
 
   function bindHandlers(): void {
     if (handlersBound) {
       return;
     }
     handlersBound = true;
-    effectOnChange(navigationContextKey, () => {
+    disposeNavigationContextSync = effectOnChange(navigationContextKey, () => {
       untracked(() => {
         workflow.handleNavigateContext();
       });
@@ -105,6 +107,11 @@ export function createSettingsSpeedSourceModule(
 
   return {
     bindHandlers,
+    dispose(): void {
+      disposeNavigationContextSync?.();
+      disposeNavigationContextSync = null;
+      workflow.dispose();
+    },
     loadSpeedSourceFromServer: workflow.loadSpeedSourceFromServer,
     saveSpeedSourceFromInputs(): void {
       void workflow.saveSpeedSource();

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -49,6 +49,7 @@ export interface SettingsSpeedSourceWorkflowDeps {
 }
 
 export interface SettingsSpeedSourceWorkflow {
+  dispose(): void;
   getRenderState(): SettingsSpeedSourceRenderState;
   readonly renderState: ReadonlySignal<SettingsSpeedSourceRenderState>;
   handleManualSpeedInput(value: string): void;
@@ -514,6 +515,9 @@ export function createSettingsSpeedSourceWorkflow(
   });
 
   return {
+    dispose(): void {
+      obdBackgroundRescan.dispose();
+    },
     getRenderState,
     renderState,
     handleManualSpeedInput,

--- a/apps/ui/src/app/features/update_feature.ts
+++ b/apps/ui/src/app/features/update_feature.ts
@@ -30,6 +30,7 @@ export interface UpdateFeatureDeps {
 
 export interface UpdateFeature {
   bindUpdateHandlers(): void;
+  dispose(): void;
   startPolling(): void;
   stopPolling(): void;
 }
@@ -97,6 +98,9 @@ export function createUpdateFeature(ctx: UpdateFeatureDeps): UpdateFeature {
 
   return {
     bindUpdateHandlers,
+    dispose(): void {
+      workflow.dispose();
+    },
     startPolling: () => workflow.startPolling(),
     stopPolling: () => workflow.stopPolling(),
   };

--- a/apps/ui/src/app/features/update_feature_workflow.ts
+++ b/apps/ui/src/app/features/update_feature_workflow.ts
@@ -55,6 +55,7 @@ export interface UpdateFeatureWorkflowDeps {
 
 export interface UpdateFeatureWorkflow {
   cancelUpdate(): Promise<void>;
+  dispose(): void;
   getRenderState(): UpdateFeatureRenderState;
   readonly renderState: ReadonlySignal<UpdateFeatureRenderState>;
   refreshStatus(): Promise<void>;
@@ -241,6 +242,9 @@ export function createUpdateFeatureWorkflow(
 
   return {
     cancelUpdate,
+    dispose(): void {
+      polling.dispose();
+    },
     getRenderState,
     renderState,
     refreshStatus,

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -52,6 +52,7 @@ export interface SpectrumCanvasRendererDeps {
 }
 
 export interface SpectrumCanvasRenderer {
+  dispose(): void;
   prepareFrame(): SpectrumPreparedRenderData;
   renderPreparedFrame(prepared: SpectrumPreparedRenderData): void;
   refreshDecorations(): void;
@@ -65,6 +66,7 @@ export function createSpectrumCanvasRenderer(
   const loadChartModule = deps.loadChartModule ?? loadSpectrumChartModule;
 
   let chartLoadPromise: Promise<void> | null = null;
+  let disposed = false;
 
   const spectrumLastFrame = signal<SpectrumHeavyFrame | null>(null);
   const pendingPreparedFrame = signal<SpectrumPreparedRenderData | null>(null);
@@ -94,10 +96,10 @@ export function createSpectrumCanvasRenderer(
 
   const spectrumBandPlugin = createBandPlugin();
   chartPlugins.value = [spectrumBandPlugin];
-  initTweenEffect();
+  const disposeTweenEffect = initTweenEffect();
 
-  function initTweenEffect(): void {
-    effect(() => {
+  function initTweenEffect(): () => void {
+    return effect(() => {
       const to = tweenTarget.value;
       if (!to) return;
       const anim = createRafAnimation({
@@ -221,6 +223,9 @@ export function createSpectrumCanvasRenderer(
   }
 
   function renderPreparedFrame(prepared: SpectrumPreparedRenderData): void {
+    if (disposed) {
+      return;
+    }
     pendingPreparedFrame.value = prepared;
     currentEntries.value = prepared.entries;
     currentFreqAxis.value = prepared.freqAxis;
@@ -259,6 +264,9 @@ export function createSpectrumCanvasRenderer(
   }
 
   function refreshDecorations(): void {
+    if (disposed) {
+      return;
+    }
     const freqAxis = currentFreqAxis.value;
     const entries = currentEntries.value;
     if (!freqAxis.length || !entries.length) {
@@ -268,6 +276,9 @@ export function createSpectrumCanvasRenderer(
   }
 
   function setSeriesIsolation(seriesIndex: number | null): void {
+    if (disposed) {
+      return;
+    }
     deps.state.spectrum.spectrumPlot.value?.setSeriesIsolation(seriesIndex);
   }
 
@@ -442,6 +453,9 @@ export function createSpectrumCanvasRenderer(
   }
 
   function createSpectrumPlot(loadedChartModule: SpectrumChartModule): void {
+    if (disposed) {
+      return;
+    }
     tweenTarget.value = null;
     spectrumLastFrame.value = null;
     if (deps.state.spectrum.spectrumPlot.value) {
@@ -460,6 +474,9 @@ export function createSpectrumCanvasRenderer(
   }
 
   function ensureSpectrumPlot(): boolean {
+    if (disposed) {
+      return false;
+    }
     if (deps.state.spectrum.spectrumPlot.value) {
       deps.state.spectrum.chartLoadErrorDetail.value = null;
       return true;
@@ -478,6 +495,9 @@ export function createSpectrumCanvasRenderer(
     deps.state.spectrum.chartLoadErrorDetail.value = null;
     chartLoadPromise = loadChartModule()
       .then((module) => {
+        if (disposed) {
+          return;
+        }
         chartModule.value = module;
         const latestPrepared = pendingPreparedFrame.value;
         if (!latestPrepared?.frame) {
@@ -489,9 +509,15 @@ export function createSpectrumCanvasRenderer(
         renderPreparedFrame(rerender);
       })
       .catch((error: unknown) => {
+        if (disposed) {
+          return;
+        }
         deps.state.spectrum.chartLoadErrorDetail.value = getChartLoadErrorDetail(error);
       })
       .finally(() => {
+        if (disposed) {
+          return;
+        }
         deps.state.spectrum.chartLoading.value = false;
         chartLoadPromise = null;
         onAsyncChartUpdate();
@@ -505,6 +531,20 @@ export function createSpectrumCanvasRenderer(
   }
 
   return {
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      disposeTweenEffect();
+      tweenTarget.value = null;
+      pendingPreparedFrame.value = null;
+      if (deps.state.spectrum.spectrumPlot.value) {
+        deps.state.spectrum.spectrumPlot.value.destroy();
+        deps.state.spectrum.spectrumPlot.value = null;
+      }
+      deps.state.spectrum.chartLoading.value = false;
+    },
     prepareFrame,
     renderPreparedFrame,
     refreshDecorations,

--- a/apps/ui/src/app/runtime/spectrum_interaction_controller.ts
+++ b/apps/ui/src/app/runtime/spectrum_interaction_controller.ts
@@ -52,6 +52,8 @@ export class SpectrumInteractionController {
 
   readonly bandLegendModel: ReadonlySignal<SpectrumBandLegendModel>;
 
+  private readonly disposeInspectorSync: () => void;
+
   constructor(
     private readonly deps: SpectrumInteractionControllerDeps,
   ) {
@@ -157,7 +159,7 @@ export class SpectrumInteractionController {
     });
 
     this.deps.panel.bindBandToggle(() => this.toggleBands());
-    effect(() => {
+    this.disposeInspectorSync = effect(() => {
       const activeFreq = this.activeFrequency();
       const activeBands = activeFreq === null ? [] : this.activeBandsForFrequency(activeFreq);
       const focusEntry = this.focusEntry();
@@ -194,6 +196,10 @@ export class SpectrumInteractionController {
         },
       ));
     });
+  }
+
+  dispose(): void {
+    this.disposeInspectorSync();
   }
 
   sync(

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -24,13 +24,32 @@ export class UiLiveTransportController {
 
   private lastSentSelectionCycle = -1;
 
+  private readonly disposeTransportStateSync: () => void;
+
+  private readonly disposePendingPayloadSync: () => void;
+
+  private readonly disposeWsStateSync: () => void;
+
+  private readonly disposeSelectionSync: () => void;
+
+  private disposed = false;
+
+  private queuedRenderFrameId: number | null = null;
+
   constructor(deps: UiLiveTransportControllerDeps) {
     this.state = deps.state;
     this.payloadErrorMessage = deps.payloadErrorMessage;
-    this.bindTransportSignalSync();
+    const disposers = this.bindTransportSignalSync();
+    this.disposeTransportStateSync = disposers.transportStateSync;
+    this.disposePendingPayloadSync = disposers.pendingPayloadSync;
+    this.disposeWsStateSync = disposers.wsStateSync;
+    this.disposeSelectionSync = disposers.selectionSync;
   }
 
   sendSelection(): void {
+    if (this.disposed) {
+      return;
+    }
     const ws = this.state.transport.ws.value;
     const clientId = this.state.realtime.selectedClientId.value;
     if (
@@ -47,8 +66,30 @@ export class UiLiveTransportController {
     ws.send({ client_id: clientId });
   }
 
-  private bindTransportSignalSync(): void {
-    effect(() => {
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    if (this.queuedRenderFrameId !== null) {
+      globalThis.cancelAnimationFrame(this.queuedRenderFrameId);
+      this.queuedRenderFrameId = null;
+    }
+    this.state.transport.ws.value?.dispose();
+    this.state.transport.ws.value = null;
+    this.disposeSelectionSync();
+    this.disposeWsStateSync();
+    this.disposePendingPayloadSync();
+    this.disposeTransportStateSync();
+  }
+
+  private bindTransportSignalSync(): {
+    pendingPayloadSync: () => void;
+    selectionSync: () => void;
+    transportStateSync: () => void;
+    wsStateSync: () => void;
+  } {
+    const transportStateSync = effect(() => {
       const ws = this.state.transport.ws.value;
       if (!ws) {
         return;
@@ -62,13 +103,13 @@ export class UiLiveTransportController {
       });
     });
 
-    effectOnChange(this.state.transport.pendingPayload, (nextPendingPayload) => {
+    const pendingPayloadSync = effectOnChange(this.state.transport.pendingPayload, (nextPendingPayload) => {
       if (nextPendingPayload !== null) {
         untracked(() => this.queueRender());
       }
     });
 
-    effectOnChange(this.state.transport.wsState, (nextWsState, previousWsState) => {
+    const wsStateSync = effectOnChange(this.state.transport.wsState, (nextWsState, previousWsState) => {
       const nextReady = nextWsState === "connected" || nextWsState === "no_data";
       const previousReady = previousWsState === "connected" || previousWsState === "no_data";
       if (nextReady && !previousReady) {
@@ -77,12 +118,22 @@ export class UiLiveTransportController {
       }
     });
 
-    effectOnChange(this.state.realtime.selectedClientId, () => {
+    const selectionSync = effectOnChange(this.state.realtime.selectedClientId, () => {
       untracked(() => this.sendSelection());
     });
+
+    return {
+      pendingPayloadSync,
+      selectionSync,
+      transportStateSync,
+      wsStateSync,
+    };
   }
 
   startTransportMode(): void {
+    if (this.disposed) {
+      return;
+    }
     const isDemoMode = new URLSearchParams(window.location.search).has("demo");
     if (isDemoMode) {
       runDemoMode({
@@ -95,9 +146,14 @@ export class UiLiveTransportController {
   }
 
   private queueRender(): void {
-    if (this.state.transport.renderQueued.value) return;
+    if (this.disposed || this.state.transport.renderQueued.value) return;
     this.state.transport.renderQueued.value = true;
-    window.requestAnimationFrame(() => {
+    this.queuedRenderFrameId = globalThis.requestAnimationFrame(() => {
+      this.queuedRenderFrameId = null;
+      if (this.disposed) {
+        this.state.transport.renderQueued.value = false;
+        return;
+      }
       this.state.transport.renderQueued.value = false;
       const now = Date.now();
       if (
@@ -118,6 +174,9 @@ export class UiLiveTransportController {
   }
 
   private applyPayload(payload: unknown): void {
+    if (this.disposed) {
+      return;
+    }
     let adapted: AdaptedPayload;
     try {
       adapted = adaptServerPayload(payload);
@@ -141,6 +200,9 @@ export class UiLiveTransportController {
   }
 
   private queueTransportPayload(payload: unknown): void {
+    if (this.disposed) {
+      return;
+    }
     batch(() => {
       this.state.transport.wsState.value = "connected";
       this.state.transport.hasReceivedPayload.value = true;
@@ -149,6 +211,9 @@ export class UiLiveTransportController {
   }
 
   private connectWs(): void {
+    if (this.disposed) {
+      return;
+    }
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     this.state.transport.ws.value = createWsClient({
       url: `${protocol}//${window.location.host}/ws`,

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -86,6 +86,10 @@ export class UiShellController {
 
   private readonly bindFeatureHandlers: () => void;
 
+  private readonly disposeDocumentLanguageSync: () => void;
+
+  private readonly disposeReactiveLanguageSync: () => void;
+
   private readonly liveStatusBadge = signal<UiShellBadgeModel>({
     text: "No live signal",
     variant: "muted",
@@ -133,8 +137,8 @@ export class UiShellController {
     this.dialogRenderModel = this.createDialogRenderModel();
     deps.liveOverview.speedText.value = this.status.speedReadoutText;
     this.bindChromeModelSignals();
-    this.bindDocumentLanguageSync();
-    this.bindReactiveLanguageSync();
+    this.disposeDocumentLanguageSync = this.bindDocumentLanguageSync();
+    this.disposeReactiveLanguageSync = this.bindReactiveLanguageSync();
   }
 
   t(key: string, vars?: Record<string, unknown>): string {
@@ -173,20 +177,26 @@ export class UiShellController {
     this.setActiveView(defaultViewId);
   }
 
+  dispose(): void {
+    this.disposeReactiveLanguageSync();
+    this.disposeDocumentLanguageSync();
+    this.notifications.dispose();
+  }
+
   async hydratePersistedPreferences(): Promise<void> {
     await this.preferences.hydratePersistedPreferences();
   }
 
-  private bindReactiveLanguageSync(): void {
-    effectOnChange(this.state.shell.lang, (currentLanguage) => {
+  private bindReactiveLanguageSync(): () => void {
+    return effectOnChange(this.state.shell.lang, (currentLanguage) => {
       untracked(() => {
         setUiLanguage(currentLanguage);
       });
     });
   }
 
-  private bindDocumentLanguageSync(): void {
-    effect(() => {
+  private bindDocumentLanguageSync(): () => void {
+    return effect(() => {
       const currentLanguage = this.state.shell.lang.value;
       untracked(() => {
         const documentElement = globalThis.document?.documentElement;

--- a/apps/ui/src/app/runtime/ui_shell_notification_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_notification_module.ts
@@ -9,6 +9,7 @@ type UiShellNotificationDeps = {
 export interface UiShellNotificationModule {
   readonly bannerModel: ReadonlySignal<UiShellErrorBannerModel>;
   clearError(): void;
+  dispose(): void;
   showError(message: string): void;
 }
 
@@ -36,6 +37,9 @@ export function createUiShellNotificationModule(
   return {
     bannerModel,
     clearError,
+    dispose(): void {
+      clearScheduledHide();
+    },
     showError(message) {
       clearScheduledHide();
       bannerModel.value = {

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -20,6 +20,12 @@ export class UiSpectrumController {
 
   private readonly canvas: SpectrumCanvasRenderer;
 
+  private readonly disposeLanguageSync: () => void;
+
+  private readonly disposeSpectraSync: () => void;
+
+  private readonly disposeTransportOverlaySync: () => void;
+
   constructor(
     private readonly deps: UiSpectrumControllerDeps,
   ) {
@@ -52,8 +58,9 @@ export class UiSpectrumController {
     this.bindInteractionModelSignals();
     this.renderSpectrumHeader();
     this.updateSpectrumOverlay();
-    this.bindReactiveTransportSync();
-    this.bindReactiveLanguageSync();
+    this.disposeSpectraSync = this.bindReactiveTransportSync();
+    this.disposeLanguageSync = this.bindReactiveLanguageSync();
+    this.disposeTransportOverlaySync = this.bindReactiveOverlaySync();
   }
 
   private get state(): AppState {
@@ -88,6 +95,14 @@ export class UiSpectrumController {
     this.canvas.renderPreparedFrame(prepared);
     this.interaction.applyPlotSelection();
     this.updateSpectrumOverlay();
+  }
+
+  dispose(): void {
+    this.disposeTransportOverlaySync();
+    this.disposeSpectraSync();
+    this.disposeLanguageSync();
+    this.interaction.dispose();
+    this.canvas.dispose();
   }
 
   private spectrumOverlayModel(): { hidden: boolean; text: string } {
@@ -134,8 +149,8 @@ export class UiSpectrumController {
     this.panel.bindBandLegendModel(this.interaction.bandLegendModel);
   }
 
-  private bindReactiveLanguageSync(): void {
-    effectOnChange(this.state.shell.lang, () => {
+  private bindReactiveLanguageSync(): () => void {
+    return effectOnChange(this.state.shell.lang, () => {
       untracked(() => {
         this.renderSpectrumHeader();
         this.updateSpectrumOverlay();
@@ -143,16 +158,19 @@ export class UiSpectrumController {
     });
   }
 
-  private bindReactiveTransportSync(): void {
-    effectOnChange(this.state.spectrum.spectra, () => {
+  private bindReactiveTransportSync(): () => void {
+    return effectOnChange(this.state.spectrum.spectra, () => {
       untracked(() => this.renderSpectrum());
     });
+  }
+
+  private bindReactiveOverlaySync(): () => void {
     const transportOverlayState = computed(() => ({
       hasReceivedPayload: this.state.transport.hasReceivedPayload.value,
       payloadError: this.state.transport.payloadError.value,
       wsState: this.state.transport.wsState.value,
     }));
-    effectOnChange(transportOverlayState, () => {
+    return effectOnChange(transportOverlayState, () => {
       untracked(() => this.updateSpectrumOverlay());
     });
   }

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -2,28 +2,23 @@ import "../styles/app.css";
 import { h, render } from "preact";
 
 import { UiAppRoot } from "./ui_app_root";
-import { createAppState } from "./ui_app_state";
-import { createUiAppRuntime } from "./ui_app_runtime";
-import { getUiShellChromeHost } from "./runtime/ui_shell_chrome";
+import {
+  mountUiApp,
+  type StartedUiApp,
+  type StartUiAppDeps,
+} from "./ui_app_mount";
 
-const UI_APP_MOUNTED_ATTR = "data-ui-app-mounted";
+export type { StartedUiApp, StartUiAppDeps };
 
-export function startUiApp(): void {
-  const host = getUiShellChromeHost();
-  if (host.getAttribute(UI_APP_MOUNTED_ATTR) === "true") {
-    return;
-  }
-  host.setAttribute(UI_APP_MOUNTED_ATTR, "true");
-  const state = createAppState();
-  const runtime = createUiAppRuntime({ state });
-  render(
-    h(UiAppRoot, {
+export function startUiApp(deps: Omit<StartUiAppDeps, "renderRoot"> = {}): StartedUiApp {
+  return mountUiApp({
+    ...deps,
+    renderApp: deps.renderApp ?? render,
+    renderRoot: (runtime) => h(UiAppRoot, {
       attachSettingsPanels: runtime.attachSettingsPanels,
       panels: runtime.panels,
       shellChrome: runtime.shellChrome,
       spectrumPanel: runtime.spectrumPanel,
     }),
-    host,
-  );
-  runtime.start();
+  });
 }

--- a/apps/ui/src/app/ui_app_mount.ts
+++ b/apps/ui/src/app/ui_app_mount.ts
@@ -1,0 +1,46 @@
+import type { ComponentChild } from "preact";
+import { render } from "preact";
+
+import { createAppState, type AppState } from "./ui_app_state";
+import { createUiAppRuntime, type UiAppRuntime } from "./ui_app_runtime";
+import { getUiShellChromeHost } from "./runtime/ui_shell_chrome";
+
+const UI_APP_MOUNTED_ATTR = "data-ui-app-mounted";
+
+export interface StartedUiApp {
+  dispose(): void;
+}
+
+export interface StartUiAppDeps {
+  createRuntime?: (deps: { state: AppState }) => UiAppRuntime;
+  createState?: () => AppState;
+  renderApp?: typeof render;
+  renderRoot(runtime: UiAppRuntime): ComponentChild;
+}
+
+let mountedApp: StartedUiApp | null = null;
+
+export function mountUiApp(deps: StartUiAppDeps): StartedUiApp {
+  const host = getUiShellChromeHost();
+  if (host.getAttribute(UI_APP_MOUNTED_ATTR) === "true" && mountedApp) {
+    return mountedApp;
+  }
+  host.setAttribute(UI_APP_MOUNTED_ATTR, "true");
+  const state = (deps.createState ?? createAppState)();
+  const runtime = (deps.createRuntime ?? createUiAppRuntime)({ state });
+  const renderApp = deps.renderApp ?? render;
+  renderApp(deps.renderRoot(runtime), host);
+  runtime.start();
+  const app: StartedUiApp = {
+    dispose() {
+      runtime.dispose();
+      renderApp(null, host);
+      host.removeAttribute(UI_APP_MOUNTED_ATTR);
+      if (mountedApp === app) {
+        mountedApp = null;
+      }
+    },
+  };
+  mountedApp = app;
+  return app;
+}

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -76,6 +76,7 @@ function createUiAppFeatureRuntimePorts(deps: {
 
 export interface UiAppRuntime {
   attachSettingsPanels(handles: UiMountedLazyPanelHandles): void;
+  dispose(): void;
   panels: UiMountedPanels;
   shellChrome: UiShellChromeBindings;
   spectrumPanel: UiLazyPanels["spectrumPanel"];
@@ -130,13 +131,28 @@ export function createUiAppRuntime(
     features: featurePorts.startup,
     defaultViewId: DEFAULT_SHELL_VIEW_ID,
   });
+  let disposed = false;
 
   return {
     attachSettingsPanels: lazyPanels.attachSettingsPanels,
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      featurePorts.dispose();
+      transport.dispose();
+      spectrum.dispose();
+      shell.dispose();
+      lazyPanels.dispose();
+    },
     panels: lazyPanels.panels,
     shellChrome,
     spectrumPanel: lazyPanels.spectrumPanel,
     start() {
+      if (disposed) {
+        return;
+      }
       startup.start();
     },
   };

--- a/apps/ui/src/app/ui_lazy_panels.ts
+++ b/apps/ui/src/app/ui_lazy_panels.ts
@@ -55,6 +55,7 @@ export interface UiMountedLazyPanelHandles {
 
 export interface UiLazyPanels {
   attachSettingsPanels(mountedPanels: UiMountedLazyPanelHandles): void;
+  dispose(): void;
   panels: UiMountedPanels;
   spectrumPanel: CreatedSpectrumPanel;
 }
@@ -62,9 +63,12 @@ export interface UiLazyPanels {
 function createDeferredTargetAction<TView, TTarget>(
   realView: ReadonlySignal<TView | null>,
   run: (view: TView, target: TTarget) => void,
-): (target: TTarget) => void {
+): {
+  dispose(): void;
+  request(target: TTarget): void;
+} {
   const pendingTarget = signal<TTarget | null>(null);
-  effect(() => {
+  const dispose = effect(() => {
     const view = realView.value;
     const target = pendingTarget.value;
     if (view === null || target === null) {
@@ -73,17 +77,23 @@ function createDeferredTargetAction<TView, TTarget>(
     run(view, target);
     pendingTarget.value = null;
   });
-  return (target) => {
-    pendingTarget.value = target;
+  return {
+    dispose,
+    request(target) {
+      pendingTarget.value = target;
+    },
   };
 }
 
 function createDeferredAction<TView>(
   realView: ReadonlySignal<TView | null>,
   run: (view: TView) => void,
-): () => void {
+): {
+  dispose(): void;
+  request(): void;
+} {
   const pending = signal(false);
-  effect(() => {
+  const dispose = effect(() => {
     const view = realView.value;
     if (view === null || !pending.value) {
       return;
@@ -91,8 +101,11 @@ function createDeferredAction<TView>(
     run(view);
     pending.value = false;
   });
-  return () => {
-    pending.value = true;
+  return {
+    dispose,
+    request() {
+      pending.value = true;
+    },
   };
 }
 
@@ -111,6 +124,7 @@ function createDeferredViewAttachment<TView>(): {
 
 function createDeferredSettingsShellView(): {
   attach(realView: SettingsShellView): void;
+  dispose(): void;
   view: SettingsShellView;
 } {
   let disposeRealViewSync: (() => void) | null = null;
@@ -134,11 +148,17 @@ function createDeferredSettingsShellView(): {
         activeTabId.value = nextRealView.activeTabId.value;
       });
     },
+    dispose() {
+      disposeRealViewSync?.();
+      disposeRealViewSync = null;
+      realView = null;
+    },
   };
 }
 
 function createDeferredCarsPanelView(): {
   attach(realView: Pick<CarsPanelView["wizard"], "focus">): void;
+  dispose(): void;
   view: CarsPanelView;
 } {
   type CarsWizardFocusTarget = Parameters<CarsPanelView["wizard"]["focus"]>[0];
@@ -165,16 +185,20 @@ function createDeferredCarsPanelView(): {
         actions: wizard.actions,
         model: wizard.model,
         focus(target) {
-          requestWizardFocus(target);
+          requestWizardFocus.request(target);
         },
       },
     },
     attach: realWizard.attach,
+    dispose() {
+      requestWizardFocus.dispose();
+    },
   };
 }
 
 function createDeferredAnalysisPanelView(): {
   attach(realView: Pick<AnalysisPanelView, "focusField" | "openGuidance">): void;
+  dispose(): void;
   view: AnalysisPanelView;
 } {
   type AnalysisFocusField = Parameters<AnalysisPanelView["focusField"]>[0];
@@ -197,13 +221,17 @@ function createDeferredAnalysisPanelView(): {
       carAvailability: createDeferredModelSignal<AnalysisPanelCarAvailability>(),
       model: createDeferredModelSignal<AnalysisPanelRenderModel>(),
       openGuidance() {
-        requestGuidanceOpen();
+        requestGuidanceOpen.request();
       },
       focusField(nextFocusField) {
-        requestFocusField(nextFocusField);
+        requestFocusField.request(nextFocusField);
       },
     },
     attach: realView.attach,
+    dispose() {
+      requestGuidanceOpen.dispose();
+      requestFocusField.dispose();
+    },
   };
 }
 
@@ -214,6 +242,7 @@ function createDeferredSpeedSourcePanelView(): {
       "focusManualSpeedInput" | "focusScanObdDevices" | "focusStaleTimeoutInput"
     >,
   ): void;
+  dispose(): void;
   view: SpeedSourcePanelView;
 } {
   type PendingFocusTarget = "manual" | "scan" | "stale";
@@ -246,21 +275,25 @@ function createDeferredSpeedSourcePanelView(): {
         return readDeferredModelValue(model)?.obdConfigVisible ?? false;
       },
       focusManualSpeedInput() {
-        requestFocusTarget("manual");
+        requestFocusTarget.request("manual");
       },
       focusScanObdDevices() {
-        requestFocusTarget("scan");
+        requestFocusTarget.request("scan");
       },
       focusStaleTimeoutInput() {
-        requestFocusTarget("stale");
+        requestFocusTarget.request("stale");
       },
     },
     attach: realView.attach,
+    dispose() {
+      requestFocusTarget.dispose();
+    },
   };
 }
 
 function createDeferredInternetPanelView(): {
   attach(realView: Pick<InternetPanelView, "focusSsidInput">): void;
+  dispose(): void;
   view: InternetPanelView;
 } {
   const realView = createDeferredViewAttachment<Pick<InternetPanelView, "focusSsidInput">>();
@@ -273,14 +306,18 @@ function createDeferredInternetPanelView(): {
       actions: signal<InternetPanelActionHandlers | null>(null),
       model: createDeferredModelSignal<InternetPanelRenderModel>(),
       focusSsidInput() {
-        requestSsidFocus();
+        requestSsidFocus.request();
       },
     },
     attach: realView.attach,
+    dispose() {
+      requestSsidFocus.dispose();
+    },
   };
 }
 
 export function createLazyUiPanels(): UiLazyPanels {
+  let disposed = false;
   const history = {
     view: createModelActionPanelBindings<HistoryPanelRenderModel, HistoryPanelActionHandlers>(),
   };
@@ -314,6 +351,9 @@ export function createLazyUiPanels(): UiLazyPanels {
   } satisfies UiMountedDashboardPanels;
 
   const attachSettingsPanels = (mountedPanels: UiMountedLazyPanelHandles): void => {
+    if (disposed) {
+      return;
+    }
     settingsShell.attach(mountedPanels.settingsShell);
     settings.cars.attach(mountedPanels.settings.cars);
     settings.analysis.attach(mountedPanels.settings.analysis);
@@ -337,6 +377,17 @@ export function createLazyUiPanels(): UiLazyPanels {
       },
     },
     attachSettingsPanels,
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      settingsShell.dispose();
+      settings.cars.dispose();
+      settings.analysis.dispose();
+      settings.internet.dispose();
+      settings.speedSource.dispose();
+    },
     spectrumPanel,
   };
 }

--- a/apps/ui/src/ws.ts
+++ b/apps/ui/src/ws.ts
@@ -19,6 +19,7 @@ export interface WsClient {
   readonly uiState: ReadonlySignal<WsUiState>;
   connect(): void;
   close(): void;
+  dispose(): void;
   send(payload: { client_id: string | null }): void;
 }
 
@@ -49,18 +50,22 @@ export function createWsClient(options: WsClientOptions): WsClient {
   const reconnectTimer = createReplaceableTimeout();
   const socketOpen = signal(false);
   const staleTimer = createReplaceableTimeout();
-
-  bindReconnectLifecycle();
-  bindStaleLifecycle();
+  const disposeReconnectLifecycle = bindReconnectLifecycle();
+  const disposeStaleLifecycle = bindStaleLifecycle();
+  let disposed = false;
 
   return {
     uiState,
     connect,
     close,
+    dispose,
     send,
   };
 
   function connect(): void {
+    if (disposed) {
+      return;
+    }
     batch(() => {
       manuallyClosed.value = false;
       reconnectDelayMs.value = null;
@@ -78,6 +83,18 @@ export function createWsClient(options: WsClientOptions): WsClient {
       ws.close();
       ws = null;
     }
+    reconnectTimer.clear();
+    staleTimer.clear();
+  }
+
+  function dispose(): void {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    close();
+    disposeReconnectLifecycle();
+    disposeStaleLifecycle();
   }
 
   function send(payload: { client_id: string | null }): void {
@@ -137,6 +154,9 @@ export function createWsClient(options: WsClientOptions): WsClient {
   }
 
   function scheduleReconnect(): void {
+    if (disposed) {
+      return;
+    }
     reconnectDelayMs.value = nextReconnectDelayMs();
   }
 
@@ -149,8 +169,8 @@ export function createWsClient(options: WsClientOptions): WsClient {
     return Math.round(raw + jitter);
   }
 
-  function bindReconnectLifecycle(): void {
-    bindReplaceableTimerEffect(reconnectTimer, () => {
+  function bindReconnectLifecycle(): () => void {
+    return bindReplaceableTimerEffect(reconnectTimer, () => {
       const pendingReconnectDelayMs = reconnectDelayMs.value;
       if (pendingReconnectDelayMs === null || manuallyClosed.value) {
         return null;
@@ -167,8 +187,8 @@ export function createWsClient(options: WsClientOptions): WsClient {
     });
   }
 
-  function bindStaleLifecycle(): void {
-    bindReplaceableTimerEffect(staleTimer, () => {
+  function bindStaleLifecycle(): () => void {
+    return bindReplaceableTimerEffect(staleTimer, () => {
       if (
         !socketOpen.value
         || manuallyClosed.value

--- a/apps/ui/tests/app_feature_ports.spec.ts
+++ b/apps/ui/tests/app_feature_ports.spec.ts
@@ -12,6 +12,9 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
     bindHandlers() {
       calls.push("history.bindHandlers");
     },
+    dispose() {
+      calls.push("history.dispose");
+    },
     async refreshHistory() {
       calls.push("history.refreshHistory");
     },
@@ -19,6 +22,9 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
   const realtime = {
     bindHandlers() {
       calls.push("realtime.bindHandlers");
+    },
+    dispose() {
+      calls.push("realtime.dispose");
     },
     async refreshLocationOptions() {
       calls.push("realtime.refreshLocationOptions");
@@ -30,6 +36,9 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
   const settings = {
     bindHandlers() {
       calls.push("settings.bindHandlers");
+    },
+    dispose() {
+      calls.push("settings.dispose");
     },
     syncSettingsInputs() {
       calls.push("settings.syncSettingsInputs");
@@ -60,15 +69,24 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
     bindWizardHandlers() {
       calls.push("cars.bindWizardHandlers");
     },
+    dispose() {
+      calls.push("cars.dispose");
+    },
   };
   const update = {
     bindUpdateHandlers() {
       calls.push("update.bindUpdateHandlers");
     },
+    dispose() {
+      calls.push("update.dispose");
+    },
   };
   const espFlash = {
     bindHandlers() {
       calls.push("espFlash.bindHandlers");
+    },
+    dispose() {
+      calls.push("espFlash.dispose");
     },
   };
 
@@ -82,7 +100,7 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
     espFlash,
   });
 
-  expect(Object.keys(bundle).sort()).toEqual(["shell", "startup"]);
+  expect(Object.keys(bundle).sort()).toEqual(["dispose", "shell", "startup"]);
 
   await recording.onRecordingStatusChanged();
 
@@ -94,6 +112,7 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
   await bundle.startup.settings.loadSpeedSourceFromServer();
   await bundle.startup.settings.loadAnalysisSettingsFromServer();
   await bundle.startup.settings.loadCarsFromServer();
+  bundle.dispose();
 
   expect(calls).toEqual([
     "history.refreshHistory",
@@ -109,6 +128,12 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
     "settings.loadSpeedSourceFromServer",
     "settings.loadAnalysisSettingsFromServer",
     "settings.loadCarsFromServer",
+    "espFlash.dispose",
+    "update.dispose",
+    "history.dispose",
+    "realtime.dispose",
+    "settings.dispose",
+    "cars.dispose",
   ]);
 });
 

--- a/apps/ui/tests/polling_controller.spec.ts
+++ b/apps/ui/tests/polling_controller.spec.ts
@@ -110,4 +110,35 @@ test.describe("createPollingController", () => {
       timers.restore();
     }
   });
+
+  test("dispose tears down enabled-signal polling permanently", async () => {
+    const timers = installTimerHarness();
+    const enabled = signal(true);
+    let pollCalls = 0;
+    const controller = createPollingController({
+      enabled,
+      poll: async () => {
+        pollCalls += 1;
+        return 500;
+      },
+      onErrorDelayMs: 2_000,
+    });
+
+    try {
+      await flushAsyncWork();
+      expect(pollCalls).toBe(1);
+      expect(timers.pendingDelays()).toEqual([500]);
+
+      controller.dispose();
+      expect(timers.pendingDelays()).toEqual([]);
+
+      enabled.value = false;
+      enabled.value = true;
+      await flushAsyncWork();
+      expect(pollCalls).toBe(1);
+      expect(timers.pendingDelays()).toEqual([]);
+    } finally {
+      timers.restore();
+    }
+  });
 });

--- a/apps/ui/tests/start_ui_app.spec.ts
+++ b/apps/ui/tests/start_ui_app.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+
+import { mountUiApp } from "../src/app/ui_app_mount";
+import type { AppState } from "../src/app/ui_app_state";
+import type { UiAppRuntime } from "../src/app/ui_app_runtime";
+
+function createHostStub() {
+  const attributes = new Map<string, string>();
+  return {
+    getAttribute(name: string) {
+      return attributes.get(name) ?? null;
+    },
+    removeAttribute(name: string) {
+      attributes.delete(name);
+    },
+    setAttribute(name: string, value: string) {
+      attributes.set(name, value);
+    },
+  } as unknown as HTMLElement;
+}
+
+test("startUiApp returns a disposable mounted app handle", () => {
+  const host = createHostStub();
+  const originalDocument = globalThis.document;
+  let runtimeCreations = 0;
+  const renderCalls: Array<{ host: Element | DocumentFragment; vnode: unknown }> = [];
+  let startCalls = 0;
+  let disposeCalls = 0;
+
+  (globalThis as { document?: Document }).document = {
+    getElementById(id: string) {
+      return id === "appShellChromeRoot" ? host : null;
+    },
+  } as unknown as Document;
+
+  try {
+    const fakeRuntimeFactory = (): UiAppRuntime => {
+      runtimeCreations += 1;
+      return {
+        attachSettingsPanels() {},
+        dispose() {
+          disposeCalls += 1;
+        },
+        panels: {} as UiAppRuntime["panels"],
+        shellChrome: {} as UiAppRuntime["shellChrome"],
+        spectrumPanel: {} as UiAppRuntime["spectrumPanel"],
+        start() {
+          startCalls += 1;
+        },
+      };
+    };
+
+    const app = mountUiApp({
+      createRuntime: () => fakeRuntimeFactory(),
+      createState: () => ({}) as AppState,
+      renderRoot: () => null,
+      renderApp: ((vnode: unknown, target: Element | DocumentFragment) => {
+        renderCalls.push({ host: target, vnode });
+      }) as typeof import("preact").render,
+    });
+
+    const second = mountUiApp({
+      createRuntime: () => fakeRuntimeFactory(),
+      createState: () => ({}) as AppState,
+      renderRoot: () => null,
+      renderApp: ((vnode: unknown, target: Element | DocumentFragment) => {
+        renderCalls.push({ host: target, vnode });
+      }) as typeof import("preact").render,
+    });
+
+    expect(second).toBe(app);
+    expect(runtimeCreations).toBe(1);
+    expect(startCalls).toBe(1);
+    expect(host.getAttribute("data-ui-app-mounted")).toBe("true");
+    expect(renderCalls).toHaveLength(1);
+
+    app.dispose();
+
+    expect(disposeCalls).toBe(1);
+    expect(host.getAttribute("data-ui-app-mounted")).toBeNull();
+    expect(renderCalls).toHaveLength(2);
+    expect(renderCalls[1]).toEqual({ host, vnode: null });
+  } finally {
+    (globalThis as { document?: Document }).document = originalDocument;
+  }
+});

--- a/apps/ui/tests/ui_lazy_panels.spec.ts
+++ b/apps/ui/tests/ui_lazy_panels.spec.ts
@@ -186,4 +186,38 @@ test.describe("createLazyUiPanels", () => {
     expect(lazyPanels.panels.settingsShell.activeTabId.value).toBe("internetTab");
   });
 
+  test("dispose prevents deferred settings replays after teardown", () => {
+    const analysisPanel = createAnalysisPanelSpy();
+    const carsPanel = createCarsPanelSpy();
+    const internetPanel = createInternetPanelSpy();
+    const settingsShell = createSettingsShellSpy();
+    const speedSourcePanel = createSpeedSourcePanelSpy();
+    const lazyPanels = createLazyUiPanels();
+
+    lazyPanels.panels.settingsShell.activateTab("updateTab");
+    lazyPanels.panels.settings.analysis.openGuidance();
+    lazyPanels.panels.settings.analysis.focusField("wheel_bandwidth_pct");
+    lazyPanels.panels.settings.cars.wizard.focus("finish");
+    lazyPanels.panels.settings.internet.focusSsidInput();
+    lazyPanels.panels.settings.speedSource.focusManualSpeedInput();
+    lazyPanels.dispose();
+
+    lazyPanels.attachSettingsPanels({
+      settingsShell: settingsShell.view,
+      settings: {
+        analysis: analysisPanel.handle,
+        cars: carsPanel.handle,
+        internet: internetPanel.handle,
+        speedSource: speedSourcePanel.handle,
+      },
+    });
+
+    expect(settingsShell.activations).toEqual([]);
+    expect(analysisPanel.guidanceOpens).toBe(0);
+    expect(analysisPanel.focusFields).toEqual([]);
+    expect(carsPanel.focusTargets).toEqual([]);
+    expect(internetPanel.focusCalls).toBe(0);
+    expect(speedSourcePanel.focusManualCalls).toBe(0);
+  });
+
 });

--- a/apps/ui/tests/ws.spec.ts
+++ b/apps/ui/tests/ws.spec.ts
@@ -231,4 +231,30 @@ test.describe("createWsClient", () => {
       globalThis.WebSocket = originalWebSocket;
     }
   });
+
+  test("dispose clears reconnect timers and leaves no active timeout lifecycle", () => {
+    const originalWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    const timeouts = installTimeoutHarness();
+    try {
+      const client = createWsClient({
+        url: "ws://example.test/ws",
+        onMessage: () => undefined,
+      });
+
+      client.connect();
+      const socket = FakeWebSocket.instances[0];
+      socket?.emitOpen();
+      socket?.close();
+
+      expect(client.uiState.value).toBe("reconnecting");
+      expect(timeouts.pendingTimeoutCount()).toBe(1);
+
+      client.dispose();
+      expect(timeouts.pendingTimeoutCount()).toBe(0);
+    } finally {
+      timeouts.restore();
+      globalThis.WebSocket = originalWebSocket;
+    }
+  });
 });


### PR DESCRIPTION
## what
- return a disposable app handle from `startUiApp()` through new `ui_app_mount.ts`
- add composed `dispose()` flow across `UiAppRuntime`, runtime controllers, lazy panels, polling, ws, and long-lived feature workflows
- add lifecycle regressions plus README updates for the public teardown path

## why
- the UI had cleanup-capable primitives, but no top-level owner to stop effects, timers, reconnect loops, spectrum RAF work, or deferred panel replays
- that made remounts, hot reload, and lifecycle tests leak-prone and harder to reason about

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/polling_controller.spec.ts tests/ws.spec.ts tests/ui_lazy_panels.spec.ts tests/start_ui_app.spec.ts tests/smoke.bootstrap.spec.ts`
- `cd apps/ui && CI=1 npm run test:visual`

## risk / tradeoffs
- feature/runtime ports now carry `dispose()`, so callers and contract tests had to move with the new lifecycle surface
- `start_ui_app.ts` stays the CSS-bearing entrypoint while `ui_app_mount.ts` holds the pure mount logic, because making startup a pure re-export dropped app CSS from the real bundle path

Closes #2707