### PR TITLE
perf(ui): cache prepared spectrum series

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -119,7 +119,7 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that splits heavy data refreshes from lighter settings-driven decoration refreshes while wiring overlay, canvas, interaction, and panel modules |
 | `app/runtime/ui_startup_coordinator.ts` | Declarative startup-task runner that lets the shell own its initial bind/language/view boot while startup loads and transport start from a named sync/async plan |
 | `app/runtime/ui_startup_feature_ports.ts` | Narrow startup-only feature contract for initial refresh/load work |
-| `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, plot lifecycle, cadence-aware tween scheduling, stable uPlot buffer reuse for same-shape frames, and canvas draw plugin orchestration |
+| `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, cached per-client display-series reuse, plot lifecycle, cadence-aware tween scheduling, stable uPlot buffer reuse for same-shape frames, and canvas draw plugin orchestration |
 | `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports |
 | `app/runtime/spectrum_panel_view.ts` | Typed spectrum panel contract for the signal-backed legend, band legend, inspector, band-toggle, and chart-host refs |
 | `app/app_feature_bundle.ts` | Creates concrete feature instances, then exposes explicit shell, transport, and startup port bundles back to the runtime |

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -68,6 +68,14 @@ export interface SpectrumCanvasRenderer {
   setSeriesIsolation(seriesIndex: number | null): void;
 }
 
+interface PreparedSpectrumCacheEntry {
+  sourceCombined: readonly number[];
+  sourceFreq: readonly number[];
+  sourceLength: number;
+  targetFreq: readonly number[];
+  values: number[];
+}
+
 export function createSpectrumCanvasRenderer(
   deps: SpectrumCanvasRendererDeps,
 ): SpectrumCanvasRenderer {
@@ -80,6 +88,7 @@ export function createSpectrumCanvasRenderer(
   let disposed = false;
   let lastAcceptedFrameAtMs: number | null = null;
   let lastPreparedFrame: SpectrumPreparedRenderData | null = null;
+  const preparedSpectrumCache = new Map<string, PreparedSpectrumCacheEntry>();
 
   const spectrumLastFrame = signal<SpectrumHeavyFrame | null>(null);
   const pendingPreparedFrame = signal<SpectrumPreparedRenderData | null>(null);
@@ -155,37 +164,26 @@ export function createSpectrumCanvasRenderer(
         continue;
       }
 
-      let blended: number[];
-      let needsInterpolation = false;
       if (!targetFreq.length) {
         targetFreq = clientFreq.length === length ? clientFreq : clientFreq.slice(0, length);
-        blended = spectrum.combined.length === length
-          ? spectrum.combined
-          : spectrum.combined.slice(0, length);
-      } else {
-        needsInterpolation = clientFreq.length !== targetFreq.length
-          || !freqGridsMatch(clientFreq, targetFreq, length);
-        if (needsInterpolation) {
-          blended = interpolateToTarget(clientFreq, spectrum.combined, targetFreq, length);
-        } else {
-          blended = spectrum.combined.length === length
-            ? spectrum.combined
-            : spectrum.combined.slice(0, length);
-        }
       }
-      if (!blended.length) {
+
+      const preparedValues = getPreparedSpectrumValues(
+        client.id,
+        spectrum.combined,
+        clientFreq,
+        length,
+        targetFreq,
+      );
+      if (!preparedValues.length) {
         continue;
       }
-      if (!needsInterpolation && blended === spectrum.combined) {
-        blended = blended.slice();
-      }
-      convertSpectrumAmplitudesToDbInPlace(blended);
 
       entries.push({
         id: client.id,
         label: client.name || client.id,
         color: colorForClient(index),
-        values: blended,
+        values: preparedValues,
       });
     }
 
@@ -328,6 +326,50 @@ export function createSpectrumCanvasRenderer(
 
   function colorForClient(index: number): string {
     return chartSeriesPalette[index % chartSeriesPalette.length];
+  }
+
+  function getPreparedSpectrumValues(
+    clientId: string,
+    combined: readonly number[],
+    clientFreq: readonly number[],
+    sourceLength: number,
+    targetFreq: readonly number[],
+  ): number[] {
+    const cached = preparedSpectrumCache.get(clientId);
+    if (
+      cached
+      && cached.sourceCombined === combined
+      && cached.sourceFreq === clientFreq
+      && cached.sourceLength === sourceLength
+      && cached.targetFreq.length === targetFreq.length
+      && (
+        cached.targetFreq === targetFreq
+        || freqGridsMatch(cached.targetFreq, targetFreq, targetFreq.length)
+      )
+    ) {
+      return cached.values;
+    }
+
+    const needsInterpolation = clientFreq.length !== targetFreq.length
+      || !freqGridsMatch(clientFreq, targetFreq, sourceLength);
+    const preparedValues = needsInterpolation
+      ? interpolateToTarget(clientFreq, combined, targetFreq, sourceLength)
+      : combined.slice(0, sourceLength);
+
+    if (!preparedValues.length) {
+      preparedSpectrumCache.delete(clientId);
+      return preparedValues;
+    }
+
+    convertSpectrumAmplitudesToDbInPlace(preparedValues);
+    preparedSpectrumCache.set(clientId, {
+      sourceCombined: combined,
+      sourceFreq: clientFreq,
+      sourceLength,
+      targetFreq,
+      values: preparedValues,
+    });
+    return preparedValues;
   }
 
   function setSpectrumDataFromFrame(frame: SpectrumHeavyFrame): void {
@@ -601,6 +643,7 @@ export function createSpectrumCanvasRenderer(
       disposeTweenEffect();
       tweenTarget.value = null;
       pendingPreparedFrame.value = null;
+      preparedSpectrumCache.clear();
       if (deps.state.spectrum.spectrumPlot.value) {
         deps.state.spectrum.spectrumPlot.value.destroy();
         deps.state.spectrum.spectrumPlot.value = null;

--- a/apps/ui/tests/spectrum_canvas_renderer.spec.ts
+++ b/apps/ui/tests/spectrum_canvas_renderer.spec.ts
@@ -455,6 +455,163 @@ test.describe("createSpectrumCanvasRenderer", () => {
     }
   });
 
+  test("reuses prepared series when source arrays and target grid are unchanged", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const { createSpectrumCanvasRenderer } = await import(
+        "../src/app/runtime/spectrum_canvas_renderer"
+      );
+      const state = createAppState();
+      state.realtime.clients.value = [
+        makeClient("sensor-a", "Front Right Wheel"),
+        makeClient("sensor-b", "Rear Left Wheel"),
+      ];
+      const sensorACombined = [1, 0.75, 0.5];
+      const sensorAFreq = [10, 15, 20];
+      const sensorBCombined = [0.8, 0.4];
+      const sensorBFreq = [10, 20];
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            freq: sensorAFreq,
+            combined: sensorACombined,
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 1,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 1,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 12,
+              }],
+              vibration_strength_db: 12,
+            },
+          },
+          "sensor-b": {
+            freq: sensorBFreq,
+            combined: sensorBCombined,
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 0.8,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 0.8,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 9,
+              }],
+              vibration_strength_db: 9,
+            },
+          },
+        },
+      };
+
+      const renderer = createSpectrumCanvasRenderer({
+        state,
+        dom: {
+          specChart: createElementStub("div"),
+          specChartWrap: createElementStub("div"),
+        } as unknown as SpectrumPanelChartDom,
+        t: (key) => key,
+        getBandsVisible: () => false,
+        getChartBands: () => [],
+        getFocusMarker: () => null,
+        onCursorDataIndexChange: () => undefined,
+      });
+
+      const firstPrepared = renderer.prepareFrame();
+      const secondPrepared = renderer.prepareFrame();
+
+      expect(secondPrepared.entries[0]?.values).toBe(firstPrepared.entries[0]?.values);
+      expect(secondPrepared.entries[1]?.values).toBe(firstPrepared.entries[1]?.values);
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("recomputes only the changed client when source amplitudes change", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const { createSpectrumCanvasRenderer } = await import(
+        "../src/app/runtime/spectrum_canvas_renderer"
+      );
+      const state = createAppState();
+      state.realtime.clients.value = [
+        makeClient("sensor-a", "Front Right Wheel"),
+        makeClient("sensor-b", "Rear Left Wheel"),
+      ];
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            freq: [10, 15, 20],
+            combined: [1, 0.75, 0.5],
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 1,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 1,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 12,
+              }],
+              vibration_strength_db: 12,
+            },
+          },
+          "sensor-b": {
+            freq: [10, 20],
+            combined: [0.8, 0.4],
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 0.8,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 0.8,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 9,
+              }],
+              vibration_strength_db: 9,
+            },
+          },
+        },
+      };
+
+      const renderer = createSpectrumCanvasRenderer({
+        state,
+        dom: {
+          specChart: createElementStub("div"),
+          specChartWrap: createElementStub("div"),
+        } as unknown as SpectrumPanelChartDom,
+        t: (key) => key,
+        getBandsVisible: () => false,
+        getChartBands: () => [],
+        getFocusMarker: () => null,
+        onCursorDataIndexChange: () => undefined,
+      });
+
+      const firstPrepared = renderer.prepareFrame();
+
+      state.spectrum.spectra.value = {
+        clients: {
+          ...state.spectrum.spectra.value.clients,
+          "sensor-b": {
+            ...getRequiredClientSpectrum(state, "sensor-b"),
+            combined: [0.9, 0.45],
+          },
+        },
+      };
+
+      const secondPrepared = renderer.prepareFrame();
+
+      expect(secondPrepared.entries[0]?.values).toBe(firstPrepared.entries[0]?.values);
+      expect(secondPrepared.entries[1]?.values).not.toBe(firstPrepared.entries[1]?.values);
+    } finally {
+      restoreDocument();
+    }
+  });
+
   test("rebuilds chart data buffers when the frame shape changes", async () => {
     const restoreDocument = installDocumentStub();
     try {


### PR DESCRIPTION
## What changed
- add a renderer-local per-client prepared-spectrum cache for stable source arrays
- reuse already-prepared interpolated dB series when the aligned target grid still matches
- only recompute interpolation and dB conversion for clients whose source arrays changed
- add renderer regressions for unchanged-source reuse and per-client recompute boundaries

## Why
- stop paying the full interpolation and dB-conversion cost on every prepareFrame() call when the source spectra did not change
- keep the optimization inside the frontend renderer without changing the WS contract yet

## Validation
- cd apps/ui && npm run lint
- cd apps/ui && npm run typecheck
- cd apps/ui && npx playwright test tests/spectrum_canvas_renderer.spec.ts
- cd apps/ui && npm run build
- cd apps/ui && CI=1 npm run test:visual

## Risks / tradeoffs
- cache reuse assumes unchanged source arrays keep stable identity; changed arrays still recompute normally
- lint still reports pre-existing warnings in untouched files

Closes #2732