### PR TITLE
perf(backend): precompute peak band ranges

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -199,6 +199,53 @@ def test_compute_vibration_strength_db_skips_repeated_alignment(
     assert result["vibration_strength_db"] > 0.0
 
 
+def test_compute_vibration_strength_db_skips_full_scan_band_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    full_scan_calls = 0
+    original = vibration_strength_module._peak_band_rms_amp_g_aligned
+
+    def counting_peak_band_rms_amp_g_aligned(**kwargs: object) -> float:
+        nonlocal full_scan_calls
+        full_scan_calls += 1
+        return original(**kwargs)
+
+    monkeypatch.setattr(
+        vibration_strength_module,
+        "_peak_band_rms_amp_g_aligned",
+        counting_peak_band_rms_amp_g_aligned,
+    )
+
+    result = compute_vibration_strength_db(
+        freq_hz=[float(index) for index in range(20)],
+        combined_spectrum_amp_g_values=[
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.002,
+            0.004,
+            0.01,
+            0.03,
+            0.06,
+            0.12,
+            0.03,
+            0.01,
+            0.004,
+            0.002,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+        ],
+    )
+
+    assert full_scan_calls == 0
+    assert result["vibration_strength_db"] > 0.0
+
+
 # -- vibration_strength_db_scalar --------------------------------------------
 
 

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -284,6 +284,36 @@ def _peak_band_rms_amp_g_aligned(
     return float(np.sqrt(np.mean(np.square(band, dtype=np.float64))))
 
 
+def _peak_band_index_ranges_aligned(
+    *,
+    freq_hz: npt.NDArray[np.float64],
+    center_indexes: list[int],
+    bandwidth_hz: float,
+) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]] | None:
+    if not center_indexes:
+        empty = np.empty(0, dtype=np.intp)
+        return empty, empty
+    if np.any(freq_hz[1:] < freq_hz[:-1]):
+        return None
+    center_idx_array = np.asarray(center_indexes, dtype=np.intp)
+    center_hz = freq_hz[center_idx_array]
+    left_bounds = np.searchsorted(freq_hz, center_hz - bandwidth_hz, side="left")
+    right_bounds = np.searchsorted(freq_hz, center_hz + bandwidth_hz, side="right")
+    return left_bounds, right_bounds
+
+
+def _peak_band_rms_amp_g_from_bounds(
+    *,
+    combined_spectrum_amp_g: npt.NDArray[np.float64],
+    start_idx: int,
+    stop_idx: int,
+) -> float:
+    band = combined_spectrum_amp_g[start_idx:stop_idx]
+    if band.size == 0:
+        return 0.0
+    return float(np.sqrt(np.mean(np.square(band, dtype=np.float64))))
+
+
 def _local_maxima_indexes(values: npt.NDArray[np.float64], threshold: float) -> list[int]:
     maxima: list[int] = []
     if values.size > 2:
@@ -369,29 +399,57 @@ def compute_vibration_strength_db(
         min_hz=float(freq[0]) if freq.size else 0.0,
         max_hz=float(freq[-1]) if freq.size else 0.0,
     )
+    peak_band_ranges = _peak_band_index_ranges_aligned(
+        freq_hz=freq,
+        center_indexes=local_maxima,
+        bandwidth_hz=peak_bandwidth_hz,
+    )
 
     candidates: list[StrengthPeak] = []
-    for idx in local_maxima:
-        band_rms = _peak_band_rms_amp_g_aligned(
-            freq_hz=freq,
-            combined_spectrum_amp_g=combined,
-            center_idx=idx,
-            bandwidth_hz=peak_bandwidth_hz,
-        )
-        db = vibration_strength_db_scalar(
-            peak_band_rms_amp_g=band_rms,
-            floor_amp_g=floor_strength,
-        )
-        if not isfinite(db):
-            continue
-        candidates.append(
-            {
-                "hz": float(freq[idx]),
-                "amp": float(band_rms),
-                "vibration_strength_db": float(db),
-                "strength_bucket": bucket_for_strength(float(db)),
-            }
-        )
+    if peak_band_ranges is None:
+        for idx in local_maxima:
+            band_rms = _peak_band_rms_amp_g_aligned(
+                freq_hz=freq,
+                combined_spectrum_amp_g=combined,
+                center_idx=idx,
+                bandwidth_hz=peak_bandwidth_hz,
+            )
+            db = vibration_strength_db_scalar(
+                peak_band_rms_amp_g=band_rms,
+                floor_amp_g=floor_strength,
+            )
+            if not isfinite(db):
+                continue
+            candidates.append(
+                {
+                    "hz": float(freq[idx]),
+                    "amp": float(band_rms),
+                    "vibration_strength_db": float(db),
+                    "strength_bucket": bucket_for_strength(float(db)),
+                }
+            )
+    else:
+        left_bounds, right_bounds = peak_band_ranges
+        for candidate_idx, idx in enumerate(local_maxima):
+            band_rms = _peak_band_rms_amp_g_from_bounds(
+                combined_spectrum_amp_g=combined,
+                start_idx=int(left_bounds[candidate_idx]),
+                stop_idx=int(right_bounds[candidate_idx]),
+            )
+            db = vibration_strength_db_scalar(
+                peak_band_rms_amp_g=band_rms,
+                floor_amp_g=floor_strength,
+            )
+            if not isfinite(db):
+                continue
+            candidates.append(
+                {
+                    "hz": float(freq[idx]),
+                    "amp": float(band_rms),
+                    "vibration_strength_db": float(db),
+                    "strength_bucket": bucket_for_strength(float(db)),
+                }
+            )
     candidates.sort(
         key=lambda item: item["vibration_strength_db"],
         reverse=True,


### PR DESCRIPTION
## What changed
- precompute left/right band bounds once in `compute_vibration_strength_db()` with `np.searchsorted(...)` when the aligned frequency axis is monotonic
- reuse slices for candidate band RMS work instead of rebuilding full-spectrum masks per peak
- keep `_peak_band_rms_amp_g_aligned(...)` as fallback when frequency ordering is not monotonic
- add regression that proves the normal hot path no longer routes through the full-scan helper

## Why
- Pi profiling showed candidate band RMS work as dominant cost inside strength scoring
- old path rescanned the full frequency axis for every candidate peak
- new path keeps same band definition, same outputs, less repeated work

## Validation
- `cd apps/server && pytest -q tests/use_cases/diagnostics/test_strength_scoring.py tests/use_cases/diagnostics/test_vibration_strength_boundaries.py tests/use_cases/diagnostics/test_vibration_math_coverage.py tests/use_cases/diagnostics/test_vibration_strength_absolute_metrics.py`
- `cd /workspace/VibeSensor && make lint`
- `cd /workspace/VibeSensor && make typecheck-backend`
- local A/B microbenchmark on synthetic 1025-bin / 175-local-maxima spectrum: optimized path `1.8712 ms` mean vs forced old fallback `2.7059 ms` mean (~`30.85%` faster on this host)

## Risk / tradeoff
- fast path assumes monotonic frequency bins; code falls back to old helper if that assumption does not hold
- scope stays tight: no floor-mask changes, no public API changes

Closes #2761