### PR TITLE
test: strengthen snapshot and config contracts

### DIFF
--- a/apps/server/tests/app/test_config.py
+++ b/apps/server/tests/app/test_config.py
@@ -27,8 +27,22 @@ def cfg_path(tmp_path: Path) -> Path:
 
 
 def test_logging_flags_allow_db_only_mode(cfg_path: Path) -> None:
-    cfg = _write_and_load(cfg_path, {"logging": {"persist_history_db": True}})
+    cfg = _write_and_load(
+        cfg_path,
+        {
+            "logging": {
+                "persist_history_db": True,
+                "history_db_path": "db/history.db",
+                "app_log_path": "logs/app.log",
+            }
+        },
+    )
+
     assert cfg.logging.persist_history_db is True
+    assert cfg.logging.history_db_path == cfg_path.parent / "db/history.db"
+    assert cfg.logging.app_log_path == cfg_path.parent / "logs/app.log"
+    assert cfg.logging.no_data_timeout_s == 15.0
+    assert cfg.logging.run_retention_days == 7
 
 
 def test_logging_no_data_timeout_defaults_and_allows_override(cfg_path: Path) -> None:
@@ -47,44 +61,62 @@ def test_logging_run_retention_days_defaults_and_allows_override(cfg_path: Path)
     assert cfg.logging.run_retention_days == 21
 
 
-def test_dev_and_docker_configs_equivalent() -> None:
-    """config.dev.yaml and config.docker.yaml share core settings but Docker
-    intentionally overrides environment-specific options (GPS disabled because
-    Docker containers have no gpsd, AP self-heal disabled because nmcli/hostapd
-    are absent, rollback_dir uses a container-local path).
-    """
+def test_base_dev_and_docker_configs_capture_intended_runtime_invariants(tmp_path: Path) -> None:
+    base_cfg = _write_and_load(tmp_path / "config.yaml", {})
     dev_cfg = load_config(SERVER_DIR / "config.dev.yaml")
     docker_cfg = load_config(SERVER_DIR / "config.docker.yaml")
-    # Core transport and processing settings must still agree
-    assert dev_cfg.server == docker_cfg.server
-    assert dev_cfg.udp == docker_cfg.udp
-    assert dev_cfg.processing == docker_cfg.processing
-    # GPS: Docker container has no gpsd — GPS is intentionally disabled there
-    assert dev_cfg.gps.gpsd_host == docker_cfg.gps.gpsd_host
-    assert dev_cfg.gps.gpsd_port == docker_cfg.gps.gpsd_port
-    assert docker_cfg.gps.gps_enabled is False, "Docker config must disable GPS"
-    # AP: self-heal is intentionally disabled in Docker (no nmcli/hostapd)
-    assert docker_cfg.ap.self_heal.enabled is False, "Docker config must disable AP self-heal"
+
+    assert base_cfg.server.host == dev_cfg.server.host == docker_cfg.server.host
+    assert base_cfg.server.port == 80
+    assert dev_cfg.server.port == docker_cfg.server.port == 8000
+    assert base_cfg.udp == dev_cfg.udp == docker_cfg.udp
+    assert base_cfg.processing == dev_cfg.processing == docker_cfg.processing
+    assert base_cfg.logging.persist_history_db is True
+    assert dev_cfg.logging.persist_history_db is True
+    assert docker_cfg.logging.persist_history_db is True
+    assert base_cfg.gps.gps_enabled is True
+    assert dev_cfg.gps.gps_enabled is False
+    assert docker_cfg.gps.gps_enabled is False
+    assert base_cfg.ap.self_heal.enabled is True
+    assert dev_cfg.ap.self_heal.enabled is True
+    assert docker_cfg.ap.self_heal.enabled is False
+    assert docker_cfg.update.rollback_dir != base_cfg.update.rollback_dir
 
 
-def test_default_server_port_is_80_for_base_config(cfg_path: Path) -> None:
-    cfg = _write_and_load(cfg_path, {})
-    assert cfg.server.port == 80
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        (4096, 4096),
+        (0, 1),
+        (-5, 1),
+        ("512", 512),
+        (1_000_000, 1_000_000),
+    ],
+)
+def test_udp_data_queue_maxsize_loader_clamps_or_preserves_integer_like_values(
+    cfg_path: Path,
+    raw_value: object,
+    expected: int,
+) -> None:
+    cfg = _write_and_load(cfg_path, {"udp": {"data_queue_maxsize": raw_value}})
+    assert cfg.udp.data_queue_maxsize == expected
 
 
-def test_dev_and_docker_override_server_port_to_8000() -> None:
-    dev_cfg = load_config(SERVER_DIR / "config.dev.yaml")
-    docker_cfg = load_config(SERVER_DIR / "config.docker.yaml")
-    assert dev_cfg.server.port == 8000
-    assert docker_cfg.server.port == 8000
-
-
-def test_udp_data_queue_maxsize_override_and_clamp(cfg_path: Path) -> None:
-    cfg = _write_and_load(cfg_path, {"udp": {"data_queue_maxsize": 4096}})
-    assert cfg.udp.data_queue_maxsize == 4096
-
-    cfg = _write_and_load(cfg_path, {"udp": {"data_queue_maxsize": 0}})
-    assert cfg.udp.data_queue_maxsize == 1
+@pytest.mark.parametrize(
+    ("raw_value", "message"),
+    [
+        (True, "udp.data_queue_maxsize"),
+        ("not-a-number", "invalid literal for int()"),
+    ],
+)
+def test_udp_data_queue_maxsize_rejects_non_integer_like_values(
+    cfg_path: Path,
+    raw_value: object,
+    message: str,
+) -> None:
+    _write_config(cfg_path, {"udp": {"data_queue_maxsize": raw_value}})
+    with pytest.raises(ValueError, match=message):
+        load_config(cfg_path)
 
 
 # --- AP WiFi channel validation ---

--- a/apps/server/tests/app/test_config_extended.py
+++ b/apps/server/tests/app/test_config_extended.py
@@ -14,28 +14,30 @@ from vibesensor.shared.json_utils import deep_merge as _deep_merge
 # -- _deep_merge ---------------------------------------------------------------
 
 
-def test_deep_merge_overrides_scalar() -> None:
-    base = {"a": 1, "b": 2}
-    override = {"a": 10}
-    result = _deep_merge(base, override)
-    assert result["a"] == 10
-    assert result["b"] == 2
+@pytest.mark.parametrize(
+    ("base", "override", "expected"),
+    [
+        ({"a": 1, "b": 2}, {"a": 10}, {"a": 10, "b": 2}),
+        ({"top": {"a": 1, "b": 2}}, {"top": {"b": 3}}, {"top": {"a": 1, "b": 3}}),
+        ({"a": 1}, {"b": 2}, {"a": 1, "b": 2}),
+        ({"items": [1, 2]}, {"items": [3]}, {"items": [3]}),
+    ],
+)
+def test_deep_merge_contract(
+    base: dict[str, object],
+    override: dict[str, object],
+    expected: dict[str, object],
+) -> None:
+    assert _deep_merge(base, override) == expected
 
 
-def test_deep_merge_nested() -> None:
-    base = {"top": {"a": 1, "b": 2}}
-    override = {"top": {"b": 3}}
-    result = _deep_merge(base, override)
-    assert result["top"]["a"] == 1
-    assert result["top"]["b"] == 3
+def test_deep_merge_null_dict_section_keeps_defaults_and_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    result = _deep_merge({"ap": {"self_heal": {"enabled": True}}}, {"ap": None})
 
-
-def test_deep_merge_new_key() -> None:
-    base = {"a": 1}
-    override = {"b": 2}
-    result = _deep_merge(base, override)
-    assert result["a"] == 1
-    assert result["b"] == 2
+    assert result == {"ap": {"self_heal": {"enabled": True}}}
+    assert "keeping default section" in caplog.text
 
 
 # -- _resolve_config_path ------------------------------------------------------
@@ -50,6 +52,31 @@ def test_resolve_config_path_relative(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     result = _resolve_config_path("data/foo.txt", config_path)
     assert result == (tmp_path / "data/foo.txt")
+
+
+def test_resolve_config_path_preserves_parent_traversal_relative_to_config(tmp_path: Path) -> None:
+    config_dir = tmp_path / "configs" / "dev"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.yaml"
+
+    result = _resolve_config_path("../shared/state.json", config_path)
+
+    assert result.resolve() == (config_dir.parent / "shared/state.json").resolve()
+
+
+def test_resolve_config_path_uses_real_config_parent_for_symlinks(tmp_path: Path) -> None:
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    real_config = real_dir / "config.yaml"
+    real_config.write_text("{}", encoding="utf-8")
+    link_dir = tmp_path / "linked"
+    link_dir.mkdir()
+    symlink_path = link_dir / "config.yaml"
+    symlink_path.symlink_to(real_config)
+
+    result = _resolve_config_path("data/file.txt", symlink_path)
+
+    assert result.resolve() == (real_dir / "data/file.txt").resolve()
 
 
 # -- _read_config_file ---------------------------------------------------------
@@ -90,6 +117,9 @@ def test_load_config_ap_self_heal_defaults(tmp_path: Path) -> None:
     result = load_config(config_path)
 
     assert result.ap.self_heal.enabled is True
+    assert result.ap.self_heal.diagnostics_lookback_minutes == 5
+    assert result.ap.self_heal.min_restart_interval_seconds == 120
+    assert result.ap.self_heal.state_file == tmp_path / "data/hotspot-self-heal-state.json"
 
 
 def test_load_config_ap_self_heal_override(tmp_path: Path) -> None:

--- a/apps/server/tests/domain/test_snapshots.py
+++ b/apps/server/tests/domain/test_snapshots.py
@@ -11,7 +11,6 @@ import pytest
 from vibesensor.domain import (
     AnalysisSettingsSnapshot,
     CarSnapshot,
-    OrderReferenceSpec,
     RunContextSnapshot,
 )
 from vibesensor.shared.boundaries.codecs import (
@@ -19,10 +18,7 @@ from vibesensor.shared.boundaries.codecs import (
     driving_phase_summary_from_mapping,
     speed_profile_summary_from_mapping,
 )
-from vibesensor.shared.order_reference_settings import (
-    order_reference_spec_from_mapping,
-    order_reference_spec_from_snapshot,
-)
+from vibesensor.shared.order_reference_settings import order_reference_spec_from_snapshot
 
 # ── AnalysisSettingsSnapshot ────────────────────────────────────────
 
@@ -30,13 +26,27 @@ from vibesensor.shared.order_reference_settings import (
 class TestAnalysisSettingsSnapshotFromDict:
     """Boundary snapshot codec tests."""
 
-    def test_empty_dict_never_raises(self) -> None:
-        snap = analysis_settings_snapshot_from_mapping({})
-        assert snap.tire_width_mm == 0.0
-        assert snap.tire_deflection_factor == 1.0
+    def test_mixed_invalid_payload_blocks_order_reference_projection(self) -> None:
+        snap = analysis_settings_snapshot_from_mapping(
+            {
+                "tire_width_mm": "bad",
+                "tire_aspect_pct": 55.0,
+                "rim_in": 16.0,
+                "current_gear_ratio": "0.82",
+                "tire_deflection_factor": None,
+            }
+        )
 
-    def test_round_trip_fields(self) -> None:
-        data = {
+        assert snap.tire_width_mm == 0.0
+        assert snap.tire_aspect_pct == 55.0
+        assert snap.rim_in == 16.0
+        assert snap.current_gear_ratio == 0.82
+        assert snap.tire_deflection_factor == 1.0
+        assert order_reference_spec_from_snapshot(snap) is None
+
+    def test_combined_fields_project_a_complete_order_reference_spec(self) -> None:
+        snap = analysis_settings_snapshot_from_mapping(
+            {
             "tire_width_mm": 285.0,
             "tire_aspect_pct": 30.0,
             "rim_in": 21.0,
@@ -52,11 +62,20 @@ class TestAnalysisSettingsSnapshotFromDict:
             "min_abs_band_hz": 1.0,
             "max_band_half_width_pct": 0.05,
             "tire_deflection_factor": 0.96,
-        }
-        snap = analysis_settings_snapshot_from_mapping(data)
-        assert snap.tire_width_mm == 285.0
-        assert snap.current_gear_ratio == 0.64
-        assert snap.tire_deflection_factor == 0.96
+            }
+        )
+
+        spec = order_reference_spec_from_snapshot(snap)
+
+        assert spec is not None
+        assert spec.tire_spec is not None
+        assert spec.tire_spec.width_mm == 285.0
+        assert spec.tire_spec.deflection_factor == 0.96
+        assert spec.final_drive_ratio == pytest.approx(3.08)
+        assert spec.current_gear_ratio == pytest.approx(0.64)
+        assert spec.has_engine_reference is True
+        assert spec.is_complete is True
+        assert spec.tire_circumference_m > 0
 
     def test_non_numeric_values_default(self) -> None:
         snap = analysis_settings_snapshot_from_mapping({"tire_width_mm": "not_a_number"})
@@ -87,24 +106,7 @@ class TestAnalysisSettingsOrderRef:
         assert spec.tire_spec is not None
         assert spec.tire_spec.width_mm == 285.0
 
-    def test_order_reference_spec_is_snapshot_projection(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        captured: dict[str, object] = {}
-        sentinel = order_reference_spec_from_mapping(
-            {"tire_width_mm": 285.0, "tire_aspect_pct": 30.0, "rim_in": 21.0},
-        )
-        assert sentinel is not None
-
-        def _fake_from_settings(data: dict[str, object]) -> OrderReferenceSpec | None:
-            captured.update(data)
-            return sentinel
-
-        monkeypatch.setattr(
-            "vibesensor.shared.order_reference_settings.order_reference_spec_from_mapping",
-            _fake_from_settings,
-        )
+    def test_snapshot_projection_preserves_engine_reference_inputs(self) -> None:
         snap = AnalysisSettingsSnapshot(
             tire_width_mm=285.0,
             tire_aspect_pct=30.0,
@@ -114,10 +116,14 @@ class TestAnalysisSettingsOrderRef:
             tire_deflection_factor=0.97,
         )
 
-        assert order_reference_spec_from_snapshot(snap) is sentinel
-        assert captured["tire_width_mm"] == 285.0
-        assert captured["final_drive_ratio"] == 3.08
-        assert captured["tire_deflection_factor"] == 0.97
+        spec = order_reference_spec_from_snapshot(snap)
+
+        assert spec is not None
+        assert spec.final_drive_ratio == pytest.approx(3.08)
+        assert spec.current_gear_ratio == pytest.approx(0.64)
+        assert spec.tire_spec is not None
+        assert spec.tire_spec.deflection_factor == pytest.approx(0.97)
+        assert spec.has_engine_reference is True
 
 
 # ── RunContextSnapshot ──────────────────────────────────────────────
@@ -126,12 +132,16 @@ class TestAnalysisSettingsOrderRef:
 class TestRunContextSnapshot:
     """Typed domain tests for RunContextSnapshot."""
 
-    def test_defaults_are_empty(self) -> None:
+    def test_absent_car_context_degrades_consumer_accessors(self) -> None:
         ctx = RunContextSnapshot()
 
         assert ctx.car is None
         assert ctx.has_car_context is False
-        assert ctx.analysis_settings.tire_width_mm == 0.0
+        assert ctx.active_car_id is None
+        assert ctx.car_name is None
+        assert ctx.car_type is None
+        assert ctx.car_variant is None
+        assert order_reference_spec_from_snapshot(ctx.analysis_settings) is None
 
     def test_order_reference_spec_delegates_to_analysis_settings(self) -> None:
         ctx = RunContextSnapshot(
@@ -170,6 +180,23 @@ class TestRunContextSnapshot:
         assert ctx.car_type is None
         assert ctx.car_variant is None
 
+    def test_partial_car_context_stays_usable_without_fake_analysis_defaults(self) -> None:
+        ctx = RunContextSnapshot(
+            car=CarSnapshot(
+                car_id=None,
+                name="Project Car",
+                car_type=None,
+                variant="prototype",
+            ),
+        )
+
+        assert ctx.has_car_context is True
+        assert ctx.active_car_id is None
+        assert ctx.car_name == "Project Car"
+        assert ctx.car_type is None
+        assert ctx.car_variant == "prototype"
+        assert order_reference_spec_from_snapshot(ctx.analysis_settings) is None
+
 
 # ── SpeedProfileSummary ──────────────────────────────────────────────
 
@@ -183,21 +210,26 @@ class TestSpeedProfileSummaryFromDict:
         assert snap.steady_speed is False
         assert snap.sample_count == 0
 
-    def test_round_trip(self) -> None:
-        data = {
-            "min_kmh": 40.0,
-            "max_kmh": 120.0,
-            "mean_kmh": 80.0,
-            "stddev_kmh": 10.5,
-            "range_kmh": 80.0,
-            "steady_speed": True,
-            "sample_count": 500,
-        }
-        snap = speed_profile_summary_from_mapping(data)
-        assert snap.min_kmh == 40.0
-        assert snap.max_kmh == 120.0
-        assert snap.steady_speed is True
-        assert snap.sample_count == 500
+    def test_sanitizes_mixed_speed_payload_without_hidden_normalization(self) -> None:
+        snap = speed_profile_summary_from_mapping(
+            {
+                "min_kmh": -5.0,
+                "max_kmh": "120.0",
+                "mean_kmh": "80.5",
+                "stddev_kmh": float("inf"),
+                "range_kmh": "bad",
+                "steady_speed": "yes",
+                "sample_count": "12",
+            }
+        )
+
+        assert snap.min_kmh == pytest.approx(-5.0)
+        assert snap.max_kmh == pytest.approx(120.0)
+        assert snap.mean_kmh == pytest.approx(80.5)
+        assert snap.stddev_kmh is None
+        assert snap.range_kmh is None
+        assert snap.steady_speed is False
+        assert snap.sample_count == 12
 
     def test_non_numeric_speed_defaults_to_none(self) -> None:
         snap = speed_profile_summary_from_mapping({"min_kmh": "bad"})
@@ -220,23 +252,40 @@ class TestDrivingPhaseSummaryFromDict:
         assert snap.has_cruise is False
         assert dict(snap.phase_counts) == {}
 
-    def test_round_trip(self) -> None:
-        data = {
-            "phase_counts": {"cruise": 100, "accel": 50},
-            "phase_pcts": {"cruise": 0.66, "accel": 0.34},
-            "total_samples": 150,
-            "segment_count": 5,
-            "has_cruise": True,
-            "has_acceleration": True,
-            "cruise_pct": 0.66,
-            "idle_pct": 0.0,
-            "speed_unknown_pct": 0.0,
-        }
-        snap = driving_phase_summary_from_mapping(data)
+    def test_counts_percentages_and_flags_fall_back_consistently(self) -> None:
+        snap = driving_phase_summary_from_mapping(
+            {
+                "phase_counts": {"cruise": "100", "acceleration": 50, "idle": "bad"},
+                "phase_pcts": {"cruise": 0.66, "idle": "0.10", "speed_unknown": "bad"},
+                "total_samples": "150",
+                "segment_count": "5",
+            }
+        )
+
+        assert dict(snap.phase_counts) == {"cruise": 100, "acceleration": 50}
+        assert dict(snap.phase_pcts) == {"cruise": 0.66, "idle": 0.10}
         assert snap.total_samples == 150
+        assert snap.segment_count == 5
         assert snap.has_cruise is True
-        assert snap.phase_counts["cruise"] == 100
+        assert snap.has_acceleration is True
         assert snap.cruise_pct == pytest.approx(0.66)
+        assert snap.idle_pct == pytest.approx(0.10)
+        assert snap.speed_unknown_pct == 0.0
+
+    def test_explicit_flags_and_percentages_override_count_fallbacks(self) -> None:
+        snap = driving_phase_summary_from_mapping(
+            {
+                "phase_counts": {"cruise": 10, "acceleration": 3},
+                "phase_pcts": {"cruise": 0.9},
+                "has_cruise": False,
+                "has_acceleration": False,
+                "cruise_pct": 0.0,
+            }
+        )
+
+        assert snap.has_cruise is False
+        assert snap.has_acceleration is False
+        assert snap.cruise_pct == 0.0
 
     def test_invalid_phase_counts_skipped(self) -> None:
         snap = driving_phase_summary_from_mapping({"phase_counts": {"cruise": "bad", "accel": 10}})

--- a/apps/server/tests/domain/test_snapshots.py
+++ b/apps/server/tests/domain/test_snapshots.py
@@ -47,21 +47,21 @@ class TestAnalysisSettingsSnapshotFromDict:
     def test_combined_fields_project_a_complete_order_reference_spec(self) -> None:
         snap = analysis_settings_snapshot_from_mapping(
             {
-            "tire_width_mm": 285.0,
-            "tire_aspect_pct": 30.0,
-            "rim_in": 21.0,
-            "final_drive_ratio": 3.08,
-            "current_gear_ratio": 0.64,
-            "wheel_bandwidth_pct": 0.0025,
-            "driveshaft_bandwidth_pct": 0.0025,
-            "engine_bandwidth_pct": 0.0025,
-            "speed_uncertainty_pct": 0.05,
-            "tire_diameter_uncertainty_pct": 0.02,
-            "final_drive_uncertainty_pct": 0.01,
-            "gear_uncertainty_pct": 0.01,
-            "min_abs_band_hz": 1.0,
-            "max_band_half_width_pct": 0.05,
-            "tire_deflection_factor": 0.96,
+                "tire_width_mm": 285.0,
+                "tire_aspect_pct": 30.0,
+                "rim_in": 21.0,
+                "final_drive_ratio": 3.08,
+                "current_gear_ratio": 0.64,
+                "wheel_bandwidth_pct": 0.0025,
+                "driveshaft_bandwidth_pct": 0.0025,
+                "engine_bandwidth_pct": 0.0025,
+                "speed_uncertainty_pct": 0.05,
+                "tire_diameter_uncertainty_pct": 0.02,
+                "final_drive_uncertainty_pct": 0.01,
+                "gear_uncertainty_pct": 0.01,
+                "min_abs_band_hz": 1.0,
+                "max_band_half_width_pct": 0.05,
+                "tire_deflection_factor": 0.96,
             }
         )
 


### PR DESCRIPTION
## What changed
- replace weak snapshot smoke/default tests with codec behavior contracts
- replace monkeypatch/delegation checks with public order-reference behavior
- replace brittle config literal/default tests with loader invariants, deep-merge/path rules, and queue-size edge cases

## Why
- old tests pinned implementation trivia and baked numbers
- new tests pin the behavior real callers depend on when decoding persisted snapshots and loading config overrides

## Validation
- `.venv/bin/python -m pytest -q apps/server/tests/domain/test_snapshots.py apps/server/tests/app/test_config.py apps/server/tests/app/test_config_extended.py`
- `.venv/bin/python -m pytest -q apps/server/tests/domain/test_snapshots.py apps/server/tests/app/`
- `.venv/bin/python -m ruff check apps/server/tests/domain/test_snapshots.py apps/server/tests/app/test_config.py apps/server/tests/app/test_config_extended.py`

## Risk / tradeoffs
- no production code changes; only test contracts moved to behavior seams
- invalid integer-like strings still surface the current raw `int()` error text because that is the live loader contract today

Closes #2821