### PR TITLE
refactor(ui): move wizard focus into panel

### DIFF
--- a/apps/ui/src/app/views/cars_panel.tsx
+++ b/apps/ui/src/app/views/cars_panel.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "preact/hooks";
 import { render } from "preact";
 
 import type { CarsFeatureFocusTarget } from "../features/cars_feature_workflow";
@@ -23,7 +24,7 @@ import {
   type CarsFeatureInteractionHandlers,
 } from "./cars_wizard_panel";
 import {
-  useCarsWizardFocusManager,
+  useCarsWizardElementRefs,
   type CarsWizardFocusRequest,
 } from "./cars_wizard_focus";
 import type { DeferredModelSignal } from "./view_model_binding";
@@ -70,10 +71,9 @@ function CarsPanel(props: {
   const wizardModel = useComputed(
     () => props.state.value.wizardModel?.value ?? DEFAULT_CARS_WIZARD_MODEL,
   );
-  const { addCarButtonRef, wizardRefs } = useCarsWizardFocusManager({
-    state: props.state,
-    wizardFocusRequest: props.wizardFocusRequest,
-  });
+  const addCarButtonRef = useRef<HTMLButtonElement | null>(null);
+  const wizardRefs = useCarsWizardElementRefs();
+  const focusRequest = props.wizardFocusRequest.value;
   const openWizard = () => {
     wizardActions.peek()?.onAction({ type: "open" });
   };
@@ -88,6 +88,8 @@ function CarsPanel(props: {
       />
       <CarsWizardPanel
         actions={wizardActions}
+        addCarButtonRef={addCarButtonRef}
+        focusRequest={focusRequest}
         refs={wizardRefs}
         wizardModel={wizardModel}
       />

--- a/apps/ui/src/app/views/cars_wizard_focus.ts
+++ b/apps/ui/src/app/views/cars_wizard_focus.ts
@@ -1,8 +1,5 @@
-import { useRef } from "preact/hooks";
-
 import type { CarsFeatureFocusTarget } from "../features/cars_feature_workflow";
-import { useSignalEffect, type ReadonlySignal } from "../ui_signals";
-import type { CarsWizardRenderModel } from "./car_wizard_view";
+import { useRef } from "preact/hooks";
 
 export type CarsWizardFocusElements = {
   addCarWizard: HTMLDivElement | null;
@@ -35,10 +32,6 @@ export type CarsWizardElementRefs = {
     key: Key,
   ) => (element: CarsWizardFocusElements[Key]) => void;
 };
-
-function focusElement(target: HTMLElement | null | undefined): void {
-  target?.focus();
-}
 
 function createCarsWizardFocusElements(): CarsWizardFocusElements {
   return {
@@ -102,68 +95,16 @@ export function resolveWizardFocusTarget(
   }
 }
 
-export function useCarsWizardFocusManager(props: {
-  state: ReadonlySignal<{ wizardModel: ReadonlySignal<CarsWizardRenderModel> | null }>;
-  wizardFocusRequest: ReadonlySignal<CarsWizardFocusRequest | null>;
-}): {
-  addCarButtonRef: { current: HTMLButtonElement | null };
-  wizardRefs: CarsWizardElementRefs;
-} {
-  const addCarButtonRef = useRef<HTMLButtonElement | null>(null);
+export function useCarsWizardElementRefs(): CarsWizardElementRefs {
   const elements = useRef<CarsWizardFocusElements>(createCarsWizardFocusElements());
-  const lastReturnFocusTargetRef = useRef<HTMLElement | null>(null);
-  const lastHandledFocusRequestTokenRef = useRef(0);
-  const lastWizardOpenStateRef = useRef(props.state.value.wizardModel?.value.isOpen ?? false);
-
-  const setElementRef: CarsWizardElementRefs["setElementRef"] = (key) => (element) => {
-    elements.current[key] = element;
-  };
-
-  useSignalEffect(() => {
-    const isOpen = props.state.value.wizardModel?.value.isOpen ?? false;
-    const wasOpen = lastWizardOpenStateRef.current;
-    if (isOpen && !wasOpen) {
-      const activeElement = document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null;
-      lastReturnFocusTargetRef.current =
-        activeElement && activeElement !== document.body ? activeElement : addCarButtonRef.current;
-      queueMicrotask(() => {
-        if (elements.current.addCarWizard) {
-          elements.current.addCarWizard.scrollTop = 0;
-        }
-      });
-    }
-    if (!isOpen && wasOpen) {
-      const target = lastReturnFocusTargetRef.current;
-      lastReturnFocusTargetRef.current = null;
-      queueMicrotask(() => {
-        const safeTarget = target && document.contains(target) ? target : addCarButtonRef.current;
-        focusElement(safeTarget);
-      });
-    }
-    lastWizardOpenStateRef.current = isOpen;
-  });
-
-  useSignalEffect(() => {
-    const wizardFocusRequest = props.wizardFocusRequest.value;
-    if (
-      !wizardFocusRequest ||
-      wizardFocusRequest.token === lastHandledFocusRequestTokenRef.current
-    ) {
-      return;
-    }
-    lastHandledFocusRequestTokenRef.current = wizardFocusRequest.token;
-    queueMicrotask(() => {
-      focusElement(resolveWizardFocusTarget(wizardFocusRequest.target, elements.current));
-    });
-  });
-
-  return {
-    addCarButtonRef,
-    wizardRefs: {
+  const refs = useRef<CarsWizardElementRefs | null>(null);
+  if (refs.current === null) {
+    refs.current = {
       elements,
-      setElementRef,
-    },
-  };
+      setElementRef: (key) => (element) => {
+        elements.current[key] = element;
+      },
+    };
+  }
+  return refs.current;
 }

--- a/apps/ui/src/app/views/cars_wizard_panel.tsx
+++ b/apps/ui/src/app/views/cars_wizard_panel.tsx
@@ -1,17 +1,21 @@
-import type { CarsFeatureFocusTarget } from "../features/cars_feature_workflow";
 import type { CarsFeatureManualInputState } from "../features/cars_manual_input";
 import { getUiText as t } from "../ui_i18n";
 import {
   useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
+import { useLayoutEffect, useRef } from "preact/hooks";
 import type { CarsWizardRenderModel } from "./car_wizard_view";
 import {
   CarsWizardStepNav,
   CarsWizardSteps,
   CarsWizardSummaryPanel,
-} from "./cars_wizard_sections";
-import type { CarsWizardElementRefs } from "./cars_wizard_focus";
+  } from "./cars_wizard_sections";
+import {
+  resolveWizardFocusTarget,
+  type CarsWizardElementRefs,
+  type CarsWizardFocusRequest,
+} from "./cars_wizard_focus";
 
 export type CarsFeatureInteraction =
   | { type: "back" }
@@ -47,6 +51,8 @@ const CARS_WIZARD_PANEL_KEYS = [
 
 export function CarsWizardPanel(props: {
   actions: ReadonlySignal<CarsFeatureInteractionHandlers | null>;
+  addCarButtonRef: { current: HTMLButtonElement | null };
+  focusRequest: CarsWizardFocusRequest | null;
   refs: CarsWizardElementRefs;
   wizardModel: ReadonlySignal<CarsWizardRenderModel>;
 }) {
@@ -62,6 +68,38 @@ export function CarsWizardPanel(props: {
     step,
     summary,
   } = useSignalProperties(props.wizardModel, CARS_WIZARD_PANEL_KEYS);
+  const lastReturnFocusTargetRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(isOpen.value);
+
+  useLayoutEffect(() => {
+    const wasOpen = wasOpenRef.current;
+    const isCurrentlyOpen = isOpen.value;
+    if (isCurrentlyOpen && !wasOpen) {
+      const activeElement = document.activeElement;
+      lastReturnFocusTargetRef.current =
+        activeElement instanceof HTMLElement && activeElement !== document.body
+          ? activeElement
+          : props.addCarButtonRef.current;
+      if (refs.elements.current.addCarWizard) {
+        refs.elements.current.addCarWizard.scrollTop = 0;
+      }
+    }
+    if (!isCurrentlyOpen && wasOpen) {
+      const returnTarget = lastReturnFocusTargetRef.current;
+      lastReturnFocusTargetRef.current = null;
+      const safeTarget = returnTarget?.isConnected ? returnTarget : props.addCarButtonRef.current;
+      safeTarget?.focus();
+    }
+    wasOpenRef.current = isCurrentlyOpen;
+  }, [isOpen.value, props.addCarButtonRef, refs]);
+
+  useLayoutEffect(() => {
+    const focusRequest = props.focusRequest;
+    if (!focusRequest) {
+      return;
+    }
+    resolveWizardFocusTarget(focusRequest.target, refs.elements.current)?.focus();
+  }, [props.focusRequest, refs]);
 
   function dispatchAction(action: CarsFeatureInteraction): void {
     props.actions.peek()?.onAction(action);


### PR DESCRIPTION
## What changed
- move the cars wizard open/close focus restore and scroll-reset lifecycle into `CarsWizardPanel`
- keep `CarsPanel` as the cross-component bridge only (`addCarButtonRef`, focus request signal, wizard refs)
- trim `cars_wizard_focus.ts` down to the target-resolution map plus stable element refs

## Why
- the wizard lifecycle belongs with the dialog component that owns the DOM refs and open state
- this removes the detached imperative focus manager without changing the guided focus UX

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts --project=laptop-light tests/smoke.car-wizard.spec.ts`
- `cd apps/ui && npx playwright test --config=playwright.temp-cars-focus.config.ts`

## Risk / tradeoffs
- the component still reads `document.activeElement` to restore focus correctly, but that DOM work is now local to the dialog lifecycle instead of a detached manager
- guided step focus requests still use the same target map, so workflow behavior stays aligned with the existing smoke coverage
