### PR TITLE
Remove unused PDF label planner

### DIFF
--- a/apps/server/tests/adapters/pdf/test_diagram_layout.py
+++ b/apps/server/tests/adapters/pdf/test_diagram_layout.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import pytest
 
 from vibesensor.adapters.pdf.diagram_layout import (
-    LabelRenderPlan,
     bounds_overflow,
     boxes_overlap,
     build_sensor_render_plan,
     canonical_location,
-    choose_label_plan,
     estimate_text_width,
     extract_amp_by_location,
     highlight_map,
@@ -97,65 +95,6 @@ def test_resolve_marker_states_classifies_correctly() -> None:
     assert states["a"] == "connected-active"
     assert states["b"] == "connected-inactive"
     assert states["c"] == "disconnected"
-
-
-# ── choose_label_plan ────────────────────────────────────────────────────────
-
-
-def test_choose_label_plan_returns_label() -> None:
-    label = choose_label_plan(
-        name="test-loc",
-        px=50,
-        py=100,
-        width=200,
-        height=300,
-        occupied_boxes=[],
-        font_size=8.0,
-        color="#000",
-    )
-    assert isinstance(label, LabelRenderPlan)
-    assert label.name == "test-loc"
-
-
-def test_choose_label_plan_avoids_occupied_boxes() -> None:
-    # Place a box right where the default "start" label would go.
-    # The planner should pick an alternative.
-    default_bbox = label_bbox(x=50 + 10.0, y=100 - 2.0, text="test", anchor="start", font_size=8.0)
-    label = choose_label_plan(
-        name="test",
-        px=50,
-        py=100,
-        width=200,
-        height=300,
-        occupied_boxes=[default_bbox],
-        font_size=8.0,
-        color="#000",
-    )
-    # Should still succeed even if the preferred spot is occupied.
-    assert isinstance(label, LabelRenderPlan)
-
-
-def test_choose_label_plan_prefers_inward_offset_before_outward_overflow() -> None:
-    blocked_inward_box = label_bbox(
-        x=74.3,
-        y=188.0,
-        text="front-right wheel",
-        anchor="end",
-        font_size=6.8,
-    )
-    label = choose_label_plan(
-        name="front-right wheel",
-        px=84.3,
-        py=190.0,
-        width=124.0,
-        height=252.0,
-        occupied_boxes=[blocked_inward_box],
-        font_size=6.8,
-        color="#000",
-    )
-    assert label.anchor == "end"
-    assert label.bbox[0] >= 2.0
-    assert label.bbox[2] <= 122.0
 
 
 # ── build_sensor_render_plan ─────────────────────────────────────────────────

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import pytest
-
 from vibesensor.adapters.pdf import pdf_diagram_render
 from vibesensor.adapters.pdf.diagram_layout import (
     build_sensor_render_plan,
-    choose_label_plan,
     estimate_text_width,
     resolve_marker_states,
 )
@@ -507,26 +504,6 @@ def test_build_report_pdf_hotspot_panel_explains_intensity_and_certainty() -> No
     assert "why this corner wins" in text
     assert "dominant corner" in text
     assert "location confidence" in text
-
-
-def test_choose_label_plan_raises_value_error_when_no_candidates(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """choose_label_plan raises ValueError when no label placement candidates exist."""
-    import vibesensor.adapters.pdf.diagram_layout as layout_mod
-
-    monkeypatch.setattr(layout_mod, "_LABEL_CANDIDATES_RIGHT", ())
-    with pytest.raises(ValueError, match="No valid label placement found"):
-        choose_label_plan(
-            name="front_left",
-            px=0.1,  # px < width * 0.5 → selects RIGHT candidates (now empty)
-            py=100.0,
-            width=200.0,
-            height=300.0,
-            occupied_boxes=[],
-            font_size=8.0,
-            color="#000000",
-        )
 
 
 def test_pdf_diagram_render_module_no_longer_reexports_layout_helpers() -> None:

--- a/apps/server/vibesensor/adapters/pdf/diagram_layout.py
+++ b/apps/server/vibesensor/adapters/pdf/diagram_layout.py
@@ -174,68 +174,6 @@ def resolve_marker_states(
     return states
 
 
-# ── Label collision resolution ───────────────────────────────────────────────
-
-_INLINE_LABEL_GAP = 16.0
-
-_LABEL_CANDIDATES_RIGHT: tuple[tuple[float, float, str], ...] = (
-    (_INLINE_LABEL_GAP, -2.0, "start"),
-    (-_INLINE_LABEL_GAP, -2.0, "end"),
-    (0.0, 9.0, "middle"),
-    (0.0, -11.0, "middle"),
-)
-_LABEL_CANDIDATES_LEFT: tuple[tuple[float, float, str], ...] = (
-    (-_INLINE_LABEL_GAP, -2.0, "end"),
-    (-_INLINE_LABEL_GAP, 18.0, "end"),
-    (-_INLINE_LABEL_GAP, -20.0, "end"),
-    (_INLINE_LABEL_GAP, -2.0, "start"),
-    (0.0, 9.0, "middle"),
-    (0.0, -11.0, "middle"),
-)
-
-
-def choose_label_plan(
-    *,
-    name: str,
-    px: float,
-    py: float,
-    width: float,
-    height: float,
-    occupied_boxes: list[tuple[float, float, float, float]],
-    font_size: float,
-    color: str,
-) -> LabelRenderPlan:
-    """Choose the best label position for *name* at pixel (px, py).
-
-    Tries several candidate offsets and picks the one with the lowest
-    overlap + overflow penalty.
-    """
-    ordered_candidates = _LABEL_CANDIDATES_RIGHT if px < (width * 0.5) else _LABEL_CANDIDATES_LEFT
-    best: tuple[float, LabelRenderPlan] | None = None
-    for idx, (dx, dy, anchor) in enumerate(ordered_candidates):
-        x = px + dx
-        y = py + dy
-        bbox = label_bbox(x=x, y=y, text=name, anchor=anchor, font_size=font_size)
-        overlap_penalty = sum(1 for box in occupied_boxes if boxes_overlap(bbox, box))
-        overflow_penalty = bounds_overflow(bbox, width=width, height=height)
-        score = (overlap_penalty * 1000.0) + (overflow_penalty * 10.0) + float(idx)
-        candidate = LabelRenderPlan(
-            name=name,
-            text=name,
-            x=x,
-            y=y,
-            anchor=anchor,
-            color=color,
-            font_size=font_size,
-            bbox=bbox,
-        )
-        if best is None or score < best[0]:
-            best = (score, candidate)
-    if best is None:
-        raise ValueError(f"No valid label placement found for {name!r} in diagram")
-    return best[1]
-
-
 # ── Full sensor render plan ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
small

what changed
- removed dead `choose_label_plan()` from PDF diagram layout
- removed its private candidate tables
- removed only the tests that existed to cover that dead path

why
- helper had zero production callers after prior pruning
- keeping it left dead surface inside PDF layout code

validation/tests
- `.venv/bin/pytest -q apps/server/tests/adapters/pdf/test_diagram_layout.py apps/server/tests/adapters/pdf/test_report_pdf_diagram_hotspots.py apps/server/tests/adapters/pdf/test_report_new_modules_pdf_layout.py`
- `make test-changed`
- `make lint`
- `make typecheck-backend`

risks tradeoffs edge
- low risk; deleted code had test-only consumers
- live PDF diagram rendering paths stayed covered by adapter/PDF suites

out of scope
- next dead-code scan starts after this PR merges