### PR TITLE
Clean up provably unused code

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_rendering.py
@@ -77,7 +77,6 @@ def test_sparse_layout_omits_sensor_location_labels() -> None:
         [],
         content_width=300.0,
         tr=lambda key, **kwargs: key,
-        text_fn=lambda en, nl: en,
         diagram_width=200.0,
         diagram_height=252.0,
     )
@@ -111,7 +110,6 @@ def test_diagram_omits_source_legend_and_keeps_text_within_bounds() -> None:
         [],
         content_width=300.0,
         tr=lambda key, **kwargs: key,
-        text_fn=lambda en, nl: en,
         diagram_width=104.0,  # narrow width that previously triggered source-legend overlap
         diagram_height=252.0,
     )
@@ -174,7 +172,6 @@ def test_tall_narrow_page1_diagram_stays_inside_bounds_without_sensor_labels() -
         [],
         content_width=300.0,
         tr=lambda key, **kwargs: key,
-        text_fn=lambda en, nl: en,
         diagram_width=128.0,
         diagram_height=490.0,
     )
@@ -227,7 +224,6 @@ def test_tall_narrow_page1_diagram_can_top_align_orientation_labels() -> None:
         [],
         content_width=300.0,
         tr=lambda key, **kwargs: key,
-        text_fn=lambda en, nl: en,
         diagram_width=128.0,
         diagram_height=490.0,
     )
@@ -237,7 +233,6 @@ def test_tall_narrow_page1_diagram_can_top_align_orientation_labels() -> None:
         [],
         content_width=300.0,
         tr=lambda key, **kwargs: key,
-        text_fn=lambda en, nl: en,
         diagram_width=128.0,
         diagram_height=490.0,
         vertical_align="top",

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py
@@ -17,7 +17,6 @@ def test_car_diagram_shell_uses_contoured_paths_and_detail_polygons() -> None:
         [],
         content_width=300.0,
         tr=lambda key, **kwargs: key,
-        text_fn=lambda en, nl: en,
         diagram_width=200.0,
         diagram_height=252.0,
     )

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -342,7 +342,6 @@ def test_car_diagram_omits_sensor_labels() -> None:
         [],
         content_width=300.0,
         tr=lambda key, **kwargs: key,
-        text_fn=lambda en, nl: en,
         diagram_width=200.0,
         diagram_height=250.0,
     )

--- a/apps/server/vibesensor/adapters/pdf/page1_proof.py
+++ b/apps/server/vibesensor/adapters/pdf/page1_proof.py
@@ -60,7 +60,6 @@ def draw_proof_block(
         plan.location_hotspot_rows,
         content_width=w - 8 * mm,
         tr=tr,
-        text_fn=lambda en, nl: nl if plan.lang == "nl" else en,
         diagram_width=left_w,
         diagram_height=diagram_h - 2 * mm,
         vertical_align="top",

--- a/apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_b.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_b.py
@@ -69,7 +69,6 @@ def _appendix_b_page(c: Canvas, plan: AppendixBRenderPlan) -> None:
         plan.location_hotspot_rows,
         content_width=left_w - 8 * mm,
         tr=lambda key, **kw: _tr(plan.lang, key, **kw),
-        text_fn=lambda en, nl: nl if plan.lang == "nl" else en,
         diagram_width=left_w - 12 * mm,
         diagram_height=top_h - 24 * mm,
     )

--- a/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_diagram_render.py
@@ -414,7 +414,6 @@ def car_location_diagram(
     *,
     content_width: float,
     tr: Callable[..., str],
-    text_fn: Callable[..., str],
     diagram_width: float | None = None,
     diagram_height: float = 252,
     vertical_align: str = "center",


### PR DESCRIPTION
## What changed
Size: tiny

- remove the unused `text_fn` parameter from `pdf_diagram_render.py::car_location_diagram()`
- update every production and test call site to match the slimmer signature
- keep the cleanup bounded to the only 100%-confidence dead-code finding from the repo audit

## Why
- issue asks for provable dead-code cleanup, not speculative deletion
- repo-wide audit found one symbol with hard proof of non-use: `text_fn` was accepted by the diagram helper but never referenced in the function body

## Validation
- `cd apps/server && python3 -m py_compile vibesensor/adapters/pdf/pdf_diagram_render.py vibesensor/adapters/pdf/page1_proof.py vibesensor/adapters/pdf/pdf_appendices/appendix_b.py tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py tests/adapters/pdf/test_report_pdf_rendering.py tests/adapters/pdf/test_report_pdf_diagram_rendering.py`
- `cd apps/server && /root/.copilot/session-state/ce98cf98-8235-4f00-9e93-78f6c3795b5c/files/backend-venv/bin/python -m ruff check vibesensor/adapters/pdf/pdf_diagram_render.py vibesensor/adapters/pdf/page1_proof.py vibesensor/adapters/pdf/pdf_appendices/appendix_b.py tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py tests/adapters/pdf/test_report_pdf_rendering.py tests/adapters/pdf/test_report_pdf_diagram_rendering.py`
- `cd apps/server && /root/.copilot/session-state/ce98cf98-8235-4f00-9e93-78f6c3795b5c/files/backend-venv/bin/python -m ruff format --check vibesensor/adapters/pdf/pdf_diagram_render.py vibesensor/adapters/pdf/page1_proof.py vibesensor/adapters/pdf/pdf_appendices/appendix_b.py tests/adapters/pdf/test_report_pdf_diagram_visual_audit.py tests/adapters/pdf/test_report_pdf_rendering.py tests/adapters/pdf/test_report_pdf_diagram_rendering.py`

## Risks / tradeoffs
- focused pytest for the touched PDF files is still blocked on this host because backend test conftest imports shared modules that already use Python 3.13-only syntax; CI is the authoritative backend gate
- other audit findings were framework-pattern false positives or ambiguous, so this PR intentionally does not guess at broader deletions

Closes #2876