### PR TITLE
perf(ui): reuse spectrum chart buffers

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -119,7 +119,7 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that splits heavy data refreshes from lighter settings-driven decoration refreshes while wiring overlay, canvas, interaction, and panel modules |
 | `app/runtime/ui_startup_coordinator.ts` | Declarative startup-task runner that lets the shell own its initial bind/language/view boot while startup loads and transport start from a named sync/async plan |
 | `app/runtime/ui_startup_feature_ports.ts` | Narrow startup-only feature contract for initial refresh/load work |
-| `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, cadence-aware tween scheduling, and canvas draw plugin orchestration |
+| `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, cadence-aware tween scheduling, stable uPlot buffer reuse for same-shape frames, and canvas draw plugin orchestration |
 | `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports |
 | `app/runtime/spectrum_panel_view.ts` | Typed spectrum panel contract for the signal-backed legend, band legend, inspector, band-toggle, and chart-host refs |
 | `app/app_feature_bundle.ts` | Creates concrete feature instances, then exposes explicit shell, transport, and startup port bundles back to the runtime |
@@ -187,7 +187,7 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `config.ts` | Centralized UI tuning constants for polling intervals, spectrum ranges, and history heatmap positions |
 | `i18n.ts` | Internationalization dictionary (English, Dutch) |
 | `spectrum.ts` | Shared spectrum math helpers such as amplitude-to-dB conversion that stay safe to import on the startup path |
-| `spectrum_chart.ts` | Lazy-loaded uPlot chart wrapper and stylesheet entry for interactive spectrum visualization |
+| `spectrum_chart.ts` | Lazy-loaded uPlot chart wrapper, explicit `setData`/`redraw` bridge, and stylesheet entry for interactive spectrum visualization |
 | `spectrum_css_vars.ts` | Shared cached spectrum CSS-variable snapshot for chart and canvas renderer colors |
 | `server_payload.ts` | Transport-boundary WebSocket payload adaptation and schema-version guardrails around the generated WS types |
 | `diagnostics.ts` | Strength band normalization and vibration matrix helpers |

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -23,6 +23,7 @@ import { closestFrequencyIndex, freqGridsMatch, type SpectrumFocusMarker, type S
 type SpectrumChartModule = Pick<typeof import("../../spectrum_chart"), "createSpectrumChart">;
 const EMPTY_FREQ_AXIS: number[] = [];
 const EMPTY_SERIES_VALUES: number[][] = [];
+const EMPTY_CHART_DATA: uPlot.AlignedData = [[]];
 
 const bandKeyPresentation: Record<string, { color: string; labelKey: string }> = {
   wheel_1x: { color: orderBandFills.wheel1, labelKey: "bands.wheel_1x" },
@@ -98,7 +99,7 @@ export function createSpectrumCanvasRenderer(
   const currentEntries = signal<readonly SpectrumSeriesEntry[]>([]);
   const currentFreqAxis = signal<readonly number[]>([]);
   const chartSeriesMeta = signal<readonly SpectrumSeriesMeta[]>([]);
-  const chartData = signal<uPlot.AlignedData>([[]]);
+  const chartData = signal<uPlot.AlignedData>(EMPTY_CHART_DATA);
   const chartHeight = signal(360);
   const chartPlugins = signal<readonly uPlot.Plugin[]>([]);
   const chartText: ReadonlySignal<SpectrumText> = computed(() => ({
@@ -213,12 +214,14 @@ export function createSpectrumCanvasRenderer(
     if (minLen < targetFreq.length) {
       targetFreq = targetFreq.slice(0, minLen);
       for (let index = 0; index < frameValues.length; index += 1) {
-        if (frameValues[index]!.length === minLen) {
+        const frameValuesEntry = frameValues[index];
+        const entry = entries[index];
+        if (!frameValuesEntry || !entry || frameValuesEntry.length === minLen) {
           continue;
         }
-        const trimmedValues = frameValues[index]!.slice(0, minLen);
+        const trimmedValues = frameValuesEntry.slice(0, minLen);
         frameValues[index] = trimmedValues;
-        entries[index]!.values = trimmedValues;
+        entry.values = trimmedValues;
       }
     }
     const frame: SpectrumHeavyFrame = {
@@ -245,7 +248,7 @@ export function createSpectrumCanvasRenderer(
     currentEntries.value = prepared.entries;
     currentFreqAxis.value = prepared.freqAxis;
     syncChartSeriesMeta(prepared.entries);
-    chartData.value = buildChartData(
+    syncChartDataBuffer(
       prepared.frame?.freq ?? prepared.freqAxis,
       prepared.frame?.values ?? EMPTY_SERIES_VALUES,
     );
@@ -256,6 +259,7 @@ export function createSpectrumCanvasRenderer(
       currentFreqAxis.value = [];
       spectrumLastFrame.value = null;
       pendingPreparedFrame.value = null;
+      deps.state.spectrum.spectrumPlot.value?.setData(chartData.value, false);
       return;
     }
 
@@ -309,12 +313,10 @@ export function createSpectrumCanvasRenderer(
     if (disposed) {
       return;
     }
-    const freqAxis = currentFreqAxis.value;
-    const entries = currentEntries.value;
-    if (!freqAxis.length || !entries.length) {
+    if (!currentFreqAxis.value.length || !currentEntries.value.length) {
       return;
     }
-    chartData.value = buildChartDataWithClonedFreqAxis(freqAxis, entries);
+    deps.state.spectrum.spectrumPlot.value?.redraw(false, false);
   }
 
   function setSeriesIsolation(seriesIndex: number | null): void {
@@ -333,7 +335,8 @@ export function createSpectrumCanvasRenderer(
       return;
     }
     currentFreqAxis.value = frame.freq;
-    chartData.value = buildChartData(frame.freq, frame.values);
+    syncChartDataBuffer(frame.freq, frame.values);
+    deps.state.spectrum.spectrumPlot.value.setData(chartData.value, false);
     spectrumLastFrame.value = frame;
   }
 
@@ -356,8 +359,7 @@ export function createSpectrumCanvasRenderer(
     }
 
     const nextMeta = new Array<SpectrumSeriesMeta>(entries.length);
-    for (let index = 0; index < entries.length; index += 1) {
-      const entry = entries[index]!;
+    for (const [index, entry] of entries.entries()) {
       nextMeta[index] = {
         label: entry.label,
         color: entry.color,
@@ -366,25 +368,41 @@ export function createSpectrumCanvasRenderer(
     chartSeriesMeta.value = nextMeta;
   }
 
-  function buildChartData(freqAxis: number[], seriesValues: readonly number[][]): uPlot.AlignedData {
-    const alignedData = new Array(seriesValues.length + 1) as uPlot.AlignedData;
-    alignedData[0] = freqAxis;
-    for (let index = 0; index < seriesValues.length; index += 1) {
-      alignedData[index + 1] = seriesValues[index]!;
+  function syncChartDataBuffer(freqAxis: readonly number[], seriesValues: readonly number[][]): void {
+    if (freqAxis.length === 0 || seriesValues.length === 0) {
+      chartData.value = EMPTY_CHART_DATA;
+      return;
     }
-    return alignedData;
+    const currentData = chartData.value;
+    const nextSeriesCount = seriesValues.length + 1;
+    const canReuse = currentData.length === nextSeriesCount
+      && currentData[0]?.length === freqAxis.length
+      && seriesValues.every((seriesValuesEntry, index) => currentData[index + 1]?.length === seriesValuesEntry.length);
+
+    if (!canReuse) {
+      const nextData = new Array(nextSeriesCount) as uPlot.AlignedData;
+      nextData[0] = Array.from(freqAxis);
+      for (const [index, seriesValuesEntry] of seriesValues.entries()) {
+        nextData[index + 1] = Array.from(seriesValuesEntry);
+      }
+      chartData.value = nextData;
+      return;
+    }
+
+    copyNumbersInto(currentData[0] as number[], freqAxis);
+    for (const [index, seriesValuesEntry] of seriesValues.entries()) {
+      copyNumbersInto(currentData[index + 1] as number[], seriesValuesEntry);
+    }
   }
 
-  function buildChartDataWithClonedFreqAxis(
-    freqAxis: readonly number[],
-    entries: readonly SpectrumSeriesEntry[],
-  ): uPlot.AlignedData {
-    const alignedData = new Array(entries.length + 1) as uPlot.AlignedData;
-    alignedData[0] = Array.from(freqAxis);
-    for (let index = 0; index < entries.length; index += 1) {
-      alignedData[index + 1] = entries[index]!.values;
+  function copyNumbersInto(target: number[], source: readonly number[]): void {
+    for (let index = 0; index < source.length; index += 1) {
+      const value = source[index];
+      if (value === undefined) {
+        continue;
+      }
+      target[index] = value;
     }
-    return alignedData;
   }
 
   function calculateBandsFromBackend(): ChartBand[] | null {

--- a/apps/ui/src/spectrum_chart.ts
+++ b/apps/ui/src/spectrum_chart.ts
@@ -25,7 +25,9 @@ export interface SpectrumText {
 
 export interface SpectrumChart {
   destroy(): void;
+  redraw(rebuildPaths?: boolean, recalcAxes?: boolean): void;
   resize(): void;
+  setData(data: uPlot.AlignedData, resetScales?: boolean): void;
   setSeriesIsolation(seriesIdx: number | null): void;
 }
 
@@ -136,14 +138,6 @@ export function createSpectrumChart(deps: CreateSpectrumChartDeps): SpectrumChar
     };
   });
 
-  const stopDataSync = effect(() => {
-    const currentPlot = plot.value;
-    if (!currentPlot) {
-      return;
-    }
-    currentPlot.setData(deps.data.value);
-  });
-
   const stopSizeSync = effect(() => {
     const currentPlot = plot.value;
     if (!currentPlot) {
@@ -162,13 +156,26 @@ export function createSpectrumChart(deps: CreateSpectrumChartDeps): SpectrumChar
       }
       disposed = true;
       stopSizeSync();
-      stopDataSync();
       stopPlotLifecycle();
       stopResizeObserver();
       plot.value = null;
     },
+    redraw(rebuildPaths?: boolean, recalcAxes?: boolean): void {
+      const currentPlot = plot.value;
+      if (!currentPlot) {
+        return;
+      }
+      currentPlot.redraw(rebuildPaths, recalcAxes);
+    },
     resize(): void {
       width.value = computeWidth(measureEl);
+    },
+    setData(data: uPlot.AlignedData, resetScales?: boolean): void {
+      const currentPlot = plot.value;
+      if (!currentPlot) {
+        return;
+      }
+      currentPlot.setData(data, resetScales);
     },
     setSeriesIsolation(seriesIdx: number | null): void {
       const currentPlot = plot.value;

--- a/apps/ui/tests/spectrum_canvas_renderer.spec.ts
+++ b/apps/ui/tests/spectrum_canvas_renderer.spec.ts
@@ -24,6 +24,14 @@ function makeClient(id: string, name: string): AdaptedClient {
   };
 }
 
+function getRequiredClientSpectrum(state: ReturnType<typeof createAppState>, clientId: string) {
+  const spectrum = state.spectrum.spectra.value.clients[clientId];
+  if (!spectrum) {
+    throw new Error(`Expected spectrum for ${clientId}`);
+  }
+  return spectrum;
+}
+
 test.describe("createSpectrumCanvasRenderer", () => {
   test.beforeEach(() => {
     installWindowGlobal();
@@ -157,7 +165,9 @@ test.describe("createSpectrumCanvasRenderer", () => {
           destroy() {
             stop();
           },
+          redraw() {},
           resize() {},
+          setData() {},
           setSeriesIsolation() {},
         };
       }
@@ -253,7 +263,9 @@ test.describe("createSpectrumCanvasRenderer", () => {
               destroy() {
                 stop();
               },
+              redraw() {},
               resize() {},
+              setData() {},
               setSeriesIsolation() {},
             };
           },
@@ -305,7 +317,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
         },
       };
       const seriesMetaSnapshots: CreateSpectrumChartDeps["seriesMeta"]["value"][] = [];
-      const dataSnapshots: readonly unknown[][] = [];
+      const setDataSnapshots: readonly unknown[][] = [];
 
       const renderer = createSpectrumCanvasRenderer({
         state,
@@ -322,13 +334,16 @@ test.describe("createSpectrumCanvasRenderer", () => {
           createSpectrumChart(deps: CreateSpectrumChartDeps): SpectrumChart {
             const stop = effect(() => {
               seriesMetaSnapshots.push(deps.seriesMeta.value);
-              dataSnapshots.push(deps.data.value as readonly unknown[]);
             });
             return {
               destroy() {
                 stop();
               },
+              redraw() {},
               resize() {},
+              setData(data) {
+                setDataSnapshots.push(data as readonly unknown[]);
+              },
               setSeriesIsolation() {},
             };
           },
@@ -342,7 +357,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
       state.spectrum.spectra.value = {
         clients: {
           "sensor-a": {
-            ...state.spectrum.spectra.value.clients["sensor-a"]!,
+            ...getRequiredClientSpectrum(state, "sensor-a"),
             combined: [0.9, 0.7, 0.45],
           },
         },
@@ -353,7 +368,8 @@ test.describe("createSpectrumCanvasRenderer", () => {
       await flushSignalUpdates();
 
       expect(new Set(seriesMetaSnapshots).size).toBe(1);
-      expect(new Set(dataSnapshots).size).toBeGreaterThan(1);
+      expect(setDataSnapshots).toHaveLength(2);
+      expect(setDataSnapshots[0]).toBe(setDataSnapshots[1]);
     } finally {
       restoreDocument();
     }
@@ -403,7 +419,9 @@ test.describe("createSpectrumCanvasRenderer", () => {
           createSpectrumChart(): SpectrumChart {
             return {
               destroy() {},
+              redraw() {},
               resize() {},
+              setData() {},
               setSeriesIsolation() {},
             };
           },
@@ -432,6 +450,164 @@ test.describe("createSpectrumCanvasRenderer", () => {
       expect(refreshed.frame).toBe(prepared.frame);
       expect(refreshed.hasData).toBe(true);
       expect(refreshed.chartBands).toHaveLength(1);
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("rebuilds chart data buffers when the frame shape changes", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const { createSpectrumCanvasRenderer } = await import(
+        "../src/app/runtime/spectrum_canvas_renderer"
+      );
+      const state = createAppState();
+      state.transport.wsState.value = "connected";
+      state.realtime.clients.value = [makeClient("sensor-a", "Front Right Wheel")];
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            freq: [10, 15, 20],
+            combined: [1, 0.75, 0.5],
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 1,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 1,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 12,
+              }],
+              vibration_strength_db: 12,
+            },
+          },
+        },
+      };
+      const setDataSnapshots: readonly unknown[][] = [];
+
+      const renderer = createSpectrumCanvasRenderer({
+        state,
+        dom: {
+          specChart: createElementStub("div"),
+          specChartWrap: createElementStub("div"),
+        } as unknown as SpectrumPanelChartDom,
+        t: (key) => key,
+        getBandsVisible: () => false,
+        getChartBands: () => [],
+        getFocusMarker: () => null,
+        onCursorDataIndexChange: () => undefined,
+        loadChartModule: async () => ({
+          createSpectrumChart(): SpectrumChart {
+            return {
+              destroy() {},
+              redraw() {},
+              resize() {},
+              setData(data) {
+                setDataSnapshots.push(data as readonly unknown[]);
+              },
+              setSeriesIsolation() {},
+            };
+          },
+        }),
+      });
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            ...getRequiredClientSpectrum(state, "sensor-a"),
+            freq: [10, 20, 30, 40],
+            combined: [1, 0.7, 0.4, 0.2],
+          },
+        },
+      };
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+
+      expect(setDataSnapshots).toHaveLength(2);
+      expect(setDataSnapshots[0]).not.toBe(setDataSnapshots[1]);
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("uses redraw instead of setData for decoration-only refreshes", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const { createSpectrumCanvasRenderer } = await import(
+        "../src/app/runtime/spectrum_canvas_renderer"
+      );
+      const state = createAppState();
+      state.transport.wsState.value = "connected";
+      state.realtime.clients.value = [makeClient("sensor-a", "Front Right Wheel")];
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            freq: [10, 15, 20],
+            combined: [1, 0.75, 0.5],
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 1,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 1,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 12,
+              }],
+              vibration_strength_db: 12,
+            },
+          },
+        },
+      };
+      let redrawCalls = 0;
+      let setDataCalls = 0;
+
+      const renderer = createSpectrumCanvasRenderer({
+        state,
+        dom: {
+          specChart: createElementStub("div"),
+          specChartWrap: createElementStub("div"),
+        } as unknown as SpectrumPanelChartDom,
+        t: (key) => key,
+        getBandsVisible: () => true,
+        getChartBands: () => [{
+          label: "Wheel",
+          min_hz: 9,
+          max_hz: 11,
+          color: "#fff",
+        }],
+        getFocusMarker: () => null,
+        onCursorDataIndexChange: () => undefined,
+        loadChartModule: async () => ({
+          createSpectrumChart(): SpectrumChart {
+            return {
+              destroy() {},
+              redraw() {
+                redrawCalls += 1;
+              },
+              resize() {},
+              setData() {
+                setDataCalls += 1;
+              },
+              setSeriesIsolation() {},
+            };
+          },
+        }),
+      });
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+      setDataCalls = 0;
+
+      renderer.refreshDecorations();
+
+      expect(redrawCalls).toBe(1);
+      expect(setDataCalls).toBe(0);
     } finally {
       restoreDocument();
     }
@@ -484,7 +660,9 @@ test.describe("createSpectrumCanvasRenderer", () => {
           createSpectrumChart(): SpectrumChart {
             return {
               destroy() {},
+              redraw() {},
               resize() {},
+              setData() {},
               setSeriesIsolation() {},
             };
           },
@@ -504,7 +682,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
       state.spectrum.spectra.value = {
         clients: {
           "sensor-a": {
-            ...state.spectrum.spectra.value.clients["sensor-a"]!,
+            ...getRequiredClientSpectrum(state, "sensor-a"),
             combined: [0.9, 0.7, 0.45],
           },
         },
@@ -566,7 +744,9 @@ test.describe("createSpectrumCanvasRenderer", () => {
           createSpectrumChart(): SpectrumChart {
             return {
               destroy() {},
+              redraw() {},
               resize() {},
+              setData() {},
               setSeriesIsolation() {},
             };
           },
@@ -586,7 +766,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
       state.spectrum.spectra.value = {
         clients: {
           "sensor-a": {
-            ...state.spectrum.spectra.value.clients["sensor-a"]!,
+            ...getRequiredClientSpectrum(state, "sensor-a"),
             combined: [0.9, 0.7, 0.45],
           },
         },


### PR DESCRIPTION
## What changed
- reuse stable aligned-data buffers for same-shape spectrum frames
- move chart updates to explicit setData() / redraw() methods on the uPlot wrapper
- use redraw(false, false) for band and focus-marker decoration refreshes
- add renderer regressions for same-shape reuse, shape-change rebuild, and redraw-without-setData

## Why
- stop cloning aligned-data shells and x-axes for work that did not change chart shape
- keep decoration-only refreshes off the full setData() path

## Validation
- cd apps/ui && npm run lint
- cd apps/ui && npm run typecheck
- cd apps/ui && npx playwright test tests/spectrum_canvas_renderer.spec.ts
- cd apps/ui && npm run build
- cd apps/ui && CI=1 npm run test:visual

## Risks / tradeoffs
- same-shape reuse only covers stable series count and array lengths; shape changes still rebuild the aligned-data shell
- lint still reports pre-existing warnings in untouched files

Closes #2730