### PR TITLE
perf(backend): finish ndarray fast path

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -259,6 +259,55 @@ def test_compute_vibration_strength_db_skips_repeated_alignment(
     assert result["vibration_strength_db"] > 0.0
 
 
+def test_compute_vibration_strength_db_skips_public_noise_floor_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    noise_floor_calls = 0
+    original = vibration_strength_module.noise_floor_amp_p20_g
+
+    def counting_noise_floor_amp_p20_g(
+        *, combined_spectrum_amp_g: vibration_strength_module.ArrayLike
+    ) -> float:
+        nonlocal noise_floor_calls
+        noise_floor_calls += 1
+        return original(combined_spectrum_amp_g=combined_spectrum_amp_g)
+
+    monkeypatch.setattr(
+        vibration_strength_module,
+        "noise_floor_amp_p20_g",
+        counting_noise_floor_amp_p20_g,
+    )
+
+    result = compute_vibration_strength_db(
+        freq_hz=[float(index) for index in range(20)],
+        combined_spectrum_amp_g_values=[
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.002,
+            0.004,
+            0.01,
+            0.03,
+            0.06,
+            0.12,
+            0.03,
+            0.01,
+            0.004,
+            0.002,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+        ],
+    )
+
+    assert noise_floor_calls == 0
+    assert result["vibration_strength_db"] > 0.0
+
+
 def test_compute_vibration_strength_db_skips_full_scan_band_helper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -166,6 +166,9 @@ def combined_spectrum_amp_g(
     return cast(list[float], result.tolist())
 
 
+# Public helper APIs accept ArrayLike for callers and tests. Once
+# compute_vibration_strength_db() normalizes its inputs, the hot path should stay
+# on the private ndarray-only helpers below.
 def noise_floor_amp_p20_g(*, combined_spectrum_amp_g: ArrayLike) -> float:
     """Return the P20 amplitude floor in g, skipping the DC bin (index 0).
 
@@ -176,6 +179,11 @@ def noise_floor_amp_p20_g(*, combined_spectrum_amp_g: ArrayLike) -> float:
     real vibration findings.
     """
     band = np.asarray(combined_spectrum_amp_g, dtype=np.float64)
+    return _noise_floor_amp_p20_g_aligned(combined_spectrum_amp_g=band)
+
+
+def _noise_floor_amp_p20_g_aligned(*, combined_spectrum_amp_g: npt.NDArray[np.float64]) -> float:
+    band = combined_spectrum_amp_g
     if band.size <= 1:
         # Empty spectrum or DC-only: no frequency content to estimate noise from.
         return 0.0
@@ -423,7 +431,7 @@ def compute_vibration_strength_db(
 
     freq = freq_arr[:n]
     combined = np.where(np.isfinite(combined_arr[:n]), np.maximum(combined_arr[:n], 0.0), 0.0)
-    floor_p20 = noise_floor_amp_p20_g(combined_spectrum_amp_g=combined)
+    floor_p20 = _noise_floor_amp_p20_g_aligned(combined_spectrum_amp_g=combined)
     threshold = max(
         floor_p20 * PEAK_THRESHOLD_FLOOR_RATIO,
         floor_p20 + STRENGTH_EPSILON_MIN_G,


### PR DESCRIPTION
## What changed
- split `noise_floor_amp_p20_g(...)` into a thin public wrapper plus private `_noise_floor_amp_p20_g_aligned(...)`
- update `compute_vibration_strength_db()` to call the private ndarray-only helper directly after its outer-boundary normalization
- add a short module note that the compute hot path should stay on ndarray-only helpers after normalization
- add a regression that proves `compute_vibration_strength_db()` no longer touches the public noise-floor wrapper

## Why
- `#2760` through `#2762` already moved floor and band work onto ndarray-only helpers, but the compute path still routed its first noise-floor estimate through the public `ArrayLike` wrapper
- this finishes the split the issue asked for: public flexible API stays intact, internal hot path stays on ndarray-only helpers
- the note makes the fast path the obvious path for future edits

## Validation
- `cd apps/server && pytest -q tests/use_cases/diagnostics/test_strength_scoring.py tests/use_cases/diagnostics/test_vibration_strength_core.py tests/use_cases/diagnostics/test_vibration_strength_boundaries.py tests/use_cases/diagnostics/test_vibration_math_coverage.py tests/use_cases/diagnostics/test_vibration_strength_absolute_metrics.py`
- `cd /workspace/VibeSensor && make lint`
- `cd /workspace/VibeSensor && make typecheck-backend`

## Risk / tradeoff
- no public signature changes
- behavior stays the same; this is mainly a hot-path ownership guardrail
- scope stays tight to `vibration_strength.py` and focused diagnostics regression coverage

Closes #2763