### PR TITLE
perf(ui): throttle spectrum hover inspector

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -120,8 +120,8 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `app/runtime/ui_startup_coordinator.ts` | Declarative startup-task runner that lets the shell own its initial bind/language/view boot while startup loads and transport start from a named sync/async plan |
 | `app/runtime/ui_startup_feature_ports.ts` | Narrow startup-only feature contract for initial refresh/load work |
 | `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, cached per-client display-series reuse, plot lifecycle, cadence-aware tween scheduling, stable uPlot buffer reuse for same-shape frames, and canvas draw plugin orchestration |
-| `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports |
-| `app/runtime/spectrum_panel_view.ts` | Typed spectrum panel contract for the signal-backed legend, band legend, inspector, band-toggle, and chart-host refs |
+| `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports plus throttled hover-inspector updates and announcement routing |
+| `app/runtime/spectrum_panel_view.ts` | Typed spectrum panel contract for the signal-backed legend, band legend, split visual inspector vs live announcer, band-toggle, and chart-host refs |
 | `app/app_feature_bundle.ts` | Creates concrete feature instances, then exposes explicit shell, transport, and startup port bundles back to the runtime |
 | `app/features/` | Feature owners for state changes, API calls, shared polling control, and typed actions emitted from local view surfaces |
 | `app/features/esp_flash_feature.ts` | Thin ESP flash facade that wires the workflow, presenter, typed island action bridge, and settings-view polling context together |

--- a/apps/ui/src/app/runtime/spectrum_interaction_controller.ts
+++ b/apps/ui/src/app/runtime/spectrum_interaction_controller.ts
@@ -12,6 +12,9 @@ import type {
   SpectrumSensorLegendModel,
 } from "./spectrum_panel_view";
 
+type TimeoutHandle = ReturnType<typeof globalThis.setTimeout>;
+const HOVER_INSPECTOR_THROTTLE_MS = 33;
+
 export interface SpectrumInteractionSyncParams {
   entries: readonly SpectrumSeriesEntry[];
   freqAxis: readonly number[];
@@ -25,6 +28,9 @@ export interface SpectrumInteractionControllerDeps {
   getTopPeakHz: (entryId: string) => number | null;
   setSeriesIsolation: (seriesIndex: number | null) => void;
   requestPlotRefresh: () => void;
+  scheduleTimeout?: (callback: () => void, delayMs: number) => TimeoutHandle;
+  cancelTimeout?: (handle: TimeoutHandle) => void;
+  nowMs?: () => number;
 }
 
 export interface SpectrumInteractionSyncOptions {
@@ -54,9 +60,28 @@ export class SpectrumInteractionController {
 
   private readonly disposeInspectorSync: () => void;
 
+  private readonly scheduleTimeout: (callback: () => void, delayMs: number) => TimeoutHandle;
+
+  private readonly cancelTimeout: (handle: TimeoutHandle) => void;
+
+  private readonly nowMs: () => number;
+
+  private pendingHoverTimeoutHandle: TimeoutHandle | null = null;
+
+  private pendingHoverInspectorText: string | null = null;
+
+  private lastHoverInspectorCommitAtMs: number | null = null;
+
+  private lastInspectorText: string | null = null;
+
+  private lastAnnouncedInspectorText: string | null = null;
+
   constructor(
     private readonly deps: SpectrumInteractionControllerDeps,
   ) {
+    this.scheduleTimeout = this.deps.scheduleTimeout ?? ((callback, delayMs) => globalThis.setTimeout(callback, delayMs));
+    this.cancelTimeout = this.deps.cancelTimeout ?? ((handle) => globalThis.clearTimeout(handle));
+    this.nowMs = this.deps.nowMs ?? (() => performance.now());
     this.bandToggleModel = computed(() => {
       const bands = this.currentBands.value;
       const entries = this.currentEntries.value;
@@ -164,7 +189,7 @@ export class SpectrumInteractionController {
       const activeBands = activeFreq === null ? [] : this.activeBandsForFrequency(activeFreq);
       const focusEntry = this.focusEntry();
       if (!focusEntry) {
-        this.deps.panel.renderInspectorText(this.deps.t("spectrum.inspector_idle"));
+        this.renderInspectorText(this.deps.t("spectrum.inspector_idle"), { announce: false });
         return;
       }
       const cursorIdx = this.cursorDataIdx.value;
@@ -173,20 +198,20 @@ export class SpectrumInteractionController {
         const valueText = typeof currentValue === "number" && Number.isFinite(currentValue)
           ? this.formatDb(currentValue)
           : "--";
-        this.deps.panel.renderInspectorText(this.deps.t("spectrum.inspector_hover", {
+        this.renderInspectorText(this.deps.t("spectrum.inspector_hover", {
           sensor: focusEntry.label,
           freq: this.formatHz(activeFreq),
           value: valueText,
           bands: this.bandSummaryText(activeBands),
-        }));
+        }), { announce: false, throttleHover: true });
         return;
       }
       const peak = this.focusPeakInfo(focusEntry);
       if (!peak) {
-        this.deps.panel.renderInspectorText(this.deps.t("spectrum.inspector_idle"));
+        this.renderInspectorText(this.deps.t("spectrum.inspector_idle"), { announce: false });
         return;
       }
-      this.deps.panel.renderInspectorText(this.deps.t(
+      this.renderInspectorText(this.deps.t(
         this.pinnedSeriesId.value ? "spectrum.inspector_focus_selected" : "spectrum.inspector_focus_strongest",
         {
           sensor: focusEntry.label,
@@ -194,11 +219,12 @@ export class SpectrumInteractionController {
           value: this.formatDb(peak.value),
           bands: this.bandSummaryText(this.activeBandsForFrequency(peak.freq)),
         },
-      ));
+      ), { announce: true });
     });
   }
 
   dispose(): void {
+    this.cancelPendingHoverInspector();
     this.disposeInspectorSync();
   }
 
@@ -276,6 +302,72 @@ export class SpectrumInteractionController {
     }
     this.bandsVisible.value = !this.bandsVisible.value;
     this.deps.requestPlotRefresh();
+  }
+
+  private renderInspectorText(
+    text: string,
+    options: { announce: boolean; throttleHover?: boolean },
+  ): void {
+    if (options.throttleHover) {
+      this.queueHoverInspectorText(text);
+      return;
+    }
+    this.cancelPendingHoverInspector();
+    this.commitInspectorText(text, options.announce);
+  }
+
+  private queueHoverInspectorText(text: string): void {
+    this.pendingHoverInspectorText = text;
+    const lastCommitAtMs = this.lastHoverInspectorCommitAtMs;
+    const nowMs = this.nowMs();
+    if (
+      lastCommitAtMs === null
+      || (nowMs - lastCommitAtMs) >= HOVER_INSPECTOR_THROTTLE_MS
+    ) {
+      this.flushPendingHoverInspector();
+      return;
+    }
+    if (this.pendingHoverTimeoutHandle !== null) {
+      return;
+    }
+    const delayMs = HOVER_INSPECTOR_THROTTLE_MS - (nowMs - lastCommitAtMs);
+    this.pendingHoverTimeoutHandle = this.scheduleTimeout(() => {
+      this.pendingHoverTimeoutHandle = null;
+      this.flushPendingHoverInspector();
+    }, delayMs);
+  }
+
+  private flushPendingHoverInspector(): void {
+    const text = this.pendingHoverInspectorText;
+    if (text === null) {
+      return;
+    }
+    this.pendingHoverInspectorText = null;
+    this.lastHoverInspectorCommitAtMs = this.nowMs();
+    this.commitInspectorText(text, false);
+  }
+
+  private cancelPendingHoverInspector(): void {
+    if (this.pendingHoverTimeoutHandle !== null) {
+      this.cancelTimeout(this.pendingHoverTimeoutHandle);
+      this.pendingHoverTimeoutHandle = null;
+    }
+    this.pendingHoverInspectorText = null;
+  }
+
+  private commitInspectorText(text: string, announce: boolean): void {
+    const shouldAnnounce = announce && text !== this.lastAnnouncedInspectorText;
+    if (text === this.lastInspectorText && !shouldAnnounce) {
+      return;
+    }
+    this.deps.panel.renderInspector({
+      text,
+      announce: shouldAnnounce,
+    });
+    this.lastInspectorText = text;
+    if (shouldAnnounce) {
+      this.lastAnnouncedInspectorText = text;
+    }
   }
 
   private activeBandsForFrequency(freqHz: number): ChartBand[] {

--- a/apps/ui/src/app/runtime/spectrum_panel_view.ts
+++ b/apps/ui/src/app/runtime/spectrum_panel_view.ts
@@ -62,6 +62,11 @@ export interface SpectrumPanelOverlayModel {
   text: string;
 }
 
+export interface SpectrumInspectorRenderModel {
+  text: string;
+  announce: boolean;
+}
+
 export interface SpectrumLegendHandlers {
   onReset: () => void;
   onSelect: (entryId: string) => void;
@@ -78,5 +83,5 @@ export interface SpectrumPanelView {
   bindBandLegendModel(model: ReadonlySignal<SpectrumBandLegendModel>): void;
   renderHeader(model: SpectrumPanelHeaderModel): void;
   renderOverlay(model: SpectrumPanelOverlayModel): void;
-  renderInspectorText(text: string): void;
+  renderInspector(model: SpectrumInspectorRenderModel): void;
 }

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -10,6 +10,7 @@ import {
 import { createDeferredModelSignal, useDeferredModel } from "./view_model_binding";
 import type {
   SpectrumBandLegendModel,
+  SpectrumInspectorRenderModel,
   SpectrumLegendHandlers,
   SpectrumPanelBandToggleModel,
   SpectrumPanelChartDom,
@@ -64,6 +65,17 @@ const SPECTRUM_BAND_TOGGLE_KEYS = [
   "text",
 ] as const;
 const SPECTRUM_BAND_LEGEND_KEYS = ["emptyText", "items", "visible"] as const;
+const SCREEN_READER_ONLY_STYLE = {
+  border: "0",
+  clip: "rect(0 0 0 0)",
+  height: "1px",
+  margin: "-1px",
+  overflow: "hidden",
+  padding: "0",
+  position: "absolute",
+  whiteSpace: "nowrap",
+  width: "1px",
+} as const satisfies JSX.CSSProperties;
 
 function requireSpectrumElement<T extends HTMLElement>(
   element: T | null,
@@ -192,6 +204,7 @@ type SpectrumPanelProps = {
   bandToggleModel: ReadonlySignal<ReadonlySignal<SpectrumPanelBandToggleModel> | null>;
   chartDom: MutableSpectrumPanelChartDom;
   header: ReadonlySignal<SpectrumPanelHeaderModel>;
+  inspectorAnnouncement: ReadonlySignal<string>;
   inspectorText: ReadonlySignal<string>;
   onBandToggle: ReadonlySignal<(() => void) | null>;
   overlayModel: ReadonlySignal<SpectrumPanelOverlayModel>;
@@ -239,7 +252,7 @@ function SpectrumPanel(props: SpectrumPanelProps) {
           {overlayModel.value.text}
         </div>
       </div>
-      <div class="spectrum-controls-panel">
+        <div class="spectrum-controls-panel">
         <div class="spectrum-toolbar">
           <div class="card__subtle spectrum-toolbar__hint">
             {hintText}
@@ -261,8 +274,16 @@ function SpectrumPanel(props: SpectrumPanelProps) {
             <SpectrumBandLegend bandLegend={bandLegend} />
           </div>
         </div>
-        <div id="spectrumInspector" class="spectrum-inspector" aria-live="polite">
+        <div id="spectrumInspector" class="spectrum-inspector">
           {props.inspectorText}
+        </div>
+        <div
+          class="spectrum-inspector-announcer"
+          aria-live="polite"
+          aria-atomic="true"
+          style={SCREEN_READER_ONLY_STYLE}
+        >
+          {props.inspectorAnnouncement}
         </div>
         <div id="legend" class="legend">
           <SpectrumSensorLegend
@@ -290,6 +311,7 @@ export function createSpectrumPanel(): CreatedSpectrumPanel {
   const sensorLegendModel = createDeferredModelSignal<SpectrumSensorLegendModel | null>();
   const sensorLegendHandlersModel = createDeferredModelSignal<SpectrumLegendHandlers | null>();
   const bandLegendModel = createDeferredModelSignal<SpectrumBandLegendModel>();
+  const inspectorAnnouncement = signal("");
   const inspectorText = signal("Use the trace chips or hover the chart to inspect the current peak.");
   const onBandToggle = signal<(() => void) | null>(null);
   const chartDom: MutableSpectrumPanelChartDom = {
@@ -302,6 +324,7 @@ export function createSpectrumPanel(): CreatedSpectrumPanel {
       bandToggleModel,
       chartDom,
       header,
+      inspectorAnnouncement,
       inspectorText,
       onBandToggle,
       overlayModel,
@@ -339,8 +362,11 @@ export function createSpectrumPanel(): CreatedSpectrumPanel {
       renderOverlay(model: SpectrumPanelOverlayModel): void {
         overlayModel.value = model;
       },
-      renderInspectorText(text: string): void {
-        inspectorText.value = text;
+      renderInspector(model: SpectrumInspectorRenderModel): void {
+        inspectorText.value = model.text;
+        if (model.announce) {
+          inspectorAnnouncement.value = model.text;
+        }
       },
     },
   };

--- a/apps/ui/tests/spectrum_interaction_controller.spec.ts
+++ b/apps/ui/tests/spectrum_interaction_controller.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { SpectrumInteractionController } from "../src/app/runtime/spectrum_interaction_controller";
 import type {
+  SpectrumInspectorRenderModel,
   SpectrumPanelView,
 } from "../src/app/runtime/spectrum_panel_view";
 import { createElementStub } from "./spectrum_test_support";
@@ -9,10 +10,12 @@ import { createElementStub } from "./spectrum_test_support";
 function createPanelStub(): {
   panel: SpectrumPanelView;
   onBandToggle: (() => void) | null;
+  inspectorCalls: SpectrumInspectorRenderModel[];
   inspectorText: string;
 } {
   let onBandToggle: (() => void) | null = null;
   let inspectorText = "";
+  const inspectorCalls: SpectrumInspectorRenderModel[] = [];
 
   return {
     panel: {
@@ -28,15 +31,66 @@ function createPanelStub(): {
         bindBandLegendModel() {},
         renderHeader() {},
         renderOverlay() {},
-        renderInspectorText(text) {
-          inspectorText = text;
+        renderInspector(model) {
+          inspectorText = model.text;
+          inspectorCalls.push(model);
         },
       },
       get onBandToggle() {
         return onBandToggle;
       },
+      get inspectorCalls() {
+        return inspectorCalls;
+      },
       get inspectorText() {
         return inspectorText;
+      },
+  };
+}
+
+function createTimerHarness(): {
+  advanceBy(ms: number): void;
+  cancelTimeout(handle: number): void;
+  nowMs(): number;
+  scheduleTimeout(callback: () => void, delayMs: number): number;
+} {
+  let nowMs = 0;
+  let nextHandle = 1;
+  const timeouts = new Map<number, { atMs: number; callback: () => void }>();
+
+  function flushDueTimeouts(): void {
+    while (true) {
+      const due = [...timeouts.entries()]
+        .filter(([, entry]) => entry.atMs <= nowMs)
+        .sort((left, right) => left[1].atMs - right[1].atMs)[0];
+      if (!due) {
+        return;
+      }
+      const [handle, entry] = due;
+      timeouts.delete(handle);
+      entry.callback();
+    }
+  }
+
+  return {
+    advanceBy(ms: number): void {
+      nowMs += ms;
+      flushDueTimeouts();
+    },
+    cancelTimeout(handle: number): void {
+      timeouts.delete(handle);
+    },
+    nowMs(): number {
+      return nowMs;
+    },
+    scheduleTimeout(callback: () => void, delayMs: number): number {
+      const handle = nextHandle;
+      nextHandle += 1;
+      timeouts.set(handle, {
+        atMs: nowMs + delayMs,
+        callback,
+      });
+      return handle;
     },
   };
 }
@@ -133,5 +187,81 @@ test.describe("SpectrumInteractionController", () => {
     expect(isolatedSeries).toBeNull();
 
     expect(panel.onBandToggle).not.toBeNull();
+  });
+
+  test("throttles hover inspector updates and keeps hover silent for aria-live", () => {
+    const panel = createPanelStub();
+    const timers = createTimerHarness();
+
+    const controller = new SpectrumInteractionController({
+      panel: panel.panel,
+      t: (key, vars) => {
+        if (key === "spectrum.legend.state_all_visible") return "All visible";
+        if (key === "spectrum.legend.state_visible") return "Visible";
+        if (key === "spectrum.legend.state_isolated") return "Isolated";
+        if (key === "spectrum.legend.state_inactive") return "Inactive";
+        if (key === "spectrum.legend.sensor_level") return `${String(vars?.value)} dB`;
+        if (key === "spectrum.legend.all_series") return "All sensor traces";
+        if (key === "spectrum.legend.clear_focus") return "Clear focus";
+        if (key === "spectrum.legend.focus_series") return `Focus ${String(vars?.sensor)}`;
+        if (key === "spectrum.inspector_idle") return "Idle";
+        if (key === "spectrum.inspector_no_band") return "No reference band";
+        if (key === "spectrum.inspector_hover") {
+          return `Hover:${String(vars?.sensor)}:${String(vars?.freq)}:${String(vars?.value)}:${String(vars?.bands)}`;
+        }
+        if (key === "spectrum.inspector_focus_selected") {
+          return `Selected:${String(vars?.sensor)}:${String(vars?.freq)}:${String(vars?.value)}:${String(vars?.bands)}`;
+        }
+        if (key === "spectrum.inspector_focus_strongest") {
+          return `Strongest:${String(vars?.sensor)}:${String(vars?.freq)}:${String(vars?.value)}:${String(vars?.bands)}`;
+        }
+        return key;
+      },
+      getStrengthDb: (entryId) => (entryId === "sensor-a" ? 12 : 8),
+      getTopPeakHz: (entryId) => (entryId === "sensor-a" ? 10 : 20),
+      setSeriesIsolation: () => undefined,
+      requestPlotRefresh: () => undefined,
+      scheduleTimeout: timers.scheduleTimeout,
+      cancelTimeout: timers.cancelTimeout,
+      nowMs: timers.nowMs,
+    });
+
+    controller.sync({
+      entries: [
+        { id: "sensor-a", label: "Front Right Wheel", color: "#ff5500", values: [12, 11, 10] },
+        { id: "sensor-b", label: "Rear Left Wheel", color: "#3366ff", values: [8, 7, 6] },
+      ],
+      freqAxis: [10, 20, 30],
+      chartBands: [],
+    });
+
+    panel.inspectorCalls.length = 0;
+
+    controller.setCursorDataIndex(0);
+    controller.setCursorDataIndex(1);
+    controller.setCursorDataIndex(2);
+
+    expect(panel.inspectorCalls).toHaveLength(1);
+    expect(panel.inspectorCalls[0]).toEqual({
+      text: "Hover:Front Right Wheel:10.0:12.0:No reference band",
+      announce: false,
+    });
+
+    timers.advanceBy(33);
+
+    expect(panel.inspectorCalls).toHaveLength(2);
+    expect(panel.inspectorCalls[1]).toEqual({
+      text: "Hover:Front Right Wheel:30.0:10.0:No reference band",
+      announce: false,
+    });
+
+    panel.inspectorCalls.length = 0;
+    controller.setCursorDataIndex(null);
+    controller.sensorLegendHandlersModel.value?.onSelect("sensor-a");
+
+    expect(panel.inspectorCalls.at(-1)).toEqual({
+      text: "Selected:Front Right Wheel:10.0:12.0:No reference band",
+      announce: true,
+    });
   });
 });

--- a/apps/ui/tests/spectrum_panel.spec.ts
+++ b/apps/ui/tests/spectrum_panel.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+import { createSpectrumPanel } from "../src/app/views/spectrum_panel";
+
+test.describe("createSpectrumPanel", () => {
+  test("keeps hover-only inspector updates out of the live announcer", () => {
+    const panel = createSpectrumPanel();
+
+    panel.view.renderInspector({
+      text: "Hover:Front Right Wheel:10.0:12.0:No reference band",
+      announce: false,
+    });
+
+    expect(panel.props.inspectorText.value).toBe("Hover:Front Right Wheel:10.0:12.0:No reference band");
+    expect(panel.props.inspectorAnnouncement.value).toBe("");
+
+    panel.view.renderInspector({
+      text: "Selected:Front Right Wheel:10.0:12.0:No reference band",
+      announce: true,
+    });
+
+    expect(panel.props.inspectorText.value).toBe("Selected:Front Right Wheel:10.0:12.0:No reference band");
+    expect(panel.props.inspectorAnnouncement.value).toBe("Selected:Front Right Wheel:10.0:12.0:No reference band");
+  });
+});

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -70,7 +70,7 @@ function createPanelStub(): {
         renderOverlay(model) {
           lastOverlayModel = model;
         },
-        renderInspectorText() {},
+        renderInspector() {},
       },
     get lastHeaderModel() {
       return lastHeaderModel;


### PR DESCRIPTION
## What changed
- split the spectrum inspector into visible text and a separate hidden live announcer
- throttle hover-driven inspector refreshes to 33 ms and coalesce queued hover updates to the latest bin
- keep selected and focused inspector announcements immediate instead of routing hover churn through `aria-live`
- add focused coverage for the throttled interaction path and the split inspector/live-announcer contract

## Why
- stop turning high-frequency cursor hover into unbounded DOM and assistive-tech churn
- keep the inspector responsive without making meaningful focus changes quieter

## Validation
- `cd apps/ui && npx playwright test tests/spectrum_interaction_controller.spec.ts tests/spectrum_panel.spec.ts tests/ui_spectrum_controller.spec.ts tests/spectrum_canvas_renderer.spec.ts`
- `cd /workspace/VibeSensor && make ui-typecheck`
- `cd apps/ui && npm run build && CI=1 npm run test:visual`

## Risks / tradeoffs
- hover text can lag by up to one throttle window by design, but pinned or strongest-focus updates still render and announce immediately

Closes #2740