### PR TITLE
Implement Valibot schemas for WS payload validation

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -320,10 +320,10 @@ instead of controller-side variant class interpolation.
 - `src/contracts/ws_payload_schema.json` defines the JSON Schema for live WS payloads.
 - `src/contracts/ws_payload_types.ts` is generated from that schema by the
   [contract sync flow](#contract-sync).
-- `src/ws_payload_validator.ts` compiles AJV against `ws_payload_schema.json` and validates raw live payloads at runtime.
+- `src/ws_payload_validator.ts` validates raw live payloads with Valibot schemas, while the large spectrum-number arrays stay on a custom finite-number-array guard so the live chart path avoids per-element schema object churn.
 - `src/server_payload.ts` then adapts the validated `LiveWsPayload` with schema-version warnings, shared-`freq` fallback, and malformed/misaligned spectrum rejection.
 
-AJV-backed runtime validation now sits at the WebSocket boundary. Live payloads must satisfy that JSON Schema directly before the app-state adapter accepts them. The remaining UI-side handling is limited to current, explicit adapter behavior: schema-version warning logging, shared-`freq` fallback when the canonical shared axis is used, and dropping spectrum series that still cannot produce aligned bins for rendering.
+Valibot-backed runtime validation now sits at the WebSocket boundary. Live payloads must satisfy the generated contract shape directly before the app-state adapter accepts them. The remaining UI-side handling is limited to current, explicit adapter behavior: schema-version warning logging, shared-`freq` fallback when the canonical shared axis is used, and dropping spectrum series that still cannot produce aligned bins for rendering.
 
 Top-level `LiveWsPayload` fields:
 

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@preact/signals": "^2.9.0",
         "preact": "^10.29.1",
-        "uplot": "^1.6.31"
+        "uplot": "^1.6.31",
+        "valibot": "^1.3.1"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
@@ -3177,6 +3178,20 @@
       "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/valibot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vite": {
       "version": "8.0.8",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "@preact/signals": "^2.9.0",
     "preact": "^10.29.1",
-    "uplot": "^1.6.31"
+    "uplot": "^1.6.31",
+    "valibot": "^1.3.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/apps/ui/src/ws_payload_validator.ts
+++ b/apps/ui/src/ws_payload_validator.ts
@@ -1,3 +1,5 @@
+import * as v from "valibot";
+
 import type {
   LiveWsPayload,
   StrengthMetricPeak,
@@ -9,405 +11,154 @@ import type {
   WsSpectrumSeries,
 } from "./contracts/ws_payload_types";
 
-type JsonRecord = Record<string, unknown>;
-
 function invalidPayload(path: string, message: string): never {
   throw new Error(`Invalid websocket payload: ${path} ${message}`);
 }
 
-function requireRecord(value: unknown, path: string): JsonRecord {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    invalidPayload(path, "must be an object");
+function isFiniteNumberArray(input: unknown): input is number[] {
+  if (!Array.isArray(input)) {
+    return false;
   }
-  return value as JsonRecord;
-}
-
-function requireProperty(
-  record: JsonRecord,
-  key: string,
-  path: string,
-): unknown {
-  if (!(key in record)) {
-    invalidPayload(path, "is required");
-  }
-  return record[key];
-}
-
-function requireString(value: unknown, path: string): string {
-  if (typeof value !== "string") {
-    invalidPayload(path, "must be a string");
-  }
-  return value;
-}
-
-function requireBoolean(value: unknown, path: string): boolean {
-  if (typeof value !== "boolean") {
-    invalidPayload(path, "must be a boolean");
-  }
-  return value;
-}
-
-function requireFiniteNumber(value: unknown, path: string): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    invalidPayload(path, "must be a finite number");
-  }
-  return value;
-}
-
-function requireInteger(value: unknown, path: string): number {
-  const numberValue = requireFiniteNumber(value, path);
-  if (!Number.isInteger(numberValue)) {
-    invalidPayload(path, "must be an integer");
-  }
-  return numberValue;
-}
-
-function requireNullableString(value: unknown, path: string): string | null {
-  if (value === null) {
-    return null;
-  }
-  return requireString(value, path);
-}
-
-function requireNullableNumber(value: unknown, path: string): number | null {
-  if (value === null) {
-    return null;
-  }
-  return requireFiniteNumber(value, path);
-}
-
-function requireNullableInteger(value: unknown, path: string): number | null {
-  if (value === null) {
-    return null;
-  }
-  return requireInteger(value, path);
-}
-
-function requireArray(value: unknown, path: string): unknown[] {
-  if (!Array.isArray(value)) {
-    invalidPayload(path, "must be an array");
-  }
-  return value;
-}
-
-function validateNumberArray(value: unknown, path: string): number[] {
-  const array = requireArray(value, path);
-  for (let index = 0; index < array.length; index += 1) {
-    requireFiniteNumber(array[index], `${path}/${index}`);
-  }
-  return array as number[];
-}
-
-function validateStringArray(value: unknown, path: string): string[] {
-  const array = requireArray(value, path);
-  for (let index = 0; index < array.length; index += 1) {
-    requireString(array[index], `${path}/${index}`);
-  }
-  return array as string[];
-}
-
-function validateStrengthPeak(
-  value: unknown,
-  path: string,
-): StrengthMetricPeak {
-  const record = requireRecord(value, path);
-  requireFiniteNumber(
-    requireProperty(record, "hz", `${path}/hz`),
-    `${path}/hz`,
-  );
-  requireFiniteNumber(
-    requireProperty(record, "amp", `${path}/amp`),
-    `${path}/amp`,
-  );
-  requireFiniteNumber(
-    requireProperty(
-      record,
-      "vibration_strength_db",
-      `${path}/vibration_strength_db`,
-    ),
-    `${path}/vibration_strength_db`,
-  );
-  requireNullableString(
-    requireProperty(record, "strength_bucket", `${path}/strength_bucket`),
-    `${path}/strength_bucket`,
-  );
-  return value as StrengthMetricPeak;
-}
-
-function validateStrengthMetrics(
-  value: unknown,
-  path: string,
-): StrengthMetricsPayload {
-  const record = requireRecord(value, path);
-  requireFiniteNumber(
-    requireProperty(
-      record,
-      "vibration_strength_db",
-      `${path}/vibration_strength_db`,
-    ),
-    `${path}/vibration_strength_db`,
-  );
-  requireFiniteNumber(
-    requireProperty(record, "peak_amp_g", `${path}/peak_amp_g`),
-    `${path}/peak_amp_g`,
-  );
-  requireFiniteNumber(
-    requireProperty(record, "noise_floor_amp_g", `${path}/noise_floor_amp_g`),
-    `${path}/noise_floor_amp_g`,
-  );
-  requireNullableString(
-    requireProperty(record, "strength_bucket", `${path}/strength_bucket`),
-    `${path}/strength_bucket`,
-  );
-  const topPeaks = requireArray(
-    requireProperty(record, "top_peaks", `${path}/top_peaks`),
-    `${path}/top_peaks`,
-  );
-  for (let index = 0; index < topPeaks.length; index += 1) {
-    validateStrengthPeak(topPeaks[index], `${path}/top_peaks/${index}`);
-  }
-  return value as StrengthMetricsPayload;
-}
-
-function validateWsClient(value: unknown, path: string): WsClientInfo {
-  const record = requireRecord(value, path);
-  requireString(requireProperty(record, "id", `${path}/id`), `${path}/id`);
-  requireString(
-    requireProperty(record, "mac_address", `${path}/mac_address`),
-    `${path}/mac_address`,
-  );
-  requireString(
-    requireProperty(record, "name", `${path}/name`),
-    `${path}/name`,
-  );
-  requireBoolean(
-    requireProperty(record, "connected", `${path}/connected`),
-    `${path}/connected`,
-  );
-  requireString(
-    requireProperty(record, "location_code", `${path}/location_code`),
-    `${path}/location_code`,
-  );
-  requireString(
-    requireProperty(record, "firmware_version", `${path}/firmware_version`),
-    `${path}/firmware_version`,
-  );
-  requireInteger(
-    requireProperty(record, "sample_rate_hz", `${path}/sample_rate_hz`),
-    `${path}/sample_rate_hz`,
-  );
-  requireNullableInteger(
-    requireProperty(record, "last_seen_age_ms", `${path}/last_seen_age_ms`),
-    `${path}/last_seen_age_ms`,
-  );
-  requireInteger(
-    requireProperty(record, "frames_total", `${path}/frames_total`),
-    `${path}/frames_total`,
-  );
-  requireInteger(
-    requireProperty(record, "dropped_frames", `${path}/dropped_frames`),
-    `${path}/dropped_frames`,
-  );
-  return value as WsClientInfo;
-}
-
-function validateRotationalSpeedValue(
-  value: unknown,
-  path: string,
-): WsRotationalSpeedValue {
-  const record = requireRecord(value, path);
-  requireNullableNumber(
-    requireProperty(record, "rpm", `${path}/rpm`),
-    `${path}/rpm`,
-  );
-  requireNullableString(
-    requireProperty(record, "mode", `${path}/mode`),
-    `${path}/mode`,
-  );
-  requireNullableString(
-    requireProperty(record, "reason", `${path}/reason`),
-    `${path}/reason`,
-  );
-  return value as WsRotationalSpeedValue;
-}
-
-function validateOrderBand(value: unknown, path: string): void {
-  const record = requireRecord(value, path);
-  requireString(requireProperty(record, "key", `${path}/key`), `${path}/key`);
-  requireFiniteNumber(
-    requireProperty(record, "center_hz", `${path}/center_hz`),
-    `${path}/center_hz`,
-  );
-  requireFiniteNumber(
-    requireProperty(record, "tolerance", `${path}/tolerance`),
-    `${path}/tolerance`,
-  );
-}
-
-function validateRotationalSpeeds(
-  value: unknown,
-  path: string,
-): WsRotationalSpeeds {
-  const record = requireRecord(value, path);
-  requireNullableString(
-    requireProperty(record, "basis_speed_source", `${path}/basis_speed_source`),
-    `${path}/basis_speed_source`,
-  );
-  validateRotationalSpeedValue(
-    requireProperty(record, "wheel", `${path}/wheel`),
-    `${path}/wheel`,
-  );
-  validateRotationalSpeedValue(
-    requireProperty(record, "driveshaft", `${path}/driveshaft`),
-    `${path}/driveshaft`,
-  );
-  validateRotationalSpeedValue(
-    requireProperty(record, "engine", `${path}/engine`),
-    `${path}/engine`,
-  );
-  const orderBands = requireProperty(
-    record,
-    "order_bands",
-    `${path}/order_bands`,
-  );
-  if (orderBands !== null) {
-    const bands = requireArray(orderBands, `${path}/order_bands`);
-    for (let index = 0; index < bands.length; index += 1) {
-      validateOrderBand(bands[index], `${path}/order_bands/${index}`);
+  for (let index = 0; index < input.length; index += 1) {
+    const value = input[index];
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      return false;
     }
   }
-  return value as WsRotationalSpeeds;
+  return true;
 }
 
-function validateSpectrumSeries(
-  value: unknown,
-  path: string,
-): WsSpectrumSeries {
-  const record = requireRecord(value, path);
-  if ("freq" in record && record.freq !== undefined) {
-    validateNumberArray(record.freq, `${path}/freq`);
-  }
-  if (
-    "combined_spectrum_amp_g" in record &&
-    record.combined_spectrum_amp_g !== undefined
-  ) {
-    validateNumberArray(
-      record.combined_spectrum_amp_g,
-      `${path}/combined_spectrum_amp_g`,
-    );
-  }
-  if ("strength_metrics" in record && record.strength_metrics !== undefined) {
-    validateStrengthMetrics(
-      record.strength_metrics,
-      `${path}/strength_metrics`,
-    );
-  }
-  return value as WsSpectrumSeries;
-}
+const finiteNumberArraySchema = v.custom<number[]>(
+  isFiniteNumberArray,
+  "must be an array of finite numbers",
+);
 
-function validateSpectra(value: unknown, path: string): WsSpectraPayload {
-  const record = requireRecord(value, path);
-  if ("freq" in record && record.freq !== undefined) {
-    validateNumberArray(record.freq, `${path}/freq`);
+const finiteNumberSchema = v.pipe(v.number(), v.finite());
+const integerSchema = v.pipe(finiteNumberSchema, v.integer());
+const nullableStringSchema = v.nullable(v.string());
+const nullableNumberSchema = v.nullable(finiteNumberSchema);
+const nullableIntegerSchema = v.nullable(integerSchema);
+
+const strengthPeakSchema = v.looseObject({
+  hz: finiteNumberSchema,
+  amp: finiteNumberSchema,
+  vibration_strength_db: finiteNumberSchema,
+  strength_bucket: nullableStringSchema,
+});
+
+const strengthMetricsSchema = v.looseObject({
+  vibration_strength_db: finiteNumberSchema,
+  peak_amp_g: finiteNumberSchema,
+  noise_floor_amp_g: finiteNumberSchema,
+  strength_bucket: nullableStringSchema,
+  top_peaks: v.array(strengthPeakSchema),
+});
+
+const wsClientSchema = v.looseObject({
+  id: v.string(),
+  mac_address: v.string(),
+  name: v.string(),
+  connected: v.boolean(),
+  location_code: v.string(),
+  firmware_version: v.string(),
+  sample_rate_hz: integerSchema,
+  last_seen_age_ms: nullableIntegerSchema,
+  frames_total: integerSchema,
+  dropped_frames: integerSchema,
+});
+
+const rotationalSpeedValueSchema = v.looseObject({
+  rpm: nullableNumberSchema,
+  mode: nullableStringSchema,
+  reason: nullableStringSchema,
+});
+
+const orderBandSchema = v.looseObject({
+  key: v.string(),
+  center_hz: finiteNumberSchema,
+  tolerance: finiteNumberSchema,
+});
+
+const rotationalSpeedsSchema = v.looseObject({
+  basis_speed_source: nullableStringSchema,
+  wheel: rotationalSpeedValueSchema,
+  driveshaft: rotationalSpeedValueSchema,
+  engine: rotationalSpeedValueSchema,
+  order_bands: v.nullable(v.array(orderBandSchema)),
+});
+
+const spectrumSeriesSchema = v.looseObject({
+  freq: v.optional(finiteNumberArraySchema),
+  combined_spectrum_amp_g: v.optional(finiteNumberArraySchema),
+  strength_metrics: v.optional(strengthMetricsSchema),
+});
+
+const warningSchema = v.looseObject({
+  code: v.string(),
+  message: v.string(),
+  client_ids: v.array(v.string()),
+});
+
+const alignmentSchema = v.looseObject({
+  aligned: v.boolean(),
+  clock_synced: v.boolean(),
+  overlap_ratio: finiteNumberSchema,
+  sensor_count: integerSchema,
+  shared_window_s: finiteNumberSchema,
+});
+
+const spectraSchema = v.looseObject({
+  freq: v.optional(finiteNumberArraySchema),
+  clients: v.optional(v.record(v.string(), spectrumSeriesSchema)),
+  warning: v.optional(warningSchema),
+  alignment: v.optional(alignmentSchema),
+});
+
+const liveWsPayloadSchema = v.looseObject({
+  schema_version: v.string(),
+  server_time: v.string(),
+  speed_mps: nullableNumberSchema,
+  clients: v.array(wsClientSchema),
+  selected_client_id: nullableStringSchema,
+  rotational_speeds: v.nullable(rotationalSpeedsSchema),
+  spectra: v.optional(spectraSchema),
+});
+
+type IssuePathItem = { key?: unknown };
+
+function formatIssuePath(path: ReadonlyArray<IssuePathItem> | undefined): string {
+  if (!path || path.length === 0) {
+    return "/";
   }
-  if ("clients" in record && record.clients !== undefined) {
-    const clients = requireRecord(record.clients, `${path}/clients`);
-    for (const [clientId, series] of Object.entries(clients)) {
-      validateSpectrumSeries(series, `${path}/clients/${clientId}`);
+
+  const segments: string[] = [];
+  for (const item of path) {
+    if (item.key === undefined) {
+      continue;
     }
+    segments.push(String(item.key));
   }
-  if ("warning" in record && record.warning !== undefined) {
-    const warning = requireRecord(record.warning, `${path}/warning`);
-    requireString(
-      requireProperty(warning, "code", `${path}/warning/code`),
-      `${path}/warning/code`,
-    );
-    requireString(
-      requireProperty(warning, "message", `${path}/warning/message`),
-      `${path}/warning/message`,
-    );
-    validateStringArray(
-      requireProperty(warning, "client_ids", `${path}/warning/client_ids`),
-      `${path}/warning/client_ids`,
-    );
+  return segments.length > 0 ? `/${segments.join("/")}` : "/";
+}
+
+function assertValidLiveWsPayload(payload: unknown): asserts payload is LiveWsPayload {
+  const result = v.safeParse(liveWsPayloadSchema, payload);
+  if (!result.success) {
+    const issue = result.issues[0];
+    invalidPayload(formatIssuePath(issue?.path), issue?.message ?? "is invalid");
   }
-  if ("alignment" in record && record.alignment !== undefined) {
-    const alignment = requireRecord(record.alignment, `${path}/alignment`);
-    requireBoolean(
-      requireProperty(alignment, "aligned", `${path}/alignment/aligned`),
-      `${path}/alignment/aligned`,
-    );
-    requireBoolean(
-      requireProperty(
-        alignment,
-        "clock_synced",
-        `${path}/alignment/clock_synced`,
-      ),
-      `${path}/alignment/clock_synced`,
-    );
-    requireFiniteNumber(
-      requireProperty(
-        alignment,
-        "overlap_ratio",
-        `${path}/alignment/overlap_ratio`,
-      ),
-      `${path}/alignment/overlap_ratio`,
-    );
-    requireInteger(
-      requireProperty(
-        alignment,
-        "sensor_count",
-        `${path}/alignment/sensor_count`,
-      ),
-      `${path}/alignment/sensor_count`,
-    );
-    requireFiniteNumber(
-      requireProperty(
-        alignment,
-        "shared_window_s",
-        `${path}/alignment/shared_window_s`,
-      ),
-      `${path}/alignment/shared_window_s`,
-    );
-  }
-  return value as WsSpectraPayload;
 }
 
 export function validateLiveWsPayload(payload: unknown): LiveWsPayload {
-  const record = requireRecord(payload, "/");
-  requireString(
-    requireProperty(record, "schema_version", "/schema_version"),
-    "/schema_version",
-  );
-  requireString(
-    requireProperty(record, "server_time", "/server_time"),
-    "/server_time",
-  );
-  requireNullableNumber(
-    requireProperty(record, "speed_mps", "/speed_mps"),
-    "/speed_mps",
-  );
-  const clients = requireArray(
-    requireProperty(record, "clients", "/clients"),
-    "/clients",
-  );
-  for (let index = 0; index < clients.length; index += 1) {
-    validateWsClient(clients[index], `/clients/${index}`);
-  }
-  requireNullableString(
-    requireProperty(record, "selected_client_id", "/selected_client_id"),
-    "/selected_client_id",
-  );
-  const rotationalSpeeds = requireProperty(
-    record,
-    "rotational_speeds",
-    "/rotational_speeds",
-  );
-  if (rotationalSpeeds !== null) {
-    validateRotationalSpeeds(rotationalSpeeds, "/rotational_speeds");
-  }
-  if ("spectra" in record && record.spectra !== undefined) {
-    validateSpectra(record.spectra, "/spectra");
-  }
-  return payload as LiveWsPayload;
+  assertValidLiveWsPayload(payload);
+  return payload;
 }
+
+void (strengthPeakSchema satisfies v.GenericSchema<StrengthMetricPeak>);
+void (strengthMetricsSchema satisfies v.GenericSchema<StrengthMetricsPayload>);
+void (wsClientSchema satisfies v.GenericSchema<WsClientInfo>);
+void (rotationalSpeedValueSchema satisfies v.GenericSchema<WsRotationalSpeedValue>);
+void (rotationalSpeedsSchema satisfies v.GenericSchema<WsRotationalSpeeds>);
+void (spectrumSeriesSchema satisfies v.GenericSchema<WsSpectrumSeries>);
+void (spectraSchema satisfies v.GenericSchema<WsSpectraPayload>);
+void (liveWsPayloadSchema satisfies v.GenericSchema<LiveWsPayload>);

--- a/apps/ui/tests/ws_payload_validator.spec.ts
+++ b/apps/ui/tests/ws_payload_validator.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "@playwright/test";
+
+import { validateLiveWsPayload } from "../src/ws_payload_validator";
+
+const basePayload = {
+  schema_version: "1",
+  server_time: "2026-01-01T00:00:00Z",
+  clients: [
+    {
+      id: "sensor-1",
+      mac_address: "aa:bb:cc:dd:ee:ff",
+      name: "Front Left",
+      connected: true,
+      location_code: "front_left",
+      firmware_version: "1.2.3",
+      sample_rate_hz: 800,
+      last_seen_age_ms: 0,
+      frames_total: 10,
+      dropped_frames: 0,
+    },
+  ],
+  selected_client_id: null,
+  rotational_speeds: null,
+  speed_mps: 12.5,
+} as const;
+
+function makeStrengthMetrics() {
+  return {
+    vibration_strength_db: 12,
+    peak_amp_g: 0.12,
+    noise_floor_amp_g: 0.01,
+    strength_bucket: null,
+    top_peaks: [
+      {
+        hz: 120,
+        amp: 0.04,
+        vibration_strength_db: 12,
+        strength_bucket: null,
+      },
+    ],
+  };
+}
+
+test.describe("validateLiveWsPayload", () => {
+  test("accepts a schema-valid payload", () => {
+    expect(
+      validateLiveWsPayload({
+        ...basePayload,
+        spectra: {
+          freq: [10, 20, 30],
+          clients: {
+            "sensor-1": {
+              combined_spectrum_amp_g: [0.1, 0.2, 0.3],
+              strength_metrics: makeStrengthMetrics(),
+            },
+          },
+        },
+      }),
+    ).toMatchObject({
+      schema_version: "1",
+      clients: [{ id: "sensor-1" }],
+    });
+  });
+
+  test("reports the failing client-row path", () => {
+    expect(() =>
+      validateLiveWsPayload({
+        ...basePayload,
+        clients: [
+          {
+            ...basePayload.clients[0],
+            frames_total: "10",
+          },
+        ],
+      }),
+    ).toThrow(/Invalid websocket payload: \/clients\/0\/frames_total/);
+  });
+
+  test("reports malformed shared spectrum arrays", () => {
+    expect(() =>
+      validateLiveWsPayload({
+        ...basePayload,
+        spectra: {
+          freq: [10, "bad", 30],
+        },
+      }),
+    ).toThrow(/Invalid websocket payload: \/spectra\/freq/);
+  });
+
+  test("reports malformed strength peak fields through Valibot", () => {
+    expect(() =>
+      validateLiveWsPayload({
+        ...basePayload,
+        spectra: {
+          clients: {
+            "sensor-1": {
+              combined_spectrum_amp_g: [0.1, 0.2, 0.3],
+              strength_metrics: {
+                ...makeStrengthMetrics(),
+                top_peaks: [
+                  {
+                    hz: 120,
+                    amp: "bad",
+                    vibration_strength_db: 12,
+                    strength_bucket: null,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow(/Invalid websocket payload: \/spectra\/clients\/sensor-1\/strength_metrics\/top_peaks\/0\/amp/);
+  });
+
+  test("reports malformed rotational-speed metadata", () => {
+    expect(() =>
+      validateLiveWsPayload({
+        ...basePayload,
+        rotational_speeds: {
+          basis_speed_source: null,
+          wheel: { rpm: 10, mode: null, reason: null },
+          driveshaft: { rpm: 20, mode: null, reason: null },
+          engine: { rpm: 30, mode: null, reason: null },
+          order_bands: [
+            {
+              key: "1x",
+              center_hz: 40,
+              tolerance: "wide",
+            },
+          ],
+        },
+      }),
+    ).toThrow(/Invalid websocket payload: \/rotational_speeds\/order_bands\/0\/tolerance/);
+  });
+});


### PR DESCRIPTION
## What changed
Size: medium

- replace the hand-written WS payload checks with Valibot schemas in `ws_payload_validator.ts`
- keep `freq` and `combined_spectrum_amp_g` on custom finite-number-array guards
- return the validated input object so accepted payloads keep zero-copy client, rotational-speed, and spectra references
- add a focused validator spec and update the UI README boundary note
- add `valibot@^1.3.1` as a bounded UI runtime dependency

## Why
- issue wants declarative runtime validation at the WebSocket boundary
- live chart path still needs cheap large-array validation and the old hot-path reference reuse

## Validation
- `cd apps/ui && npx biome lint src/ws_payload_validator.ts tests/ws_payload_validator.spec.ts`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=tests ws_payload_validator.spec.ts ws_contract.spec.ts --workers=1`
- `cd apps/ui && npm run analyze`

## Risks / tradeoffs
- Valibot object parsing clones nested objects by default; the validator returns the validated input after a successful parse so accepted payloads keep the old reference-reuse behavior
- large numeric arrays stay on custom guards instead of full per-item Valibot array schemas to keep the hot path flat

## Bundle / timing
- benchmark on a 4-client / 2048-bin payload: avg 0.033 ms, p50 0.030 ms, p95 0.040 ms, p99 0.067 ms per `validateLiveWsPayload`
- bundle vs `main`: `vendor` unchanged, `chart` unchanged, `index` +2791 raw bytes / +971 gzip bytes

Closes #2872