### PR TITLE
test(ui): extract smoke workflow fixtures

### DIFF
--- a/apps/ui/tests/smoke.cars.spec.ts
+++ b/apps/ui/tests/smoke.cars.spec.ts
@@ -2,11 +2,15 @@ import { expect, test } from "@playwright/test";
 
 import {
   activateWizardCloseButton,
+  bootLiveDashboard,
   buildCaptureReadiness,
   confirmPrompt,
   fulfillJson,
   installCommonRoutes,
-  installFakeWebSocket,
+  openAnalysisTab,
+  openCarsTab,
+  openHistoryTab,
+  openSettingsTab,
   readSemanticToneStyles,
   requestPath,
 } from "./smoke.helpers";
@@ -62,9 +66,9 @@ test("dark mode warning pills use semantic theme tokens in Live and Cars", async
       }),
     });
   });
-  await installFakeWebSocket(page, {
-    payload: {
-      server_time: new Date().toISOString(),
+  await bootLiveDashboard(page, {
+    installRoutes: false,
+    liveSensorPayload: {
       clients: [
         {
           id: "001122334455",
@@ -79,11 +83,8 @@ test("dark mode warning pills use semantic theme tokens in Live and Cars", async
           firmware_version: "fw-1.0.0",
         },
       ],
-      spectra: { clients: {} },
     },
   });
-
-  await page.goto("/");
   const liveHealth = page.locator("#liveRunHealth");
   await expect(liveHealth).toHaveText("Needs attention");
   const liveHealthStyles = await readSemanticToneStyles(liveHealth, {
@@ -93,8 +94,7 @@ test("dark mode warning pills use semantic theme tokens in Live and Cars", async
   expect(liveHealthStyles.backgroundColor).toBe(liveHealthStyles.expectedBackgroundColor);
   expect(liveHealthStyles.color).toBe(liveHealthStyles.expectedColor);
 
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="carTab"]').click();
+  await openCarsTab(page);
   const readinessPill = page.locator(
     '#carListBody tr[data-car-id="car-1"] .car-readiness-pill[data-state="incomplete"]',
   );
@@ -109,7 +109,7 @@ test("dark mode warning pills use semantic theme tokens in Live and Cars", async
 
 test("dark mode quiet danger buttons use semantic danger tokens in Cars", async ({ page }) => {
   await page.emulateMedia({ colorScheme: "dark" });
-  await installCommonRoutes(page, {
+  await bootLiveDashboard(page, {
     settingsHandler: async (route) => {
       const path = requestPath(route);
       const method = route.request().method();
@@ -136,11 +136,7 @@ test("dark mode quiet danger buttons use semantic danger tokens in Cars", async 
       await fulfillJson(route, {});
     },
   });
-  await installFakeWebSocket(page);
-
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="carTab"]').click();
+  await openCarsTab(page);
   const deleteButton = page.locator('#carListBody tr[data-car-id="car-1"] .car-delete-btn');
   await expect(deleteButton).toBeVisible();
 
@@ -190,8 +186,7 @@ test("routes no-car blockers to the add-car flow from Live and Cars", async ({ p
     }
     await fulfillJson(route, {});
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
+  await bootLiveDashboard(page, { installRoutes: false });
   await expect(page.locator("#liveActiveCar")).not.toHaveAttribute("data-variant", "warn");
   await expect(page.locator("#liveActiveCar .stat__value-icon")).toHaveCount(0);
   await expect(page.locator("#liveActiveCar [data-value]")).toContainText("No cars added yet");
@@ -204,10 +199,9 @@ test("routes no-car blockers to the add-car flow from Live and Cars", async ({ p
   await expect(page.locator("#wizardBackdrop")).toBeVisible();
   await activateWizardCloseButton(page);
   await expect(page.locator("#carSelectionBanner")).toHaveCount(0);
-  await page.locator("#tab-history").click();
+  await openHistoryTab(page);
   await expect(page.locator("#carSelectionBanner")).toHaveCount(0);
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="carTab"]').click();
+  await openCarsTab(page);
   await expect(page.locator("#carSelectionGuidance")).toBeHidden();
   await expect(page.locator("#carListBody .settings-table-empty-state")).toBeVisible();
   const carEmptyState = page.locator("#carListBody .empty-state");
@@ -216,8 +210,7 @@ test("routes no-car blockers to the add-car flow from Live and Cars", async ({ p
   await carEmptyState.getByRole("button", { name: "Add a car" }).click();
   await expect(page.locator("#wizardBackdrop")).toBeVisible();
   await activateWizardCloseButton(page);
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await openAnalysisTab(page);
   await expect(page.locator("#analysisNoCarMessage")).toBeVisible();
   await expect(page.locator("#saveAnalysisBtn")).toBeDisabled();
   await expect(page.locator("#resetAnalysisBtn")).toBeDisabled();
@@ -234,12 +227,10 @@ test("hides contextual car guidance when a valid selected car exists", async ({ 
       await fulfillJson(route, {});
     },
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="carTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openCarsTab(page);
   await expect(page.locator("#carSelectionGuidance")).toBeHidden();
-  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await openAnalysisTab(page);
   await expect(page.locator("#analysisNoCarMessage")).toBeHidden();
   await expect(page.locator("#resetAnalysisBtn")).toBeEnabled();
 });
@@ -297,26 +288,6 @@ test("keeps contextual no-car guidance hidden until active car bootstrap resolve
       await fulfillJson(route, {});
     },
   });
-  await installFakeWebSocket(page, {
-    payload: {
-      server_time: new Date().toISOString(),
-      clients: [
-        {
-          id: "001122334455",
-          name: "Front Left",
-          connected: true,
-          sample_rate_hz: 1000,
-          last_seen_age_ms: 12,
-          dropped_frames: 0,
-          frames_total: 100,
-          location_code: "front_left_wheel",
-          mac_address: "001122334455",
-          firmware_version: "fw-1.0.0",
-        },
-      ],
-      spectra: { clients: {} },
-    },
-  });
   await page.route("**/api/recording/status", async (route) => {
     await fulfillJson(route, {
       enabled: false,
@@ -348,7 +319,25 @@ test("keeps contextual no-car guidance hidden until active car bootstrap resolve
         }),
     });
   });
-  await page.goto("/");
+  await bootLiveDashboard(page, {
+    installRoutes: false,
+    liveSensorPayload: {
+      clients: [
+        {
+          id: "001122334455",
+          name: "Front Left",
+          connected: true,
+          sample_rate_hz: 1000,
+          last_seen_age_ms: 12,
+          dropped_frames: 0,
+          frames_total: 100,
+          location_code: "front_left_wheel",
+          mac_address: "001122334455",
+          firmware_version: "fw-1.0.0",
+        },
+      ],
+    },
+  });
   await expect(page.locator("#carSelectionBanner")).toHaveCount(0);
   await expect(page.locator("#liveActiveCar [data-value]")).toHaveText("Loading active car...");
   await expect(page.locator("#liveRecordingState [data-value]")).toHaveText("Blocked");
@@ -356,14 +345,13 @@ test("keeps contextual no-car guidance hidden until active car bootstrap resolve
   await expect(page.locator("#loggingStatus")).toBeHidden();
   await expect(page.locator("#startLoggingBtn")).toBeDisabled();
 
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await openAnalysisTab(page);
 
   await expect(page.locator("#wheelBandwidthInput")).toHaveValue("7.5");
   await expect(page.locator("#saveAnalysisBtn")).toBeDisabled();
   await expect(page.locator("#resetAnalysisBtn")).toBeDisabled();
   await expect(page.locator("#analysisNoCarMessage")).toBeHidden();
-  await page.locator('[data-settings-tab="carTab"]').click();
+  await openCarsTab(page);
   await expect(page.locator("#carSelectionGuidance")).toBeHidden();
 
   if (!releaseCars) {
@@ -372,12 +360,12 @@ test("keeps contextual no-car guidance hidden until active car bootstrap resolve
   captureReady = true;
   releaseCars();
 
-  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await openAnalysisTab(page);
   await expect(page.locator("#saveAnalysisBtn")).toBeEnabled();
   await expect(page.locator("#resetAnalysisBtn")).toBeEnabled();
   await expect(page.locator("#analysisNoCarMessage")).toBeHidden();
 
-  await page.locator('[data-settings-tab="carTab"]').click();
+  await openCarsTab(page);
   await expect(page.locator("#carSelectionGuidance")).toBeHidden();
   const activeRow = page.locator('#carListBody tr[data-car-id="car-1"]');
   await expect(activeRow).toContainText("Audit Demo Car");
@@ -475,9 +463,9 @@ test("shows a live warning state until an active car is selected, then clears it
       last_completed_run_error: null,
     });
   });
-  await installFakeWebSocket(page, {
-    payload: {
-      server_time: new Date().toISOString(),
+  await bootLiveDashboard(page, {
+    installRoutes: false,
+    liveSensorPayload: {
       clients: [
         {
           id: "001122334455",
@@ -492,11 +480,8 @@ test("shows a live warning state until an active car is selected, then clears it
           firmware_version: "fw-1.0.0",
         },
       ],
-      spectra: { clients: {} },
     },
   });
-
-  await page.goto("/");
   await expect(page.locator("#liveActiveCar")).not.toHaveAttribute("data-variant", "warn");
   await expect(page.locator("#liveActiveCar .stat__value-icon")).toHaveCount(0);
   await expect(page.locator("#liveActiveCar [data-value]")).toContainText("No active car selected");
@@ -581,9 +566,8 @@ test("shows car-tab guidance for invalid persisted selection and after deleting 
       await fulfillJson(route, {});
     },
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openSettingsTab(page);
   await expect(page.locator("#carSelectionGuidance")).toBeVisible();
   await page.locator("#carListBody .car-activate-btn").last().click();
   await expect(page.locator("#carSelectionGuidance")).toBeHidden();
@@ -658,10 +642,8 @@ test("routes incomplete cars through Finish setup instead of generic activation"
       await fulfillJson(route, {});
     },
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="carTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openCarsTab(page);
 
   const incompleteRow = page.locator('#carListBody tr[data-car-id="car-2"]');
   await expect(incompleteRow).toContainText("Inactive");
@@ -712,10 +694,8 @@ test("returns from the add-car flow with visible success feedback and row highli
       await fulfillJson(route, {});
     },
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="carTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openCarsTab(page);
   await page.getByRole("button", { name: "+ Add Car" }).click();
   await page.locator("#wizardCustomBrand").fill("Track");
   await page.locator("#wizardCustomBrandBtn").click();

--- a/apps/ui/tests/smoke.helpers.ts
+++ b/apps/ui/tests/smoke.helpers.ts
@@ -8,6 +8,12 @@ export type FakeWebSocketOptions = {
   trackerKey?: string;
 };
 
+export type LiveSensorPayloadOptions = Omit<FakeWebSocketOptions, "payload"> & {
+  clients?: Array<Record<string, unknown>>;
+  extraPayload?: Record<string, unknown>;
+  speedMps?: number | null;
+};
+
 export async function installFakeWebSocket(page: Page, options: FakeWebSocketOptions = {}): Promise<void> {
   await page.addInitScript(({ payload, schemaVersion, repeatPayloadCount, repeatPayloadIntervalMs, trackerKey }) => {
     const mergedPayload = payload
@@ -93,6 +99,28 @@ export async function installFakeWebSocket(page: Page, options: FakeWebSocketOpt
   }, { ...options, schemaVersion: EXPECTED_SCHEMA_VERSION });
 }
 
+export async function installLiveSensorPayload(
+  page: Page,
+  options: LiveSensorPayloadOptions = {},
+): Promise<void> {
+  const {
+    clients = [],
+    extraPayload = {},
+    speedMps = null,
+    ...webSocketOptions
+  } = options;
+  await installFakeWebSocket(page, {
+    ...webSocketOptions,
+    payload: {
+      server_time: new Date().toISOString(),
+      speed_mps: speedMps,
+      clients,
+      spectra: { clients: {} },
+      ...extraPayload,
+    },
+  });
+}
+
 export async function waitForFakeWebSocketSettled(
   page: Page,
   trackerKey: string,
@@ -146,6 +174,12 @@ export type CommonRouteOptions = {
   historyHandler?: (route: Route) => Promise<void>;
   settingsHandler?: (route: Route) => Promise<void>;
   espFlashHandler?: (route: Route) => Promise<void>;
+};
+
+export type BootLiveDashboardOptions = CommonRouteOptions & {
+  fakeWebSocket?: FakeWebSocketOptions;
+  installRoutes?: boolean;
+  liveSensorPayload?: LiveSensorPayloadOptions;
 };
 
 export type SettingsRouteValue = unknown | ((route: Route, path: string, method: string) => Promise<unknown | undefined>);
@@ -376,6 +410,65 @@ export async function installCommonRoutes(page: Page, options: CommonRouteOption
       diagnostic: "No USB network interface is currently detected.",
     });
   });
+}
+
+export async function bootLiveDashboard(
+  page: Page,
+  options: BootLiveDashboardOptions = {},
+): Promise<void> {
+  const {
+    fakeWebSocket,
+    installRoutes = true,
+    liveSensorPayload,
+    ...routeOptions
+  } = options;
+  if (installRoutes) {
+    await installCommonRoutes(page, routeOptions);
+  }
+  if (liveSensorPayload) {
+    await installLiveSensorPayload(page, liveSensorPayload);
+  } else {
+    await installFakeWebSocket(page, fakeWebSocket);
+  }
+  await page.goto("/");
+}
+
+export async function openSettingsTab(
+  page: Page,
+  settingsTabId?: string,
+): Promise<void> {
+  await page.locator("#tab-settings").click();
+  if (settingsTabId) {
+    await page.locator(`[data-settings-tab="${settingsTabId}"]`).click();
+  }
+}
+
+export async function openCarsTab(page: Page): Promise<void> {
+  await openSettingsTab(page, "carTab");
+}
+
+export async function openSpeedSourceTab(page: Page): Promise<void> {
+  await openSettingsTab(page, "speedSourceTab");
+}
+
+export async function openAnalysisTab(page: Page): Promise<void> {
+  await openSettingsTab(page, "analysisTab");
+}
+
+export async function openSensorsTab(page: Page): Promise<void> {
+  await openSettingsTab(page, "sensorsTab");
+}
+
+export async function openInternetTab(page: Page): Promise<void> {
+  await openSettingsTab(page, "internetTab");
+}
+
+export async function openUpdateTab(page: Page): Promise<void> {
+  await openSettingsTab(page, "updateTab");
+}
+
+export async function openHistoryTab(page: Page): Promise<void> {
+  await page.locator("#tab-history").click();
 }
 
 export function createSettingsHandlerFromMap(settingsMap: Record<string, SettingsRouteValue>) {

--- a/apps/ui/tests/smoke.history.spec.ts
+++ b/apps/ui/tests/smoke.history.spec.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "@playwright/test";
 
 import {
+  bootLiveDashboard,
   fulfillJson,
-  installCommonRoutes,
-  installFakeWebSocket,
+  openHistoryTab,
   readSemanticSurfaceStyles,
   readSemanticToneStyles,
   requestPath,
+  installCommonRoutes,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 15_000 });
@@ -26,7 +27,7 @@ test("dark mode diagnosis cards use semantic theme surfaces", async ({ page }) =
   await page.emulateMedia({ colorScheme: "dark" });
   let confidenceTone: "success" | "warn" = "success";
 
-  await installCommonRoutes(page, {
+  await bootLiveDashboard(page, {
     historyHandler: async (route) => {
       const pathname = requestPath(route);
       if (!pathname.startsWith("/api/history") || pathname.includes("/insights")) {
@@ -86,8 +87,6 @@ test("dark mode diagnosis cards use semantic theme surfaces", async ({ page }) =
       ],
     });
   });
-  await installFakeWebSocket(page);
-
   const expectations = [
     {
       tone: "success",
@@ -104,7 +103,7 @@ test("dark mode diagnosis cards use semantic theme surfaces", async ({ page }) =
   for (const expectation of expectations) {
     confidenceTone = expectation.tone;
     await page.goto("/");
-    await page.locator("#tab-history").click();
+    await openHistoryTab(page);
     await page.locator('[data-run-toggle="details"][data-run="run-001"]').click();
     const diagnosisCard = page.locator(`.history-diagnosis-card--${expectation.tone}`);
     await expect(diagnosisCard).toBeVisible();
@@ -121,7 +120,7 @@ test("dark mode diagnosis cards use semantic theme surfaces", async ({ page }) =
 test("dark mode history warning pills and banners use semantic theme tokens", async ({ page }) => {
   await page.emulateMedia({ colorScheme: "dark" });
 
-  await installCommonRoutes(page, {
+  await bootLiveDashboard(page, {
     historyHandler: async (route) => {
       const pathname = requestPath(route);
       if (!pathname.startsWith("/api/history") || pathname.includes("/insights")) {
@@ -189,10 +188,8 @@ test("dark mode history warning pills and banners use semantic theme tokens", as
       ],
     });
   });
-  await installFakeWebSocket(page);
-
   await page.goto("/");
-  await page.locator("#tab-history").click();
+  await openHistoryTab(page);
   await page.locator('[data-run-toggle="details"][data-run="run-001"]').click();
 
   const confidencePill = page.locator(".history-diagnosis-card__confidence--warn");
@@ -218,11 +215,8 @@ test("dark mode history warning pills and banners use semantic theme tokens", as
 
 test("dark mode quiet danger buttons use semantic danger tokens in History", async ({ page }) => {
   await page.emulateMedia({ colorScheme: "dark" });
-  await installCommonRoutes(page, { runs: [historyListRun] });
-  await installFakeWebSocket(page);
-
-  await page.goto("/");
-  await page.locator("#tab-history").click();
+  await bootLiveDashboard(page, { runs: [historyListRun] });
+  await openHistoryTab(page);
   await page.locator('[data-run-toggle="details"][data-run="run-001"]').click();
   const deleteButton = page.locator('[data-run-action="delete-run"][data-run="run-001"]');
   await expect(deleteButton).toBeVisible();
@@ -256,7 +250,7 @@ test("dark mode quiet danger buttons use semantic danger tokens in History", asy
 });
 
 test("history empty state points users back to Live", async ({ page }) => {
-  await installCommonRoutes(page, {
+  await bootLiveDashboard(page, {
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
         await fulfillJson(route, { cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }], active_car_id: "car-1" });
@@ -273,9 +267,7 @@ test("history empty state points users back to Live", async ({ page }) => {
       await fulfillJson(route, { runs: [] });
     },
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-history").click();
+  await openHistoryTab(page);
   const emptyState = page.locator("#historyTableBody .empty-state");
   await expect(emptyState).toContainText("Capture the first run from Live.");
   await expect(emptyState).toContainText("History fills automatically");
@@ -284,7 +276,7 @@ test("history empty state points users back to Live", async ({ page }) => {
 });
 
 test("history rows show diagnostic context before expansion", async ({ page }) => {
-  await installCommonRoutes(page, {
+  await bootLiveDashboard(page, {
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
         await fulfillJson(route, { cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }], active_car_id: "car-1" });
@@ -341,9 +333,7 @@ test("history rows show diagnostic context before expansion", async ({ page }) =
       ],
     });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-history").click();
+  await openHistoryTab(page);
   const row = page.locator('[data-run-row="1"][data-run="run-001"]');
   await expect(row).toContainText("Analysis ready");
   await expect(row).toContainText("Front-right wheel imbalance");
@@ -360,7 +350,7 @@ test("history rows show diagnostic context before expansion", async ({ page }) =
 });
 
 test("history preview uses dB intensity fields from insights payload", async ({ page }) => {
-  await installCommonRoutes(page, {
+  await bootLiveDashboard(page, {
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
         await fulfillJson(route, { cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }], active_car_id: "car-1" });
@@ -397,9 +387,7 @@ test("history preview uses dB intensity fields from insights payload", async ({ 
       ],
     });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-history").click();
+  await openHistoryTab(page);
   const toggle = page.locator('[data-run-toggle="details"][data-run="run-001"]');
   const diagnosisSummary = page.locator('[data-run-row="1"][data-run="run-001"] .history-row__diagnosis');
   await expect(toggle).toContainText("Open diagnosis");
@@ -437,10 +425,8 @@ test("history preview uses dB intensity fields from insights payload", async ({ 
 });
 
 test("history keeps destructive actions inside the expanded management footer", async ({ page }) => {
-  await installCommonRoutes(page, { runs: [historyListRun] });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-history").click();
+  await bootLiveDashboard(page, { runs: [historyListRun] });
+  await openHistoryTab(page);
   const row = page.locator('[data-run-row="1"][data-run="run-001"]');
   const actionCell = row.locator("td").nth(3);
   await expect(actionCell.locator('[data-run-action="download-pdf"][data-run="run-001"]')).toContainText("PDF");
@@ -485,9 +471,8 @@ test("history PDF download revokes object URL with safe delay", async ({ page })
       globalState.__revokeCallCount = (globalState.__revokeCallCount ?? 0) + 1;
     }) as typeof URL.revokeObjectURL;
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-history").click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openHistoryTab(page);
   const pdfButton = page.locator('[data-run-action="download-pdf"][data-run="run-001"]');
   await expect(pdfButton).toBeVisible();
   await pdfButton.click();
@@ -497,7 +482,7 @@ test("history PDF download revokes object URL with safe delay", async ({ page })
 });
 
 test("history loaded insights promote the result summary above supporting evidence", async ({ page }) => {
-  await installCommonRoutes(page, {
+  await bootLiveDashboard(page, {
     settingsHandler: async (route) => {
       if (requestPath(route) === "/api/settings/cars") {
         await fulfillJson(route, { cars: [{ id: "car-1", name: "Selected", type: "sedan", aspects: {} }], active_car_id: "car-1" });
@@ -566,9 +551,7 @@ test("history loaded insights promote the result summary above supporting eviden
       ],
     });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-history").click();
+  await openHistoryTab(page);
   await page.locator('[data-run-toggle="details"][data-run="run-001"]').click();
   await expect(page.locator(".history-details-header [data-run-action='load-insights']")).toBeVisible();
   await page.locator(".history-details-header [data-run-action='load-insights']").click();

--- a/apps/ui/tests/smoke.settings.spec.ts
+++ b/apps/ui/tests/smoke.settings.spec.ts
@@ -1,13 +1,17 @@
 import { expect, test } from "@playwright/test";
 
 import {
+  bootLiveDashboard,
   cancelPrompt,
   confirmPrompt,
   createSettingsHandlerFromMap,
   fulfillJson,
   gpsStatus,
   installCommonRoutes,
-  installFakeWebSocket,
+  openAnalysisTab,
+  openSensorsTab,
+  openSettingsTab,
+  openSpeedSourceTab,
   requestPath,
 } from "./smoke.helpers";
 
@@ -15,10 +19,8 @@ test.describe.configure({ timeout: 20_000 });
 
 test("gps status uses selected speed unit in settings panel", async ({ page }) => {
   await installCommonRoutes(page, { settingsHandler: createSettingsHandlerFromMap({ "/api/settings/language": { language: "en" }, "/api/settings/speed-unit": { speed_unit: "mps" }, "/api/settings/speed-source/status": gpsStatus({ last_update_age_s: 0.333, raw_speed_kmh: 36 }) }) });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openSpeedSourceTab(page);
   await expect(page.locator("#gpsStatusRawSpeed")).toHaveText("10.0 m/s");
   await expect(page.locator("#gpsStatusEffectiveSpeed")).toHaveText("5.0 m/s");
 });
@@ -35,8 +37,10 @@ test("gps status polling does not override websocket speed readout", async ({ pa
       },
     }),
   });
-  await installFakeWebSocket(page, { payload: { server_time: new Date().toISOString(), speed_mps: 20, clients: [], spectra: { clients: {} } } });
-  await page.goto("/");
+  await bootLiveDashboard(page, {
+    installRoutes: false,
+    liveSensorPayload: { speedMps: 20 },
+  });
   await expect(page.locator("#speed")).toContainText("72.0 km/h");
   await expect.poll(() => gpsStatusCalls, { timeout: 5_000 }).toBeGreaterThanOrEqual(2);
   await expect(page.locator("#speed")).toContainText("72.0 km/h");
@@ -44,10 +48,10 @@ test("gps status polling does not override websocket speed readout", async ({ pa
 
 test("spectrum title updates when switching language", async ({ page }) => {
   await installCommonRoutes(page, { settingsHandler: createSettingsHandlerFromMap({ "GET /api/settings/language": { language: "en" }, "PUT /api/settings/language": { language: "nl" }, "/api/settings/speed-unit": { speed_unit: "kmh" }, "/api/settings/speed-source/status": gpsStatus({ raw_speed_kmh: 72, effective_speed_kmh: 72 }) }) });
-  await installFakeWebSocket(page, {
-    payload: {
-      server_time: new Date().toISOString(),
-      speed_mps: 20,
+  await bootLiveDashboard(page, {
+    installRoutes: false,
+    liveSensorPayload: {
+      speedMps: 20,
       clients: [
         {
           id: "c1",
@@ -62,10 +66,8 @@ test("spectrum title updates when switching language", async ({ page }) => {
           firmware_version: "fw-1.0.0",
         },
       ],
-      spectra: { clients: {} },
     },
   });
-  await page.goto("/");
   const spectrumTitle = page.locator("#spectrumPanelRoot .card__title");
   await expect(spectrumTitle).toHaveText("Multi-Sensor Blended Spectrum");
   await expect(page.locator("#languageSelect")).toHaveValue("en");
@@ -82,10 +84,8 @@ test("manual speed save uses settings endpoint only (no speed-override call)", a
     speedOverrideCalls += 1;
     await route.fulfill({ status: 404, contentType: "application/json", body: JSON.stringify({ detail: "missing" }) });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openSpeedSourceTab(page);
   await expect(page.locator("#speedSourceCurrentSource")).toHaveText("GPS");
   await expect(page.locator("#gpsFallbackPanel")).toBeVisible();
   await expect(page.locator("#manualSpeedConfig")).toBeHidden();
@@ -110,11 +110,8 @@ test("manual speed validation marks the field invalid while keeping the active G
       },
     }),
   });
-  await installFakeWebSocket(page);
-
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openSpeedSourceTab(page);
   await page.locator('[data-speed-source-choice="manual"]').click();
   await page.locator("#manualSpeedInput").fill("0");
   await page.locator("#saveSpeedSourceBtn").click();
@@ -145,24 +142,19 @@ test("resolved fallback manual state stays coherent across header status, form, 
       }),
     }),
   });
-  await installFakeWebSocket(page, {
-    payload: {
-      server_time: new Date().toISOString(),
-      speed_mps: 80 / 3.6,
-      clients: [],
-      spectra: { clients: {} },
-    },
+  await bootLiveDashboard(page, {
+    installRoutes: false,
+    liveSensorPayload: { speedMps: 80 / 3.6 },
   });
-  await page.goto("/");
   await expect(page.locator("#speed")).toContainText("80.0 km/h");
   await expect(page.locator("#speed")).toContainText("Manual");
   await expect(page.locator(".site-header__status")).toBeHidden();
 
-  await page.locator("#tab-settings").click();
+  await openSettingsTab(page);
   await expect(page.locator(".site-header__status")).toBeVisible();
   await expect(page.locator("#linkState")).toHaveText("Connected");
   await expect(page.locator("#shellLiveStatus")).toHaveText("No live signal");
-  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await openSpeedSourceTab(page);
   await expect(page.locator("#speedSourceCurrentSource")).toHaveText("Manual fallback");
   await expect(page.locator("#speedSourceEffectiveSpeed")).toHaveText("80.0 km/h");
   await expect(page.locator("#speedSourceFallbackActive")).toHaveText("Yes");
@@ -218,21 +210,14 @@ test("resolved OBD2 state stays coherent across header status, form, and device 
       },
     }),
   });
-  await installFakeWebSocket(page, {
-    payload: {
-      server_time: new Date().toISOString(),
-      speed_mps: 81 / 3.6,
-      clients: [],
-      spectra: { clients: {} },
-    },
+  await bootLiveDashboard(page, {
+    installRoutes: false,
+    liveSensorPayload: { speedMps: 81 / 3.6 },
   });
-
-  await page.goto("/");
   await expect(page.locator("#speed")).toContainText("81.0 km/h");
   await expect(page.locator("#speed")).toContainText("OBD2");
 
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await openSpeedSourceTab(page);
   await expect(page.locator("#speedSourceCurrentSource")).toHaveText("OBD2");
   await expect(page.locator("#speedSourceEffectiveSpeed")).toHaveText("81.0 km/h");
   await expect(page.locator('input[name="speedSourceRadio"][value="obd2"]')).toBeChecked();
@@ -261,10 +246,8 @@ test("analysis bandwidth and uncertainty settings persist through API round-trip
     }
     await fulfillJson(route, persistedAnalysisSettings);
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openAnalysisTab(page);
   await page.locator("#wheelBandwidthInput").fill("7.5");
   await page.locator("#driveshaftBandwidthInput").fill("8.5");
   await page.locator("#engineBandwidthInput").fill("9.5");
@@ -277,8 +260,7 @@ test("analysis bandwidth and uncertainty settings persist through API round-trip
   await page.locator("#saveAnalysisBtn").click();
   await expect.poll(() => analysisPutCalls).toBe(1);
   await page.reload();
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await openAnalysisTab(page);
   await expect(page.locator("#wheelBandwidthInput")).toHaveValue("7.5");
 });
 
@@ -330,10 +312,8 @@ test("analysis tab adds guided helper copy and can reset tuning to defaults", as
     }
     await fulfillJson(route, lastAnalysisPayload);
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openAnalysisTab(page);
 
   const analysisGuidance = page.locator("#analysisGuidanceHelp");
   const analysisGuidanceBody = analysisGuidance.locator(".settings-help-disclosure__body");
@@ -393,10 +373,8 @@ test("analysis settings ask for confirmation before saving risky values", async 
     }
     await fulfillJson(route, {});
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openAnalysisTab(page);
   await page.locator("#wheelBandwidthInput").fill("40");
   await page.locator("#saveAnalysisBtn").click();
   await cancelPrompt(page);
@@ -429,10 +407,8 @@ test("analysis settings show a field-specific error when a hard limit is exceede
     }
     await fulfillJson(route, {});
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openAnalysisTab(page);
   await page.locator("#wheelBandwidthInput").fill("120");
   await page.locator("#saveAnalysisBtn").click();
 
@@ -484,10 +460,8 @@ test("failed analysis save preserves the draft and explains that saved settings 
       tire_deflection_factor: 0.97,
     });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="analysisTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openAnalysisTab(page);
   await page.locator("#wheelBandwidthInput").fill("7.5");
   await page.locator("#maxBandHalfWidthInput").fill("11");
   await page.locator("#saveAnalysisBtn").click();
@@ -511,9 +485,9 @@ test("assigning a sensor location preserves the original sensor name", async ({ 
     locationUpdateCalls += 1;
     await fulfillJson(route, {});
   });
-  await installFakeWebSocket(page, {
-    payload: {
-      server_time: new Date().toISOString(),
+  await bootLiveDashboard(page, {
+    installRoutes: false,
+    liveSensorPayload: {
       clients: [
         {
           id: "sensor-1",
@@ -528,13 +502,9 @@ test("assigning a sensor location preserves the original sensor name", async ({ 
           firmware_version: "fw-1.0.0",
         },
       ],
-      spectra: { clients: {} },
     },
   });
-
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="sensorsTab"]').click();
+  await openSensorsTab(page);
 
   const row = page.locator('#sensorsSettingsBody tr[data-client-id="sensor-1"]');
   const locationSelect = row.locator("select.row-location-select");
@@ -567,9 +537,9 @@ test("sensor identify and remove actions stay wired through the Sensors panel", 
     removeCalls += 1;
     await fulfillJson(route, {});
   });
-  await installFakeWebSocket(page, {
-    payload: {
-      server_time: new Date().toISOString(),
+  await bootLiveDashboard(page, {
+    installRoutes: false,
+    liveSensorPayload: {
       clients: [
         {
           id: "sensor-1",
@@ -584,13 +554,9 @@ test("sensor identify and remove actions stay wired through the Sensors panel", 
           firmware_version: "fw-1.0.0",
         },
       ],
-      spectra: { clients: {} },
     },
   });
-
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="sensorsTab"]').click();
+  await openSensorsTab(page);
 
   const row = page.locator('#sensorsSettingsBody tr[data-client-id="sensor-1"]');
 
@@ -607,9 +573,9 @@ test("settings keep inferred sensor names unassigned until an explicit location 
   await installCommonRoutes(page, {
     locations: [{ code: "front_left_wheel", label: "Front Left Wheel" }],
   });
-  await installFakeWebSocket(page, {
-    payload: {
-      server_time: new Date().toISOString(),
+  await bootLiveDashboard(page, {
+    installRoutes: false,
+    liveSensorPayload: {
       clients: [
         {
           id: "sensor-1",
@@ -624,13 +590,9 @@ test("settings keep inferred sensor names unassigned until an explicit location 
           firmware_version: "fw-1.0.0",
         },
       ],
-      spectra: { clients: {} },
     },
   });
-
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="sensorsTab"]').click();
+  await openSensorsTab(page);
 
   const row = page.locator('#sensorsSettingsBody tr[data-client-id="sensor-1"]');
   const locationSelect = row.locator("select.row-location-select");
@@ -653,11 +615,8 @@ test("failed speed-source save keeps the draft and explains which source remains
       },
     }),
   });
-  await installFakeWebSocket(page);
-
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openSpeedSourceTab(page);
   await page.locator('[data-speed-source-choice="manual"]').click();
   await page.locator("#manualSpeedInput").fill("45");
   await page.locator("#saveSpeedSourceBtn").click();
@@ -746,11 +705,8 @@ test("manual OBD scan sorts named devices first and background rescans progressi
       },
     }),
   });
-  await installFakeWebSocket(page);
-
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openSpeedSourceTab(page);
   await page.locator("#scanObdDevicesBtn").click();
 
   const deviceNames = page.locator(".speed-source-device__name");
@@ -816,11 +772,8 @@ test("background OBD rescans stop when the Speed Source OBD panel is no longer v
       },
     }),
   });
-  await installFakeWebSocket(page);
-
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="speedSourceTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openSpeedSourceTab(page);
   await page.locator("#scanObdDevicesBtn").click();
 
   await expect.poll(() => scanCalls, { timeout: 5_000 }).toBeGreaterThanOrEqual(2);
@@ -846,9 +799,7 @@ test("failed language save reverts the selector and shows an error", async ({ pa
       "GET /api/settings/speed-unit": { speed_unit: "kmh" },
     }),
   });
-  await installFakeWebSocket(page);
-
-  await page.goto("/");
+  await bootLiveDashboard(page, { installRoutes: false });
   await page.locator("#languageSelect").selectOption("nl");
 
   await expect(page.locator("#languageFeedback")).toBeVisible();

--- a/apps/ui/tests/smoke.update.spec.ts
+++ b/apps/ui/tests/smoke.update.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "@playwright/test";
 
 import {
+  bootLiveDashboard,
   fulfillJson,
   installCommonRoutes,
-  installFakeWebSocket,
+  openInternetTab,
+  openUpdateTab,
 } from "./smoke.helpers";
 
 test.describe.configure({ timeout: 15_000 });
@@ -64,10 +66,8 @@ test("settings update tab renders readiness guidance when idle", async ({
       },
     });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="updateTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openUpdateTab(page);
   await expect(page.locator("#updateOverviewPanel")).toContainText(
     "Ready to start once the Pi has either temporary Wi-Fi credentials or a usable USB internet uplink.",
   );
@@ -91,7 +91,7 @@ test("settings update tab renders readiness guidance when idle", async ({
     "Background service health",
   );
   await expect(page.locator("#updateStartBtn")).toBeDisabled();
-  await page.locator('[data-settings-tab="internetTab"]').click();
+  await openInternetTab(page);
   await expect(page.locator("#updateTransportOptions")).toHaveJSProperty(
     "hidden",
     false,
@@ -135,7 +135,7 @@ test("settings update tab renders readiness guidance when idle", async ({
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "A Wi-Fi network name is entered and ready to use.",
   );
-  await page.locator('[data-settings-tab="updateTab"]').click();
+  await openUpdateTab(page);
   await expect(page.locator("#updateStartBtn")).toBeEnabled();
 });
 
@@ -208,10 +208,8 @@ test("settings internet tab and updater show USB internet when usable", async ({
       diagnostic: "USB internet is ready on 'usb0'.",
     });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="internetTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openInternetTab(page);
   await expect(page.locator("#internetStatusPanel")).toContainText(
     "USB internet status",
   );
@@ -263,7 +261,7 @@ test("settings internet tab and updater show USB internet when usable", async ({
     "data-choice-state",
     "active",
   );
-  await page.locator('[data-settings-tab="updateTab"]').click();
+  await openUpdateTab(page);
   await expect(page.locator("#updateStartBtn")).toBeEnabled();
 });
 
@@ -323,15 +321,13 @@ test("settings internet tab restores persisted Wi-Fi SSID after reboot", async (
       },
     });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="internetTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openInternetTab(page);
   await expect(page.locator("#updateSsidInput")).toHaveValue("Workshop Wi-Fi");
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "All visible prerequisites are ready to start the update.",
   );
-  await page.locator('[data-settings-tab="updateTab"]').click();
+  await openUpdateTab(page);
   await expect(page.locator("#updateStartBtn")).toBeEnabled();
 });
 
@@ -391,10 +387,8 @@ test("settings internet tab toggles the Wi-Fi password field without losing the 
       },
     });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="internetTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openInternetTab(page);
   await page.locator("#updatePasswordInput").fill("secret");
   await expect(page.locator("#updatePasswordInput")).toHaveAttribute(
     "type",
@@ -492,10 +486,8 @@ test("settings update failure shows retry guidance, failed-stage retention, and 
       diagnostic: "USB internet is ready on 'usb0'.",
     });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="internetTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openInternetTab(page);
   await page.locator("#updateTransportChoiceUsb").click();
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "Recovery guidance",
@@ -509,7 +501,7 @@ test("settings update failure shows retry guidance, failed-stage retention, and 
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "Check upstream connectivity",
   );
-  await page.locator('[data-settings-tab="updateTab"]').click();
+  await openUpdateTab(page);
   await expect(page.locator("#updateStartBtn")).toHaveText("Retry Update");
   await expect(page.locator("#updateStartBtn")).toBeEnabled();
   await expect(page.locator("#updateStatusPanel")).toContainText(
@@ -604,14 +596,12 @@ test("settings update recovery keeps Retry Update enabled even when readiness st
       diagnostic: "USB internet is not available.",
     });
   });
-  await installFakeWebSocket(page);
-  await page.goto("/");
-  await page.locator("#tab-settings").click();
-  await page.locator('[data-settings-tab="internetTab"]').click();
+  await bootLiveDashboard(page, { installRoutes: false });
+  await openInternetTab(page);
   await expect(page.locator("#updateReadinessSummary")).toContainText(
     "Clear the blocked item before retrying.",
   );
-  await page.locator('[data-settings-tab="updateTab"]').click();
+  await openUpdateTab(page);
   await expect(page.locator("#updateStartBtn")).toHaveText("Retry Update");
   await expect(page.locator("#updateStartBtn")).toBeEnabled();
 });


### PR DESCRIPTION
## what changed
- add shared smoke workflow helpers in `apps/ui/tests/smoke.helpers.ts`
- add `bootLiveDashboard`, `installLiveSensorPayload`, and shared tab openers for settings/history/cars/update flows
- refactor `smoke.settings.spec.ts`, `smoke.cars.spec.ts`, `smoke.history.spec.ts`, and `smoke.update.spec.ts` to use the shared workflow layer

## why
- these smoke specs kept repeating route install, fake websocket payloads, app boot, and tab navigation
- helper layer makes test bodies read like user flow instead of setup plumbing

## validation
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts --project=laptop-light smoke.settings.spec.ts smoke.cars.spec.ts smoke.history.spec.ts smoke.update.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## risk / tradeoffs
- helper indirection can hide route order details, so specs that install their own routes keep using `installRoutes: false`
- no behavior expansion here; same smoke coverage, less duplicated setup