### PR TITLE
test: parameterize dense domain value-object cases

### DIFF
--- a/apps/server/tests/domain/test_domain_objects.py
+++ b/apps/server/tests/domain/test_domain_objects.py
@@ -115,10 +115,16 @@ def test_speed_source_modes(
         assert src.effective_speed_kmh == pytest.approx(expected_effective_speed_kmh)
 
 
-def test_speed_source_rejects_zero_or_negative_manual_speed() -> None:
-    for manual_speed_kmh in (0.0, -10.0):
-        with pytest.raises(ValueError, match="positive manual_speed_kmh"):
-            SpeedSource(kind="manual", manual_speed_kmh=manual_speed_kmh)
+@pytest.mark.parametrize(
+    "manual_speed_kmh",
+    [
+        pytest.param(0.0, id="zero"),
+        pytest.param(-10.0, id="negative"),
+    ],
+)
+def test_speed_source_rejects_zero_or_negative_manual_speed(manual_speed_kmh: float) -> None:
+    with pytest.raises(ValueError, match="positive manual_speed_kmh"):
+        SpeedSource(kind="manual", manual_speed_kmh=manual_speed_kmh)
 
 
 @pytest.mark.parametrize(
@@ -264,10 +270,17 @@ def test_car_derived_properties(
     assert car.rim_in == expected_rim_in
 
 
-def test_car_rejects_zero_tire_dimension() -> None:
-    for key in ("tire_width_mm", "tire_aspect_pct", "rim_in"):
-        with pytest.raises(ValueError, match="positive finite"):
-            Car(aspects={key: 0.0})
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param("tire_width_mm", id="width"),
+        pytest.param("tire_aspect_pct", id="aspect"),
+        pytest.param("rim_in", id="rim"),
+    ],
+)
+def test_car_rejects_zero_tire_dimension(key: str) -> None:
+    with pytest.raises(ValueError, match="positive finite"):
+        Car(aspects={key: 0.0})
 
 
 # ---------------------------------------------------------------------------
@@ -278,27 +291,58 @@ def test_car_rejects_zero_tire_dimension() -> None:
 class TestFindingDomainObject:
     """Finding domain object (distinct from the TypedDict payload)."""
 
-    def test_diagnostic_finding(self) -> None:
-        f = Finding(
-            finding_id="F001",
-            suspected_source="wheel/tire",
-            confidence=0.85,
-            severity="high",
-        )
-        assert f.is_diagnostic
-        assert not f.is_reference
-        assert not f.is_informational
-        assert f.confidence_pct == 85
-
-    def test_reference_finding(self) -> None:
-        f = Finding(finding_id="REF_SPEED")
-        assert f.is_reference
-        assert not f.is_diagnostic
-
-    def test_informational_finding(self) -> None:
-        f = Finding(finding_id="F010", severity="info")
-        assert f.is_informational
-        assert not f.is_diagnostic
+    @pytest.mark.parametrize(
+        (
+            "finding",
+            "expected_is_diagnostic",
+            "expected_is_reference",
+            "expected_is_info",
+            "expected_confidence_pct",
+        ),
+        [
+            pytest.param(
+                Finding(
+                    finding_id="F001",
+                    suspected_source="wheel/tire",
+                    confidence=0.85,
+                    severity="high",
+                ),
+                True,
+                False,
+                False,
+                85,
+                id="diagnostic-finding",
+            ),
+            pytest.param(
+                Finding(finding_id="REF_SPEED"),
+                False,
+                True,
+                False,
+                None,
+                id="reference-finding",
+            ),
+            pytest.param(
+                Finding(finding_id="F010", severity="info"),
+                False,
+                False,
+                True,
+                None,
+                id="informational-finding",
+            ),
+        ],
+    )
+    def test_finding_kind_cases(
+        self,
+        finding: Finding,
+        expected_is_diagnostic: bool,
+        expected_is_reference: bool,
+        expected_is_info: bool,
+        expected_confidence_pct: int | None,
+    ) -> None:
+        assert finding.is_diagnostic is expected_is_diagnostic
+        assert finding.is_reference is expected_is_reference
+        assert finding.is_informational is expected_is_info
+        assert finding.confidence_pct == expected_confidence_pct
 
     def test_source_normalized(self) -> None:
         f = Finding(suspected_source=" Wheel/Tire ")
@@ -386,45 +430,76 @@ class TestBridgeMethods:
 class TestFindingEnrichments:
     """Tests for enriched Finding domain object behaviour."""
 
-    def test_effective_confidence(self) -> None:
-        f = Finding(confidence=0.75)
-        assert f.effective_confidence == 0.75
+    @pytest.mark.parametrize(
+        ("confidence", "expected"),
+        [
+            pytest.param(0.75, 0.75, id="explicit-confidence"),
+            pytest.param(None, 0.0, id="missing-confidence"),
+        ],
+    )
+    def test_effective_confidence_cases(
+        self,
+        confidence: float | None,
+        expected: float,
+    ) -> None:
+        finding = Finding(confidence=confidence)
+        assert finding.effective_confidence == expected
 
-    def test_effective_confidence_none(self) -> None:
-        f = Finding(confidence=None)
-        assert f.effective_confidence == 0.0
+    @pytest.mark.parametrize(
+        ("finding", "expected"),
+        [
+            pytest.param(
+                Finding(suspected_source="wheel/tire"),
+                True,
+                id="known-source",
+            ),
+            pytest.param(
+                Finding(suspected_source="unknown"),
+                False,
+                id="placeholder-no-location",
+            ),
+            pytest.param(
+                Finding(suspected_source="unknown", strongest_location="front_left_wheel"),
+                True,
+                id="placeholder-with-location",
+            ),
+            pytest.param(
+                Finding(suspected_source="unknown_resonance"),
+                False,
+                id="unknown-resonance",
+            ),
+        ],
+    )
+    def test_is_actionable_cases(self, finding: Finding, expected: bool) -> None:
+        assert finding.is_actionable is expected
 
-    def test_is_actionable_known_source(self) -> None:
-        f = Finding(suspected_source="wheel/tire")
-        assert f.is_actionable
-
-    def test_is_actionable_placeholder_source_no_location(self) -> None:
-        f = Finding(suspected_source="unknown")
-        assert not f.is_actionable
-
-    def test_is_actionable_placeholder_source_with_location(self) -> None:
-        f = Finding(suspected_source="unknown", strongest_location="front_left_wheel")
-        assert f.is_actionable
-
-    def test_is_actionable_unknown_resonance(self) -> None:
-        f = Finding(suspected_source="unknown_resonance")
-        assert not f.is_actionable
-
-    def test_should_surface_diagnostic(self) -> None:
-        f = Finding(confidence=0.5, severity="diagnostic")
-        assert f.should_surface
-
-    def test_should_surface_low_confidence(self) -> None:
-        f = Finding(confidence=0.1, severity="diagnostic")
-        assert not f.should_surface
-
-    def test_should_surface_reference(self) -> None:
-        f = Finding(finding_id="REF_SPEED", confidence=0.9)
-        assert not f.should_surface
-
-    def test_should_surface_informational(self) -> None:
-        f = Finding(confidence=0.8, severity="info")
-        assert not f.should_surface
+    @pytest.mark.parametrize(
+        ("finding", "expected"),
+        [
+            pytest.param(
+                Finding(confidence=0.5, severity="diagnostic"),
+                True,
+                id="diagnostic",
+            ),
+            pytest.param(
+                Finding(confidence=0.1, severity="diagnostic"),
+                False,
+                id="low-confidence",
+            ),
+            pytest.param(
+                Finding(finding_id="REF_SPEED", confidence=0.9),
+                False,
+                id="reference",
+            ),
+            pytest.param(
+                Finding(confidence=0.8, severity="info"),
+                False,
+                id="informational",
+            ),
+        ],
+    )
+    def test_should_surface_cases(self, finding: Finding, expected: bool) -> None:
+        assert finding.should_surface is expected
 
     def test_rank_key_quantised(self) -> None:
         f1 = Finding(confidence=0.751, ranking_score=1.0)
@@ -437,13 +512,23 @@ class TestFindingEnrichments:
         f2 = Finding(confidence=0.5, ranking_score=1.0)
         assert f1.rank_key > f2.rank_key
 
-    def test_phase_adjusted_score_no_phase(self) -> None:
-        f = Finding(confidence=0.8)
-        assert f.phase_adjusted_score == pytest.approx(0.8 * 0.85)
-
-    def test_phase_adjusted_score_full_cruise(self) -> None:
-        f = Finding(confidence=0.8, cruise_fraction=1.0)
-        assert f.phase_adjusted_score == pytest.approx(0.8 * 1.0)
+    @pytest.mark.parametrize(
+        ("finding", "expected"),
+        [
+            pytest.param(
+                Finding(confidence=0.8),
+                pytest.approx(0.8 * 0.85),
+                id="no-phase",
+            ),
+            pytest.param(
+                Finding(confidence=0.8, cruise_fraction=1.0),
+                pytest.approx(0.8 * 1.0),
+                id="full-cruise",
+            ),
+        ],
+    )
+    def test_phase_adjusted_score_cases(self, finding: Finding, expected: float) -> None:
+        assert finding.phase_adjusted_score == expected
 
     def test_is_stronger_than(self) -> None:
         f1 = Finding(confidence=0.8, ranking_score=1.0)

--- a/apps/server/tests/domain/test_finding_origin_value_objects.py
+++ b/apps/server/tests/domain/test_finding_origin_value_objects.py
@@ -35,31 +35,64 @@ class TestFindingEvidence:
         assert e.phase_confidences == ()
         assert e.vibration_strength_db is None
 
-    def test_is_strong_true(self) -> None:
-        e = FindingEvidence(match_rate=0.8, snr_db=10.0)
-        assert e.is_strong
+    @pytest.mark.parametrize(
+        ("evidence", "expected"),
+        [
+            pytest.param(
+                FindingEvidence(match_rate=0.8, snr_db=10.0),
+                True,
+                id="strong-evidence",
+            ),
+            pytest.param(
+                FindingEvidence(match_rate=0.5, snr_db=10.0),
+                False,
+                id="low-match-rate",
+            ),
+            pytest.param(
+                FindingEvidence(match_rate=0.8, snr_db=None),
+                False,
+                id="missing-snr",
+            ),
+        ],
+    )
+    def test_is_strong_cases(self, evidence: FindingEvidence, expected: bool) -> None:
+        assert evidence.is_strong is expected
 
-    def test_is_strong_false_low_match(self) -> None:
-        e = FindingEvidence(match_rate=0.5, snr_db=10.0)
-        assert not e.is_strong
+    @pytest.mark.parametrize(
+        ("evidence", "expected"),
+        [
+            pytest.param(
+                FindingEvidence(burstiness=0.1, presence_ratio=0.7),
+                True,
+                id="consistent",
+            ),
+            pytest.param(
+                FindingEvidence(burstiness=0.5, presence_ratio=0.3),
+                False,
+                id="inconsistent",
+            ),
+        ],
+    )
+    def test_is_consistent_cases(self, evidence: FindingEvidence, expected: bool) -> None:
+        assert evidence.is_consistent is expected
 
-    def test_is_strong_false_no_snr(self) -> None:
-        e = FindingEvidence(match_rate=0.8, snr_db=None)
-        assert not e.is_strong
-
-    def test_is_consistent_true(self) -> None:
-        e = FindingEvidence(burstiness=0.1, presence_ratio=0.7)
-        assert e.is_consistent
-
-    def test_is_consistent_false(self) -> None:
-        e = FindingEvidence(burstiness=0.5, presence_ratio=0.3)
-        assert not e.is_consistent
-
-    def test_is_well_localized(self) -> None:
-        e = FindingEvidence(spatial_concentration=0.8)
-        assert e.is_well_localized
-        e2 = FindingEvidence(spatial_concentration=0.3)
-        assert not e2.is_well_localized
+    @pytest.mark.parametrize(
+        ("evidence", "expected"),
+        [
+            pytest.param(
+                FindingEvidence(spatial_concentration=0.8),
+                True,
+                id="well-localized",
+            ),
+            pytest.param(
+                FindingEvidence(spatial_concentration=0.3),
+                False,
+                id="diffuse",
+            ),
+        ],
+    )
+    def test_is_well_localized_cases(self, evidence: FindingEvidence, expected: bool) -> None:
+        assert evidence.is_well_localized is expected
 
     def test_boundary_decode_full(self) -> None:
         d = {
@@ -90,13 +123,20 @@ class TestFindingEvidence:
         assert e.snr_db is None
         assert e.phase_confidences == ()
 
-    def test_boundary_decode_uses_canonical_keys_only(self) -> None:
-        e = finding_evidence_from_mapping({"snr_ratio": 8.0})
-        assert e.snr_db is None
-
-    def test_boundary_decode_snr_db_canonical(self) -> None:
-        e = finding_evidence_from_mapping({"snr_db": 8.0})
-        assert e.snr_db == 8.0
+    @pytest.mark.parametrize(
+        ("payload", "expected_snr_db"),
+        [
+            pytest.param({"snr_ratio": 8.0}, None, id="noncanonical-key-ignored"),
+            pytest.param({"snr_db": 8.0}, 8.0, id="canonical-key-used"),
+        ],
+    )
+    def test_boundary_decode_snr_keys(
+        self,
+        payload: dict[str, float],
+        expected_snr_db: float | None,
+    ) -> None:
+        evidence = finding_evidence_from_mapping(payload)
+        assert evidence.snr_db == expected_snr_db
 
 
 class TestLocationHotspot:
@@ -113,36 +153,75 @@ class TestLocationHotspot:
         assert not h.ambiguous
         assert h.alternative_locations == ()
 
-    def test_is_well_localized_true(self) -> None:
-        h = LocationHotspot(
-            strongest_location="front_left",
-            dominance_ratio=0.8,
-            weak_spatial_separation=False,
-            ambiguous=False,
-        )
-        assert h.is_well_localized
+    @pytest.mark.parametrize(
+        ("hotspot", "expected"),
+        [
+            pytest.param(
+                LocationHotspot(
+                    strongest_location="front_left",
+                    dominance_ratio=0.8,
+                    weak_spatial_separation=False,
+                    ambiguous=False,
+                ),
+                True,
+                id="clear-location",
+            ),
+            pytest.param(
+                LocationHotspot(strongest_location="unknown"),
+                False,
+                id="unknown-location",
+            ),
+            pytest.param(
+                LocationHotspot(
+                    strongest_location="front_left",
+                    weak_spatial_separation=True,
+                ),
+                False,
+                id="weak-spatial-separation",
+            ),
+        ],
+    )
+    def test_is_well_localized_cases(self, hotspot: LocationHotspot, expected: bool) -> None:
+        assert hotspot.is_well_localized is expected
 
-    def test_is_well_localized_false_unknown(self) -> None:
-        h = LocationHotspot(strongest_location="unknown")
-        assert not h.is_well_localized
+    @pytest.mark.parametrize(
+        ("hotspot", "expected"),
+        [
+            pytest.param(LocationHotspot(strongest_location="FL wheel"), True, id="known-location"),
+            pytest.param(LocationHotspot(strongest_location=""), False, id="blank-location"),
+            pytest.param(
+                LocationHotspot(strongest_location="unknown"),
+                False,
+                id="unknown-location",
+            ),
+            pytest.param(
+                LocationHotspot(strongest_location="FL wheel", ambiguous=True),
+                False,
+                id="ambiguous-location",
+            ),
+        ],
+    )
+    def test_is_actionable_cases(self, hotspot: LocationHotspot, expected: bool) -> None:
+        assert hotspot.is_actionable is expected
 
-    def test_is_well_localized_false_weak_spatial(self) -> None:
-        h = LocationHotspot(
-            strongest_location="front_left",
-            weak_spatial_separation=True,
-        )
-        assert not h.is_well_localized
-
-    def test_is_actionable(self) -> None:
-        assert LocationHotspot(strongest_location="FL wheel").is_actionable
-        assert not LocationHotspot(strongest_location="").is_actionable
-        assert not LocationHotspot(strongest_location="unknown").is_actionable
-        assert not LocationHotspot(strongest_location="FL wheel", ambiguous=True).is_actionable
-
-    def test_display_location(self) -> None:
-        assert LocationHotspot(strongest_location="front_left").display_location == "Front Left"
-        assert LocationHotspot(strongest_location="").display_location == "Unknown"
-        assert LocationHotspot(strongest_location="unknown").display_location == "Unknown"
+    @pytest.mark.parametrize(
+        ("hotspot", "expected"),
+        [
+            pytest.param(
+                LocationHotspot(strongest_location="front_left"),
+                "Front Left",
+                id="known-location",
+            ),
+            pytest.param(LocationHotspot(strongest_location=""), "Unknown", id="blank-location"),
+            pytest.param(
+                LocationHotspot(strongest_location="unknown"),
+                "Unknown",
+                id="unknown-location",
+            ),
+        ],
+    )
+    def test_display_location_cases(self, hotspot: LocationHotspot, expected: str) -> None:
+        assert hotspot.display_location == expected
 
     def test_has_clear_separation_false_for_ambiguous_hotspot(self) -> None:
         hotspot = LocationHotspot(strongest_location="front_left", ambiguous=True)
@@ -208,29 +287,34 @@ class TestLocationHotspot:
         assert not hotspot.is_actionable
         assert not hotspot.is_well_localized
 
-    def test_weak_spatial_threshold_baseline_for_none(self) -> None:
-        assert LocationHotspot.weak_spatial_threshold(None) == LocationHotspot.WEAK_SPATIAL_BASELINE
-
-    def test_weak_spatial_threshold_baseline_for_two_locations(self) -> None:
-        assert LocationHotspot.weak_spatial_threshold(2) == pytest.approx(
-            LocationHotspot.WEAK_SPATIAL_BASELINE
-        )
-
-    def test_weak_spatial_threshold_scales_up_per_additional_location(self) -> None:
-        baseline = LocationHotspot.WEAK_SPATIAL_BASELINE
-        assert LocationHotspot.weak_spatial_threshold(3) == pytest.approx(
-            baseline * 1.1,
+    @pytest.mark.parametrize(
+        ("location_count", "expected"),
+        [
+            pytest.param(None, LocationHotspot.WEAK_SPATIAL_BASELINE, id="none-count"),
+            pytest.param(2, LocationHotspot.WEAK_SPATIAL_BASELINE, id="two-locations"),
+            pytest.param(1, LocationHotspot.WEAK_SPATIAL_BASELINE, id="one-location-clamped"),
+            pytest.param(0, LocationHotspot.WEAK_SPATIAL_BASELINE, id="zero-location-clamped"),
+            pytest.param(
+                3,
+                LocationHotspot.WEAK_SPATIAL_BASELINE * 1.1,
+                id="three-locations-scaled",
+            ),
+            pytest.param(
+                4,
+                LocationHotspot.WEAK_SPATIAL_BASELINE * 1.2,
+                id="four-locations-scaled",
+            ),
+        ],
+    )
+    def test_weak_spatial_threshold_cases(
+        self,
+        location_count: int | None,
+        expected: float,
+    ) -> None:
+        assert LocationHotspot.weak_spatial_threshold(location_count) == pytest.approx(
+            expected,
             rel=1e-6,
         )
-        assert LocationHotspot.weak_spatial_threshold(4) == pytest.approx(
-            baseline * 1.2,
-            rel=1e-6,
-        )
-
-    def test_weak_spatial_threshold_clamps_below_two(self) -> None:
-        baseline = LocationHotspot.WEAK_SPATIAL_BASELINE
-        assert LocationHotspot.weak_spatial_threshold(1) == pytest.approx(baseline)
-        assert LocationHotspot.weak_spatial_threshold(0) == pytest.approx(baseline)
 
     def test_weak_spatial_threshold_monotonically_increasing(self) -> None:
         thresholds = [LocationHotspot.weak_spatial_threshold(n) for n in range(2, 8)]

--- a/apps/server/tests/domain/test_test_run_value_objects.py
+++ b/apps/server/tests/domain/test_test_run_value_objects.py
@@ -331,65 +331,115 @@ class TestTestRunWithValueObjects:
 
 
 class TestTestRunSensors:
-    def test_test_run_default_sensors_empty(self) -> None:
-        tr = TestRun(
-            capture=RunCapture(run_id="r1"),
-        )
-        assert tr.capture.setup.sensors == ()
-        assert tr.sensor_count == 0
+    @pytest.mark.parametrize(
+        ("location_codes", "expected_count"),
+        [
+            pytest.param([], 0, id="default-empty"),
+            pytest.param(["front_left_wheel", "rear_axle"], 2, id="two-sensors"),
+            pytest.param(
+                ["front_left_wheel", "rear_axle", "dashboard"],
+                3,
+                id="sensor-count-property",
+            ),
+        ],
+    )
+    def test_test_run_sensor_cases(
+        self,
+        location_codes: list[str],
+        expected_count: int,
+    ) -> None:
+        if location_codes:
+            sensors = Sensor.from_location_codes(location_codes)
+            test_run = TestRun(
+                capture=RunCapture(run_id="r1", setup=RunSetup(sensors=sensors)),
+            )
+        else:
+            test_run = TestRun(capture=RunCapture(run_id="r1"))
 
-    def test_test_run_with_sensors(self) -> None:
-        sensors = Sensor.from_location_codes(["front_left_wheel", "rear_axle"])
-        tr = TestRun(
-            capture=RunCapture(run_id="r1", setup=RunSetup(sensors=sensors)),
-        )
-        assert len(tr.capture.setup.sensors) == 2
-        assert tr.sensor_count == 2
-
-    def test_test_run_sensor_count_property(self) -> None:
-        sensors = Sensor.from_location_codes(["front_left_wheel", "rear_axle", "dashboard"])
-        tr = TestRun(
-            capture=RunCapture(run_id="r1", setup=RunSetup(sensors=sensors)),
-        )
-        assert tr.sensor_count == len(sensors)
+        assert len(test_run.capture.setup.sensors) == expected_count
+        assert test_run.sensor_count == expected_count
 
 
 class TestDrivingSegment:
     """Tests for DrivingSegment diagnostic-usability semantics."""
 
-    def test_cruise_segment_is_usable(self) -> None:
-        seg = DrivingSegment(phase=DrivingPhase.CRUISE, start_idx=0, end_idx=99, sample_count=100)
-        assert seg.is_diagnostically_usable is True
+    @pytest.mark.parametrize(
+        ("segment", "expected"),
+        [
+            pytest.param(
+                DrivingSegment(
+                    phase=DrivingPhase.CRUISE,
+                    start_idx=0,
+                    end_idx=99,
+                    sample_count=100,
+                ),
+                True,
+                id="cruise-usable",
+            ),
+            pytest.param(
+                DrivingSegment(
+                    phase=DrivingPhase.IDLE,
+                    start_idx=0,
+                    end_idx=99,
+                    sample_count=100,
+                ),
+                False,
+                id="idle-not-usable",
+            ),
+            pytest.param(
+                DrivingSegment(
+                    phase=DrivingPhase.CRUISE,
+                    start_idx=0,
+                    end_idx=4,
+                    sample_count=5,
+                ),
+                False,
+                id="too-few-samples",
+            ),
+        ],
+    )
+    def test_diagnostic_usability_cases(self, segment: DrivingSegment, expected: bool) -> None:
+        assert segment.is_diagnostically_usable is expected
 
-    def test_idle_segment_is_not_usable(self) -> None:
-        seg = DrivingSegment(phase=DrivingPhase.IDLE, start_idx=0, end_idx=99, sample_count=100)
-        assert seg.is_diagnostically_usable is False
+    @pytest.mark.parametrize(
+        ("segment", "expected"),
+        [
+            pytest.param(
+                DrivingSegment(
+                    phase=DrivingPhase.CRUISE,
+                    start_idx=0,
+                    end_idx=10,
+                    start_t_s=1.0,
+                    end_t_s=3.5,
+                ),
+                pytest.approx(2.5),
+                id="with-timestamps",
+            ),
+            pytest.param(
+                DrivingSegment(phase=DrivingPhase.CRUISE, start_idx=0, end_idx=10),
+                None,
+                id="without-timestamps",
+            ),
+        ],
+    )
+    def test_duration_s_cases(
+        self,
+        segment: DrivingSegment,
+        expected: float | None,
+    ) -> None:
+        assert segment.duration_s == expected
 
-    def test_segment_with_few_samples_is_not_usable(self) -> None:
-        seg = DrivingSegment(phase=DrivingPhase.CRUISE, start_idx=0, end_idx=4, sample_count=5)
-        assert seg.is_diagnostically_usable is False
-
-    def test_duration_with_timestamps(self) -> None:
-        seg = DrivingSegment(
-            phase=DrivingPhase.CRUISE,
-            start_idx=0,
-            end_idx=10,
-            start_t_s=1.0,
-            end_t_s=3.5,
-        )
-        assert seg.duration_s == pytest.approx(2.5)
-
-    def test_duration_without_timestamps(self) -> None:
-        seg = DrivingSegment(phase=DrivingPhase.CRUISE, start_idx=0, end_idx=10)
-        assert seg.duration_s is None
-
-    def test_is_cruise_property(self) -> None:
-        cruise = DrivingSegment(phase=DrivingPhase.CRUISE, start_idx=0, end_idx=10)
-        accel = DrivingSegment(phase=DrivingPhase.ACCELERATION, start_idx=0, end_idx=10)
-        idle = DrivingSegment(phase=DrivingPhase.IDLE, start_idx=0, end_idx=10)
-        assert cruise.is_cruise is True
-        assert accel.is_cruise is False
-        assert idle.is_cruise is False
+    @pytest.mark.parametrize(
+        ("phase", "expected"),
+        [
+            pytest.param(DrivingPhase.CRUISE, True, id="cruise"),
+            pytest.param(DrivingPhase.ACCELERATION, False, id="acceleration"),
+            pytest.param(DrivingPhase.IDLE, False, id="idle"),
+        ],
+    )
+    def test_is_cruise_property_cases(self, phase: DrivingPhase, expected: bool) -> None:
+        segment = DrivingSegment(phase=phase, start_idx=0, end_idx=10)
+        assert segment.is_cruise is expected
 
 
 class TestDrivingPhaseSegment:


### PR DESCRIPTION
## What changed
- fold repeated pure value-object/property/threshold cases in `test_finding_origin_value_objects.py`, `test_test_run_value_objects.py`, and `test_domain_objects.py` into grouped param tables
- add readable case ids so the dense case families still scan by behavior
- keep reconstruction/serialization and other narrative tests as standalone specs

## Why
- issue #2858 asks for high-density domain value-object tests to read as behavior tables instead of long one-off piles
- this cuts repetition without flattening the distinct scenarios

## Validation
- `ruff check apps/server/tests/domain/test_finding_origin_value_objects.py apps/server/tests/domain/test_test_run_value_objects.py apps/server/tests/domain/test_domain_objects.py`
- `python3 -m py_compile apps/server/tests/domain/test_finding_origin_value_objects.py apps/server/tests/domain/test_test_run_value_objects.py apps/server/tests/domain/test_domain_objects.py`
- `PYTHONPATH=apps/server pytest --noconftest -q apps/server/tests/domain/test_finding_origin_value_objects.py apps/server/tests/domain/test_test_run_value_objects.py apps/server/tests/domain/test_domain_objects.py`

## Risk / tradeoffs
- test-only change; runtime risk low
- local pytest bypasses shared backend `conftest` because this host still lacks `orjson` on the shared path; PR CI will cover the full repo path

Closes #2858