### PR TITLE
test(pdf): isolate OCR audit lane

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -66,7 +66,7 @@ where = ["."]
 include = ["vibesensor*"]
 
 [tool.pytest.ini_options]
-addopts = "-n auto --dist worksteal"
+addopts = "-n auto --dist worksteal -m 'not ocr_audit'"
 asyncio_mode = "auto"
 timeout = 120
 # Keep tests/ importable so shared helpers use `from test_support...` short imports.
@@ -75,6 +75,7 @@ testpaths = ["tests"]
 markers = [
     "e2e: end-to-end tests",
     "long_sim: longer simulated-run tests (>20 s of synthetic data)",
+    "ocr_audit: OCR and rasterized PDF audit tests kept out of the default correctness lane",
     "smoke: minimal critical path checks",
 ]
 filterwarnings = [

--- a/apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py
@@ -19,6 +19,8 @@ from vibesensor.use_cases.history.report_document import build_report_document
 pdfium = pytest.importorskip("pypdfium2")
 RapidOCR = pytest.importorskip("rapidocr_onnxruntime").RapidOCR
 
+pytestmark = pytest.mark.ocr_audit
+
 
 def _normalize_text(value: str) -> str:
     normalized = value.lower()

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -149,6 +149,22 @@ python3 tools/tests/run_ci_parallel.py --job frontend-typecheck --job ui-smoke
   `act -j ui-smoke -W .github/workflows/ci.yml` when you need GitHub-workflow
   parity for those jobs.
 
+## PDF OCR audit
+
+The heavyweight OCR/rasterized PDF text-fidelity audit is intentionally excluded
+from the default backend pytest lane. Run it only on purpose:
+
+```bash
+cd apps/server
+VIBESENSOR_OCR_AUDIT_DIR="$PWD/../../artifacts/pdf-ocr-audit" \
+  python3 -m pytest -o addopts='' -m ocr_audit \
+  tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py
+```
+
+`VIBESENSOR_OCR_AUDIT_DIR` is optional but recommended when you want the PDF,
+PNG, and JSON audit artifacts to land in a deterministic retained directory
+instead of pytest's temp path.
+
 ## Firmware and Pi-image validation
 
 Use the narrowest existing validation path that matches the layer you changed:


### PR DESCRIPTION
## What changed
- add `ocr_audit` marker to the OCR/rasterized PDF text-fidelity module
- exclude that marker from default backend pytest addopts
- document the explicit retained-artifact command in `docs/testing.md`

## Why
- keep the normal backend correctness lane free of the heavy OCR audit
- keep the OCR check runnable on purpose when PDF text fidelity needs a real audit

## Validation
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf/test_report_pdf_rendering.py`
- `.venv/bin/python -m pytest --collect-only apps/server/tests/adapters/pdf`
- `VIBESENSOR_OCR_AUDIT_DIR=$(mktemp -d) .venv/bin/python -m pytest -o addopts='' -q -m ocr_audit apps/server/tests/adapters/pdf/test_report_pdf_ocr_text_fidelity.py`

## Risk / tradeoffs
- default backend pytest no longer runs the OCR audit automatically
- lightweight PDF rendering/content checks stay in the default lane; OCR stays opt-in by design