### PR TITLE
Harden remaining server test contracts

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_metrics_consistency.py
+++ b/apps/server/tests/adapters/pdf/test_report_metrics_consistency.py
@@ -297,6 +297,10 @@ def _assert_scenario_consistency(scenario: ScenarioPair) -> None:
     _run_all_consistency_checks(summary, rd)
 
 
+def _warn_checks(rd: ReportDocument) -> set[str]:
+    return {item.check for item in rd.data_trust if item.state == "warn"}
+
+
 # ---------------------------------------------------------------------------
 # Scenario 1: No-fault baseline
 # ---------------------------------------------------------------------------
@@ -312,19 +316,16 @@ class TestScenario1NoFaultBaseline:
     def test_consistency(self, scenario: ScenarioPair) -> None:
         _assert_scenario_consistency(scenario)
 
-    def test_no_overconfident_claims(self, scenario: ScenarioPair) -> None:
+    def test_no_fault_baseline_stays_guarded(self, scenario: ScenarioPair) -> None:
         _, rd = scenario
-        assert rd.certainty_tier_key in ("A", "B"), (
-            f"No-fault baseline should be tier A or B, got '{rd.certainty_tier_key}'"
-        )
-
-    def test_no_repair_actions(self, scenario: ScenarioPair) -> None:
-        _, rd = scenario
-        for card in rd.system_cards:
-            if rd.certainty_tier_key in ("A", "B"):
-                assert len(card.parts) == 0, (
-                    f"No-fault baseline card '{card.system_name}' should have no repair parts"
-                )
+        assert rd.certainty_tier_key == "A"
+        assert rd.observed.primary_system == "No significant pattern"
+        assert rd.system_cards == []
+        assert len(rd.next_steps) == 2
+        assert _warn_checks(rd) == {
+            "Reference completeness",
+            "Order-analysis reference context was incomplete for this run",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -342,29 +343,19 @@ class TestScenario2SingleWheelFault:
     def test_consistency(self, scenario: ScenarioPair) -> None:
         _assert_scenario_consistency(scenario)
 
-    def test_fl_localisation(self, scenario: ScenarioPair) -> None:
+    def test_single_wheel_fault_contract(self, scenario: ScenarioPair) -> None:
         _, rd = scenario
-        loc = (rd.observed.strongest_location or "").lower()
-        assert "front" in loc and "left" in loc, (
-            f"Expected front-left localisation, got '{rd.observed.strongest_location}'"
-        )
-
-    def test_wheel_source_identified(self, scenario: ScenarioPair) -> None:
-        _, rd = scenario
-        system = (rd.observed.primary_system or "").lower()
-        assert "wheel" in system or "tire" in system, (
-            f"Expected wheel/tire source, got '{rd.observed.primary_system}'"
-        )
-
-    def test_strength_nonzero(self, scenario: ScenarioPair) -> None:
-        _, rd = scenario
-        assert rd.observed.strength_label is not None
-        assert rd.observed.strength_label != ""
-        assert rd.observed.strength_label != "Unknown"
-
-    def test_peak_rows_present(self, scenario: ScenarioPair) -> None:
-        _, rd = scenario
-        assert len(rd.peak_rows) > 0, "Single wheel fault should have peak rows"
+        assert rd.certainty_tier_key == "B"
+        assert rd.observed.primary_system == "Wheel / Tire"
+        assert rd.observed.strongest_location == "Front-Left"
+        assert rd.observed.speed_band == "80-90 km/h"
+        assert (rd.observed.strength_label or "").startswith("Moderate (")
+        assert (rd.observed.strength_label or "").endswith(" dB)")
+        assert rd.system_cards[0].status_label == "Possible source"
+        first_peak = rd.peak_rows[0]
+        assert first_peak.relevance == "Repeated pattern"
+        assert first_peak.speed_band == "80-90 km/h"
+        assert first_peak.peak_db != "\u2014"
 
 
 # ---------------------------------------------------------------------------
@@ -382,18 +373,17 @@ class TestScenario3HighSpeedFault:
     def test_consistency(self, scenario: ScenarioPair) -> None:
         _assert_scenario_consistency(scenario)
 
-    def test_speed_band_reflects_high_speed(self, scenario: ScenarioPair) -> None:
+    def test_high_speed_fault_tracks_high_band_and_uncertainty_reason(
+        self,
+        scenario: ScenarioPair,
+    ) -> None:
         _, rd = scenario
-        band = (rd.observed.speed_band or "").lower()
-        assert band != "unknown" and band != "", (
-            f"High-speed fault should have a specific speed band, got '{rd.observed.speed_band}'"
-        )
-
-    def test_fr_localisation(self, scenario: ScenarioPair) -> None:
-        _, rd = scenario
-        loc = (rd.observed.strongest_location or "").lower()
-        assert "front" in loc and "right" in loc, (
-            f"Expected front-right localisation, got '{rd.observed.strongest_location}'"
+        assert rd.observed.primary_system == "Wheel / Tire"
+        assert rd.observed.strongest_location == "Front-Right"
+        assert rd.observed.speed_band == "110-120 km/h"
+        assert rd.observed.certainty_label == "High"
+        assert rd.observed.certainty_reason == (
+            "Missing reference data may affect accuracy; Speed was not steady during measurement"
         )
 
 
@@ -414,12 +404,14 @@ class TestScenario4MixedNoiseFault:
 
     def test_fault_not_masked_by_noise(self, scenario: ScenarioPair) -> None:
         _, rd = scenario
-        assert rd.observed.primary_system is not None
-        assert rd.observed.primary_system != "Unknown"
-
-    def test_data_trust_present(self, scenario: ScenarioPair) -> None:
-        _, rd = scenario
-        assert isinstance(rd.data_trust, list)
+        assert rd.observed.primary_system == "Wheel / Tire"
+        assert rd.observed.strongest_location == "Rear-Left"
+        assert rd.observed.speed_band == "80-90 km/h"
+        assert rd.observed.certainty_label == "Medium"
+        assert _warn_checks(rd) == {
+            "Reference completeness",
+            "Order-analysis reference context was incomplete for this run",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -444,9 +436,18 @@ class TestScenario5SparseSensors:
         )
         assert rd.sensor_count == len(connected or [])
 
-    def test_no_false_precision(self, scenario: ScenarioPair) -> None:
+    def test_sparse_sensor_contract_degrades_location_granularity(
+        self,
+        scenario: ScenarioPair,
+    ) -> None:
         _, rd = scenario
-        assert rd.sensor_count <= 2
+        assert rd.sensor_count == 2
+        assert sorted(rd.sensor_locations) == ["engine-bay", "front-left"]
+        assert {row.location for row in rd.location_hotspot_rows} == {
+            "engine-bay",
+            "front-left",
+        }
+        assert {row.unit for row in rd.location_hotspot_rows} == {"db"}
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/adapters/pdf/test_report_tier_gating.py
+++ b/apps/server/tests/adapters/pdf/test_report_tier_gating.py
@@ -109,162 +109,109 @@ def _make_summary(
     }
 
 
-# ---------------------------------------------------------------------------
-# Report output tests: Tier A behavior
-# ---------------------------------------------------------------------------
+def _build_report_data(**kwargs: object):
+    return build_report_document(prepare_report_input(_make_summary(**kwargs)))
 
 
-class TestTierAReportOutput:
-    """Tier A (low certainty, < 40%): no specific systems, no repair steps."""
+class TestTierReportOutput:
+    """Tier A/B/C report behavior should follow semantic gating rules."""
 
-    @pytest.fixture
-    def tier_a_data(self):
-        return build_report_document(prepare_report_input(_make_summary(confidence=0.10)))
+    @pytest.mark.parametrize(
+        ("confidence", "expected_tier", "lang", "expect_status_label", "expect_parts"),
+        [
+            pytest.param(0.10, "A", "en", False, False, id="tier-a-en"),
+            pytest.param(0.06, "A", "nl", False, False, id="tier-a-nl"),
+            pytest.param(0.50, "B", "en", True, False, id="tier-b-en"),
+            pytest.param(0.50, "B", "nl", True, False, id="tier-b-nl"),
+            pytest.param(0.75, "C", "en", False, True, id="tier-c-en"),
+        ],
+    )
+    def test_tier_gating_contracts(
+        self,
+        confidence: float,
+        expected_tier: str,
+        lang: str,
+        expect_status_label: bool,
+        expect_parts: bool,
+    ) -> None:
+        data = _build_report_data(confidence=confidence, lang=lang)
 
-    def test_tier_a_no_system_cards(self, tier_a_data):
-        assert tier_a_data.certainty_tier_key == "A"
-        assert tier_a_data.system_cards == []
+        assert data.certainty_tier_key == expected_tier
+        assert data.observed.certainty_label is not None
+        assert data.observed.certainty_pct is not None
 
-    def test_tier_a_no_repair_actions(self, tier_a_data):
-        for step in tier_a_data.next_steps:
-            assert "balance" not in step.action.lower()
-            assert "inspect" not in step.action.lower()
-            assert "runout" not in step.action.lower()
+        if expected_tier == "A":
+            assert data.system_cards == []
+            assert len(data.next_steps) == 3
+            assert all(step.confirm is None for step in data.next_steps)
+            assert all(step.falsify is None for step in data.next_steps)
+            assert {step.action for step in data.next_steps} != {
+                "Inspect wheel balance and radial/lateral runout"
+            }
+            return
 
-    def test_tier_a_shows_capture_guidance(self, tier_a_data):
-        actions = [s.action for s in tier_a_data.next_steps]
-        assert len(actions) >= 3
-        assert any("speed sweep" in a.lower() or "speed" in a.lower() for a in actions)
-        assert any("sensor" in a.lower() for a in actions)
-        assert any("reference" in a.lower() or "tire size" in a.lower() for a in actions)
+        assert len(data.system_cards) == 1
+        assert [step.action for step in data.next_steps] == [
+            "Inspect wheel balance and radial/lateral runout"
+        ]
 
-    def test_tier_a_next_steps_not_empty(self, tier_a_data):
-        """The report should not be empty — it must guide the user."""
-        assert len(tier_a_data.next_steps) > 0
-
-    def test_tier_a_observed_signature_still_present(self, tier_a_data):
-        """Observed signature should still show (pattern data, certainty label)."""
-        assert tier_a_data.observed.certainty_label is not None
-        assert tier_a_data.observed.certainty_pct is not None
-
-
-# ---------------------------------------------------------------------------
-# Report output tests: Tier B behavior
-# ---------------------------------------------------------------------------
-
-
-class TestTierBReportOutput:
-    """Tier B (medium certainty, 40%–70%): hypotheses only, no repair parts."""
-
-    @pytest.fixture
-    def tier_b_data(self):
-        return build_report_document(prepare_report_input(_make_summary(confidence=0.50)))
-
-    def test_tier_b_system_cards_present(self, tier_b_data):
-        assert tier_b_data.certainty_tier_key == "B"
-        assert len(tier_b_data.system_cards) > 0
-
-    def test_tier_b_cards_use_possible_source_status_label(self, tier_b_data):
-        for card in tier_b_data.system_cards:
-            assert card.system_name
-            assert "hypothesis" not in card.system_name.lower()
-            assert card.status_label == "Possible source"
-
-    def test_tier_b_no_repair_parts(self, tier_b_data):
-        for card in tier_b_data.system_cards:
-            assert card.parts == [], f"Tier B cards should have no parts, got {card.parts}"
-
-    def test_tier_b_next_steps_from_test_plan(self, tier_b_data):
-        """Tier B should still pass through test_plan steps (verification)."""
-        assert len(tier_b_data.next_steps) > 0
-        assert tier_b_data.next_steps[0].action != ""
-
-
-# ---------------------------------------------------------------------------
-# Report output tests: Tier C behavior
-# ---------------------------------------------------------------------------
-
-
-class TestTierCReportOutput:
-    """Tier C (high certainty, ≥ 70%): full diagnostic behavior."""
-
-    @pytest.fixture
-    def tier_c_data(self):
-        return build_report_document(prepare_report_input(_make_summary(confidence=0.75)))
-
-    def test_tier_c_system_cards_present(self, tier_c_data):
-        assert tier_c_data.certainty_tier_key == "C"
-        assert len(tier_c_data.system_cards) > 0
-
-    def test_tier_c_cards_have_parts(self, tier_c_data):
-        has_parts = any(card.parts for card in tier_c_data.system_cards)
-        assert has_parts, "Tier C cards should have repair-oriented parts"
-
-    def test_tier_c_cards_no_hypothesis_label(self, tier_c_data):
-        for card in tier_c_data.system_cards:
-            assert "hypothesis" not in card.system_name.lower()
+        card = data.system_cards[0]
+        assert card.system_name
+        assert card.strongest_location == "front_left"
+        assert bool(card.status_label) is expect_status_label
+        assert bool(card.parts) is expect_parts
+        if expect_status_label:
+            assert card.status_label not in {"", None}
+            assert card.parts == []
+        else:
             assert card.status_label is None
+            assert [part.name for part in card.parts] == [
+                "Tire flat spot / out-of-round",
+                "Wheel balance weights",
+                "Wheel hub bearing",
+            ]
 
-    def test_tier_c_next_steps_from_test_plan(self, tier_c_data):
-        assert len(tier_c_data.next_steps) > 0
+    @pytest.mark.parametrize(
+        ("confidence", "expected_tier"),
+        [
+            pytest.param(0.06, "A", id="tier-a"),
+            pytest.param(0.50, "B", id="tier-b"),
+            pytest.param(0.75, "C", id="tier-c"),
+        ],
+    )
+    def test_dutch_localization_preserves_same_tier_semantics(
+        self,
+        confidence: float,
+        expected_tier: str,
+    ) -> None:
+        english = _build_report_data(confidence=confidence, lang="en")
+        dutch = _build_report_data(confidence=confidence, lang="nl")
 
+        assert english.certainty_tier_key == dutch.certainty_tier_key == expected_tier
+        assert len(english.system_cards) == len(dutch.system_cards)
+        assert len(english.next_steps) == len(dutch.next_steps)
 
-# ---------------------------------------------------------------------------
-# Regression test: low certainty scenario
-# ---------------------------------------------------------------------------
+        if expected_tier == "A":
+            assert english.system_cards == dutch.system_cards == []
+            assert [step.action for step in english.next_steps] != [
+                step.action for step in dutch.next_steps
+            ]
+            return
 
+        english_card = english.system_cards[0]
+        dutch_card = dutch.system_cards[0]
+        assert english_card.system_name
+        assert dutch_card.system_name
+        assert english_card.system_name != dutch_card.system_name
+        assert english_card.strongest_location == dutch_card.strongest_location == "front_left"
+        assert bool(english_card.parts) is bool(dutch_card.parts)
+        assert (english_card.status_label is None) is (dutch_card.status_label is None)
+        if english_card.status_label is not None:
+            assert dutch_card.status_label not in {"", None, english_card.status_label}
 
-class TestLowCertaintyRegression:
-    """Regression: at low certainty the report must not suggest specific repairs."""
+    def test_baseline_noise_low_certainty_stays_capture_guidance_only(self) -> None:
+        data = _build_report_data(confidence=0.08, source="baseline_noise")
 
-    @pytest.fixture
-    def low_cert_data(self):
-        return build_report_document(prepare_report_input(_make_summary(confidence=0.06)))
-
-    def test_six_percent_certainty_no_parts_to_inspect(self, low_cert_data):
-        """With ~6% certainty, no parts inspection should be suggested."""
-        for step in low_cert_data.next_steps:
-            assert "tire" not in step.action.lower() or "tire size" in step.action.lower()
-            assert "bearing" not in step.action.lower()
-            assert "mount" not in step.action.lower()
-
-    def test_six_percent_certainty_provides_guidance(self, low_cert_data):
-        """With ~6% certainty, guidance on how to improve data quality must be shown."""
-        actions_text = " ".join(s.action.lower() for s in low_cert_data.next_steps)
-        assert "speed" in actions_text, "Should mention speed sweep guidance"
-        assert "sensor" in actions_text, "Should mention sensor coverage guidance"
-
-    def test_baseline_noise_low_certainty(self):
-        """Baseline Noise as primary system with low certainty stays in Tier A."""
-        data = build_report_document(
-            prepare_report_input(_make_summary(confidence=0.08, source="baseline_noise"))
-        )
         assert data.certainty_tier_key == "A"
         assert data.system_cards == []
-        assert len(data.next_steps) >= 3
-
-
-# ---------------------------------------------------------------------------
-# NL language support
-# ---------------------------------------------------------------------------
-
-
-class TestCertaintyTierNL:
-    """Verify tier behavior works with Dutch (nl) language."""
-
-    def test_tier_a_nl_capture_guidance(self):
-        data = build_report_document(
-            prepare_report_input(_make_summary(confidence=0.06, lang="nl"))
-        )
-        assert data.certainty_tier_key == "A"
-        assert len(data.next_steps) >= 3
-        actions_text = " ".join(s.action for s in data.next_steps)
-        assert "snelheidsvariatie" in actions_text or "sensorlocaties" in actions_text
-
-    def test_tier_b_nl_status_label(self):
-        data = build_report_document(
-            prepare_report_input(_make_summary(confidence=0.50, lang="nl"))
-        )
-        for card in data.system_cards:
-            assert "hypothese" not in card.system_name.lower()
-            assert card.status_label == "Mogelijke bron"
+        assert len(data.next_steps) == 3

--- a/apps/server/tests/domain/test_aggregate_invariants.py
+++ b/apps/server/tests/domain/test_aggregate_invariants.py
@@ -65,6 +65,10 @@ def _run(
     )
 
 
+def _action(action_id: str, what: str) -> RecommendedAction:
+    return RecommendedAction(action_id=action_id, what=what)
+
+
 def _passing_suitability() -> RunSuitability:
     return RunSuitability(
         checks=(SuitabilityCheck(check_key="test", state="pass"),),
@@ -102,6 +106,36 @@ class TestCaseLifecycle:
     def test_case_with_no_runs_has_no_primary(self) -> None:
         case = DiagnosticCase.start()
         assert case.primary_run is None
+
+    def test_primary_run_advances_without_mutating_previous_case(self) -> None:
+        first = _run(
+            "run-1",
+            findings=(_finding("F001"),),
+            actions=(_action("inspect-wheel", "Inspect wheel balance"),),
+            suitability=_passing_suitability(),
+        )
+        second = _run(
+            "run-2",
+            findings=(_finding("F002", source="driveline", location="center"),),
+            actions=(_action("inspect-driveline", "Inspect driveline joints"),),
+            suitability=_failing_suitability(),
+        )
+
+        initial_case = DiagnosticCase.start()
+        first_case = initial_case.add_run(first)
+        latest_case = first_case.add_run(second)
+
+        assert initial_case.test_runs == ()
+        assert first_case.test_runs == (first,)
+        assert first_case.primary_run == first
+        assert latest_case.test_runs == (first, second)
+        assert latest_case.primary_run == second
+        assert latest_case.primary_run.primary_source is VibrationSource.DRIVELINE
+        assert latest_case.primary_run.primary_location == "center"
+        assert latest_case.primary_run.recommended_actions == (
+            _action("inspect-driveline", "Inspect driveline joints"),
+        )
+        assert latest_case.primary_run.suitability == _failing_suitability()
 
 
 # ── Impossible aggregate state tests ────────────────────────────────────────
@@ -188,17 +222,21 @@ class TestImpossibleFindingStates:
         with pytest.raises(ValueError, match="confidence must be in"):
             Finding(finding_id="F001", confidence=1.01)
 
-    def test_confidence_boundary_zero_ok(self) -> None:
-        f = Finding(finding_id="F001", confidence=0.0)
-        assert f.confidence == 0.0
-
-    def test_confidence_boundary_one_ok(self) -> None:
-        f = Finding(finding_id="F001", confidence=1.0)
-        assert f.confidence == 1.0
-
-    def test_confidence_none_ok(self) -> None:
-        f = Finding(finding_id="F001", confidence=None)
-        assert f.confidence is None
+    @pytest.mark.parametrize(
+        ("confidence", "expected"),
+        [
+            pytest.param(0.0, 0.0, id="zero"),
+            pytest.param(1.0, 1.0, id="one"),
+            pytest.param(None, None, id="none"),
+        ],
+    )
+    def test_confidence_boundary_cases_ok(
+        self,
+        confidence: float | None,
+        expected: float | None,
+    ) -> None:
+        f = Finding(finding_id="F001", confidence=confidence)
+        assert f.confidence == expected
 
     def test_cruise_fraction_below_zero_raises(self) -> None:
         with pytest.raises(ValueError, match="cruise_fraction must be in"):
@@ -235,45 +273,42 @@ class TestImpossibleFindingStates:
 class TestImpossibleSuitabilityStates:
     """SuitabilityCheck state values and RunSuitability aggregation."""
 
-    def test_arbitrary_state_string_is_accepted(self) -> None:
-        """SuitabilityCheck.state is a plain str, not an enum — any value is stored."""
-        c = SuitabilityCheck(check_key="test", state="banana")
+    def test_arbitrary_state_string_is_explicitly_neutral_downstream(self) -> None:
+        """Unknown states remain stored but do not count as pass/warn/fail."""
+        c = SuitabilityCheck(check_key="test", state="banana", details=(("stride", 4),))
+        suitability = RunSuitability(checks=(c,))
+
         assert c.state == "banana"
         assert not c.passed
         assert not c.failed
         assert not c.is_warning
+        assert c.details_dict == {"stride": 4}
+        assert c.explanation_i18n_ref() == ""
+        assert suitability.overall == "pass"
+        assert suitability.is_usable
+        assert suitability.failed_checks == ()
+        assert suitability.warning_checks == ()
 
-    def test_overall_fail_when_any_check_fails(self) -> None:
+    @pytest.mark.parametrize(
+        ("states", "expected_overall", "expected_usable"),
+        [
+            pytest.param((), "pass", True, id="empty"),
+            pytest.param(("pass", "pass"), "pass", True, id="all-pass"),
+            pytest.param(("pass", "warn"), "caution", True, id="warning-present"),
+            pytest.param(("pass", "fail"), "fail", False, id="failure-present"),
+        ],
+    )
+    def test_overall_state_aggregation(
+        self,
+        states: tuple[str, ...],
+        expected_overall: str,
+        expected_usable: bool,
+    ) -> None:
         s = RunSuitability(
-            checks=(
-                SuitabilityCheck(check_key="a", state="pass"),
-                SuitabilityCheck(check_key="b", state="fail"),
+            checks=tuple(
+                SuitabilityCheck(check_key=f"check-{index}", state=state)
+                for index, state in enumerate(states)
             )
         )
-        assert s.overall == "fail"
-        assert not s.is_usable
-
-    def test_overall_caution_when_only_warnings(self) -> None:
-        s = RunSuitability(
-            checks=(
-                SuitabilityCheck(check_key="a", state="pass"),
-                SuitabilityCheck(check_key="b", state="warn"),
-            )
-        )
-        assert s.overall == "caution"
-        assert s.is_usable
-
-    def test_overall_pass_when_all_pass(self) -> None:
-        s = RunSuitability(
-            checks=(
-                SuitabilityCheck(check_key="a", state="pass"),
-                SuitabilityCheck(check_key="b", state="pass"),
-            )
-        )
-        assert s.overall == "pass"
-        assert s.is_usable
-
-    def test_empty_checks_is_pass(self) -> None:
-        s = RunSuitability(checks=())
-        assert s.overall == "pass"
-        assert s.is_usable
+        assert s.overall == expected_overall
+        assert s.is_usable is expected_usable

--- a/apps/server/tests/integration/test_exception_discipline.py
+++ b/apps/server/tests/integration/test_exception_discipline.py
@@ -37,6 +37,12 @@ def _metadata(run_id: str, **overrides: object) -> RunMetadata:
     return run_metadata_from_mapping(payload)
 
 
+def _assert_client_name_not_persisted(db: HistoryDB, client_id: str) -> None:
+    assert db.list_client_names() == {}
+    fresh_registry = ClientRegistry(db=db)
+    assert fresh_registry.get(client_id) is None
+
+
 class TestHistoryDBExceptionDiscipline:
     """HistoryDB catches sqlite3.Error but lets coding bugs propagate."""
 
@@ -61,6 +67,9 @@ class TestHistoryDBExceptionDiscipline:
         with pytest.raises(TypeError), db.write_transaction_cursor() as cur:
             cur.execute("SELECT 1")
             raise TypeError("simulated code bug")
+        run_id = "run-after-type-error"
+        db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="t"))
+        assert any(run.run_id == run_id for run in db.list_runs())
         db.close()
 
     def test_attribute_error_in_cursor_propagates(self, tmp_path: Path) -> None:
@@ -69,6 +78,9 @@ class TestHistoryDBExceptionDiscipline:
         with pytest.raises(AttributeError), db._cursor() as cur:
             cur.execute("SELECT 1")
             raise AttributeError("simulated code bug")
+        run_id = "run-after-attribute-error"
+        db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="t"))
+        assert any(run.run_id == run_id for run in db.list_runs())
         db.close()
 
 
@@ -82,6 +94,7 @@ class TestSettingsStoreExceptionDiscipline:
         """An sqlite3.OperationalError from the DB is wrapped as PersistenceError."""
         db = HistoryDB(tmp_path / "test.db")
         services = build_settings_services(db=db)
+        before = services.car_settings.get_cars()
         services.coordinator._db = MagicMock()
         services.coordinator._db.set_settings_snapshot.side_effect = sqlite3.OperationalError(
             "disk I/O error"
@@ -89,31 +102,37 @@ class TestSettingsStoreExceptionDiscipline:
 
         with pytest.raises(PersistenceError, match="Failed to persist"):
             services.car_settings.add_car({"name": "Test"})
+        assert services.car_settings.get_cars() == before
 
     def test_os_error_wrapped_as_persistence_error(self, tmp_path: Path) -> None:
         """An OSError from the DB is wrapped as PersistenceError."""
         db = HistoryDB(tmp_path / "test.db")
         services = build_settings_services(db=db)
+        before = services.car_settings.get_cars()
         services.coordinator._db = MagicMock()
         services.coordinator._db.set_settings_snapshot.side_effect = OSError("disk full")
 
         with pytest.raises(PersistenceError, match="Failed to persist"):
             services.car_settings.add_car({"name": "Test"})
+        assert services.car_settings.get_cars() == before
 
     def test_type_error_propagates_through_persist(self, tmp_path: Path) -> None:
         """TypeError from the DB is NOT wrapped — it propagates as a code bug."""
         db = HistoryDB(tmp_path / "test.db")
         services = build_settings_services(db=db)
+        before = services.car_settings.get_cars()
         services.coordinator._db = MagicMock()
         services.coordinator._db.set_settings_snapshot.side_effect = TypeError("bad argument type")
 
         with pytest.raises(TypeError, match="bad argument type"):
             services.car_settings.add_car({"name": "Test"})
+        assert services.car_settings.get_cars() == before
 
     def test_attribute_error_propagates_through_persist(self, tmp_path: Path) -> None:
         """AttributeError from the DB is NOT wrapped — it's a code bug."""
         db = HistoryDB(tmp_path / "test.db")
         services = build_settings_services(db=db)
+        before = services.car_settings.get_cars()
         services.coordinator._db = MagicMock()
         services.coordinator._db.set_settings_snapshot.side_effect = AttributeError(
             "no such method"
@@ -121,6 +140,7 @@ class TestSettingsStoreExceptionDiscipline:
 
         with pytest.raises(AttributeError, match="no such method"):
             services.car_settings.add_car({"name": "Test"})
+        assert services.car_settings.get_cars() == before
 
 
 # ── ClientRegistry — sqlite3.Error caught, bugs propagate ────────────────
@@ -144,6 +164,7 @@ class TestRegistryExceptionDiscipline:
         rec = registry.get(client_id)
         assert rec is not None
         assert rec.name == "My Sensor"
+        _assert_client_name_not_persisted(db, client_id)
 
     def test_type_error_on_persist_name_propagates(self, tmp_path: Path) -> None:
         """TypeError during name persistence indicates a code bug and must propagate."""
@@ -154,3 +175,4 @@ class TestRegistryExceptionDiscipline:
         with patch.object(db, "upsert_client_name", side_effect=TypeError("wrong type")):
             with pytest.raises(TypeError, match="wrong type"):
                 registry.set_name(client_id, "My Sensor")
+        _assert_client_name_not_persisted(db, client_id)

--- a/apps/server/tests/shared/utils/test_json_utils.py
+++ b/apps/server/tests/shared/utils/test_json_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import numpy as np
 import pytest
@@ -177,25 +178,38 @@ class TestSanitizeValue:
 class TestSafeJsonDumps:
     """Tests for :func:`safe_json_dumps`."""
 
-    def test_plain_dict(self) -> None:
-        result = safe_json_dumps({"key": "value", "num": 42})
-        parsed = json.loads(result)
-        assert parsed == {"key": "value", "num": 42}
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param({"key": "value", "num": 42}, {"key": "value", "num": 42}, id="plain"),
+            pytest.param({"val": float("nan")}, {"val": None}, id="nan"),
+            pytest.param({"val": float("inf")}, {"val": None}, id="inf"),
+            pytest.param(
+                {"a": np.float32(1.5), "b": np.int64(42)},
+                {"a": 1.5, "b": 42},
+                id="numpy-scalars",
+            ),
+        ],
+    )
+    def test_projects_supported_values(self, value: object, expected: object) -> None:
+        parsed = json.loads(safe_json_dumps(value))
+        assert parsed == expected
 
-    def test_sanitises_nan(self) -> None:
-        result = safe_json_dumps({"val": float("nan")})
-        parsed = json.loads(result)
-        assert parsed["val"] is None
-
-    def test_sanitises_inf(self) -> None:
-        result = safe_json_dumps({"val": float("inf")})
-        parsed = json.loads(result)
-        assert parsed["val"] is None
-
-    def test_numpy_values(self) -> None:
-        result = safe_json_dumps({"a": np.float32(1.5), "b": np.int64(42)})
-        parsed = json.loads(result)
-        assert parsed == {"a": 1.5, "b": 42}
+    def test_nested_numpy_payload_round_trip(self) -> None:
+        result = safe_json_dumps(
+            {
+                "matrix": np.array([[1.0, float("nan")], [3.0, 4.0]]),
+                "meta": {
+                    "sensor": np.int64(2),
+                    "levels": (np.float32(1.5), float("-inf")),
+                },
+            }
+        )
+        parsed = safe_json_loads(result, context="nested-payload")
+        assert parsed == {
+            "matrix": [[1.0, None], [3.0, 4.0]],
+            "meta": {"sensor": 2, "levels": [1.5, None]},
+        }
 
     def test_unicode_preserved(self) -> None:
         result = safe_json_dumps({"text": "Ünïcödé"})
@@ -212,44 +226,50 @@ class TestSafeJsonDumps:
 class TestSafeJsonLoads:
     """Tests for :func:`safe_json_loads`."""
 
-    def test_valid_json(self) -> None:
-        result = safe_json_loads('{"key": "value"}', context="test")
-        assert result == {"key": "value"}
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param('{"key": "value"}', {"key": "value"}, id="object"),
+            pytest.param("[1, 2, 3]", [1, 2, 3], id="array"),
+            pytest.param("42", 42, id="scalar"),
+            pytest.param(None, None, id="none"),
+            pytest.param("", None, id="empty"),
+        ],
+    )
+    def test_loads_expected_values(self, value: str | None, expected: object) -> None:
+        assert safe_json_loads(value, context="test") == expected
 
-    def test_none_input(self) -> None:
-        assert safe_json_loads(None, context="test") is None
-
-    def test_empty_string(self) -> None:
-        assert safe_json_loads("", context="test") is None
-
-    def test_invalid_json_returns_none(self) -> None:
-        result = safe_json_loads("{invalid json", context="test-field")
+    def test_invalid_json_returns_none_and_logs_context(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="vibesensor.shared.json_utils"):
+            result = safe_json_loads("{invalid json", context="test-field")
         assert result is None
-
-    def test_array_json(self) -> None:
-        result = safe_json_loads("[1, 2, 3]", context="test")
-        assert result == [1, 2, 3]
-
-    def test_scalar_json(self) -> None:
-        result = safe_json_loads("42", context="test")
-        assert result == 42
+        assert any(
+            record.message == "Skipping invalid JSON payload while reading test-field"
+            for record in caplog.records
+        )
 
 
-def test_payload_value_from_json_projects_nested_json() -> None:
+def test_depth_limited_value_still_round_trips_through_json() -> None:
+    nested = {"a": {"b": {"c": {"d": "deep"}}}}
+    cleaned, had = sanitize_for_json(nested, _max_depth=2)
+    assert had is False
+    assert json.loads(json.dumps(cleaned, allow_nan=False)) == {"a": {"b": {"c": None}}}
+
+
+def test_payload_helpers_project_nested_json_objects() -> None:
     value = {
         "_i18n_key": "SUMMARY_LABEL",
         "params": {"severity": "warn"},
         "bands": [1, {"name": "cruise"}],
     }
-
-    assert payload_value_from_json(value) == value
-
-
-def test_payload_object_helpers_project_json_object_sequences() -> None:
     values = [
         {"code": "speed_gap", "state": "warn"},
-        {"title": {"_i18n_key": "SUMMARY_LABEL"}},
+        {"title": value},
     ]
 
+    assert payload_value_from_json(value) == value
     assert payload_object_from_json(values[1]) == values[1]
     assert payload_objects_from_json(values) == values

--- a/apps/server/tests/use_cases/updates/test_update_models_roundtrip.py
+++ b/apps/server/tests/use_cases/updates/test_update_models_roundtrip.py
@@ -7,6 +7,8 @@ runtime when the state-store reloads a persisted snapshot.
 
 from __future__ import annotations
 
+import pytest
+
 from vibesensor.use_cases.updates.models import (
     UpdateIssue,
     UpdateJobStatus,
@@ -80,19 +82,98 @@ class TestUpdateJobStatusRoundTrip:
         assert status.log_tail[-1] == "log-line-199"
         assert status.log_tail[0] == "log-line-150"
 
-    def test_from_payload_ignores_malformed_nested_runtime_payloads(self) -> None:
-        """Malformed nested fields must fall back to explicit typed defaults."""
+    def test_to_payload_truncates_log_tail_to_last_50_lines(self) -> None:
+        status = UpdateJobStatus(log_tail=[f"log-line-{i}" for i in range(80)])
+
+        payload = status.to_payload()
+
+        assert payload["log_tail"] == [f"log-line-{i}" for i in range(30, 80)]
+
+    @pytest.mark.parametrize(
+        ("payload", "expected_message"),
+        [
+            pytest.param({"state": "broken"}, "Unsupported update state", id="bad-state"),
+            pytest.param({"phase": "broken"}, "Unsupported update phase", id="bad-phase"),
+            pytest.param(
+                {"transport": "broken"},
+                "Unsupported update transport",
+                id="bad-transport",
+            ),
+            pytest.param({"state": 7}, "update state must be a string", id="non-string-state"),
+        ],
+    )
+    def test_from_payload_rejects_invalid_enum_values(
+        self,
+        payload: dict[str, object],
+        expected_message: str,
+    ) -> None:
+        with pytest.raises(ValueError, match=expected_message):
+            UpdateJobStatus.from_payload(payload)
+
+    def test_finished_at_must_not_precede_started_at(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="finished_at must be greater than or equal to started_at",
+        ):
+            UpdateJobStatus(
+                state=UpdateState.success,
+                phase=UpdatePhase.done,
+                started_at=20.0,
+                finished_at=10.0,
+            )
+
+    def test_from_payload_preserves_partial_valid_fields(self) -> None:
+        """Malformed nested fields must drop cleanly while valid pieces survive."""
         status = UpdateJobStatus.from_payload(
             {
-                "issues": ["bad", {"phase": "downloading", "message": "warn", "detail": 99}],
+                "state": "failed",
+                "phase": "installing",
+                "transport": "usb_internet",
+                "started_at": "10.5",
+                "finished_at": "20.5",
+                "last_success_at": "7",
+                "phase_started_at": "12.25",
+                "updated_at": "18",
+                "ssid": 123,
+                "uplink_interface": ["usb0"],
+                "issues": [
+                    "bad",
+                    {"phase": "downloading", "message": "warn", "detail": 99},
+                    {"phase": "installing", "message": "retry"},
+                ],
                 "log_tail": ["ok", 7, None],
-                "runtime": ["not-a-dict"],
+                "exit_code": "5",
+                "runtime": {
+                    "version": 9,
+                    "commit": None,
+                    "assets_verified": 1,
+                    "has_packaged_static": "true",
+                },
             },
         )
 
-        assert status.runtime == UpdateRuntimeDetails()
+        assert status.state == UpdateState.failed
+        assert status.phase == UpdatePhase.installing
+        assert status.transport == UpdateTransport.usb_internet
+        assert status.started_at == 10.5
+        assert status.finished_at == 20.5
+        assert status.last_success_at == 7.0
+        assert status.phase_started_at == 12.25
+        assert status.updated_at == 18.0
+        assert status.ssid is None
+        assert status.uplink_interface is None
         assert status.log_tail == ["ok", "7", "None"]
-        assert status.issues == [UpdateIssue(phase="downloading", message="warn", detail="99")]
+        assert status.exit_code == 5
+        assert status.issues == [
+            UpdateIssue(phase="downloading", message="warn", detail="99"),
+            UpdateIssue(phase="installing", message="retry", detail=""),
+        ]
+        assert status.runtime == UpdateRuntimeDetails(
+            version="9",
+            commit="",
+            assets_verified=True,
+            has_packaged_static=True,
+        )
 
     def test_from_payload_coerces_legacy_boolish_runtime_flags(self) -> None:
         status = UpdateJobStatus.from_payload(

--- a/apps/server/vibesensor/infra/config/settings_transaction.py
+++ b/apps/server/vibesensor/infra/config/settings_transaction.py
@@ -66,7 +66,7 @@ def update_with_rollback[SnapshotT, ResultT](
             return result()
         try:
             persist()
-        except PersistenceError:
+        except (PersistenceError, TypeError, AttributeError, KeyError):
             restore(previous)
             raise
         if audit_log is not None:

--- a/apps/server/vibesensor/infra/config/settings_transaction.py
+++ b/apps/server/vibesensor/infra/config/settings_transaction.py
@@ -66,7 +66,10 @@ def update_with_rollback[SnapshotT, ResultT](
             return result()
         try:
             persist()
-        except (PersistenceError, TypeError, AttributeError, KeyError):
+        except PersistenceError:
+            restore(previous)
+            raise
+        except (TypeError, AttributeError, KeyError):
             restore(previous)
             raise
         if audit_log is not None:

--- a/apps/server/vibesensor/use_cases/updates/models.py
+++ b/apps/server/vibesensor/use_cases/updates/models.py
@@ -228,6 +228,14 @@ class UpdateJobStatus:
     exit_code: int | None = None
     runtime: UpdateRuntimeDetails = field(default_factory=lambda: UpdateRuntimeDetails())
 
+    def __post_init__(self) -> None:
+        if (
+            self.started_at is not None
+            and self.finished_at is not None
+            and self.finished_at < self.started_at
+        ):
+            raise ValueError("finished_at must be greater than or equal to started_at")
+
     def to_payload(self) -> UpdateJobStatusPayload:
         phase_elapsed_s = None
         if self.state == UpdateState.running and self.phase_started_at is not None:


### PR DESCRIPTION
## What change
- replace brittle PDF tier/report checks with semantic gating and exact scenario outcomes
- strengthen aggregate, exception, JSON, and update-model contracts
- fix settings rollback on propagated persist code bugs
- reject update status snapshots where finished_at is earlier than started_at

## Why
- #2831 left the highest-payoff untouched tests still too copy-coupled, shallow, or happy-path-heavy
- stronger contracts exposed two real integrity gaps tied to those tests

## Validation
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf/test_report_tier_gating.py apps/server/tests/adapters/pdf/test_report_metrics_consistency.py apps/server/tests/domain/test_aggregate_invariants.py apps/server/tests/integration/test_exception_discipline.py apps/server/tests/shared/utils/test_json_utils.py apps/server/tests/use_cases/updates/test_update_models_roundtrip.py`
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/pdf/ apps/server/tests/use_cases/updates/ apps/server/tests/infra/config/`
- `.venv/bin/python -m ruff check apps/server/tests/adapters/pdf/test_report_tier_gating.py apps/server/tests/adapters/pdf/test_report_metrics_consistency.py apps/server/tests/domain/test_aggregate_invariants.py apps/server/tests/integration/test_exception_discipline.py apps/server/tests/shared/utils/test_json_utils.py apps/server/tests/use_cases/updates/test_update_models_roundtrip.py apps/server/vibesensor/use_cases/updates/models.py apps/server/vibesensor/infra/config/settings_transaction.py`
- `.venv/bin/python -m ruff format --check apps/server/tests/adapters/pdf/test_report_tier_gating.py apps/server/tests/adapters/pdf/test_report_metrics_consistency.py apps/server/tests/domain/test_aggregate_invariants.py apps/server/tests/integration/test_exception_discipline.py apps/server/tests/shared/utils/test_json_utils.py apps/server/tests/use_cases/updates/test_update_models_roundtrip.py apps/server/vibesensor/use_cases/updates/models.py apps/server/vibesensor/infra/config/settings_transaction.py`

## Risk / tradeoff
- settings rollback is broader for propagated TypeError/AttributeError/KeyError from persist; those bugs still raise
- corrupted persisted update timestamps now fail model reconstruction and rely on the existing state-store corrupt-file fallback
- no broader runtime behavior intended

Closes #2831