### PR TITLE
Drop dead PDF style leftovers

### DIFF
--- a/apps/server/vibesensor/adapters/pdf/pdf_style.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_style.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
 
@@ -59,17 +57,8 @@ FS_CARD_TITLE = 9.0
 
 R_CARD = 8
 GAP = 4 * mm
-DATA_TRUST_WIDTH_RATIO = 0.32
 PANEL_HEADER_H = 10.5 * mm
 
 _HELVETICA_AVG_CHAR_RATIO = 0.48
 
 # ── Page Geometry ────────────────────────────────────────────────────────────
-
-
-@dataclass(frozen=True)
-class PanelLayout:
-    x: float
-    y: float
-    w: float
-    h: float


### PR DESCRIPTION
tiny

what changed
- removed definition-only `PanelLayout` and `DATA_TRUST_WIDTH_RATIO` from `pdf_style.py`

why
- both became dead after the earlier PDF layout helper pruning

validation/tests
- `.venv/bin/pytest -q apps/server/tests/adapters/pdf/test_report_pdf_rendering.py`
- `make test-changed`
- `make lint`
- `make typecheck-backend`

risks tradeoffs edge
- low risk; pure deletion of symbols with zero repo references