### PR TITLE
build(backend): add deptry dependency checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,10 @@ jobs:
       - name: Validate dependency consistency
         run: python -m pip check
 
+      - name: Validate declared Python dependencies
+        working-directory: apps/server
+        run: deptry . tests --config pyproject.toml
+
       - name: Config preflight (dev)
         run: python -m vibesensor.cli.preflight apps/server/config.dev.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ format: ## Run Ruff formatter over backend and tooling files
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" -m ruff format $(LINT_TARGETS)
 
-lint: ## Run repo hygiene, static guards, docs lint, and contract drift checks
+lint: ## Run repo hygiene, dependency/static guards, docs lint, and contract drift checks
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" -m ruff check $(LINT_TARGETS) && \
 	"$$PYTHON" -m ruff format --check $(LINT_TARGETS) && \
 	"$$PYTHON" tools/dev/check_hygiene.py && \
-	cd $(SERVER_DIR) && lint-imports --config pyproject.toml && "$$PYTHON" ../../tools/dev/verify_backend_static_guards.py && \
+	cd $(SERVER_DIR) && deptry . tests --config pyproject.toml && lint-imports --config pyproject.toml && "$$PYTHON" ../../tools/dev/verify_backend_static_guards.py && \
 	cd "$(CURDIR)" && "$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.dev.yaml && \
 	"$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.docker.yaml && \
 	"$$PYTHON" -m vibesensor.cli.preflight $(SERVER_DIR)/config.pi.yaml && \

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -123,10 +123,11 @@ while the Vite dev server proxies browser traffic to `http://127.0.0.1:8000`.
 
 Backend Python dependencies are declared in `apps/server/pyproject.toml` with
 bounded version ranges and installed through the editable package flow (`python
--m pip install -e "./apps/server[dev]"`). The repo currently validates that
-model with CI `pip check` plus automated Dependabot update PRs rather than
-maintaining a second checked-in Python lockfile workflow alongside the editable
-install path.
+-m pip install -e "./apps/server[dev]"`). The repo validates that model with
+`deptry . tests --config pyproject.toml` for declared-import hygiene, CI
+`pip check` for installed-package consistency, and automated Dependabot update
+PRs rather than maintaining a second checked-in Python lockfile workflow
+alongside the editable install path.
 
 ## Payload boundary pattern
 

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -11,7 +11,9 @@ requires-python = ">=3.13"
 dependencies = [
   "fastapi>=0.111,<1",
   "msgspec>=0.19,<1",
+  "pydantic>=2.7,<3",
   "pydantic-settings>=2.10,<3",
+  "starlette>=0.37.2,<1",
   "tenacity>=9.1,<10",
   "uvicorn[standard]>=0.30,<1",
   "numpy>=2.4.4,<3",
@@ -25,8 +27,10 @@ dependencies = [
 [project.optional-dependencies]
 esp = [
   "esptool>=5.2.0,<6",
+  "pyserial>=3.3,<4",
 ]
 dev = [
+  "deptry>=0.25,<0.26",
   "hypothesis>=6.131,<7",
   "httpx>=0.27,<1",
   "import-linter>=2.11,<3",
@@ -176,6 +180,15 @@ name = "Adapters stay below app entrypoints"
 type = "forbidden"
 source_modules = ["vibesensor.adapters"]
 forbidden_modules = ["vibesensor.app", "vibesensor.cli"]
+
+[tool.deptry]
+known_first_party = ["test_support"]
+optional_dependencies_dev_groups = ["dev"]
+package_module_name_map = { PyYAML = ["yaml"], pyserial = ["serial"] }
+# ESP flashing intentionally resolves esptool via PATH / `python -m esptool`
+# rather than importing it directly, so DEP002 would otherwise be a false
+# positive for the optional firmware-flash extra.
+per_rule_ignores = { DEP002 = ["esptool"] }
 
 [[tool.mypy.overrides]]
 module = [

--- a/apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py
+++ b/apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py
@@ -43,6 +43,9 @@ def test_server_pyproject_includes_esp_flash_and_firmware_cache_entrypoints() ->
     assert "esptool" in pyproject_text, (
         "Server dependencies must include esptool for offline ESP flash"
     )
+    assert "pyserial" in pyproject_text, (
+        "Server dependencies must include pyserial for ESP port discovery"
+    )
     assert "vibesensor-fw-refresh" in pyproject_text, (
         "Server must expose firmware cache refresh CLI entry point"
     )

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -353,7 +353,8 @@ workflow-backed CI manifest:
 - `repo-hygiene`: line endings plus repo/path/runtime/CI hygiene checks.
 - `backend-static-guards`: import-linter backend architecture contracts plus the
   remaining repo-specific backend static guards.
-- `backend-preflight`: dependency consistency plus config preflight validation for dev, docker, and pi configs.
+- `backend-preflight`: `pip check`, backend `deptry` dependency-declaration
+  validation, and config preflight validation for dev, docker, and pi configs.
 - `docs-lint`: docs misuse and markdown-link validation.
 - `backend-contract-drift`: WS schema and HTTP API contract drift checks.
 - `backend-typecheck`: mypy on the `vibesensor` backend package; package discovery keeps new backend files checked by default without an internal module denylist.


### PR DESCRIPTION
## what changed
- add `deptry` to backend dev tooling and check in repo-specific `[tool.deptry]`
- run `deptry . tests --config pyproject.toml` from `make lint` and CI `backend-preflight`
- declare direct deps for `pydantic`, `starlette`, and `pyserial`
- keep `esptool` as a narrow documented DEP002 ignore because the flash path shells out or probes `python -m esptool`
- update backend/testing docs and extend the offline-flash hygiene guard

## why
- catch missing direct deps and transitive reliance before packaging drift lands in review

## validation
- `cd apps/server && /workspace/VibeSensor/.ai-temp/deptry-venv/bin/deptry . tests --config pyproject.toml`
- `/workspace/VibeSensor/.ai-temp/deptry-venv/bin/python -m ruff check apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py`
- `/workspace/VibeSensor/.ai-temp/deptry-venv/bin/python -m ruff format --check apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py`
- `python3 -m py_compile apps/server/tests/hygiene/test_install_offline_artifact_guardrails.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/dev/docs_lint.py`
- `git diff --check`

## risks / tradeoffs / edge
- deptry still cannot infer the `esptool` extra automatically because firmware flashing resolves it via PATH or `python -m esptool`; keep that ignore narrow and documented
- this checkout used a temp deptry/Ruff venv for local validation because the host only has Python 3.11 while backend CI/tooling is pinned to 3.13

Closes #2886
