### PR TITLE
perf(ui): skip unchanged spectrum redraws

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -111,7 +111,7 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `app/ui_lazy_panels.ts` | Typed panel binding factory that gives the runtime full dashboard/history/settings contracts up front, then attaches the real settings shell handles when that subtree mounts |
 | `app/dom/` | Focused DOM-only utilities for download and RAF lifecycles after removing the shared global query helper |
 | `app/ui_app_runtime.ts` | Thin UI composition root that creates the shell, spectrum, transport, feature bundle, and startup coordinator, then exposes one composed runtime `dispose()` |
-| `app/ui_app_state.ts` | Canonical AppState shape plus reactive slice helpers that keep object-style reads/writes working while shared shell/transport/realtime/history/settings/spectrum state becomes signal-observable |
+| `app/ui_app_state.ts` | Canonical AppState shape plus reactive slice helpers that keep object-style reads/writes working while shared shell/transport/realtime/history/settings/spectrum state becomes signal-observable, preserve light-tick spectrum frames, and dedupe unchanged heavy frames before redraws |
 | `app/ui_signals.ts` | Canonical re-export surface for shared `signal`, `computed`, and `effect` usage across runtime, features, and views |
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, app-level error banner, and the top-level dashboard/history/settings view containers plus the typed shell bridge |
 | `app/runtime/ui_shell_controller.ts` | Menu/view shell, language and preference hydration, and the reactive shell-chrome model that feeds header pills, feedback, and app-level banners |

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -169,12 +169,89 @@ function hasRenderableSpectrumData(spectra: { clients: Record<string, SpectrumCl
   return Object.values(spectra.clients).some((clientSpec) => clientSpec.freq.length > 0 && clientSpec.combined.length > 0);
 }
 
+function areNumberArraysEqual(left: readonly number[], right: readonly number[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function areStrengthPeaksEqual(
+  left: ReadonlyArray<SpectrumClientData["strength_metrics"]["top_peaks"][number]>,
+  right: ReadonlyArray<SpectrumClientData["strength_metrics"]["top_peaks"][number]>,
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    const leftPeak = left[index];
+    const rightPeak = right[index];
+    if (
+      leftPeak.amp !== rightPeak.amp
+      || leftPeak.hz !== rightPeak.hz
+      || leftPeak.strength_bucket !== rightPeak.strength_bucket
+      || leftPeak.vibration_strength_db !== rightPeak.vibration_strength_db
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function areStrengthMetricsEqual(
+  left: SpectrumClientData["strength_metrics"],
+  right: SpectrumClientData["strength_metrics"],
+): boolean {
+  return left.vibration_strength_db === right.vibration_strength_db
+    && left.peak_amp_g === right.peak_amp_g
+    && left.noise_floor_amp_g === right.noise_floor_amp_g
+    && left.strength_bucket === right.strength_bucket
+    && areStrengthPeaksEqual(left.top_peaks, right.top_peaks);
+}
+
+function areSpectrumClientDataEqual(left: SpectrumClientData, right: SpectrumClientData): boolean {
+  return areNumberArraysEqual(left.freq, right.freq)
+    && areNumberArraysEqual(left.combined, right.combined)
+    && areStrengthMetricsEqual(left.strength_metrics, right.strength_metrics);
+}
+
+export function areSpectrumFramesEqual(
+  left: { clients: Record<string, SpectrumClientData> },
+  right: { clients: Record<string, SpectrumClientData> },
+): boolean {
+  const leftClientIds = Object.keys(left.clients);
+  const rightClientIds = Object.keys(right.clients);
+  if (leftClientIds.length !== rightClientIds.length) {
+    return false;
+  }
+  for (const clientId of leftClientIds) {
+    const leftClient = left.clients[clientId];
+    const rightClient = right.clients[clientId];
+    if (!leftClient || !rightClient || !areSpectrumClientDataEqual(leftClient, rightClient)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function applySpectrumTick(
   previousSpectra: { clients: Record<string, SpectrumClientData> },
   previousHasSpectrumData: boolean,
   incomingSpectra: { clients: Record<string, SpectrumClientData> } | null,
 ): SpectrumTickUpdate {
   if (!incomingSpectra) {
+    return {
+      spectra: previousSpectra,
+      hasSpectrumData: previousHasSpectrumData,
+      hasNewSpectrumFrame: false,
+    };
+  }
+  if (areSpectrumFramesEqual(previousSpectra, incomingSpectra)) {
     return {
       spectra: previousSpectra,
       hasSpectrumData: previousHasSpectrumData,

--- a/apps/ui/tests/ui_live_payload_application.spec.ts
+++ b/apps/ui/tests/ui_live_payload_application.spec.ts
@@ -103,4 +103,51 @@ test.describe("applyLivePayloadUpdate", () => {
     expect(update.hasNewSpectrumFrame).toBe(false);
     expect(update.selectedClient?.id).toBe("client-1");
   });
+
+  test("preserves the previous spectrum frame when the heavy payload is unchanged", () => {
+    const state = createAppState();
+    const previousSpectra = {
+      clients: {
+        "client-1": {
+          freq: [1, 2, 3],
+          combined: [0.01, 0.02, 0.03],
+          strength_metrics: {
+            vibration_strength_db: 5,
+            peak_amp_g: 0,
+            noise_floor_amp_g: 0,
+            strength_bucket: null,
+            top_peaks: [{ amp: 0.03, hz: 3, strength_bucket: null, vibration_strength_db: 5 }],
+          },
+        },
+      },
+    };
+    state.spectrum.spectra.value = previousSpectra;
+    state.spectrum.hasSpectrumData.value = true;
+
+    const update = applyLivePayloadUpdate({
+      realtime: state.realtime,
+      spectrum: state.spectrum,
+      adaptedPayload: makeAdaptedPayload({
+        clients: [makeClient("client-1")],
+        spectra: {
+          clients: {
+            "client-1": {
+              freq: [1, 2, 3],
+              combined: [0.01, 0.02, 0.03],
+              strength_metrics: {
+                vibration_strength_db: 5,
+                peak_amp_g: 0,
+                noise_floor_amp_g: 0,
+                strength_bucket: null,
+                top_peaks: [{ amp: 0.03, hz: 3, strength_bucket: null, vibration_strength_db: 5 }],
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    expect(state.spectrum.spectra.value).toBe(previousSpectra);
+    expect(update.hasNewSpectrumFrame).toBe(false);
+  });
 });

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -1,13 +1,49 @@
 import { expect, test } from "@playwright/test";
 
 import type { SpectrumPanelView } from "../src/app/runtime/spectrum_panel_view";
-import { createAppState } from "../src/app/ui_app_state";
+import { applyLivePayloadUpdate, createAppState } from "../src/app/ui_app_state";
 import { batch } from "../src/app/ui_signals";
+import type { AdaptedPayload } from "../src/transport/live_models";
 import { installWindowGlobal } from "./async_test_helpers";
 import { createElementStub, installDocumentStub } from "./spectrum_test_support";
 
 async function importUiSpectrumController() {
   return (await import("../src/app/runtime/ui_spectrum_controller")).UiSpectrumController;
+}
+
+function makeSpectrumPayload(values: readonly number[]): AdaptedPayload {
+  return {
+    clients: [{
+      id: "sensor-a",
+      name: "Sensor A",
+      connected: true,
+      mac_address: "00:11:22:33:44:55",
+      location_code: "",
+      last_seen_age_ms: 0,
+      dropped_frames: 0,
+      frames_total: 1,
+      frame_samples: 0,
+      sample_rate_hz: 1600,
+      firmware_version: "1.0.0",
+    }],
+    speed_mps: 10,
+    rotational_speeds: null,
+    spectra: {
+      clients: {
+        "sensor-a": {
+          freq: [10, 20, 30],
+          combined: [...values],
+          strength_metrics: {
+            vibration_strength_db: 12,
+            peak_amp_g: 0,
+            noise_floor_amp_g: 0,
+            strength_bucket: null,
+            top_peaks: [],
+          },
+        },
+      },
+    },
+  };
 }
 
 function createPanelStub(): {
@@ -128,6 +164,47 @@ test.describe("UiSpectrumController", () => {
 
       expect(renderCalls).toBe(1);
       expect(overlayCalls).toBe(1);
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("skips redraws for repeated heavy frames and redraws when the frame changes", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const UiSpectrumController = await importUiSpectrumController();
+      const state = createAppState();
+      const panel = createPanelStub();
+      const controller = new UiSpectrumController({
+        state,
+        panel: panel.panel,
+        t: (key) => key,
+      });
+      let renderCalls = 0;
+      controller.renderSpectrum = () => {
+        renderCalls += 1;
+      };
+
+      applyLivePayloadUpdate({
+        realtime: state.realtime,
+        spectrum: state.spectrum,
+        adaptedPayload: makeSpectrumPayload([0.1, 0.2, 0.3]),
+      });
+      expect(renderCalls).toBe(1);
+
+      applyLivePayloadUpdate({
+        realtime: state.realtime,
+        spectrum: state.spectrum,
+        adaptedPayload: makeSpectrumPayload([0.1, 0.2, 0.3]),
+      });
+      expect(renderCalls).toBe(1);
+
+      applyLivePayloadUpdate({
+        realtime: state.realtime,
+        spectrum: state.spectrum,
+        adaptedPayload: makeSpectrumPayload([0.1, 0.2, 0.4]),
+      });
+      expect(renderCalls).toBe(2);
     } finally {
       restoreDocument();
     }


### PR DESCRIPTION
## Summary
- compare heavy spectrum frames in `apps/ui/src/app/ui_app_state.ts` before replacing state
- keep previous `spectra` identity and `hasNewSpectrumFrame=false` when FFT content is unchanged
- add regressions for state reuse and redraw counts, and sync the UI runtime map note

## Why
- repeated identical heavy WS frames still paid for prepare/convert/rebuild/redraw work with no visible graph change
- Pi-class hardware should skip that graph path when the frame did not actually change

## Validation
- `cd apps/ui && npx playwright test tests/ui_live_payload_application.spec.ts tests/ui_spectrum_controller.spec.ts tests/cycle2_fixes.spec.ts && npm run typecheck && npm run build`
- `cd apps/ui && CI=1 npm run test:visual`

## Risks / tradeoffs / edge cases
- dedupe uses exact array and metric equality, so tiny numeric drift still redraws by design
- light ticks still preserve the previous heavy frame; changed heavy frames still redraw
- live Pi hardware verification remains out of scope for this repo-only pass

Closes #2727
