### PR TITLE
test(ui): isolate wiki screenshot lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,16 @@ deterministic demo mode (`?demo=1`). When you want broader visual coverage, run
 the opt-in audit sweep for the full laptop/tablet light/dark matrix.
 Baselines live in `apps/ui/tests/snapshots/`.
 
+Wiki screenshot generation is separate from that visual regression lane:
+
+```bash
+cd apps/ui
+npm run wiki:screenshots
+```
+
+It writes to `apps/ui/wiki-screenshots/` by default, or to
+`$WIKI_SCREENSHOT_DIR` when you want an explicit output directory.
+
 ## Reports
 
 Generate a PDF diagnostic report from a recorded run:

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -366,7 +366,7 @@ npm run wiki:screenshots          # capture release/wiki screenshots (build dist
 Baselines live in `tests/snapshots/`. Tests use demo mode for deterministic
 payloads. The default lane stays on `laptop-light`; the audit command keeps the
 older multi-viewport sweep available when broader visual review is worth the
-cost.
+cost. Both visual commands only run `tests/visual.spec.ts`.
 
 The release/wiki screenshot flow is separate from the visual-regression baselines.
 It runs `tests/wiki_screenshots.spec.ts` through `playwright.wiki.config.ts` and
@@ -374,6 +374,16 @@ captures a curated laptop-light set of product screenshots with realistic seeded
 data for Live, History, Cars, Analysis, and Speed Source. Release CI publishes
 only these screenshot assets into the existing GitHub wiki; the wiki markdown
 pages are seeded manually.
+
+Run it on purpose with:
+
+```bash
+npm run wiki:screenshots
+```
+
+Screenshots write to `apps/ui/wiki-screenshots/` by default. Set
+`WIKI_SCREENSHOT_DIR=/path/to/output` when you need a different deterministic
+output directory.
 
 ## Signal-driven island tests
 

--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -44,6 +44,7 @@ export const visualAuditProjects = [
 
 export const visualBaseConfig = {
   testDir: "tests",
+  testMatch: ["visual.spec.ts"],
   outputDir: "tests/test-results",
   snapshotDir: "tests/snapshots",
   snapshotPathTemplate: "{snapshotDir}/{testFilePath}/{arg}-{projectName}{ext}",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -141,6 +141,9 @@ python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-smoke
   `npm run test:visual:update` only for intentional baseline changes.
 - `npm run test:visual:audit` is the opt-in four-project visual audit sweep
   when you need dark/tablet coverage on purpose instead of in the default lane.
+- `npm run wiki:screenshots` is separate docs asset generation. It does not
+  belong to the default visual lane; by default it writes screenshots under
+  `apps/ui/wiki-screenshots/` unless `WIKI_SCREENSHOT_DIR` overrides the path.
 - `frontend-typecheck` is the contract/type gate, while `ui-smoke` is the CI
   browser path. Use `act -j frontend-typecheck -W .github/workflows/ci.yml` or
   `act -j ui-smoke -W .github/workflows/ci.yml` when you need GitHub-workflow


### PR DESCRIPTION
## What changed
- make the shared visual Playwright config match only `visual.spec.ts`
- keep `wiki_screenshots.spec.ts` on the dedicated `wiki:screenshots` command and wiki config
- document the intentional wiki generation path plus default output dir / `WIKI_SCREENSHOT_DIR` override

## Why
- default visual runs were still sweeping the wiki screenshot generator by accident
- wiki asset export is useful, but it belongs on an explicit docs-generation path, not the normal visual lane

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run test:visual`
- `cd apps/ui && npm run test:visual:audit`
- `cd apps/ui && WIKI_SCREENSHOT_DIR=$(mktemp -d) npm run wiki:screenshots`

## Risks / tradeoffs
- this narrows default visual selection to the real snapshot spec only; broader Playwright selection stays out of scope
- wiki screenshots still write the same file set, but only when the dedicated command is run

## Out of scope
- rewriting wiki demo payloads or screenshot file names
