### PR TITLE
perf: early candidate limiting in compute_vibration_strength_db

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -355,6 +355,52 @@ def test_compute_vibration_strength_db_skips_full_scan_band_helper(
     assert result["vibration_strength_db"] > 0.0
 
 
+def test_compute_vibration_strength_db_limits_scored_candidates_before_band_rms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scored_candidate_calls = 0
+    original = vibration_strength_module._peak_band_rms_amp_g_from_bounds
+
+    def counting_peak_band_rms_amp_g_from_bounds(
+        *,
+        combined_spectrum_amp_g: vibration_strength_module.npt.NDArray[
+            vibration_strength_module.np.float64
+        ],
+        start_idx: int,
+        stop_idx: int,
+    ) -> float:
+        nonlocal scored_candidate_calls
+        scored_candidate_calls += 1
+        return original(
+            combined_spectrum_amp_g=combined_spectrum_amp_g,
+            start_idx=start_idx,
+            stop_idx=stop_idx,
+        )
+
+    monkeypatch.setattr(
+        vibration_strength_module,
+        "_peak_band_rms_amp_g_from_bounds",
+        counting_peak_band_rms_amp_g_from_bounds,
+    )
+
+    combined = [
+        value
+        for peak in [0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21]
+        for value in (0.001, peak)
+    ]
+    combined.append(0.001)
+
+    result = compute_vibration_strength_db(
+        freq_hz=[float(index) for index in range(len(combined))],
+        combined_spectrum_amp_g_values=combined,
+        top_n=4,
+    )
+
+    assert scored_candidate_calls == 8
+    assert [peak["hz"] for peak in result["top_peaks"]] == [23.0, 21.0, 19.0, 17.0]
+    assert result["vibration_strength_db"] == result["top_peaks"][0]["vibration_strength_db"]
+
+
 # -- vibration_strength_db_scalar --------------------------------------------
 
 

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -443,25 +443,28 @@ def compute_vibration_strength_db(
         raise ValueError(
             f"peak index {invalid_idx} out of range for aligned spectrum size {freq.size}"
         )
-    peak_indexes = [int(idx) for idx in local_maxima[: max(1, top_n)]]
+    floor_peak_limit = max(1, top_n)
+    scored_candidate_limit = max(1, top_n * 2)
+    scored_candidate_indexes = [int(idx) for idx in local_maxima[:scored_candidate_limit]]
+    floor_peak_indexes = scored_candidate_indexes[:floor_peak_limit]
 
     floor_strength = _strength_floor_amp_g_aligned(
         freq_hz=freq,
         combined_spectrum_amp_g=combined,
-        peak_indexes=peak_indexes,
+        peak_indexes=floor_peak_indexes,
         exclusion_hz=peak_separation_hz,
         min_hz=float(freq[0]) if freq.size else 0.0,
         max_hz=float(freq[-1]) if freq.size else 0.0,
     )
     peak_band_ranges = _peak_band_index_ranges_aligned(
         freq_hz=freq,
-        center_indexes=local_maxima,
+        center_indexes=scored_candidate_indexes,
         bandwidth_hz=peak_bandwidth_hz,
     )
 
     candidates: list[StrengthPeak] = []
     if peak_band_ranges is None:
-        for idx in local_maxima:
+        for idx in scored_candidate_indexes:
             band_rms = _peak_band_rms_amp_g_aligned(
                 freq_hz=freq,
                 combined_spectrum_amp_g=combined,
@@ -484,7 +487,7 @@ def compute_vibration_strength_db(
             )
     else:
         left_bounds, right_bounds = peak_band_ranges
-        for candidate_idx, idx in enumerate(local_maxima):
+        for candidate_idx, idx in enumerate(scored_candidate_indexes):
             band_rms = _peak_band_rms_amp_g_from_bounds(
                 combined_spectrum_amp_g=combined,
                 start_idx=int(left_bounds[candidate_idx]),


### PR DESCRIPTION
## Size
small

## What changed
- cap `compute_vibration_strength_db()` RMS+dB scoring to `2 * top_n` amplitude-sorted candidates
- keep floor exclusion path on strongest `top_n` peaks
- add regression test that many local maxima only score capped candidates

## Why
- hot path already sorts local maxima by raw amplitude
- old path still scored every candidate, then dropped most of them
- `2 * top_n` keeps headroom for separation filter without full scoring cost

## Validation
- `pytest -q apps/server/tests/use_cases/diagnostics/test_strength_scoring.py`
- `make lint`
- `.venv/bin/python3 tools/tests/benchmark_pipeline.py --sensors 5 --rounds 20`

## Risks / tradeoffs / edge cases
- assumes strongest raw-amplitude candidates remain strongest scored candidates for fixed floor
- separation still happens after dB sort, so cap keeps `2 * top_n` headroom
- benchmark output is end-to-end pipeline timing, not isolated function microbench

Closes #2768