### PR TITLE
fix(ui): surface silent load failures

### DIFF
--- a/apps/ui/src/app/features/api_loader.ts
+++ b/apps/ui/src/app/features/api_loader.ts
@@ -10,6 +10,7 @@ export interface CreateApiLoaderOptions<TValue> {
   load: () => Promise<TValue>;
   apply: (value: TValue) => void;
   onError?: (error: unknown) => void;
+  swallowError?: boolean;
 }
 
 export function createApiLoader<TValue>(
@@ -28,7 +29,10 @@ export function createApiLoader<TValue>(
         return value;
       } catch (error) {
         options.onError?.(error);
-        return null;
+        if (options.swallowError) {
+          return null;
+        }
+        throw error;
       } finally {
         loading.value = false;
       }

--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -348,6 +348,7 @@ export function createCarsFeatureWorkflow(
       brandOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_brands"));
       deps.view.focus("custom-brand");
     },
+    swallowError: true,
   });
 
   const typeStepLoader = createApiLoader({
@@ -363,6 +364,7 @@ export function createCarsFeatureWorkflow(
       typeOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_types"));
       deps.view.focus("custom-type");
     },
+    swallowError: true,
   });
 
   const modelStepLoader = createApiLoader({
@@ -378,6 +380,7 @@ export function createCarsFeatureWorkflow(
       modelOptions.value = createErrorOptionsState(deps.t("settings.wizard.load_failed_models"));
       deps.view.focus("custom-model");
     },
+    swallowError: true,
   });
 
   async function loadBrandStep(): Promise<void> {

--- a/apps/ui/src/app/features/esp_flash_feature_workflow.ts
+++ b/apps/ui/src/app/features/esp_flash_feature_workflow.ts
@@ -134,6 +134,10 @@ export function createEspFlashFeatureWorkflow(
     apply: (payload) => {
       latestAttempts.value = payload.attempts || [];
     },
+    onError: (error) => {
+      deps.showError(error instanceof Error ? error.message : String(error));
+    },
+    swallowError: true,
   });
 
   const portsLoader = createApiLoader({
@@ -147,6 +151,10 @@ export function createEspFlashFeatureWorkflow(
         }
       });
     },
+    onError: (error) => {
+      deps.showError(error instanceof Error ? error.message : String(error));
+    },
+    swallowError: true,
   });
 
   async function refreshHistory(): Promise<void> {

--- a/apps/ui/src/app/features/polling_controller.ts
+++ b/apps/ui/src/app/features/polling_controller.ts
@@ -11,6 +11,7 @@ export interface PollingController {
 export interface PollingControllerOptions {
   enabled?: ReadonlySignal<boolean>;
   poll: () => Promise<number>;
+  onError?: (error: unknown) => void;
   onErrorDelayMs: number;
 }
 
@@ -18,6 +19,11 @@ export function createPollingController(
   options: PollingControllerOptions,
 ): PollingController {
   const { enabled, poll, onErrorDelayMs } = options;
+  const onError = options.onError ?? ((error: unknown) => {
+    if (typeof window !== "undefined") {
+      console.warn("Polling task failed", error);
+    }
+  });
 
   const pollTimer = createReplaceableTimeout();
   let pollGeneration = 0;
@@ -39,7 +45,8 @@ export function createPollingController(
     try {
       const delayMs = await poll();
       schedulePoll(delayMs, generation);
-    } catch {
+    } catch (error) {
+      onError(error);
       schedulePoll(onErrorDelayMs, generation);
     }
   }

--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -313,15 +313,11 @@ export function createRealtimeFeatureWorkflow(
   }
 
   async function refreshLocationOptions(): Promise<void> {
-    try {
-      const payload = await api.getClientLocations();
-      const codes = Array.isArray(payload.locations)
-        ? payload.locations.map((row) => row.code).filter((code): code is string => typeof code === "string")
-        : [];
-      applyLocationCodes(codes);
-    } catch {
-      applyLocationCodes([]);
-    }
+    const payload = await api.getClientLocations();
+    const codes = Array.isArray(payload.locations)
+      ? payload.locations.map((row) => row.code).filter((code): code is string => typeof code === "string")
+      : [];
+    applyLocationCodes(codes);
   }
 
   async function setClientLocation(clientId: string, locationCode: string): Promise<void> {

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -365,13 +365,9 @@ export function createSettingsAnalysisModule(
   }
 
   async function loadAnalysisSettingsFromServer(): Promise<void> {
-    try {
-      const serverSettings = await getAnalysisSettings();
-      if (serverSettings) {
-        applyAnalysisSettingsPayload(serverSettings);
-      }
-    } catch (_err) {
-      /* ignore */
+    const serverSettings = await getAnalysisSettings();
+    if (serverSettings) {
+      applyAnalysisSettingsPayload(serverSettings);
     }
   }
 

--- a/apps/ui/tests/api_loader.spec.ts
+++ b/apps/ui/tests/api_loader.spec.ts
@@ -31,7 +31,7 @@ test.describe("createApiLoader", () => {
     dispose();
   });
 
-  test("returns null and calls onError when the load fails", async () => {
+  test("rethrows and calls onError when the load fails", async () => {
     const events: string[] = [];
     const loader = createApiLoader({
       load: async () => {
@@ -43,6 +43,26 @@ test.describe("createApiLoader", () => {
       onError: (error) => {
         events.push(error instanceof Error ? error.message : String(error));
       },
+    });
+
+    await expect(loader.load()).rejects.toThrow("offline");
+    expect(events).toEqual(["offline"]);
+    expect(loader.loading.value).toBe(false);
+  });
+
+  test("can swallow a handled load failure when the caller opts in", async () => {
+    const events: string[] = [];
+    const loader = createApiLoader({
+      load: async () => {
+        throw new Error("offline");
+      },
+      apply: () => {
+        events.push("apply");
+      },
+      onError: (error) => {
+        events.push(error instanceof Error ? error.message : String(error));
+      },
+      swallowError: true,
     });
 
     await expect(loader.load()).resolves.toBeNull();

--- a/apps/ui/tests/polling_controller.spec.ts
+++ b/apps/ui/tests/polling_controller.spec.ts
@@ -63,9 +63,13 @@ test.describe("createPollingController", () => {
 
   test("errors schedule the configured retry delay", async () => {
     const timers = installTimerHarness();
+    const seenErrors: string[] = [];
     const controller = createPollingController({
       poll: async () => {
         throw new Error("temporary failure");
+      },
+      onError: (error) => {
+        seenErrors.push(error instanceof Error ? error.message : String(error));
       },
       onErrorDelayMs: 3_000,
     });
@@ -73,6 +77,7 @@ test.describe("createPollingController", () => {
     try {
       controller.start();
       await flushAsyncWork();
+      expect(seenErrors).toEqual(["temporary failure"]);
       expect(timers.pendingDelays()).toEqual([3_000]);
     } finally {
       timers.restore();

--- a/apps/ui/tests/realtime_feature_workflow.spec.ts
+++ b/apps/ui/tests/realtime_feature_workflow.spec.ts
@@ -171,7 +171,7 @@ test.describe("createRealtimeFeatureWorkflow", () => {
     ]);
   });
 
-  test("falls back to default location codes when refreshing locations fails", async () => {
+test("keeps the last known location codes and rejects when refreshing locations fails", async () => {
     const harness = createHarness();
     harness.state.realtime.locationCodes.value = ["custom-code"];
     const workflow = createRealtimeFeatureWorkflow({
@@ -200,10 +200,10 @@ test.describe("createRealtimeFeatureWorkflow", () => {
       },
     });
 
-    await workflow.refreshLocationOptions();
+    await expect(workflow.refreshLocationOptions()).rejects.toThrow("network unavailable");
 
-    expect(harness.state.realtime.locationCodes.value).toEqual(defaultLocationCodes);
-  });
+  expect(harness.state.realtime.locationCodes.value).toEqual(["custom-code"]);
+});
 
   test("refreshes history once when polling observes analysis completion", async () => {
     const harness = createHarness();


### PR DESCRIPTION
## what
- make `createApiLoader()` reject by default instead of quietly returning `null`
- keep swallowing only in interactive loaders that already surface their own errors locally
- stop analysis-settings and location refresh startup paths from eating failures
- make `PollingController` report failures through an explicit hook, with a browser-runtime warning fallback

## why
- shared loader and poller helpers were normalizing real failures into stale state, empty state, or silent retries
- that hid startup problems from `UiStartupCoordinator` and made important flows look like nothing happened instead of failed

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/api_loader.spec.ts tests/polling_controller.spec.ts tests/realtime_feature_workflow.spec.ts tests/settings_speed_source_workflow.spec.ts tests/settings_analysis_module.spec.ts tests/settings_cars_module.spec.ts tests/cars_feature_workflow.spec.ts tests/esp_flash_feature_workflow.spec.ts tests/smoke.bootstrap.spec.ts tests/smoke.settings.spec.ts`
- `cd apps/ui && CI=1 npm run test:visual`
- `cd apps/ui && npm run typecheck && npx playwright test tests/polling_controller.spec.ts tests/realtime_feature_workflow.spec.ts tests/esp_flash_feature_workflow.spec.ts`

## risk / tradeoffs
- some callers now need to opt into swallowing explicitly, which is intentional because silence is no longer the default
- the final polling warning trim is browser-only so runtime failures still surface without spamming node-side tests

Closes #2709