### PR TITLE
perf: cache noise-floor frequency masks across ticks

### DIFF
--- a/apps/server/tests/infra/processing/test_compute_filtering.py
+++ b/apps/server/tests/infra/processing/test_compute_filtering.py
@@ -150,3 +150,31 @@ def test_compute_reuses_single_square_call_for_rms_and_combined_metrics(
     assert square_calls == 1
     assert result.metrics["x"]["rms"] > 0.0
     assert result.metrics["combined"]["vib_mag_rms"] > 0.0
+
+
+def test_compute_fft_spectrum_reuses_cached_strength_range_mask(monkeypatch) -> None:
+    metrics = SignalMetricsComputer(_config(fft_n=8))
+    block = np.zeros((3, 8), dtype=np.float32)
+    seen_masks: list[np.ndarray] = []
+
+    def _fake_compute_fft_spectrum(
+        fft_block: np.ndarray,
+        sample_rate_hz: int,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        del fft_block, sample_rate_hz
+        seen_masks.append(kwargs["strength_range_mask"])
+        return _empty_fft_result()
+
+    monkeypatch.setattr(
+        "vibesensor.infra.processing.compute.compute_fft_spectrum",
+        _fake_compute_fft_spectrum,
+    )
+
+    metrics.compute_fft_spectrum(block, 800, spike_filter_enabled=False)
+    metrics.compute_fft_spectrum(block, 800, spike_filter_enabled=False)
+
+    assert len(seen_masks) == 2
+    assert seen_masks[0] is seen_masks[1]
+    assert seen_masks[0].dtype == np.bool_
+    assert np.all(seen_masks[0])

--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from math import sqrt
 
+import numpy as np
 import pytest
 
 import vibesensor.vibration_strength as vibration_strength_module
@@ -352,6 +353,40 @@ def test_compute_vibration_strength_db_skips_full_scan_band_helper(
     )
 
     assert full_scan_calls == 0
+    assert result["vibration_strength_db"] > 0.0
+
+
+def test_compute_vibration_strength_db_does_not_mutate_cached_strength_range_mask() -> None:
+    strength_range_mask = np.ones(20, dtype=np.bool_)
+
+    result = compute_vibration_strength_db(
+        freq_hz=[float(index) for index in range(20)],
+        combined_spectrum_amp_g_values=[
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.002,
+            0.004,
+            0.01,
+            0.03,
+            0.06,
+            0.12,
+            0.03,
+            0.01,
+            0.004,
+            0.002,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+            0.001,
+        ],
+        strength_range_mask=strength_range_mask,
+    )
+
+    assert np.all(strength_range_mask)
     assert result["vibration_strength_db"] > 0.0
 
 

--- a/apps/server/vibesensor/infra/processing/compute.py
+++ b/apps/server/vibesensor/infra/processing/compute.py
@@ -14,6 +14,7 @@ from vibesensor.infra.processing.fft import (
     medfilt3,
 )
 from vibesensor.infra.processing.models import (
+    BoolArray,
     ClientMetrics,
     FftSpectrumResult,
     FloatArray,
@@ -29,6 +30,7 @@ from vibesensor.vibration_strength import empty_vibration_strength_metrics
 LOGGER = logging.getLogger(__name__)
 _FFT_CACHE_MAXSIZE = 64
 _EMPTY_F32: FloatArray = np.array([], dtype=np.float32)
+_EMPTY_BOOL: BoolArray = np.empty(0, dtype=np.bool_)
 
 
 def _finite_or_zero(value: float) -> float:
@@ -42,10 +44,12 @@ class SignalMetricsComputer:
         self._config = config
         self.fft_window: FloatArray = np.hanning(config.fft_n).astype(np.float32)
         self.fft_scale = float(2.0 / max(1.0, float(np.sum(self.fft_window))))
-        self.fft_cache: OrderedDict[int, tuple[FloatArray, IntIndexArray]] = OrderedDict()
+        self.fft_cache: OrderedDict[int, tuple[FloatArray, IntIndexArray, BoolArray]] = (
+            OrderedDict()
+        )
         self.fft_cache_lock = RLock()
 
-    def fft_params(self, sample_rate_hz: int) -> tuple[FloatArray, IntIndexArray]:
+    def _fft_cache_entry(self, sample_rate_hz: int) -> tuple[FloatArray, IntIndexArray, BoolArray]:
         with self.fft_cache_lock:
             cached = self.fft_cache.get(sample_rate_hz)
             if cached is not None:
@@ -57,17 +61,26 @@ class SignalMetricsComputer:
                     "returning empty frequency slice.",
                     sample_rate_hz,
                 )
-                return _EMPTY_F32, np.empty(0, dtype=np.intp)
+                return _EMPTY_F32, np.empty(0, dtype=np.intp), _EMPTY_BOOL
             freqs = np.fft.rfftfreq(self._config.fft_n, d=1.0 / sample_rate_hz)
             valid = (freqs >= self._config.spectrum_min_hz) & (
                 freqs <= self._config.spectrum_max_hz
             )
             freq_slice = freqs[valid].astype(np.float32)
             valid_idx = np.flatnonzero(valid)
-            self.fft_cache[sample_rate_hz] = (freq_slice, valid_idx)
+            strength_range_mask = np.ones(freq_slice.shape, dtype=np.bool_)
+            self.fft_cache[sample_rate_hz] = (freq_slice, valid_idx, strength_range_mask)
             if len(self.fft_cache) > _FFT_CACHE_MAXSIZE:
                 self.fft_cache.popitem(last=False)
-            return freq_slice, valid_idx
+            return freq_slice, valid_idx, strength_range_mask
+
+    def fft_params(self, sample_rate_hz: int) -> tuple[FloatArray, IntIndexArray]:
+        freq_slice, valid_idx, _ = self._fft_cache_entry(sample_rate_hz)
+        return freq_slice, valid_idx
+
+    def strength_range_mask(self, sample_rate_hz: int) -> BoolArray:
+        _, _, strength_range_mask = self._fft_cache_entry(sample_rate_hz)
+        return strength_range_mask
 
     def compute_fft_spectrum(
         self,
@@ -76,7 +89,7 @@ class SignalMetricsComputer:
         *,
         spike_filter_enabled: bool = True,
     ) -> FftSpectrumResult:
-        freq_slice, valid_idx = self.fft_params(sample_rate_hz)
+        freq_slice, valid_idx, strength_range_mask = self._fft_cache_entry(sample_rate_hz)
         return compute_fft_spectrum(
             fft_block,
             sample_rate_hz,
@@ -84,6 +97,7 @@ class SignalMetricsComputer:
             fft_scale=self.fft_scale,
             freq_slice=freq_slice,
             valid_idx=valid_idx,
+            strength_range_mask=strength_range_mask,
             spike_filter_enabled=spike_filter_enabled,
         )
 

--- a/apps/server/vibesensor/infra/processing/fft.py
+++ b/apps/server/vibesensor/infra/processing/fft.py
@@ -13,7 +13,13 @@ import math
 import numpy as np
 import numpy.typing as npt
 
-from vibesensor.infra.processing.models import Axis, AxisPeak, FftSpectrumResult, SpectrumByAxis
+from vibesensor.infra.processing.models import (
+    Axis,
+    AxisPeak,
+    BoolArray,
+    FftSpectrumResult,
+    SpectrumByAxis,
+)
 from vibesensor.shared.constants.dsp import PEAK_BANDWIDTH_HZ, PEAK_SEPARATION_HZ
 from vibesensor.vibration_strength import (
     VibrationStrengthMetrics,
@@ -184,6 +190,7 @@ def compute_fft_spectrum(
     fft_scale: float,
     freq_slice: FloatArray,
     valid_idx: IntIndexArray,
+    strength_range_mask: BoolArray | None = None,
     spike_filter_enabled: bool = True,
 ) -> FftSpectrumResult:
     """Compute per-axis and combined FFT spectra from a sample block.
@@ -266,6 +273,7 @@ def compute_fft_spectrum(
             peak_bandwidth_hz=PEAK_BANDWIDTH_HZ,
             peak_separation_hz=PEAK_SEPARATION_HZ,
             top_n=8,
+            strength_range_mask=strength_range_mask,
         )
 
     return {

--- a/apps/server/vibesensor/infra/processing/models.py
+++ b/apps/server/vibesensor/infra/processing/models.py
@@ -11,6 +11,7 @@ from vibesensor.vibration_strength import VibrationStrengthMetrics
 
 type FloatArray = npt.NDArray[np.float32]
 type IntIndexArray = npt.NDArray[np.intp]
+type BoolArray = npt.NDArray[np.bool_]
 
 Axis = Literal["x", "y", "z"]
 

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -191,6 +191,7 @@ def noise_floor_amp_p20_g(*, combined_spectrum_amp_g: ArrayLike) -> float:
     real vibration findings.
     """
     band = np.asarray(combined_spectrum_amp_g, dtype=np.float64)
+    band = np.where(np.isfinite(band), np.maximum(band, 0.0), 0.0)
     return _noise_floor_amp_p20_g_aligned(combined_spectrum_amp_g=band)
 
 
@@ -199,9 +200,7 @@ def _noise_floor_amp_p20_g_aligned(*, combined_spectrum_amp_g: npt.NDArray[np.fl
     if band.size <= 1:
         # Empty spectrum or DC-only: no frequency content to estimate noise from.
         return 0.0
-    finite = band[1:]
-    finite = finite[np.isfinite(finite) & (finite >= 0.0)]
-    return _quantile_or_zero(finite, 0.20)
+    return _quantile_or_zero(band[1:], 0.20)
 
 
 def strength_floor_amp_g(
@@ -219,13 +218,13 @@ def strength_floor_amp_g(
     Falls back to :func:`noise_floor_amp_p20_g` when all bins are excluded.
     """
     freq, amps = _aligned_float_arrays(freq_hz, combined_spectrum_amp_g)
+    clean_amps = np.where(np.isfinite(amps), np.maximum(amps, 0.0), 0.0)
     return _strength_floor_amp_g_aligned(
         freq_hz=freq,
-        combined_spectrum_amp_g=amps,
+        combined_spectrum_amp_g=clean_amps,
         peak_indexes=peak_indexes,
         exclusion_hz=exclusion_hz,
-        min_hz=min_hz,
-        max_hz=max_hz,
+        in_range_mask=(freq >= min_hz) & (freq <= max_hz),
     )
 
 
@@ -235,16 +234,21 @@ def _strength_floor_amp_g_aligned(
     combined_spectrum_amp_g: npt.NDArray[np.float64],
     peak_indexes: list[int],
     exclusion_hz: float,
-    min_hz: float,
-    max_hz: float,
+    in_range_mask: npt.NDArray[np.bool_] | None = None,
 ) -> float:
     freq = freq_hz
     amps = combined_spectrum_amp_g
     if freq.size == 0:
         return 0.0
-    in_range = (freq >= min_hz) & (freq <= max_hz)
-    valid_amp = np.isfinite(amps) & (amps >= 0.0)
-    selected_mask = in_range & valid_amp
+    base_mask = in_range_mask
+    if base_mask is None:
+        base_mask = np.ones(freq.shape, dtype=np.bool_)
+    elif base_mask.shape != freq.shape:
+        raise ValueError(
+            "strength floor range mask shape does not match aligned spectrum size "
+            f"{base_mask.shape} != {freq.shape}"
+        )
+    selected_mask = base_mask.copy()
     peak_idx = [idx for idx in peak_indexes if 0 <= idx < freq.size]
     if peak_idx:
         _exclude_peak_regions_aligned(
@@ -260,7 +264,7 @@ def _strength_floor_amp_g_aligned(
         # noise_floor_amp_p20_g, which unconditionally skips index 0
         # (assuming DC content at 0 Hz) — an assumption that breaks when
         # the caller has already stripped the DC bin from the spectrum.
-        return _quantile_or_zero(amps[in_range & valid_amp], 0.20)
+        return _quantile_or_zero(amps[base_mask], 0.20)
     return float(np.median(selected))
 
 
@@ -446,6 +450,7 @@ def compute_vibration_strength_db(
     peak_bandwidth_hz: float = PEAK_BANDWIDTH_HZ,
     peak_separation_hz: float = PEAK_SEPARATION_HZ,
     top_n: int = 5,
+    strength_range_mask: npt.NDArray[np.bool_] | None = None,
 ) -> VibrationStrengthMetrics:
     """Run the full vibration-strength pipeline on a combined spectrum.
 
@@ -486,8 +491,7 @@ def compute_vibration_strength_db(
         combined_spectrum_amp_g=combined,
         peak_indexes=floor_peak_indexes,
         exclusion_hz=peak_separation_hz,
-        min_hz=float(freq[0]) if freq.size else 0.0,
-        max_hz=float(freq[-1]) if freq.size else 0.0,
+        in_range_mask=strength_range_mask,
     )
     peak_band_ranges = _peak_band_index_ranges_aligned(
         freq_hz=freq,


### PR DESCRIPTION
## Summary
- cache reusable strength-range bool mask per sample rate inside `SignalMetricsComputer`
- thread cached mask through FFT compute into `compute_vibration_strength_db()`
- keep private floor helpers on already-clean amplitude arrays; public wrappers stay defensive

## Why
Strength/noise-floor hot path rebuilt invariant range masks and re-filtered cleaned FFT amplitudes every tick. Reusing cached mask cuts repeat work without changing outputs.

## Validation
- `.venv/bin/pytest -q apps/server/tests/infra/processing/test_compute_filtering.py apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/infra/processing/test_processing_fft.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py`
- `make lint`
- `make typecheck-backend`
- `.venv/bin/python3 tools/tests/benchmark_pipeline.py --sensors 5 --rounds 20`

## Risk / tradeoffs
- cached mask must stay immutable across ticks; added regression for reuse + no-mutation
- public helpers still sanitize caller input, so behavior stays same outside cached FFT path

Closes #2777