### PR TITLE
test(ui): replace smoke spec hard sleeps

### DIFF
--- a/apps/ui/tests/realtime_logging_summary.spec.ts
+++ b/apps/ui/tests/realtime_logging_summary.spec.ts
@@ -1,8 +1,15 @@
 import { expect, test } from "@playwright/test";
 
-import { fulfillJson, installCommonRoutes, installFakeWebSocket, requestPath } from "./smoke.helpers";
+import {
+  fulfillJson,
+  installCommonRoutes,
+  installFakeWebSocket,
+  requestPath,
+  waitForFakeWebSocketSettled,
+} from "./smoke.helpers";
 
 test("keeps the no-car Live CTA stable while repeated websocket payloads arrive", async ({ page }) => {
+  const trackerKey = "__loggingSummaryRepeatTracker";
   await installCommonRoutes(page, {
     settingsHandler: async (route) => {
       const path = requestPath(route);
@@ -34,6 +41,7 @@ test("keeps the no-car Live CTA stable while repeated websocket payloads arrive"
     },
     repeatPayloadCount: 16,
     repeatPayloadIntervalMs: 25,
+    trackerKey,
   });
 
   await page.goto("/");
@@ -75,7 +83,7 @@ test("keeps the no-car Live CTA stable while repeated websocket payloads arrive"
     ).__loggingSummaryObserver = observer;
   });
 
-  await page.waitForTimeout(450);
+  await waitForFakeWebSocketSettled(page, trackerKey, 17);
 
   expect(await page.evaluate(() => (
     window as Window & typeof globalThis & {

--- a/apps/ui/tests/smoke.cars.spec.ts
+++ b/apps/ui/tests/smoke.cars.spec.ts
@@ -162,7 +162,6 @@ test("dark mode quiet danger buttons use semantic danger tokens in Cars", async 
     deleteButtonBox.y + (deleteButtonBox.height / 2),
   );
   await expect.poll(() => deleteButton.evaluate((element) => element.matches(":hover"))).toBe(true);
-  await page.waitForTimeout(150);
   const hoverStyles = await readSemanticToneStyles(deleteButton, {
     surfaceVar: "--button-danger-quiet-hover-surface",
     borderVar: "--button-danger-quiet-hover-border",
@@ -222,8 +221,7 @@ test("routes no-car blockers to the add-car flow from Live and Cars", async ({ p
   await expect(page.locator("#analysisNoCarMessage")).toBeVisible();
   await expect(page.locator("#saveAnalysisBtn")).toBeDisabled();
   await expect(page.locator("#resetAnalysisBtn")).toBeDisabled();
-  await page.waitForTimeout(150);
-  await expect.poll(() => analysisPutCalls).toBe(0);
+  expect(analysisPutCalls).toBe(0);
 });
 
 test("hides contextual car guidance when a valid selected car exists", async ({ page }) => {

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -5,10 +5,11 @@ export type FakeWebSocketOptions = {
   payload?: Record<string, unknown>;
   repeatPayloadCount?: number;
   repeatPayloadIntervalMs?: number;
+  trackerKey?: string;
 };
 
 export async function installFakeWebSocket(page: Page, options: FakeWebSocketOptions = {}): Promise<void> {
-  await page.addInitScript(({ payload, schemaVersion, repeatPayloadCount, repeatPayloadIntervalMs }) => {
+  await page.addInitScript(({ payload, schemaVersion, repeatPayloadCount, repeatPayloadIntervalMs, trackerKey }) => {
     const mergedPayload = payload
       ? {
           schema_version: schemaVersion,
@@ -20,6 +21,16 @@ export async function installFakeWebSocket(page: Page, options: FakeWebSocketOpt
           ...payload,
         }
       : null;
+    const globalState = window as Window & typeof globalThis & Record<string, unknown>;
+    const tracker = trackerKey
+      ? {
+          deliveredCount: 0,
+          repeatTimerActive: false,
+        }
+      : null;
+    if (trackerKey && tracker) {
+      globalState[trackerKey] = tracker;
+    }
     class FakeWebSocket {
       static OPEN = 1;
       readyState = 1;
@@ -31,15 +42,25 @@ export async function installFakeWebSocket(page: Page, options: FakeWebSocketOpt
       constructor() {
         queueMicrotask(() => this.onopen?.(new Event("open")));
         if (mergedPayload) {
-          const emitPayload = () =>
+          const emitPayload = () => {
+            if (tracker) {
+              tracker.deliveredCount += 1;
+            }
             this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(mergedPayload) }));
+          };
           queueMicrotask(emitPayload);
           if ((repeatPayloadCount ?? 0) > 0) {
+            if (tracker) {
+              tracker.repeatTimerActive = true;
+            }
             let remainingRepeats = repeatPayloadCount ?? 0;
             this.repeatTimer = window.setInterval(() => {
               if (this.readyState !== FakeWebSocket.OPEN) {
                 window.clearInterval(this.repeatTimer);
                 this.repeatTimer = 0;
+                if (tracker) {
+                  tracker.repeatTimerActive = false;
+                }
                 return;
               }
               emitPayload();
@@ -47,6 +68,9 @@ export async function installFakeWebSocket(page: Page, options: FakeWebSocketOpt
               if (remainingRepeats <= 0) {
                 window.clearInterval(this.repeatTimer);
                 this.repeatTimer = 0;
+                if (tracker) {
+                  tracker.repeatTimerActive = false;
+                }
               }
             }, repeatPayloadIntervalMs ?? 50);
           }
@@ -57,6 +81,9 @@ export async function installFakeWebSocket(page: Page, options: FakeWebSocketOpt
         if (this.repeatTimer) {
           window.clearInterval(this.repeatTimer);
           this.repeatTimer = 0;
+          if (tracker) {
+            tracker.repeatTimerActive = false;
+          }
         }
         this.readyState = 3;
         this.onclose?.(new CloseEvent("close"));
@@ -64,6 +91,36 @@ export async function installFakeWebSocket(page: Page, options: FakeWebSocketOpt
     }
     window.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
   }, { ...options, schemaVersion: EXPECTED_SCHEMA_VERSION });
+}
+
+export async function waitForFakeWebSocketSettled(
+  page: Page,
+  trackerKey: string,
+  minimumDeliveredCount: number,
+): Promise<void> {
+  await expect.poll(async () => {
+    const tracker = await page.evaluate((key) => {
+      const tracker = (
+        window as Window & typeof globalThis & Record<string, unknown>
+      )[key];
+      if (
+        typeof tracker !== "object"
+        || tracker === null
+        || !("deliveredCount" in tracker)
+        || !("repeatTimerActive" in tracker)
+        || typeof tracker.deliveredCount !== "number"
+        || typeof tracker.repeatTimerActive !== "boolean"
+      ) {
+        throw new Error(`Missing fake WebSocket tracker: ${key}`);
+      }
+      return {
+        deliveredCount: tracker.deliveredCount,
+        repeatTimerActive: tracker.repeatTimerActive,
+      };
+    }, trackerKey);
+    return tracker.repeatTimerActive === false
+      && tracker.deliveredCount >= minimumDeliveredCount;
+  }).toBe(true);
 }
 
 export async function confirmPrompt(page: Page): Promise<void> {

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -245,7 +245,6 @@ test("dark mode quiet danger buttons use semantic danger tokens in History", asy
     deleteButtonBox.y + (deleteButtonBox.height / 2),
   );
   await expect.poll(() => deleteButton.evaluate((element) => element.matches(":hover"))).toBe(true);
-  await page.waitForTimeout(150);
   const hoverStyles = await readSemanticToneStyles(deleteButton, {
     surfaceVar: "--button-danger-quiet-hover-surface",
     borderVar: "--button-danger-quiet-hover-border",
@@ -493,10 +492,8 @@ test("history PDF download revokes object URL with safe delay", async ({ page })
   await expect(pdfButton).toBeVisible();
   await pdfButton.click();
   await expect.poll(() => reportPdfCalls).toBe(1);
-  await page.waitForTimeout(200);
   expect(await revokeCallCount()).toBe(0);
-  await page.waitForTimeout(1000);
-  expect(await revokeCallCount()).toBe(1);
+  await expect.poll(revokeCallCount, { timeout: 2_000 }).toBe(1);
 });
 
 test("history loaded insights promote the result summary above supporting evidence", async ({ page }) => {

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -24,11 +24,21 @@ test("gps status uses selected speed unit in settings panel", async ({ page }) =
 });
 
 test("gps status polling does not override websocket speed readout", async ({ page }) => {
-  await installCommonRoutes(page, { settingsHandler: createSettingsHandlerFromMap({ "/api/settings/language": { language: "en" }, "/api/settings/speed-unit": { speed_unit: "kmh" }, "/api/settings/speed-source/status": gpsStatus({}) }) });
+  let gpsStatusCalls = 0;
+  await installCommonRoutes(page, {
+    settingsHandler: createSettingsHandlerFromMap({
+      "/api/settings/language": { language: "en" },
+      "/api/settings/speed-unit": { speed_unit: "kmh" },
+      "GET /api/settings/speed-source/status": async () => {
+        gpsStatusCalls += 1;
+        return gpsStatus({});
+      },
+    }),
+  });
   await installFakeWebSocket(page, { payload: { server_time: new Date().toISOString(), speed_mps: 20, clients: [], spectra: { clients: {} } } });
   await page.goto("/");
   await expect(page.locator("#speed")).toContainText("72.0 km/h");
-  await page.waitForTimeout(500);
+  await expect.poll(() => gpsStatusCalls, { timeout: 5_000 }).toBeGreaterThanOrEqual(2);
   await expect(page.locator("#speed")).toContainText("72.0 km/h");
 });
 
@@ -817,7 +827,8 @@ test("background OBD rescans stop when the Speed Source OBD panel is no longer v
   await page.locator('[data-speed-source-choice="gps"]').click();
 
   const stoppedAt = scanCalls;
-  await page.waitForTimeout(2_500);
+  await expect(page.locator('input[name="speedSourceRadio"][value="gps"]')).toBeChecked();
+  await expect(page.locator("#obdSpeedConfig")).toBeHidden();
   expect(scanCalls).toBe(stoppedAt);
 });
 

--- a/apps/ui/tests/smoke.spectrum.spec.ts
+++ b/apps/ui/tests/smoke.spectrum.spec.ts
@@ -6,6 +6,7 @@ import {
   installCommonRoutes,
   installFakeWebSocket,
   requestPath,
+  waitForFakeWebSocketSettled,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 12_000 });
@@ -64,6 +65,7 @@ test("spectrum controls simplify the chart and update the inspector", async ({ p
 });
 
 test("spectrum controls stay interactive while repeated websocket updates arrive", async ({ page }) => {
+  const trackerKey = "__spectrumRepeatTracker";
   await installCommonRoutes(page, {
     locations: [
       { code: "front_left_wheel", label: "Front Left Wheel" },
@@ -172,6 +174,7 @@ test("spectrum controls stay interactive while repeated websocket updates arrive
     },
     repeatPayloadCount: 6,
     repeatPayloadIntervalMs: 50,
+    trackerKey,
   });
 
   await page.goto("/");
@@ -196,7 +199,7 @@ test("spectrum controls stay interactive while repeated websocket updates arrive
   await expect(bandToggle).toHaveAttribute("aria-pressed", "true");
   await expect(bandLegend).toBeVisible();
 
-  await page.waitForTimeout(350);
+  await waitForFakeWebSocketSettled(page, trackerKey, 7);
 
   await expect(sensorChip).toHaveAttribute("aria-pressed", "true");
   await expect(sensorChip).toHaveAttribute("data-legend-state", "active");


### PR DESCRIPTION
## What changed
- remove all `page.waitForTimeout(...)` calls in scoped smoke specs
- add fake WebSocket tracker helper so repeated-payload specs wait for delivery settlement
- switch remaining waits to CSS hover state, GPS status request counts, revoke counts, and GPS-selected / OBD-hidden panel state

## Why
- hard sleeps wait for time, not state
- state waits keep same test intent with less flake and less dead time

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts --project=laptop-light tests/smoke.history.spec.ts tests/smoke.spectrum.spec.ts tests/smoke.settings.spec.ts tests/smoke.cars.spec.ts tests/realtime_logging_summary.spec.ts`

## Risks / tradeoffs
- fake WebSocket settle helper waits for minimum delivered payload count plus inactive repeat timer, not exact count, because spectrum flow can open more than one fake socket during same test
- OBD rescan-stop check keys off GPS radio checked plus hidden OBD panel because that state stops polling controller

## Out of scope
- broader Playwright test redesign
