### PR TITLE
perf: combined_spectrum_amp_g return ndarray internally

### DIFF
--- a/apps/server/tests/infra/processing/test_processing_fft.py
+++ b/apps/server/tests/infra/processing/test_processing_fft.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+import vibesensor.infra.processing.fft as fft_module
 from vibesensor.infra.processing.fft import (
     compute_fft_spectrum,
     float_list,
@@ -330,6 +331,40 @@ class TestComputeFftSpectrum:
             "axis_peaks",
         }
         assert set(result.keys()) == expected_keys
+
+    def test_uses_internal_ndarray_combined_spectrum_helper(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sr = 256
+        fft_n = 256
+        params = _make_fft_params(sr=sr, fft_n=fft_n)
+        block = np.random.default_rng(42).standard_normal((3, fft_n)).astype(np.float32) * 0.01
+        expected = np.linspace(
+            0.1,
+            0.3,
+            num=params["freq_slice"].size,
+            dtype=np.float64,
+        )
+        helper_calls = 0
+
+        def fake_combined(
+            *,
+            axis_spectra_amp_g: object,
+            axis_count_for_mean: int | None = None,
+        ) -> np.ndarray:
+            del axis_spectra_amp_g, axis_count_for_mean
+            nonlocal helper_calls
+            helper_calls += 1
+            return expected
+
+        monkeypatch.setattr(fft_module, "_combined_spectrum_amp_g_array", fake_combined)
+
+        result = compute_fft_spectrum(block, sr, **params)
+
+        assert helper_calls == 1
+        assert result["combined_amp"].dtype == np.float32
+        np.testing.assert_allclose(result["combined_amp"], expected.astype(np.float32))
 
     def test_zero_length_fft_block_returns_empty_result(self) -> None:
         result = compute_fft_spectrum(

--- a/apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py
+++ b/apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
 import pytest
 
 from vibesensor.vibration_strength import (
+    _combined_spectrum_amp_g_array,
     combined_spectrum_amp_g,
     median,
     noise_floor_amp_p20_g,
@@ -56,6 +58,14 @@ class TestPercentile:
 
 
 class TestCombinedSpectrumAmpG:
+    def test_internal_helper_returns_ndarray(self) -> None:
+        result = _combined_spectrum_amp_g_array(
+            axis_spectra_amp_g=[[3.0], [4.0], [0.0]],
+        )
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == np.float64
+        assert result[0] == pytest.approx(math.sqrt(25.0 / 3.0))
+
     def test_empty_input(self) -> None:
         assert combined_spectrum_amp_g(axis_spectra_amp_g=[]) == []
 

--- a/apps/server/vibesensor/infra/processing/fft.py
+++ b/apps/server/vibesensor/infra/processing/fft.py
@@ -17,7 +17,7 @@ from vibesensor.infra.processing.models import Axis, AxisPeak, FftSpectrumResult
 from vibesensor.shared.constants.dsp import PEAK_BANDWIDTH_HZ, PEAK_SEPARATION_HZ
 from vibesensor.vibration_strength import (
     VibrationStrengthMetrics,
-    combined_spectrum_amp_g,
+    _combined_spectrum_amp_g_array,
     compute_vibration_strength_db,
     empty_vibration_strength_metrics,
 )
@@ -253,12 +253,12 @@ def compute_fft_spectrum(
     strength_metrics: VibrationStrengthMetrics = empty_vibration_strength_metrics()
     if spectrum_by_axis:
         amp_slices = [spectrum_by_axis[axis]["amp"] for axis in spectrum_by_axis]
-        combined_amp = np.asarray(
-            combined_spectrum_amp_g(
-                axis_spectra_amp_g=amp_slices,
-                axis_count_for_mean=len(amp_slices),
-            ),
-            dtype=np.float32,
+        combined_amp = _combined_spectrum_amp_g_array(
+            axis_spectra_amp_g=amp_slices,
+            axis_count_for_mean=len(amp_slices),
+        ).astype(
+            np.float32,
+            copy=False,
         )
         strength_metrics = compute_vibration_strength_db(
             freq_hz=freq_slice,

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -143,7 +143,8 @@ def _combined_spectrum_amp_g_array(
         if axis_count_for_mean is not None
         else max(1.0, float(arr.shape[0]))
     )
-    return np.sqrt(np.sum(arr**2, axis=0) / divisor)
+    result: npt.NDArray[np.float64] = np.sqrt(np.sum(arr**2, axis=0) / divisor)
+    return result
 
 
 def combined_spectrum_amp_g(

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -116,6 +116,36 @@ def _quantile_or_zero(values: npt.NDArray[np.float64], q: float) -> float:
     return float(np.quantile(values, q))
 
 
+def _combined_spectrum_amp_g_array(
+    *,
+    axis_spectra_amp_g: Sequence[ArrayLike] | npt.NDArray[np.floating],
+    axis_count_for_mean: int | None = None,
+) -> npt.NDArray[np.float64]:
+    if isinstance(axis_spectra_amp_g, np.ndarray):
+        if axis_spectra_amp_g.size == 0:
+            return np.empty(0, dtype=np.float64)
+        arr = np.asarray(axis_spectra_amp_g, dtype=np.float64)
+        if arr.ndim == 1:
+            arr = arr.reshape(1, -1)
+    else:
+        if not axis_spectra_amp_g:
+            return np.empty(0, dtype=np.float64)
+        target_len = min((len(a) for a in axis_spectra_amp_g), default=0)
+        if target_len <= 0:
+            return np.empty(0, dtype=np.float64)
+        arr = np.empty((len(axis_spectra_amp_g), target_len), dtype=np.float64)
+        for i, a in enumerate(axis_spectra_amp_g):
+            arr[i] = np.asarray(a, dtype=np.float64)[:target_len]
+
+    arr = np.where(np.isfinite(arr), arr, 0.0)
+    divisor = (
+        max(1.0, float(axis_count_for_mean))
+        if axis_count_for_mean is not None
+        else max(1.0, float(arr.shape[0]))
+    )
+    return np.sqrt(np.sum(arr**2, axis=0) / divisor)
+
+
 def combined_spectrum_amp_g(
     *,
     axis_spectra_amp_g: Sequence[ArrayLike] | npt.NDArray[np.floating],
@@ -140,29 +170,10 @@ def combined_spectrum_amp_g(
         denominator fixed (e.g. always divide by 3 even when only 2 axes are
         valid), which preserves comparability across partial-axis frames.
     """
-    if isinstance(axis_spectra_amp_g, np.ndarray):
-        if axis_spectra_amp_g.size == 0:
-            return []
-        arr = np.asarray(axis_spectra_amp_g, dtype=np.float64)
-        if arr.ndim == 1:
-            arr = arr.reshape(1, -1)
-    else:
-        if not axis_spectra_amp_g:
-            return []
-        target_len = min((len(a) for a in axis_spectra_amp_g), default=0)
-        if target_len <= 0:
-            return []
-        arr = np.empty((len(axis_spectra_amp_g), target_len), dtype=np.float64)
-        for i, a in enumerate(axis_spectra_amp_g):
-            arr[i] = np.asarray(a, dtype=np.float64)[:target_len]
-
-    arr = np.where(np.isfinite(arr), arr, 0.0)
-    divisor = (
-        max(1.0, float(axis_count_for_mean))
-        if axis_count_for_mean is not None
-        else max(1.0, float(arr.shape[0]))
+    result = _combined_spectrum_amp_g_array(
+        axis_spectra_amp_g=axis_spectra_amp_g,
+        axis_count_for_mean=axis_count_for_mean,
     )
-    result: npt.NDArray[np.floating] = np.sqrt(np.sum(arr**2, axis=0) / divisor)
     return cast(list[float], result.tolist())
 
 


### PR DESCRIPTION
## What changed
- add internal `_combined_spectrum_amp_g_array()` helper that returns ndarray
- keep public `combined_spectrum_amp_g()` list API by wrapping helper
- switch `compute_fft_spectrum()` hot path to helper and cast once to `float32`
- add focused helper and FFT caller regressions

## Why
- old hot path did ndarray -> list -> ndarray before strength scoring
- this removes conversion churn without changing math or public API

## Validation
- `pytest -q apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py apps/server/tests/infra/processing/test_processing_fft.py`
- `make lint`
- `.venv/bin/python3 tools/tests/benchmark_pipeline.py --sensors 5 --rounds 20`

## Risks / tradeoffs
- FFT now imports internal ndarray helper; public list helper behavior stays same
- internal helper still returns `float64`; hot path keeps one explicit narrow-to-`float32` cast by design

Closes #2772