### PR TITLE
perf: batch bucket_for_strength via vectorized lookup

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py
@@ -4,10 +4,17 @@ import json
 import re
 from pathlib import Path
 
+import numpy as np
 import pytest
 from _paths import REPO_ROOT
 
-from vibesensor.strength_bands import BANDS, band_by_key, band_rank, bucket_for_strength
+from vibesensor.strength_bands import (
+    BANDS,
+    _buckets_for_strength_db_aligned,
+    band_by_key,
+    band_rank,
+    bucket_for_strength,
+)
 
 # -- bucket_for_strength -------------------------------------------------------
 
@@ -29,6 +36,13 @@ def test_bucket_returns_highest_matching() -> None:
     # Meets L1-L3 thresholds → returns L3
     result = bucket_for_strength(vibration_strength_db=26.0)
     assert result == "l3"
+
+
+def test_batch_buckets_match_scalar_helper() -> None:
+    values = np.array([-5.0, 0.0, 7.9, 8.0, 15.9, 16.0, 45.9, 46.0, 120.0], dtype=np.float64)
+    result = _buckets_for_strength_db_aligned(values)
+    expected = [bucket_for_strength(float(value)) for value in values]
+    assert result == expected
 
 
 # -- band_by_key ---------------------------------------------------------------

--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -457,6 +457,53 @@ def test_compute_vibration_strength_db_skips_scalar_db_helper(
     assert result["vibration_strength_db"] > 0.0
 
 
+def test_compute_vibration_strength_db_skips_scalar_bucket_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bucket_calls = 0
+    original = vibration_strength_module.bucket_for_strength
+
+    def counting_bucket_for_strength(vibration_strength_db: float) -> str:
+        nonlocal bucket_calls
+        bucket_calls += 1
+        return original(vibration_strength_db)
+
+    monkeypatch.setattr(
+        vibration_strength_module,
+        "bucket_for_strength",
+        counting_bucket_for_strength,
+    )
+
+    result = compute_vibration_strength_db(
+        freq_hz=[float(index) for index in range(20)],
+        combined_spectrum_amp_g_values=[
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.002,
+            0.004,
+            0.01,
+            0.03,
+            0.06,
+            0.12,
+            0.03,
+            0.01,
+            0.004,
+            0.002,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+        ],
+    )
+
+    assert bucket_calls == 0
+    assert result["strength_bucket"] == result["top_peaks"][0]["strength_bucket"]
+
+
 # -- vibration_strength_db_scalar --------------------------------------------
 
 

--- a/apps/server/vibesensor/strength_bands.py
+++ b/apps/server/vibesensor/strength_bands.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 from typing import Final, TypedDict
 
+import numpy as np
+import numpy.typing as npt
+
 __all__ = [
     "BANDS",
     "DECAY_TICKS",
@@ -42,6 +45,25 @@ DECAY_TICKS: Final[int] = 5
 
 _BAND_BY_KEY: dict[str, StrengthBand] = {b["key"]: b for b in BANDS}
 _BAND_RANK: dict[str, int] = {b["key"]: i for i, b in enumerate(BANDS)}
+_BAND_KEYS: Final[tuple[str, ...]] = tuple(b["key"] for b in BANDS)
+_BAND_MIN_DB_VALUES: Final[npt.NDArray[np.float64]] = np.array(
+    [b["min_db"] for b in BANDS],
+    dtype=np.float64,
+)
+
+
+def _buckets_for_strength_db_aligned(
+    vibration_strength_db_values: npt.NDArray[np.float64],
+) -> list[str]:
+    indexes = np.searchsorted(
+        _BAND_MIN_DB_VALUES,
+        vibration_strength_db_values,
+        side="right",
+    ).astype(np.intp, copy=False)
+    indexes -= 1
+    np.maximum(indexes, 0, out=indexes)
+    np.minimum(indexes, len(_BAND_KEYS) - 1, out=indexes)
+    return [_BAND_KEYS[int(idx)] for idx in indexes]
 
 
 def bucket_for_strength(vibration_strength_db: float) -> str:

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -28,7 +28,7 @@ from typing import Final, TypedDict, cast
 import numpy as np
 import numpy.typing as npt
 
-from vibesensor.strength_bands import bucket_for_strength
+from vibesensor.strength_bands import _buckets_for_strength_db_aligned, bucket_for_strength
 
 __all__ = [
     "compute_db",
@@ -521,8 +521,15 @@ def compute_vibration_strength_db(
         peak_band_rms_amp_g_values=np.asarray(candidate_band_rms, dtype=np.float64),
         floor_amp_g=floor_strength,
     )
+    candidate_buckets = _buckets_for_strength_db_aligned(candidate_db)
     candidates: list[StrengthPeak] = []
-    for hz, band_rms, db in zip(candidate_hz, candidate_band_rms, candidate_db, strict=True):
+    for hz, band_rms, db, strength_bucket in zip(
+        candidate_hz,
+        candidate_band_rms,
+        candidate_db,
+        candidate_buckets,
+        strict=True,
+    ):
         db_value = float(db)
         if not isfinite(db_value):
             continue
@@ -531,7 +538,7 @@ def compute_vibration_strength_db(
                 "hz": hz,
                 "amp": band_rms,
                 "vibration_strength_db": db_value,
-                "strength_bucket": bucket_for_strength(db_value),
+                "strength_bucket": strength_bucket,
             }
         )
     candidates.sort(
@@ -554,15 +561,18 @@ def compute_vibration_strength_db(
         top_db = float(_db_val) if _db_val is not None else 0.0
         _amp_val = top_peak.get("amp")
         peak_amp_g = float(_amp_val) if _amp_val is not None else 0.0
+        _bucket_val = top_peak.get("strength_bucket")
+        strength_bucket = _bucket_val if _bucket_val is not None else bucket_for_strength(top_db)
     else:
         top_db = 0.0
         peak_amp_g = 0.0
+        strength_bucket = bucket_for_strength(top_db)
 
     return {
         "vibration_strength_db": top_db,
         "peak_amp_g": peak_amp_g,
         "noise_floor_amp_g": float(floor_strength),
-        "strength_bucket": bucket_for_strength(top_db),
+        "strength_bucket": strength_bucket,
         "top_peaks": list(chosen),
     }
 


### PR DESCRIPTION
## What changed
- add internal vectorized strength-band lookup in `strength_bands.py` using `np.searchsorted`
- batch candidate bucket assignment in `compute_vibration_strength_db()`
- reuse chosen peak bucket for top-level response instead of re-calling scalar helper
- add parity and no-scalar-helper regressions

## Why
- old hot path called scalar `bucket_for_strength()` once per candidate peak
- this keeps band mapping identical while cutting Python call churn

## Validation
- `pytest -q apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py`
- `make lint`
- `make typecheck-backend`
- `.venv/bin/python3 tools/tests/benchmark_pipeline.py --sensors 5 --rounds 20`

## Risks / tradeoffs
- scalar helper stays unchanged for external callers; vectorized helper is internal-only
- batch helper now depends on numpy in `strength_bands.py`, but uses same band thresholds and returns same keys

Closes #2775