### PR TITLE
Skip late contract recheck in release-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
       - name: Build release-smoke UI static artifact
         run: >-
           "${{ steps.setup-python.outputs.python-path }}"
-          tools/build_ui_static.py --skip-typecheck
+          tools/build_ui_static.py --skip-typecheck --assume-prevalidated-contracts
 
       - name: Package release-smoke UI static artifact
         run: |

--- a/apps/server/tests/hygiene/test_build_ui_static.py
+++ b/apps/server/tests/hygiene/test_build_ui_static.py
@@ -7,6 +7,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 from tests._paths import REPO_ROOT
 
 _BUILD_UI_STATIC = REPO_ROOT / "tools" / "build_ui_static.py"
@@ -116,3 +118,36 @@ def test_build_ui_static_passes_skip_npm_ci_to_shared_bootstrap(
         ],
         ui_dir,
     )
+
+
+def test_build_ui_static_can_use_prevalidated_contract_build_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module, repo, ui_dir = _load_temp_build_ui_static(tmp_path)
+    commands: list[tuple[list[str], Path]] = []
+
+    monkeypatch.setattr(
+        module,
+        "_run",
+        lambda command, cwd: commands.append((command, cwd)),
+    )
+
+    module.main(["--skip-typecheck", "--assume-prevalidated-contracts"])
+
+    assert commands == [
+        (["node", str(repo / "tools" / "ui" / "ensure_ui_bootstrap.mjs")], ui_dir),
+        (["npm", "run", "sync:generated-contracts"], ui_dir),
+        (["npm", "run", "build:prevalidated-contracts"], ui_dir),
+    ]
+
+
+def test_build_ui_static_rejects_prevalidated_contracts_without_skip_typecheck(
+    tmp_path: Path,
+) -> None:
+    module, _repo, _ui_dir = _load_temp_build_ui_static(tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main(["--assume-prevalidated-contracts"])
+
+    assert exc_info.value.code == 2

--- a/apps/server/tests/use_cases/updates/test_run_release_smoke.py
+++ b/apps/server/tests/use_cases/updates/test_run_release_smoke.py
@@ -37,6 +37,7 @@ def test_run_release_smoke_builds_ui_and_wheel_then_runs_smoke(monkeypatch, tmp_
         module.sys.executable,
         "tools/build_ui_static.py",
         "--skip-typecheck",
+        "--assume-prevalidated-contracts",
         "--skip-npm-ci",
     ]
     assert commands[0][1] == repo_root

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -70,6 +70,8 @@ Those derivative outputs are materialized locally from the tracked inputs and ar
 
 `npm run build` and `npm run typecheck` no longer regenerate those files automatically. They run `npm run check:contracts` first and fail fast with guidance to `make sync-contracts` if the local derivative copy is missing or stale. CI contract drift and human-facing regeneration should still use `make sync-contracts`.
 
+The release-smoke artifact helper is the intentional narrow exception: after the same commit already passed `backend-contract-drift` and `frontend-typecheck`, `tools/build_ui_static.py --skip-typecheck --assume-prevalidated-contracts` still regenerates the UI-only derivatives for that fresh checkout but switches to `npm run build:prevalidated-contracts` so the late packaged smoke path does not repeat `check:contracts`.
+
 ## Code Quality
 
 - `npm run lint` checks the hand-written TypeScript, config, and support scripts

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -15,6 +15,7 @@
     "dev:open": "vite --open",
     "dev:docker": "sh ./dev-docker.sh",
     "build": "npm run check:contracts && vite build",
+    "build:prevalidated-contracts": "vite build",
     "preview": "vite preview",
     "typecheck": "npm run check:contracts && tsc --noEmit",
     "pretest:smoke": "npm run sync:generated-contracts",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -126,8 +126,13 @@ wheel, validates packaged static assets, boots the packaged server, and checks
 that `/api/health` reaches readiness. In GitHub CI it now consumes the
 same-commit `release-smoke-ui-static` artifact built after `frontend-typecheck`
 and runs `tools/tests/run_release_smoke.py --skip-ui-build` so the final smoke
-job validates packaged assets without rebuilding the UI from source again. It
-is complementary to Docker/e2e validation, not a duplicate of it.
+job validates packaged assets without rebuilding the UI from source again. That
+artifact build still runs `npm run sync:generated-contracts` to materialize the
+UI-only derivative files on a fresh checkout, but it now switches to the
+prevalidated-contracts build path instead of re-running the late
+`check:contracts` gate already owned by `backend-contract-drift` and
+`frontend-typecheck`. It is complementary to Docker/e2e validation, not a
+duplicate of it.
 
 ## Frontend validation
 

--- a/tools/build_ui_static.py
+++ b/tools/build_ui_static.py
@@ -77,7 +77,20 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Skip npm run typecheck (useful when CI already validates types).",
     )
+    parser.add_argument(
+        "--assume-prevalidated-contracts",
+        action="store_true",
+        help=(
+            "Use the prevalidated-contracts build path after earlier same-commit "
+            "CI jobs already checked contract sync and UI types."
+        ),
+    )
     args = parser.parse_args(argv)
+    if args.assume_prevalidated_contracts and not args.skip_typecheck:
+        parser.error(
+            "--assume-prevalidated-contracts requires --skip-typecheck because "
+            "npm run typecheck already re-checks UI contracts."
+        )
 
     repo_root = Path(__file__).resolve().parents[1]
     ui_dir = repo_root / "apps" / "ui"
@@ -93,7 +106,12 @@ def main(argv: list[str] | None = None) -> None:
     _run(["npm", "run", "sync:generated-contracts"], cwd=ui_dir)
     if not args.skip_typecheck:
         _run(["npm", "run", "typecheck"], cwd=ui_dir)
-    _run(["npm", "run", "build"], cwd=ui_dir)
+    build_script = (
+        "build:prevalidated-contracts"
+        if args.assume_prevalidated_contracts
+        else "build"
+    )
+    _run(["npm", "run", build_script], cwd=ui_dir)
 
     shutil.rmtree(static_dir, ignore_errors=True)
     static_dir.mkdir(parents=True, exist_ok=True)

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -869,6 +869,7 @@ def check_contract_sync_entrypoint() -> list[str]:
         "sync:generated-contracts": "node ../../tools/config/sync_shared_contracts_to_ui.mjs",
         "check:contracts": "node ../../tools/config/sync_shared_contracts_to_ui.mjs --check",
         "build": "npm run check:contracts && vite build",
+        "build:prevalidated-contracts": "vite build",
         "typecheck": "npm run check:contracts && tsc --noEmit",
         "pretest:smoke": "npm run sync:generated-contracts",
     }
@@ -960,6 +961,19 @@ def check_contract_sync_entrypoint() -> list[str]:
                 errors.append(
                     "frontend-typecheck must explicitly sync generated UI contract derivatives before running npm run typecheck."
                 )
+
+    ui_build_artifact = jobs.get(_UI_BUILD_ARTIFACT_JOB)
+    if isinstance(ui_build_artifact, Mapping):
+        steps = ui_build_artifact.get("steps")
+        if isinstance(steps, list) and not any(
+            isinstance(step, Mapping)
+            and step.get("run")
+            == '"${{ steps.setup-python.outputs.python-path }}" tools/build_ui_static.py --skip-typecheck --assume-prevalidated-contracts'
+            for step in steps
+        ):
+            errors.append(
+                "ui-build-artifact must build static assets with tools/build_ui_static.py --skip-typecheck --assume-prevalidated-contracts."
+            )
 
     for path in (_UI_README_PATH, _SERVER_README_PATH, _CONTRIBUTING_PATH):
         if "make sync-contracts" not in path.read_text(encoding="utf-8"):

--- a/tools/tests/run_release_smoke.py
+++ b/tools/tests/run_release_smoke.py
@@ -84,7 +84,12 @@ def main(argv: list[str] | None = None) -> int:
     python_cmd = sys.executable
 
     if not args.skip_ui_build:
-        build_ui_cmd = [python_cmd, "tools/build_ui_static.py", "--skip-typecheck"]
+        build_ui_cmd = [
+            python_cmd,
+            "tools/build_ui_static.py",
+            "--skip-typecheck",
+            "--assume-prevalidated-contracts",
+        ]
         if args.skip_npm_ci:
             build_ui_cmd.append("--skip-npm-ci")
         _run(build_ui_cmd, cwd=repo_root)


### PR DESCRIPTION
## What changed
- add `--assume-prevalidated-contracts` to `tools/build_ui_static.py`
- keep `sync:generated-contracts` for fresh checkouts, but route that prevalidated path to `npm run build:prevalidated-contracts`
- wire `tools/tests/run_release_smoke.py` and CI `ui-build-artifact` to the prevalidated path
- guard the new package/workflow contract in hygiene and cover it in tests/docs

## Why
- `backend-contract-drift` and `frontend-typecheck` already own contract validation for the same commit
- late `release-smoke` should validate packaged assets and runtime, not rerun `check:contracts`

## Validation
- `pytest -q apps/server/tests/hygiene/test_build_ui_static.py apps/server/tests/use_cases/updates/test_run_release_smoke.py apps/server/tests/hygiene/test_check_hygiene_entrypoints.py`
- `python -m ruff check tools/build_ui_static.py tools/tests/run_release_smoke.py tools/dev/check_hygiene.py apps/server/tests/hygiene/test_build_ui_static.py apps/server/tests/use_cases/updates/test_run_release_smoke.py`
- `python -m ruff format --check tools/build_ui_static.py tools/tests/run_release_smoke.py tools/dev/check_hygiene.py apps/server/tests/hygiene/test_build_ui_static.py apps/server/tests/use_cases/updates/test_run_release_smoke.py`
- `python tools/dev/check_hygiene.py`
- `python tools/dev/docs_lint.py`
- `cd apps/ui && node ../../tools/ui/ensure_ui_bootstrap.mjs && npm run typecheck && npm run build`

## Risk / tradeoffs
- prevalidated mode assumes earlier same-commit CI already passed `backend-contract-drift` and `frontend-typecheck`
- default `tools/build_ui_static.py` and `main-release` still keep the full checked build path
- release-smoke still regenerates UI-only derivatives in a fresh checkout; only the late `check:contracts` rerun is removed

Closes #2837
