### PR TITLE
perf: vectorize dB computation across peak candidates

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -401,7 +401,88 @@ def test_compute_vibration_strength_db_limits_scored_candidates_before_band_rms(
     assert result["vibration_strength_db"] == result["top_peaks"][0]["vibration_strength_db"]
 
 
+def test_compute_vibration_strength_db_skips_scalar_db_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scalar_calls = 0
+    original = vibration_strength_module.vibration_strength_db_scalar
+
+    def counting_vibration_strength_db_scalar(
+        *,
+        peak_band_rms_amp_g: float,
+        floor_amp_g: float,
+        epsilon_g: float | None = None,
+    ) -> float:
+        nonlocal scalar_calls
+        scalar_calls += 1
+        return original(
+            peak_band_rms_amp_g=peak_band_rms_amp_g,
+            floor_amp_g=floor_amp_g,
+            epsilon_g=epsilon_g,
+        )
+
+    monkeypatch.setattr(
+        vibration_strength_module,
+        "vibration_strength_db_scalar",
+        counting_vibration_strength_db_scalar,
+    )
+
+    result = compute_vibration_strength_db(
+        freq_hz=[float(index) for index in range(20)],
+        combined_spectrum_amp_g_values=[
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.002,
+            0.004,
+            0.01,
+            0.03,
+            0.06,
+            0.12,
+            0.03,
+            0.01,
+            0.004,
+            0.002,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+        ],
+    )
+
+    assert scalar_calls == 0
+    assert result["vibration_strength_db"] > 0.0
+
+
 # -- vibration_strength_db_scalar --------------------------------------------
+
+
+def test_batch_vibration_strength_db_matches_scalar() -> None:
+    floor = 0.01
+    band_rms = vibration_strength_module.np.array(
+        [0.0, 0.01, 0.5, float("nan"), float("inf"), -1.0],
+        dtype=vibration_strength_module.np.float64,
+    )
+
+    batch = vibration_strength_module._batch_vibration_strength_db_aligned(
+        peak_band_rms_amp_g_values=band_rms,
+        floor_amp_g=floor,
+    )
+    expected = vibration_strength_module.np.array(
+        [
+            vibration_strength_db_scalar(
+                peak_band_rms_amp_g=float(value),
+                floor_amp_g=floor,
+            )
+            for value in band_rms
+        ],
+        dtype=vibration_strength_module.np.float64,
+    )
+
+    vibration_strength_module.np.testing.assert_allclose(batch, expected)
 
 
 def test_strength_db_equal_band_and_floor() -> None:

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -406,6 +406,27 @@ def vibration_strength_db_scalar(
     return 20.0 * log10((band + eps) / (floor + eps))
 
 
+def _batch_vibration_strength_db_aligned(
+    *,
+    peak_band_rms_amp_g_values: npt.NDArray[np.float64],
+    floor_amp_g: float,
+    epsilon_g: float | None = None,
+) -> npt.NDArray[np.float64]:
+    floor_raw = float(floor_amp_g)
+    floor = max(0.0, floor_raw) if isfinite(floor_raw) else 0.0
+    eps = (
+        max(STRENGTH_EPSILON_MIN_G, floor * STRENGTH_EPSILON_FLOOR_RATIO)
+        if epsilon_g is None
+        else max(STRENGTH_EPSILON_MIN_G, float(epsilon_g))
+    )
+    band = np.where(
+        np.isfinite(peak_band_rms_amp_g_values),
+        np.maximum(peak_band_rms_amp_g_values, 0.0),
+        0.0,
+    )
+    return 20.0 * np.log10((band + eps) / (floor + eps))
+
+
 def compute_vibration_strength_db(
     *,
     freq_hz: ArrayLike,
@@ -462,7 +483,8 @@ def compute_vibration_strength_db(
         bandwidth_hz=peak_bandwidth_hz,
     )
 
-    candidates: list[StrengthPeak] = []
+    candidate_hz: list[float] = []
+    candidate_band_rms: list[float] = []
     if peak_band_ranges is None:
         for idx in scored_candidate_indexes:
             band_rms = _peak_band_rms_amp_g_aligned(
@@ -471,20 +493,8 @@ def compute_vibration_strength_db(
                 center_idx=idx,
                 bandwidth_hz=peak_bandwidth_hz,
             )
-            db = vibration_strength_db_scalar(
-                peak_band_rms_amp_g=band_rms,
-                floor_amp_g=floor_strength,
-            )
-            if not isfinite(db):
-                continue
-            candidates.append(
-                {
-                    "hz": float(freq[idx]),
-                    "amp": float(band_rms),
-                    "vibration_strength_db": float(db),
-                    "strength_bucket": bucket_for_strength(float(db)),
-                }
-            )
+            candidate_hz.append(float(freq[idx]))
+            candidate_band_rms.append(float(band_rms))
     else:
         left_bounds, right_bounds = peak_band_ranges
         for candidate_idx, idx in enumerate(scored_candidate_indexes):
@@ -493,20 +503,25 @@ def compute_vibration_strength_db(
                 start_idx=int(left_bounds[candidate_idx]),
                 stop_idx=int(right_bounds[candidate_idx]),
             )
-            db = vibration_strength_db_scalar(
-                peak_band_rms_amp_g=band_rms,
-                floor_amp_g=floor_strength,
-            )
-            if not isfinite(db):
-                continue
-            candidates.append(
-                {
-                    "hz": float(freq[idx]),
-                    "amp": float(band_rms),
-                    "vibration_strength_db": float(db),
-                    "strength_bucket": bucket_for_strength(float(db)),
-                }
-            )
+            candidate_hz.append(float(freq[idx]))
+            candidate_band_rms.append(float(band_rms))
+    candidate_db = _batch_vibration_strength_db_aligned(
+        peak_band_rms_amp_g_values=np.asarray(candidate_band_rms, dtype=np.float64),
+        floor_amp_g=floor_strength,
+    )
+    candidates: list[StrengthPeak] = []
+    for hz, band_rms, db in zip(candidate_hz, candidate_band_rms, candidate_db, strict=True):
+        db_value = float(db)
+        if not isfinite(db_value):
+            continue
+        candidates.append(
+            {
+                "hz": hz,
+                "amp": band_rms,
+                "vibration_strength_db": db_value,
+                "strength_bucket": bucket_for_strength(db_value),
+            }
+        )
     candidates.sort(
         key=lambda item: item["vibration_strength_db"],
         reverse=True,


### PR DESCRIPTION
## Size
small

## What changed
- add private batch dB helper in `vibration_strength.py` using `np.log10`
- gather candidate RMS values first, then compute candidate dB values in one array pass
- keep scalar helper for single-value callers and add parity/no-scalar-call tests

## Why
- old path called pure-Python scalar dB math once per candidate
- candidate count is already capped by `#2768`, but per-candidate scalar overhead still remains
- vectorized dB math keeps same formula while reducing Python loop cost

## Validation
- `pytest -q apps/server/tests/use_cases/diagnostics/test_strength_scoring.py`
- `make lint`
- `.venv/bin/python3 tools/tests/benchmark_pipeline.py --sensors 5 --rounds 20`

## Risks / tradeoffs / edge cases
- helper expects aligned float64 arrays inside internal path
- bucket assignment still stays per-candidate in Python after vectorized dB values
- benchmark output is pipeline-level timing, not isolated candidate-loop microbench

Closes #2770