### PR TITLE
Remove dead backend symbols

### DIFF
--- a/apps/server/vibesensor/adapters/pdf/pdf_style.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_style.py
@@ -37,13 +37,6 @@ REPORT_COLORS = {
     "card_error_border": "#f5a6a2",
 }
 
-FINDING_SOURCE_COLORS: dict[str, str] = {
-    "wheel/tire": "#0f9d58",
-    "driveline": "#7c3aed",
-    "engine": "#c5221f",
-    "unknown": "#52555e",
-}
-
 # ── Style Constants ──────────────────────────────────────────────────────────
 
 PAGE_SIZE = A4
@@ -55,8 +48,6 @@ SUB_CLR = REPORT_COLORS["text_secondary"]
 MUTED_CLR = REPORT_COLORS["text_muted"]
 LINE_CLR = REPORT_COLORS["border"]
 PANEL_BG = "#ffffff"
-SOFT_BG = REPORT_COLORS["surface"]
-WARN_CLR = REPORT_COLORS["warning"]
 
 FONT = "Helvetica"
 FONT_B = "Helvetica-Bold"
@@ -68,10 +59,7 @@ FS_CARD_TITLE = 9.0
 
 R_CARD = 8
 GAP = 4 * mm
-OBSERVED_LABEL_W = 28 * mm
 DATA_TRUST_WIDTH_RATIO = 0.32
-DATA_TRUST_LABEL_W = 27 * mm
-DISCLAIMER_Y_OFFSET = 5.5 * mm
 PANEL_HEADER_H = 10.5 * mm
 
 _HELVETICA_AVG_CHAR_RATIO = 0.48

--- a/apps/server/vibesensor/adapters/simulator/profiles.py
+++ b/apps/server/vibesensor/adapters/simulator/profiles.py
@@ -7,9 +7,6 @@ from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 from vibesensor.shared.constants.units import KMH_TO_MPS
 
 DEFAULT_SPEED_KMH = 100.0
-DEFAULT_TIRE_WIDTH_MM = AnalysisSettingsSnapshot.DEFAULTS["tire_width_mm"]
-DEFAULT_TIRE_ASPECT_PCT = AnalysisSettingsSnapshot.DEFAULTS["tire_aspect_pct"]
-DEFAULT_RIM_IN = AnalysisSettingsSnapshot.DEFAULTS["rim_in"]
 DEFAULT_DEFLECTION_FACTOR = AnalysisSettingsSnapshot.DEFAULTS["tire_deflection_factor"]
 DEFAULT_FINAL_DRIVE = AnalysisSettingsSnapshot.DEFAULTS["final_drive_ratio"]
 DEFAULT_GEAR_RATIO = AnalysisSettingsSnapshot.DEFAULTS["current_gear_ratio"]

--- a/apps/server/vibesensor/shared/constants/analysis.py
+++ b/apps/server/vibesensor/shared/constants/analysis.py
@@ -14,16 +14,6 @@ Used as the lower bound for SNR computations to prevent ratio blow-up when
 the measured floor is near zero (sensor artifact / perfectly clean signal).
 """
 
-ROAD_RESONANCE_MIN_HZ: Final[float] = 0.5
-"""Lower bound of the road-surface resonance frequency range (Hz).
-
-Covers body/suspension modes (~0.5–3 Hz); the primary low-frequency cutoff
-is ``spectrum_min_hz`` in the processing config.
-"""
-
-ROAD_RESONANCE_MAX_HZ: Final[float] = 12.0
-"""Upper bound of the road-surface resonance frequency range (Hz)."""
-
 MULTI_SENSOR_CORROBORATION_DB: Final[float] = 3.0
 """Bonus dB added when ≥2 sensors agree on a finding, boosting effective
 confidence in the detected vibration."""

--- a/apps/server/vibesensor/shared/types/payload_types.py
+++ b/apps/server/vibesensor/shared/types/payload_types.py
@@ -62,12 +62,6 @@ class ClientMetrics(TypedDict, total=False):
     combined: CombinedMetrics
 
 
-class TimingHealthPayload(TypedDict, total=False):
-    jitter_us_ema: float
-    drift_us_total: float
-    last_t0_us: int
-
-
 class ClientApiRow(TypedDict, total=True):
     id: str
     mac_address: str

--- a/apps/server/vibesensor/shared/types/speed_source_config.py
+++ b/apps/server/vibesensor/shared/types/speed_source_config.py
@@ -19,14 +19,12 @@ __all__ = [
     "SpeedSourceConfig",
     "SpeedSourcePayload",
     "SpeedSourceUpdatePayload",
-    "VALID_SPEED_SOURCES",
     "_parse_manual_speed",
 ]
 
 _isfinite = math.isfinite
 
 type ResolvedSpeedSource = Literal["gps", "obd2", "manual", "fallback_manual", "none"]
-VALID_SPEED_SOURCES: tuple[str, ...] = tuple(kind.value for kind in SpeedSourceKind)
 
 
 class SpeedSourceUpdatePayload(TypedDict, total=False):


### PR DESCRIPTION
small

what changed
- removed five dead backend symbol groups with zero repo consumers
- cut unused PDF style constants in `pdf_style.py`
- cut unused simulator default tire constants in `profiles.py`
- cut unused `TimingHealthPayload`, road-resonance constants, and `VALID_SPEED_SOURCES`

why
- dead surface adds noise to backend ownership and type/export contracts
- frontend is only frontend; none of these names were consumed there or anywhere else in repo

validation/tests
- `.venv/bin/pytest -q apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py apps/server/tests/adapters/pdf/test_report_pdf_rendering.py apps/server/tests/infra/config/test_speed_source_settings.py apps/server/tests/infra/runtime/test_ws_payload_projection.py apps/server/tests/adapters/websocket/test_build_ws_payload.py`
- `make test-changed`
- `make lint`
- `make typecheck-backend`

risks tradeoffs edge
- low risk; deletions only
- verified no wildcard-import or generated-contract dependency on removed symbols

out of scope
- more dead-code passes still exist; kept this PR to five safe cuts