### PR TITLE
fix(ui): stop vehicle settings race

### DIFF
--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -6,8 +6,8 @@ import { getAnalysisSettings, setAnalysisSettings } from "../../api";
 import type { FeatureServices } from "../feature_deps_base";
 import {
   defaultVehicleSettings,
+  mergeAnalysisOwnedVehicleSettings,
   type SettingsState,
-  type VehicleSettings,
 } from "../ui_app_state";
 import { batch, computed, signal } from "../ui_signals";
 import type {
@@ -17,24 +17,6 @@ import type {
   SettingsAnalysisGuidanceRenderModel,
 } from "../views/analysis_panel";
 import type { SettingsFeedbackMessage } from "../views/settings_feedback";
-
-export const ANALYSIS_SETTING_KEYS = [
-  "tire_width_mm",
-  "tire_aspect_pct",
-  "rim_in",
-  "final_drive_ratio",
-  "current_gear_ratio",
-  "wheel_bandwidth_pct",
-  "driveshaft_bandwidth_pct",
-  "engine_bandwidth_pct",
-  "speed_uncertainty_pct",
-  "tire_diameter_uncertainty_pct",
-  "final_drive_uncertainty_pct",
-  "gear_uncertainty_pct",
-  "min_abs_band_hz",
-  "max_band_half_width_pct",
-  "tire_deflection_factor",
-] as const satisfies readonly (keyof AnalysisSettingsPayload & keyof VehicleSettings)[];
 
 export interface SettingsAnalysisModuleDeps {
   panel: AnalysisPanelView;
@@ -352,25 +334,13 @@ export function createSettingsAnalysisModule(
     saveFeedback.value = null;
   }
 
-  function updateVehicleSettings(
-    updater: (current: VehicleSettings) => VehicleSettings,
-  ): void {
-    settings.vehicleSettings.value = updater(settings.vehicleSettings.value);
-  }
-
   function applyAnalysisSettingsPayload(
     serverSettings: AnalysisSettingsPayload,
   ): void {
-    updateVehicleSettings((current) => {
-      const next = { ...current };
-      for (const key of ANALYSIS_SETTING_KEYS) {
-        const value = serverSettings[key];
-        if (typeof value === "number") {
-          next[key] = value;
-        }
-      }
-      return next;
-    });
+    settings.vehicleSettings.value = mergeAnalysisOwnedVehicleSettings(
+      settings.vehicleSettings.value,
+      serverSettings,
+    );
     syncSettingsInputs();
     ctx.renderSpectrum();
   }
@@ -476,12 +446,6 @@ export function createSettingsAnalysisModule(
       }
     }
     const payload = buildEditableAnalysisPayload(fieldStates);
-    const vehicleSettings = settings.vehicleSettings.value;
-    for (const key of ANALYSIS_SETTING_KEYS) {
-      if (!(key in payload)) {
-        payload[key] = vehicleSettings[key];
-      }
-    }
     void syncAnalysisSettingsToServer(payload);
   }
 

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -4,7 +4,10 @@ import {
   type CarSelectionState,
   getCarCompleteness,
 } from "../car_selection_state";
-import type { SettingsState } from "../ui_app_state";
+import {
+  mergeCarOwnedVehicleSettings,
+  type SettingsState,
+} from "../ui_app_state";
 import type { CarRecord, CarsPayload } from "../../api/types";
 import type {
   CarsListPanelView,
@@ -70,13 +73,10 @@ function copyActiveCarAspects(
   if (!car?.aspects || typeof car.aspects !== "object") {
     return;
   }
-  const nextVehicleSettings = { ...settings.vehicleSettings.value };
-  for (const [key, value] of Object.entries(car.aspects)) {
-    if (typeof value === "number" && key in nextVehicleSettings) {
-      nextVehicleSettings[key as keyof typeof nextVehicleSettings] = value;
-    }
-  }
-  settings.vehicleSettings.value = nextVehicleSettings;
+  settings.vehicleSettings.value = mergeCarOwnedVehicleSettings(
+    settings.vehicleSettings.value,
+    car.aspects,
+  );
 }
 
 export function createSettingsCarsModule(

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -53,6 +53,62 @@ export const defaultVehicleSettings: Readonly<VehicleSettings> = {
   tire_deflection_factor: 0.97,
 };
 
+export const carOwnedVehicleSettingKeys = [
+  "tire_width_mm",
+  "tire_aspect_pct",
+  "rim_in",
+  "final_drive_ratio",
+  "current_gear_ratio",
+  "tire_deflection_factor",
+] as const satisfies readonly (keyof VehicleSettings)[];
+
+export const analysisOwnedVehicleSettingKeys = [
+  "wheel_bandwidth_pct",
+  "driveshaft_bandwidth_pct",
+  "engine_bandwidth_pct",
+  "speed_uncertainty_pct",
+  "tire_diameter_uncertainty_pct",
+  "final_drive_uncertainty_pct",
+  "gear_uncertainty_pct",
+  "min_abs_band_hz",
+  "max_band_half_width_pct",
+] as const satisfies readonly (keyof VehicleSettings)[];
+
+type VehicleSettingsNumericPatch = Partial<
+  Record<keyof VehicleSettings, number | null | undefined>
+>;
+
+function mergeVehicleSettingsPatch<
+  TKeys extends readonly (keyof VehicleSettings)[],
+>(
+  current: VehicleSettings,
+  source: VehicleSettingsNumericPatch,
+  keys: TKeys,
+): VehicleSettings {
+  const next = { ...current };
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "number") {
+      next[key] = value;
+    }
+  }
+  return next;
+}
+
+export function mergeCarOwnedVehicleSettings(
+  current: VehicleSettings,
+  source: VehicleSettingsNumericPatch,
+): VehicleSettings {
+  return mergeVehicleSettingsPatch(current, source, carOwnedVehicleSettingKeys);
+}
+
+export function mergeAnalysisOwnedVehicleSettings(
+  current: VehicleSettings,
+  source: VehicleSettingsNumericPatch,
+): VehicleSettings {
+  return mergeVehicleSettingsPatch(current, source, analysisOwnedVehicleSettingKeys);
+}
+
 export interface RunDetail {
   preview: HistoryInsightsPayload | null;
   previewLoading: boolean;

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -9,6 +9,7 @@ import type {
   AnalysisPanelRenderModel,
   AnalysisPanelView,
 } from "../src/app/views/analysis_panel";
+import { installWindowGlobal, jsonResponse } from "./async_test_helpers";
 
 function lastRender(renders: AnalysisPanelRenderModel[]): AnalysisPanelRenderModel {
   const render = renders.at(-1);
@@ -38,6 +39,10 @@ function translate(key: string, vars?: Record<string, unknown>): string {
       return key;
   }
 }
+
+test.beforeEach(() => {
+  installWindowGlobal();
+});
 
 test("settings analysis module renders guidance and surfaces invalid input through the typed panel bridge", () => {
   const state = createAppState().settings;
@@ -121,4 +126,77 @@ test("settings analysis module renders guidance and surfaces invalid input throu
   const recoveredRender = lastRender(renders);
   expect(recoveredRender.fields.wheel_bandwidth_pct.invalid).toBe(false);
   expect(recoveredRender.fields.wheel_bandwidth_pct.guidance.error).toBeNull();
+});
+
+test("settings analysis module keeps active-car geometry when loading server analysis settings", async () => {
+  const originalFetch = globalThis.fetch;
+  const state = createAppState().settings;
+  let renderSpectrumCalls = 0;
+
+  state.vehicleSettings.value = {
+    ...state.vehicleSettings.value,
+    tire_width_mm: 245,
+    tire_aspect_pct: 40,
+    rim_in: 19,
+    final_drive_ratio: 3.23,
+    current_gear_ratio: 0.72,
+    tire_deflection_factor: 0.95,
+    wheel_bandwidth_pct: 5,
+    speed_uncertainty_pct: 1,
+    min_abs_band_hz: 0.2,
+  };
+
+  globalThis.fetch = (async () =>
+    jsonResponse({
+      tire_width_mm: 999,
+      tire_aspect_pct: 99,
+      rim_in: 24,
+      final_drive_ratio: 9.99,
+      current_gear_ratio: 2.22,
+      tire_deflection_factor: 0.5,
+      wheel_bandwidth_pct: 7.5,
+      speed_uncertainty_pct: 2.5,
+      min_abs_band_hz: 1.5,
+    })) as typeof fetch;
+
+  const module = createSettingsAnalysisModule({
+    panel: {
+      actions: signal(null),
+      carAvailability: signal(null),
+      model: signal(null),
+      focusField: () => undefined,
+      openGuidance: () => undefined,
+    },
+    hasValidActiveCar: () => true,
+    onMissingActiveCar: () => undefined,
+    onSaveError: () => undefined,
+    renderSpectrum: () => {
+      renderSpectrumCalls += 1;
+    },
+    settings: state,
+    services: {
+      t: translate,
+      requestConfirmation: async () => true,
+      showError: () => undefined,
+    },
+  });
+
+  try {
+    await module.loadAnalysisSettingsFromServer();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  expect(state.vehicleSettings.value).toMatchObject({
+    tire_width_mm: 245,
+    tire_aspect_pct: 40,
+    rim_in: 19,
+    final_drive_ratio: 3.23,
+    current_gear_ratio: 0.72,
+    tire_deflection_factor: 0.95,
+    wheel_bandwidth_pct: 7.5,
+    speed_uncertainty_pct: 2.5,
+    min_abs_band_hz: 1.5,
+  });
+  expect(renderSpectrumCalls).toBe(1);
 });

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -120,10 +120,17 @@ test("settings cars module dismisses transient creation feedback through typed t
   expect(dismissedByView.table.rows[0].highlightedStatusText).toBeNull();
 });
 
-test("settings cars module loads cars through the shared async loader and syncs active-car inputs", async () => {
+test("settings cars module loads cars through the shared async loader without overwriting analysis-owned settings", async () => {
   const state = createAppState().settings;
   const renders: CarsListRenderModel[] = [];
   let syncAnalysisInputsCalls = 0;
+
+  state.vehicleSettings.value = {
+    ...state.vehicleSettings.value,
+    wheel_bandwidth_pct: 7.5,
+    speed_uncertainty_pct: 2.5,
+    min_abs_band_hz: 1.5,
+  };
 
   const panel: CarsListPanelView = {
     actions: signal(null),
@@ -175,12 +182,15 @@ test("settings cars module loads cars through the shared async loader and syncs 
             aspects: {
               tire_width_mm: 245,
               tire_aspect_pct: 40,
-              rim_in: 19,
-              final_drive_ratio: 3.23,
-              current_gear_ratio: 0.72,
-            },
-          }],
-        };
+            rim_in: 19,
+            final_drive_ratio: 3.23,
+            current_gear_ratio: 0.72,
+            wheel_bandwidth_pct: 99,
+            speed_uncertainty_pct: 99,
+            min_abs_band_hz: 99,
+          },
+        }],
+      };
       },
     },
   });
@@ -192,8 +202,11 @@ test("settings cars module loads cars through the shared async loader and syncs 
     current_gear_ratio: 0.72,
     final_drive_ratio: 3.23,
     rim_in: 19,
+    min_abs_band_hz: 1.5,
+    speed_uncertainty_pct: 2.5,
     tire_aspect_pct: 40,
     tire_width_mm: 245,
+    wheel_bandwidth_pct: 7.5,
   });
   expect(syncAnalysisInputsCalls).toBe(1);
   expect(lastRender(renders).table?.kind).toBe("rows");


### PR DESCRIPTION
## what
- split frontend `vehicleSettings` ownership into shared car-owned vs analysis-owned key sets
- make analysis load/save only touch analysis-owned keys
- make car sync only copy car-owned aspects, even if the payload echoes analysis fields
- add focused regressions for both module paths

## why
- startup was firing analysis load and cars load concurrently
- both flows wrote into the same object, so whichever finished last could overwrite the other
- ordering alone would hide the race; removing the key overlap makes the final state deterministic

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ui_startup_coordinator.spec.ts tests/settings_analysis_module.spec.ts tests/settings_cars_module.spec.ts tests/smoke.settings.spec.ts tests/smoke.bootstrap.spec.ts`
- `cd apps/ui && CI=1 npm run test:visual`

## risk / tradeoffs
- this fixes the startup overlap without taking on the full broader settings-ownership cleanup from `#2711`
- backend payloads can still contain mixed keys, so the frontend now deliberately ignores out-of-owner fields instead of trusting payload shape alone

Closes #2708