### PR TITLE
test(domain): strengthen contract coverage

### DIFF
--- a/apps/server/tests/domain/test_core.py
+++ b/apps/server/tests/domain/test_core.py
@@ -247,6 +247,20 @@ class TestRun:
         with pytest.raises(RuntimeError, match="Cannot stop run"):
             session.stop()
 
+    def test_stop_when_already_stopped_raises(self) -> None:
+        session = Run()
+        session.start()
+        session.stop()
+        with pytest.raises(RuntimeError, match="Cannot stop run: already stopped"):
+            session.stop()
+
+    def test_restart_after_stop_raises(self) -> None:
+        session = Run()
+        session.start()
+        session.stop()
+        with pytest.raises(RuntimeError, match="Cannot start run: already started"):
+            session.start()
+
     def test_analysis_settings(self) -> None:
         from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 

--- a/apps/server/tests/domain/test_domain_objects.py
+++ b/apps/server/tests/domain/test_domain_objects.py
@@ -12,11 +12,9 @@ import pytest
 from vibesensor.domain import (
     Car,
     Finding,
-    Run,
     Sensor,
     SensorPlacement,
     SpeedSource,
-    SpeedSourceKind,
 )
 from vibesensor.shared.boundaries.reporting.document import Report
 from vibesensor.shared.boundaries.summary_fields.finding import finding_from_payload
@@ -29,22 +27,11 @@ from vibesensor.shared.boundaries.summary_fields.finding import finding_from_pay
 class TestSpeedSource:
     """Speed source value object."""
 
-    def test_default_is_gps(self) -> None:
-        src = SpeedSource()
-        assert src.kind == "gps"
-        assert src.is_gps
-        assert not src.is_manual
-
     def test_manual_speed_source(self) -> None:
         src = SpeedSource(kind="manual", manual_speed_kmh=80.0)
         assert src.is_manual
         assert not src.is_gps
         assert src.manual_speed_kmh == 80.0
-
-    def test_label(self) -> None:
-        assert SpeedSource(kind="gps").label == "GPS"
-        assert SpeedSource(kind="obd2").label == "OBD-II"
-        assert SpeedSource(kind="manual", manual_speed_kmh=1.0).label == "Manual"
 
     def test_frozen(self) -> None:
         src = SpeedSource()
@@ -68,17 +55,9 @@ class TestSpeedSource:
 class TestSensorPlacement:
     """Sensor placement value object."""
 
-    def test_wheel_location(self) -> None:
-        p = SensorPlacement(code="front_left_wheel", label="Front Left Wheel")
-        assert p.display_name == "Front Left Wheel"
-
     def test_non_wheel_location(self) -> None:
         p = SensorPlacement(code="engine_bay", label="Engine Bay")
         assert p.display_name == "Engine Bay"
-
-    def test_display_name_fallback(self) -> None:
-        p = SensorPlacement(code="rear_subframe")
-        assert p.display_name == "Rear Subframe"
 
     def test_frozen(self) -> None:
         p = SensorPlacement(code="trunk")
@@ -94,21 +73,11 @@ class TestSensorPlacement:
 class TestSensor:
     """Sensor domain object."""
 
-    def test_basic_sensor(self) -> None:
-        s = Sensor(sensor_id="aabbccddeeff", name="Sensor 1")
-        assert s.display_name == "Sensor 1"
-        assert not s.is_placed
-        assert s.location_code == ""
-
     def test_sensor_with_placement(self) -> None:
         p = SensorPlacement(code="front_left_wheel", label="Front Left Wheel")
         s = Sensor(sensor_id="aabbccddeeff", name="FL", placement=p)
         assert s.is_placed
         assert s.location_code == "front_left_wheel"
-
-    def test_display_name_fallback(self) -> None:
-        s = Sensor(sensor_id="aabbccddeeff")
-        assert s.display_name == "aabbccddeeff"
 
     def test_frozen(self) -> None:
         s = Sensor(sensor_id="aabbccddeeff")
@@ -123,16 +92,6 @@ class TestSensor:
 
 class TestCar:
     """Car domain object."""
-
-    def test_default_car(self) -> None:
-        car = Car()
-        assert car.name == "Unnamed Car"
-        assert car.car_type == "sedan"
-        assert car.display_name == "Unnamed Car (sedan)"
-
-    def test_car_with_type(self) -> None:
-        car = Car(name="BMW 3 Series", car_type="suv")
-        assert car.display_name == "BMW 3 Series (suv)"
 
     def test_tire_aspects(self) -> None:
         car = Car(
@@ -196,10 +155,6 @@ class TestFindingDomainObject:
     def test_source_normalized(self) -> None:
         f = Finding(suspected_source=" Wheel/Tire ")
         assert f.source_normalized == "wheel/tire"
-
-    def test_confidence_pct_none(self) -> None:
-        f = Finding()
-        assert f.confidence_pct is None
 
     def test_frozen(self) -> None:
         f = Finding(finding_id="F001")
@@ -266,52 +221,10 @@ class TestFindingDomainObject:
 class TestReport:
     """Report domain object."""
 
-    def test_basic_report(self) -> None:
-        r = Report(
-            run_id="abc123",
-            title="Diagnostic Report",
-            lang="en",
-            car_name="BMW 3 Series",
-        )
-        assert r.run_id == "abc123"
-        assert r.lang == "en"
-        assert r.car_name == "BMW 3 Series"
-
     def test_frozen(self) -> None:
         r = Report(run_id="abc")
         with pytest.raises(AttributeError):
             r.title = "new"
-
-
-# ---------------------------------------------------------------------------
-# Package-level imports
-# ---------------------------------------------------------------------------
-
-
-class TestPackageImports:
-    """All primary domain objects must be importable from vibesensor.domain."""
-
-    def test_all_ten_importable(self) -> None:
-        from vibesensor.domain import (
-            Car,
-            DrivingPhase,
-            Finding,
-            Measurement,
-            Run,
-            Sensor,
-            SensorPlacement,
-            SpeedSource,
-        )
-
-        # Verify they are the expected types
-        assert Run is not None
-        assert Measurement is not None
-        assert Car is not None
-        assert Sensor is not None
-        assert SensorPlacement is not None
-        assert SpeedSource is not None
-        assert DrivingPhase is not None
-        assert Finding is not None
 
 
 # ---------------------------------------------------------------------------
@@ -321,35 +234,6 @@ class TestPackageImports:
 
 class TestBridgeMethods:
     """Config objects bridge to domain objects correctly."""
-
-    def test_speed_source_config_to_speed_source(self) -> None:
-        from vibesensor.shared.types.speed_source_config import SpeedSourceConfig
-
-        cfg = SpeedSourceConfig.default()
-        speed = cfg.to_speed_source()
-        assert isinstance(speed, SpeedSource)
-        assert speed.is_gps
-        assert speed.label == "GPS"
-
-    def test_sensor_placement_from_code(self) -> None:
-        p = SensorPlacement.from_code("engine_bay")
-        assert p.code == "engine_bay"
-        assert p.label == "Engine Bay"
-
-    def test_sensor_placement_from_code_unknown(self) -> None:
-        p = SensorPlacement.from_code("custom_spot")
-        assert p.code == "custom_spot"
-        assert p.label == "Custom Spot"
-
-    def test_settings_store_domain_accessors(self) -> None:
-        from test_support.settings_services import build_settings_services
-
-        services = build_settings_services()
-        assert (
-            services.speed_source_settings.speed_source_config().speed_source == SpeedSourceKind.GPS
-        )
-        assert services.car_settings.active_car() is None
-        assert services.sensor_settings.sensors() == []
 
     def test_finding_payload_is_distinct_from_domain_finding(self) -> None:
         """FindingPayload is the analysis TypedDict; domain Finding is the dataclass."""
@@ -477,12 +361,6 @@ class TestReportValidation:
 
 class TestRunEnrichments:
     """Tests for enriched Run domain object."""
-
-    def test_lifecycle_pending_to_running(self) -> None:
-        run = Run()
-        assert not run.is_recording
-        run.start()
-        assert run.is_recording
 
 
 class TestSpeedSourceEnrichments:

--- a/apps/server/tests/domain/test_domain_public_api_contracts.py
+++ b/apps/server/tests/domain/test_domain_public_api_contracts.py
@@ -1,0 +1,106 @@
+"""Focused public API and settings-to-domain contract tests."""
+
+from __future__ import annotations
+
+import pytest
+from test_support.settings_services import build_settings_services
+
+from vibesensor.domain import Car, DrivingPhase, Run, Sensor, SensorPlacement, SpeedSource
+
+
+def test_public_domain_imports_support_run_ready_configuration() -> None:
+    car = Car(
+        name="Track Car",
+        car_type="hatchback",
+        aspects={
+            "tire_width_mm": 245.0,
+            "tire_aspect_pct": 40.0,
+            "rim_in": 18.0,
+            "final_drive_ratio": 3.23,
+        },
+    )
+    sensor = Sensor(
+        sensor_id="aabbccddeeff",
+        placement=SensorPlacement.from_code("front_left_wheel"),
+    )
+    speed_source = SpeedSource(kind="manual", manual_speed_kmh=82.0)
+    run = Run()
+
+    run.start()
+
+    assert car.display_name == "Track Car (hatchback)"
+    assert car.tire_circumference_m is not None
+    assert sensor.is_placed
+    assert sensor.location_code == "front_left_wheel"
+    assert sensor.placement is not None
+    assert sensor.placement.display_name == "Front Left Wheel"
+    assert speed_source.is_manual
+    assert speed_source.effective_speed_kmh == pytest.approx(82.0)
+    assert DrivingPhase.CRUISE.value == "cruise"
+    assert run.is_recording
+
+
+def test_default_car_profile_becomes_analysis_ready_after_selection() -> None:
+    services = build_settings_services()
+
+    created = services.car_settings.add_car({})
+    car_id = created.cars[0]["id"]
+    services.car_settings.set_active_car(car_id)
+
+    active_car = services.car_settings.active_car()
+    active_snapshot = services.car_settings.active_car_snapshot()
+    active_aspects = services.car_settings.active_car_aspects()
+
+    assert active_car is not None
+    assert active_car.display_name == "Unnamed Car (sedan)"
+    assert active_car.tire_circumference_m is not None
+    assert active_snapshot is not None
+    assert active_snapshot.car_id == car_id
+    assert active_snapshot.name == "Unnamed Car"
+    assert active_snapshot.car_type == "sedan"
+    assert active_aspects is not None
+    assert active_aspects["tire_width_mm"] > 0
+    assert active_aspects["tire_aspect_pct"] > 0
+    assert active_aspects["rim_in"] > 0
+
+
+def test_settings_service_mutations_derive_updated_domain_objects() -> None:
+    services = build_settings_services()
+
+    created = services.car_settings.add_car(
+        {
+            "name": "Daily Driver",
+            "type": "wagon",
+            "aspects": {
+                "tire_width_mm": 225.0,
+                "tire_aspect_pct": 45.0,
+                "rim_in": 17.0,
+                "final_drive_ratio": 3.08,
+            },
+        }
+    )
+    car_id = created.cars[0]["id"]
+    services.car_settings.set_active_car(car_id)
+    services.sensor_settings.assign_sensor_location("AA:BB:CC:DD:EE:FF", "front_left_wheel")
+    services.speed_source_settings.update_speed_source(
+        {"speedSource": "manual", "manualSpeedKph": 62.0}
+    )
+
+    active_car = services.car_settings.active_car()
+    active_snapshot = services.car_settings.active_car_snapshot()
+    derived_sensors = services.sensor_settings.sensors()
+    speed_source = services.speed_source_settings.speed_source_config().to_speed_source()
+
+    assert active_car is not None
+    assert active_car.display_name == "Daily Driver (wagon)"
+    assert active_car.tire_width_mm == pytest.approx(225.0)
+    assert active_car.tire_circumference_m is not None
+    assert active_snapshot is not None
+    assert active_snapshot.car_id == car_id
+    assert active_snapshot.car_type == "wagon"
+    assert derived_sensors[0].sensor_id == "aabbccddeeff"
+    assert derived_sensors[0].display_name == "Front Left Wheel"
+    assert derived_sensors[0].placement is not None
+    assert derived_sensors[0].placement.display_name == "Front Left Wheel"
+    assert speed_source.label == "Manual"
+    assert speed_source.effective_speed_kmh == pytest.approx(62.0)

--- a/apps/server/tests/domain/test_finding_report_contracts.py
+++ b/apps/server/tests/domain/test_finding_report_contracts.py
@@ -1,0 +1,84 @@
+"""Focused Finding and Report contract tests."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+import pytest
+
+from vibesensor.domain import Finding
+from vibesensor.shared.boundaries.reporting.document import Report, ReportDocument
+
+
+@pytest.mark.parametrize(
+    ("confidence", "expected_pct"),
+    [
+        (None, None),
+        (0.0, 0),
+        (0.0049, 0),
+        (0.005, 0),
+        (0.0051, 1),
+        (0.245, 24),
+        (0.255, 26),
+        (0.9949, 99),
+        (0.995, 100),
+        (1.0, 100),
+    ],
+)
+def test_finding_confidence_pct_covers_rounding_boundaries(
+    confidence: float | None,
+    expected_pct: int | None,
+) -> None:
+    finding = Finding(confidence=confidence)
+
+    assert finding.confidence_pct == expected_pct
+
+
+@pytest.mark.parametrize("confidence", [-0.01, 1.01])
+def test_finding_rejects_out_of_range_confidence(confidence: float) -> None:
+    with pytest.raises(ValueError, match="must be in \\[0, 1\\]"):
+        Finding(confidence=confidence)
+
+
+def test_report_serializes_core_metadata_for_document_consumers() -> None:
+    report = Report(
+        run_id="run-123",
+        title="Diagnostic Report",
+        lang="nl",
+        car_name="BMW 3 Series",
+        car_type="sedan",
+        duration_s=18.5,
+        sample_count=3200,
+        sensor_count=4,
+    )
+
+    payload = asdict(report)
+    serialized = json.loads(json.dumps(payload))
+    document = ReportDocument(
+        title=report.title,
+        run_id=report.run_id,
+        car_name=report.car_name,
+        car_type=report.car_type,
+        sample_count=report.sample_count,
+        sensor_count=report.sensor_count,
+        lang=report.lang,
+    )
+
+    assert serialized == {
+        "run_id": "run-123",
+        "title": "Diagnostic Report",
+        "lang": "nl",
+        "car_name": "BMW 3 Series",
+        "car_type": "sedan",
+        "report_date": None,
+        "duration_s": 18.5,
+        "sample_count": 3200,
+        "sensor_count": 4,
+    }
+    assert document.run_id == report.run_id
+    assert document.car_name == report.car_name
+    assert document.car_type == report.car_type
+    assert document.sample_count == report.sample_count
+    assert document.sensor_count == report.sensor_count
+    assert document.lang == report.lang

--- a/apps/server/tests/domain/test_speed_source_sensor_contracts.py
+++ b/apps/server/tests/domain/test_speed_source_sensor_contracts.py
@@ -1,0 +1,119 @@
+"""Focused SpeedSource, SensorPlacement, and Sensor behavior contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.domain import Sensor, SensorPlacement, SpeedSource, SpeedSourceKind
+
+
+@pytest.mark.parametrize(
+    ("kind", "manual_speed_kmh", "expected_label", "expected_live"),
+    [
+        (SpeedSourceKind.GPS, None, "GPS", True),
+        (SpeedSourceKind.OBD2, None, "OBD-II", True),
+        (SpeedSourceKind.MANUAL, 88.0, "Manual", False),
+    ],
+)
+def test_speed_source_supported_kinds_follow_public_contract(
+    kind: SpeedSourceKind,
+    manual_speed_kmh: float | None,
+    expected_label: str,
+    expected_live: bool,
+) -> None:
+    source = SpeedSource(kind=kind, manual_speed_kmh=manual_speed_kmh)
+
+    assert source.kind is kind
+    assert source.label == expected_label
+    assert source.is_live is expected_live
+    assert source.is_gps is (kind is SpeedSourceKind.GPS)
+    assert source.is_obd2 is (kind is SpeedSourceKind.OBD2)
+    assert source.is_manual is (kind is SpeedSourceKind.MANUAL)
+    if kind is SpeedSourceKind.MANUAL:
+        assert source.effective_speed_kmh == pytest.approx(88.0)
+    else:
+        assert source.effective_speed_kmh is None
+
+
+@pytest.mark.parametrize(
+    ("manual_speed_kmh",),
+    [
+        (None,),
+        (0.0,),
+        (-10.0,),
+    ],
+)
+def test_speed_source_manual_contract_rejects_missing_or_non_positive_speed(
+    manual_speed_kmh: float | None,
+) -> None:
+    with pytest.raises(ValueError, match="manual_speed_kmh"):
+        SpeedSource(kind="manual", manual_speed_kmh=manual_speed_kmh)
+
+
+def test_speed_source_rejects_unknown_kind() -> None:
+    with pytest.raises(ValueError):
+        SpeedSource(kind="satnav")
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_label"),
+    [
+        ("front_left_wheel", "Front Left Wheel"),
+        ("engine_bay", "Engine Bay"),
+        ("custom_spot", "Custom Spot"),
+    ],
+)
+def test_sensor_placement_from_code_maps_known_and_custom_locations(
+    code: str,
+    expected_label: str,
+) -> None:
+    placement = SensorPlacement.from_code(code)
+
+    assert placement.code == code
+    assert placement.label == expected_label
+    assert placement.display_name == expected_label
+
+
+def test_sensor_placement_fallback_formats_unknown_casing_without_rewriting_code() -> None:
+    placement = SensorPlacement.from_code("Rear_Subframe")
+
+    assert placement.code == "Rear_Subframe"
+    assert placement.label == "Rear Subframe"
+    assert placement.display_name == "Rear Subframe"
+
+
+def test_sensor_placement_rejects_blank_code() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        SensorPlacement(code="  ")
+
+
+def test_sensor_contract_tracks_unplaced_and_placed_state() -> None:
+    unplaced = Sensor(sensor_id="aabbccddeeff", name="Cabin")
+    placed = Sensor(
+        sensor_id="112233445566",
+        placement=SensorPlacement.from_code("rear_subframe"),
+    )
+
+    assert unplaced.display_name == "Cabin"
+    assert not unplaced.is_placed
+    assert unplaced.location_code == ""
+    assert placed.display_name == "112233445566"
+    assert placed.is_placed
+    assert placed.location_code == "rear_subframe"
+    assert placed.placement is not None
+    assert placed.placement.display_name == "Rear Subframe"
+
+
+def test_sensor_from_location_codes_builds_roundtrip_ready_domain_objects() -> None:
+    sensors = Sensor.from_location_codes(["front_left_wheel", "custom_spot"])
+
+    assert sensors == (
+        Sensor(
+            sensor_id="front_left_wheel",
+            placement=SensorPlacement(code="front_left_wheel", label="Front Left Wheel"),
+        ),
+        Sensor(
+            sensor_id="custom_spot",
+            placement=SensorPlacement(code="custom_spot", label="Custom Spot"),
+        ),
+    )


### PR DESCRIPTION
## What changed
- add focused domain contract files for public API imports, speed source/sensor behavior, and finding/report behavior
- expand `test_core.py` with stop-twice and restart-after-stop run lifecycle failures
- strip the weak import/default/accessor happy-path checks out of `test_domain_objects.py`

## Why
- `test_domain_objects.py` was carrying the exact low-signal tests from #2820: import smoke, literal-default checks, shallow accessors, and one happy-path lifecycle assertion
- the replacement tests pin real behavior: invalid combinations, public API invariants, settings-to-domain derivation, serialization-facing report shape, and invalid run transitions

## Validation
- `.venv/bin/python -m pytest -q apps/server/tests/domain/test_domain_public_api_contracts.py apps/server/tests/domain/test_speed_source_sensor_contracts.py apps/server/tests/domain/test_finding_report_contracts.py apps/server/tests/domain/test_core.py apps/server/tests/domain/test_domain_objects.py`
- `.venv/bin/python -m ruff check apps/server/tests/domain/test_domain_public_api_contracts.py apps/server/tests/domain/test_speed_source_sensor_contracts.py apps/server/tests/domain/test_finding_report_contracts.py apps/server/tests/domain/test_core.py apps/server/tests/domain/test_domain_objects.py`
- `.venv/bin/python -m pytest -q apps/server/tests/domain/`

## Risk / tradeoffs
- this is test-only, but it intentionally changes test seams: fewer omnibus smoke assertions, more focused contract modules
- settings-bridge coverage overlaps some infra tests on purpose because #2820 is about proving the public/domain-facing behavior, not just the storage helpers
