### PR TITLE
test(websocket): harden WS schema smoke

### DIFF
--- a/apps/server/tests/adapters/websocket/test_ws_models.py
+++ b/apps/server/tests/adapters/websocket/test_ws_models.py
@@ -19,12 +19,47 @@ from vibesensor.vibration_strength import empty_vibration_strength_metrics
 
 
 def test_schema_export_check_passes() -> None:
-    """Verify the committed schema matches what the export generates."""
+    """Verify the exported schema exposes the live WS contract shape consumers use."""
     generated = export_schema()
-    assert len(generated) > 100, "Schema should be non-trivial"
     parsed = json.loads(generated)
-    assert "properties" in parsed
-    assert "schema_version" in parsed["properties"]
+    assert parsed["title"] == "LiveWsPayload"
+    assert parsed["type"] == "object"
+
+    properties = parsed["properties"]
+    assert set(properties) == {
+        "schema_version",
+        "server_time",
+        "speed_mps",
+        "clients",
+        "selected_client_id",
+        "rotational_speeds",
+        "spectra",
+    }
+    assert set(parsed["required"]) == {
+        "schema_version",
+        "server_time",
+        "speed_mps",
+        "clients",
+        "selected_client_id",
+        "rotational_speeds",
+    }
+    assert properties["spectra"] == {"$ref": "#/$defs/SpectraPayload"}
+    assert properties["rotational_speeds"]["anyOf"] == [
+        {"$ref": "#/$defs/RotationalSpeedsPayload"},
+        {"type": "null"},
+    ]
+
+    rotational_speeds = parsed["$defs"]["RotationalSpeedsPayload"]
+    assert set(rotational_speeds["required"]) == {
+        "basis_speed_source",
+        "wheel",
+        "driveshaft",
+        "engine",
+        "order_bands",
+    }
+
+    spectra = parsed["$defs"]["SpectraPayload"]
+    assert set(spectra["properties"]) == {"alignment", "clients", "freq", "warning"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Weak WS schema smoke check only proved schema had length and `schema_version`. Replace with contract-shape assertions over exported `LiveWsPayload`.

## What changed
- strengthen `test_schema_export_check_passes()` in `test_ws_models.py`
- assert top-level WS payload keys and required fields
- assert nullable `rotational_speeds` contract, optional `spectra` contract, and nested schema structure

## Why
Length check easy satisfy while real contract drifts. New assertions hit shape UI and WS consumers care about.

## Validation
- `.venv/bin/pytest -q apps/server/tests/adapters/websocket/`
- `.venv/bin/ruff check apps/server/tests/adapters/websocket/test_ws_models.py`

## Risk / tradeoffs
- low risk: test-only change
- schema assertions more specific, so intentional WS contract edits must update this smoke check too
- local `ci-lite` wrapper blocked on this host because `make`/`node` missing; covered touched backend area directly instead

Closes #2799
