### PR TITLE
Reuse UI artifact in release-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,33 +279,19 @@ jobs:
           npx playwright install chromium
           npm run test:smoke
 
-  release-smoke:
-    name: Release smoke
+  ui-build-artifact:
+    name: UI build artifact
     needs:
       - ci-scope
-      - backend-lint
-      - repo-hygiene
-      - backend-static-guards
-      - backend-preflight
-      - docs-lint
-      - backend-contract-drift
-      - backend-typecheck
       - frontend-typecheck
     if: >-
       ${{
         always() &&
         needs.ci-scope.outputs.run_release_smoke == 'true' &&
-        needs.backend-lint.result != 'failure' &&
-        needs.repo-hygiene.result != 'failure' &&
-        needs.backend-static-guards.result != 'failure' &&
-        needs.backend-preflight.result != 'failure' &&
-        needs.docs-lint.result != 'failure' &&
-        needs.backend-contract-drift.result != 'failure' &&
-        needs.backend-typecheck.result != 'failure' &&
-        needs.frontend-typecheck.result != 'failure'
+        needs.frontend-typecheck.result == 'success'
       }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v6
@@ -322,10 +308,79 @@ jobs:
         id: setup-python
         uses: ./.github/actions/setup-python
 
+      - name: Build release-smoke UI static artifact
+        run: >-
+          "${{ steps.setup-python.outputs.python-path }}"
+          tools/build_ui_static.py --skip-typecheck
+
+      - name: Package release-smoke UI static artifact
+        run: |
+          mkdir -p artifacts/release-smoke
+          tar -C apps/server/vibesensor/static -czf artifacts/release-smoke/ui-static.tar.gz .
+
+      - name: Upload release-smoke UI static artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-smoke-ui-static
+          path: artifacts/release-smoke/ui-static.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  release-smoke:
+    name: Release smoke
+    needs:
+      - ci-scope
+      - backend-lint
+      - repo-hygiene
+      - backend-static-guards
+      - backend-preflight
+      - docs-lint
+      - backend-contract-drift
+      - backend-typecheck
+      - frontend-typecheck
+      - ui-build-artifact
+    if: >-
+      ${{
+        always() &&
+        needs.ci-scope.outputs.run_release_smoke == 'true' &&
+        needs.backend-lint.result != 'failure' &&
+        needs.repo-hygiene.result != 'failure' &&
+        needs.backend-static-guards.result != 'failure' &&
+        needs.backend-preflight.result != 'failure' &&
+        needs.docs-lint.result != 'failure' &&
+        needs.backend-contract-drift.result != 'failure' &&
+        needs.backend-typecheck.result != 'failure' &&
+        needs.frontend-typecheck.result != 'failure' &&
+        needs.ui-build-artifact.result == 'success'
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up configured Python runtime
+        id: setup-python
+        uses: ./.github/actions/setup-python
+
+      - name: Download release-smoke UI static artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-smoke-ui-static
+          path: artifacts/release-smoke
+
+      - name: Restore release-smoke UI static artifact
+        run: |
+          rm -rf apps/server/vibesensor/static
+          mkdir -p apps/server/vibesensor/static
+          tar -xzf artifacts/release-smoke/ui-static.tar.gz -C apps/server/vibesensor/static
+
       - name: Release smoke validation
         run: >-
           "${{ steps.setup-python.outputs.python-path }}"
-          tools/tests/run_release_smoke.py
+          tools/tests/run_release_smoke.py --skip-ui-build
 
   firmware-native-tests:
     name: Firmware native tests

--- a/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
+++ b/apps/server/tests/hygiene/test_ci_parallel_bootstrap.py
@@ -108,6 +108,38 @@ def test_main_refuses_skip_bootstrap_when_release_smoke_would_race_ui_jobs(
     assert "release-smoke would trigger npm ci inside apps/ui" in output
 
 
+def test_release_smoke_skip_ui_build_does_not_trigger_ui_race(monkeypatch) -> None:
+    module = _load_ci_parallel_module()
+    release_smoke_step = module.Step(
+        "Release smoke validation",
+        ["python3", "tools/tests/run_release_smoke.py", "--skip-ui-build"],
+    )
+    ui_step = module.Step("UI lint", ["npm", "run", "lint"], cwd=module.UI_DIR)
+    jobs = {
+        "frontend-typecheck": [ui_step],
+        "release-smoke": [release_smoke_step],
+    }
+
+    monkeypatch.setattr(
+        module,
+        "_ui_bootstrap_status",
+        lambda skip_npm_ci: module.UiBootstrapStatus(
+            needs_npm_ci=not skip_npm_ci,
+            lock_hash="lock",
+            current_lock_hash="",
+            node_modules_exists=True,
+        ),
+    )
+
+    assert not module._job_runs_release_smoke_ui_build([release_smoke_step])
+    assert not module._shared_ui_workspace_would_race(
+        ["frontend-typecheck", "release-smoke"],
+        jobs,
+        skip_bootstrap=True,
+        skip_npm_ci=False,
+    )
+
+
 def test_ui_bootstrap_status_reads_shared_helper_json(monkeypatch, tmp_path: Path) -> None:
     module = _load_ci_parallel_module()
     ui_dir = tmp_path / "apps" / "ui"

--- a/apps/server/tests/hygiene/test_ci_workflow_manifest.py
+++ b/apps/server/tests/hygiene/test_ci_workflow_manifest.py
@@ -53,6 +53,7 @@ def test_backend_quality_jobs_are_split_into_focused_gates() -> None:
 
     job_names = set(module.all_job_names())
     assert "ci-scope" not in job_names
+    assert "ui-build-artifact" not in job_names
     assert "backend-quality" not in job_names
     assert {
         "backend-lint",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -123,8 +123,11 @@ make test-full-suite
 
 `release-smoke` is the packaged-artifact gate. It builds or reuses the server
 wheel, validates packaged static assets, boots the packaged server, and checks
-that `/api/health` reaches readiness. It is complementary to Docker/e2e
-validation, not a duplicate of it.
+that `/api/health` reaches readiness. In GitHub CI it now consumes the
+same-commit `release-smoke-ui-static` artifact built after `frontend-typecheck`
+and runs `tools/tests/run_release_smoke.py --skip-ui-build` so the final smoke
+job validates packaged assets without rebuilding the UI from source again. It
+is complementary to Docker/e2e validation, not a duplicate of it.
 
 ## Frontend validation
 

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -92,6 +92,7 @@ def check_path_indirections() -> tuple[list[str], list[str]]:
 
 _BACKEND_TEST_MATRIX_JOB = "backend-tests"
 _CI_SCOPE_JOB = "ci-scope"
+_UI_BUILD_ARTIFACT_JOB = "ui-build-artifact"
 _BACKEND_QUALITY_JOBS = (
     "backend-lint",
     "repo-hygiene",
@@ -106,8 +107,10 @@ _RELEASE_SMOKE_QUALITY_NEEDS = (
     *_BACKEND_QUALITY_JOBS,
     "backend-typecheck",
     "frontend-typecheck",
+    _UI_BUILD_ARTIFACT_JOB,
 )
 _UI_SMOKE_NEEDS = (_CI_SCOPE_JOB, "frontend-typecheck")
+_UI_BUILD_ARTIFACT_NEEDS = (_CI_SCOPE_JOB, "frontend-typecheck")
 _BACKEND_TEST_SHARD_JOBS = (
     "backend-tests-1",
     "backend-tests-2",
@@ -1091,8 +1094,14 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
         and _workflow_job_needs(release_smoke) != _RELEASE_SMOKE_QUALITY_NEEDS
     ):
         errors.append(
-            "release-smoke must depend on ci-scope, the split quality jobs, backend-typecheck, and frontend-typecheck."
+            "release-smoke must depend on ci-scope, the split quality jobs, backend-typecheck, frontend-typecheck, and ui-build-artifact."
         )
+    ui_build_artifact = jobs.get(_UI_BUILD_ARTIFACT_JOB)
+    if (
+        isinstance(ui_build_artifact, Mapping)
+        and _workflow_job_needs(ui_build_artifact) != _UI_BUILD_ARTIFACT_NEEDS
+    ):
+        errors.append("ui-build-artifact must depend on ci-scope and frontend-typecheck.")
     firmware_job = jobs.get(_FIRMWARE_INSTALL_JOB)
     if (
         isinstance(firmware_job, Mapping)

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -1101,7 +1101,9 @@ def check_docker_ci_dependency_hygiene() -> list[str]:
         isinstance(ui_build_artifact, Mapping)
         and _workflow_job_needs(ui_build_artifact) != _UI_BUILD_ARTIFACT_NEEDS
     ):
-        errors.append("ui-build-artifact must depend on ci-scope and frontend-typecheck.")
+        errors.append(
+            "ui-build-artifact must depend on ci-scope and frontend-typecheck."
+        )
     firmware_job = jobs.get(_FIRMWARE_INSTALL_JOB)
     if (
         isinstance(firmware_job, Mapping)

--- a/tools/tests/ci_workflow_manifest.py
+++ b/tools/tests/ci_workflow_manifest.py
@@ -21,7 +21,7 @@ _INSTALL_STEP_NAMES = frozenset(
     }
 )
 _CI_LITE_EXCLUDED_JOBS = frozenset({"e2e"})
-_WORKFLOW_ONLY_EXCLUDED_JOBS = frozenset({"ci-scope"})
+_WORKFLOW_ONLY_EXCLUDED_JOBS = frozenset({"ci-scope", "ui-build-artifact"})
 _PYTHON_PATH_TOKENS = frozenset(
     {
         "${{ steps.setup-backend.outputs.python-path }}",

--- a/tools/tests/run_ci_parallel.py
+++ b/tools/tests/run_ci_parallel.py
@@ -99,15 +99,19 @@ def _job_uses_ui_workspace(steps: list[Step]) -> bool:
     return any(step.cwd == UI_DIR for step in steps)
 
 
-def _job_runs_release_smoke(steps: list[Step]) -> bool:
-    return any("tools/tests/run_release_smoke.py" in step.cmd for step in steps)
+def _job_runs_release_smoke_ui_build(steps: list[Step]) -> bool:
+    return any(
+        "tools/tests/run_release_smoke.py" in step.cmd
+        and "--skip-ui-build" not in step.cmd
+        for step in steps
+    )
 
 
 def _selected_jobs_touch_ui(
     selected_jobs: list[str], all_jobs: dict[str, list[Step]]
 ) -> bool:
     return any(
-        _job_runs_release_smoke(all_jobs[job_name])
+        _job_runs_release_smoke_ui_build(all_jobs[job_name])
         or _job_uses_ui_workspace(all_jobs[job_name])
         for job_name in selected_jobs
     )
@@ -123,7 +127,8 @@ def _shared_ui_workspace_would_race(
     if not skip_bootstrap:
         return False
     if not any(
-        _job_runs_release_smoke(all_jobs[job_name]) for job_name in selected_jobs
+        _job_runs_release_smoke_ui_build(all_jobs[job_name])
+        for job_name in selected_jobs
     ):
         return False
     if not any(


### PR DESCRIPTION
## What changed
- add a workflow-only `ui-build-artifact` job that builds and uploads same-commit static assets after `frontend-typecheck`
- make `release-smoke` download that artifact, restore `apps/server/vibesensor/static`, and run `tools/tests/run_release_smoke.py --skip-ui-build`
- treat the artifact job as workflow-only in the local CI manifest and narrow the local release-smoke/UI race guard to only the UI-building path
- document the artifact flow in `docs/testing.md`

## Why
- `release-smoke` rebuilt the UI late in CI even though earlier jobs had already validated the UI surface
- this keeps packaged validation semantics intact while removing the duplicate source rebuild from the final smoke job
- keep `#2837` separate by reusing the existing `tools/build_ui_static.py` path instead of redesigning contract-check behavior here

## Validation
- `.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_ci_parallel_bootstrap.py apps/server/tests/hygiene/test_ci_workflow_manifest.py apps/server/tests/hygiene/test_check_hygiene_entrypoints.py apps/server/tests/use_cases/updates/test_run_release_smoke.py apps/server/tests/hygiene/test_build_ui_static.py`
- `.venv/bin/python tools/dev/check_hygiene.py`
- `.venv/bin/python tools/dev/docs_lint.py`

## Risk / edge
- artifact plumbing is GitHub-workflow-only; the local CI manifest intentionally excludes `ui-build-artifact`
- local attempt to benchmark the full release-smoke script hit an existing smoke-server health-startup failure on this workstation, so the release-smoke speedup proof should come from the GitHub job duration on this PR run
- release-smoke still uses the existing UI build helper, so duplicate contract-check cleanup stays for `#2837`

Closes #2836