### PR TITLE
test(ui): narrow default visual lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,10 +291,12 @@ cd apps/ui
 npx playwright install chromium   # first time only
 npm run test:visual               # compare against baselines
 npm run test:visual:update        # regenerate after intentional changes
+npm run test:visual:audit         # run broader visual audit on purpose
 ```
 
-Screenshots are captured for 4 viewports (laptop-light, laptop-dark,
-tablet-light, tablet-dark) using a deterministic demo mode (`?demo=1`).
+Default snapshot coverage uses one intentional viewport (`laptop-light`) with a
+deterministic demo mode (`?demo=1`). When you want broader visual coverage, run
+the opt-in audit sweep for the full laptop/tablet light/dark matrix.
 Baselines live in `apps/ui/tests/snapshots/`.
 
 ## Reports

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -340,23 +340,33 @@ frame instead of the normal payload.
 
 ## Visual Tests
 
-Playwright snapshot tests capture the UI across 4 viewports:
+Playwright snapshot tests default to one intentional regression target:
 
-| Viewport | Theme |
-|----------|-------|
-| Laptop (1280x800) | Light |
-| Laptop (1280x800) | Dark |
-| Tablet (768x1024) | Light |
-| Tablet (768x1024) | Dark |
+| Viewport | Theme | Command |
+|----------|-------|---------|
+| Laptop (1280x800) | Light | `npm run test:visual` |
+
+Use the broader visual audit sweep only on purpose:
+
+| Viewport | Theme | Command |
+|----------|-------|---------|
+| Laptop (1280x800) | Light | `npm run test:visual:audit` |
+| Laptop (1280x800) | Dark | `npm run test:visual:audit` |
+| Tablet (768x1024) | Light | `npm run test:visual:audit` |
+| Tablet (768x1024) | Dark | `npm run test:visual:audit` |
 
 ```bash
 npx playwright install chromium   # first time only
 npm run test:visual               # compare against baselines
 npm run test:visual:update        # regenerate after intentional changes
+npm run test:visual:audit         # run wider multi-viewport audit on purpose
 npm run wiki:screenshots          # capture release/wiki screenshots (build dist first)
 ```
 
-Baselines live in `tests/snapshots/`. Tests use demo mode for deterministic payloads.
+Baselines live in `tests/snapshots/`. Tests use demo mode for deterministic
+payloads. The default lane stays on `laptop-light`; the audit command keeps the
+older multi-viewport sweep available when broader visual review is worth the
+cost.
 
 The release/wiki screenshot flow is separate from the visual-regression baselines.
 It runs `tests/wiki_screenshots.spec.ts` through `playwright.wiki.config.ts` and

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -22,6 +22,8 @@
     "test:signals": "tsx tests/signal_view_reference_tests.ts",
     "test:visual": "npx playwright test",
     "test:visual:update": "npx playwright test --update-snapshots",
+    "test:visual:audit": "npx playwright test --config=playwright.visual-audit.config.ts",
+    "test:visual:audit:update": "npx playwright test --config=playwright.visual-audit.config.ts --update-snapshots",
     "wiki:screenshots": "npx playwright test --config=playwright.wiki.config.ts tests/wiki_screenshots.spec.ts --workers=1",
     "screenshot": "node take-screenshot.mjs",
     "snapshot:update": "node update-snapshots.mjs",

--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -1,6 +1,48 @@
 import { defineConfig, devices } from "@playwright/test";
 
-export default defineConfig({
+const laptopLightProject = {
+  name: "laptop-light",
+  use: {
+    ...devices["Desktop Chrome"],
+    viewport: { width: 1280, height: 800 },
+    colorScheme: "light" as const,
+  },
+};
+
+export const visualAuditProjects = [
+  laptopLightProject,
+  {
+    name: "laptop-dark",
+    use: {
+      ...devices["Desktop Chrome"],
+      viewport: { width: 1280, height: 800 },
+      colorScheme: "dark" as const,
+    },
+  },
+  {
+    name: "tablet-light",
+    use: {
+      ...devices["iPad (gen 7)"],
+      // Use Chromium for all projects (only browser installed)
+      channel: undefined,
+      browserName: "chromium" as const,
+      colorScheme: "light" as const,
+      hasTouch: true,
+    },
+  },
+  {
+    name: "tablet-dark",
+    use: {
+      ...devices["iPad (gen 7)"],
+      channel: undefined,
+      browserName: "chromium" as const,
+      colorScheme: "dark" as const,
+      hasTouch: true,
+    },
+  },
+];
+
+export const visualBaseConfig = {
   testDir: "tests",
   outputDir: "tests/test-results",
   snapshotDir: "tests/snapshots",
@@ -21,43 +63,9 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },
-  projects: [
-    {
-      name: "laptop-light",
-      use: {
-        ...devices["Desktop Chrome"],
-        viewport: { width: 1280, height: 800 },
-        colorScheme: "light",
-      },
-    },
-    {
-      name: "laptop-dark",
-      use: {
-        ...devices["Desktop Chrome"],
-        viewport: { width: 1280, height: 800 },
-        colorScheme: "dark",
-      },
-    },
-    {
-      name: "tablet-light",
-      use: {
-        ...devices["iPad (gen 7)"],
-        // Use Chromium for all projects (only browser installed)
-        channel: undefined,
-        browserName: "chromium",
-        colorScheme: "light",
-        hasTouch: true,
-      },
-    },
-    {
-      name: "tablet-dark",
-      use: {
-        ...devices["iPad (gen 7)"],
-        channel: undefined,
-        browserName: "chromium",
-        colorScheme: "dark",
-        hasTouch: true,
-      },
-    },
-  ],
+};
+
+export default defineConfig({
+  ...visualBaseConfig,
+  projects: [laptopLightProject],
 });

--- a/apps/ui/playwright.visual-audit.config.ts
+++ b/apps/ui/playwright.visual-audit.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "@playwright/test";
+
+import { visualAuditProjects, visualBaseConfig } from "./playwright.config";
+
+export default defineConfig({
+  ...visualBaseConfig,
+  projects: visualAuditProjects,
+});

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -133,11 +133,14 @@ Use the standard UI workflow for `apps/ui/**` changes:
 ```bash
 cd apps/ui && npm run typecheck && npm run build
 cd apps/ui && npm run test:visual
+cd apps/ui && npm run test:visual:audit   # optional broader visual sweep
 python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-smoke
 ```
 
 - `npm run test:visual` is the rendered-state and snapshot gate; use
   `npm run test:visual:update` only for intentional baseline changes.
+- `npm run test:visual:audit` is the opt-in four-project visual audit sweep
+  when you need dark/tablet coverage on purpose instead of in the default lane.
 - `frontend-typecheck` is the contract/type gate, while `ui-smoke` is the CI
   browser path. Use `act -j frontend-typecheck -W .github/workflows/ci.yml` or
   `act -j ui-smoke -W .github/workflows/ci.yml` when you need GitHub-workflow


### PR DESCRIPTION
## What changed
- shrink default `playwright.config.ts` visual project matrix to one intentional `laptop-light` project
- add `playwright.visual-audit.config.ts` plus `npm run test:visual:audit` and `npm run test:visual:audit:update` for the old 4-project sweep on purpose
- update UI/root/testing docs so default visual guidance matches the narrower lane and points broader review to the audit command

## Why
- default visual coverage was multiplying one snapshot spec across four projects even though this path is a local/docs-facing workflow
- narrower default lane keeps intentional visual coverage while cutting baseline drift and snapshot cost

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run test:visual`
- `cd apps/ui && npm run test:visual:audit`

## Risks / tradeoffs
- default `npm run test:visual` still runs the existing UI Playwright test dir; this change narrows project surface, not test-file selection
- broader dark/tablet snapshot coverage becomes opt-in through the new audit command instead of default behavior

## Out of scope
- broader Playwright test selection redesign
