### PR TITLE
perf(ui): adapt spectrum tween cadence

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -119,7 +119,7 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that wires overlay updates plus the extracted canvas, interaction, and panel modules |
 | `app/runtime/ui_startup_coordinator.ts` | Declarative startup-task runner that lets the shell own its initial bind/language/view boot while startup loads and transport start from a named sync/async plan |
 | `app/runtime/ui_startup_feature_ports.ts` | Narrow startup-only feature contract for initial refresh/load work |
-| `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, tweening, and canvas draw plugin orchestration |
+| `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, cadence-aware tween scheduling, and canvas draw plugin orchestration |
 | `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports |
 | `app/runtime/spectrum_panel_view.ts` | Typed spectrum panel contract for the signal-backed legend, band legend, inspector, band-toggle, and chart-host refs |
 | `app/app_feature_bundle.ts` | Creates concrete feature instances, then exposes explicit shell, transport, and startup port bundles back to the runtime |

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -5,9 +5,14 @@ import { convertSpectrumAmplitudesToDbInPlace } from "../../spectrum";
 import type { SpectrumSeriesMeta, SpectrumText } from "../../spectrum_chart";
 import { getSpectrumCssVars } from "../../spectrum_css_vars";
 import { chartSeriesPalette, orderBandFills } from "../../theme";
-import { createRafAnimation } from "../dom/raf_animation";
+import {
+  createRafAnimation,
+  type RafAnimation,
+  type RafAnimationCallbacks,
+} from "../dom/raf_animation";
 import {
   createSpectrumTweenDerivedState,
+  resolveSpectrumTweenDurationMs,
   type SpectrumHeavyFrame,
 } from "../spectrum_animation";
 import type { AppState, ChartBand } from "../ui_app_state";
@@ -49,6 +54,8 @@ export interface SpectrumCanvasRendererDeps {
   onCursorDataIndexChange: (cursorDataIdx: number | null) => void;
   onAsyncChartUpdate?: () => void;
   loadChartModule?: () => Promise<SpectrumChartModule>;
+  createAnimation?: (callbacks: RafAnimationCallbacks) => RafAnimation;
+  nowMs?: () => number;
 }
 
 export interface SpectrumCanvasRenderer {
@@ -64,15 +71,19 @@ export function createSpectrumCanvasRenderer(
 ): SpectrumCanvasRenderer {
   const onAsyncChartUpdate = deps.onAsyncChartUpdate ?? (() => undefined);
   const loadChartModule = deps.loadChartModule ?? loadSpectrumChartModule;
+  const createAnimation = deps.createAnimation ?? ((callbacks) => createRafAnimation(callbacks));
+  const nowMs = deps.nowMs ?? (() => performance.now());
 
   let chartLoadPromise: Promise<void> | null = null;
   let disposed = false;
+  let lastAcceptedFrameAtMs: number | null = null;
 
   const spectrumLastFrame = signal<SpectrumHeavyFrame | null>(null);
   const pendingPreparedFrame = signal<SpectrumPreparedRenderData | null>(null);
   const chartModule = signal<SpectrumChartModule | null>(null);
 
   const tweenAlpha = signal(1);
+  const tweenDurationMs = signal(SPECTRUM_TWEEN_DURATION_MS);
   const tweenFromFrame = signal<SpectrumHeavyFrame | null>(null);
   const tweenToFrame = signal<SpectrumHeavyFrame | null>(null);
   const tweenState = createSpectrumTweenDerivedState(
@@ -101,9 +112,10 @@ export function createSpectrumCanvasRenderer(
   function initTweenEffect(): () => void {
     return effect(() => {
       const to = tweenTarget.value;
-      if (!to) return;
-      const anim = createRafAnimation({
-        durationMs: SPECTRUM_TWEEN_DURATION_MS,
+      const durationMs = tweenDurationMs.value;
+      if (!to || durationMs <= 0) return;
+      const anim = createAnimation({
+        durationMs,
         onFrame: (alpha) => {
           tweenAlpha.value = alpha;
           const frame = tweenState.frame.value;
@@ -249,17 +261,25 @@ export function createSpectrumCanvasRenderer(
     }
 
     const nextFrame = prepared.frame;
+    const renderAtMs = nowMs();
+    const previousFrameAtMs = lastAcceptedFrameAtMs;
+    lastAcceptedFrameAtMs = renderAtMs;
     tweenFromFrame.value = spectrumLastFrame.value;
     tweenToFrame.value = nextFrame;
     tweenTarget.value = null; // cancel any in-flight animation
+    const tweenDurationForFrameMs = resolveSpectrumTweenDurationMs(
+      SPECTRUM_TWEEN_DURATION_MS,
+      previousFrameAtMs === null ? null : renderAtMs - previousFrameAtMs,
+    );
     const canTween = deps.state.transport.wsState.value === "connected"
       && tweenState.canTween.value;
-    if (!canTween || !spectrumLastFrame.value) {
+    if (!canTween || !spectrumLastFrame.value || tweenDurationForFrameMs <= 0) {
       setSpectrumDataFromFrame(nextFrame);
       return;
     }
 
     tweenAlpha.value = 0;
+    tweenDurationMs.value = tweenDurationForFrameMs;
     tweenTarget.value = nextFrame; // triggers RAF effect
   }
 
@@ -458,6 +478,7 @@ export function createSpectrumCanvasRenderer(
     }
     tweenTarget.value = null;
     spectrumLastFrame.value = null;
+    lastAcceptedFrameAtMs = null;
     if (deps.state.spectrum.spectrumPlot.value) {
       deps.state.spectrum.spectrumPlot.value.destroy();
       deps.state.spectrum.spectrumPlot.value = null;

--- a/apps/ui/src/app/spectrum_animation.ts
+++ b/apps/ui/src/app/spectrum_animation.ts
@@ -79,6 +79,22 @@ export function interpolateHeavyFrame(previous: SpectrumHeavyFrame, next: Spectr
   };
 }
 
+export function resolveSpectrumTweenDurationMs(
+  baseDurationMs: number,
+  frameIntervalMs: number | null,
+): number {
+  if (!Number.isFinite(baseDurationMs) || baseDurationMs <= 0) {
+    return 0;
+  }
+  if (frameIntervalMs === null) {
+    return baseDurationMs;
+  }
+  if (!Number.isFinite(frameIntervalMs) || frameIntervalMs <= 0) {
+    return 0;
+  }
+  return frameIntervalMs < baseDurationMs ? 0 : baseDurationMs;
+}
+
 export interface SpectrumTweenDerivedState {
   canTween: ReadonlySignal<boolean>;
   frame: ReadonlySignal<SpectrumHeavyFrame | null>;

--- a/apps/ui/tests/spectrum_animation.spec.ts
+++ b/apps/ui/tests/spectrum_animation.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import {
   createSpectrumTweenDerivedState,
+  resolveSpectrumTweenDurationMs,
   type SpectrumHeavyFrame,
 } from "../src/app/spectrum_animation";
 import { signal } from "../src/app/ui_signals";
@@ -34,5 +35,12 @@ test.describe("spectrum tween derived state", () => {
 
     expect(tween.canTween.value).toBe(false);
     expect(tween.frame.value).toBe(next.value);
+  });
+
+  test("suppresses tweening when heavy frames arrive faster than the tween budget", () => {
+    expect(resolveSpectrumTweenDurationMs(180, null)).toBe(180);
+    expect(resolveSpectrumTweenDurationMs(180, 220)).toBe(180);
+    expect(resolveSpectrumTweenDurationMs(180, 100)).toBe(0);
+    expect(resolveSpectrumTweenDurationMs(180, 0)).toBe(0);
   });
 });

--- a/apps/ui/tests/spectrum_canvas_renderer.spec.ts
+++ b/apps/ui/tests/spectrum_canvas_renderer.spec.ts
@@ -358,4 +358,168 @@ test.describe("createSpectrumCanvasRenderer", () => {
       restoreDocument();
     }
   });
+
+  test("suppresses tween animations when heavy frames arrive faster than the tween budget", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const { createSpectrumCanvasRenderer } = await import(
+        "../src/app/runtime/spectrum_canvas_renderer"
+      );
+      const state = createAppState();
+      state.transport.wsState.value = "connected";
+      state.realtime.clients.value = [makeClient("sensor-a", "Front Right Wheel")];
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            freq: [10, 15, 20],
+            combined: [1, 0.75, 0.5],
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 1,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 1,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 12,
+              }],
+              vibration_strength_db: 12,
+            },
+          },
+        },
+      };
+      const animationStarts: number[] = [];
+      const renderTimesMs = [1_000, 1_100];
+
+      const renderer = createSpectrumCanvasRenderer({
+        state,
+        dom: {
+          specChart: createElementStub("div"),
+          specChartWrap: createElementStub("div"),
+        } as unknown as SpectrumPanelChartDom,
+        t: (key) => key,
+        getBandsVisible: () => false,
+        getChartBands: () => [],
+        getFocusMarker: () => null,
+        onCursorDataIndexChange: () => undefined,
+        loadChartModule: async () => ({
+          createSpectrumChart(): SpectrumChart {
+            return {
+              destroy() {},
+              resize() {},
+              setSeriesIsolation() {},
+            };
+          },
+        }),
+        createAnimation: ({ durationMs }) => ({
+          start() {
+            animationStarts.push(durationMs);
+          },
+          stop() {},
+        }),
+        nowMs: () => renderTimesMs.shift() ?? 0,
+      });
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            ...state.spectrum.spectra.value.clients["sensor-a"]!,
+            combined: [0.9, 0.7, 0.45],
+          },
+        },
+      };
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+
+      expect(animationStarts).toEqual([]);
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("keeps tween animations enabled when heavy frames arrive slower than the tween budget", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const { createSpectrumCanvasRenderer } = await import(
+        "../src/app/runtime/spectrum_canvas_renderer"
+      );
+      const state = createAppState();
+      state.transport.wsState.value = "connected";
+      state.realtime.clients.value = [makeClient("sensor-a", "Front Right Wheel")];
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            freq: [10, 15, 20],
+            combined: [1, 0.75, 0.5],
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 1,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 1,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 12,
+              }],
+              vibration_strength_db: 12,
+            },
+          },
+        },
+      };
+      const animationStarts: number[] = [];
+      const renderTimesMs = [1_000, 1_250];
+
+      const renderer = createSpectrumCanvasRenderer({
+        state,
+        dom: {
+          specChart: createElementStub("div"),
+          specChartWrap: createElementStub("div"),
+        } as unknown as SpectrumPanelChartDom,
+        t: (key) => key,
+        getBandsVisible: () => false,
+        getChartBands: () => [],
+        getFocusMarker: () => null,
+        onCursorDataIndexChange: () => undefined,
+        loadChartModule: async () => ({
+          createSpectrumChart(): SpectrumChart {
+            return {
+              destroy() {},
+              resize() {},
+              setSeriesIsolation() {},
+            };
+          },
+        }),
+        createAnimation: ({ durationMs }) => ({
+          start() {
+            animationStarts.push(durationMs);
+          },
+          stop() {},
+        }),
+        nowMs: () => renderTimesMs.shift() ?? 0,
+      });
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            ...state.spectrum.spectra.value.clients["sensor-a"]!,
+            combined: [0.9, 0.7, 0.45],
+          },
+        },
+      };
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+
+      expect(animationStarts).toEqual([180]);
+    } finally {
+      restoreDocument();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add cadence policy in `apps/ui/src/app/spectrum_animation.ts` so tweening only runs when the previous accepted heavy frame is old enough
- track the last accepted heavy-frame timestamp inside `apps/ui/src/app/runtime/spectrum_canvas_renderer.ts`
- inject renderer time/animation hooks for focused tests, add cadence regressions, and sync the UI runtime map note

## Why
- the fixed `180ms` tween budget could outlive the default `100ms` accepted heavy-frame cadence
- that kept the graph in near-permanent tween mode during active streaming and amplified redraw work instead of smoothing it

## Validation
- `cd apps/ui && npx playwright test tests/spectrum_animation.spec.ts tests/spectrum_canvas_renderer.spec.ts && npm run typecheck && npm run build`
- `cd apps/ui && CI=1 npm run test:visual`

## Risks / tradeoffs / edge cases
- fast compatible frames now swap directly instead of tweening, so motion is less smooth under sustained high cadence by design
- slower compatible frames still tween at the existing `180ms` budget
- live Pi hardware verification remains out of scope for this repo-only pass

Closes #2728
