### PR TITLE
perf(backend): avoid floor broadcast mask

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -95,6 +95,66 @@ def test_floor_rms_peak_index_out_of_range_ignored() -> None:
     assert result > 0
 
 
+def test_floor_rms_skips_broadcast_peak_exclusion_on_sorted_freq(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broadcast_calls = 0
+    original = vibration_strength_module._peak_exclusion_mask_broadcast_aligned
+
+    def counting_peak_exclusion_mask_broadcast_aligned(**kwargs: object) -> object:
+        nonlocal broadcast_calls
+        broadcast_calls += 1
+        return original(**kwargs)
+
+    monkeypatch.setattr(
+        vibration_strength_module,
+        "_peak_exclusion_mask_broadcast_aligned",
+        counting_peak_exclusion_mask_broadcast_aligned,
+    )
+
+    result = strength_floor_amp_g(
+        freq_hz=[10.0, 20.0, 30.0, 40.0, 50.0],
+        combined_spectrum_amp_g=[0.1, 0.2, 5.0, 0.3, 0.4],
+        peak_indexes=[2],
+        exclusion_hz=5.0,
+        min_hz=0.0,
+        max_hz=100.0,
+    )
+
+    assert broadcast_calls == 0
+    assert result == pytest.approx(0.25)
+
+
+def test_floor_rms_uses_broadcast_fallback_for_non_monotonic_freq(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broadcast_calls = 0
+    original = vibration_strength_module._peak_exclusion_mask_broadcast_aligned
+
+    def counting_peak_exclusion_mask_broadcast_aligned(**kwargs: object) -> object:
+        nonlocal broadcast_calls
+        broadcast_calls += 1
+        return original(**kwargs)
+
+    monkeypatch.setattr(
+        vibration_strength_module,
+        "_peak_exclusion_mask_broadcast_aligned",
+        counting_peak_exclusion_mask_broadcast_aligned,
+    )
+
+    result = strength_floor_amp_g(
+        freq_hz=[10.0, 30.0, 20.0, 40.0, 50.0],
+        combined_spectrum_amp_g=[0.1, 5.0, 0.2, 0.3, 0.4],
+        peak_indexes=[1],
+        exclusion_hz=5.0,
+        min_hz=0.0,
+        max_hz=100.0,
+    )
+
+    assert broadcast_calls == 1
+    assert result == pytest.approx(0.25)
+
+
 # -- peak_band_rms_amp_g ----------------------------------------------------
 
 

--- a/apps/server/tests/use_cases/run/test_post_analysis_worker.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_worker.py
@@ -107,6 +107,45 @@ class TestPostAnalysisWorkerSchedule:
         assert worker.wait(timeout_s=5.0)
         assert seen == [f"run-{index}" for index in range(105)]
 
+    def test_schedule_restarts_worker_when_run_is_queued_during_worker_exit(
+        self,
+        make_worker,
+    ) -> None:
+        seen: list[str] = []
+        ready_to_schedule = threading.Event()
+        scheduled_during_exit = threading.Event()
+        loop_calls = 0
+
+        worker = make_worker(history_db=None)
+
+        def _controlled_worker_loop() -> None:
+            nonlocal loop_calls
+            loop_calls += 1
+            if loop_calls == 1:
+                with worker._lock:
+                    run_id = worker._state.start_next(started_at=time.time())
+                    assert run_id == "run-1"
+                    worker._state.finish_active(run_id)
+                seen.append("run-1")
+                ready_to_schedule.set()
+                assert scheduled_during_exit.wait(timeout=2.0)
+                return
+            with worker._lock:
+                run_id = worker._state.start_next(started_at=time.time())
+                assert run_id == "run-2"
+                worker._state.finish_active(run_id)
+            seen.append("run-2")
+
+        worker._worker_loop = _controlled_worker_loop
+
+        worker.schedule("run-1")
+        assert ready_to_schedule.wait(timeout=2.0)
+        worker.schedule("run-2")
+        scheduled_during_exit.set()
+
+        assert worker.wait(timeout_s=2.0)
+        assert seen == ["run-1", "run-2"]
+
 
 class TestPostAnalysisWorkerIsActive:
     def test_inactive_when_idle(self) -> None:

--- a/apps/server/vibesensor/use_cases/run/post_analysis.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis.py
@@ -189,6 +189,11 @@ class PostAnalysisWorker:
         finally:
             with self._lock:
                 self._analysis_thread = None
+                if not self._shutdown_event.is_set() and self._state.snapshot().queue_depth > 0:
+                    # A run can be scheduled after the worker decides the queue
+                    # is empty but before the thread clears `_analysis_thread`.
+                    # Restart immediately so that queued work cannot strand.
+                    self._ensure_worker_running()
 
     def _worker_loop(self) -> None:
         while True:

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -227,12 +227,12 @@ def _strength_floor_amp_g_aligned(
     selected_mask = in_range & valid_amp
     peak_idx = [idx for idx in peak_indexes if 0 <= idx < freq.size]
     if peak_idx:
-        peak_hz = freq[np.asarray(peak_idx, dtype=np.intp)]
-        if peak_hz.size:
-            selected_mask &= ~np.any(
-                np.abs(freq[:, None] - peak_hz[None, :]) <= exclusion_hz,
-                axis=1,
-            )
+        _exclude_peak_regions_aligned(
+            selected_mask=selected_mask,
+            freq_hz=freq,
+            peak_indexes=peak_idx,
+            exclusion_hz=exclusion_hz,
+        )
     selected = amps[selected_mask]
     if selected.size == 0:
         # All bins were within peak exclusion zones.  Compute P20 of all
@@ -242,6 +242,52 @@ def _strength_floor_amp_g_aligned(
         # the caller has already stripped the DC bin from the spectrum.
         return _quantile_or_zero(amps[in_range & valid_amp], 0.20)
     return float(np.median(selected))
+
+
+def _exclude_peak_regions_aligned(
+    *,
+    selected_mask: npt.NDArray[np.bool_],
+    freq_hz: npt.NDArray[np.float64],
+    peak_indexes: list[int],
+    exclusion_hz: float,
+) -> None:
+    peak_ranges = _peak_band_index_ranges_aligned(
+        freq_hz=freq_hz,
+        center_indexes=peak_indexes,
+        bandwidth_hz=exclusion_hz,
+    )
+    if peak_ranges is None:
+        peak_hz = freq_hz[np.asarray(peak_indexes, dtype=np.intp)]
+        if peak_hz.size:
+            selected_mask &= ~_peak_exclusion_mask_broadcast_aligned(
+                freq_hz=freq_hz,
+                peak_hz=peak_hz,
+                exclusion_hz=exclusion_hz,
+            )
+        return
+    left_bounds, right_bounds = peak_ranges
+    for start_idx, stop_idx in zip(
+        left_bounds.tolist(),
+        right_bounds.tolist(),
+        strict=True,
+    ):
+        selected_mask[start_idx:stop_idx] = False
+
+
+def _peak_exclusion_mask_broadcast_aligned(
+    *,
+    freq_hz: npt.NDArray[np.float64],
+    peak_hz: npt.NDArray[np.float64],
+    exclusion_hz: float,
+) -> npt.NDArray[np.bool_]:
+    return cast(
+        npt.NDArray[np.bool_],
+        np.count_nonzero(
+            np.abs(freq_hz[:, None] - peak_hz[None, :]) <= exclusion_hz,
+            axis=1,
+        )
+        > 0,
+    )
 
 
 def peak_band_rms_amp_g(


### PR DESCRIPTION
## What changed
- replace the sorted hot-path floor exclusion broadcast with direct interval marking on the existing selected mask
- reuse `_peak_band_index_ranges_aligned(...)` to derive exclusion slices for each peak neighborhood
- keep `_peak_exclusion_mask_broadcast_aligned(...)` as the fallback when the frequency axis is not monotonic
- add regressions that prove sorted inputs skip the broadcast helper and non-monotonic inputs still use the fallback
- fix a queued post-analysis worker exit race that CI exposed on this branch, and add a deterministic regression so queued work cannot strand if a run is scheduled during worker teardown

## Why
- Pi profiling showed `strength_floor_amp_g()` spending avoidable time building an `N x P` broadcast mask
- hot path only needs the final 1-D exclusion result
- interval marking keeps the same exclusion semantics with less work and less allocation
- CI exposed a real worker-boundary race in `PostAnalysisWorker`; fixing it keeps the branch green and hardens the queue lifecycle

## Validation
- `cd apps/server && pytest -q tests/use_cases/run/test_post_analysis_worker.py tests/use_cases/diagnostics/test_strength_scoring.py tests/use_cases/diagnostics/test_vibration_strength_boundaries.py tests/use_cases/diagnostics/test_vibration_math_coverage.py tests/use_cases/diagnostics/test_vibration_strength_absolute_metrics.py`
- `cd /workspace/VibeSensor && make lint`
- `cd /workspace/VibeSensor && make typecheck-backend`
- local A/B microbenchmark on synthetic 1025-bin case with 210 local maxima and 5 excluded peaks: optimized floor path `0.0608 ms` mean vs forced old broadcast fallback `0.0901 ms` mean (~`32.55%` faster on this host)

## Risk / tradeoff
- fast path assumes monotonic frequency bins; code falls back to the old broadcast helper if that assumption does not hold
- worker fix only restarts when queued work exists after thread teardown; it does not change analysis ordering or retry policy
- scope stays tight: no peak ranking changes, no public API changes

Closes #2762