### PR TITLE
perf: use orjson for WebSocket payload serialization

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "fastapi>=0.111,<1",
   "uvicorn[standard]>=0.30,<1",
   "numpy>=2.4.4,<3",
+  "orjson>=3.11.4,<4",
   "packaging>=24,<27",
   "PyYAML>=6.0.3,<7",
   "reportlab>=4.4.10,<5",

--- a/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
+++ b/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from unittest.mock import MagicMock, patch
 
+import orjson
 import pytest
 
 from vibesensor.adapters.websocket.payload_orchestrator import PayloadBuildOrchestrator
@@ -85,16 +86,16 @@ async def test_prepare_reuses_serialized_template_across_selected_clients() -> N
 
     orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
     dict_dump_calls = 0
-    real_dumps = json.dumps
+    real_dumps = orjson.dumps
 
-    def counting_dumps(value: object, *args, **kwargs) -> str:
+    def counting_dumps(value: object) -> str:
         nonlocal dict_dump_calls
         if isinstance(value, dict):
             dict_dump_calls += 1
-        return real_dumps(value, *args, **kwargs)
+        return real_dumps(value).decode()
 
     with patch(
-        "vibesensor.adapters.websocket.payload_orchestrator.json.dumps",
+        "vibesensor.adapters.websocket.payload_orchestrator._dump_json_text",
         side_effect=counting_dumps,
     ):
         await orchestrator.prepare(["sensor-a", "sensor-b"])

--- a/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
+++ b/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
+import math
 from collections.abc import Callable, Iterable, Mapping
+from typing import cast
+
+import orjson
 
 from vibesensor.shared.json_utils import sanitize_for_json
 from vibesensor.shared.types.payload_types import LiveWsPayload, WsErrorPayload
@@ -15,8 +18,38 @@ LOGGER = logging.getLogger("vibesensor.adapters.websocket.hub")
 __all__ = ["PayloadBuildOrchestrator"]
 
 _ERROR_PAYLOAD_BODY: WsErrorPayload = {"error": "payload_build_failed"}
-_ERROR_PAYLOAD: str = json.dumps(_ERROR_PAYLOAD_BODY, separators=(",", ":"))
+_ERROR_PAYLOAD: str = orjson.dumps(_ERROR_PAYLOAD_BODY).decode()
 _SELECTED_CLIENT_ID_NULL_JSON = '"selected_client_id":null'
+
+
+def _dump_json_text(value: object) -> str:
+    return orjson.dumps(value).decode()
+
+
+def _payload_contains_non_finite(obj: object, *, _max_depth: int = 128) -> bool:
+    _isfinite = math.isfinite
+
+    def _walk(value: object, depth: int = 0) -> bool:
+        if depth > _max_depth:
+            return True
+        t = type(value)
+        if t is int or t is str or t is bool or value is None:
+            return False
+        if hasattr(value, "tolist") and hasattr(value, "ndim"):
+            value = value.tolist()
+            t = type(value)
+        elif hasattr(value, "item"):
+            value = value.item()
+            t = type(value)
+        if t is float:
+            return not _isfinite(cast(float, value))
+        if isinstance(value, dict):
+            return any(_walk(item, depth + 1) for item in value.values())
+        if isinstance(value, (list, tuple)):
+            return any(_walk(item, depth + 1) for item in value)
+        return False
+
+    return _walk(obj)
 
 
 class PayloadBuildOrchestrator:
@@ -84,15 +117,23 @@ class PayloadBuildOrchestrator:
         """Serialize *raw_payload* off the event loop and report debug metadata."""
 
         payload_for_debug: object = raw_payload
-        _dumps = json.dumps
+        _dumps = _dump_json_text
         try:
             try:
+                if _payload_contains_non_finite(raw_payload):
+                    payload_for_debug, had_non_finite = sanitize_for_json(raw_payload)
+                    LOGGER.warning(
+                        "WebSocket payload for client %r contained NaN/Inf values; "
+                        "replaced with null.",
+                        selected_client_id,
+                    )
+                else:
+                    had_non_finite = False
                 text = self._serialize_selected_client_payload(
                     selected_client_id,
-                    raw_payload,
+                    payload_for_debug,
                     _dumps,
                 )
-                had_non_finite = False
             except (TypeError, ValueError, OverflowError):
                 payload_for_debug, had_non_finite = sanitize_for_json(raw_payload)
                 if had_non_finite:
@@ -137,10 +178,10 @@ class PayloadBuildOrchestrator:
         self,
         selected_client_id: str | None,
         raw_payload: object,
-        dumps: Callable[..., str],
+        dumps: Callable[[object], str],
     ) -> str:
         if not isinstance(raw_payload, dict) or "selected_client_id" not in raw_payload:
-            return dumps(raw_payload, separators=(",", ":"), allow_nan=False)
+            return dumps(raw_payload)
         template_key = self._payload_template_key(raw_payload)
         template_text = self._payload_template_cache.get(template_key)
         if template_text is None:
@@ -149,13 +190,11 @@ class PayloadBuildOrchestrator:
                     **raw_payload,
                     "selected_client_id": None,
                 },
-                separators=(",", ":"),
-                allow_nan=False,
             )
             self._payload_template_cache[template_key] = template_text
         if selected_client_id is None:
             return template_text
-        selected_client_text = dumps(selected_client_id, separators=(",", ":"), allow_nan=False)
+        selected_client_text = dumps(selected_client_id)
         selected_client_payload = template_text.replace(
             _SELECTED_CLIENT_ID_NULL_JSON,
             f'"selected_client_id":{selected_client_text}',
@@ -163,7 +202,7 @@ class PayloadBuildOrchestrator:
         )
         if selected_client_payload != template_text:
             return selected_client_payload
-        return dumps(raw_payload, separators=(",", ":"), allow_nan=False)
+        return dumps(raw_payload)
 
     async def prepare(self, selected_client_ids: Iterable[str | None]) -> None:
         """Prime cached payloads for the current snapshot's unique client selections."""


### PR DESCRIPTION
## Summary
- swap WebSocket payload serialization from stdlib `json.dumps` to `orjson.dumps(...).decode()`
- keep cached/send contract as text; no send-path churn in this PR
- preserve NaN/Inf warning and null sanitization with cheap pre-scan before dump

## Why
`json.dumps` sits in broadcast hot path. `orjson` cuts that cost without changing payload shape.

## Validation
- `.venv/bin/pytest -q apps/server/tests/adapters/websocket/test_payload_orchestrator.py apps/server/tests/adapters/websocket/test_ws_hub.py`
- `make lint`
- `make typecheck-backend`

## Risk / tradeoffs
- live `orjson` here emits `null` for NaN/Inf instead of raising as issue text expected; pre-scan keeps current warning/sanitize behavior
- kept text payload contract, so byte-send path stays out of scope here

Closes #2776