### PR TITLE
Move updater retries onto tenacity

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -362,12 +362,13 @@ Production devices use the wheel-based updater in `apps/server/vibesensor/use_ca
 
 `firmware_cache.py` is now the thin public cache/CLI surface, while `firmware_release_fetcher.py` owns GitHub firmware HTTP access, `firmware_bundle.py` owns bundle extraction/validation/metadata helpers, and `firmware_types.py` owns the updater-local cache/release contracts.
 
-- The Wi-Fi uplink connect path in `wifi_uplink_setup.py` now uses
-  `tenacity` for the specific retryable "SSID not found yet" scan-lag case.
-  Nearby updater loops with different semantics stay custom for now:
-  `wifi_hotspot_recovery.py` retries every restore failure uniformly, and
-  `transport/uplink_readiness.py` owns a minimum-wait DNS readiness window
-  rather than a simple attempt-count policy.
+- The updater now centralizes its real retry and polling loops on `tenacity`:
+  `wifi_uplink_setup.py` handles retryable SSID scan lag,
+  `wifi_hotspot_recovery.py` handles hotspot restore retries,
+  `transport/uplink_readiness.py` handles DNS readiness polling, and
+  `releases/release_validation.py` handles packaged smoke-server startup
+  polling. `restart_scheduler.py` stays custom because it is a two-command
+  fallback path, not a timed retry policy.
 
 - Normal delivery should go through release wheels.
 - Do not rely on manual edits inside deployed `site-packages` as a normal workflow.

--- a/apps/server/tests/use_cases/updates/releases/test_release_validation.py
+++ b/apps/server/tests/use_cases/updates/releases/test_release_validation.py
@@ -185,8 +185,12 @@ def test_release_validation_cli_import_path_does_not_require_pydantic(tmp_path: 
     assert "Validated release wheel metadata" in result.stdout
 
 
-def test_run_server_smoke_probes_health_and_static(monkeypatch, tmp_path: Path) -> None:
-    recorded: dict[str, object] = {}
+def _patch_release_smoke_process(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    recorded: dict[str, object],
+) -> None:
+    monkeypatch.setattr(release_validation, "_RELEASE_SMOKE_RETRY_WAIT_S", 0.0)
 
     class FakeProcess:
         def __init__(self) -> None:
@@ -234,15 +238,6 @@ def test_run_server_smoke_probes_health_and_static(monkeypatch, tmp_path: Path) 
         recorded["config"] = (source_config, runtime_root, host, port)
         return config_path
 
-    responses = [
-        (
-            200,
-            "application/json",
-            '{"status":"ok","startup_state":"ready","background_task_failures":{}}',
-        ),
-        (200, "text/html; charset=utf-8", "<html><title>VibeSensor</title></html>"),
-    ]
-
     monkeypatch.setattr(
         release_validation,
         "build_release_smoke_config",
@@ -265,6 +260,19 @@ def test_run_server_smoke_probes_health_and_static(monkeypatch, tmp_path: Path) 
         "terminate_subprocess",
         lambda process: (process.terminate(), process.wait(timeout=10.0)),
     )
+
+
+def test_run_server_smoke_probes_health_and_static(monkeypatch, tmp_path: Path) -> None:
+    recorded: dict[str, object] = {}
+    _patch_release_smoke_process(monkeypatch, tmp_path, recorded)
+    responses = [
+        (
+            200,
+            "application/json",
+            '{"status":"ok","startup_state":"ready","background_task_failures":{}}',
+        ),
+        (200, "text/html; charset=utf-8", "<html><title>VibeSensor</title></html>"),
+    ]
     monkeypatch.setattr(release_validation, "_read_http", lambda url: responses.pop(0))
 
     run_server_smoke(
@@ -281,6 +289,58 @@ def test_run_server_smoke_probes_health_and_static(monkeypatch, tmp_path: Path) 
     assert popen_kwargs["env"]["VIBESENSOR_SERVE_STATIC"] == "0"
     assert popen_kwargs["env"]["VIBESENSOR_UPDATE_STATE_PATH"].endswith("update_status.json")
     assert popen_kwargs["stdout"] == subprocess.PIPE
+    assert recorded["terminated"] is True
+
+
+def test_run_server_smoke_retries_until_server_is_ready(monkeypatch, tmp_path: Path) -> None:
+    recorded: dict[str, object] = {}
+    _patch_release_smoke_process(monkeypatch, tmp_path, recorded)
+    responses = [
+        (
+            200,
+            "application/json",
+            '{"status":"ok","startup_state":"booting","background_task_failures":{}}',
+        ),
+        (
+            200,
+            "application/json",
+            '{"status":"ok","startup_state":"ready","background_task_failures":{}}',
+        ),
+        (200, "text/html; charset=utf-8", "<html><title>VibeSensor</title></html>"),
+    ]
+    monkeypatch.setattr(release_validation, "_read_http", lambda url: responses.pop(0))
+
+    run_server_smoke(
+        SERVER_ROOT / "config.dev.yaml",
+        host="127.0.0.1",
+        port=18081,
+        startup_timeout_s=1.0,
+    )
+
+    assert responses == []
+    assert recorded["terminated"] is True
+
+
+def test_run_server_smoke_times_out_with_last_error(monkeypatch, tmp_path: Path) -> None:
+    recorded: dict[str, object] = {}
+    _patch_release_smoke_process(monkeypatch, tmp_path, recorded)
+    monkeypatch.setattr(
+        release_validation,
+        "_read_http",
+        lambda url: (503, "text/plain", "still starting"),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Release smoke validation timed out waiting for server readiness",
+    ):
+        run_server_smoke(
+            SERVER_ROOT / "config.dev.yaml",
+            host="127.0.0.1",
+            port=18081,
+            startup_timeout_s=0.0,
+        )
+
     assert recorded["terminated"] is True
 
 

--- a/apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py
+++ b/apps/server/tests/use_cases/updates/wifi/test_wifi_readiness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from test_support.update_status import build_update_status_harness
@@ -33,6 +34,36 @@ def _build_readiness(
         config=config,
     )
     return readiness, runner
+
+
+@pytest.mark.asyncio
+async def test_wait_for_dns_ready_retries_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    readiness, runner = _build_readiness(tmp_path, dns_ready_min_wait_s=1.0)
+    original_run = runner.run
+    probe_attempts = {"count": 0}
+
+    async def flaky_probe(args, *, timeout=30, env=None):
+        joined = " ".join(args)
+        if "socket.getaddrinfo" in joined:
+            probe_attempts["count"] += 1
+            if probe_attempts["count"] < 3:
+                return (1, "", "Temporary failure in name resolution")
+        return await original_run(args, timeout=timeout, env=env)
+
+    runner.run = flaky_probe
+    sleep = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "vibesensor.use_cases.updates.transport.uplink_readiness.asyncio.sleep",
+        sleep,
+    )
+
+    await readiness.wait_for_dns_ready()
+
+    assert probe_attempts["count"] == 3
+    assert sleep.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
@@ -8,13 +8,20 @@ import json
 import subprocess
 import sys
 import tempfile
-import time
 import urllib.error
 import urllib.request
 from collections.abc import Sequence
 from pathlib import Path
 
+from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
+
 from vibesensor.use_cases.updates.artifact_validation import wheel_metadata_validation_errors
+
+_RELEASE_SMOKE_RETRY_WAIT_S = 0.5
+
+
+class _RetryableReleaseSmokeServerNotReadyError(Exception):
+    pass
 
 
 def _sha256_file(path: Path) -> str:
@@ -200,38 +207,56 @@ def run_server_smoke(
             stdout=subprocess.PIPE,
         )
         try:
-            deadline = time.monotonic() + startup_timeout_s
             health_url = f"http://{host}:{port}/api/health"
             index_url = f"http://{host}:{port}/index.html"
             last_error: Exception | None = None
-            while time.monotonic() < deadline:
-                if process.poll() is not None:
-                    output = process.stdout.read() if process.stdout is not None else ""
-                    raise RuntimeError(
-                        f"Release smoke server exited before becoming healthy.\nOutput:\n{output}",
-                    )
-                try:
-                    status, content_type, body = _read_http(health_url)
-                    if status != 200:
-                        raise RuntimeError(f"Health endpoint returned HTTP {status}")
-                    payload = json.loads(body)
-                    if payload.get("status") not in {"ok", "degraded"}:
-                        raise RuntimeError(f"Unexpected health payload: {payload}")
-                    if payload.get("startup_state") != "ready":
-                        raise RuntimeError(f"Server not ready yet: {payload}")
-                    if payload.get("background_task_failures"):
-                        raise RuntimeError(f"Managed startup task failed: {payload}")
-                    index_status, index_type, index_body = _read_http(index_url)
-                    if index_status != 200:
-                        raise RuntimeError(f"Static index returned HTTP {index_status}")
-                    if "text/html" not in index_type:
-                        raise RuntimeError(f"Static index content type mismatch: {index_type}")
-                    if "VibeSensor" not in index_body:
-                        raise RuntimeError("Static index content did not include application title")
-                    return
-                except (OSError, RuntimeError, urllib.error.URLError, json.JSONDecodeError) as exc:
-                    last_error = exc
-                    time.sleep(0.5)
+            try:
+                for attempt in Retrying(
+                    stop=stop_after_delay(startup_timeout_s),
+                    wait=wait_fixed(_RELEASE_SMOKE_RETRY_WAIT_S),
+                    retry=retry_if_exception_type(_RetryableReleaseSmokeServerNotReadyError),
+                    reraise=True,
+                ):
+                    with attempt:
+                        if process.poll() is not None:
+                            output = process.stdout.read() if process.stdout is not None else ""
+                            raise RuntimeError(
+                                "Release smoke server exited before becoming healthy.\n"
+                                f"Output:\n{output}",
+                            )
+                        try:
+                            status, content_type, body = _read_http(health_url)
+                            if status != 200:
+                                raise RuntimeError(f"Health endpoint returned HTTP {status}")
+                            payload = json.loads(body)
+                            if payload.get("status") not in {"ok", "degraded"}:
+                                raise RuntimeError(f"Unexpected health payload: {payload}")
+                            if payload.get("startup_state") != "ready":
+                                raise RuntimeError(f"Server not ready yet: {payload}")
+                            if payload.get("background_task_failures"):
+                                raise RuntimeError(f"Managed startup task failed: {payload}")
+                            index_status, index_type, index_body = _read_http(index_url)
+                            if index_status != 200:
+                                raise RuntimeError(f"Static index returned HTTP {index_status}")
+                            if "text/html" not in index_type:
+                                raise RuntimeError(
+                                    f"Static index content type mismatch: {index_type}",
+                                )
+                            if "VibeSensor" not in index_body:
+                                raise RuntimeError(
+                                    "Static index content did not include application title",
+                                )
+                            return
+                        except (
+                            OSError,
+                            RuntimeError,
+                            urllib.error.URLError,
+                            json.JSONDecodeError,
+                        ) as exc:
+                            last_error = exc
+                            raise _RetryableReleaseSmokeServerNotReadyError(str(exc)) from exc
+            except _RetryableReleaseSmokeServerNotReadyError:
+                pass
 
             output = process.stdout.read() if process.stdout is not None else ""
             raise RuntimeError(

--- a/apps/server/vibesensor/use_cases/updates/transport/uplink_readiness.py
+++ b/apps/server/vibesensor/use_cases/updates/transport/uplink_readiness.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from typing import TYPE_CHECKING
+
+from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
 from vibesensor.use_cases.updates.models import UpdatePhase
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
@@ -13,6 +14,14 @@ if TYPE_CHECKING:
     from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
 
 __all__ = ["UpdateUplinkReadiness"]
+
+
+class _RetryableDnsNotReadyError(Exception):
+    __slots__ = ("detail",)
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
 
 
 class UpdateUplinkReadiness:
@@ -44,9 +53,7 @@ class UpdateUplinkReadiness:
             f"Validating {readiness_subject} internet/DNS readiness for at least "
             f"{int(self._config.dns_ready_min_wait_s)}s...",
         )
-        deadline = time.monotonic() + self._config.dns_ready_min_wait_s
         last_error = ""
-        attempt = 0
         probe_cmd = [
             "python3",
             "-c",
@@ -56,23 +63,34 @@ class UpdateUplinkReadiness:
                 f"'{self._config.dns_probe_host}', 443, proto=socket.IPPROTO_TCP)"
             ),
         ]
-        while True:
-            attempt += 1
-            probe_result = await self._commands.run(
-                probe_cmd,
-                phase=str(phase),
-                timeout=5,
-                sudo=False,
-            )
-            if probe_result.returncode == 0:
-                self._status.log(f"DNS probe succeeded on attempt {attempt}")
-                return
-            last_error = (
-                probe_result.stderr or probe_result.stdout or f"exit {probe_result.returncode}"
-            ).strip()
-            if time.monotonic() >= deadline:
-                break
-            await asyncio.sleep(self._config.dns_retry_interval_s)
+        try:
+            async for attempt in AsyncRetrying(
+                stop=stop_after_delay(self._config.dns_ready_min_wait_s),
+                wait=wait_fixed(self._config.dns_retry_interval_s),
+                retry=retry_if_exception_type(_RetryableDnsNotReadyError),
+                sleep=asyncio.sleep,
+                reraise=True,
+            ):
+                with attempt:
+                    probe_result = await self._commands.run(
+                        probe_cmd,
+                        phase=str(phase),
+                        timeout=5,
+                        sudo=False,
+                    )
+                    if probe_result.returncode == 0:
+                        self._status.log(
+                            f"DNS probe succeeded on attempt {attempt.retry_state.attempt_number}",
+                        )
+                        return
+                    last_error = (
+                        probe_result.stderr
+                        or probe_result.stdout
+                        or f"exit {probe_result.returncode}"
+                    ).strip()
+                    raise _RetryableDnsNotReadyError(last_error)
+        except _RetryableDnsNotReadyError as exc:
+            last_error = exc.detail
         raise UpdateTransportStepError(
             phase=phase,
             message=failure_message,

--- a/apps/server/vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py
+++ b/apps/server/vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py
@@ -2,9 +2,19 @@ from __future__ import annotations
 
 import asyncio
 
+from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_attempt, wait_fixed
+
 from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.wifi.wifi_config import UpdateWifiConfig
+
+
+class _RetryableHotspotRestoreError(Exception):
+    __slots__ = ("returncode",)
+
+    def __init__(self, returncode: int) -> None:
+        super().__init__(str(returncode))
+        self.returncode = returncode
 
 
 class UpdateHotspotRecovery:
@@ -57,21 +67,33 @@ class UpdateHotspotRecovery:
         """Re-enable the hotspot, retrying within the configured restore budget."""
 
         await self.cleanup_uplink()
-        for attempt in range(1, self._config.hotspot_restore_retries + 1):
-            result = await self._commands.run(
-                ["nmcli", "connection", "up", self._config.ap_con_name],
-                phase="restore",
-                timeout=self._config.nmcli_timeout_s,
-                sudo=True,
-            )
-            if result.returncode == 0:
-                self._status.log(f"Hotspot restored on attempt {attempt}")
-                return True
-            self._status.log(
-                f"Hotspot restore attempt {attempt} failed (rc={result.returncode})",
-            )
-            if attempt < self._config.hotspot_restore_retries:
-                await asyncio.sleep(self._config.hotspot_restore_delay_s)
+        try:
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(self._config.hotspot_restore_retries),
+                wait=wait_fixed(self._config.hotspot_restore_delay_s),
+                retry=retry_if_exception_type(_RetryableHotspotRestoreError),
+                sleep=asyncio.sleep,
+                reraise=True,
+            ):
+                with attempt:
+                    result = await self._commands.run(
+                        ["nmcli", "connection", "up", self._config.ap_con_name],
+                        phase="restore",
+                        timeout=self._config.nmcli_timeout_s,
+                        sudo=True,
+                    )
+                    if result.returncode == 0:
+                        self._status.log(
+                            f"Hotspot restored on attempt {attempt.retry_state.attempt_number}",
+                        )
+                        return True
+                    attempt_number = attempt.retry_state.attempt_number
+                    self._status.log(
+                        f"Hotspot restore attempt {attempt_number} failed (rc={result.returncode})",
+                    )
+                    raise _RetryableHotspotRestoreError(result.returncode)
+        except _RetryableHotspotRestoreError:
+            pass
         self._status.add_issue(
             "restoring_hotspot",
             "Failed to restore hotspot after retries",


### PR DESCRIPTION
## what changed
size: medium

- move hotspot restore retries in `wifi_hotspot_recovery.py` to `AsyncRetrying`
- move DNS readiness polling in `transport/uplink_readiness.py` to `AsyncRetrying`
- move release smoke startup polling in `releases/release_validation.py` to sync `Retrying`
- add focused retry coverage for DNS readiness and release smoke polling
- update updater docs to mark the new tenacity seams

## why
- updater already used tenacity for Wi-Fi connect scan lag, but other real retry paths still hand-rolled their own loops
- this makes retry policy more consistent across the updater flow without forcing tenacity onto paths that are not actually retries

## validation
- `cd apps/server && python3 -m py_compile vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py vibesensor/use_cases/updates/transport/uplink_readiness.py vibesensor/use_cases/updates/releases/release_validation.py tests/use_cases/updates/wifi/test_wifi_readiness.py tests/use_cases/updates/releases/test_release_validation.py tests/use_cases/updates/wifi/test_hotspot_recovery.py tests/use_cases/updates/test_restart_scheduler.py`
- `cd apps/server && /root/.copilot/session-state/ce98cf98-8235-4f00-9e93-78f6c3795b5c/files/backend-venv/bin/python -m ruff check vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py vibesensor/use_cases/updates/transport/uplink_readiness.py vibesensor/use_cases/updates/releases/release_validation.py tests/use_cases/updates/wifi/test_wifi_readiness.py tests/use_cases/updates/releases/test_release_validation.py tests/use_cases/updates/wifi/test_hotspot_recovery.py tests/use_cases/updates/test_restart_scheduler.py`
- `cd apps/server && /root/.copilot/session-state/ce98cf98-8235-4f00-9e93-78f6c3795b5c/files/backend-venv/bin/python -m ruff format --check vibesensor/use_cases/updates/wifi/wifi_hotspot_recovery.py vibesensor/use_cases/updates/transport/uplink_readiness.py vibesensor/use_cases/updates/releases/release_validation.py tests/use_cases/updates/wifi/test_wifi_readiness.py tests/use_cases/updates/releases/test_release_validation.py tests/use_cases/updates/wifi/test_hotspot_recovery.py tests/use_cases/updates/test_restart_scheduler.py`

## risks / tradeoffs
- `restart_scheduler.py` stays custom on purpose because it is a two-command fallback path, not a timed retry loop
- focused `pytest` is still blocked in this checkout because `tests/conftest.py` imports backend modules that already use Python 3.13-only syntax while the available interpreters here are Python 3.11
- remaining `while True` loops in updater code are stream readers, not retry seams