### PR TITLE
Adopt import-linter for backend architecture rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,11 @@ jobs:
 
       - uses: ./.github/actions/setup-backend
 
-      - name: Backend static guard checks
+      - name: Backend architecture checks
         working-directory: apps/server
-        run: python ../../tools/dev/verify_backend_static_guards.py
+        run: |
+          lint-imports --config pyproject.toml
+          python ../../tools/dev/verify_backend_static_guards.py
 
   backend-preflight:
     name: Backend preflight

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ lint: ## Run repo hygiene, static guards, docs lint, and contract drift checks
 	"$$PYTHON" -m ruff check $(LINT_TARGETS) && \
 	"$$PYTHON" -m ruff format --check $(LINT_TARGETS) && \
 	"$$PYTHON" tools/dev/check_hygiene.py && \
-	cd $(SERVER_DIR) && "$$PYTHON" ../../tools/dev/verify_backend_static_guards.py && \
+	cd $(SERVER_DIR) && lint-imports --config pyproject.toml && "$$PYTHON" ../../tools/dev/verify_backend_static_guards.py && \
 	cd "$(CURDIR)" && "$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.dev.yaml && \
 	"$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.docker.yaml && \
 	"$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.pi.yaml && \

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -21,6 +21,9 @@ Backend ownership boundaries:
 See [docs/ai/repo-map.md#backend-package-layout](../../docs/ai/repo-map.md#backend-package-layout)
 for the detailed backend ownership map. This README stays focused on
 backend-specific setup, configuration, routes, updates, and testing.
+Package-level backend dependency direction is declared in
+`apps/server/pyproject.toml` under `[tool.importlinter]`; keep repo-specific
+root-module and structural guardrails in `tools/dev/verify_backend_static_guards.py`.
 
 ## State and configuration scopes
 

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -29,6 +29,7 @@ esp = [
 dev = [
   "hypothesis>=6.131,<7",
   "httpx>=0.27,<1",
+  "import-linter>=2.11,<3",
   "mypy>=1.19,<2",
   "pypdf>=5,<7",
   "pypdfium2>=5.7.0,<6",
@@ -113,6 +114,68 @@ warn_unused_ignores = true
 warn_return_any = true
 strict_equality = true
 show_error_codes = true
+
+[tool.importlinter]
+# Keep the package-level backend dependency direction declarative here.
+# Root-level `vibesensor/*.py` shared-module rules and other repo-specific
+# guardrails still live in `tools/dev/verify_backend_static_guards.py`.
+root_package = "vibesensor"
+
+[[tool.importlinter.contracts]]
+name = "Domain stays isolated from outer layers"
+type = "forbidden"
+source_modules = ["vibesensor.domain"]
+forbidden_modules = [
+  "vibesensor.shared",
+  "vibesensor.use_cases",
+  "vibesensor.infra",
+  "vibesensor.adapters",
+  "vibesensor.app",
+  "vibesensor.cli",
+]
+
+[[tool.importlinter.contracts]]
+name = "Shared stays below service and adapter layers"
+type = "forbidden"
+source_modules = ["vibesensor.shared"]
+forbidden_modules = [
+  "vibesensor.use_cases",
+  "vibesensor.infra",
+  "vibesensor.adapters",
+  "vibesensor.app",
+  "vibesensor.cli",
+]
+
+[[tool.importlinter.contracts]]
+name = "Use cases and infra stay independent"
+type = "independence"
+modules = ["vibesensor.use_cases", "vibesensor.infra"]
+
+[[tool.importlinter.contracts]]
+name = "Use cases stay below adapters and app entrypoints"
+type = "forbidden"
+source_modules = ["vibesensor.use_cases"]
+forbidden_modules = [
+  "vibesensor.adapters",
+  "vibesensor.app",
+  "vibesensor.cli",
+]
+
+[[tool.importlinter.contracts]]
+name = "Infra stays below adapters and app entrypoints"
+type = "forbidden"
+source_modules = ["vibesensor.infra"]
+forbidden_modules = [
+  "vibesensor.adapters",
+  "vibesensor.app",
+  "vibesensor.cli",
+]
+
+[[tool.importlinter.contracts]]
+name = "Adapters stay below app entrypoints"
+type = "forbidden"
+source_modules = ["vibesensor.adapters"]
+forbidden_modules = ["vibesensor.app", "vibesensor.cli"]
 
 [[tool.mypy.overrides]]
 module = [

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -54,7 +54,9 @@ Paths below are repo-relative unless a line explicitly calls out a Python import
 
 ## Backend layer dependency DAG
 
-- Import-direction enforcement lives in `tools/dev/verify_backend_static_guards.py::_check_layer_boundaries()`.
+- Package-level import-direction enforcement lives in `apps/server/pyproject.toml`
+  under `[tool.importlinter]`. Repo-specific backend static guards remain in
+  `tools/dev/verify_backend_static_guards.py`.
 - Allowed dependency directions are:
   - `domain` -> none
   - `shared` -> `domain`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -348,7 +348,8 @@ workflow-backed CI manifest:
 
 - `backend-lint`: Ruff lint and formatter drift checks for backend and tooling Python code.
 - `repo-hygiene`: line endings plus repo/path/runtime/CI hygiene checks.
-- `backend-static-guards`: backend layer and import-boundary static guards.
+- `backend-static-guards`: import-linter backend architecture contracts plus the
+  remaining repo-specific backend static guards.
 - `backend-preflight`: dependency consistency plus config preflight validation for dev, docker, and pi configs.
 - `docs-lint`: docs misuse and markdown-link validation.
 - `backend-contract-drift`: WS schema and HTTP API contract drift checks.

--- a/tools/dev/verify_backend_static_guards.py
+++ b/tools/dev/verify_backend_static_guards.py
@@ -1038,16 +1038,6 @@ def _check_shared_types_no_domain_factory_methods() -> list[str]:
     return factory_methods
 
 
-_LAYERS = ("domain", "shared", "use_cases", "infra", "adapters", "app")
-_ALLOWED_IMPORTS: dict[str, frozenset[str]] = {
-    "domain": frozenset(),
-    "shared": frozenset({"domain"}),
-    "use_cases": frozenset({"domain", "shared"}),
-    "infra": frozenset({"domain", "shared"}),
-    "adapters": frozenset({"domain", "shared", "infra", "use_cases"}),
-    "app": frozenset({"domain", "shared", "use_cases", "infra", "adapters"}),
-}
-
 _ALLOWED_ROOT_MODULE_FILES = frozenset(
     {
         "__init__.py",
@@ -1058,109 +1048,6 @@ _ALLOWED_ROOT_MODULE_FILES = frozenset(
         "vibration_strength.py",
     }
 )
-
-_ALLOWED_ROOT_MODULE_FILES = frozenset(
-    {
-        "__init__.py",
-        "__main__.py",
-        "_version.py",
-        "report_i18n.py",
-        "strength_bands.py",
-        "vibration_strength.py",
-    }
-)
-
-_ALLOWED_ROOT_MODULE_FILES = frozenset(
-    {
-        "__init__.py",
-        "__main__.py",
-        "_version.py",
-        "report_i18n.py",
-        "strength_bands.py",
-        "vibration_strength.py",
-    }
-)
-
-
-def _classify_layer(rel_path: str) -> str:
-    first = rel_path.split("/")[0]
-    if first in _LAYERS:
-        return first
-    if first == "cli":
-        return "app"
-    return "shared"
-
-
-def _import_target_layer(module: str) -> str | None:
-    if not module.startswith("vibesensor"):
-        return None
-    rest = module.removeprefix("vibesensor.")
-    if not rest:
-        return None
-    top = rest.split(".")[0]
-    if top in _LAYERS:
-        return top
-    if top == "cli":
-        return "app"
-    return "shared"
-
-
-_KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset()
-
-
-def _scan_layer_boundary_violations() -> set[tuple[str, str]]:
-    violations: set[tuple[str, str]] = set()
-    for path in _python_files(VIBESENSOR_DIR):
-        if "static" in path.parts:
-            continue
-        rel = str(path.relative_to(VIBESENSOR_DIR))
-        layer = _classify_layer(rel)
-        allowed = _ALLOWED_IMPORTS[layer]
-        tree = _parse_python(path)
-        if tree is None:
-            continue
-        for node in ast.walk(tree):
-            modules: list[str] = []
-            if isinstance(node, ast.Import):
-                modules = [alias.name for alias in node.names]
-            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
-                modules = [node.module]
-            for module in modules:
-                target = _import_target_layer(module)
-                if target is None or target == layer:
-                    continue
-                if target not in allowed:
-                    violations.add((rel, module))
-    return violations
-
-
-def _check_layer_boundaries() -> list[str]:
-    violations = _scan_layer_boundary_violations()
-    failures: list[str] = []
-    new_violations = violations - _KNOWN_VIOLATIONS
-    if new_violations:
-        failures.append(
-            "New layer-boundary violations found:\n  "
-            + "\n  ".join(f"{src} -> {mod}" for src, mod in sorted(new_violations))
-        )
-    stale = _KNOWN_VIOLATIONS - violations
-    if stale:
-        failures.append(
-            "Stale layer-boundary allowlist entries found:\n  "
-            + "\n  ".join(f"{src} -> {mod}" for src, mod in sorted(stale))
-        )
-    for layer in _LAYERS:
-        expected = VIBESENSOR_DIR / ("app" if layer == "app" else layer)
-        if not expected.is_dir():
-            failures.append(
-                f"Missing layer directory: {expected.relative_to(REPO_ROOT)}"
-            )
-    for layer, allowed in _ALLOWED_IMPORTS.items():
-        for target in allowed:
-            peer_allowed = _ALLOWED_IMPORTS.get(target, frozenset())
-            if layer in peer_allowed:
-                failures.append(f"Layer DAG cycle detected: {layer} <-> {target}")
-    return failures
 
 
 def _check_root_module_allowlist() -> list[str]:
@@ -2057,7 +1944,6 @@ CHECKS: tuple[Check, ...] = (
         "Shared types avoid domain factory methods",
         _check_shared_types_no_domain_factory_methods,
     ),
-    ("Layer boundaries stay acyclic and clean", _check_layer_boundaries),
     (
         "run_analysis keeps normalize_lang in report_i18n",
         _check_run_analysis_does_not_define_normalize_lang,


### PR DESCRIPTION
## what changed
size: medium

- add `import-linter` to the backend dev toolchain
- declare the main backend dependency direction in `apps/server/pyproject.toml` with declarative `forbidden` and `independence` contracts
- run `lint-imports --config pyproject.toml` in `make lint` and in the existing `backend-static-guards` CI job
- remove the overlapping package-layer AST scan from `tools/dev/verify_backend_static_guards.py`
- update backend docs to point at the new contract authority and keep repo-specific static guards separate

## why

- backend import boundaries were still encoded in one custom AST scan inside `verify_backend_static_guards.py`
- that made the rules harder to read, review, and extend than they needed to be
- import-linter is a better fit for the package-level architecture contract, while the custom script still keeps the repo-specific checks that are not just import direction

## validation

- `python3 -m venv .ai-temp/import-linter-venv && .ai-temp/import-linter-venv/bin/pip install --quiet import-linter==2.11`
- `PYTHONPATH=apps/server .ai-temp/import-linter-venv/bin/lint-imports --config apps/server/pyproject.toml`
- `python3 -m py_compile tools/dev/verify_backend_static_guards.py`
- `/root/.copilot/session-state/ce98cf98-8235-4f00-9e93-78f6c3795b5c/files/backend-venv/bin/python -m ruff check tools/dev/verify_backend_static_guards.py`
- `/root/.copilot/session-state/ce98cf98-8235-4f00-9e93-78f6c3795b5c/files/backend-venv/bin/python -m ruff format --check tools/dev/verify_backend_static_guards.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/dev/docs_lint.py`
- `git diff --check`

## risks / tradeoffs

- this keeps root-level `vibesensor/*.py` rules and other repo-specific structural checks in `verify_backend_static_guards.py`; only the package-layer DAG moved to import-linter
- local full backend static-guard execution is still blocked in this checkout because the available interpreter is Python 3.11 while backend modules already use Python 3.13 `type` statements
- CI is the real gate for the full backend architecture path because the shared setup action installs the backend dev extra under Python 3.13

Closes #2884
