### PR TITLE
perf(ui): split spectrum refresh paths

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -116,7 +116,7 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, app-level error banner, and the top-level dashboard/history/settings view containers plus the typed shell bridge |
 | `app/runtime/ui_shell_controller.ts` | Menu/view shell, language and preference hydration, and the reactive shell-chrome model that feeds header pills, feedback, and app-level banners |
 | `app/runtime/ui_live_transport_controller.ts` | Demo/WebSocket transport coordinator that queues payloads through AppState, throttles live-session adaptation, and lets realtime, shell, and spectrum surfaces react from signal-backed state |
-| `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that wires overlay updates plus the extracted canvas, interaction, and panel modules |
+| `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that splits heavy data refreshes from lighter settings-driven decoration refreshes while wiring overlay, canvas, interaction, and panel modules |
 | `app/runtime/ui_startup_coordinator.ts` | Declarative startup-task runner that lets the shell own its initial bind/language/view boot while startup loads and transport start from a named sync/async plan |
 | `app/runtime/ui_startup_feature_ports.ts` | Narrow startup-only feature contract for initial refresh/load work |
 | `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, cadence-aware tween scheduling, and canvas draw plugin orchestration |

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -133,7 +133,7 @@ export function createAppFeatureBundle(
     showCarCreationSuccess: (carId, carName) =>
       settings.showCarCreationSuccess(carId, carName),
     renderCarList: () => settings.renderCarList(),
-    renderSpectrum: runtime.view.renderSpectrum,
+    refreshSpectrumDecorations: runtime.view.refreshSpectrumDecorations,
   });
 
   const cars: CarsFeature = createCarsFeature({

--- a/apps/ui/src/app/features/settings_analysis_module.ts
+++ b/apps/ui/src/app/features/settings_analysis_module.ts
@@ -22,7 +22,7 @@ export interface SettingsAnalysisModuleDeps {
   panel: AnalysisPanelView;
   settings: SettingsState;
   services: FeatureServices;
-  renderSpectrum: () => void;
+  refreshSpectrumDecorations: () => void;
   hasValidActiveCar: () => boolean;
   onMissingActiveCar: () => void;
   onSaveError: (error: unknown) => void;
@@ -342,7 +342,7 @@ export function createSettingsAnalysisModule(
       serverSettings,
     );
     syncSettingsInputs();
-    ctx.renderSpectrum();
+    ctx.refreshSpectrumDecorations();
   }
 
   async function syncAnalysisSettingsToServer(

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -42,7 +42,7 @@ interface SettingsCarsModulePorts {
   activeSettingsTabId: ReadonlySignal<string>;
   openAnalysisTab: () => void;
   openCarWizard: () => void;
-  renderSpectrum: () => void;
+  refreshSpectrumDecorations: () => void;
   syncAnalysisInputs: () => void;
 }
 
@@ -196,7 +196,7 @@ export function createSettingsCarsModule(
       syncCarsPayload(await transport.activateCar(carId));
       syncActiveCarToInputs();
       clearHighlightedCarFeedback();
-      ctx.ports.renderSpectrum();
+      ctx.ports.refreshSpectrumDecorations();
     } catch (_err) {
       services.showError(t("settings.car.activate_failed"));
     }
@@ -214,7 +214,7 @@ export function createSettingsCarsModule(
       if (car.id !== settings.car.activeCarId.value) {
         syncCarsPayload(await transport.activateCar(carId));
         syncActiveCarToInputs();
-        ctx.ports.renderSpectrum();
+        ctx.ports.refreshSpectrumDecorations();
       }
       clearHighlightedCarFeedback();
       ctx.ports.openAnalysisTab();
@@ -238,7 +238,7 @@ export function createSettingsCarsModule(
       syncCarsPayload(await transport.deleteCar(carId));
       syncActiveCarToInputs();
       clearHighlightedCarFeedback();
-      ctx.ports.renderSpectrum();
+      ctx.ports.refreshSpectrumDecorations();
     } catch (_err) {
       services.showError(t("settings.car.delete_failed"));
     }

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -52,6 +52,7 @@ export interface SettingsFeatureDeps {
 
 export interface SettingsFeatureViewPorts {
   renderSpectrum: () => void;
+  refreshSpectrumDecorations: () => void;
 }
 
 export interface SettingsFeature {
@@ -92,7 +93,7 @@ export function createSettingsFeature(
     panel: ctx.panels.analysisPanel,
     settings,
     services,
-    renderSpectrum: ctx.ports.view.renderSpectrum,
+    refreshSpectrumDecorations: ctx.ports.view.refreshSpectrumDecorations,
     hasValidActiveCar: () => carSelection.hasResolvedActiveCar.value,
     onMissingActiveCar: () => carsModule.renderCarList(),
     onSaveError: showSettingsSaveError,
@@ -135,7 +136,7 @@ export function createSettingsFeature(
       openCarWizard: ctx.ports.openCarWizard,
       activeViewId: ctx.ports.activeViewId,
       activeSettingsTabId: ctx.panels.settingsShell.activeTabId,
-      renderSpectrum: ctx.ports.view.renderSpectrum,
+      refreshSpectrumDecorations: ctx.ports.view.refreshSpectrumDecorations,
       syncAnalysisInputs: analysisModule.syncSettingsInputs,
     },
     services,

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -61,6 +61,7 @@ export interface SpectrumCanvasRendererDeps {
 export interface SpectrumCanvasRenderer {
   dispose(): void;
   prepareFrame(): SpectrumPreparedRenderData;
+  refreshPreparedFrameMetadata(): SpectrumPreparedRenderData;
   renderPreparedFrame(prepared: SpectrumPreparedRenderData): void;
   refreshDecorations(): void;
   setSeriesIsolation(seriesIndex: number | null): void;
@@ -77,6 +78,7 @@ export function createSpectrumCanvasRenderer(
   let chartLoadPromise: Promise<void> | null = null;
   let disposed = false;
   let lastAcceptedFrameAtMs: number | null = null;
+  let lastPreparedFrame: SpectrumPreparedRenderData | null = null;
 
   const spectrumLastFrame = signal<SpectrumHeavyFrame | null>(null);
   const pendingPreparedFrame = signal<SpectrumPreparedRenderData | null>(null);
@@ -238,6 +240,7 @@ export function createSpectrumCanvasRenderer(
     if (disposed) {
       return;
     }
+    lastPreparedFrame = prepared;
     pendingPreparedFrame.value = prepared;
     currentEntries.value = prepared.entries;
     currentFreqAxis.value = prepared.freqAxis;
@@ -281,6 +284,25 @@ export function createSpectrumCanvasRenderer(
     tweenAlpha.value = 0;
     tweenDurationMs.value = tweenDurationForFrameMs;
     tweenTarget.value = nextFrame; // triggers RAF effect
+  }
+
+  function refreshPreparedFrameMetadata(): SpectrumPreparedRenderData {
+    const chartBands = calculateBands();
+    if (!lastPreparedFrame) {
+      return {
+        entries: [],
+        freqAxis: [],
+        chartBands,
+        frame: null,
+        hasData: false,
+      };
+    }
+    const refreshed = {
+      ...lastPreparedFrame,
+      chartBands,
+    };
+    lastPreparedFrame = refreshed;
+    return refreshed;
   }
 
   function refreshDecorations(): void {
@@ -479,6 +501,7 @@ export function createSpectrumCanvasRenderer(
     tweenTarget.value = null;
     spectrumLastFrame.value = null;
     lastAcceptedFrameAtMs = null;
+    lastPreparedFrame = null;
     if (deps.state.spectrum.spectrumPlot.value) {
       deps.state.spectrum.spectrumPlot.value.destroy();
       deps.state.spectrum.spectrumPlot.value = null;
@@ -567,6 +590,7 @@ export function createSpectrumCanvasRenderer(
       deps.state.spectrum.chartLoading.value = false;
     },
     prepareFrame,
+    refreshPreparedFrameMetadata,
     renderPreparedFrame,
     refreshDecorations,
     setSeriesIsolation,

--- a/apps/ui/src/app/runtime/ui_car_creation_command.ts
+++ b/apps/ui/src/app/runtime/ui_car_creation_command.ts
@@ -8,7 +8,7 @@ export interface UiCarCreationCommandDeps {
   syncActiveCarToInputs: () => void;
   showCarCreationSuccess?: (carId: string, carName: string) => void;
   renderCarList: () => void;
-  renderSpectrum: () => void;
+  refreshSpectrumDecorations: () => void;
   addSettingsCar?: (payload: CarUpsertRequest) => Promise<CarsPayload>;
   setActiveSettingsCar?: (carId: string) => Promise<CarsPayload>;
 }
@@ -56,7 +56,7 @@ export function createUiCarCreationCommand(
           deps.showCarCreationSuccess?.(newCar.id, newCar.name);
         }
         deps.renderCarList();
-        deps.renderSpectrum();
+        deps.refreshSpectrumDecorations();
       } catch (_err) {
         // Preserve the current silent wizard failure behavior while removing
         // the cross-feature dependency from CarsFeature to SettingsFeature.

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -82,9 +82,10 @@ export class UiSpectrumController {
     });
   }
 
-  renderSpectrum(): void {
-    this.renderSpectrumHeader();
-    const prepared = this.canvas.prepareFrame();
+  private applyPreparedSpectrum(
+    prepared: ReturnType<SpectrumCanvasRenderer["prepareFrame"]>,
+    mode: "data" | "decorations",
+  ): void {
     this.state.spectrum.chartBands.value = prepared.chartBands;
     this.state.spectrum.hasSpectrumData.value = prepared.hasData;
     this.interaction.sync({
@@ -92,9 +93,25 @@ export class UiSpectrumController {
       freqAxis: prepared.freqAxis,
       chartBands: prepared.chartBands,
     }, { applyPlotIsolation: false });
-    this.canvas.renderPreparedFrame(prepared);
+    if (mode === "data") {
+      this.canvas.renderPreparedFrame(prepared);
+    } else {
+      this.canvas.refreshDecorations();
+    }
     this.interaction.applyPlotSelection();
     this.updateSpectrumOverlay();
+  }
+
+  renderSpectrum(): void {
+    this.renderSpectrumHeader();
+    const prepared = this.canvas.prepareFrame();
+    this.applyPreparedSpectrum(prepared, "data");
+  }
+
+  refreshSpectrumDecorations(): void {
+    this.renderSpectrumHeader();
+    const prepared = this.canvas.refreshPreparedFrameMetadata();
+    this.applyPreparedSpectrum(prepared, "decorations");
   }
 
   dispose(): void {

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -67,6 +67,7 @@ function createUiAppFeatureRuntimePorts(deps: {
     },
     view: {
       renderSpectrum: () => spectrum.renderSpectrum(),
+      refreshSpectrumDecorations: () => spectrum.refreshSpectrumDecorations(),
     },
     transport: {
       sendSelection: () => transport.sendSelection(),

--- a/apps/ui/tests/settings_analysis_module.spec.ts
+++ b/apps/ui/tests/settings_analysis_module.spec.ts
@@ -78,7 +78,7 @@ test("settings analysis module renders guidance and surfaces invalid input throu
     hasValidActiveCar: () => true,
     onMissingActiveCar: () => undefined,
     onSaveError: () => undefined,
-    renderSpectrum: () => undefined,
+    refreshSpectrumDecorations: () => undefined,
     settings: state,
     services: {
       t: translate,
@@ -131,7 +131,7 @@ test("settings analysis module renders guidance and surfaces invalid input throu
 test("settings analysis module keeps active-car geometry when loading server analysis settings", async () => {
   const originalFetch = globalThis.fetch;
   const state = createAppState().settings;
-  let renderSpectrumCalls = 0;
+  let refreshSpectrumDecorationCalls = 0;
 
   state.car.activeVehicleSettings.value = {
     ...state.car.activeVehicleSettings.value,
@@ -173,8 +173,8 @@ test("settings analysis module keeps active-car geometry when loading server ana
     hasValidActiveCar: () => true,
     onMissingActiveCar: () => undefined,
     onSaveError: () => undefined,
-    renderSpectrum: () => {
-      renderSpectrumCalls += 1;
+    refreshSpectrumDecorations: () => {
+      refreshSpectrumDecorationCalls += 1;
     },
     settings: state,
     services: {
@@ -203,5 +203,5 @@ test("settings analysis module keeps active-car geometry when loading server ana
     speed_uncertainty_pct: 2.5,
     min_abs_band_hz: 1.5,
   });
-  expect(renderSpectrumCalls).toBe(1);
+  expect(refreshSpectrumDecorationCalls).toBe(1);
 });

--- a/apps/ui/tests/settings_cars_module.spec.ts
+++ b/apps/ui/tests/settings_cars_module.spec.ts
@@ -45,7 +45,7 @@ test("settings cars module dismisses transient creation feedback through typed t
       activeSettingsTabId,
       openAnalysisTab: () => undefined,
       openCarWizard: () => undefined,
-      renderSpectrum: () => undefined,
+      refreshSpectrumDecorations: () => undefined,
       syncAnalysisInputs: () => undefined,
     },
     services: {
@@ -157,7 +157,7 @@ test("settings cars module loads cars through the shared async loader without ov
       activeSettingsTabId: signal("carTab"),
       openAnalysisTab: () => undefined,
       openCarWizard: () => undefined,
-      renderSpectrum: () => undefined,
+      refreshSpectrumDecorations: () => undefined,
       syncAnalysisInputs: () => {
         syncAnalysisInputsCalls += 1;
       },

--- a/apps/ui/tests/spectrum_canvas_renderer.spec.ts
+++ b/apps/ui/tests/spectrum_canvas_renderer.spec.ts
@@ -359,6 +359,84 @@ test.describe("createSpectrumCanvasRenderer", () => {
     }
   });
 
+  test("reuses cached prepared data when only chart-band metadata changes", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const { createSpectrumCanvasRenderer } = await import(
+        "../src/app/runtime/spectrum_canvas_renderer"
+      );
+      const state = createAppState();
+      state.realtime.clients.value = [makeClient("sensor-a", "Front Right Wheel")];
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            freq: [10, 15, 20],
+            combined: [1, 0.75, 0.5],
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 1,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 1,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 12,
+              }],
+              vibration_strength_db: 12,
+            },
+          },
+        },
+      };
+
+      const renderer = createSpectrumCanvasRenderer({
+        state,
+        dom: {
+          specChart: createElementStub("div"),
+          specChartWrap: createElementStub("div"),
+        } as unknown as SpectrumPanelChartDom,
+        t: (key) => key,
+        getBandsVisible: () => false,
+        getChartBands: () => [],
+        getFocusMarker: () => null,
+        onCursorDataIndexChange: () => undefined,
+        loadChartModule: async () => ({
+          createSpectrumChart(): SpectrumChart {
+            return {
+              destroy() {},
+              resize() {},
+              setSeriesIsolation() {},
+            };
+          },
+        }),
+      });
+
+      const prepared = renderer.prepareFrame();
+      renderer.renderPreparedFrame(prepared);
+      await flushSignalUpdates();
+
+      state.realtime.rotationalSpeeds.value = {
+        wheel_rpm: 600,
+        engine_rpm: 1800,
+        driveshaft_rpm: 600,
+        order_bands: [{
+          key: "wheel_1x",
+          center_hz: 10,
+          tolerance: 0.1,
+        }],
+      };
+
+      const refreshed = renderer.refreshPreparedFrameMetadata();
+
+      expect(refreshed.entries).toBe(prepared.entries);
+      expect(refreshed.freqAxis).toBe(prepared.freqAxis);
+      expect(refreshed.frame).toBe(prepared.frame);
+      expect(refreshed.hasData).toBe(true);
+      expect(refreshed.chartBands).toHaveLength(1);
+    } finally {
+      restoreDocument();
+    }
+  });
+
   test("suppresses tween animations when heavy frames arrive faster than the tween budget", async () => {
     const restoreDocument = installDocumentStub();
     try {

--- a/apps/ui/tests/ui_car_creation_command.spec.ts
+++ b/apps/ui/tests/ui_car_creation_command.spec.ts
@@ -55,8 +55,8 @@ test.describe("createUiCarCreationCommand", () => {
       renderCarList: () => {
         lifecycleCalls.push("renderCarList");
       },
-      renderSpectrum: () => {
-        lifecycleCalls.push("renderSpectrum");
+      refreshSpectrumDecorations: () => {
+        lifecycleCalls.push("refreshSpectrumDecorations");
       },
       addSettingsCar: async (payload) => {
         addRequests.push(payload);
@@ -104,7 +104,7 @@ test.describe("createUiCarCreationCommand", () => {
       "syncActiveCarToInputs",
       "showCarCreationSuccess:car-2:Volvo XC40 Recharge",
       "renderCarList",
-      "renderSpectrum",
+      "refreshSpectrumDecorations",
     ]);
   });
 
@@ -124,8 +124,8 @@ test.describe("createUiCarCreationCommand", () => {
       renderCarList: () => {
         lifecycleCalls.push("renderCarList");
       },
-      renderSpectrum: () => {
-        lifecycleCalls.push("renderSpectrum");
+      refreshSpectrumDecorations: () => {
+        lifecycleCalls.push("refreshSpectrumDecorations");
       },
       addSettingsCar: async () => {
         throw new Error("network failed");

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -210,6 +210,57 @@ test.describe("UiSpectrumController", () => {
     }
   });
 
+  test("refreshes decorations without rebuilding spectrum data", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const UiSpectrumController = await importUiSpectrumController();
+      const state = createAppState();
+      const panel = createPanelStub();
+      const controller = new UiSpectrumController({
+        state,
+        panel: panel.panel,
+        t: (key) => key,
+      });
+      const canvas = (controller as unknown as {
+        canvas: {
+          prepareFrame: () => unknown;
+          refreshPreparedFrameMetadata: () => {
+            entries: [];
+            freqAxis: [];
+            chartBands: [];
+            frame: null;
+            hasData: false;
+          };
+          refreshDecorations: () => void;
+        };
+      }).canvas;
+      let prepareCalls = 0;
+      let refreshCalls = 0;
+
+      canvas.prepareFrame = () => {
+        prepareCalls += 1;
+        return null;
+      };
+      canvas.refreshPreparedFrameMetadata = () => ({
+        entries: [],
+        freqAxis: [],
+        chartBands: [],
+        frame: null,
+        hasData: false,
+      });
+      canvas.refreshDecorations = () => {
+        refreshCalls += 1;
+      };
+
+      controller.refreshSpectrumDecorations();
+
+      expect(prepareCalls).toBe(0);
+      expect(refreshCalls).toBe(1);
+    } finally {
+      restoreDocument();
+    }
+  });
+
   test("shows the loading overlay while the chart chunk is still loading", async () => {
     const restoreDocument = installDocumentStub();
     try {


### PR DESCRIPTION
## Summary
- cache the last prepared spectrum payload in `apps/ui/src/app/runtime/spectrum_canvas_renderer.ts`
- add a lighter metadata refresh path so settings/car flows can recompute chart bands without rerunning heavy frame prep
- route analysis-settings, car-management, and car-creation spectrum refreshes through the lighter path and cover it with focused tests

## Why
- non-WS settings flows were still calling the full `renderSpectrum()` path
- that forced interpolation, dB conversion, and prepared-frame rebuilding even when only band/legend context changed

## Validation
- `cd apps/ui && npx playwright test tests/spectrum_canvas_renderer.spec.ts tests/ui_spectrum_controller.spec.ts tests/settings_analysis_module.spec.ts tests/settings_cars_module.spec.ts tests/ui_car_creation_command.spec.ts && npm run typecheck && npm run build`
- `cd apps/ui && CI=1 npm run test:visual`

## Risks / tradeoffs / edge cases
- decoration refreshes now rely on the last cached prepared frame, so before any heavy frame arrives they stay in the empty-state path by design
- new WS heavy frames still go through the full prepare/render path
- live Pi hardware verification remains out of scope for this repo-only pass

Closes #2729
