### PR TITLE
refactor: remove dead backend strength-band helpers

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py
@@ -11,8 +11,6 @@ from _paths import REPO_ROOT
 from vibesensor.strength_bands import (
     BANDS,
     _buckets_for_strength_db_aligned,
-    band_by_key,
-    band_rank,
     bucket_for_strength,
 )
 
@@ -43,39 +41,6 @@ def test_batch_buckets_match_scalar_helper() -> None:
     result = _buckets_for_strength_db_aligned(values)
     expected = [bucket_for_strength(float(value)) for value in values]
     assert result == expected
-
-
-# -- band_by_key ---------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("key", "expected_min_db"),
-    [("l0", 0.0), ("l1", 8.0), ("l5", 46.0)],
-    ids=["l0", "l1", "l5"],
-)
-def test_band_by_key_valid(key: str, expected_min_db: float) -> None:
-    band = band_by_key(key)
-    assert band is not None
-    assert band["min_db"] == expected_min_db
-
-
-@pytest.mark.parametrize("key", ["l99", ""], ids=["l99", "empty"])
-def test_band_by_key_unknown(key: str) -> None:
-    assert band_by_key(key) is None
-
-
-# -- band_rank -----------------------------------------------------------------
-
-
-def test_band_rank_ordering() -> None:
-    assert band_rank("l0") == 0
-    assert band_rank("l1") == 1
-    assert band_rank("l5") == 5
-    assert band_rank("l3") == 3
-
-
-def test_band_rank_unknown_returns_neg1() -> None:
-    assert band_rank("unknown") == -1
 
 
 # -- UI i18n severity labels match core BANDS -----------------------------------

--- a/apps/server/vibesensor/strength_bands.py
+++ b/apps/server/vibesensor/strength_bands.py
@@ -13,12 +13,7 @@ import numpy.typing as npt
 
 __all__ = [
     "BANDS",
-    "DECAY_TICKS",
-    "HYSTERESIS_DB",
-    "PERSISTENCE_TICKS",
     "StrengthBand",
-    "band_by_key",
-    "band_rank",
     "bucket_for_strength",
 ]
 
@@ -39,12 +34,6 @@ BANDS: Final[tuple[StrengthBand, ...]] = (
     {"key": "l5", "min_db": 46.0},
 )
 
-HYSTERESIS_DB: Final[float] = 2.0
-PERSISTENCE_TICKS: Final[int] = 3
-DECAY_TICKS: Final[int] = 5
-
-_BAND_BY_KEY: dict[str, StrengthBand] = {b["key"]: b for b in BANDS}
-_BAND_RANK: dict[str, int] = {b["key"]: i for i, b in enumerate(BANDS)}
 _BAND_KEYS: Final[tuple[str, ...]] = tuple(b["key"] for b in BANDS)
 _BAND_MIN_DB_VALUES: Final[npt.NDArray[np.float64]] = np.array(
     [b["min_db"] for b in BANDS],
@@ -76,13 +65,3 @@ def bucket_for_strength(vibration_strength_db: float) -> str:
         if vibration_strength_db >= band["min_db"]:
             return band["key"]
     return "l0"
-
-
-def band_by_key(key: str) -> StrengthBand | None:
-    """Return the :class:`StrengthBand` for *key*, or ``None`` if unknown."""
-    return _BAND_BY_KEY.get(key)
-
-
-def band_rank(key: str) -> int:
-    """Return the 0-based rank of *key* in ``BANDS``, or ``-1`` if unknown."""
-    return _BAND_RANK.get(key, -1)


### PR DESCRIPTION
## Summary
- delete unused `band_by_key` and `band_rank` helpers from `apps/server/vibesensor/strength_bands.py`
- delete orphaned constants `HYSTERESIS_DB`, `PERSISTENCE_TICKS`, and `DECAY_TICKS`
- remove tests that only exercised that dead surface

## Why
These symbols had no production consumers in backend, frontend, CLI, config, or docs. Only their own test module referenced the helpers, so this was dead backend surface.

## Validation
- `.venv/bin/pytest -q apps/server/tests/use_cases/diagnostics/test_strength_bands_extended.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py`
- `make lint`
- `make typecheck-backend`

## Risk / tradeoffs
- removes test-only APIs; any out-of-repo consumer would break, but repo evidence shows no real consumers
- keeps live bucket classification path unchanged