### PR TITLE
Implement tenacity for backend update and network retry policies

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -362,6 +362,13 @@ Production devices use the wheel-based updater in `apps/server/vibesensor/use_ca
 
 `firmware_cache.py` is now the thin public cache/CLI surface, while `firmware_release_fetcher.py` owns GitHub firmware HTTP access, `firmware_bundle.py` owns bundle extraction/validation/metadata helpers, and `firmware_types.py` owns the updater-local cache/release contracts.
 
+- The Wi-Fi uplink connect path in `wifi_uplink_setup.py` now uses
+  `tenacity` for the specific retryable "SSID not found yet" scan-lag case.
+  Nearby updater loops with different semantics stay custom for now:
+  `wifi_hotspot_recovery.py` retries every restore failure uniformly, and
+  `transport/uplink_readiness.py` owns a minimum-wait DNS readiness window
+  rather than a simple attempt-count policy.
+
 - Normal delivery should go through release wheels.
 - Do not rely on manual edits inside deployed `site-packages` as a normal workflow.
 - Emergency in-place patching is allowed only to restore a broken live updater and must be followed by the matching in-repo fix, validation, and a successful updater run.

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "fastapi>=0.111,<1",
   "msgspec>=0.19,<1",
   "pydantic-settings>=2.10,<3",
+  "tenacity>=9.1,<10",
   "uvicorn[standard]>=0.30,<1",
   "numpy>=2.4.4,<3",
   "orjson>=3.11.4,<4",

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_uplink_setup.py
@@ -86,3 +86,56 @@ async def test_bring_uplink_up_retries_ssid_not_found_then_succeeds(
     assert connect_calls["count"] == 2
     assert sleep.await_count == 1
     assert any("dev wifi list ifname wlan0" in " ".join(call[0]) for call in runner.calls)
+
+
+@pytest.mark.asyncio
+async def test_bring_uplink_up_fails_immediately_for_non_retryable_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    provisioner, runner = _build_uplink_provisioner(tmp_path)
+    runner.set_response(
+        "connection up VibeSensor-Uplink",
+        10,
+        "",
+        "Error: Connection activation failed",
+    )
+    sleep = AsyncMock(return_value=None)
+    monkeypatch.setattr("vibesensor.use_cases.updates.wifi.wifi_uplink_setup.asyncio.sleep", sleep)
+
+    with pytest.raises(
+        UpdateTransportStepError,
+        match="Failed to connect to Wi-Fi 'TestNet'",
+    ) as exc_info:
+        await provisioner.bring_uplink_up("TestNet")
+
+    assert exc_info.value.detail == "Error: Connection activation failed"
+    assert sleep.await_count == 0
+    assert not any("dev wifi list ifname wlan0" in " ".join(call[0]) for call in runner.calls)
+
+
+@pytest.mark.asyncio
+async def test_bring_uplink_up_exhausts_retryable_ssid_not_found_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    provisioner, runner = _build_uplink_provisioner(tmp_path)
+    runner.set_response(
+        "connection up VibeSensor-Uplink",
+        10,
+        "",
+        "Error: No network with SSID 'TestNet' found.\n",
+    )
+    sleep = AsyncMock(return_value=None)
+    monkeypatch.setattr("vibesensor.use_cases.updates.wifi.wifi_uplink_setup.asyncio.sleep", sleep)
+
+    with pytest.raises(
+        UpdateTransportStepError,
+        match="Failed to connect to Wi-Fi 'TestNet'",
+    ) as exc_info:
+        await provisioner.bring_uplink_up("TestNet")
+
+    assert exc_info.value.detail == "Error: No network with SSID 'TestNet' found.\n"
+    assert sleep.await_count == 2
+    assert sum("connection up VibeSensor-Uplink" in " ".join(call[0]) for call in runner.calls) == 3
+    assert sum("dev wifi list ifname wlan0" in " ".join(call[0]) for call in runner.calls) == 2

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import re
 
+from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_attempt, wait_fixed
+
 from vibesensor.use_cases.updates.models import UpdatePhase
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
@@ -10,6 +12,23 @@ from vibesensor.use_cases.updates.transport.failures import UpdateTransportStepE
 from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 
 _UNESCAPED_COLON_RE = re.compile(r"(?<!\\):")
+_UPLINK_RESCAN_DELAY_S = 2.0
+
+
+class _RetryableSsidNotFoundError(Exception):
+    __slots__ = ("detail",)
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+class _NonRetryableUplinkConnectError(Exception):
+    __slots__ = ("detail",)
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
 
 
 def ssid_security_modes(scan_output: str, ssid: str) -> set[str]:
@@ -65,51 +84,71 @@ class UpdateUplinkProvisioner:
     async def bring_uplink_up(self, ssid: str) -> None:
         """Bring the prepared uplink connection up, retrying on scan lag."""
 
-        connect_result = None
-        for attempt in range(1, self._config.uplink_connect_retries + 1):
-            connect_result = await self._commands.run(
-                [
-                    "nmcli",
-                    "--wait",
-                    str(self._config.uplink_connect_wait_s),
-                    "connection",
-                    "up",
-                    self._config.uplink_connection_name,
-                ],
-                phase="connecting_wifi",
-                timeout=float(self._config.uplink_connect_wait_s + 10),
-                sudo=True,
-            )
-            if connect_result.returncode == 0:
-                return
-            if "No network with SSID" not in (connect_result.stderr or ""):
-                break
-            self._status.log(
-                f"SSID '{ssid}' not found on connect attempt {attempt}; rescanning and retrying",
-            )
-            await self._commands.run(
-                [
-                    "nmcli",
-                    "-t",
-                    "-f",
-                    "SSID,SIGNAL,CHAN,FREQ",
-                    "dev",
-                    "wifi",
-                    "list",
-                    "ifname",
-                    self._config.wifi_ifname,
-                    "--rescan",
-                    "yes",
-                ],
-                phase="connecting_wifi",
-                timeout=self._config.nmcli_timeout_s,
-                sudo=True,
-            )
-            await asyncio.sleep(2.0)
+        detail = ""
+        try:
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(self._config.uplink_connect_retries),
+                wait=wait_fixed(_UPLINK_RESCAN_DELAY_S),
+                retry=retry_if_exception_type(_RetryableSsidNotFoundError),
+                sleep=asyncio.sleep,
+                reraise=True,
+            ):
+                with attempt:
+                    connect_result = await self._commands.run(
+                        [
+                            "nmcli",
+                            "--wait",
+                            str(self._config.uplink_connect_wait_s),
+                            "connection",
+                            "up",
+                            self._config.uplink_connection_name,
+                        ],
+                        phase="connecting_wifi",
+                        timeout=float(self._config.uplink_connect_wait_s + 10),
+                        sudo=True,
+                    )
+                    if connect_result.returncode == 0:
+                        return
+                    detail = connect_result.stderr or ""
+                    attempt_number = attempt.retry_state.attempt_number
+                    if "No network with SSID" not in detail:
+                        raise _NonRetryableUplinkConnectError(detail)
+                    if attempt_number < self._config.uplink_connect_retries:
+                        self._status.log(
+                            "SSID "
+                            f"'{ssid}' not found on connect attempt {attempt_number}; "
+                            "rescanning and retrying",
+                        )
+                        await self._rescan_wifi_networks()
+                    raise _RetryableSsidNotFoundError(detail)
+        except _RetryableSsidNotFoundError as exc:
+            detail = exc.detail
+        except _NonRetryableUplinkConnectError as exc:
+            detail = exc.detail
         raise UpdateTransportStepError(
             phase=UpdatePhase.connecting_wifi,
             message=f"Failed to connect to Wi-Fi '{ssid}'",
-            detail="" if connect_result is None else connect_result.stderr,
+            detail=detail,
+        )
+
+    async def _rescan_wifi_networks(self) -> None:
+        await self._commands.run(
+            [
+                "nmcli",
+                "-t",
+                "-f",
+                "SSID,SIGNAL,CHAN,FREQ",
+                "dev",
+                "wifi",
+                "list",
+                "ifname",
+                self._config.wifi_ifname,
+                "--rescan",
+                "yes",
+            ],
+            phase="connecting_wifi",
+            timeout=self._config.nmcli_timeout_s,
+            sudo=True,
         )
 
     async def _validate_open_network(self, ssid: str) -> None:


### PR DESCRIPTION
## What changed
Size: small

- add `tenacity>=9.1,<10` to the backend runtime deps
- replace the hand-written retry loop in `wifi_uplink_setup.py::bring_uplink_up()` with `tenacity.AsyncRetrying`
- keep retries limited to the retryable scan-lag case: `nmcli` saying `No network with SSID ... found`
- keep non-retryable connect failures fast-fail with the same updater error surface
- keep the rescan/log step between retryable attempts
- add focused tests for retry-then-success, non-retryable failure, and retry exhaustion
- update backend README to note this new `tenacity` seam and the nearby retry loops intentionally left custom

## Why
- issue asks for one meaningful update/network retry path to move from custom attempt/sleep logic to `tenacity`
- uplink connect was the cleanest first target because it already had a real retryable failure mode and clear non-retryable fallback

## Validation
- `cd apps/server && python3 -m py_compile vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py tests/use_cases/updates/wifi/test_wifi_uplink_setup.py`
- `cd apps/server && /root/.copilot/session-state/ce98cf98-8235-4f00-9e93-78f6c3795b5c/files/backend-venv/bin/python -m ruff check vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py tests/use_cases/updates/wifi/test_wifi_uplink_setup.py`
- `cd apps/server && /root/.copilot/session-state/ce98cf98-8235-4f00-9e93-78f6c3795b5c/files/backend-venv/bin/python -m ruff format --check vibesensor/use_cases/updates/wifi/wifi_uplink_setup.py tests/use_cases/updates/wifi/test_wifi_uplink_setup.py`

## Risks / tradeoffs
- this PR only migrates the uplink connect retry path; hotspot restore and DNS readiness stay custom for now because they have different retry semantics
- focused pytest on this host is still blocked by the known Python 3.11 vs backend 3.13 syntax gap in shared modules, so CI is the authoritative backend test/type gate

Closes #2874