### PR TITLE
perf(ws): reuse payload text template

### DIFF
--- a/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
+++ b/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
@@ -60,3 +60,45 @@ async def test_prepare_falls_back_to_error_payload_on_serialization_failure() ->
     assert json.loads(orchestrator.payload_cache["broken"]) == {
         "error": "payload_build_failed",
     }
+
+
+@pytest.mark.asyncio
+async def test_prepare_reuses_serialized_template_across_selected_clients() -> None:
+    shared_clients = [{"id": "sensor-a", "connected": True}]
+    shared_rotational_speeds = {
+        "basis_speed_source": None,
+        "wheel": {"rpm": None, "mode": None, "reason": None},
+        "driveshaft": {"rpm": None, "mode": None, "reason": None},
+        "engine": {"rpm": None, "mode": None, "reason": None},
+        "order_bands": None,
+    }
+
+    def payload_builder(selected: str | None) -> dict[str, object]:
+        return {
+            "schema_version": "1",
+            "server_time": "2026-04-18T00:00:00Z",
+            "speed_mps": None,
+            "clients": shared_clients,
+            "selected_client_id": selected,
+            "rotational_speeds": shared_rotational_speeds,
+        }
+
+    orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
+    dict_dump_calls = 0
+    real_dumps = json.dumps
+
+    def counting_dumps(value: object, *args, **kwargs) -> str:
+        nonlocal dict_dump_calls
+        if isinstance(value, dict):
+            dict_dump_calls += 1
+        return real_dumps(value, *args, **kwargs)
+
+    with patch(
+        "vibesensor.adapters.websocket.payload_orchestrator.json.dumps",
+        side_effect=counting_dumps,
+    ):
+        await orchestrator.prepare(["sensor-a", "sensor-b"])
+
+    assert dict_dump_calls == 1
+    assert json.loads(orchestrator.payload_cache["sensor-a"])["selected_client_id"] == "sensor-a"
+    assert json.loads(orchestrator.payload_cache["sensor-b"])["selected_client_id"] == "sensor-b"

--- a/apps/server/tests/hygiene/test_analysis_settings_sync.py
+++ b/apps/server/tests/hygiene/test_analysis_settings_sync.py
@@ -8,20 +8,17 @@ from tests._paths import REPO_ROOT
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 
 _UI_APP_STATE_TS = REPO_ROOT / "apps" / "ui" / "src" / "app" / "ui_app_state.ts"
-_SETTINGS_ANALYSIS_MODULE_TS = (
-    REPO_ROOT / "apps" / "ui" / "src" / "app" / "features" / "settings_analysis_module.ts"
-)
 
 
-def _parse_ui_vehicle_defaults() -> dict[str, float]:
-    """Extract defaultVehicleSettings from ui_app_state.ts."""
+def _parse_ts_numeric_block(name: str, type_name: str) -> dict[str, float]:
+    """Extract a numeric object literal block from ui_app_state.ts."""
     text = _UI_APP_STATE_TS.read_text()
     match = re.search(
-        r"defaultVehicleSettings:\s*Readonly<VehicleSettings>\s*=\s*\{([^}]+)\}",
+        rf"{name}:\s*Readonly<{type_name}>\s*=\s*\{{([^}}]+)\}}",
         text,
         re.DOTALL,
     )
-    assert match, "Could not find defaultVehicleSettings block in ui_app_state.ts"
+    assert match, f"Could not find {name} block in ui_app_state.ts"
     block = match.group(1)
     pairs: dict[str, float] = {}
     for line_match in re.finditer(r"(\w+):\s*([0-9.]+)", block):
@@ -29,26 +26,41 @@ def _parse_ui_vehicle_defaults() -> dict[str, float]:
     return pairs
 
 
-def _parse_ui_setting_keys() -> list[str]:
-    """Extract ANALYSIS_SETTING_KEYS from settings_analysis_module.ts."""
-    text = _SETTINGS_ANALYSIS_MODULE_TS.read_text()
+def _parse_ui_vehicle_defaults() -> dict[str, float]:
+    """Extract the composed vehicle defaults from ui_app_state.ts."""
+    return {
+        **_parse_ts_numeric_block("defaultCarAspectSettings", "CarAspectSettings"),
+        **_parse_ts_numeric_block("defaultAnalysisTuningSettings", "AnalysisTuningSettings"),
+    }
+
+
+def _parse_ts_string_array(name: str) -> list[str]:
+    """Extract a string array constant from ui_app_state.ts."""
+    text = _UI_APP_STATE_TS.read_text()
     match = re.search(
-        r"ANALYSIS_SETTING_KEYS\s*=\s*\[([^\]]+)\]",
+        rf"{name}\s*=\s*\[([^\]]+)\]",
         text,
         re.DOTALL,
     )
-    assert match, "Could not find ANALYSIS_SETTING_KEYS in settings_analysis_module.ts"
+    assert match, f"Could not find {name} in ui_app_state.ts"
     return re.findall(r'"(\w+)"', match.group(1))
 
 
+def _parse_ui_setting_keys() -> list[str]:
+    """Extract the composed vehicle-setting key set from ui_app_state.ts."""
+    return [
+        *_parse_ts_string_array("carAspectSettingKeys"),
+        *_parse_ts_string_array("analysisTuningSettingKeys"),
+    ]
+
+
 def test_ui_defaults_match_backend() -> None:
-    """Every backend DEFAULTS key must appear in UI vehicleSettings with the
-    same value."""
+    """Every backend DEFAULTS key must appear in UI vehicle defaults with the same value."""
     backend = AnalysisSettingsSnapshot.DEFAULTS
     frontend = _parse_ui_vehicle_defaults()
 
     missing = set(backend) - set(frontend)
-    assert not missing, f"UI vehicleSettings is missing keys: {sorted(missing)}"
+    assert not missing, f"UI vehicle defaults are missing keys: {sorted(missing)}"
 
     mismatched: list[str] = []
     for key, be_val in backend.items():
@@ -61,12 +73,12 @@ def test_ui_defaults_match_backend() -> None:
 
 
 def test_ui_setting_keys_match_backend() -> None:
-    """ANALYSIS_SETTING_KEYS must list every backend DEFAULTS key."""
+    """UI vehicle-setting key unions must list every backend DEFAULTS key."""
     backend_keys = set(AnalysisSettingsSnapshot.DEFAULTS)
     frontend_keys = set(_parse_ui_setting_keys())
 
     missing = backend_keys - frontend_keys
-    assert not missing, f"ANALYSIS_SETTING_KEYS missing: {sorted(missing)}"
+    assert not missing, f"UI vehicle-setting keys missing: {sorted(missing)}"
 
     extra = frontend_keys - backend_keys
-    assert not extra, f"ANALYSIS_SETTING_KEYS has extra keys: {sorted(extra)}"
+    assert not extra, f"UI vehicle-setting keys have extra entries: {sorted(extra)}"

--- a/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
+++ b/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
@@ -16,6 +16,7 @@ __all__ = ["PayloadBuildOrchestrator"]
 
 _ERROR_PAYLOAD_BODY: WsErrorPayload = {"error": "payload_build_failed"}
 _ERROR_PAYLOAD: str = json.dumps(_ERROR_PAYLOAD_BODY, separators=(",", ":"))
+_SELECTED_CLIENT_ID_NULL_JSON = '"selected_client_id":null'
 
 
 class PayloadBuildOrchestrator:
@@ -29,6 +30,7 @@ class PayloadBuildOrchestrator:
     ) -> None:
         self._payload_builder = payload_builder
         self._payload_cache: dict[str | None, str] = {}
+        self._payload_template_cache: dict[tuple[tuple[str, object], ...], str] = {}
         self._pending_payload_tasks: dict[str | None, asyncio.Task[str]] = {}
         self._failed_client_ids: set[str | None] = set()
         self._debug_info: dict[str | None, bool] | None = {} if capture_debug else None
@@ -85,10 +87,10 @@ class PayloadBuildOrchestrator:
         _dumps = json.dumps
         try:
             try:
-                text = _dumps(
+                text = self._serialize_selected_client_payload(
+                    selected_client_id,
                     raw_payload,
-                    separators=(",", ":"),
-                    allow_nan=False,
+                    _dumps,
                 )
                 had_non_finite = False
             except (TypeError, ValueError, OverflowError):
@@ -99,10 +101,10 @@ class PayloadBuildOrchestrator:
                         "replaced with null.",
                         selected_client_id,
                     )
-                text = _dumps(
+                text = self._serialize_selected_client_payload(
+                    selected_client_id,
                     payload_for_debug,
-                    separators=(",", ":"),
-                    allow_nan=False,
+                    _dumps,
                 )
             has_freq = (
                 self._payload_has_per_client_freq(payload_for_debug)
@@ -118,6 +120,50 @@ class PayloadBuildOrchestrator:
                 exc_info=True,
             )
             return _ERROR_PAYLOAD, True, None
+
+    @staticmethod
+    def _payload_template_key(raw_payload: Mapping[str, object]) -> tuple[tuple[str, object], ...]:
+        key_parts: list[tuple[str, object]] = []
+        for field, value in raw_payload.items():
+            if field == "selected_client_id":
+                continue
+            if value is None or isinstance(value, str | int | float | bool):
+                key_parts.append((field, value))
+            else:
+                key_parts.append((field, id(value)))
+        return tuple(key_parts)
+
+    def _serialize_selected_client_payload(
+        self,
+        selected_client_id: str | None,
+        raw_payload: object,
+        dumps: Callable[..., str],
+    ) -> str:
+        if not isinstance(raw_payload, dict) or "selected_client_id" not in raw_payload:
+            return dumps(raw_payload, separators=(",", ":"), allow_nan=False)
+        template_key = self._payload_template_key(raw_payload)
+        template_text = self._payload_template_cache.get(template_key)
+        if template_text is None:
+            template_text = dumps(
+                {
+                    **raw_payload,
+                    "selected_client_id": None,
+                },
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+            self._payload_template_cache[template_key] = template_text
+        if selected_client_id is None:
+            return template_text
+        selected_client_text = dumps(selected_client_id, separators=(",", ":"), allow_nan=False)
+        selected_client_payload = template_text.replace(
+            _SELECTED_CLIENT_ID_NULL_JSON,
+            f'"selected_client_id":{selected_client_text}',
+            1,
+        )
+        if selected_client_payload != template_text:
+            return selected_client_payload
+        return dumps(raw_payload, separators=(",", ":"), allow_nan=False)
 
     async def prepare(self, selected_client_ids: Iterable[str | None]) -> None:
         """Prime cached payloads for the current snapshot's unique client selections."""


### PR DESCRIPTION
## What changed
- cache one serialized payload template per shared heavy payload body in PayloadBuildOrchestrator
- serialize that template with `selected_client_id = null` and patch only the top-level `selected_client_id` field for subscriber variants
- keep the existing sanitize/error fallback path and fall back to a normal dump if the expected fragment is missing
- add a regression that counts dict-level `json.dumps()` calls and proves two selection variants reuse one full payload serialization
- update the backend settings-sync hygiene test to read the current split UI settings authority in `ui_app_state.ts`, which unblocks CI after the earlier frontend settings refactor

## Why
- stop paying full JSON serialization cost for every selected-client variant when the heavy payload body is otherwise identical
- keep the wire contract unchanged while reducing per-tick serializer CPU
- keep the branch mergeable by aligning the stale hygiene guard with the live frontend settings model instead of reintroducing dead UI exports

## Validation
- `cd apps/server && pytest -q tests/hygiene/test_analysis_settings_sync.py tests/adapters/websocket/test_payload_orchestrator.py tests/adapters/websocket/test_ws_hub.py`
- `cd /workspace/VibeSensor && make format && make lint && make typecheck-backend`

## Risks / tradeoffs
- template reuse assumes the payload variant only differs at the top-level `selected_client_id` field; the code falls back to a normal dump if that fragment is not present

Closes #2739