### PR TITLE
perf: RMS/P2P in-place numpy operations

### DIFF
--- a/apps/server/tests/infra/processing/test_compute_filtering.py
+++ b/apps/server/tests/infra/processing/test_compute_filtering.py
@@ -114,3 +114,39 @@ def test_compute_filters_short_fft_block_only_once(monkeypatch) -> None:
     assert len(fft_calls) == 1
     np.testing.assert_array_equal(fft_calls[0][0], filtered_fft_block)
     assert fft_calls[0][1] is False
+
+
+def test_compute_reuses_single_square_call_for_rms_and_combined_metrics(
+    monkeypatch,
+) -> None:
+    metrics = SignalMetricsComputer(_config(fft_n=4))
+    time_window = np.array(
+        [
+            [1.0, 3.0, 5.0, 7.0],
+            [2.0, 4.0, 6.0, 8.0],
+            [0.5, 1.5, 2.5, 3.5],
+        ],
+        dtype=np.float32,
+    )
+    snapshot = MetricsSnapshot(
+        client_id="client-1",
+        sample_rate_hz=800,
+        ingest_generation=1,
+        time_window=time_window,
+        fft_block=None,
+    )
+    square_calls = 0
+    original_square = np.square
+
+    def counting_square(*args: object, **kwargs: object) -> np.ndarray:
+        nonlocal square_calls
+        square_calls += 1
+        return original_square(*args, **kwargs)
+
+    monkeypatch.setattr("vibesensor.infra.processing.compute.np.square", counting_square)
+
+    result = metrics.compute(snapshot)
+
+    assert square_calls == 1
+    assert result.metrics["x"]["rms"] > 0.0
+    assert result.metrics["combined"]["vib_mag_rms"] > 0.0

--- a/apps/server/vibesensor/infra/processing/compute.py
+++ b/apps/server/vibesensor/infra/processing/compute.py
@@ -108,9 +108,12 @@ class SignalMetricsComputer:
         time_window_detrended = time_window - np.mean(time_window, axis=1, keepdims=True)
 
         metrics: ClientMetrics = {}
-        if time_window_detrended.shape[1] > 0:
-            rms_vals = np.sqrt(np.mean(np.square(time_window_detrended, dtype=np.float64), axis=1))
-            p2p_vals = np.max(time_window_detrended, axis=1) - np.min(time_window_detrended, axis=1)
+        if time_window_detrended.size > 0:
+            squared = np.empty_like(time_window_detrended, dtype=np.float64)
+            np.square(time_window_detrended, out=squared, dtype=np.float64)
+
+            rms_vals = np.sqrt(np.mean(squared, axis=1))
+            p2p_vals = np.ptp(time_window_detrended, axis=1)
             for axis_idx, axis in enumerate(AXES):
                 metrics[axis] = {
                     "rms": _finite_or_zero(float(rms_vals[axis_idx])),
@@ -118,12 +121,12 @@ class SignalMetricsComputer:
                     "peaks": [],
                 }
 
-        if time_window_detrended.size > 0:
-            vib_mag = np.sqrt(np.sum(np.square(time_window_detrended, dtype=np.float64), axis=0))
+            vib_mag_sq = np.sum(squared, axis=0)
+            vib_mag = np.sqrt(vib_mag_sq)
             vib_mag_rms = _finite_or_zero(
-                float(np.sqrt(np.mean(np.square(vib_mag), dtype=np.float64))),
+                float(np.sqrt(np.mean(vib_mag_sq, dtype=np.float64))),
             )
-            vib_mag_p2p = _finite_or_zero(float(np.max(vib_mag) - np.min(vib_mag)))
+            vib_mag_p2p = _finite_or_zero(float(np.ptp(vib_mag)))
         else:
             vib_mag_rms = 0.0
             vib_mag_p2p = 0.0


### PR DESCRIPTION
## What changed
- square detrended window once into reusable `float64` scratch in `SignalMetricsComputer.compute()`
- reuse squared data for axis RMS and combined vibration magnitude/RMS
- switch axis and combined P2P calculations to `np.ptp`
- add focused regression that asserts metrics path only squares once

## Why
- old hot path built multiple full-size squared temporaries per tick
- this cuts allocation churn without changing metric outputs

## Validation
- `pytest -q apps/server/tests/infra/processing/test_compute_filtering.py apps/server/tests/infra/processing/test_processing.py apps/server/tests/infra/processing/test_processing_extended.py`
- `make lint`
- `make typecheck-backend`
- `.venv/bin/python3 tools/tests/benchmark_pipeline.py --sensors 5 --rounds 20`

## Risks / tradeoffs
- math stays same, but metrics path now depends on one shared squared scratch array inside single compute call
- combined P2P now uses `np.ptp`, which is equivalent to `max-min` for same data

Closes #2773