### PR TITLE
refactor(ui): split settings ownership

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -17,7 +17,7 @@ import {
 } from "./features/settings_feature";
 import { createUpdateFeature } from "./features/update_feature";
 import type { FeatureFormatting, FeatureServices } from "./feature_deps_base";
-import type { AppState } from "./ui_app_state";
+import { composeVehicleSettings, type AppState } from "./ui_app_state";
 import type { UiMountedPanels } from "./ui_lazy_panels";
 import type { ReadonlySignal } from "./ui_signals";
 import { createUiCarCreationCommand } from "./runtime/ui_car_creation_command";
@@ -123,7 +123,11 @@ export function createAppFeatureBundle(
   });
 
   const carCreation = createUiCarCreationCommand({
-    getVehicleSettings: () => state.settings.vehicleSettings.value,
+    getVehicleSettings: () =>
+      composeVehicleSettings(
+        state.settings.car.activeVehicleSettings.value,
+        state.settings.analysis.vehicleSettings.value,
+      ),
     syncCarsPayload: (payload) => settings.syncCarsPayload(payload),
     syncActiveCarToInputs: () => settings.syncActiveCarToInputs(),
     showCarCreationSuccess: (carId, carName) =>

--- a/apps/ui/src/app/car_selection_state.ts
+++ b/apps/ui/src/app/car_selection_state.ts
@@ -13,9 +13,9 @@ const REQUIRED_CAR_ASPECT_KEYS = [
 export type RequiredCarAspectKey = (typeof REQUIRED_CAR_ASPECT_KEYS)[number];
 
 export interface CarSelectionStateSource {
-  cars: SettingsState["cars"];
-  activeCarId: SettingsState["activeCarId"];
-  carsLoaded: SettingsState["carsLoaded"];
+  cars: SettingsState["car"]["cars"];
+  activeCarId: SettingsState["car"]["activeCarId"];
+  carsLoaded: SettingsState["car"]["carsLoaded"];
 }
 
 export type CarSelectionState =

--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -1,5 +1,5 @@
 import { EXPECTED_LIVE_PAYLOAD_SCHEMA_VERSION } from "../transport/live_models";
-import type { AppState } from "./ui_app_state";
+import { composeVehicleSettings, type AppState } from "./ui_app_state";
 import { batch } from "./ui_signals";
 
 type DemoDeps = {
@@ -178,17 +178,20 @@ export function runDemoMode(deps: DemoDeps): void {
   };
 
   batch(() => {
-    state.settings.carsLoaded.value = true;
-    state.settings.cars.value = [
+    state.settings.car.carsLoaded.value = true;
+    state.settings.car.cars.value = [
       {
         id: "demo-car-1",
         name: "Demo Hatch",
         type: "Simulated setup",
         variant: "Audit baseline",
-        aspects: { ...state.settings.vehicleSettings.value },
+        aspects: composeVehicleSettings(
+          state.settings.car.activeVehicleSettings.value,
+          state.settings.analysis.vehicleSettings.value,
+        ),
       },
     ];
-    state.settings.activeCarId.value = "demo-car-1";
+    state.settings.car.activeCarId.value = "demo-car-1";
   });
   deps.queueTransportPayload(demoPayload);
 

--- a/apps/ui/src/app/features/realtime_feature_view_state.ts
+++ b/apps/ui/src/app/features/realtime_feature_view_state.ts
@@ -11,7 +11,7 @@ import type {
   SpectrumState,
 } from "../ui_app_state";
 import { bindReplaceableTimerEffect, createReplaceableInterval } from "../timer_cleanup";
-import { computed, effect, signal, type ReadonlySignal } from "../ui_signals";
+import { computed, signal, type ReadonlySignal } from "../ui_signals";
 import type { AdaptedClient } from "../../transport/live_models";
 import {
   buildRealtimeLoggingPanelViewModel,
@@ -395,7 +395,7 @@ export function createRealtimeFeatureViewState(
       )
       .sort()
       .join("|");
-    return `${settings.activeCarId.value ?? ""}##${clientsSignature}`;
+    return `${settings.car.activeCarId.value ?? ""}##${clientsSignature}`;
   });
 
   return {

--- a/apps/ui/src/app/features/realtime_sensor_state.ts
+++ b/apps/ui/src/app/features/realtime_sensor_state.ts
@@ -62,7 +62,7 @@ const SHORTHAND_LOCATION_MAP: Record<string, string> = {
 
 export function createRealtimeSensorState(ctx: RealtimeSensorStateDeps): RealtimeSensorState {
   const { realtime, settings, shell, spectrum, t, formatInt } = ctx;
-  const carSelection = createCarSelectionDerivedState(settings);
+  const carSelection = createCarSelectionDerivedState(settings.car);
 
   function locationLabelForLang(lang: string, code: string): string {
     return I18N.get(lang, `location.${code}`, { code });

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -6,7 +6,7 @@ import { getAnalysisSettings, setAnalysisSettings } from "../../api";
 import type { FeatureServices } from "../feature_deps_base";
 import {
   defaultVehicleSettings,
-  mergeAnalysisOwnedVehicleSettings,
+  mergeAnalysisTuningSettings,
   type SettingsState,
 } from "../ui_app_state";
 import { batch, computed, signal } from "../ui_signals";
@@ -165,7 +165,7 @@ function analysisFieldConfig(key: AnalysisPanelFieldKey): AnalysisFieldConfig {
 }
 
 function buildDraftValues(settings: SettingsState): EditableAnalysisDrafts {
-  const vehicleSettings = settings.vehicleSettings.value;
+  const vehicleSettings = settings.analysis.vehicleSettings.value;
   return {
     wheel_bandwidth_pct: formatSettingValue(vehicleSettings.wheel_bandwidth_pct),
     driveshaft_bandwidth_pct: formatSettingValue(
@@ -337,8 +337,8 @@ export function createSettingsAnalysisModule(
   function applyAnalysisSettingsPayload(
     serverSettings: AnalysisSettingsPayload,
   ): void {
-    settings.vehicleSettings.value = mergeAnalysisOwnedVehicleSettings(
-      settings.vehicleSettings.value,
+    settings.analysis.vehicleSettings.value = mergeAnalysisTuningSettings(
+      settings.analysis.vehicleSettings.value,
       serverSettings,
     );
     syncSettingsInputs();

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -5,7 +5,7 @@ import {
   getCarCompleteness,
 } from "../car_selection_state";
 import {
-  mergeCarOwnedVehicleSettings,
+  mergeCarAspectSettings,
   type SettingsState,
 } from "../ui_app_state";
 import type { CarRecord, CarsPayload } from "../../api/types";
@@ -73,8 +73,8 @@ function copyActiveCarAspects(
   if (!car?.aspects || typeof car.aspects !== "object") {
     return;
   }
-  settings.vehicleSettings.value = mergeCarOwnedVehicleSettings(
-    settings.vehicleSettings.value,
+  settings.car.activeVehicleSettings.value = mergeCarAspectSettings(
+    settings.car.activeVehicleSettings.value,
     car.aspects,
   );
 }
@@ -85,7 +85,7 @@ export function createSettingsCarsModule(
   const { settings, services, formatting } = ctx;
   const { t } = services;
   const transport = createSettingsCarsTransport(ctx.transport);
-  const carSelection = createCarSelectionDerivedState(settings);
+  const carSelection = createCarSelectionDerivedState(settings.car);
   let handlersBound = false;
   let disposeHighlightedCarSync: (() => void) | null = null;
   const highlightedCar = signal<CarsListHighlightedFeedback | null>(null);
@@ -116,8 +116,8 @@ export function createSettingsCarsModule(
       table: carSelectionState.kind === "loading"
         ? null
         : buildCarListRenderModel({
-          activeCarId: settings.activeCarId.value,
-          cars: settings.cars.value,
+          activeCarId: settings.car.activeCarId.value,
+          cars: settings.car.cars.value,
           highlightedCarId: highlightedCar.value?.carId ?? null,
           fmt: formatting.fmt,
           t,
@@ -142,23 +142,23 @@ export function createSettingsCarsModule(
   }
 
   function syncCarsPayload(payload: CarsPayload): void {
-    settings.cars.value = payload.cars;
-    settings.carsLoaded.value = true;
+    settings.car.cars.value = payload.cars;
+    settings.car.carsLoaded.value = true;
     const requestedActiveCarId = payload.active_car_id;
     const hasRequestedActive = requestedActiveCarId
-      ? settings.cars.value.some((car) => car.id === requestedActiveCarId)
+      ? settings.car.cars.value.some((car) => car.id === requestedActiveCarId)
       : false;
-    settings.activeCarId.value = hasRequestedActive ? requestedActiveCarId : null;
+    settings.car.activeCarId.value = hasRequestedActive ? requestedActiveCarId : null;
     if (
       highlightedCar.value
-      && !settings.cars.value.some((car) => car.id === highlightedCar.value?.carId)
+      && !settings.car.cars.value.some((car) => car.id === highlightedCar.value?.carId)
     ) {
       highlightedCar.value = null;
     }
   }
 
   function findCar(carId: string): CarRecord | null {
-    return settings.cars.value.find((entry) => entry.id === carId) ?? null;
+    return settings.car.cars.value.find((entry) => entry.id === carId) ?? null;
   }
 
   function syncActiveCarToInputs(): void {
@@ -211,7 +211,7 @@ export function createSettingsCarsModule(
       return;
     }
     try {
-      if (car.id !== settings.activeCarId.value) {
+      if (car.id !== settings.car.activeCarId.value) {
         syncCarsPayload(await transport.activateCar(carId));
         syncActiveCarToInputs();
         ctx.ports.renderSpectrum();

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -74,7 +74,7 @@ export function createSettingsFeature(
 ): SettingsFeature {
   const { services, formatting } = ctx;
   const settings = ctx.state.settings;
-  const carSelection = createCarSelectionDerivedState(settings);
+  const carSelection = createCarSelectionDerivedState(settings.car);
   let handlersBound = false;
   let carsModule!: SettingsCarsModule;
 

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -66,15 +66,15 @@ export function createSettingsGpsStatusModule(
     enabled: pollingEnabled,
     poll: async () => {
       const shouldLoadObdStatus =
-        settings.speedSource.value === "obd2" || settings.obdDeviceMac.value != null;
+        settings.speed.source.value === "obd2" || settings.speed.obdDeviceMac.value != null;
       const [status, obdStatus] = await Promise.all([
         getSpeedSourceStatus(),
         shouldLoadObdStatus ? getSettingsObdStatus() : Promise.resolve(null),
       ]);
       batch(() => {
-        settings.gpsFallbackActive.value = status.fallback_active;
-        settings.gpsEffectiveSpeedKph.value = status.effective_speed_kmh;
-        settings.resolvedSpeedSource.value = status.speed_source;
+        settings.speed.gpsFallbackActive.value = status.fallback_active;
+        settings.speed.gpsEffectiveSpeedKph.value = status.effective_speed_kmh;
+        settings.speed.resolvedSource.value = status.speed_source;
         diagnosticsModel.value = buildSpeedSourceDiagnosticsRenderModel(
           status,
           obdStatus,

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -73,9 +73,9 @@ function activeSourceLabel(
   t: SettingsSpeedSourceWorkflowDeps["t"],
 ): string {
   const effectiveSource = resolveEffectiveSpeedSource({
-    speedSource: settings.speedSource.value,
-    manualSpeedKph: settings.manualSpeedKph.value,
-    resolvedSpeedSource: settings.resolvedSpeedSource.value,
+    speedSource: settings.speed.source.value,
+    manualSpeedKph: settings.speed.manualSpeedKph.value,
+    resolvedSpeedSource: settings.speed.resolvedSource.value,
   });
   if (effectiveSource === "fallback_manual") {
     return t("settings.speed.current_source_fallback_manual");
@@ -138,7 +138,7 @@ export function createSettingsSpeedSourceWorkflow(
 ): SettingsSpeedSourceWorkflow {
   const transport = createSettingsSpeedSourceTransport(deps.transport);
   const createPolling = deps.createPollingController ?? createPollingController;
-  const speedSourceState = createSpeedSourceDerivedState(deps.settings);
+  const speedSourceState = createSpeedSourceDerivedState(deps.settings.speed);
   const selectedModeDraft = signal<DisplayedSpeedSourceMode | null>(null);
   const manualSpeedInputDraft = signal<string | null>(null);
   const selectedMode = computed<DisplayedSpeedSourceMode>(() =>
@@ -149,8 +149,8 @@ export function createSettingsSpeedSourceWorkflow(
     if (draft != null) {
       return draft;
     }
-    return deps.settings.manualSpeedKph.value != null
-      ? String(deps.settings.manualSpeedKph.value)
+    return deps.settings.speed.manualSpeedKph.value != null
+      ? String(deps.settings.speed.manualSpeedKph.value)
       : "";
   });
   const staleTimeoutInputValue = signal("");
@@ -172,13 +172,13 @@ export function createSettingsSpeedSourceWorkflow(
       obdDeviceMac: string | null;
       obdDeviceName: string | null;
     } = {
-      gpsFallbackActive: deps.settings.gpsFallbackActive.value,
-      gpsEffectiveSpeedKph: deps.settings.gpsEffectiveSpeedKph.value,
-      manualSpeedKph: deps.settings.manualSpeedKph.value,
-      obdDeviceMac: deps.settings.obdDeviceMac.value,
-      obdDeviceName: deps.settings.obdDeviceName.value,
-      resolvedSpeedSource: deps.settings.resolvedSpeedSource.value,
-      speedSource: deps.settings.speedSource.value,
+      gpsFallbackActive: deps.settings.speed.gpsFallbackActive.value,
+      gpsEffectiveSpeedKph: deps.settings.speed.gpsEffectiveSpeedKph.value,
+      manualSpeedKph: deps.settings.speed.manualSpeedKph.value,
+      obdDeviceMac: deps.settings.speed.obdDeviceMac.value,
+      obdDeviceName: deps.settings.speed.obdDeviceName.value,
+      resolvedSpeedSource: deps.settings.speed.resolvedSource.value,
+      speedSource: deps.settings.speed.source.value,
     };
     return {
       diagnosticsOpen: diagnosticsOpen.value,
@@ -307,11 +307,11 @@ export function createSettingsSpeedSourceWorkflow(
 
   function applyPayload(payload: SpeedSourcePayload): void {
     batch(() => {
-      deps.settings.speedSource.value = payload.speed_source;
-      deps.settings.manualSpeedKph.value = payload.manual_speed_kph;
-      deps.settings.obdDeviceMac.value = payload.obd_device_mac ?? null;
-      deps.settings.obdDeviceName.value = payload.obd_device_name ?? null;
-      deps.settings.resolvedSpeedSource.value = null;
+      deps.settings.speed.source.value = payload.speed_source;
+      deps.settings.speed.manualSpeedKph.value = payload.manual_speed_kph;
+      deps.settings.speed.obdDeviceMac.value = payload.obd_device_mac ?? null;
+      deps.settings.speed.obdDeviceName.value = payload.obd_device_name ?? null;
+      deps.settings.speed.resolvedSource.value = null;
       staleTimeoutInputValue.value = String(payload.stale_timeout_s);
       syncInputsFromSettings();
     });
@@ -352,7 +352,7 @@ export function createSettingsSpeedSourceWorkflow(
     clearAllFeedback();
 
     const source: SpeedSourceKind =
-      selectedModeDraft.value ?? deps.settings.speedSource.value;
+      selectedModeDraft.value ?? deps.settings.speed.source.value;
     const manualInputValue = manualSpeedInputValue.value.trim();
     const manualSpeedKph = parseManualSpeedKph(Number(manualInputValue));
     const staleValueRaw = staleTimeoutInputValue.value.trim();
@@ -400,7 +400,7 @@ export function createSettingsSpeedSourceWorkflow(
       return;
     }
 
-    if (source === "obd2" && !deps.settings.obdDeviceMac.value) {
+    if (source === "obd2" && !deps.settings.speed.obdDeviceMac.value) {
       batch(() => {
         obdSelectionError.value = true;
         showSaveFeedback(
@@ -478,8 +478,8 @@ export function createSettingsSpeedSourceWorkflow(
     try {
       const payload = await transport.pairObdDevice(macAddress);
       batch(() => {
-        deps.settings.obdDeviceMac.value = payload.configured_device_mac ?? null;
-        deps.settings.obdDeviceName.value = payload.configured_device_name ?? null;
+        deps.settings.speed.obdDeviceMac.value = payload.configured_device_mac ?? null;
+        deps.settings.speed.obdDeviceName.value = payload.configured_device_name ?? null;
         mergeScannedDevices([{
           connected: payload.connected,
           mac_address: payload.configured_device_mac ?? macAddress,

--- a/apps/ui/src/app/runtime/ui_shell_status_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_status_module.ts
@@ -57,7 +57,7 @@ export function createUiShellStatusModule(
     return deps.realtime.rotationalSpeeds.value?.basis_speed_source ?? null;
   });
   const speedSourceState = createSpeedSourceDerivedState(
-    deps.settings,
+    deps.settings.speed,
     runtimeSpeedSource,
   );
 

--- a/apps/ui/src/app/speed_source_state.ts
+++ b/apps/ui/src/app/speed_source_state.ts
@@ -8,9 +8,9 @@ export interface SpeedSourceStateSnapshot {
 }
 
 export interface SpeedSourceStateSource {
-  speedSource: ReadonlySignal<SpeedSourceKind>;
+  source: ReadonlySignal<SpeedSourceKind>;
   manualSpeedKph: ReadonlySignal<number | null>;
-  resolvedSpeedSource: ReadonlySignal<SpeedSourceStatusPayload["speed_source"] | null>;
+  resolvedSource: ReadonlySignal<SpeedSourceStatusPayload["speed_source"] | null>;
 }
 
 export type DisplayedSpeedSourceMode = "gps" | "manual" | "obd2";
@@ -76,9 +76,9 @@ export function createSpeedSourceDerivedState(
   runtimeSpeedSource?: ReadonlySignal<string | null>,
 ): SpeedSourceDerivedState {
   const snapshot = (): SpeedSourceStateSnapshot => ({
-    speedSource: settings.speedSource.value,
+    speedSource: settings.source.value,
     manualSpeedKph: settings.manualSpeedKph.value,
-    resolvedSpeedSource: settings.resolvedSpeedSource.value,
+    resolvedSpeedSource: settings.resolvedSource.value,
   });
   const effectiveSource = computed(() =>
     resolveEffectiveSpeedSource(snapshot(), runtimeSpeedSource?.value)
@@ -91,7 +91,7 @@ export function createSpeedSourceDerivedState(
     if (isManualLikeSpeedSource(resolvedSource)) {
       return "manual";
     }
-    return settings.speedSource.value;
+    return settings.source.value;
   });
   const isManualEffective = computed(() =>
     isManualLikeSpeedSource(effectiveSource.value),

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -17,12 +17,16 @@ import type {
 } from "../api/types";
 import { batch, signal, type Signal } from "./ui_signals";
 
-export interface VehicleSettings {
+export interface CarAspectSettings {
   tire_width_mm: number;
   tire_aspect_pct: number;
   rim_in: number;
   final_drive_ratio: number;
   current_gear_ratio: number;
+  tire_deflection_factor: number;
+}
+
+export interface AnalysisTuningSettings {
   wheel_bandwidth_pct: number;
   driveshaft_bandwidth_pct: number;
   engine_bandwidth_pct: number;
@@ -32,15 +36,20 @@ export interface VehicleSettings {
   gear_uncertainty_pct: number;
   min_abs_band_hz: number;
   max_band_half_width_pct: number;
-  tire_deflection_factor: number;
 }
 
-export const defaultVehicleSettings: Readonly<VehicleSettings> = {
+export interface VehicleSettings extends CarAspectSettings, AnalysisTuningSettings {}
+
+export const defaultCarAspectSettings: Readonly<CarAspectSettings> = {
   tire_width_mm: 285.0,
   tire_aspect_pct: 30.0,
   rim_in: 21.0,
   final_drive_ratio: 3.08,
   current_gear_ratio: 0.64,
+  tire_deflection_factor: 0.97,
+};
+
+export const defaultAnalysisTuningSettings: Readonly<AnalysisTuningSettings> = {
   wheel_bandwidth_pct: 5.0,
   driveshaft_bandwidth_pct: 4.5,
   engine_bandwidth_pct: 5.2,
@@ -50,19 +59,23 @@ export const defaultVehicleSettings: Readonly<VehicleSettings> = {
   gear_uncertainty_pct: 0.2,
   min_abs_band_hz: 0.2,
   max_band_half_width_pct: 6.0,
-  tire_deflection_factor: 0.97,
 };
 
-export const carOwnedVehicleSettingKeys = [
+export const defaultVehicleSettings: Readonly<VehicleSettings> = {
+  ...defaultCarAspectSettings,
+  ...defaultAnalysisTuningSettings,
+};
+
+export const carAspectSettingKeys = [
   "tire_width_mm",
   "tire_aspect_pct",
   "rim_in",
   "final_drive_ratio",
   "current_gear_ratio",
   "tire_deflection_factor",
-] as const satisfies readonly (keyof VehicleSettings)[];
+] as const satisfies readonly (keyof CarAspectSettings)[];
 
-export const analysisOwnedVehicleSettingKeys = [
+export const analysisTuningSettingKeys = [
   "wheel_bandwidth_pct",
   "driveshaft_bandwidth_pct",
   "engine_bandwidth_pct",
@@ -72,21 +85,28 @@ export const analysisOwnedVehicleSettingKeys = [
   "gear_uncertainty_pct",
   "min_abs_band_hz",
   "max_band_half_width_pct",
-] as const satisfies readonly (keyof VehicleSettings)[];
+] as const satisfies readonly (keyof AnalysisTuningSettings)[];
 
 type VehicleSettingsNumericPatch = Partial<
   Record<keyof VehicleSettings, number | null | undefined>
 >;
 
-function mergeVehicleSettingsPatch<
-  TKeys extends readonly (keyof VehicleSettings)[],
->(
-  current: VehicleSettings,
-  source: VehicleSettingsNumericPatch,
-  keys: TKeys,
+export function composeVehicleSettings(
+  car: CarAspectSettings,
+  analysis: AnalysisTuningSettings,
 ): VehicleSettings {
+  return {
+    ...car,
+    ...analysis,
+  };
+}
+
+export function mergeCarAspectSettings(
+  current: CarAspectSettings,
+  source: VehicleSettingsNumericPatch,
+): CarAspectSettings {
   const next = { ...current };
-  for (const key of keys) {
+  for (const key of carAspectSettingKeys) {
     const value = source[key];
     if (typeof value === "number") {
       next[key] = value;
@@ -95,18 +115,18 @@ function mergeVehicleSettingsPatch<
   return next;
 }
 
-export function mergeCarOwnedVehicleSettings(
-  current: VehicleSettings,
+export function mergeAnalysisTuningSettings(
+  current: AnalysisTuningSettings,
   source: VehicleSettingsNumericPatch,
-): VehicleSettings {
-  return mergeVehicleSettingsPatch(current, source, carOwnedVehicleSettingKeys);
-}
-
-export function mergeAnalysisOwnedVehicleSettings(
-  current: VehicleSettings,
-  source: VehicleSettingsNumericPatch,
-): VehicleSettings {
-  return mergeVehicleSettingsPatch(current, source, analysisOwnedVehicleSettingKeys);
+): AnalysisTuningSettings {
+  const next = { ...current };
+  for (const key of analysisTuningSettingKeys) {
+    const value = source[key];
+    if (typeof value === "number") {
+      next[key] = value;
+    }
+  }
+  return next;
 }
 
 export interface RunDetail {
@@ -250,16 +270,23 @@ export interface HistoryStateValue {
   runDetailsById: Record<string, RunDetail>;
 }
 
-export interface SettingsStateValue {
-  vehicleSettings: VehicleSettings;
+export interface CarSettingsValue {
+  activeVehicleSettings: CarAspectSettings;
   cars: CarRecord[];
   carsLoaded: boolean;
   activeCarId: string | null;
-  speedSource: SpeedSourceKind;
+}
+
+export interface AnalysisSettingsValue {
+  vehicleSettings: AnalysisTuningSettings;
+}
+
+export interface SpeedSettingsValue {
+  source: SpeedSourceKind;
   manualSpeedKph: number | null;
   obdDeviceMac: string | null;
   obdDeviceName: string | null;
-  resolvedSpeedSource: SpeedSourceStatusPayload["speed_source"] | null;
+  resolvedSource: SpeedSourceStatusPayload["speed_source"] | null;
   gpsFallbackActive: boolean;
   gpsEffectiveSpeedKph: number | null;
 }
@@ -277,7 +304,14 @@ export type ShellState = SignalState<ShellStateValue>;
 export type TransportState = SignalState<TransportStateValue>;
 export type RealtimeState = SignalState<RealtimeStateValue>;
 export type HistoryState = SignalState<HistoryStateValue>;
-export type SettingsState = SignalState<SettingsStateValue>;
+export type CarSettingsState = SignalState<CarSettingsValue>;
+export type AnalysisSettingsState = SignalState<AnalysisSettingsValue>;
+export type SpeedSettingsState = SignalState<SpeedSettingsValue>;
+export interface SettingsState {
+  car: CarSettingsState;
+  analysis: AnalysisSettingsState;
+  speed: SpeedSettingsState;
+}
 export type SpectrumState = SignalState<SpectrumStateValue>;
 
 export interface AppState {
@@ -332,17 +366,24 @@ export function createAppState(): AppState {
       runDetailsById: signal<Record<string, RunDetail>>({}),
     },
     settings: {
-      vehicleSettings: signal<VehicleSettings>({ ...defaultVehicleSettings }),
-      cars: signal<CarRecord[]>([]),
-      carsLoaded: signal(false),
-      activeCarId: signal<string | null>(null),
-      speedSource: signal<SpeedSourceKind>("gps"),
-      manualSpeedKph: signal<number | null>(null),
-      obdDeviceMac: signal<string | null>(null),
-      obdDeviceName: signal<string | null>(null),
-      resolvedSpeedSource: signal<SpeedSourceStatusPayload["speed_source"] | null>(null),
-      gpsFallbackActive: signal(false),
-      gpsEffectiveSpeedKph: signal<number | null>(null),
+      car: {
+        activeVehicleSettings: signal<CarAspectSettings>({ ...defaultCarAspectSettings }),
+        cars: signal<CarRecord[]>([]),
+        carsLoaded: signal(false),
+        activeCarId: signal<string | null>(null),
+      },
+      analysis: {
+        vehicleSettings: signal<AnalysisTuningSettings>({ ...defaultAnalysisTuningSettings }),
+      },
+      speed: {
+        source: signal<SpeedSourceKind>("gps"),
+        manualSpeedKph: signal<number | null>(null),
+        obdDeviceMac: signal<string | null>(null),
+        obdDeviceName: signal<string | null>(null),
+        resolvedSource: signal<SpeedSourceStatusPayload["speed_source"] | null>(null),
+        gpsFallbackActive: signal(false),
+        gpsEffectiveSpeedKph: signal<number | null>(null),
+      },
     },
     spectrum: {
       spectrumPlot: signal<SpectrumChart | null>(null),

--- a/apps/ui/tests/car_selection_state.spec.ts
+++ b/apps/ui/tests/car_selection_state.spec.ts
@@ -20,19 +20,19 @@ function makeCar(overrides: Partial<CarRecord> = {}): CarRecord {
 test.describe("car selection derived state", () => {
   test("tracks loading, empty, missing-active, and active states reactively", () => {
     const state = createAppState();
-    const derived = createCarSelectionDerivedState(state.settings);
+    const derived = createCarSelectionDerivedState(state.settings.car);
 
     expect(derived.selection.value).toEqual({ kind: "loading" });
     expect(derived.activeCar.value).toBeNull();
     expect(derived.hasResolvedActiveCar.value).toBe(false);
 
-    state.settings.carsLoaded.value = true;
+    state.settings.car.carsLoaded.value = true;
     expect(derived.selection.value).toEqual({ kind: "no_cars" });
 
-    state.settings.cars.value = [makeCar()];
+    state.settings.car.cars.value = [makeCar()];
     expect(derived.selection.value).toEqual({ kind: "no_active_car" });
 
-    state.settings.activeCarId.value = "car-1";
+    state.settings.car.activeCarId.value = "car-1";
     expect(derived.selection.value).toEqual({
       kind: "active",
       car: makeCar(),
@@ -40,7 +40,7 @@ test.describe("car selection derived state", () => {
     expect(derived.activeCar.value?.id).toBe("car-1");
     expect(derived.hasResolvedActiveCar.value).toBe(true);
 
-    state.settings.activeCarId.value = "missing";
+    state.settings.car.activeCarId.value = "missing";
     expect(derived.selection.value).toEqual({ kind: "no_active_car" });
     expect(derived.activeCar.value).toBeNull();
     expect(derived.hasResolvedActiveCar.value).toBe(false);

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -133,14 +133,17 @@ test("settings analysis module keeps active-car geometry when loading server ana
   const state = createAppState().settings;
   let renderSpectrumCalls = 0;
 
-  state.vehicleSettings.value = {
-    ...state.vehicleSettings.value,
+  state.car.activeVehicleSettings.value = {
+    ...state.car.activeVehicleSettings.value,
     tire_width_mm: 245,
     tire_aspect_pct: 40,
     rim_in: 19,
     final_drive_ratio: 3.23,
     current_gear_ratio: 0.72,
     tire_deflection_factor: 0.95,
+  };
+  state.analysis.vehicleSettings.value = {
+    ...state.analysis.vehicleSettings.value,
     wheel_bandwidth_pct: 5,
     speed_uncertainty_pct: 1,
     min_abs_band_hz: 0.2,
@@ -187,13 +190,15 @@ test("settings analysis module keeps active-car geometry when loading server ana
     globalThis.fetch = originalFetch;
   }
 
-  expect(state.vehicleSettings.value).toMatchObject({
+  expect(state.car.activeVehicleSettings.value).toMatchObject({
     tire_width_mm: 245,
     tire_aspect_pct: 40,
     rim_in: 19,
     final_drive_ratio: 3.23,
     current_gear_ratio: 0.72,
     tire_deflection_factor: 0.95,
+  });
+  expect(state.analysis.vehicleSettings.value).toMatchObject({
     wheel_bandwidth_pct: 7.5,
     speed_uncertainty_pct: 2.5,
     min_abs_band_hz: 1.5,

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -125,8 +125,8 @@ test("settings cars module loads cars through the shared async loader without ov
   const renders: CarsListRenderModel[] = [];
   let syncAnalysisInputsCalls = 0;
 
-  state.vehicleSettings.value = {
-    ...state.vehicleSettings.value,
+  state.analysis.vehicleSettings.value = {
+    ...state.analysis.vehicleSettings.value,
     wheel_bandwidth_pct: 7.5,
     speed_uncertainty_pct: 2.5,
     min_abs_band_hz: 1.5,
@@ -197,15 +197,17 @@ test("settings cars module loads cars through the shared async loader without ov
 
   await module.loadCarsFromServer();
 
-  expect(state.activeCarId.value).toBe("car-1");
-  expect(state.vehicleSettings.value).toMatchObject({
+  expect(state.car.activeCarId.value).toBe("car-1");
+  expect(state.car.activeVehicleSettings.value).toMatchObject({
     current_gear_ratio: 0.72,
     final_drive_ratio: 3.23,
     rim_in: 19,
-    min_abs_band_hz: 1.5,
-    speed_uncertainty_pct: 2.5,
     tire_aspect_pct: 40,
     tire_width_mm: 245,
+  });
+  expect(state.analysis.vehicleSettings.value).toMatchObject({
+    min_abs_band_hz: 1.5,
+    speed_uncertainty_pct: 2.5,
     wheel_bandwidth_pct: 7.5,
   });
   expect(syncAnalysisInputsCalls).toBe(1);

--- a/apps/ui/tests/settings_speed_source_workflow.spec.ts
+++ b/apps/ui/tests/settings_speed_source_workflow.spec.ts
@@ -134,10 +134,10 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
   test("keeps the configured GPS source when saving fallback-manual edits without a radio change", async () => {
     const harness = createHarness();
     const appState = createAppState();
-    appState.settings.speedSource.value = "gps";
-    appState.settings.manualSpeedKph.value = 80;
-    appState.settings.resolvedSpeedSource.value = "fallback_manual";
-    appState.settings.gpsEffectiveSpeedKph.value = 80;
+    appState.settings.speed.source.value = "gps";
+    appState.settings.speed.manualSpeedKph.value = 80;
+    appState.settings.speed.resolvedSource.value = "fallback_manual";
+    appState.settings.speed.gpsEffectiveSpeedKph.value = 80;
     let savedPayload: SpeedSourceRequest | null = null;
 
     const workflow = createSettingsSpeedSourceWorkflow({
@@ -171,8 +171,8 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
       stale_timeout_s: 5,
     });
     expect(workflow.getRenderState().selectedMode).toBe("gps");
-    expect(appState.settings.speedSource.value).toBe("gps");
-    expect(appState.settings.manualSpeedKph.value).toBe(90);
+    expect(appState.settings.speed.source.value).toBe("gps");
+    expect(appState.settings.speed.manualSpeedKph.value).toBe(90);
     expect(harness.focuses).toEqual([]);
     expect(harness.errors).toEqual([]);
   });
@@ -303,8 +303,8 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
       rfcomm_channel: 1,
       trusted: true,
     }]);
-    expect(appState.settings.obdDeviceMac.value).toBe(scannedDevice.mac_address);
-    expect(appState.settings.obdDeviceName.value).toBe("OBDLink CX");
+    expect(appState.settings.speed.obdDeviceMac.value).toBe(scannedDevice.mac_address);
+    expect(appState.settings.speed.obdDeviceName.value).toBe("OBDLink CX");
     expect(harness.errors).toEqual([]);
   });
 
@@ -378,9 +378,9 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
       view: createViewPorts(harness),
     });
 
-    appState.settings.speedSource.value = "obd2";
-    appState.settings.resolvedSpeedSource.value = "obd2";
-    appState.settings.gpsEffectiveSpeedKph.value = 81;
+    appState.settings.speed.source.value = "obd2";
+    appState.settings.speed.resolvedSource.value = "obd2";
+    appState.settings.speed.gpsEffectiveSpeedKph.value = 81;
 
     expect(workflow.getRenderState().settings.gpsEffectiveSpeedKph).toBe(81);
     expect(harness.errors).toEqual([]);
@@ -409,9 +409,9 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
       selectedMode: "gps",
     });
 
-    appState.settings.manualSpeedKph.value = 88;
-    appState.settings.speedSource.value = "manual";
-    appState.settings.resolvedSpeedSource.value = "manual";
+    appState.settings.speed.manualSpeedKph.value = 88;
+    appState.settings.speed.source.value = "manual";
+    appState.settings.speed.resolvedSource.value = "manual";
 
     expect(workflow.getRenderState()).toMatchObject({
       manualSpeedInputValue: "88",
@@ -423,8 +423,8 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
   test("keeps local manual input draft when settings change externally", () => {
     const harness = createHarness();
     const appState = createAppState();
-    appState.settings.speedSource.value = "gps";
-    appState.settings.manualSpeedKph.value = 80;
+    appState.settings.speed.source.value = "gps";
+    appState.settings.speed.manualSpeedKph.value = 80;
 
     const workflow = createSettingsSpeedSourceWorkflow({
       createPollingController: () => ({
@@ -442,7 +442,7 @@ test.describe("createSettingsSpeedSourceWorkflow", () => {
     });
 
     workflow.handleManualSpeedInput("90");
-    appState.settings.manualSpeedKph.value = 70;
+    appState.settings.speed.manualSpeedKph.value = 70;
     workflow.syncFromSettings();
 
     expect(workflow.getRenderState()).toMatchObject({

--- a/apps/ui/tests/speed_source_state.spec.ts
+++ b/apps/ui/tests/speed_source_state.spec.ts
@@ -80,7 +80,7 @@ test.describe("speed source state helpers", () => {
     const state = createAppState();
     const runtimeSpeedSource = signal<string | null>(null);
     const derived = createSpeedSourceDerivedState(
-      state.settings,
+      state.settings.speed,
       runtimeSpeedSource,
     );
 
@@ -93,7 +93,7 @@ test.describe("speed source state helpers", () => {
     expect(derived.speedReadoutLabelKey.value).toBe("speed.override");
     expect(derived.isManualEffective.value).toBe(true);
 
-    state.settings.resolvedSpeedSource.value = "obd2";
+    state.settings.speed.resolvedSource.value = "obd2";
     expect(derived.effectiveSource.value).toBe("obd2");
     expect(derived.displayedMode.value).toBe("obd2");
     expect(derived.speedReadoutLabelKey.value).toBe("speed.obd2");

--- a/apps/ui/tests/ui_app_state.spec.ts
+++ b/apps/ui/tests/ui_app_state.spec.ts
@@ -62,13 +62,13 @@ test.describe("ui_app_state reactivity", () => {
     const seenRatios: number[] = [];
 
     const dispose = effect(() => {
-      seenRatios.push(state.settings.vehicleSettings.value.current_gear_ratio);
+      seenRatios.push(state.settings.car.activeVehicleSettings.value.current_gear_ratio);
     });
 
     expect(seenRatios).toEqual([0.64]);
 
-    state.settings.vehicleSettings.value = {
-      ...state.settings.vehicleSettings.value,
+    state.settings.car.activeVehicleSettings.value = {
+      ...state.settings.car.activeVehicleSettings.value,
       current_gear_ratio: 0.72,
     };
 
@@ -88,7 +88,7 @@ test.describe("ui_app_state reactivity", () => {
     });
     const disposeSettings = effect(() => {
       settingsRuns += 1;
-      void state.settings.vehicleSettings.value;
+      void state.settings.analysis.vehicleSettings.value;
     });
 
     expect(transportRuns).toBe(1);

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -232,7 +232,7 @@ test.describe("UiShellController", () => {
     expect(liveOverview.speedText.value).toBe(speedText);
     expect(speedText?.value).toBe("12.3 m/s · GPS");
 
-    state.settings.resolvedSpeedSource.value = "obd2";
+    state.settings.speed.resolvedSource.value = "obd2";
     expect(speedText?.value).toBe("12.3 m/s · OBD2");
   });
 
@@ -543,12 +543,12 @@ test.describe("createUiShellStatusModule", () => {
   test("renders speed override after car bootstrap resolves", () => {
     const state = createAppState();
     state.realtime.speedMps.value = 12;
-    state.settings.speedSource.value = "manual";
-    state.settings.manualSpeedKph.value = 43.2;
+    state.settings.speed.source.value = "manual";
+    state.settings.speed.manualSpeedKph.value = 43.2;
     state.shell.speedUnit.value = "kmh";
-    state.settings.carsLoaded.value = true;
-    state.settings.cars.value = [];
-    state.settings.activeCarId.value = null;
+    state.settings.car.carsLoaded.value = true;
+    state.settings.car.cars.value = [];
+    state.settings.car.activeCarId.value = null;
 
     const module = createUiShellStatusModule({
       realtime: state.realtime,
@@ -565,8 +565,8 @@ test.describe("createUiShellStatusModule", () => {
   test("renders OBD2 when OBD2 is the resolved speed source", () => {
     const state = createAppState();
     state.realtime.speedMps.value = 22.5;
-    state.settings.speedSource.value = "obd2";
-    state.settings.resolvedSpeedSource.value = "obd2";
+    state.settings.speed.source.value = "obd2";
+    state.settings.speed.resolvedSource.value = "obd2";
     state.shell.speedUnit.value = "kmh";
 
     const module = createUiShellStatusModule({


### PR DESCRIPTION
## What changed
- split the UI settings store into owned `settings.car`, `settings.analysis`, and `settings.speed` slices
- keep `VehicleSettings` only as an explicit composed payload where callers still need the full shape
- update cars, analysis, speed-source, realtime, shell-status, demo, and car-creation callers plus regressions to use owned slices

## Why
- the old shared bag still had no single owner
- car activation, analysis loading, and speed-source status could all appear to own the same values
- this is the structural cleanup behind `#2708` and part of the confusion behind `#2709`, so future writes stay traceable

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test tests/ui_app_state.spec.ts tests/car_selection_state.spec.ts tests/speed_source_state.spec.ts tests/settings_analysis_module.spec.ts tests/settings_cars_module.spec.ts tests/settings_speed_source_workflow.spec.ts tests/ui_shell_runtime_modules.spec.ts`
- `cd apps/ui && CI=1 npm run test:visual`

## Risks / tradeoffs
- internal-only breaking refactor: the old flat settings shape is removed on purpose
- backend payload shape stays the same for now; only frontend ownership changes here

Closes #2711