### PR TITLE
[codex] Remove unused axis top peaks

### DIFF
--- a/apps/server/tests/adapters/udp/test_reset_buffer_flush.py
+++ b/apps/server/tests/adapters/udp/test_reset_buffer_flush.py
@@ -99,7 +99,7 @@ def test_no_pre_reset_samples_contaminate_post_reset_fft() -> None:
     proc.ingest("c1", pre_reset, sample_rate_hz=800)
 
     pre_metrics = proc.compute_metrics("c1", sample_rate_hz=800)
-    pre_peaks = pre_metrics.get("x", {}).get("peaks", [])
+    pre_peaks = pre_metrics.get("combined", {}).get("peaks", [])
     assert any(abs(p["hz"] - 50.0) < 2.0 for p in pre_peaks), "Pre-reset should detect 50 Hz"
 
     # --- Sensor reset ---
@@ -112,7 +112,7 @@ def test_no_pre_reset_samples_contaminate_post_reset_fft() -> None:
     proc.ingest("c1", post_reset, sample_rate_hz=800)
 
     post_metrics = proc.compute_metrics("c1", sample_rate_hz=800)
-    post_peaks = post_metrics.get("x", {}).get("peaks", [])
+    post_peaks = post_metrics.get("combined", {}).get("peaks", [])
     # Should see 120 Hz, NOT 50 Hz residual
     assert any(abs(p["hz"] - 120.0) < 2.0 for p in post_peaks), "Post-reset should detect 120 Hz"
     # No residual 50 Hz peak

--- a/apps/server/tests/infra/processing/test_processing.py
+++ b/apps/server/tests/infra/processing/test_processing.py
@@ -10,7 +10,6 @@ from threading import Event, Thread
 import numpy as np
 
 from vibesensor.infra.processing import SignalProcessor
-from vibesensor.infra.processing.fft import top_peaks
 from vibesensor.infra.processing.time_align import compute_overlap
 
 
@@ -346,18 +345,6 @@ def test_spectrum_min_hz_zero_allows_all_frequencies() -> None:
     combined_peaks = metrics.get("combined", {}).get("peaks", [])
     # With min_hz=0, the 2 Hz peak should appear.
     assert any(abs(float(p["hz"]) - 2.0) < 1.0 for p in combined_peaks)
-
-
-def test_top_peaks_handles_nan_noise_floor() -> None:
-    """_top_peaks must not produce NaN when noise floor returns non-finite values."""
-    freqs = np.array([10.0, 20.0, 30.0], dtype=np.float32)
-    amps = np.array([0.01, 0.05, 0.01], dtype=np.float32)
-    peaks = top_peaks(freqs, amps, top_n=3)
-    assert len(peaks) > 0
-    for p in peaks:
-        assert math.isfinite(p["snr_ratio"]), f"snr_ratio is not finite: {p['snr_ratio']}"
-        assert math.isfinite(p["hz"])
-        assert math.isfinite(p["amp"])
 
 
 def test_compute_overlap_empty_lists() -> None:

--- a/apps/server/tests/infra/processing/test_processing_extended.py
+++ b/apps/server/tests/infra/processing/test_processing_extended.py
@@ -6,8 +6,7 @@ import numpy as np
 import pytest
 
 from vibesensor.infra.processing import MAX_CLIENT_SAMPLE_RATE_HZ, SignalProcessor
-from vibesensor.infra.processing.fft import noise_floor, smooth_spectrum, top_peaks
-from vibesensor.vibration_strength import compute_vibration_strength_db
+from vibesensor.infra.processing.fft import noise_floor, smooth_spectrum
 
 
 def _make_processor(**kwargs) -> SignalProcessor:
@@ -335,42 +334,6 @@ def test_evict_clients() -> None:
     proc.evict_clients({"keep"})
     assert proc.latest_sample_xyz("keep") is not None
     assert proc.latest_sample_xyz("evict") is None
-
-
-# -- _top_peaks edge cases -----------------------------------------------------
-
-
-def test_top_peaks_empty() -> None:
-    result = top_peaks(np.array([]), np.array([]))
-    assert result == []
-
-
-def test_top_peaks_with_data() -> None:
-    freqs = np.linspace(0, 100, 64, dtype=np.float32)
-    # Create a broad peak (several bins high) so smoothing doesn't flatten it
-    amps = np.zeros(64, dtype=np.float32)
-    for i in range(8, 13):
-        amps[i] = 1.0
-    amps[10] = 2.0  # Peak center
-    peaks = top_peaks(freqs, amps, top_n=3, smoothing_bins=3)
-    assert len(peaks) >= 1
-    assert peaks[0]["amp"] > 0
-
-
-def test_top_peaks_dominant_frequency_aligns_with_strength_metrics() -> None:
-    freqs = np.linspace(0, 100, 128, dtype=np.float32)
-    amps = np.zeros(128, dtype=np.float32)
-    amps[35] = 2.0
-    amps[74] = 1.6
-    peaks = top_peaks(freqs, amps, top_n=1, smoothing_bins=1)
-    strength = compute_vibration_strength_db(
-        freq_hz=freqs.tolist(),
-        combined_spectrum_amp_g_values=amps.tolist(),
-        top_n=1,
-    )
-    assert peaks
-    assert strength["top_peaks"]
-    assert peaks[0]["hz"] == pytest.approx(float(strength["top_peaks"][0]["hz"]))
 
 
 # -- compute_all ---------------------------------------------------------------

--- a/apps/server/tests/infra/processing/test_processing_fft.py
+++ b/apps/server/tests/infra/processing/test_processing_fft.py
@@ -18,7 +18,6 @@ from vibesensor.infra.processing.fft import (
     medfilt3,
     noise_floor,
     smooth_spectrum,
-    top_peaks,
 )
 
 
@@ -154,32 +153,6 @@ class TestFloatList:
         assert np.isneginf(arr[3])
 
 
-class TestTopPeaks:
-    """Tests for spectral peak detection."""
-
-    def test_empty_input(self) -> None:
-        result = top_peaks(np.array([]), np.array([]))
-        assert result == []
-
-    def test_single_peak(self) -> None:
-        freqs = np.linspace(1, 100, 200, dtype=np.float32)
-        amps = np.zeros(200, dtype=np.float32)
-        amps[50] = 1.0  # Clear peak at index 50
-        peaks = top_peaks(freqs, amps, top_n=3, smoothing_bins=1)
-        assert len(peaks) >= 1
-        assert peaks[0]["hz"] == pytest.approx(float(freqs[50]))
-
-    def test_respects_top_n(self) -> None:
-        freqs = np.linspace(1, 100, 200, dtype=np.float32)
-        amps = np.zeros(200, dtype=np.float32)
-        amps[30] = 0.8
-        amps[60] = 0.6
-        amps[90] = 0.4
-        amps[120] = 0.2
-        peaks = top_peaks(freqs, amps, top_n=2, smoothing_bins=1)
-        assert len(peaks) <= 2
-
-
 class TestComputeFftSpectrum:
     """Tests for the pure FFT spectrum computation."""
 
@@ -199,11 +172,8 @@ class TestComputeFftSpectrum:
         assert "strength_metrics" in result
         assert "axis_peaks" in result
 
-        # The dominant peak on each axis should be near 50 Hz
         for axis in ("x", "y", "z"):
-            peaks = result["axis_peaks"][axis]
-            assert len(peaks) >= 1
-            assert abs(peaks[0]["hz"] - 50.0) < 2.0
+            assert result["axis_peaks"][axis] == []
 
     def test_spike_filter_toggle(self) -> None:
         """Verify spike filter can be disabled."""

--- a/apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py
+++ b/apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py
@@ -1,8 +1,8 @@
 """Spectrum smoothing and peak-selection regressions:
 - _smooth_spectrum uses edge-padding instead of zero-padding to prevent
   boundary attenuation of edge frequency bins.
-- _top_peaks (and compute_vibration_strength_db) considers the last
-  spectrum bin as a potential peak candidate.
+- compute_vibration_strength_db considers the last spectrum bin as a
+  potential peak candidate.
 """
 
 from __future__ import annotations
@@ -10,7 +10,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from vibesensor.infra.processing.fft import smooth_spectrum, top_peaks
+from vibesensor.infra.processing.fft import smooth_spectrum
 from vibesensor.vibration_strength import compute_vibration_strength_db
 
 
@@ -56,39 +56,6 @@ class TestSmoothSpectrumEdgePadding:
             amps = np.random.default_rng(42).random(n).astype(np.float32)
             smoothed = smooth_spectrum(amps, bins=5)
             assert smoothed.shape == amps.shape, f"Shape mismatch for n={n}"
-
-
-class TestTopPeaksLastBin:
-    """Regression: _top_peaks must consider the final spectrum bin as a
-    valid peak candidate, not silently skip it.
-    """
-
-    def test_peak_at_last_bin_detected(self) -> None:
-        """A clear peak at the last frequency bin must appear in results."""
-        n = 50
-        freqs = np.arange(n, dtype=np.float32) * 4.0  # 0..196 Hz
-        amps = np.full(n, 0.01, dtype=np.float32)
-        # Place a strong peak at the last bin.
-        amps[-1] = 1.0
-        peaks = top_peaks(freqs, amps, top_n=5, smoothing_bins=1)
-        peak_hz = [p["hz"] for p in peaks]
-        assert float(freqs[-1]) in peak_hz, (
-            f"Last-bin peak at {freqs[-1]} Hz not found in {peak_hz}"
-        )
-
-    def test_last_bin_not_detected_when_lower_than_neighbor(self) -> None:
-        """Last bin should NOT be reported if it's lower than its neighbor."""
-        n = 50
-        freqs = np.arange(n, dtype=np.float32) * 4.0
-        amps = np.full(n, 0.01, dtype=np.float32)
-        # Peak at second-to-last bin, last bin is lower.
-        amps[-2] = 1.0
-        amps[-1] = 0.5
-        peaks = top_peaks(freqs, amps, top_n=5, smoothing_bins=1)
-        peak_hz = [p["hz"] for p in peaks]
-        assert float(freqs[-2]) in peak_hz, "Penultimate peak should be found"
-        # Last bin is lower than its left neighbor and not a local max.
-        assert float(freqs[-1]) not in peak_hz, "Last bin should not be a peak here"
 
 
 class TestCoreStrengthLastBin:

--- a/apps/server/vibesensor/infra/processing/fft.py
+++ b/apps/server/vibesensor/infra/processing/fft.py
@@ -16,8 +16,6 @@ import numpy.typing as npt
 from vibesensor.infra.processing.models import Axis, AxisPeak, FftSpectrumResult, SpectrumByAxis
 from vibesensor.shared.constants.dsp import PEAK_BANDWIDTH_HZ, PEAK_SEPARATION_HZ
 from vibesensor.vibration_strength import (
-    PEAK_THRESHOLD_FLOOR_RATIO,
-    STRENGTH_EPSILON_MIN_G,
     VibrationStrengthMetrics,
     combined_spectrum_amp_g,
     compute_vibration_strength_db,
@@ -174,61 +172,6 @@ def float_list(values: FloatArray | list[float]) -> list[float]:
     return [float(v) if _isfinite(v) else 0.0 for v in values]
 
 
-def top_peaks(
-    freqs: FloatArray,
-    amps: FloatArray,
-    *,
-    top_n: int = 5,
-    floor_ratio: float = PEAK_THRESHOLD_FLOOR_RATIO,
-    smoothing_bins: int = 5,
-) -> list[AxisPeak]:
-    """Extract the *top_n* spectral peaks above the noise floor."""
-    if freqs.size == 0 or amps.size == 0:
-        return []
-    smoothed = smooth_spectrum(amps, bins=smoothing_bins)
-    floor_amp = noise_floor(smoothed)
-    if not math.isfinite(floor_amp) or floor_amp < 0:
-        floor_amp = 0.0
-    threshold = max(floor_amp * max(1.1, floor_ratio), floor_amp + STRENGTH_EPSILON_MIN_G)
-
-    # Vectorised interior-peak detection (replaces per-element Python loop).
-    if smoothed.size > 2:
-        interior = smoothed[1:-1]
-        mask = (interior >= threshold) & (interior > smoothed[:-2]) & (interior >= smoothed[2:])
-        peak_idx: list[int] = (np.flatnonzero(mask) + 1).tolist()
-    else:
-        peak_idx = []
-    # Boundary check: last bin can be a peak if it exceeds its left neighbor.
-    if smoothed.size > 1:
-        last = smoothed.size - 1
-        amp_last = float(smoothed[last])
-        if amp_last >= threshold and amp_last > float(smoothed[last - 1]):
-            peak_idx.append(last)
-
-    if not peak_idx:
-        if smoothed.size > 1:
-            candidate = int(np.argmax(smoothed[1:]) + 1)
-        else:
-            candidate = int(np.argmax(smoothed))
-        if candidate >= 0 and float(smoothed[candidate]) > 0:
-            peak_idx = [candidate]
-
-    peak_idx.sort(key=lambda idx: float(smoothed[idx]), reverse=True)
-    peaks: list[AxisPeak] = []
-    for idx in peak_idx[:top_n]:
-        raw_amp = float(amps[idx])
-        peaks.append(
-            {
-                "hz": float(freqs[idx]),
-                "amp": raw_amp,
-                "snr_ratio": (
-                    (raw_amp + STRENGTH_EPSILON_MIN_G) / (floor_amp + STRENGTH_EPSILON_MIN_G)
-                ),
-            },
-        )
-    return peaks
-
-
 def compute_fft_spectrum(
     fft_block: FloatArray,
     sample_rate_hz: int,
@@ -296,15 +239,7 @@ def compute_fft_spectrum(
 
     for axis_idx, axis in enumerate(AXES):
         amp_slice = specs_all[axis_idx, valid_idx]
-        amp_for_peaks = amp_slice.copy()
-        if amp_for_peaks.size > 1 and freq_slice.size > 0 and freq_slice[0] < 0.5:
-            amp_for_peaks[0] = 0.0
-        axis_peaks[axis] = top_peaks(
-            freq_slice,
-            amp_for_peaks,
-            top_n=3,
-            smoothing_bins=3,
-        )
+        axis_peaks[axis] = []
         spectrum_by_axis[axis] = {
             "freq": freq_slice,
             "amp": amp_slice,


### PR DESCRIPTION
## What changed
- removed the unused per-axis `top_peaks()` helper from the FFT processing path
- kept the `axis_peaks` response shape stable, but now return empty per-axis peak lists instead of computing them
- updated processing and reset-buffer tests to validate combined strength peaks instead of the removed axis-level helper behavior

## Why it changed
Per-axis axis-peak extraction was extra hot-path work in the server compute loop, but the current product and diagnostics pipeline rely on combined strength peaks rather than these per-axis peak lists.

## Impact
- reduces backend FFT post-processing work on the live server path
- preserves existing payload and metrics shapes so downstream callers do not need a contract migration
- keeps combined strength metrics and diagnostics behavior intact

## Root cause
The backend was still computing per-axis peak summaries on every FFT pass even though the main runtime and diagnostics flows use the combined `strength_metrics.top_peaks` path instead.

## Validation
- `make test-ci-lite`
- `pytest -q apps/server/tests/use_cases/run/test_post_analysis_worker.py::TestPostAnalysisWorkerSchedule::test_queue_does_not_evict_when_many_runs_are_scheduled`
- `./.venv/bin/python tools/tests/run_backend_parallel.py --shards 5 --shard-index 1`
