### PR TITLE
test(pdf): isolate visual audit lane

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -66,7 +66,7 @@ where = ["."]
 include = ["vibesensor*"]
 
 [tool.pytest.ini_options]
-addopts = "-n auto --dist worksteal -m 'not ocr_audit'"
+addopts = "-n auto --dist worksteal -m 'not ocr_audit and not visual_audit'"
 asyncio_mode = "auto"
 timeout = 120
 # Keep tests/ importable so shared helpers use `from test_support...` short imports.
@@ -77,6 +77,7 @@ markers = [
     "long_sim: longer simulated-run tests (>20 s of synthetic data)",
     "ocr_audit: OCR and rasterized PDF audit tests kept out of the default correctness lane",
     "smoke: minimal critical path checks",
+    "visual_audit: screenshot-exporting visual audit tests kept out of the default correctness lane",
 ]
 filterwarnings = [
     "ignore:cannot collect test class 'TestRun':pytest.PytestCollectionWarning",

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
@@ -41,6 +41,7 @@ def test_car_diagram_shell_uses_contoured_paths_and_detail_polygons() -> None:
     assert shape_counts["Rect"] >= 4
 
 
+@pytest.mark.visual_audit
 def test_appendix_b_diagram_visual_audit_exports_screenshot(tmp_path: Path) -> None:
     audit_root_env = os.getenv("VIBESENSOR_DIAGRAM_AUDIT_DIR")
     artifact_dir = Path(audit_root_env) if audit_root_env else tmp_path / "diagram_audit"

--- a/apps/server/tests/adapters/pdf/test_report_pdf_timeline_visual_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_timeline_visual_audit.py
@@ -17,6 +17,7 @@ from vibesensor.use_cases.history.report_document import build_report_document
 pdfium = pytest.importorskip("pypdfium2")
 
 
+@pytest.mark.visual_audit
 def test_page_one_timeline_visual_audit_exports_screenshot(tmp_path: Path) -> None:
     audit_root_env = os.getenv("VIBESENSOR_TIMELINE_AUDIT_DIR")
     artifact_dir = Path(audit_root_env) if audit_root_env else tmp_path / "timeline_audit"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -165,6 +165,24 @@ VIBESENSOR_OCR_AUDIT_DIR="$PWD/../../artifacts/pdf-ocr-audit" \
 PNG, and JSON audit artifacts to land in a deterministic retained directory
 instead of pytest's temp path.
 
+## PDF visual audits
+
+The screenshot-exporting PDF visual audits are also intentionally excluded from
+the default backend pytest lane. Run them only on purpose:
+
+```bash
+cd apps/server
+VIBESENSOR_DIAGRAM_AUDIT_DIR="$PWD/../../artifacts/pdf-diagram-audit" \
+  VIBESENSOR_TIMELINE_AUDIT_DIR="$PWD/../../artifacts/pdf-timeline-audit" \
+  python3 -m pytest -o addopts='' -m visual_audit \
+  tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py \
+  tests/adapters/pdf/test_report_pdf_timeline_visual_audit.py
+```
+
+The fast structural diagram assertion in
+`test_report_pdf_diagram_visual_audit.py` stays in the normal correctness lane;
+only the artifact-exporting screenshot checks moved behind `visual_audit`.
+
 ## Firmware and Pi-image validation
 
 Use the narrowest existing validation path that matches the layer you changed:


### PR DESCRIPTION
## What changed
- add `visual_audit` marker to the screenshot-exporting PDF diagram and timeline audit tests
- exclude that marker from default backend pytest addopts
- keep the fast structural diagram assertion in the normal lane
- document the explicit retained-artifact command in `docs/testing.md`

## Why
- stop the default correctness lane from producing screenshot audit artifacts
- keep the PDF visual audits runnable on purpose when manual review is needed

## Validation
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py apps/server/tests/adapters/pdf/test_report_pdf_timeline_visual_audit.py`
- `.venv/bin/python -m pytest --collect-only apps/server/tests/adapters/pdf`
- `VIBESENSOR_DIAGRAM_AUDIT_DIR=$(mktemp -d) VIBESENSOR_TIMELINE_AUDIT_DIR=$(mktemp -d) .venv/bin/python -m pytest -o addopts='' -q -m visual_audit apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py apps/server/tests/adapters/pdf/test_report_pdf_timeline_visual_audit.py`

## Risk / tradeoffs
- default backend pytest no longer runs the screenshot-exporting PDF visual audits automatically
- fast structural diagram coverage stays in the default lane; artifact generation is opt-in by design