### PR TITLE
[codex] Restore spectrum tween frame painting

### DIFF
--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -373,12 +373,16 @@ export function createSpectrumCanvasRenderer(
   }
 
   function setSpectrumDataFromFrame(frame: SpectrumHeavyFrame): void {
-    if (!deps.state.spectrum.spectrumPlot.value) {
+    const plot = deps.state.spectrum.spectrumPlot.value;
+    if (!plot) {
       return;
     }
     currentFreqAxis.value = frame.freq;
     syncChartDataBuffer(frame.freq, frame.values);
-    deps.state.spectrum.spectrumPlot.value.setData(chartData.value, false);
+    plot.setData(chartData.value, false);
+    // uPlot does not commit a paint when setData() skips scale recalculation.
+    // Tween frames reuse fixed axes, so explicitly rebuild paths and redraw.
+    plot.redraw(true, false);
     spectrumLastFrame.value = frame;
   }
 

--- a/apps/ui/tests/spectrum_canvas_renderer.spec.ts
+++ b/apps/ui/tests/spectrum_canvas_renderer.spec.ts
@@ -760,6 +760,7 @@ test.describe("createSpectrumCanvasRenderer", () => {
       renderer.renderPreparedFrame(renderer.prepareFrame());
       await flushSignalUpdates();
       setDataCalls = 0;
+      redrawCalls = 0;
 
       renderer.refreshDecorations();
 
@@ -849,6 +850,101 @@ test.describe("createSpectrumCanvasRenderer", () => {
       await flushSignalUpdates();
 
       expect(animationStarts).toEqual([75]);
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("redraws tween frames when setData skips scale recalculation", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const { createSpectrumCanvasRenderer } = await import(
+        "../src/app/runtime/spectrum_canvas_renderer"
+      );
+      const state = createAppState();
+      state.transport.wsState.value = "connected";
+      state.realtime.clients.value = [makeClient("sensor-a", "Front Right Wheel")];
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            freq: [10, 15, 20],
+            combined: [1, 0.75, 0.5],
+            strength_metrics: {
+              noise_floor_amp_g: 0.1,
+              peak_amp_g: 1,
+              strength_bucket: null,
+              top_peaks: [{
+                amp: 1,
+                hz: 10,
+                strength_bucket: null,
+                vibration_strength_db: 12,
+              }],
+              vibration_strength_db: 12,
+            },
+          },
+        },
+      };
+      let setDataCalls = 0;
+      let redrawCalls = 0;
+      const renderTimesMs = [1_000, 1_165];
+
+      const renderer = createSpectrumCanvasRenderer({
+        state,
+        dom: {
+          specChart: createElementStub("div"),
+          specChartWrap: createElementStub("div"),
+        } as unknown as SpectrumPanelChartDom,
+        t: (key) => key,
+        getBandsVisible: () => false,
+        getChartBands: () => [],
+        getFocusMarker: () => null,
+        onCursorDataIndexChange: () => undefined,
+        loadChartModule: async () => ({
+          createSpectrumChart(): SpectrumChart {
+            return {
+              destroy() {},
+              redraw(rebuildPaths, recalcAxes) {
+                expect(rebuildPaths).toBe(true);
+                expect(recalcAxes).toBe(false);
+                redrawCalls += 1;
+              },
+              resize() {},
+              setData(_data, resetScales) {
+                expect(resetScales).toBe(false);
+                setDataCalls += 1;
+              },
+              setSeriesIsolation() {},
+            };
+          },
+        }),
+        createAnimation: ({ onFrame }) => ({
+          start() {
+            onFrame(0.5);
+          },
+          stop() {},
+        }),
+        nowMs: () => renderTimesMs.shift() ?? 0,
+      });
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+      setDataCalls = 0;
+      redrawCalls = 0;
+
+      state.spectrum.spectra.value = {
+        clients: {
+          "sensor-a": {
+            ...getRequiredClientSpectrum(state, "sensor-a"),
+            combined: [0.9, 0.7, 0.45],
+          },
+        },
+      };
+
+      renderer.renderPreparedFrame(renderer.prepareFrame());
+      await flushSignalUpdates();
+
+      expect(setDataCalls).toBe(1);
+      expect(redrawCalls).toBe(1);
     } finally {
       restoreDocument();
     }


### PR DESCRIPTION
## Summary
- force spectrum data/tween frames to redraw uPlot paths when `setData(..., false)` skips scale recalculation
- add regression coverage so tween frames must call both `setData(..., false)` and `redraw(true, false)`

## Root cause
The previous spectrum fluency fix made near-budget frames start tween animations again, but the renderer still updated uPlot via `setData(data, false)`. In uPlot, that updates the data reference without committing a paint when scale recalculation is skipped, so tween frames could be computed without being visibly drawn.

## Live Pi check
Against `10.4.0.1`, the packaged UI produced 19 canvas clear/draw events in 5 seconds, clustered around heavy WS cadence. The patched local UI proxied to the same Pi produced 209 draw events in 5 seconds, with most intervals around 16.7ms, confirming tween frames are now painted.

## Validation
- `npx playwright test -c /home/psewu/repos/VibeSensor/apps/ui/tests /home/psewu/repos/VibeSensor/apps/ui/tests/spectrum_canvas_renderer.spec.ts /home/psewu/repos/VibeSensor/apps/ui/tests/spectrum_animation.spec.ts`
- `npm run typecheck`
- `npm run build`
- `npm run lint` exits 0; reports existing unrelated warnings
