### PR TITLE
test(server): merge bridge scenario tests

### DIFF
--- a/apps/server/tests/hygiene/test_ui_smoke_contract.py
+++ b/apps/server/tests/hygiene/test_ui_smoke_contract.py
@@ -51,10 +51,19 @@ def _smoke_workers_env_contract() -> tuple[str, str]:
     return str(match.group(1)), str(match.group(2))
 
 
-def test_ui_smoke_script_defers_test_selection_to_smoke_config() -> None:
+def _resolved_smoke_specs() -> set[str]:
+    return {
+        path.name
+        for pattern in _smoke_test_match_patterns()
+        for path in (REPO_ROOT / "apps" / "ui" / _smoke_test_dir()).glob(pattern)
+    }
+
+
+def test_ui_smoke_command_and_config_alignment() -> None:
     scripts = _package_scripts()
     smoke_tokens = _smoke_script_tokens()
     workers_env_var, workers_default = _smoke_workers_env_contract()
+    smoke_specs = _resolved_smoke_specs()
 
     assert scripts["pretest:smoke"] == "npm run sync:generated-contracts"
     assert smoke_tokens[:3] == ["npx", "playwright", "test"]
@@ -69,15 +78,6 @@ def test_ui_smoke_script_defers_test_selection_to_smoke_config() -> None:
     )
     assert workers_env_var == "PLAYWRIGHT_SMOKE_WORKERS"
     assert workers_default == "1"
-
-
-def test_ui_smoke_config_uses_split_smoke_glob() -> None:
-    smoke_specs = {
-        path.name
-        for pattern in _smoke_test_match_patterns()
-        for path in (REPO_ROOT / "apps" / "ui" / _smoke_test_dir()).glob(pattern)
-    }
-
     assert _smoke_test_dir() == "tests"
     assert smoke_specs
     assert all(name.startswith("smoke") for name in smoke_specs)
@@ -85,11 +85,7 @@ def test_ui_smoke_config_uses_split_smoke_glob() -> None:
 
 
 def test_core_ui_smoke_specs_exist() -> None:
-    smoke_specs = {
-        path.name
-        for pattern in _smoke_test_match_patterns()
-        for path in _UI_TESTS_DIR.glob(pattern)
-    }
+    smoke_specs = _resolved_smoke_specs()
 
     missing = _EXPECTED_CORE_SMOKE_SPECS - smoke_specs
     assert not missing, f"Missing core smoke specs: {sorted(missing)}"

--- a/apps/server/tests/integration/test_contract_analysis_report.py
+++ b/apps/server/tests/integration/test_contract_analysis_report.py
@@ -65,14 +65,15 @@ def _make_steady_speed_fault_dataset() -> tuple[dict, list[dict]]:
     return meta, samples
 
 
-def _report_data_from_samples(
+def _summarize_and_prepare_report(
     meta: dict,
     samples: list[dict],
     *,
     lang: str,
-) -> ReportDocument:
+) -> tuple[dict, object, ReportDocument]:
     summary = summarize_run_data(meta, samples, lang=lang)
-    return build_report_document(prepare_report_input(summary))
+    prepared = prepare_report_input(summary)
+    return summary, prepared, build_report_document(prepared)
 
 
 # ------------------------------------------------------------------
@@ -80,20 +81,52 @@ def _report_data_from_samples(
 # ------------------------------------------------------------------
 
 
-def test_analysis_output_accepted_by_report_mapper():
-    """summarize_run_data() output must prepare and map cleanly."""
-    meta, samples = _make_small_dataset()
-    summary = summarize_run_data(meta, samples, lang="en")
-    prepared = prepare_report_input(summary)
-    report_data = build_report_document(prepared)
+@pytest.mark.parametrize(
+    ("meta", "samples", "lang", "expect_top_cause_mapping"),
+    [
+        pytest.param(*_make_small_dataset(), "en", True, id="fault-en"),
+        pytest.param(
+            standard_metadata(language="en"),
+            make_noise_samples(sensors=ALL_WHEEL_SENSORS, n_samples=30, speed_kmh=60.0),
+            "en",
+            False,
+            id="noise-en",
+        ),
+        pytest.param(
+            standard_metadata(language="nl"),
+            make_noise_samples(sensors=ALL_WHEEL_SENSORS, n_samples=20, speed_kmh=60.0),
+            "nl",
+            False,
+            id="noise-nl",
+        ),
+    ],
+)
+def test_analysis_to_report_bridge_scenarios(
+    meta: dict,
+    samples: list[dict],
+    lang: str,
+    expect_top_cause_mapping: bool,
+) -> None:
+    """Analysis output should prepare and map cleanly across bridge scenarios."""
+    summary, prepared, report_data = _summarize_and_prepare_report(
+        meta,
+        samples,
+        lang=lang,
+    )
 
     assert prepared.domain_test_run is not None
     assert isinstance(report_data, ReportDocument)
     assert report_data.run_id == summary["run_id"] == prepared.report_facts.run.run_id
+    assert report_data.title
+    assert report_data.lang == lang
     assert report_data.sensor_count == summary["sensor_count_used"]
     assert report_data.sensor_locations == summary["sensor_locations"]
-    assert report_data.top_causes
+    assert report_data.observed.certainty_label
 
+    if not expect_top_cause_mapping:
+        return
+
+    assert report_data.top_causes
     domain_top_cause = prepared.domain_test_run.effective_top_causes()[0]
     report_top_cause = report_data.top_causes[0]
     assert report_top_cause.suspected_source == str(domain_top_cause.suspected_source)
@@ -102,43 +135,6 @@ def test_analysis_output_accepted_by_report_mapper():
     assert report_top_cause.effective_confidence == pytest.approx(
         domain_top_cause.effective_confidence,
     )
-
-
-def test_report_data_has_populated_fields():
-    """Key report fields must be non-empty after mapping real analysis output."""
-    meta, samples = _make_small_dataset()
-    report_data = _report_data_from_samples(meta, samples, lang="en")
-
-    # Structural: the report must have a title and language
-    assert report_data.title
-    assert report_data.lang == "en"
-
-    # Content: sensor information propagated
-    assert report_data.sensor_count > 0
-    assert len(report_data.sensor_locations) > 0
-
-    # Diagnostic output: observed signature populated
-    assert report_data.observed.certainty_label
-
-
-def test_analysis_without_fault_maps_cleanly():
-    """A run with only road-noise (no fault) must still map without errors."""
-    meta = standard_metadata(language="en")
-    samples = make_noise_samples(sensors=ALL_WHEEL_SENSORS, n_samples=30, speed_kmh=60.0)
-    report_data = _report_data_from_samples(meta, samples, lang="en")
-
-    assert isinstance(report_data, ReportDocument)
-    assert report_data.lang == "en"
-
-
-def test_multilingual_mapping():
-    """Analysis + report mapping must work for non-English languages."""
-    meta = standard_metadata(language="nl")
-    samples = make_noise_samples(sensors=ALL_WHEEL_SENSORS, n_samples=20, speed_kmh=60.0)
-    report_data = _report_data_from_samples(meta, samples, lang="nl")
-
-    assert isinstance(report_data, ReportDocument)
-    assert report_data.lang == "nl"
 
 
 def test_report_certainty_uses_confidence_assessment_reason() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
+++ b/apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py
@@ -361,96 +361,187 @@ class TestSuppressEngineAliases:
 class TestSpeedBreakdown:
     """Test _speed_breakdown."""
 
-    def test_empty_samples(self) -> None:
-        assert _speed_breakdown([]) == []
-
-    def test_single_speed_bin(self) -> None:
-        samples = [
-            {"speed_kmh": 65.0, "vibration_strength_db": 20.0},
-            {"speed_kmh": 68.0, "vibration_strength_db": 22.0},
-            {"speed_kmh": 0.0, "vibration_strength_db": 99.0},
-        ]
+    @pytest.mark.parametrize(
+        ("samples", "expected_rows"),
+        [
+            pytest.param([], (), id="empty"),
+            pytest.param(
+                [
+                    {"speed_kmh": 65.0, "vibration_strength_db": 20.0},
+                    {"speed_kmh": 68.0, "vibration_strength_db": 22.0},
+                    {"speed_kmh": 0.0, "vibration_strength_db": 99.0},
+                ],
+                (("60-70 km/h", 2, 21.0, 22.0),),
+                id="single-speed-bin",
+            ),
+        ],
+    )
+    def test_speed_breakdown_cases(
+        self,
+        samples: list[dict[str, float]],
+        expected_rows: tuple[tuple[str, int, float, float], ...],
+    ) -> None:
         rows = _speed_breakdown(sensor_frames_from_mappings(samples))
-        assert len(rows) == 1
-        assert rows[0].speed_range == "60-70 km/h"
-        assert rows[0].count == 2
-        assert rows[0].mean_vibration_strength_db == pytest.approx(21.0)
-        assert rows[0].max_vibration_strength_db == pytest.approx(22.0)
+
+        assert len(rows) == len(expected_rows)
+        for row, (
+            speed_range,
+            count,
+            mean_vibration_strength_db,
+            max_vibration_strength_db,
+        ) in zip(rows, expected_rows, strict=True):
+            assert row.speed_range == speed_range
+            assert row.count == count
+            assert row.mean_vibration_strength_db == pytest.approx(mean_vibration_strength_db)
+            assert row.max_vibration_strength_db == pytest.approx(max_vibration_strength_db)
 
 
 class TestPhaseSpeedBreakdown:
     """Test _phase_speed_breakdown."""
 
-    def test_single_phase(self) -> None:
-        samples = [
-            {"speed_kmh": 60.0, "vibration_strength_db": 18.0},
-            {"speed_kmh": 65.0, "vibration_strength_db": 20.0},
-            {"speed_kmh": 0.0, "vibration_strength_db": 8.0},
-        ]
-        phases = [DrivingPhase.CRUISE, DrivingPhase.CRUISE]
+    @pytest.mark.parametrize(
+        ("samples", "phases", "expected_rows"),
+        [
+            pytest.param([], [], (), id="empty"),
+            pytest.param(
+                [
+                    {"speed_kmh": 60.0, "vibration_strength_db": 18.0},
+                    {"speed_kmh": 65.0, "vibration_strength_db": 20.0},
+                    {"speed_kmh": 0.0, "vibration_strength_db": 8.0},
+                ],
+                [DrivingPhase.CRUISE, DrivingPhase.CRUISE],
+                (
+                    ("cruise", 2, 62.5, 65.0, 19.0, 20.0),
+                    ("unknown", 1, None, None, 8.0, 8.0),
+                ),
+                id="single-phase-plus-unknown-tail",
+            ),
+        ],
+    )
+    def test_phase_speed_breakdown_cases(
+        self,
+        samples: list[dict[str, float]],
+        phases: list[DrivingPhase],
+        expected_rows: tuple[
+            tuple[str, int, float | None, float | None, float | None, float | None],
+            ...,
+        ],
+    ) -> None:
         rows = _phase_speed_breakdown(sensor_frames_from_mappings(samples), phases)
-        cruise_rows = [r for r in rows if r.phase == "cruise"]
-        assert len(cruise_rows) == 1
-        assert cruise_rows[0].count == 2
-        assert cruise_rows[0].mean_speed_kmh == pytest.approx(62.5)
-        assert cruise_rows[0].max_speed_kmh == pytest.approx(65.0)
-        assert cruise_rows[0].mean_vibration_strength_db == pytest.approx(19.0)
-        assert cruise_rows[0].max_vibration_strength_db == pytest.approx(20.0)
-        unknown_rows = [r for r in rows if r.phase == "unknown"]
-        assert len(unknown_rows) == 1
-        assert unknown_rows[0].count == 1
-        assert unknown_rows[0].mean_speed_kmh is None
+
+        assert len(rows) == len(expected_rows)
+        for row, (
+            phase,
+            count,
+            mean_speed_kmh,
+            max_speed_kmh,
+            mean_vibration_strength_db,
+            max_vibration_strength_db,
+        ) in zip(rows, expected_rows, strict=True):
+            assert row.phase == phase
+            assert row.count == count
+            if mean_speed_kmh is None:
+                assert row.mean_speed_kmh is None
+            else:
+                assert row.mean_speed_kmh == pytest.approx(mean_speed_kmh)
+            if max_speed_kmh is None:
+                assert row.max_speed_kmh is None
+            else:
+                assert row.max_speed_kmh == pytest.approx(max_speed_kmh)
+            assert (
+                row.mean_vibration_strength_db == pytest.approx(mean_vibration_strength_db)
+                if mean_vibration_strength_db is not None
+                else row.mean_vibration_strength_db is None
+            )
+            assert (
+                row.max_vibration_strength_db == pytest.approx(max_vibration_strength_db)
+                if max_vibration_strength_db is not None
+                else row.max_vibration_strength_db is None
+            )
 
 
 class TestSensorIntensityByLocation:
     """Test _sensor_intensity_by_location."""
 
-    def test_empty_samples(self) -> None:
-        assert _sensor_intensity_by_location([]) == []
-
-    def test_single_location(self) -> None:
-        samples = [
-            {
-                "t_s": 0.0,
-                "location": "front_left",
-                "vibration_strength_db": 20.0,
-                "frames_dropped_total": 1,
-                "queue_overflow_drops": 0,
-                "strength_bucket": "l2",
-            },
-            {
-                "t_s": 1.0,
-                "location": "front_left",
-                "vibration_strength_db": 22.0,
-                "frames_dropped_total": 3,
-                "queue_overflow_drops": 1,
-                "strength_bucket": "l2",
-            },
-            {
-                "t_s": 2.0,
-                "location": "front_left",
-                "vibration_strength_db": 30.0,
-                "frames_dropped_total": 6,
-                "queue_overflow_drops": 1,
-                "strength_bucket": "l3",
-            },
-        ]
+    @pytest.mark.parametrize(
+        ("samples", "expected_rows"),
+        [
+            pytest.param([], (), id="empty"),
+            pytest.param(
+                [
+                    {
+                        "t_s": 0.0,
+                        "location": "front_left",
+                        "vibration_strength_db": 20.0,
+                        "frames_dropped_total": 1,
+                        "queue_overflow_drops": 0,
+                        "strength_bucket": "l2",
+                    },
+                    {
+                        "t_s": 1.0,
+                        "location": "front_left",
+                        "vibration_strength_db": 22.0,
+                        "frames_dropped_total": 3,
+                        "queue_overflow_drops": 1,
+                        "strength_bucket": "l2",
+                    },
+                    {
+                        "t_s": 2.0,
+                        "location": "front_left",
+                        "vibration_strength_db": 30.0,
+                        "frames_dropped_total": 6,
+                        "queue_overflow_drops": 1,
+                        "strength_bucket": "l3",
+                    },
+                ],
+                (
+                    (
+                        "front_left",
+                        3,
+                        24.0,
+                        22.0,
+                        29.2,
+                        30.0,
+                        5,
+                        1,
+                        3,
+                        {"l0": 0, "l1": 0, "l2": 2, "l3": 1, "l4": 0, "l5": 0},
+                    ),
+                ),
+                id="single-location",
+            ),
+        ],
+    )
+    def test_sensor_intensity_by_location_cases(
+        self,
+        samples: list[dict[str, float | str]],
+        expected_rows: tuple[
+            tuple[str, int, float, float, float, float, int, int, int, dict[str, int]],
+            ...,
+        ],
+    ) -> None:
         rows = _sensor_intensity_by_location(sensor_frames_from_mappings(samples))
-        assert len(rows) == 1
-        assert rows[0].location == "front_left"
-        assert rows[0].sample_count == 3
-        assert rows[0].mean_intensity_db == pytest.approx(24.0)
-        assert rows[0].p50_intensity_db == pytest.approx(22.0)
-        assert rows[0].p95_intensity_db == pytest.approx(29.2)
-        assert rows[0].max_intensity_db == pytest.approx(30.0)
-        assert rows[0].dropped_frames_delta == 5
-        assert rows[0].queue_overflow_drops_delta == 1
-        assert rows[0].strength_bucket_distribution.total == 3
-        assert rows[0].strength_bucket_distribution.counts == {
-            "l0": 0,
-            "l1": 0,
-            "l2": 2,
-            "l3": 1,
-            "l4": 0,
-            "l5": 0,
-        }
+
+        assert len(rows) == len(expected_rows)
+        for row, (
+            location,
+            sample_count,
+            mean_intensity_db,
+            p50_intensity_db,
+            p95_intensity_db,
+            max_intensity_db,
+            dropped_frames_delta,
+            queue_overflow_drops_delta,
+            bucket_total,
+            bucket_counts,
+        ) in zip(rows, expected_rows, strict=True):
+            assert row.location == location
+            assert row.sample_count == sample_count
+            assert row.mean_intensity_db == pytest.approx(mean_intensity_db)
+            assert row.p50_intensity_db == pytest.approx(p50_intensity_db)
+            assert row.p95_intensity_db == pytest.approx(p95_intensity_db)
+            assert row.max_intensity_db == pytest.approx(max_intensity_db)
+            assert row.dropped_frames_delta == dropped_frames_delta
+            assert row.queue_overflow_drops_delta == queue_overflow_drops_delta
+            assert row.strength_bucket_distribution.total == bucket_total
+            assert row.strength_bucket_distribution.counts == bucket_counts


### PR DESCRIPTION
small

what changed
- merge empty and single-case aggregation helper checks into explicit scenario matrices
- merge the UI smoke command and config split checks into one alignment contract while keeping core smoke-spec presence separate
- merge the analysis-to-report fault, no-fault, and language fragments into one bridge scenario matrix and keep the certainty-reason regression separate

why
- these bridge and aggregation contracts were still scattered across tiny overlapping tests instead of one scenario per public surface

validation
- PYTHONPATH=apps/server/tests .venv/bin/pytest -q apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/integration/test_contract_analysis_report.py
- .venv/bin/ruff check apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/integration/test_contract_analysis_report.py
- .venv/bin/ruff format --check apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/integration/test_contract_analysis_report.py
- PYTHONPATH=apps/server/tests .venv/bin/pytest -q apps/server/tests/use_cases/diagnostics/ apps/server/tests/hygiene/test_ui_smoke_contract.py apps/server/tests/integration/test_contract_analysis_report.py

risks tradeoffs
- broader scenario tables make failures denser, but they match the public bridge surfaces more directly

Closes #2829