### PR TITLE
Enable limited xdist inside backend CI shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,6 +432,8 @@ jobs:
         run: mkdir -p artifacts/ai/logs/ci
 
       - name: Backend tests shard ${{ matrix.shard_label }}
+        env:
+          VIBESENSOR_BACKEND_XDIST_WORKERS: "2"
         run: >-
           "${{ steps.setup-backend.outputs.python-path }}"
           tools/tests/run_backend_parallel.py --shards 5 --shard-index ${{ matrix.shard_index }}

--- a/apps/server/tests/hygiene/test_run_backend_parallel.py
+++ b/apps/server/tests/hygiene/test_run_backend_parallel.py
@@ -78,6 +78,7 @@ def test_observed_durations_from_junit_matches_selected_test_ids(tmp_path) -> No
 
 def test_parse_args_defaults_to_single_shard(monkeypatch) -> None:
     module = _load_run_backend_parallel_module()
+    monkeypatch.delenv(module._XDIST_WORKERS_ENV, raising=False)
     monkeypatch.setattr(module.sys, "argv", ["run_backend_parallel.py"])
 
     args = module._parse_args()
@@ -85,3 +86,28 @@ def test_parse_args_defaults_to_single_shard(monkeypatch) -> None:
     assert args.shards == 1
     assert args.shard_index == 1
     assert args.junitxml is None
+    assert args.xdist_workers == 2
+
+
+def test_parse_args_reads_xdist_workers_from_env(monkeypatch) -> None:
+    module = _load_run_backend_parallel_module()
+    monkeypatch.setenv(module._XDIST_WORKERS_ENV, "3")
+    monkeypatch.setattr(module.sys, "argv", ["run_backend_parallel.py"])
+
+    args = module._parse_args()
+
+    assert args.xdist_workers == 3
+
+
+def test_parse_args_cli_overrides_env_xdist_workers(monkeypatch) -> None:
+    module = _load_run_backend_parallel_module()
+    monkeypatch.setenv(module._XDIST_WORKERS_ENV, "3")
+    monkeypatch.setattr(
+        module.sys,
+        "argv",
+        ["run_backend_parallel.py", "--xdist-workers", "2"],
+    )
+
+    args = module._parse_args()
+
+    assert args.xdist_workers == 2

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,7 +9,7 @@
 - Use `make test-ci-lite` (`python3 tools/tests/run_ci_parallel.py --ci-lite`) for the non-Docker blocking-CI subset.
 - Use `make test-all` (`python3 tools/tests/run_ci_parallel.py`) for the broader local runner.
 - The full end-to-end verification runner is `make test-full-suite` (`python3 tools/tests/run_e2e_parallel.py --shards 1`), which starts an isolated direct server subprocess per shard from `apps/server/config.docker.yaml` with static UI serving disabled.
-- `tools/tests/run_backend_parallel.py` shards `apps/server/tests` by whole test file, using cached JUnit timings from `~/.cache/vibesensor/backend-duration-cache.json` to keep the backend CI shards balanced over time.
+- `tools/tests/run_backend_parallel.py` shards `apps/server/tests` by whole test file, using cached JUnit timings from `~/.cache/vibesensor/backend-duration-cache.json` to keep the backend CI shards balanced over time. It also accepts `--xdist-workers` / `VIBESENSOR_BACKEND_XDIST_WORKERS` for controlled intra-shard xdist; CI pins that to `2` because the repo's five-shard local CI-parallel benchmark beat `-n 0` (48.6s wall time) and still edged out the higher `-n 3` setting (41.5s) with `-n 2` (41.1s) while keeping the same shard contents.
 - `tools/tests/run_e2e_parallel.py` records observed shard test durations in `~/.cache/vibesensor/e2e-duration-cache.json` so later local or CI runs can rebalance without hand-maintained timing hints.
 - Python test configuration lives in `apps/server/pyproject.toml`.
 - Backend structural AST/import guards live in `tools/dev/verify_backend_static_guards.py`, and repo/frontend hygiene guards live in `tools/dev/check_hygiene.py`; both run via `make lint`.

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -624,7 +624,14 @@ def _normalize_tokenized_command(tokens: list[str]) -> str:
     if not tokens:
         return ""
     normalized = list(tokens)
-    normalized[0] = _normalize_python_token(normalized[0])
+    command_index = 0
+    if normalized[0] == "env":
+        command_index = 1
+        while command_index < len(normalized) and "=" in normalized[command_index]:
+            command_index += 1
+        if command_index >= len(normalized):
+            return shlex.join(normalized)
+    normalized[command_index] = _normalize_python_token(normalized[command_index])
     return shlex.join(normalized)
 
 

--- a/tools/tests/run_backend_parallel.py
+++ b/tools/tests/run_backend_parallel.py
@@ -44,7 +44,9 @@ collect_normalized_test_ids = _parallel_runner_support.parse_collected_test_ids
 ROOT = Path(__file__).resolve().parents[2]
 LOG_DIR = ROOT / "artifacts" / "ai" / "logs" / "ci"
 _DURATION_CACHE_ENV = "VIBESENSOR_BACKEND_DURATION_CACHE"
+_XDIST_WORKERS_ENV = "VIBESENSOR_BACKEND_XDIST_WORKERS"
 _DEFAULT_DURATION = 1.0
+_DEFAULT_XDIST_WORKERS = 2
 
 
 def _emit(line: str) -> None:
@@ -61,6 +63,20 @@ def _normalize_collected_test_id(line: str) -> str | None:
 
 def _parse_collected_test_ids(output: str) -> list[str]:
     return collect_normalized_test_ids(output, normalize=_normalize_collected_test_id)
+
+
+def _xdist_workers_default(env: Mapping[str, str] | None = None) -> int:
+    source = os.environ if env is None else env
+    raw = source.get(_XDIST_WORKERS_ENV)
+    if raw is None or raw == "":
+        return _DEFAULT_XDIST_WORKERS
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"{_XDIST_WORKERS_ENV} must be an integer >= 0") from exc
+    if value < 0:
+        raise SystemExit(f"{_XDIST_WORKERS_ENV} must be >= 0")
+    return value
 
 
 def _duration_cache_path(env: Mapping[str, str] | None = None) -> Path:
@@ -238,11 +254,22 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         help="Optional JUnit XML output path for the selected shard.",
     )
+    parser.add_argument(
+        "--xdist-workers",
+        type=int,
+        default=_xdist_workers_default(),
+        help=(
+            "Intra-shard pytest-xdist worker count; defaults to "
+            f"{_XDIST_WORKERS_ENV} or {_DEFAULT_XDIST_WORKERS}."
+        ),
+    )
     args = parser.parse_args()
     if args.shards < 1:
         raise SystemExit("--shards must be >= 1")
     if not 1 <= args.shard_index <= args.shards:
         raise SystemExit("--shard-index must be between 1 and --shards")
+    if args.xdist_workers < 0:
+        raise SystemExit("--xdist-workers must be >= 0")
     return args
 
 
@@ -276,7 +303,8 @@ def main() -> int:
     _emit(
         f"[backend-parallel] collected {len(collected)} test cases across "
         f"{len(grouped_tests)} test files; running shard {args.shard_index}/{args.shards} "
-        f"with {len(selected_targets)} files and {len(selected_tests)} test cases"
+        f"with {len(selected_targets)} files and {len(selected_tests)} test cases "
+        f"using pytest -n {args.xdist_workers}"
     )
 
     if not selected_targets:
@@ -292,7 +320,7 @@ def main() -> int:
         "pytest",
         "-q",
         "-n",
-        "0",
+        str(args.xdist_workers),
         "--tb=short",
         "--junitxml",
         str(junit_path),


### PR DESCRIPTION
## What changed
- add `--xdist-workers` and `VIBESENSOR_BACKEND_XDIST_WORKERS` to `tools/tests/run_backend_parallel.py`
- pin backend shard jobs to `2` workers in `.github/workflows/ci.yml`
- cover default/env/CLI override behavior and fix hygiene sync for `env ... python` commands
- record the benchmark result in `docs/testing.md`

## Why
- backend shard runner forced `pytest -n 0` even though backend pytest defaults already use xdist
- five-shard local CI benchmark came out `-n 0` = 48.6s, `-n 2` = 41.1s, `-n 3` = 41.5s
- `2` keeps the change conservative while still beating both the disabled path and the higher setting

## Validation
- `.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_run_backend_parallel.py apps/server/tests/hygiene/test_check_hygiene_entrypoints.py apps/server/tests/hygiene/test_ci_workflow_manifest.py`
- `.venv/bin/python tools/dev/check_hygiene.py`
- `.venv/bin/python tools/dev/docs_lint.py`
- `VIBESENSOR_BACKEND_XDIST_WORKERS=0 .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`
- `VIBESENSOR_BACKEND_XDIST_WORKERS=2 .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`
- `VIBESENSOR_BACKEND_XDIST_WORKERS=3 .venv/bin/python tools/tests/run_ci_parallel.py --skip-bootstrap --job backend-tests-1 --job backend-tests-2 --job backend-tests-3 --job backend-tests-4 --job backend-tests-5`

## Risk / edge
- shard contents stay the same; only intra-shard worker count changes
- `-n 3` was close but still slower on the benchmark path, so keep `2` as the default
- local runner and GitHub workflow share the same env-driven knob

Closes #2835