### PR TITLE
Implement msgspec for updater status boundary

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -120,6 +120,33 @@ model with CI `pip check` plus automated Dependabot update PRs rather than
 maintaining a second checked-in Python lockfile workflow alongside the editable
 install path.
 
+## Payload boundary pattern
+
+Updater status persistence and `/api/update/status` now share one msgspec-owned
+boundary in `vibesensor/use_cases/updates/status/payload_codec.py`.
+
+- Keep the domain models (`UpdateJobStatus`, `UpdateRuntimeDetails`,
+  `UpdateIssue`) as the internal source of truth.
+- Use `Update*Payload` `msgspec.Struct` types only at the persistence/HTTP
+  boundary, then route both JSON file I/O and FastAPI response shaping through
+  `update_status_to_payload()`, `update_status_to_builtins()`,
+  `update_status_to_json()`, `update_status_from_builtins()`, and
+  `update_status_from_json()`.
+- Keep compatibility code narrow: legacy persisted status oddities normalize in
+  one decode fallback path instead of leaking loose coercion into domain models
+  or route handlers.
+- Keep Pydantic response models at the HTTP edge when OpenAPI generation still
+  depends on them; msgspec feeds those models with already-validated builtins.
+
+For Pi or Pi-like timing checks before widening this pattern, run:
+
+```bash
+python tools/tests/benchmark_update_status_codec.py --iterations 5000 --rounds 20
+```
+
+The benchmark uses a representative updater-status payload and reports payload
+bytes plus median/p95 encode/decode latency in microseconds per operation.
+
 ## Configuration
 
 Configuration is YAML-based. Runtime defaults live in `vibesensor/app/config_defaults.py`, and `load_config()` applies precedence `DEFAULT_CONFIG -> selected YAML override file -> typed validation/clamping`. Run `vibesensor-config-preflight --dump-defaults` to see all available keys with defaults, or run `vibesensor-config-preflight apps/server/config.dev.yaml` / `apps/server/config.docker.yaml` to inspect a resolved override file.

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
   "fastapi>=0.111,<1",
+  "msgspec>=0.19,<1",
   "uvicorn[standard]>=0.30,<1",
   "numpy>=2.4.4,<3",
   "orjson>=3.11.4,<4",

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -19,7 +19,7 @@ from _update_manager_test_helpers import (
 
 from vibesensor.shared.exceptions import UpdateCleanupError
 from vibesensor.use_cases.updates.models import UpdateState, UpdateTransport, UsbInternetStatus
-from vibesensor.use_cases.updates.status import collect_runtime_details
+from vibesensor.use_cases.updates.status import collect_runtime_details, update_status_to_builtins
 
 
 class _StaticUsbInternetService:
@@ -329,7 +329,7 @@ class TestUpdateManagerAsync:
                 server_release_fetcher=fetcher,
             )
             await run_update(manager, "TestNet", secret)
-        serialized = str(manager.status.to_payload())
+        serialized = str(update_status_to_builtins(manager.status))
         assert secret not in serialized
         for line in manager.status.log_tail:
             assert secret not in line

--- a/apps/server/tests/use_cases/updates/test_update_manager_core.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_core.py
@@ -13,7 +13,7 @@ from vibesensor.shared.exceptions import ConfigurationError, UpdateError
 from vibesensor.use_cases.updates.manager import UpdateManager
 from vibesensor.use_cases.updates.models import UpdatePhase, UpdateState
 from vibesensor.use_cases.updates.runtime import build_update_manager
-from vibesensor.use_cases.updates.status import UpdateStateStore
+from vibesensor.use_cases.updates.status import UpdateStateStore, update_status_to_builtins
 
 
 class TestUpdateManager:
@@ -105,7 +105,7 @@ class TestUpdateManager:
         with patch("shutil.which", mock_which):
             manager.start("TestNet", "supersecret")
 
-        assert "supersecret" not in str(manager.status.to_payload())
+        assert "supersecret" not in str(update_status_to_builtins(manager.status))
         await cancel_task(manager)
 
     @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/updates/test_update_manager_models.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_models.py
@@ -7,11 +7,11 @@ from vibesensor.use_cases.updates.models import (
     UpdateIssue,
     UpdateJobStatus,
     UpdatePhase,
-    UpdateRuntimeDetails,
     UpdateState,
     UpdateTransport,
 )
 from vibesensor.use_cases.updates.runner import sanitize_log_line as sanitize_log_line
+from vibesensor.use_cases.updates.status import update_status_to_builtins
 from vibesensor.use_cases.updates.venv_paths import (
     is_reinstall_venv_ready,
     reinstall_python_executable,
@@ -21,7 +21,7 @@ from vibesensor.use_cases.updates.venv_paths import (
 class TestUpdateJobStatus:
     def test_default_status_to_payload(self) -> None:
         status = UpdateJobStatus()
-        data = status.to_payload()
+        data = update_status_to_builtins(status)
         assert data["state"] == "idle"
         assert data["phase"] == "idle"
         assert data["started_at"] is None
@@ -32,7 +32,16 @@ class TestUpdateJobStatus:
         assert data["issues"] == []
         assert data["log_tail"] == []
         assert data["exit_code"] is None
-        assert data["runtime"] == UpdateRuntimeDetails().to_payload()
+        assert data["runtime"] == {
+            "version": "",
+            "commit": "",
+            "ui_source_hash": "",
+            "static_assets_hash": "",
+            "static_build_source_hash": "",
+            "static_build_commit": "",
+            "assets_verified": False,
+            "has_packaged_static": False,
+        }
 
     def test_status_with_issues(self) -> None:
         status = UpdateJobStatus(
@@ -41,14 +50,14 @@ class TestUpdateJobStatus:
             ssid="TestNet",
             issues=[UpdateIssue(phase="installing", message="Install failed", detail="rc=1")],
         )
-        data = status.to_payload()
+        data = update_status_to_builtins(status)
         assert data["state"] == "failed"
         assert data["ssid"] == "TestNet"
         assert len(data["issues"]) == 1
 
     def test_log_tail_truncated(self) -> None:
         status = UpdateJobStatus(log_tail=[f"line {i}" for i in range(100)])
-        assert len(status.to_payload()["log_tail"]) == 50
+        assert len(update_status_to_builtins(status)["log_tail"]) == 50
 
 
 class TestUpdaterInterpreterSelection:

--- a/apps/server/tests/use_cases/updates/test_update_models_roundtrip.py
+++ b/apps/server/tests/use_cases/updates/test_update_models_roundtrip.py
@@ -1,12 +1,8 @@
-"""Round-trip and edge-case tests for UpdateJobStatus payload serialization.
-
-These tests cover the ``from_payload`` / ``to_payload`` contract of
-:class:`~vibesensor.use_cases.updates.models.UpdateJobStatus`, which is exercised at
-runtime when the state-store reloads a persisted snapshot.
-"""
+"""Round-trip and edge-case tests for the updater status msgspec codec."""
 
 from __future__ import annotations
 
+import msgspec
 import pytest
 
 from vibesensor.use_cases.updates.models import (
@@ -17,13 +13,17 @@ from vibesensor.use_cases.updates.models import (
     UpdateState,
     UpdateTransport,
 )
+from vibesensor.use_cases.updates.status import (
+    update_status_from_builtins,
+    update_status_to_builtins,
+)
 
 
 class TestUpdateJobStatusRoundTrip:
-    """Payload round-trip tests for UpdateJobStatus."""
+    """Payload round-trip tests for the updater status codec."""
 
-    def test_to_payload_from_payload_round_trip(self) -> None:
-        """A fully populated status must survive a to_payload → from_payload cycle."""
+    def test_to_builtins_from_builtins_round_trip(self) -> None:
+        """A fully populated status must survive a msgspec builtins round trip."""
         original = UpdateJobStatus(
             state=UpdateState.success,
             phase=UpdatePhase.done,
@@ -36,7 +36,7 @@ class TestUpdateJobStatusRoundTrip:
             exit_code=0,
             runtime=UpdateRuntimeDetails(version="1.2.3"),
         )
-        restored = UpdateJobStatus.from_payload(original.to_payload())
+        restored = update_status_from_builtins(update_status_to_builtins(original))
 
         assert restored.state == original.state
         assert restored.phase == original.phase
@@ -52,8 +52,8 @@ class TestUpdateJobStatusRoundTrip:
         assert restored.log_tail == ["line1", "line2", "line3"]
 
     def test_from_payload_empty_yields_idle_defaults(self) -> None:
-        """Calling from_payload with an empty dict must produce a blank idle status."""
-        status = UpdateJobStatus.from_payload({})
+        """Decoding an empty payload must produce a blank idle status."""
+        status = update_status_from_builtins({})
 
         assert status.state == UpdateState.idle
         assert status.phase == UpdatePhase.idle
@@ -68,14 +68,14 @@ class TestUpdateJobStatusRoundTrip:
         assert status.runtime == UpdateRuntimeDetails()
 
     def test_from_payload_truncates_log_tail_to_50_lines(self) -> None:
-        """from_payload must honour the _LOG_TAIL_LIMIT of 50 lines."""
+        """Decoding must honour the updater log-tail limit of 50 lines."""
         long_tail = [f"log-line-{i}" for i in range(200)]
         data = {
             "state": "failed",
             "phase": "installing",
             "log_tail": long_tail,
         }
-        status = UpdateJobStatus.from_payload(data)
+        status = update_status_from_builtins(data)
 
         # Only the last 50 lines should be kept.
         assert len(status.log_tail) == 50
@@ -85,21 +85,21 @@ class TestUpdateJobStatusRoundTrip:
     def test_to_payload_truncates_log_tail_to_last_50_lines(self) -> None:
         status = UpdateJobStatus(log_tail=[f"log-line-{i}" for i in range(80)])
 
-        payload = status.to_payload()
+        payload = update_status_to_builtins(status)
 
         assert payload["log_tail"] == [f"log-line-{i}" for i in range(30, 80)]
 
     @pytest.mark.parametrize(
         ("payload", "expected_message"),
         [
-            pytest.param({"state": "broken"}, "Unsupported update state", id="bad-state"),
-            pytest.param({"phase": "broken"}, "Unsupported update phase", id="bad-phase"),
+            pytest.param({"state": "broken"}, "Invalid enum value 'broken'", id="bad-state"),
+            pytest.param({"phase": "broken"}, "Invalid enum value 'broken'", id="bad-phase"),
             pytest.param(
                 {"transport": "broken"},
-                "Unsupported update transport",
+                "Invalid enum value 'broken'",
                 id="bad-transport",
             ),
-            pytest.param({"state": 7}, "update state must be a string", id="non-string-state"),
+            pytest.param({"state": 7}, r"Expected `str`, got `int`", id="non-string-state"),
         ],
     )
     def test_from_payload_rejects_invalid_enum_values(
@@ -107,8 +107,8 @@ class TestUpdateJobStatusRoundTrip:
         payload: dict[str, object],
         expected_message: str,
     ) -> None:
-        with pytest.raises(ValueError, match=expected_message):
-            UpdateJobStatus.from_payload(payload)
+        with pytest.raises(msgspec.ValidationError, match=expected_message):
+            update_status_from_builtins(payload)
 
     def test_finished_at_must_not_precede_started_at(self) -> None:
         with pytest.raises(
@@ -124,7 +124,7 @@ class TestUpdateJobStatusRoundTrip:
 
     def test_from_payload_preserves_partial_valid_fields(self) -> None:
         """Malformed nested fields must drop cleanly while valid pieces survive."""
-        status = UpdateJobStatus.from_payload(
+        status = update_status_from_builtins(
             {
                 "state": "failed",
                 "phase": "installing",
@@ -176,7 +176,7 @@ class TestUpdateJobStatusRoundTrip:
         )
 
     def test_from_payload_coerces_legacy_boolish_runtime_flags(self) -> None:
-        status = UpdateJobStatus.from_payload(
+        status = update_status_from_builtins(
             {
                 "runtime": {
                     "assets_verified": 1,

--- a/apps/server/tests/use_cases/updates/test_update_state_persistence.py
+++ b/apps/server/tests/use_cases/updates/test_update_state_persistence.py
@@ -27,6 +27,8 @@ from vibesensor.use_cases.updates.status import (
     UpdatePhaseTransitionError,
     UpdateStateStore,
     build_update_status_tracker,
+    update_status_from_builtins,
+    update_status_to_builtins,
 )
 
 # ---------------------------------------------------------------------------
@@ -112,14 +114,14 @@ def update_env(
 
 
 # ---------------------------------------------------------------------------
-# UpdateJobStatus round-trip (to_payload / from_payload)
+# UpdateJobStatus round-trip (msgspec payload codec)
 # ---------------------------------------------------------------------------
 
 
 class TestUpdateJobStatusRoundTrip:
     def test_idle_round_trip(self) -> None:
         status = UpdateJobStatus()
-        restored = UpdateJobStatus.from_payload(status.to_payload())
+        restored = update_status_from_builtins(update_status_to_builtins(status))
         assert restored.state == UpdateState.idle
         assert restored.phase == UpdatePhase.idle
         assert restored.issues == []
@@ -150,7 +152,7 @@ class TestUpdateJobStatusRoundTrip:
             exit_code=1,
             runtime=UpdateRuntimeDetails(version="1.0.0"),
         )
-        restored = UpdateJobStatus.from_payload(status.to_payload())
+        restored = update_status_from_builtins(update_status_to_builtins(status))
         assert restored.state == UpdateState.failed
         assert restored.phase == UpdatePhase.installing
         assert restored.started_at == 1700000000.0
@@ -203,6 +205,48 @@ class TestUpdateStateStore:
         assert len(loaded.issues) == 1
         assert loaded.issues[0].message == "ok"
         assert loaded.log_tail == ["log entry 1"]
+
+    def test_load_accepts_backward_compatible_legacy_payload(self, tmp_path: Path) -> None:
+        path = tmp_path / "state.json"
+        path.write_text(
+            """
+            {
+              "state": "failed",
+              "phase": "installing",
+              "transport": "usb_internet",
+              "started_at": "10.5",
+              "issues": [
+                "bad",
+                {"phase": "downloading", "message": "warn", "detail": 99}
+              ],
+              "log_tail": ["ok", 7, null],
+              "runtime": {
+                "version": 9,
+                "assets_verified": 1,
+                "has_packaged_static": "true"
+              }
+            }
+            """.strip(),
+            encoding="utf-8",
+        )
+        store = UpdateStateStore(path=path)
+
+        loaded = store.load()
+
+        assert loaded is not None
+        assert loaded.state == UpdateState.failed
+        assert loaded.phase == UpdatePhase.installing
+        assert loaded.transport == UpdateTransport.usb_internet
+        assert loaded.started_at == 10.5
+        assert loaded.issues == [
+            UpdateIssue(phase="downloading", message="warn", detail="99"),
+        ]
+        assert loaded.log_tail == ["ok", "7", "None"]
+        assert loaded.runtime == UpdateRuntimeDetails(
+            version="9",
+            assets_verified=True,
+            has_packaged_static=True,
+        )
 
     @pytest.mark.parametrize(
         "file_content",

--- a/apps/server/vibesensor/adapters/http/updates.py
+++ b/apps/server/vibesensor/adapters/http/updates.py
@@ -25,6 +25,7 @@ from vibesensor.adapters.http.models import (
     UpdateStatusResponse,
     UsbInternetStatusResponse,
 )
+from vibesensor.use_cases.updates.status import update_status_to_builtins
 
 if TYPE_CHECKING:
     from vibesensor.use_cases.updates.firmware.esp_flash_manager import EspFlashManager
@@ -57,7 +58,7 @@ def create_update_routes(
     @router.get("/api/update/status", response_model=UpdateStatusResponse)
     async def get_update_status() -> UpdateStatusResponse:
         """Return the current OTA software update job state, logs, and runtime details."""
-        return UpdateStatusResponse.model_validate(update_manager.status.to_payload())
+        return UpdateStatusResponse.model_validate(update_status_to_builtins(update_manager.status))
 
     @router.get("/api/update/internet-status", response_model=UsbInternetStatusResponse)
     async def get_usb_internet_status() -> UsbInternetStatusResponse:

--- a/apps/server/vibesensor/use_cases/updates/models.py
+++ b/apps/server/vibesensor/use_cases/updates/models.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 import enum
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TypedDict
 
 from vibesensor.shared.exceptions import ConfigurationError
-from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
-from vibesensor.shared.types.json_types import JsonObject, is_json_array, is_json_object
 
 _SSID_MAX_LEN = 64
 _PASSWORD_MAX_LEN = 128
+UPDATE_STATUS_LOG_TAIL_LIMIT: int = 50
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,9 +58,6 @@ class UpdateExecutionOutcome(enum.StrEnum):
     aborted = "aborted"
     refresh_only = "refresh_only"
     installed = "installed"
-
-
-_LOG_TAIL_LIMIT: int = 50
 
 
 @dataclass(frozen=True, slots=True)
@@ -128,87 +122,6 @@ class UsbInternetStatus:
     diagnostic: str = ""
 
 
-class UpdateIssuePayload(TypedDict):
-    phase: str
-    message: str
-    detail: str
-
-
-class UpdateRuntimeDetailsPayload(TypedDict):
-    version: str
-    commit: str
-    ui_source_hash: str
-    static_assets_hash: str
-    static_build_source_hash: str
-    static_build_commit: str
-    assets_verified: bool
-    has_packaged_static: bool
-
-
-class UpdateJobStatusPayload(TypedDict):
-    state: str
-    phase: str
-    transport: str
-    started_at: float | None
-    finished_at: float | None
-    last_success_at: float | None
-    phase_started_at: float | None
-    phase_elapsed_s: float | None
-    updated_at: float | None
-    ssid: str | None
-    uplink_interface: str | None
-    issues: list[UpdateIssuePayload]
-    log_tail: list[str]
-    exit_code: int | None
-    runtime: UpdateRuntimeDetailsPayload
-
-
-def _require_update_state(value: object) -> UpdateState:
-    """Decode a persisted update state or raise for unsupported values."""
-
-    if not isinstance(value, str):
-        raise ValueError(f"update state must be a string, got {type(value).__name__}")
-    try:
-        return UpdateState(value)
-    except ValueError as exc:
-        raise ValueError(f"Unsupported update state: {value!r}") from exc
-
-
-def _require_update_phase(value: object) -> UpdatePhase:
-    """Decode a persisted update phase or raise for unsupported values."""
-
-    if not isinstance(value, str):
-        raise ValueError(f"update phase must be a string, got {type(value).__name__}")
-    try:
-        return UpdatePhase(value)
-    except ValueError as exc:
-        raise ValueError(f"Unsupported update phase: {value!r}") from exc
-
-
-def _require_update_transport(value: object) -> UpdateTransport:
-    """Decode a persisted transport or raise for unsupported values."""
-
-    if not isinstance(value, str):
-        raise ValueError(f"update transport must be a string, got {type(value).__name__}")
-    try:
-        return UpdateTransport(value)
-    except ValueError as exc:
-        raise ValueError(f"Unsupported update transport: {value!r}") from exc
-
-
-def _coerce_bool(value: object) -> bool:
-    """Decode loosely typed persisted booleans used by status payloads."""
-
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return value != 0
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        return normalized in {"1", "true", "yes", "on"}
-    return False
-
-
 @dataclass(slots=True)
 class UpdateJobStatus:
     """Full status snapshot of the current or most-recent OTA update job."""
@@ -236,76 +149,6 @@ class UpdateJobStatus:
         ):
             raise ValueError("finished_at must be greater than or equal to started_at")
 
-    def to_payload(self) -> UpdateJobStatusPayload:
-        phase_elapsed_s = None
-        if self.state == UpdateState.running and self.phase_started_at is not None:
-            phase_elapsed_s = max(0.0, time.time() - self.phase_started_at)
-        return {
-            "state": self.state.value,
-            "phase": self.phase.value,
-            "transport": self.transport.value,
-            "started_at": self.started_at,
-            "finished_at": self.finished_at,
-            "last_success_at": self.last_success_at,
-            "phase_started_at": self.phase_started_at,
-            "phase_elapsed_s": phase_elapsed_s,
-            "updated_at": self.updated_at,
-            "ssid": self.ssid,
-            "uplink_interface": self.uplink_interface,
-            "issues": [
-                {"phase": i.phase, "message": i.message, "detail": i.detail} for i in self.issues
-            ],
-            "log_tail": self.log_tail[-_LOG_TAIL_LIMIT:],
-            "exit_code": self.exit_code,
-            "runtime": self.runtime.to_payload(),
-        }
-
-    @classmethod
-    def from_payload(cls, data: JsonObject) -> UpdateJobStatus:
-        """Reconstruct from a serialized payload (e.g. loaded from disk)."""
-        issues_raw = data.get("issues")
-        issues = []
-        if is_json_array(issues_raw):
-            for issue_raw in issues_raw:
-                if not is_json_object(issue_raw):
-                    continue
-                issues.append(
-                    UpdateIssue(
-                        phase=str(issue_raw.get("phase", "")),
-                        message=str(issue_raw.get("message", "")),
-                        detail=str(issue_raw.get("detail", "")),
-                    ),
-                )
-        log_tail_raw = data.get("log_tail")
-        log_tail = (
-            [str(line) for line in log_tail_raw[-_LOG_TAIL_LIMIT:]]
-            if is_json_array(log_tail_raw)
-            else []
-        )
-        runtime_raw = data.get("runtime")
-        ssid_raw = data.get("ssid")
-        uplink_interface_raw = data.get("uplink_interface")
-        return cls(
-            state=_require_update_state(data.get("state", UpdateState.idle.value)),
-            phase=_require_update_phase(data.get("phase", UpdatePhase.idle.value)),
-            transport=_require_update_transport(
-                data.get("transport", UpdateTransport.wifi.value),
-            ),
-            started_at=as_float_or_none(data.get("started_at")),
-            finished_at=as_float_or_none(data.get("finished_at")),
-            last_success_at=as_float_or_none(data.get("last_success_at")),
-            phase_started_at=as_float_or_none(data.get("phase_started_at")),
-            updated_at=as_float_or_none(data.get("updated_at")),
-            ssid=ssid_raw if isinstance(ssid_raw, str) else None,
-            uplink_interface=(
-                uplink_interface_raw if isinstance(uplink_interface_raw, str) else None
-            ),
-            issues=issues,
-            log_tail=log_tail,
-            exit_code=as_int_or_none(data.get("exit_code")),
-            runtime=UpdateRuntimeDetails.from_payload(runtime_raw),
-        )
-
 
 @dataclass(frozen=True, slots=True)
 class UpdateRuntimeDetails:
@@ -319,30 +162,3 @@ class UpdateRuntimeDetails:
     static_build_commit: str = ""
     assets_verified: bool = False
     has_packaged_static: bool = False
-
-    def to_payload(self) -> UpdateRuntimeDetailsPayload:
-        return {
-            "version": self.version,
-            "commit": self.commit,
-            "ui_source_hash": self.ui_source_hash,
-            "static_assets_hash": self.static_assets_hash,
-            "static_build_source_hash": self.static_build_source_hash,
-            "static_build_commit": self.static_build_commit,
-            "assets_verified": self.assets_verified,
-            "has_packaged_static": self.has_packaged_static,
-        }
-
-    @classmethod
-    def from_payload(cls, data: object) -> UpdateRuntimeDetails:
-        if not is_json_object(data):
-            return cls()
-        return cls(
-            version=str(data.get("version") or ""),
-            commit=str(data.get("commit") or ""),
-            ui_source_hash=str(data.get("ui_source_hash") or ""),
-            static_assets_hash=str(data.get("static_assets_hash") or ""),
-            static_build_source_hash=str(data.get("static_build_source_hash") or ""),
-            static_build_commit=str(data.get("static_build_commit") or ""),
-            assets_verified=_coerce_bool(data.get("assets_verified")),
-            has_packaged_static=_coerce_bool(data.get("has_packaged_static")),
-        )

--- a/apps/server/vibesensor/use_cases/updates/status/__init__.py
+++ b/apps/server/vibesensor/use_cases/updates/status/__init__.py
@@ -1,5 +1,12 @@
 """Update status boundary: canonical status surface plus persistence helpers."""
 
+from .payload_codec import (
+    update_status_from_builtins,
+    update_status_from_json,
+    update_status_to_builtins,
+    update_status_to_json,
+    update_status_to_payload,
+)
 from .reporter import UpdateTerminalStateReporter
 from .runtime_details import collect_runtime_details, hash_tree
 from .state_machine import UpdatePhaseTransitionError
@@ -15,4 +22,9 @@ __all__ = [
     "build_update_status_tracker",
     "collect_runtime_details",
     "hash_tree",
+    "update_status_from_builtins",
+    "update_status_from_json",
+    "update_status_to_builtins",
+    "update_status_to_json",
+    "update_status_to_payload",
 ]

--- a/apps/server/vibesensor/use_cases/updates/status/payload_codec.py
+++ b/apps/server/vibesensor/use_cases/updates/status/payload_codec.py
@@ -1,0 +1,213 @@
+"""msgspec codecs for updater status persistence and HTTP payloads."""
+
+from __future__ import annotations
+
+import time
+
+import msgspec
+
+from vibesensor.shared.types.json_types import JsonObject, is_json_array, is_json_object
+from vibesensor.use_cases.updates.models import (
+    UPDATE_STATUS_LOG_TAIL_LIMIT,
+    UpdateJobStatus,
+    UpdatePhase,
+    UpdateState,
+    UpdateTransport,
+)
+
+__all__ = [
+    "UpdateIssuePayload",
+    "UpdateJobStatusPayload",
+    "UpdateRuntimeDetailsPayload",
+    "update_status_from_builtins",
+    "update_status_from_json",
+    "update_status_to_builtins",
+    "update_status_to_json",
+    "update_status_to_payload",
+]
+
+
+class UpdateIssuePayload(msgspec.Struct, kw_only=True, frozen=True):
+    """Wire contract for a single updater issue entry."""
+
+    phase: str = ""
+    message: str = ""
+    detail: str = ""
+
+
+class UpdateRuntimeDetailsPayload(msgspec.Struct, kw_only=True, frozen=True):
+    """Wire contract for updater runtime/build verification details."""
+
+    version: str = ""
+    commit: str = ""
+    ui_source_hash: str = ""
+    static_assets_hash: str = ""
+    static_build_source_hash: str = ""
+    static_build_commit: str = ""
+    assets_verified: bool = False
+    has_packaged_static: bool = False
+
+
+class UpdateJobStatusPayload(msgspec.Struct, kw_only=True):
+    """Wire contract for persisted and HTTP-exposed updater status."""
+
+    state: UpdateState = UpdateState.idle
+    phase: UpdatePhase = UpdatePhase.idle
+    transport: UpdateTransport = UpdateTransport.wifi
+    started_at: float | None = None
+    finished_at: float | None = None
+    last_success_at: float | None = None
+    phase_started_at: float | None = None
+    phase_elapsed_s: float | None = None
+    updated_at: float | None = None
+    ssid: str | None = None
+    uplink_interface: str | None = None
+    issues: list[UpdateIssuePayload] = msgspec.field(default_factory=list)
+    log_tail: list[str] = msgspec.field(default_factory=list)
+    exit_code: int | None = None
+    runtime: UpdateRuntimeDetailsPayload = msgspec.field(
+        default_factory=UpdateRuntimeDetailsPayload
+    )
+
+
+def update_status_to_payload(
+    status: UpdateJobStatus,
+    *,
+    now_s: float | None = None,
+) -> UpdateJobStatusPayload:
+    """Convert a domain updater status into the shared msgspec payload struct."""
+
+    payload = msgspec.convert(
+        status,
+        type=UpdateJobStatusPayload,
+        from_attributes=True,
+        strict=False,
+    )
+    payload.log_tail = payload.log_tail[-UPDATE_STATUS_LOG_TAIL_LIMIT:]
+    payload.phase_elapsed_s = _phase_elapsed_s(status, now_s=now_s)
+    return payload
+
+
+def update_status_to_builtins(
+    status: UpdateJobStatus,
+    *,
+    now_s: float | None = None,
+) -> JsonObject:
+    """Convert a domain updater status into JSON-safe builtins for Pydantic/HTTP."""
+
+    builtins = msgspec.to_builtins(update_status_to_payload(status, now_s=now_s))
+    if not is_json_object(builtins):
+        raise TypeError("msgspec updater status payload must encode to a JSON object")
+    return builtins
+
+
+def update_status_to_json(
+    status: UpdateJobStatus,
+    *,
+    now_s: float | None = None,
+) -> bytes:
+    """Encode a domain updater status as persisted JSON bytes."""
+
+    return msgspec.json.encode(update_status_to_payload(status, now_s=now_s)) + b"\n"
+
+
+def update_status_from_builtins(data: object) -> UpdateJobStatus:
+    """Decode a JSON-like updater status object into the domain status model."""
+
+    return _status_from_payload(_convert_status_payload_object(data))
+
+
+def update_status_from_json(raw: bytes | str) -> UpdateJobStatus:
+    """Decode persisted updater status JSON into the domain status model."""
+
+    try:
+        payload = msgspec.json.decode(raw, type=UpdateJobStatusPayload)
+    except msgspec.ValidationError:
+        payload = _convert_status_payload_object(msgspec.json.decode(raw))
+    return _status_from_payload(payload)
+
+
+def _status_from_payload(payload: UpdateJobStatusPayload) -> UpdateJobStatus:
+    payload.log_tail = payload.log_tail[-UPDATE_STATUS_LOG_TAIL_LIMIT:]
+    return msgspec.convert(
+        payload,
+        type=UpdateJobStatus,
+        from_attributes=True,
+        strict=False,
+    )
+
+
+def _convert_status_payload_object(data: object) -> UpdateJobStatusPayload:
+    try:
+        return msgspec.convert(data, type=UpdateJobStatusPayload, strict=False)
+    except msgspec.ValidationError:
+        if not is_json_object(data):
+            raise
+        # Legacy persisted updater status files allowed loose nested values.
+        normalized = dict(data)
+        normalized["issues"] = _normalize_legacy_issues(data.get("issues"))
+        normalized["log_tail"] = _normalize_legacy_log_tail(data.get("log_tail"))
+        normalized["runtime"] = _normalize_legacy_runtime(data.get("runtime"))
+        normalized["ssid"] = data.get("ssid") if isinstance(data.get("ssid"), str) else None
+        normalized["uplink_interface"] = (
+            data.get("uplink_interface") if isinstance(data.get("uplink_interface"), str) else None
+        )
+        return msgspec.convert(normalized, type=UpdateJobStatusPayload, strict=False)
+
+
+def _normalize_legacy_issues(value: object) -> list[JsonObject]:
+    if not is_json_array(value):
+        return []
+    issues: list[JsonObject] = []
+    for issue in value:
+        if not is_json_object(issue):
+            continue
+        issues.append(
+            {
+                "phase": str(issue.get("phase", "")),
+                "message": str(issue.get("message", "")),
+                "detail": str(issue.get("detail", "")),
+            }
+        )
+    return issues
+
+
+def _normalize_legacy_log_tail(value: object) -> list[str]:
+    if not is_json_array(value):
+        return []
+    return [str(line) for line in value[-UPDATE_STATUS_LOG_TAIL_LIMIT:]]
+
+
+def _normalize_legacy_runtime(value: object) -> JsonObject:
+    if not is_json_object(value):
+        return {}
+    return {
+        "version": _legacy_text(value.get("version")),
+        "commit": _legacy_text(value.get("commit")),
+        "ui_source_hash": _legacy_text(value.get("ui_source_hash")),
+        "static_assets_hash": _legacy_text(value.get("static_assets_hash")),
+        "static_build_source_hash": _legacy_text(value.get("static_build_source_hash")),
+        "static_build_commit": _legacy_text(value.get("static_build_commit")),
+        "assets_verified": _coerce_legacy_bool(value.get("assets_verified")),
+        "has_packaged_static": _coerce_legacy_bool(value.get("has_packaged_static")),
+    }
+
+
+def _legacy_text(value: object) -> str:
+    return "" if value is None else str(value)
+
+
+def _coerce_legacy_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _phase_elapsed_s(status: UpdateJobStatus, *, now_s: float | None) -> float | None:
+    if status.state != UpdateState.running or status.phase_started_at is None:
+        return None
+    return max(0.0, (time.time() if now_s is None else now_s) - status.phase_started_at)

--- a/apps/server/vibesensor/use_cases/updates/status/payload_codec.py
+++ b/apps/server/vibesensor/use_cases/updates/status/payload_codec.py
@@ -6,7 +6,12 @@ import time
 
 import msgspec
 
-from vibesensor.shared.types.json_types import JsonObject, is_json_array, is_json_object
+from vibesensor.shared.types.json_types import (
+    JsonArray,
+    JsonObject,
+    is_json_array,
+    is_json_object,
+)
 from vibesensor.use_cases.updates.models import (
     UPDATE_STATUS_LOG_TAIL_LIMIT,
     UpdateJobStatus,
@@ -155,10 +160,10 @@ def _convert_status_payload_object(data: object) -> UpdateJobStatusPayload:
         return msgspec.convert(normalized, type=UpdateJobStatusPayload, strict=False)
 
 
-def _normalize_legacy_issues(value: object) -> list[JsonObject]:
+def _normalize_legacy_issues(value: object) -> JsonArray:
     if not is_json_array(value):
         return []
-    issues: list[JsonObject] = []
+    issues: JsonArray = []
     for issue in value:
         if not is_json_object(issue):
             continue
@@ -172,7 +177,7 @@ def _normalize_legacy_issues(value: object) -> list[JsonObject]:
     return issues
 
 
-def _normalize_legacy_log_tail(value: object) -> list[str]:
+def _normalize_legacy_log_tail(value: object) -> JsonArray:
     if not is_json_array(value):
         return []
     return [str(line) for line in value[-UPDATE_STATUS_LOG_TAIL_LIMIT:]]

--- a/apps/server/vibesensor/use_cases/updates/status/state_store.py
+++ b/apps/server/vibesensor/use_cases/updates/status/state_store.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import contextlib
-import json
 import logging
 import os
 import tempfile
 from pathlib import Path
 
-from vibesensor.shared.types.json_types import is_json_object
+import msgspec
+
 from vibesensor.use_cases.updates.models import UpdateJobStatus
+from vibesensor.use_cases.updates.status.payload_codec import (
+    update_status_from_json,
+    update_status_to_json,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -41,12 +45,8 @@ class UpdateStateStore:
         if not self._path.is_file():
             return None
         try:
-            raw = self._path.read_text(encoding="utf-8")
-            data = json.loads(raw)
-            if not is_json_object(data):
-                raise ValueError("update state payload must be a JSON object")
-            return UpdateJobStatus.from_payload(data)
-        except (json.JSONDecodeError, ValueError, KeyError, TypeError) as exc:
+            return update_status_from_json(self._path.read_bytes())
+        except (msgspec.DecodeError, msgspec.ValidationError, ValueError, TypeError) as exc:
             LOGGER.warning("Corrupt update state file %s: %s", self._path, exc)
             return None
         except OSError as exc:
@@ -55,7 +55,7 @@ class UpdateStateStore:
 
     def save(self, status: UpdateJobStatus) -> None:
         """Persist *status* atomically (temp-file + ``os.replace``)."""
-        payload = json.dumps(status.to_payload(), indent=2, default=str) + "\n"
+        payload = update_status_to_json(status)
         tmp: str | None = None
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
@@ -65,7 +65,7 @@ class UpdateStateStore:
                 suffix=".tmp",
             )
             try:
-                os.write(fd, payload.encode("utf-8"))
+                os.write(fd, payload)
                 os.fsync(fd)
             finally:
                 os.close(fd)

--- a/tools/tests/benchmark_update_status_codec.py
+++ b/tools/tests/benchmark_update_status_codec.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Benchmark the updater status msgspec codec with a representative payload.
+
+Usage::
+
+    python tools/tests/benchmark_update_status_codec.py
+    python tools/tests/benchmark_update_status_codec.py --iterations 5000 --rounds 20
+
+Run this on a Raspberry Pi or similar low-power Linux host before copying the
+pattern to larger payload boundaries. Output reports payload bytes plus encode
+and decode latency in microseconds per operation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+from vibesensor.use_cases.updates.models import (
+    UpdateIssue,
+    UpdateJobStatus,
+    UpdatePhase,
+    UpdateRuntimeDetails,
+    UpdateState,
+    UpdateTransport,
+)
+from vibesensor.use_cases.updates.status import (
+    update_status_from_json,
+    update_status_to_json,
+)
+
+_NOW_S = 1_700_000_120.0
+
+
+def _p95(values: list[float]) -> float:
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, int(len(ordered) * 0.95))
+    return ordered[idx]
+
+
+def _representative_status() -> UpdateJobStatus:
+    return UpdateJobStatus(
+        state=UpdateState.running,
+        phase=UpdatePhase.installing,
+        transport=UpdateTransport.usb_internet,
+        started_at=1_700_000_000.0,
+        last_success_at=1_699_999_500.0,
+        phase_started_at=1_700_000_090.0,
+        updated_at=1_700_000_110.0,
+        uplink_interface="usb0",
+        issues=[
+            UpdateIssue(
+                phase="checking", message="Network slow", detail="retry budget 2"
+            ),
+            UpdateIssue(
+                phase="downloading", message="Wheel cached", detail="cache hit"
+            ),
+            UpdateIssue(phase="installing", message="Service restart pending"),
+        ],
+        log_tail=[f"log line {idx:02d}" for idx in range(32)],
+        runtime=UpdateRuntimeDetails(
+            version="2026.4.19",
+            commit="08915691",
+            ui_source_hash="ui-source-hash",
+            static_assets_hash="static-assets-hash",
+            static_build_source_hash="build-source-hash",
+            static_build_commit="build-commit",
+            assets_verified=True,
+            has_packaged_static=True,
+        ),
+    )
+
+
+def run_benchmark(*, iterations: int, rounds: int) -> dict[str, float | int]:
+    status = _representative_status()
+    encode_us: list[float] = []
+    decode_us: list[float] = []
+    payload_size_bytes = 0
+
+    for _ in range(rounds):
+        started = time.perf_counter()
+        encoded = b""
+        for _iteration in range(iterations):
+            encoded = update_status_to_json(status, now_s=_NOW_S)
+        encode_us.append((time.perf_counter() - started) * 1_000_000 / iterations)
+        payload_size_bytes = len(encoded)
+
+        started = time.perf_counter()
+        decoded = status
+        for _iteration in range(iterations):
+            decoded = update_status_from_json(encoded)
+        decode_us.append((time.perf_counter() - started) * 1_000_000 / iterations)
+
+        assert decoded.phase == status.phase
+        assert decoded.transport == status.transport
+        assert decoded.runtime == status.runtime
+
+    return {
+        "payload_size_bytes": payload_size_bytes,
+        "encode_median_us": round(statistics.median(encode_us), 2),
+        "encode_p95_us": round(_p95(encode_us), 2),
+        "decode_median_us": round(statistics.median(decode_us), 2),
+        "decode_p95_us": round(_p95(decode_us), 2),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark updater status msgspec codec"
+    )
+    parser.add_argument(
+        "--iterations", type=int, default=5000, help="Ops per timing round"
+    )
+    parser.add_argument(
+        "--rounds", type=int, default=20, help="Number of timing rounds"
+    )
+    args = parser.parse_args()
+
+    results = run_benchmark(iterations=args.iterations, rounds=args.rounds)
+    print(f"payload_size_bytes={results['payload_size_bytes']}")
+    print(
+        "encode_us_per_op median={encode_median_us:.2f} p95={encode_p95_us:.2f}".format(
+            **results
+        )
+    )
+    print(
+        "decode_us_per_op median={decode_median_us:.2f} p95={decode_p95_us:.2f}".format(
+            **results
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed
- replace updater status TypedDict/to_payload/from_payload plumbing with one msgspec Struct codec
- route persisted update-status JSON and `/api/update/status` through the same boundary
- keep FastAPI/Pydantic response models, but feed them validated builtins from msgspec
- keep old persisted status files loading through one narrow legacy-normalization fallback
- add focused updater tests, a repeatable benchmark script, and a backend README pattern note

## Why
- one boundary, one codec
- less duplicate payload code in models, state-store, and HTTP route layer
- better path for future backend payload migrations without touching hot numeric arrays

## Validation
- `py_compile` on changed backend/test files
- `ruff check` and `ruff format --check` on changed files
- representative standalone msgspec timing note for a 1229-byte updater payload:
  - encode median 4.50 us/op, p95 7.35 us/op
  - decode median 4.96 us/op, p95 6.50 us/op
- full runtime pytest + mypy on the real backend package could not run locally because this host only has Python 3.11 and the Docker daemon is unavailable; CI owns the 3.13/runtime gate for this PR

## Risks / tradeoffs
- legacy compatibility still keeps a small normalization shim for older persisted status files
- benchmark script is the repeatable Pi/Pi-like check before copying this pattern to other backend boundaries

Closes #2871