### PR TITLE
Remove dead history export wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
   Reduces data loss from brief lock contention.
 - **Stale-run recovery logging** — `create_run()` now logs a warning when it
   recovers stale recording runs, providing visibility into interrupted sessions.
-- **Export NaN/Inf sanitization** — `build_run_details_json()` scrubs
+- **Export NaN/Inf sanitization** — export JSON serialization scrubs
   non-finite float values before JSON serialization, preventing export failures.
 - **Docker resource limits** — `docker-compose.yml` now sets `mem_limit`,
   `memswap_limit` (384MB), and `pids_limit` (200) for Pi deployment safety.

--- a/apps/server/tests/integration/test_decode_project_roundtrip.py
+++ b/apps/server/tests/integration/test_decode_project_roundtrip.py
@@ -205,7 +205,7 @@ def test_report_from_reconstructed_aggregate(tmp_path: Path) -> None:
 
 
 def test_export_from_reconstructed_aggregate(tmp_path: Path) -> None:
-    """build_run_details_json must produce valid JSON from a history run
+    """build_projected_run_details_json must produce valid JSON from a history run
     whose analysis was projected through domain."""
     _analysis, result = _run_analysis()
     direct_summary = analysis_result_to_summary(result)

--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -29,7 +29,7 @@ from vibesensor.shared.run_context_warning import (
 from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.sensor_frame import SensorFrame
-from vibesensor.use_cases.history.exports import HistoryExportService, build_run_details_json
+from vibesensor.use_cases.history.exports import HistoryExportService
 from vibesensor.use_cases.history.report_cache import HistoryReportPdfCache
 from vibesensor.use_cases.history.report_loader import HistoryReportRequestLoader
 from vibesensor.use_cases.history.runs import HistoryRunService, raise_delete_run_error
@@ -353,10 +353,10 @@ async def test_projected_run_service_drops_persisted_origin_without_primary_find
     assert "_internal" not in analysis
 
 
-def test_build_run_details_json_strips_internal_analysis_fields() -> None:
+def test_build_projected_run_details_json_strips_internal_analysis_fields() -> None:
     payload = json.loads(
-        build_run_details_json(
-            run=_stored_run(
+        build_projected_run_details_json(
+            _stored_run(
                 {
                     "run_id": "run-1",
                     "analysis": {"visible": 1, "_internal": {"secret": True}},
@@ -364,7 +364,7 @@ def test_build_run_details_json_strips_internal_analysis_fields() -> None:
             ),
             sample_count=5,
             run_id="run-1",
-        ),
+        )
     )
 
     assert payload["sample_count"] == 5
@@ -453,9 +453,9 @@ def test_project_history_insights_keeps_non_projectable_analysis_shape() -> None
     }
 
 
-def test_build_run_details_json_sanitizes_non_finite_floats() -> None:
+def test_build_projected_run_details_json_sanitizes_non_finite_floats() -> None:
     """Non-finite floats in analysis are replaced with null, producing valid JSON."""
-    result = build_run_details_json(
+    result = build_projected_run_details_json(
         _stored_run(
             {
                 "run_id": "run-nan",

--- a/apps/server/vibesensor/use_cases/history/exports.py
+++ b/apps/server/vibesensor/use_cases/history/exports.py
@@ -17,10 +17,7 @@ from vibesensor.shared.json_utils import sanitize_for_json
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.json_types import JsonObject
-from vibesensor.use_cases.history.helpers import (
-    async_require_run,
-    strip_internal_fields,
-)
+from vibesensor.use_cases.history.helpers import async_require_run
 
 LOGGER = logging.getLogger(__name__)
 
@@ -168,15 +165,3 @@ def serialize_run_details_json(run_details: JsonObject, *, sample_count: int, ru
         sort_keys=True,
         allow_nan=False,
     )
-
-
-def build_run_details_json(
-    run: StoredHistoryRun,
-    sample_count: int,
-    run_id: str,
-) -> str:
-    """Build the exported JSON metadata document for a history run."""
-    run_details = run.to_json_object()
-    if run.analysis is not None:
-        run_details["analysis"] = strip_internal_fields(run.analysis.payload)
-    return serialize_run_details_json(run_details, sample_count=sample_count, run_id=run_id)


### PR DESCRIPTION
small

what changed
- removed dead `build_run_details_json()` from history exports
- retargeted export sanitization and internal-field coverage to the live projected export path
- updated stale changelog/internal wording

why
- runtime export path uses `build_projected_run_details_json()`
- dead wrapper was only referenced by tests and an internal changelog note

validation/tests
- `.venv/bin/pytest -q apps/server/tests/use_cases/history/test_history_http_services.py apps/server/tests/integration/test_decode_project_roundtrip.py`
- `make test-changed`
- `make lint`
- `make typecheck-backend`

risks tradeoffs edge
- low risk; behavior stayed covered on the live export path
- kept shared serializer in place because projected export still uses it

out of scope
- next dead-code scan starts after this PR merges