### PR TITLE
perf: float_list skip sanitize when no NaN present

### DIFF
--- a/apps/server/tests/infra/processing/test_processing_fft.py
+++ b/apps/server/tests/infra/processing/test_processing_fft.py
@@ -189,6 +189,26 @@ class TestFloatList:
         assert result == [1.0, 2.0, 3.0]
         assert all(type(value) is float for value in result)
 
+    def test_ndarray_finite_values_skip_sanitize_copy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        nan_to_num_calls = 0
+        original = np.nan_to_num
+        arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+
+        def counting_nan_to_num(*args: object, **kwargs: object) -> np.ndarray:
+            nonlocal nan_to_num_calls
+            nan_to_num_calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr("vibesensor.infra.processing.fft.np.nan_to_num", counting_nan_to_num)
+
+        result = float_list(arr)
+
+        assert result == [1.0, 2.0, 3.0]
+        assert nan_to_num_calls == 0
+
     def test_python_list(self) -> None:
         result = float_list([1, 2, 3])
         assert result == [1.0, 2.0, 3.0]
@@ -200,6 +220,26 @@ class TestFloatList:
         assert np.isnan(arr[1])
         assert np.isposinf(arr[2])
         assert np.isneginf(arr[3])
+
+    def test_ndarray_non_finite_values_use_sanitize_fallback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        nan_to_num_calls = 0
+        original = np.nan_to_num
+        arr = np.array([1.0, np.nan], dtype=np.float32)
+
+        def counting_nan_to_num(*args: object, **kwargs: object) -> np.ndarray:
+            nonlocal nan_to_num_calls
+            nan_to_num_calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr("vibesensor.infra.processing.fft.np.nan_to_num", counting_nan_to_num)
+
+        result = float_list(arr)
+
+        assert result == [1.0, 0.0]
+        assert nan_to_num_calls == 1
 
 
 class TestComputeFftSpectrum:

--- a/apps/server/vibesensor/infra/processing/fft.py
+++ b/apps/server/vibesensor/infra/processing/fft.py
@@ -162,6 +162,8 @@ def float_list(values: FloatArray | list[float]) -> list[float]:
     """
     _isfinite = math.isfinite
     if isinstance(values, np.ndarray):
+        if np.all(np.isfinite(values)):
+            return values.ravel().tolist()
         sanitized: FloatArray = np.nan_to_num(
             values,
             copy=True,


### PR DESCRIPTION
## Size
small

## What changed
- add finite-array fast path in `float_list()` for ndarray input
- skip `np.nan_to_num(..., copy=True)` when all values are finite
- add focused tests for fast path and sanitize fallback

## Why
- old path always copied and sanitized ndarray input before `.tolist()`
- live FFT output is finite for finite sensor input
- fallback stays in place for NaN and Inf cases

## Validation
- `pytest -q apps/server/tests/infra/processing/test_processing_fft.py`
- `make lint`
- `.venv/bin/python3 tools/tests/benchmark_pipeline.py --sensors 5 --rounds 20`

## Risks / tradeoffs / edge cases
- fast path still scans array for finiteness before deciding whether to copy
- non-finite ndarray values still go through sanitize fallback
- benchmark output is pipeline-level timing, not isolated `float_list()` microbench

Closes #2771