### PR TITLE
test(server): merge snapshot config matrices

### DIFF
--- a/apps/server/tests/app/test_config.py
+++ b/apps/server/tests/app/test_config.py
@@ -45,20 +45,33 @@ def test_logging_flags_allow_db_only_mode(cfg_path: Path) -> None:
     assert cfg.logging.run_retention_days == 7
 
 
-def test_logging_no_data_timeout_defaults_and_allows_override(cfg_path: Path) -> None:
-    cfg = _write_and_load(cfg_path, {})
-    assert cfg.logging.no_data_timeout_s == 15.0
-
-    cfg = _write_and_load(cfg_path, {"logging": {"no_data_timeout_s": 30}})
-    assert cfg.logging.no_data_timeout_s == 30.0
-
-
-def test_logging_run_retention_days_defaults_and_allows_override(cfg_path: Path) -> None:
-    cfg = _write_and_load(cfg_path, {})
-    assert cfg.logging.run_retention_days == 7
-
-    cfg = _write_and_load(cfg_path, {"logging": {"run_retention_days": 21}})
-    assert cfg.logging.run_retention_days == 21
+@pytest.mark.parametrize(
+    ("override", "field", "expected"),
+    [
+        pytest.param({}, "no_data_timeout_s", 15.0, id="no-data-timeout-default"),
+        pytest.param(
+            {"logging": {"no_data_timeout_s": 30}},
+            "no_data_timeout_s",
+            30.0,
+            id="no-data-timeout-override",
+        ),
+        pytest.param({}, "run_retention_days", 7, id="run-retention-default"),
+        pytest.param(
+            {"logging": {"run_retention_days": 21}},
+            "run_retention_days",
+            21,
+            id="run-retention-override",
+        ),
+    ],
+)
+def test_logging_defaults_and_overrides(
+    cfg_path: Path,
+    override: dict[str, object],
+    field: str,
+    expected: float | int,
+) -> None:
+    cfg = _write_and_load(cfg_path, override)
+    assert getattr(cfg.logging, field) == expected
 
 
 def test_base_dev_and_docker_configs_capture_intended_runtime_invariants(tmp_path: Path) -> None:

--- a/apps/server/tests/domain/test_snapshots.py
+++ b/apps/server/tests/domain/test_snapshots.py
@@ -20,7 +20,81 @@ from vibesensor.shared.boundaries.codecs import (
 )
 from vibesensor.shared.order_reference_settings import order_reference_spec_from_snapshot
 
-# ── AnalysisSettingsSnapshot ────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    ("factory", "extract", "expected"),
+    [
+        pytest.param(
+            lambda: analysis_settings_snapshot_from_mapping({}),
+            lambda snap: {
+                "tire_width_mm": snap.tire_width_mm,
+                "rim_in": snap.rim_in,
+                "tire_deflection_factor": snap.tire_deflection_factor,
+                "has_order_reference": order_reference_spec_from_snapshot(snap) is not None,
+            },
+            {
+                "tire_width_mm": 0.0,
+                "rim_in": 0.0,
+                "tire_deflection_factor": 1.0,
+                "has_order_reference": False,
+            },
+            id="analysis-settings-empty",
+        ),
+        pytest.param(
+            lambda: RunContextSnapshot(),
+            lambda ctx: {
+                "car": ctx.car,
+                "has_car_context": ctx.has_car_context,
+                "active_car_id": ctx.active_car_id,
+                "car_name": ctx.car_name,
+                "car_type": ctx.car_type,
+                "car_variant": ctx.car_variant,
+                "has_order_reference": order_reference_spec_from_snapshot(ctx.analysis_settings)
+                is not None,
+            },
+            {
+                "car": None,
+                "has_car_context": False,
+                "active_car_id": None,
+                "car_name": None,
+                "car_type": None,
+                "car_variant": None,
+                "has_order_reference": False,
+            },
+            id="run-context-empty",
+        ),
+        pytest.param(
+            lambda: speed_profile_summary_from_mapping({}),
+            lambda snap: {
+                "min_kmh": snap.min_kmh,
+                "steady_speed": snap.steady_speed,
+                "sample_count": snap.sample_count,
+            },
+            {
+                "min_kmh": None,
+                "steady_speed": False,
+                "sample_count": 0,
+            },
+            id="speed-profile-empty",
+        ),
+        pytest.param(
+            lambda: driving_phase_summary_from_mapping({}),
+            lambda snap: {
+                "total_samples": snap.total_samples,
+                "has_cruise": snap.has_cruise,
+                "phase_counts": dict(snap.phase_counts),
+            },
+            {
+                "total_samples": 0,
+                "has_cruise": False,
+                "phase_counts": {},
+            },
+            id="driving-phase-empty",
+        ),
+    ],
+)
+def test_snapshot_codecs_accept_empty_input(factory, extract, expected) -> None:
+    assert extract(factory()) == expected
 
 
 class TestAnalysisSettingsSnapshotFromDict:
@@ -77,17 +151,21 @@ class TestAnalysisSettingsSnapshotFromDict:
         assert spec.is_complete is True
         assert spec.tire_circumference_m > 0
 
-    def test_non_numeric_values_default(self) -> None:
-        snap = analysis_settings_snapshot_from_mapping({"tire_width_mm": "not_a_number"})
-        assert snap.tire_width_mm == 0.0
-
-    def test_none_values_default(self) -> None:
-        snap = analysis_settings_snapshot_from_mapping({"rim_in": None})
-        assert snap.rim_in == 0.0
-
-    def test_infinity_defaults(self) -> None:
-        snap = analysis_settings_snapshot_from_mapping({"tire_width_mm": float("inf")})
-        assert snap.tire_width_mm == 0.0
+    @pytest.mark.parametrize(
+        ("payload", "field"),
+        [
+            pytest.param({"tire_width_mm": "not_a_number"}, "tire_width_mm", id="non-numeric"),
+            pytest.param({"rim_in": None}, "rim_in", id="none"),
+            pytest.param({"tire_width_mm": float("inf")}, "tire_width_mm", id="infinity"),
+        ],
+    )
+    def test_invalid_scalar_values_default_to_zero(
+        self,
+        payload: dict[str, object],
+        field: str,
+    ) -> None:
+        snap = analysis_settings_snapshot_from_mapping(payload)
+        assert getattr(snap, field) == 0.0
 
 
 class TestAnalysisSettingsOrderRef:
@@ -132,17 +210,6 @@ class TestAnalysisSettingsOrderRef:
 class TestRunContextSnapshot:
     """Typed domain tests for RunContextSnapshot."""
 
-    def test_absent_car_context_degrades_consumer_accessors(self) -> None:
-        ctx = RunContextSnapshot()
-
-        assert ctx.car is None
-        assert ctx.has_car_context is False
-        assert ctx.active_car_id is None
-        assert ctx.car_name is None
-        assert ctx.car_type is None
-        assert ctx.car_variant is None
-        assert order_reference_spec_from_snapshot(ctx.analysis_settings) is None
-
     def test_order_reference_spec_delegates_to_analysis_settings(self) -> None:
         ctx = RunContextSnapshot(
             analysis_settings=AnalysisSettingsSnapshot(
@@ -171,15 +238,6 @@ class TestRunContextSnapshot:
         assert ctx.car_type == "sedan"
         assert ctx.car_variant == "track"
 
-    def test_convenience_accessors_degrade_when_car_absent(self) -> None:
-        ctx = RunContextSnapshot()
-
-        assert ctx.has_car_context is False
-        assert ctx.active_car_id is None
-        assert ctx.car_name is None
-        assert ctx.car_type is None
-        assert ctx.car_variant is None
-
     def test_partial_car_context_stays_usable_without_fake_analysis_defaults(self) -> None:
         ctx = RunContextSnapshot(
             car=CarSnapshot(
@@ -204,12 +262,6 @@ class TestRunContextSnapshot:
 class TestSpeedProfileSummaryFromDict:
     """Boundary snapshot codec tests."""
 
-    def test_empty_dict_never_raises(self) -> None:
-        snap = speed_profile_summary_from_mapping({})
-        assert snap.min_kmh is None
-        assert snap.steady_speed is False
-        assert snap.sample_count == 0
-
     def test_sanitizes_mixed_speed_payload_without_hidden_normalization(self) -> None:
         snap = speed_profile_summary_from_mapping(
             {
@@ -231,13 +283,20 @@ class TestSpeedProfileSummaryFromDict:
         assert snap.steady_speed is False
         assert snap.sample_count == 12
 
-    def test_non_numeric_speed_defaults_to_none(self) -> None:
-        snap = speed_profile_summary_from_mapping({"min_kmh": "bad"})
-        assert snap.min_kmh is None
-
-    def test_infinity_speed_defaults_to_none(self) -> None:
-        snap = speed_profile_summary_from_mapping({"mean_kmh": float("inf")})
-        assert snap.mean_kmh is None
+    @pytest.mark.parametrize(
+        ("payload", "field"),
+        [
+            pytest.param({"min_kmh": "bad"}, "min_kmh", id="non-numeric"),
+            pytest.param({"mean_kmh": float("inf")}, "mean_kmh", id="infinity"),
+        ],
+    )
+    def test_invalid_speed_values_default_to_none(
+        self,
+        payload: dict[str, object],
+        field: str,
+    ) -> None:
+        snap = speed_profile_summary_from_mapping(payload)
+        assert getattr(snap, field) is None
 
 
 # ── DrivingPhaseSummary ────────────────────────────────────────────────────
@@ -245,12 +304,6 @@ class TestSpeedProfileSummaryFromDict:
 
 class TestDrivingPhaseSummaryFromDict:
     """from_dict() constructor tests."""
-
-    def test_empty_dict_never_raises(self) -> None:
-        snap = driving_phase_summary_from_mapping({})
-        assert snap.total_samples == 0
-        assert snap.has_cruise is False
-        assert dict(snap.phase_counts) == {}
 
     def test_counts_percentages_and_flags_fall_back_consistently(self) -> None:
         snap = driving_phase_summary_from_mapping(

--- a/apps/server/tests/domain/test_strength_metrics.py
+++ b/apps/server/tests/domain/test_strength_metrics.py
@@ -11,137 +11,207 @@ from vibesensor.shared.boundaries.codecs import (
     strength_peak_to_payload,
 )
 
-# ── StrengthPeak ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    ("decoder", "payload", "extract", "expected"),
+    [
+        pytest.param(
+            strength_peak_from_mapping,
+            {},
+            lambda peak: {
+                "hz": peak.hz,
+                "amp": peak.amp,
+                "vibration_strength_db": peak.vibration_strength_db,
+                "strength_bucket": peak.strength_bucket,
+            },
+            {
+                "hz": 0.0,
+                "amp": 0.0,
+                "vibration_strength_db": None,
+                "strength_bucket": None,
+            },
+            id="strength-peak-empty",
+        ),
+        pytest.param(
+            strength_peak_from_mapping,
+            {
+                "hz": 42.5,
+                "amp": 0.03,
+                "vibration_strength_db": 12.3,
+                "strength_bucket": "moderate",
+            },
+            lambda peak: {
+                "hz": peak.hz,
+                "amp": peak.amp,
+                "vibration_strength_db": peak.vibration_strength_db,
+                "strength_bucket": peak.strength_bucket,
+            },
+            {
+                "hz": 42.5,
+                "amp": 0.03,
+                "vibration_strength_db": 12.3,
+                "strength_bucket": "moderate",
+            },
+            id="strength-peak-round-trip",
+        ),
+        pytest.param(
+            strength_metrics_from_mapping,
+            {},
+            lambda metrics: {
+                "vibration_strength_db": metrics.vibration_strength_db,
+                "peak_amp_g": metrics.peak_amp_g,
+                "noise_floor_amp_g": metrics.noise_floor_amp_g,
+                "strength_bucket": metrics.strength_bucket,
+                "top_peaks": metrics.top_peaks,
+            },
+            {
+                "vibration_strength_db": None,
+                "peak_amp_g": None,
+                "noise_floor_amp_g": None,
+                "strength_bucket": None,
+                "top_peaks": (),
+            },
+            id="strength-metrics-empty",
+        ),
+        pytest.param(
+            strength_metrics_from_mapping,
+            {
+                "vibration_strength_db": 18.5,
+                "peak_amp_g": 0.05,
+                "noise_floor_amp_g": 0.002,
+                "strength_bucket": "strong",
+                "top_peaks": [
+                    {
+                        "hz": 42.0,
+                        "amp": 0.05,
+                        "vibration_strength_db": 18.5,
+                        "strength_bucket": "strong",
+                    },
+                    {
+                        "hz": 84.0,
+                        "amp": 0.02,
+                        "vibration_strength_db": 10.0,
+                        "strength_bucket": "moderate",
+                    },
+                ],
+            },
+            lambda metrics: {
+                "vibration_strength_db": metrics.vibration_strength_db,
+                "peak_amp_g": metrics.peak_amp_g,
+                "noise_floor_amp_g": metrics.noise_floor_amp_g,
+                "strength_bucket": metrics.strength_bucket,
+                "top_peaks": tuple(
+                    (peak.hz, peak.amp, peak.vibration_strength_db, peak.strength_bucket)
+                    for peak in metrics.top_peaks
+                ),
+            },
+            {
+                "vibration_strength_db": 18.5,
+                "peak_amp_g": 0.05,
+                "noise_floor_amp_g": 0.002,
+                "strength_bucket": "strong",
+                "top_peaks": (
+                    (42.0, 0.05, 18.5, "strong"),
+                    (84.0, 0.02, 10.0, "moderate"),
+                ),
+            },
+            id="strength-metrics-round-trip",
+        ),
+    ],
+)
+def test_strength_codecs_decode_expected_fields(decoder, payload, extract, expected) -> None:
+    assert extract(decoder(payload)) == expected
 
 
-class TestStrengthPeakFromDict:
-    def test_empty_dict_never_raises(self) -> None:
-        p = strength_peak_from_mapping({})
-        assert p.hz == 0.0
-        assert p.amp == 0.0
-        assert p.vibration_strength_db is None
-        assert p.strength_bucket is None
-
-    def test_round_trip(self) -> None:
-        data = {
-            "hz": 42.5,
-            "amp": 0.03,
-            "vibration_strength_db": 12.3,
-            "strength_bucket": "moderate",
-        }
-        p = strength_peak_from_mapping(data)
-        assert p.hz == 42.5
-        assert p.amp == 0.03
-        assert p.vibration_strength_db == pytest.approx(12.3)
-        assert p.strength_bucket == "moderate"
-
-    def test_invalid_hz_defaults(self) -> None:
-        p = strength_peak_from_mapping({"hz": "bad"})
-        assert p.hz == 0.0
-
-    def test_infinity_defaults(self) -> None:
-        p = strength_peak_from_mapping({"amp": float("inf")})
-        assert p.amp == 0.0
-
-    def test_to_dict_omits_missing_optional_fields(self) -> None:
-        p = strength_peak_from_mapping({"hz": 42.0, "amp": 0.3})
-        assert strength_peak_to_payload(p) == {"hz": 42.0, "amp": 0.3}
-
-    def test_empty_bucket_becomes_none(self) -> None:
-        p = strength_peak_from_mapping({"strength_bucket": ""})
-        assert p.strength_bucket is None
-
-    def test_is_valid_requires_positive_hz_and_amp(self) -> None:
-        assert strength_peak_from_mapping({"hz": 42.0, "amp": 0.3}).is_valid is True
-        assert strength_peak_from_mapping({"hz": 0.0, "amp": 0.3}).is_valid is False
-        assert strength_peak_from_mapping({"hz": 42.0, "amp": 0.0}).is_valid is False
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        pytest.param({"hz": "bad"}, {"hz": 0.0, "amp": 0.0}, id="invalid-hz"),
+        pytest.param({"amp": float("inf")}, {"hz": 0.0, "amp": 0.0}, id="infinite-amp"),
+        pytest.param({"strength_bucket": ""}, {"strength_bucket": None}, id="empty-bucket"),
+    ],
+)
+def test_strength_peak_from_mapping_sanitizes_invalid_inputs(
+    payload: dict[str, object],
+    expected: dict[str, object],
+) -> None:
+    peak = strength_peak_from_mapping(payload)
+    for field, expected_value in expected.items():
+        assert getattr(peak, field) == expected_value
 
 
-# ── StrengthMetrics ─────────────────────────────────────────────────
+def test_strength_peak_to_payload_omits_missing_optional_fields() -> None:
+    peak = strength_peak_from_mapping({"hz": 42.0, "amp": 0.3})
+    assert strength_peak_to_payload(peak) == {"hz": 42.0, "amp": 0.3}
 
 
-class TestStrengthMetricsFromDict:
-    def test_empty_dict_never_raises(self) -> None:
-        m = strength_metrics_from_mapping({})
-        assert m.vibration_strength_db is None
-        assert m.peak_amp_g is None
-        assert m.noise_floor_amp_g is None
-        assert m.strength_bucket is None
-        assert m.top_peaks == ()
+def test_strength_peak_is_valid_requires_positive_hz_and_amp() -> None:
+    assert strength_peak_from_mapping({"hz": 42.0, "amp": 0.3}).is_valid is True
+    assert strength_peak_from_mapping({"hz": 0.0, "amp": 0.3}).is_valid is False
+    assert strength_peak_from_mapping({"hz": 42.0, "amp": 0.0}).is_valid is False
 
-    def test_round_trip(self) -> None:
-        data = {
-            "vibration_strength_db": 18.5,
-            "peak_amp_g": 0.05,
-            "noise_floor_amp_g": 0.002,
-            "strength_bucket": "strong",
+
+@pytest.mark.parametrize(
+    ("payload", "expected_hz_values", "expected_dominant_hz"),
+    [
+        pytest.param({}, (), None, id="empty-defaults"),
+        pytest.param({"vibration_strength_db": 5.0}, (), None, id="missing-top-peaks"),
+        pytest.param(
+            {"top_peaks": [42, "bad", {"hz": 10.0}]},
+            (10.0,),
+            10.0,
+            id="skip-non-mapping-items",
+        ),
+        pytest.param(
+            {"top_peaks": [{"hz": "bad", "amp": 0.05}]},
+            (0.0,),
+            None,
+            id="invalid-first-peak-drops-dominant-hz",
+        ),
+    ],
+)
+def test_strength_metrics_from_mapping_handles_missing_and_invalid_peak_inputs(
+    payload: dict[str, object],
+    expected_hz_values: tuple[float, ...],
+    expected_dominant_hz: float | None,
+) -> None:
+    metrics = strength_metrics_from_mapping(payload)
+
+    assert isinstance(metrics.top_peaks, tuple)
+    assert tuple(peak.hz for peak in metrics.top_peaks) == expected_hz_values
+    assert metrics.dominant_hz == expected_dominant_hz
+
+
+def test_strength_metrics_dominant_peak_and_hz_follow_first_typed_peak() -> None:
+    metrics = strength_metrics_from_mapping(
+        {
             "top_peaks": [
-                {
-                    "hz": 42.0,
-                    "amp": 0.05,
-                    "vibration_strength_db": 18.5,
-                    "strength_bucket": "strong",
-                },
-                {
-                    "hz": 84.0,
-                    "amp": 0.02,
-                    "vibration_strength_db": 10.0,
-                    "strength_bucket": "moderate",
-                },
+                {"hz": 42.0, "amp": 0.05},
+                {"hz": 84.0, "amp": 0.04},
             ],
-        }
-        m = strength_metrics_from_mapping(data)
-        assert m.vibration_strength_db == pytest.approx(18.5)
-        assert len(m.top_peaks) == 2
-        assert m.top_peaks[0].hz == 42.0
-        assert m.top_peaks[1].strength_bucket == "moderate"
+        },
+    )
+    assert metrics.dominant_peak is not None
+    assert metrics.dominant_peak.hz == 42.0
+    assert metrics.dominant_hz == 42.0
 
-    def test_non_mapping_peaks_skipped(self) -> None:
-        m = strength_metrics_from_mapping({"top_peaks": [42, "bad", {"hz": 10.0}]})
-        assert len(m.top_peaks) == 1
-        assert m.top_peaks[0].hz == 10.0
 
-    def test_no_top_peaks_key(self) -> None:
-        m = strength_metrics_from_mapping({"vibration_strength_db": 5.0})
-        assert m.top_peaks == ()
+def test_strength_metrics_to_peak_payloads_filters_invalid_peaks_and_truncates() -> None:
+    metrics = strength_metrics_from_mapping(
+        {
+            "top_peaks": [
+                {"hz": float(i), "amp": 0.1, "vibration_strength_db": float(i)}
+                for i in range(1, 11)
+            ]
+            + [
+                {"hz": 100.0, "amp": 0.0},
+                {"hz": 0.0, "amp": 0.3},
+            ],
+        },
+    )
 
-    def test_top_peaks_immutable(self) -> None:
-        m = strength_metrics_from_mapping({"top_peaks": [{"hz": 1.0}]})
-        assert isinstance(m.top_peaks, tuple)
+    payloads = strength_peak_payloads(metrics.top_peaks, max_items=8)
 
-    def test_dominant_peak_and_hz_follow_first_typed_peak(self) -> None:
-        m = strength_metrics_from_mapping(
-            {
-                "top_peaks": [
-                    {"hz": 42.0, "amp": 0.05},
-                    {"hz": 84.0, "amp": 0.04},
-                ],
-            },
-        )
-        assert m.dominant_peak is not None
-        assert m.dominant_peak.hz == 42.0
-        assert m.dominant_hz == 42.0
-
-    def test_dominant_hz_degrades_gracefully_for_invalid_first_peak(self) -> None:
-        m = strength_metrics_from_mapping({"top_peaks": [{"hz": "bad", "amp": 0.05}]})
-        assert m.dominant_hz is None
-
-    def test_to_peak_payloads_filters_invalid_peaks_and_truncates(self) -> None:
-        m = strength_metrics_from_mapping(
-            {
-                "top_peaks": [
-                    {"hz": float(i), "amp": 0.1, "vibration_strength_db": float(i)}
-                    for i in range(1, 11)
-                ]
-                + [
-                    {"hz": 100.0, "amp": 0.0},
-                    {"hz": 0.0, "amp": 0.3},
-                ],
-            },
-        )
-
-        payloads = strength_peak_payloads(m.top_peaks, max_items=8)
-
-        assert len(payloads) == 8
-        assert payloads[0] == {"hz": 1.0, "amp": 0.1, "vibration_strength_db": 1.0}
-        assert payloads[-1] == {"hz": 8.0, "amp": 0.1, "vibration_strength_db": 8.0}
+    assert len(payloads) == 8
+    assert payloads[0] == {"hz": 1.0, "amp": 0.1, "vibration_strength_db": 1.0}
+    assert payloads[-1] == {"hz": 8.0, "amp": 0.1, "vibration_strength_db": 8.0}


### PR DESCRIPTION
small\n\nwhat changed\n- merge repeated strength peak/metrics empty-default and degraded-input checks into grouped codec matrices\n- merge snapshot empty-default checks and scalar fallback cases into shared parameterized contracts\n- merge logging timeout and retention default/override checks into one config matrix\n\nwhy\n- these files still had several tiny empty/default/round-trip variants for the same codec and config behavior families\n\nvalidation\n- PYTHONPATH=apps/server/tests .venv/bin/pytest -q apps/server/tests/domain/test_strength_metrics.py apps/server/tests/domain/test_snapshots.py apps/server/tests/app/test_config.py\n- .venv/bin/ruff check apps/server/tests/domain/test_strength_metrics.py apps/server/tests/domain/test_snapshots.py apps/server/tests/app/test_config.py\n- .venv/bin/ruff format --check apps/server/tests/domain/test_strength_metrics.py apps/server/tests/domain/test_snapshots.py apps/server/tests/app/test_config.py\n- PYTHONPATH=apps/server/tests .venv/bin/pytest -q apps/server/tests/domain/ apps/server/tests/app/\n\nrisks tradeoffs\n- broader tables make intentional codec-default contract changes touch fewer but denser assertions\n\nCloses #2826