### PR TITLE
Use setup-python for docs-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,10 +147,13 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: ./.github/actions/setup-backend
+      - id: setup-python
+        uses: ./.github/actions/setup-python
 
       - name: Docs lint
-        run: python tools/dev/docs_lint.py
+        run: >-
+          "${{ steps.setup-python.outputs.python-path }}"
+          tools/dev/docs_lint.py
 
   backend-contract-drift:
     name: Backend contract drift

--- a/apps/server/tests/hygiene/test_workflow_python_runtime_usage.py
+++ b/apps/server/tests/hygiene/test_workflow_python_runtime_usage.py
@@ -95,6 +95,24 @@ def test_workflows_use_configured_python_runtime_paths() -> None:
     assert "steps.setup-python.outputs.python-path" in ci_text
     assert "steps.setup-backend.outputs.python-path" in ci_text
 
+    ci = _load_yaml(_CI)
+    docs_lint_steps = ci["jobs"]["docs-lint"]["steps"]
+    assert isinstance(docs_lint_steps, list)
+    setup_python_step = next(
+        step
+        for step in docs_lint_steps
+        if isinstance(step, dict) and step.get("id") == "setup-python"
+    )
+    assert setup_python_step["uses"] == "./.github/actions/setup-python"
+    docs_lint_step = next(
+        step
+        for step in docs_lint_steps
+        if isinstance(step, dict) and step.get("name") == "Docs lint"
+    )
+    assert docs_lint_step["run"] == (
+        '"${{ steps.setup-python.outputs.python-path }}" tools/dev/docs_lint.py'
+    )
+
 
 def test_pi_image_release_scripts_accept_configured_python_path() -> None:
     app_artifacts = _APP_ARTIFACTS.read_text(encoding="utf-8")

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -119,7 +119,11 @@ _BACKEND_TEST_SHARD_JOBS = (
     "backend-tests-5",
 )
 _BACKEND_SETUP_JOBS = (
-    *_BACKEND_QUALITY_JOBS,
+    "backend-lint",
+    "repo-hygiene",
+    "backend-static-guards",
+    "backend-preflight",
+    "backend-contract-drift",
     "backend-typecheck",
     _BACKEND_TEST_MATRIX_JOB,
     "e2e",
@@ -974,6 +978,33 @@ def check_contract_sync_entrypoint() -> list[str]:
             errors.append(
                 "ui-build-artifact must build static assets with tools/build_ui_static.py --skip-typecheck --assume-prevalidated-contracts."
             )
+
+    docs_lint = jobs.get("docs-lint")
+    if isinstance(docs_lint, Mapping):
+        steps = docs_lint.get("steps")
+        if isinstance(steps, list):
+            if not any(
+                isinstance(step, Mapping)
+                and step.get("id") == "setup-python"
+                and step.get("uses") == _LOCAL_PYTHON_SETUP_ACTION
+                for step in steps
+            ):
+                errors.append("docs-lint must use ./.github/actions/setup-python.")
+            if any(
+                isinstance(step, Mapping)
+                and step.get("uses") == _LOCAL_BACKEND_SETUP_ACTION
+                for step in steps
+            ):
+                errors.append("docs-lint must not use ./.github/actions/setup-backend.")
+            if not any(
+                isinstance(step, Mapping)
+                and step.get("run")
+                == '"${{ steps.setup-python.outputs.python-path }}" tools/dev/docs_lint.py'
+                for step in steps
+            ):
+                errors.append(
+                    "docs-lint must invoke tools/dev/docs_lint.py with the configured setup-python interpreter path."
+                )
 
     for path in (_UI_README_PATH, _SERVER_README_PATH, _CONTRIBUTING_PATH):
         if "make sync-contracts" not in path.read_text(encoding="utf-8"):


### PR DESCRIPTION
## What changed
- switch `docs-lint` from `./.github/actions/setup-backend` to `./.github/actions/setup-python`
- run `tools/dev/docs_lint.py` through the configured `setup-python` interpreter output
- guard that workflow contract in hygiene and runtime-usage tests

## Why
- `tools/dev/docs_lint.py` is stdlib-only
- this job should not pay for `pip install -e ./apps/server[dev]`

## Validation
- `pytest -q apps/server/tests/hygiene/test_workflow_python_runtime_usage.py apps/server/tests/hygiene/test_check_hygiene_entrypoints.py apps/server/tests/hygiene/test_ci_workflow_manifest.py`
- `python -m ruff check tools/dev/check_hygiene.py apps/server/tests/hygiene/test_workflow_python_runtime_usage.py`
- `python -m ruff format --check tools/dev/check_hygiene.py apps/server/tests/hygiene/test_workflow_python_runtime_usage.py`
- `python tools/dev/check_hygiene.py`
- `python tools/dev/docs_lint.py`
- `python tools/tests/run_ci_parallel.py --job docs-lint`

## Risk / tradeoffs
- local `run_ci_parallel` still does its shared bootstrap before selected jobs; the no-backend-install proof for this issue is the workflow contract plus the stdlib-only script surface
- only `docs-lint` moves to `setup-python`; backend jobs keep `setup-backend`

Closes #2838
