### PR TITLE
Remove unused spectrum smoother

### DIFF
--- a/apps/server/tests/infra/processing/test_processing_extended.py
+++ b/apps/server/tests/infra/processing/test_processing_extended.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from vibesensor.infra.processing import MAX_CLIENT_SAMPLE_RATE_HZ, SignalProcessor
-from vibesensor.infra.processing.fft import noise_floor, smooth_spectrum
+from vibesensor.infra.processing.fft import noise_floor
 
 
 def _make_processor(**kwargs) -> SignalProcessor:
@@ -285,27 +285,6 @@ def test_compute_metrics_with_data() -> None:
     assert "z" in metrics
     assert "combined" in metrics
     assert metrics["x"]["rms"] > 0
-
-
-# -- _smooth_spectrum edge cases -----------------------------------------------
-
-
-def test_smooth_spectrum_empty() -> None:
-    result = smooth_spectrum(np.array([], dtype=np.float32))
-    assert result.size == 0
-
-
-def test_smooth_spectrum_small_array() -> None:
-    arr = np.array([1.0, 2.0], dtype=np.float32)
-    result = smooth_spectrum(arr, bins=5)
-    # Array smaller than kernel → returns copy
-    assert result.size == 2
-
-
-def test_smooth_spectrum_single_bin() -> None:
-    arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-    result = smooth_spectrum(arr, bins=1)
-    np.testing.assert_array_equal(result, arr)
 
 
 # -- _noise_floor edge cases ---------------------------------------------------

--- a/apps/server/tests/infra/processing/test_processing_fft.py
+++ b/apps/server/tests/infra/processing/test_processing_fft.py
@@ -18,7 +18,6 @@ from vibesensor.infra.processing.fft import (
     float_list,
     medfilt3,
     noise_floor,
-    smooth_spectrum,
 )
 
 
@@ -123,44 +122,6 @@ class TestMedfilt3:
         assert sanitize_calls == 1
         assert np.all(np.isfinite(result))
         assert result[0, 1] == pytest.approx(1.0)
-
-
-class TestSmoothSpectrum:
-    """Tests for the sliding-average spectrum smoother."""
-
-    def test_empty_array(self) -> None:
-        result = smooth_spectrum(np.array([], dtype=np.float32))
-        assert result.size == 0
-
-    def test_identity_with_bins_1(self) -> None:
-        amps = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float32)
-        result = smooth_spectrum(amps, bins=1)
-        np.testing.assert_allclose(result, amps)
-
-    def test_output_same_length(self) -> None:
-        amps = np.random.default_rng(42).random(100).astype(np.float32)
-        result = smooth_spectrum(amps, bins=5)
-        assert result.shape == amps.shape
-
-    def test_smoothing_reduces_variance(self) -> None:
-        amps = np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0], dtype=np.float32)
-        result = smooth_spectrum(amps, bins=3)
-        assert np.var(result) < np.var(amps)
-
-    def test_even_bins_rounded_up(self) -> None:
-        """Even bin counts should be rounded up to the next odd number."""
-        amps = np.ones(10, dtype=np.float32)
-        result_4 = smooth_spectrum(amps, bins=4)
-        result_5 = smooth_spectrum(amps, bins=5)
-        np.testing.assert_allclose(result_4, result_5)
-
-    def test_nan_input_is_sanitized_before_smoothing(self) -> None:
-        amps = np.array([1.0, np.nan, 3.0], dtype=np.float32)
-        result = smooth_spectrum(amps, bins=3)
-        np.testing.assert_allclose(
-            result,
-            np.array([2.0 / 3.0, 4.0 / 3.0, 2.0], dtype=np.float32),
-        )
 
 
 class TestNoiseFloor:

--- a/apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py
+++ b/apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py
@@ -1,61 +1,8 @@
-"""Spectrum smoothing and peak-selection regressions:
-- _smooth_spectrum uses edge-padding instead of zero-padding to prevent
-  boundary attenuation of edge frequency bins.
-- compute_vibration_strength_db considers the last spectrum bin as a
-  potential peak candidate.
-"""
+"""Peak-selection regressions for core vibration-strength scoring."""
 
 from __future__ import annotations
 
-import numpy as np
-import pytest
-
-from vibesensor.infra.processing.fft import smooth_spectrum
 from vibesensor.vibration_strength import compute_vibration_strength_db
-
-
-class TestSmoothSpectrumEdgePadding:
-    """Regression: _smooth_spectrum must not attenuate edge bins via
-    zero-padding.  Using edge-replication prevents artificial reduction
-    of boundary amplitudes.
-    """
-
-    def test_constant_signal_unchanged(self) -> None:
-        """A constant-amplitude spectrum must be unchanged after smoothing."""
-        amps = np.full(20, 0.5, dtype=np.float32)
-        smoothed = smooth_spectrum(amps, bins=5)
-        np.testing.assert_allclose(smoothed, amps, atol=1e-6)
-
-    def test_edge_not_attenuated(self) -> None:
-        """First and last bins must not be reduced compared to the raw value
-        when the signal is constant near the boundary.
-        """
-        amps = np.full(20, 1.0, dtype=np.float32)
-        smoothed = smooth_spectrum(amps, bins=5)
-        # With zero-padding the first bin would be ~0.6; with edge-pad it stays 1.0.
-        assert smoothed[0] == pytest.approx(1.0, abs=1e-6), (
-            f"First bin {smoothed[0]} should not be attenuated"
-        )
-        assert smoothed[-1] == pytest.approx(1.0, abs=1e-6), (
-            f"Last bin {smoothed[-1]} should not be attenuated"
-        )
-
-    def test_edge_peak_preserved(self) -> None:
-        """A peak at the last bin must not be suppressed by zero-padding."""
-        amps = np.full(20, 0.1, dtype=np.float32)
-        amps[-1] = 1.0
-        amps[-2] = 0.8
-        smoothed = smooth_spectrum(amps, bins=3)
-        # With edge-padding the last bin should reflect the actual values,
-        # not be dragged toward zero.
-        assert smoothed[-1] > 0.85, f"Last-bin smoothed value {smoothed[-1]} should remain high"
-
-    def test_output_length_matches_input(self) -> None:
-        """Smoothed output must have the same length as the input."""
-        for n in (5, 10, 50, 200):
-            amps = np.random.default_rng(42).random(n).astype(np.float32)
-            smoothed = smooth_spectrum(amps, bins=5)
-            assert smoothed.shape == amps.shape, f"Shape mismatch for n={n}"
 
 
 class TestCoreStrengthLastBin:

--- a/apps/server/vibesensor/infra/processing/fft.py
+++ b/apps/server/vibesensor/infra/processing/fft.py
@@ -125,24 +125,6 @@ def medfilt3(block: FloatArray) -> FloatArray:
     return _sanitize_float_array(filtered)
 
 
-def smooth_spectrum(amps: FloatArray, bins: int = 5) -> FloatArray:
-    """Smooth a spectrum using a sliding-average convolution kernel."""
-    if amps.size == 0:
-        return amps
-    sanitized = _sanitize_float_array(amps)
-    width = max(1, int(bins))
-    if width <= 1:
-        return sanitized
-    if (width % 2) == 0:
-        width += 1
-    if sanitized.size < width:
-        return sanitized
-    kernel = np.ones(width, dtype=np.float32) / np.float32(width)
-    half = width // 2
-    padded = np.pad(sanitized, (half, half), mode="edge")
-    return np.convolve(padded, kernel, mode="valid").astype(np.float32)
-
-
 def noise_floor(amps: FloatArray) -> float:
     """Compute the P20 noise floor from the provided analysis-band amplitudes.
 


### PR DESCRIPTION
small

what changed
- removed dead `smooth_spectrum()` from backend FFT processing
- removed only the tests that existed to cover that dead helper

why
- helper had zero production callers after prior pruning
- keeping it left dead API surface in `infra.processing.fft`

validation/tests
- `.venv/bin/pytest -q apps/server/tests/infra/processing/test_processing_fft.py apps/server/tests/infra/processing/test_processing_extended.py apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py`
- `make test-changed`
- `make lint`
- `make typecheck-backend`

risks tradeoffs edge
- low risk; deleted code had test-only consumers
- preserved live last-bin strength regression coverage

out of scope
- next dead-code scan starts after this PR merges