### PR TITLE
fix: restore fluent spectrum chart updates

### DIFF
--- a/apps/ui/src/app/spectrum_animation.ts
+++ b/apps/ui/src/app/spectrum_animation.ts
@@ -11,6 +11,8 @@ export interface SpectrumHeavyFrame {
 const FREQ_EPSILON = 1e-6;
 const MAX_INTERIOR_FINGERPRINT_SAMPLES = 4;
 const FINGERPRINT_SAMPLE_SEGMENTS = MAX_INTERIOR_FINGERPRINT_SAMPLES + 1;
+const MIN_TWEEN_DURATION_MS = 60;
+const FAST_FRAME_TWEEN_FRACTION = 0.75;
 
 /** Compute a lightweight fingerprint (length + sampled values) for a freq array. */
 function freqFingerprint(freq: number[]): string {
@@ -92,7 +94,14 @@ export function resolveSpectrumTweenDurationMs(
   if (!Number.isFinite(frameIntervalMs) || frameIntervalMs <= 0) {
     return 0;
   }
-  return frameIntervalMs < baseDurationMs ? 0 : baseDurationMs;
+  if (frameIntervalMs >= baseDurationMs) {
+    return baseDurationMs;
+  }
+  const shortenedDurationMs = Math.min(
+    baseDurationMs,
+    frameIntervalMs * FAST_FRAME_TWEEN_FRACTION,
+  );
+  return shortenedDurationMs >= MIN_TWEEN_DURATION_MS ? shortenedDurationMs : 0;
 }
 
 export interface SpectrumTweenDerivedState {

--- a/apps/ui/tests/spectrum_animation.spec.ts
+++ b/apps/ui/tests/spectrum_animation.spec.ts
@@ -37,10 +37,12 @@ test.describe("spectrum tween derived state", () => {
     expect(tween.frame.value).toBe(next.value);
   });
 
-  test("suppresses tweening when heavy frames arrive faster than the tween budget", () => {
+  test("shortens tweening for near-budget heavy frames and still guards very fast updates", () => {
     expect(resolveSpectrumTweenDurationMs(180, null)).toBe(180);
     expect(resolveSpectrumTweenDurationMs(180, 220)).toBe(180);
-    expect(resolveSpectrumTweenDurationMs(180, 100)).toBe(0);
+    expect(resolveSpectrumTweenDurationMs(180, 165)).toBe(123.75);
+    expect(resolveSpectrumTweenDurationMs(180, 100)).toBe(75);
+    expect(resolveSpectrumTweenDurationMs(180, 50)).toBe(0);
     expect(resolveSpectrumTweenDurationMs(180, 0)).toBe(0);
   });
 });

--- a/apps/ui/tests/spectrum_canvas_renderer.spec.ts
+++ b/apps/ui/tests/spectrum_canvas_renderer.spec.ts
@@ -770,7 +770,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
     }
   });
 
-  test("suppresses tween animations when heavy frames arrive faster than the tween budget", async () => {
+  test("keeps tween animations for near-budget heavy frames with shorter duration", async () => {
     const restoreDocument = installDocumentStub();
     try {
       const { createSpectrumCanvasRenderer } = await import(
@@ -801,6 +801,90 @@ test.describe("createSpectrumCanvasRenderer", () => {
       };
       const animationStarts: number[] = [];
       const renderTimesMs = [1_000, 1_100];
+
+      const renderer = createSpectrumCanvasRenderer({
+        state,
+        dom: {
+          specChart: createElementStub("div"),
+          specChartWrap: createElementStub("div"),
+        } as unknown as SpectrumPanelChartDom,
+        t: (key) => key,
+        getBandsVisible: () => false,
+        getChartBands: () => [],
+        getFocusMarker: () => null,
+        onCursorDataIndexChange: () => undefined,
+        loadChartModule: async () => ({
+          createSpectrumChart(): SpectrumChart {
+            return {
+              destroy() {},
+              redraw() {},
+              resize() {},
+              setData() {},
+              setSeriesIsolation() {},
+            };
+          },
+        }),
+        createAnimation: ({ durationMs }) => ({
+          start() {
+            animationStarts.push(durationMs);
+          },
+          stop() {},
+        }),
+        nowMs: () => renderTimesMs.shift() ?? 0,
+      });
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            ...getRequiredClientSpectrum(state, "sensor-a"),
+            combined: [0.9, 0.7, 0.45],
+          },
+        },
+      };
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+
+      expect(animationStarts).toEqual([75]);
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("still suppresses tween animations for genuinely high-cadence heavy frames", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const { createSpectrumCanvasRenderer } = await import(
+        "../src/app/runtime/spectrum_canvas_renderer"
+      );
+      const state = createAppState();
+      state.transport.wsState.value = "connected";
+      state.realtime.clients.value = [makeClient("sensor-a", "Front Right Wheel")];
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            freq: [10, 15, 20],
+            combined: [1, 0.75, 0.5],
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 1,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 1,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 12,
+              }],
+              vibration_strength_db: 12,
+            },
+          },
+        },
+      };
+      const animationStarts: number[] = [];
+      const renderTimesMs = [1_000, 1_050];
 
       const renderer = createSpectrumCanvasRenderer({
         state,


### PR DESCRIPTION
## Summary
- soften adaptive tween cutoff for heavy spectrum frames near 180 ms budget
- keep immediate render fallback for genuinely high-cadence updates
- add focused coverage for direct tween duration logic and renderer behavior

## Why
Hard cutoff made real-world heavy-frame jitter around the budget look like discrete jumps. Short bounded tweens keep motion fluent without bringing back runaway animation.

## Validation
- `cd apps/ui && npx playwright test tests/spectrum_animation.spec.ts tests/spectrum_canvas_renderer.spec.ts`
- `make ui-typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoffs
- near-budget fast frames animate again, but only with shortened duration
- truly fast frames still skip tweening once the shortened duration falls below the minimum guard
- existing unrelated UI lint warnings remain unchanged

Closes #2788