### PR TITLE
perf(backend): skip strength realignment

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -4,7 +4,9 @@ from math import sqrt
 
 import pytest
 
+import vibesensor.vibration_strength as vibration_strength_module
 from vibesensor.vibration_strength import (
+    compute_vibration_strength_db,
     median,
     peak_band_rms_amp_g,
     strength_floor_amp_g,
@@ -142,6 +144,59 @@ def test_band_rms_last_bin_uses_available_neighbors() -> None:
     )
     expected = sqrt((1.0 + 4.0) / 2)
     assert result == pytest.approx(expected)
+
+
+def test_compute_vibration_strength_db_skips_repeated_alignment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    aligned_calls = 0
+    original = vibration_strength_module._aligned_float_arrays
+
+    def counting_aligned_float_arrays(
+        left: vibration_strength_module.ArrayLike,
+        right: vibration_strength_module.ArrayLike,
+    ) -> tuple[
+        vibration_strength_module.npt.NDArray[vibration_strength_module.np.float64],
+        vibration_strength_module.npt.NDArray[vibration_strength_module.np.float64],
+    ]:
+        nonlocal aligned_calls
+        aligned_calls += 1
+        return original(left, right)
+
+    monkeypatch.setattr(
+        vibration_strength_module,
+        "_aligned_float_arrays",
+        counting_aligned_float_arrays,
+    )
+
+    result = compute_vibration_strength_db(
+        freq_hz=[float(index) for index in range(20)],
+        combined_spectrum_amp_g_values=[
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.002,
+            0.004,
+            0.01,
+            0.03,
+            0.06,
+            0.12,
+            0.03,
+            0.01,
+            0.004,
+            0.002,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+        ],
+    )
+
+    assert aligned_calls == 0
+    assert result["vibration_strength_db"] > 0.0
 
 
 # -- vibration_strength_db_scalar --------------------------------------------

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -199,6 +199,27 @@ def strength_floor_amp_g(
     Falls back to :func:`noise_floor_amp_p20_g` when all bins are excluded.
     """
     freq, amps = _aligned_float_arrays(freq_hz, combined_spectrum_amp_g)
+    return _strength_floor_amp_g_aligned(
+        freq_hz=freq,
+        combined_spectrum_amp_g=amps,
+        peak_indexes=peak_indexes,
+        exclusion_hz=exclusion_hz,
+        min_hz=min_hz,
+        max_hz=max_hz,
+    )
+
+
+def _strength_floor_amp_g_aligned(
+    *,
+    freq_hz: npt.NDArray[np.float64],
+    combined_spectrum_amp_g: npt.NDArray[np.float64],
+    peak_indexes: list[int],
+    exclusion_hz: float,
+    min_hz: float,
+    max_hz: float,
+) -> float:
+    freq = freq_hz
+    amps = combined_spectrum_amp_g
     if freq.size == 0:
         return 0.0
     in_range = (freq >= min_hz) & (freq <= max_hz)
@@ -235,6 +256,23 @@ def peak_band_rms_amp_g(
     Raises ``ValueError`` when *center_idx* is outside the aligned spectrum.
     """
     freq, amps = _aligned_float_arrays(freq_hz, combined_spectrum_amp_g)
+    return _peak_band_rms_amp_g_aligned(
+        freq_hz=freq,
+        combined_spectrum_amp_g=amps,
+        center_idx=center_idx,
+        bandwidth_hz=bandwidth_hz,
+    )
+
+
+def _peak_band_rms_amp_g_aligned(
+    *,
+    freq_hz: npt.NDArray[np.float64],
+    combined_spectrum_amp_g: npt.NDArray[np.float64],
+    center_idx: int,
+    bandwidth_hz: float,
+) -> float:
+    freq = freq_hz
+    amps = combined_spectrum_amp_g
     if not (0 <= center_idx < freq.size):
         raise ValueError(
             f"center_idx {center_idx} out of range for aligned spectrum size {freq.size}"
@@ -323,7 +361,7 @@ def compute_vibration_strength_db(
         )
     peak_indexes = [int(idx) for idx in local_maxima[: max(1, top_n)]]
 
-    floor_strength = strength_floor_amp_g(
+    floor_strength = _strength_floor_amp_g_aligned(
         freq_hz=freq,
         combined_spectrum_amp_g=combined,
         peak_indexes=peak_indexes,
@@ -334,7 +372,7 @@ def compute_vibration_strength_db(
 
     candidates: list[StrengthPeak] = []
     for idx in local_maxima:
-        band_rms = peak_band_rms_amp_g(
+        band_rms = _peak_band_rms_amp_g_aligned(
             freq_hz=freq,
             combined_spectrum_amp_g=combined,
             center_idx=idx,


### PR DESCRIPTION
## What changed
- add private aligned-ndarray helpers for strength floor and peak-band RMS work in `vibration_strength.py`
- keep the public `strength_floor_amp_g()` and `peak_band_rms_amp_g()` APIs unchanged as compatibility wrappers
- route `compute_vibration_strength_db()` through the private helpers so its floor estimate and candidate loop stop re-running `_aligned_float_arrays(...)`
- add a focused regression that monkeypatches `_aligned_float_arrays` and proves the hot path no longer touches it

## Why
- `compute_vibration_strength_db()` already owns aligned `float64` arrays
- repeating `np.asarray(...)`, truncation, and alignment inside the hot loop is wasted Pi-side CPU

## Validation
- `cd apps/server && pytest -q tests/use_cases/diagnostics/test_strength_scoring.py tests/use_cases/diagnostics/test_vibration_strength_boundaries.py tests/use_cases/diagnostics/test_vibration_math_coverage.py tests/use_cases/diagnostics/test_vibration_strength_absolute_metrics.py`
- `cd /workspace/VibeSensor && make lint`
- `cd /workspace/VibeSensor && make typecheck-backend`

## Risks / tradeoffs
- internal helper split adds one private seam in `vibration_strength.py`, but public helper signatures and outputs stay unchanged
- this intentionally does not take the later floor-mask or peak-range perf follow-ups

Closes #2760