### PR TITLE
test(server): harden report smoke contracts

### DIFF
--- a/apps/server/tests/hygiene/test_ui_smoke_contract.py
+++ b/apps/server/tests/hygiene/test_ui_smoke_contract.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import ast
 import json
+import re
+import shlex
 
 from tests._paths import REPO_ROOT
 
@@ -18,38 +21,75 @@ _EXPECTED_CORE_SMOKE_SPECS = {
 }
 
 
-def _smoke_script() -> str:
+def _package_scripts() -> dict[str, str]:
     package_json = json.loads(_UI_PACKAGE_JSON.read_text())
-    return str(package_json["scripts"]["test:smoke"])
+    return {key: str(value) for key, value in package_json["scripts"].items()}
+
+
+def _smoke_script_tokens() -> list[str]:
+    return shlex.split(_package_scripts()["test:smoke"])
+
+
+def _smoke_test_match_patterns() -> list[str]:
+    config_text = _SMOKE_CONFIG.read_text()
+    match = re.search(r"testMatch:\s*(\[[^\]]+\])", config_text)
+    assert match is not None
+    return [str(pattern) for pattern in ast.literal_eval(match.group(1))]
+
+
+def _smoke_test_dir() -> str:
+    config_text = _SMOKE_CONFIG.read_text()
+    match = re.search(r'testDir:\s*"([^"]+)"', config_text)
+    assert match is not None
+    return str(match.group(1))
+
+
+def _smoke_workers_env_contract() -> tuple[str, str]:
+    config_text = _SMOKE_CONFIG.read_text()
+    match = re.search(r'process\.env\.(\w+)\s*\?\?\s*"([^"]+)"', config_text)
+    assert match is not None
+    return str(match.group(1)), str(match.group(2))
 
 
 def test_ui_smoke_script_defers_test_selection_to_smoke_config() -> None:
-    package_json = json.loads(_UI_PACKAGE_JSON.read_text())
-    scripts = package_json["scripts"]
-    script = str(scripts["test:smoke"])
-    config_text = _SMOKE_CONFIG.read_text()
+    scripts = _package_scripts()
+    smoke_tokens = _smoke_script_tokens()
+    workers_env_var, workers_default = _smoke_workers_env_contract()
 
     assert scripts["pretest:smoke"] == "npm run sync:generated-contracts"
-    assert "--config=playwright.smoke.config.ts" in script
-    assert "--project=laptop-light" in script
-    assert "--workers=" not in script
-    assert "tests/" not in script, (
+    assert smoke_tokens[:3] == ["npx", "playwright", "test"]
+    assert "--config=playwright.smoke.config.ts" in smoke_tokens
+    assert "--project=laptop-light" in smoke_tokens
+    assert not any(token.startswith("--workers") for token in smoke_tokens)
+    assert not any(
+        token.startswith("tests/") or token.endswith(".spec.ts") for token in smoke_tokens[3:]
+    ), (
         "Smoke file selection should live in playwright.smoke.config.ts, "
         "not as hard-coded paths in package.json."
     )
-    assert "PLAYWRIGHT_SMOKE_WORKERS" in config_text
-    assert '?? "1"' in config_text
+    assert workers_env_var == "PLAYWRIGHT_SMOKE_WORKERS"
+    assert workers_default == "1"
 
 
 def test_ui_smoke_config_uses_split_smoke_glob() -> None:
-    config_text = _SMOKE_CONFIG.read_text()
+    smoke_specs = {
+        path.name
+        for pattern in _smoke_test_match_patterns()
+        for path in (REPO_ROOT / "apps" / "ui" / _smoke_test_dir()).glob(pattern)
+    }
 
-    assert "testMatch" in config_text
-    assert "smoke*.spec.ts" in config_text
+    assert _smoke_test_dir() == "tests"
+    assert smoke_specs
+    assert all(name.startswith("smoke") for name in smoke_specs)
+    assert "visual.spec.ts" not in smoke_specs
 
 
 def test_core_ui_smoke_specs_exist() -> None:
-    smoke_specs = {path.name for path in _UI_TESTS_DIR.glob("smoke*.spec.ts")}
+    smoke_specs = {
+        path.name
+        for pattern in _smoke_test_match_patterns()
+        for path in _UI_TESTS_DIR.glob(pattern)
+    }
 
     missing = _EXPECTED_CORE_SMOKE_SPECS - smoke_specs
     assert not missing, f"Missing core smoke specs: {sorted(missing)}"

--- a/apps/server/tests/integration/test_contract_analysis_report.py
+++ b/apps/server/tests/integration/test_contract_analysis_report.py
@@ -83,9 +83,25 @@ def _report_data_from_samples(
 def test_analysis_output_accepted_by_report_mapper():
     """summarize_run_data() output must prepare and map cleanly."""
     meta, samples = _make_small_dataset()
-    report_data = _report_data_from_samples(meta, samples, lang="en")
+    summary = summarize_run_data(meta, samples, lang="en")
+    prepared = prepare_report_input(summary)
+    report_data = build_report_document(prepared)
 
+    assert prepared.domain_test_run is not None
     assert isinstance(report_data, ReportDocument)
+    assert report_data.run_id == summary["run_id"] == prepared.report_facts.run.run_id
+    assert report_data.sensor_count == summary["sensor_count_used"]
+    assert report_data.sensor_locations == summary["sensor_locations"]
+    assert report_data.top_causes
+
+    domain_top_cause = prepared.domain_test_run.effective_top_causes()[0]
+    report_top_cause = report_data.top_causes[0]
+    assert report_top_cause.suspected_source == str(domain_top_cause.suspected_source)
+    assert report_top_cause.strongest_location == domain_top_cause.strongest_location
+    assert report_top_cause.order == domain_top_cause.order
+    assert report_top_cause.effective_confidence == pytest.approx(
+        domain_top_cause.effective_confidence,
+    )
 
 
 def test_report_data_has_populated_fields():

--- a/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
+++ b/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
@@ -335,13 +335,22 @@ class TestSuppressEngineAliases:
 
     def test_engine_suppressed_when_wheel_stronger(self) -> None:
         input_findings = [
-            (0.5, make_finding(suspected_source="wheel/tire", confidence=0.60, ranking_score=0.5)),
-            (0.4, make_finding(suspected_source="engine", confidence=0.50, ranking_score=0.4)),
+            (
+                0.62,
+                make_finding(suspected_source="wheel/tire", confidence=0.62, ranking_score=0.62),
+            ),
+            (
+                0.49,
+                make_finding(suspected_source="engine", confidence=0.45, ranking_score=0.49),
+            ),
         ]
         result = _suppress_engine_aliases(input_findings)
-        engine_results = [f for f in result if str(f.suspected_source) == "engine"]
-        if engine_results:
-            assert engine_results[0].effective_confidence < 0.50
+        assert [str(f.suspected_source) for f in result] == ["wheel/tire", "engine"]
+        wheel_result, engine_result = result
+        assert wheel_result.effective_confidence == pytest.approx(0.62)
+        assert engine_result.effective_confidence == pytest.approx(0.27)
+        assert engine_result.ranking_score == pytest.approx(0.294)
+        assert engine_result.effective_confidence < wheel_result.effective_confidence
 
     def test_engine_suppression_normalizes_source_tokens(self) -> None:
         input_findings = [
@@ -374,10 +383,14 @@ class TestSpeedBreakdown:
         samples = [
             {"speed_kmh": 65.0, "vibration_strength_db": 20.0},
             {"speed_kmh": 68.0, "vibration_strength_db": 22.0},
+            {"speed_kmh": 0.0, "vibration_strength_db": 99.0},
         ]
         rows = _speed_breakdown(sensor_frames_from_mappings(samples))
         assert len(rows) == 1
+        assert rows[0].speed_range == "60-70 km/h"
         assert rows[0].count == 2
+        assert rows[0].mean_vibration_strength_db == pytest.approx(21.0)
+        assert rows[0].max_vibration_strength_db == pytest.approx(22.0)
 
 
 class TestPhaseSpeedBreakdown:
@@ -387,12 +400,21 @@ class TestPhaseSpeedBreakdown:
         samples = [
             {"speed_kmh": 60.0, "vibration_strength_db": 18.0},
             {"speed_kmh": 65.0, "vibration_strength_db": 20.0},
+            {"speed_kmh": 0.0, "vibration_strength_db": 8.0},
         ]
         phases = [DrivingPhase.CRUISE, DrivingPhase.CRUISE]
         rows = _phase_speed_breakdown(sensor_frames_from_mappings(samples), phases)
         cruise_rows = [r for r in rows if r.phase == "cruise"]
         assert len(cruise_rows) == 1
         assert cruise_rows[0].count == 2
+        assert cruise_rows[0].mean_speed_kmh == pytest.approx(62.5)
+        assert cruise_rows[0].max_speed_kmh == pytest.approx(65.0)
+        assert cruise_rows[0].mean_vibration_strength_db == pytest.approx(19.0)
+        assert cruise_rows[0].max_vibration_strength_db == pytest.approx(20.0)
+        unknown_rows = [r for r in rows if r.phase == "unknown"]
+        assert len(unknown_rows) == 1
+        assert unknown_rows[0].count == 1
+        assert unknown_rows[0].mean_speed_kmh is None
 
 
 class TestSensorIntensityByLocation:
@@ -403,10 +425,47 @@ class TestSensorIntensityByLocation:
 
     def test_single_location(self) -> None:
         samples = [
-            {"location": "front_left", "vibration_strength_db": 20.0},
-            {"location": "front_left", "vibration_strength_db": 22.0},
+            {
+                "t_s": 0.0,
+                "location": "front_left",
+                "vibration_strength_db": 20.0,
+                "frames_dropped_total": 1,
+                "queue_overflow_drops": 0,
+                "strength_bucket": "l2",
+            },
+            {
+                "t_s": 1.0,
+                "location": "front_left",
+                "vibration_strength_db": 22.0,
+                "frames_dropped_total": 3,
+                "queue_overflow_drops": 1,
+                "strength_bucket": "l2",
+            },
+            {
+                "t_s": 2.0,
+                "location": "front_left",
+                "vibration_strength_db": 30.0,
+                "frames_dropped_total": 6,
+                "queue_overflow_drops": 1,
+                "strength_bucket": "l3",
+            },
         ]
         rows = _sensor_intensity_by_location(sensor_frames_from_mappings(samples))
         assert len(rows) == 1
         assert rows[0].location == "front_left"
-        assert rows[0].sample_count == 2
+        assert rows[0].sample_count == 3
+        assert rows[0].mean_intensity_db == pytest.approx(24.0)
+        assert rows[0].p50_intensity_db == pytest.approx(22.0)
+        assert rows[0].p95_intensity_db == pytest.approx(29.2)
+        assert rows[0].max_intensity_db == pytest.approx(30.0)
+        assert rows[0].dropped_frames_delta == 5
+        assert rows[0].queue_overflow_drops_delta == 1
+        assert rows[0].strength_bucket_distribution.total == 3
+        assert rows[0].strength_bucket_distribution.counts == {
+            "l0": 0,
+            "l1": 0,
+            "l2": 2,
+            "l3": 1,
+            "l4": 0,
+            "l5": 0,
+        }


### PR DESCRIPTION
small\n\nwhat changed\n- pin engine-alias suppression and speed/phase/location aggregation outputs in diagnostics tests\n- parse UI smoke script/config and assert discovered smoke spec coverage instead of substring policing\n- assert analysis -> prepared report input -> report document keeps run metadata and top-cause fields intact\n\nwhy\n- weak count/type/text checks could drift while real contracts broke\n\nvalidation\n- PYTHONPATH=apps/server/tests .venv/bin/pytest -q apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/integration/test_contract_analysis_report.py\n- .venv/bin/ruff check apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/integration/test_contract_analysis_report.py\n- .venv/bin/ruff format --check apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/integration/test_contract_analysis_report.py\n- PYTHONPATH=apps/server/tests .venv/bin/pytest -q apps/server/tests/use_cases/diagnostics/ apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/integration/test_contract_analysis_report.py\n\nrisks tradeoffs\n- tests now pin real aggregation and report-bridge behavior, so intentional contract changes will need explicit fixture updates\n\nCloses #2824