### PR TITLE
test(backend): add pytest-benchmark suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-.PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck test test-changed test-ci-lite test-all test-full-suite sync-contracts regen-contracts coverage smoke loc docs-lint
+.PHONY: help doctor setup dev format lint typecheck-backend typecheck ui-lint ui-typecheck test test-changed test-ci-lite test-all test-full-suite benchmark-backend benchmark-compare-backend sync-contracts regen-contracts coverage smoke loc docs-lint
 
 SERVER_DIR := apps/server
 UI_DIR := apps/ui
@@ -11,6 +11,7 @@ PYTHON_MAJOR_MINOR := $(PYTHON_MAJOR).$(PYTHON_MINOR)
 PYTHON_BOOTSTRAP := python$(PYTHON_MAJOR_MINOR)
 VENV_DIR := $(CURDIR)/.venv
 VENV_PYTHON := $(VENV_DIR)/bin/python
+BACKEND_BENCHMARK_TARGETS ?= tests/infra/workers/benchmark_compute_all.py tests/use_cases/updates/benchmark_update_status_codec.py
 
 # Prefer the repo venv after setup, but still allow bootstrap targets to run
 # against the pinned host interpreter before `.venv` exists.
@@ -82,6 +83,15 @@ test-all: ## Run the broader local CI runner
 test-full-suite: ## Run the full end-to-end suite locally
 	@$(RESOLVE_PYTHON) \
 	"$$PYTHON" tools/tests/run_e2e_parallel.py --shards 1
+
+benchmark-backend: ## Run explicit backend benchmark suite (set BENCHMARK_OPTS / BACKEND_BENCHMARK_TARGETS as needed)
+	@$(RESOLVE_PYTHON) \
+	cd $(SERVER_DIR) && "$$PYTHON" -m pytest --benchmark-only $(BACKEND_BENCHMARK_TARGETS) $(BENCHMARK_OPTS)
+
+benchmark-compare-backend: ## Compare saved backend benchmark runs from apps/server/.benchmarks
+	@$(RESOLVE_PYTHON) \
+	BENCHMARK_CLI="$$(dirname "$$PYTHON")/py.test-benchmark"; \
+	cd $(SERVER_DIR) && "$$BENCHMARK_CLI" compare .benchmarks
 
 sync-contracts: ## Regenerate or check the authoritative contract sync pipeline
 	@$(RESOLVE_PYTHON) \

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -153,14 +153,19 @@ settings snapshots now follow the same pattern in
 - Keep Pydantic response models at the HTTP edge when OpenAPI generation still
   depends on them; msgspec feeds those models with already-validated builtins.
 
-For Pi or Pi-like timing checks before widening this pattern, run:
+For repeatable codec comparisons, run the explicit benchmark suite:
 
 ```bash
-python tools/tests/benchmark_update_status_codec.py --iterations 5000 --rounds 20
+make benchmark-backend \
+  BACKEND_BENCHMARK_TARGETS=tests/use_cases/updates/benchmark_update_status_codec.py \
+  BENCHMARK_OPTS="--benchmark-save=update-status-codec"
+make benchmark-compare-backend
 ```
 
-The benchmark uses a representative updater-status payload and reports payload
-bytes plus median/p95 encode/decode latency in microseconds per operation.
+The benchmark uses a representative updater-status payload. Saved runs land in
+`apps/server/.benchmarks/` so later runs can be compared with the same target.
+The older `tools/tests/benchmark_update_status_codec.py` script remains as a
+standalone single-shot harness when you just want the raw Pi timing printout.
 
 ## Configuration
 

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
   "pypdfium2>=5.7.0,<6",
   "pytest>=8,<10",
   "pytest-asyncio>=0.23,<2",
+  "pytest-benchmark>=5.2,<6",
   "pytest-cov>=7.1.0,<8",
   "pytest-timeout>=2.4.0,<3",
   "pytest-xdist>=3.8.0,<4",
@@ -84,6 +85,7 @@ markers = [
     "e2e: end-to-end tests",
     "long_sim: longer simulated-run tests (>20 s of synthetic data)",
     "smoke: minimal critical path checks",
+    "benchmark: explicit performance regression benchmarks run outside default CI",
 ]
 filterwarnings = [
     "ignore:cannot collect test class 'TestRun':pytest.PytestCollectionWarning",

--- a/apps/server/tests/infra/workers/benchmark_compute_all.py
+++ b/apps/server/tests/infra/workers/benchmark_compute_all.py
@@ -1,0 +1,63 @@
+"""Explicit pytest-benchmark suite for SignalProcessor compute_all hot path."""
+
+from __future__ import annotations
+
+from math import pi
+
+import numpy as np
+import pytest
+
+from vibesensor.infra.processing import SignalProcessor
+from vibesensor.infra.workers.worker_pool import WorkerPool
+
+SAMPLE_RATE_HZ = 800
+FFT_N = 512
+WAVEFORM_SECONDS = 4
+SPECTRUM_MAX_HZ = 200
+INGEST_BATCHES = 5
+CLIENT_IDS = [f"sensor-{idx:02d}" for idx in range(4)]
+FREQS_HZ = [20.0 + idx * 7.5 for idx in range(len(CLIENT_IDS))]
+
+
+def _make_processor(pool: WorkerPool | None = None) -> SignalProcessor:
+    return SignalProcessor(
+        sample_rate_hz=SAMPLE_RATE_HZ,
+        waveform_seconds=WAVEFORM_SECONDS,
+        waveform_display_hz=100,
+        fft_n=FFT_N,
+        spectrum_max_hz=SPECTRUM_MAX_HZ,
+        accel_scale_g_per_lsb=1.0 / 256.0,
+        worker_pool=pool,
+    )
+
+
+def _inject_signal(proc: SignalProcessor, client_id: str, freq_hz: float) -> None:
+    t = np.arange(FFT_N, dtype=np.float64) / SAMPLE_RATE_HZ
+    x_lsb = (0.05 * np.sin(2.0 * pi * freq_hz * t) * 256.0).astype(np.int16)
+    y_lsb = (0.03 * np.sin(2.0 * pi * (freq_hz + 10.0) * t) * 256.0).astype(np.int16)
+    z_lsb = np.zeros(FFT_N, dtype=np.int16)
+    samples = np.stack([x_lsb, y_lsb, z_lsb], axis=1)
+    proc.ingest(client_id, samples, sample_rate_hz=SAMPLE_RATE_HZ)
+
+
+def _run_compute_round(use_worker_pool: bool) -> dict[str, object]:
+    pool = WorkerPool(max_workers=4, thread_name_prefix="bench-fft") if use_worker_pool else None
+    try:
+        proc = _make_processor(pool=pool)
+        for client_id, freq_hz in zip(CLIENT_IDS, FREQS_HZ, strict=True):
+            for _ in range(INGEST_BATCHES):
+                _inject_signal(proc, client_id, freq_hz)
+        return proc.compute_all(CLIENT_IDS)
+    finally:
+        if pool is not None:
+            pool.shutdown()
+
+
+@pytest.mark.benchmark(group="signal-processor-compute-round")
+@pytest.mark.parametrize("use_worker_pool", [False, True], ids=["sequential", "parallel"])
+def test_signal_processor_compute_round_benchmark(benchmark, use_worker_pool: bool) -> None:
+    result = benchmark(lambda: _run_compute_round(use_worker_pool))
+
+    assert sorted(result) == CLIENT_IDS
+    assert result["sensor-00"]["x"]["rms"] > 0
+    assert result["sensor-01"]["y"]["rms"] > 0

--- a/apps/server/tests/use_cases/updates/benchmark_update_status_codec.py
+++ b/apps/server/tests/use_cases/updates/benchmark_update_status_codec.py
@@ -1,0 +1,76 @@
+"""Explicit pytest-benchmark suite for updater-status codec hot path."""
+
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.use_cases.updates.models import (
+    UpdateIssue,
+    UpdateJobStatus,
+    UpdatePhase,
+    UpdateRuntimeDetails,
+    UpdateState,
+    UpdateTransport,
+)
+from vibesensor.use_cases.updates.status import (
+    update_status_from_json,
+    update_status_to_json,
+)
+
+_NOW_S = 1_700_000_120.0
+
+
+def _representative_status() -> UpdateJobStatus:
+    return UpdateJobStatus(
+        state=UpdateState.running,
+        phase=UpdatePhase.installing,
+        transport=UpdateTransport.usb_internet,
+        started_at=1_700_000_000.0,
+        last_success_at=1_699_999_500.0,
+        phase_started_at=1_700_000_090.0,
+        updated_at=1_700_000_110.0,
+        uplink_interface="usb0",
+        issues=[
+            UpdateIssue(phase="checking", message="Network slow", detail="retry budget 2"),
+            UpdateIssue(phase="downloading", message="Wheel cached", detail="cache hit"),
+            UpdateIssue(phase="installing", message="Service restart pending"),
+        ],
+        log_tail=[f"log line {idx:02d}" for idx in range(32)],
+        runtime=UpdateRuntimeDetails(
+            version="2026.4.19",
+            commit="08915691",
+            ui_source_hash="ui-source-hash",
+            static_assets_hash="static-assets-hash",
+            static_build_source_hash="build-source-hash",
+            static_build_commit="build-commit",
+            assets_verified=True,
+            has_packaged_static=True,
+        ),
+    )
+
+
+@pytest.mark.benchmark(group="update-status-codec")
+def test_update_status_encode_benchmark(benchmark) -> None:
+    status = _representative_status()
+    encoded = benchmark(lambda: update_status_to_json(status, now_s=_NOW_S))
+
+    assert len(encoded) > 0
+
+
+@pytest.mark.benchmark(group="update-status-codec")
+def test_update_status_decode_benchmark(benchmark) -> None:
+    encoded = update_status_to_json(_representative_status(), now_s=_NOW_S)
+    decoded = benchmark(lambda: update_status_from_json(encoded))
+
+    assert decoded.phase == UpdatePhase.installing
+    assert decoded.transport == UpdateTransport.usb_internet
+    assert decoded.runtime == UpdateRuntimeDetails(
+        version="2026.4.19",
+        commit="08915691",
+        ui_source_hash="ui-source-hash",
+        static_assets_hash="static-assets-hash",
+        static_build_source_hash="build-source-hash",
+        static_build_commit="build-commit",
+        assets_verified=True,
+        has_packaged_static=True,
+    )

--- a/docs/multithreading_performance.md
+++ b/docs/multithreading_performance.md
@@ -48,7 +48,7 @@ with explicit drop logging.
 | `processing/` | `compute_all()` dispatches per-client FFT in parallel; ingest/compute timing counters added |
 | `runtime/builders.py` | Creates shared `WorkerPool(max_workers=4)`, injects into `SignalProcessor`, runtime shuts it down on stop |
 | Tests | 14 new tests: pool correctness, parallel/sequential equivalence, concurrent ingest+compute safety |
-| Benchmark | `tools/tests/benchmark_pipeline.py` — repeatable throughput measurement |
+| Benchmark | `apps/server/tests/infra/workers/benchmark_compute_all.py` — canonical pytest-benchmark regression path; `tools/tests/benchmark_pipeline.py` stays as the standalone throughput table harness |
 
 ## Before/After Metrics
 
@@ -70,9 +70,10 @@ slower per-core performance, the median also improves.
 ## How to run the benchmark
 
 ```bash
-cd apps/server
-pip install -e ".[dev]"
-python ../../tools/tests/benchmark_pipeline.py --sensors 4 --rounds 20
+make benchmark-backend \
+  BACKEND_BENCHMARK_TARGETS=tests/infra/workers/benchmark_compute_all.py \
+  BENCHMARK_OPTS="--benchmark-save=worker-pool"
+make benchmark-compare-backend
 ```
 
 ## Design decisions for a 4-core Pi

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,6 +8,8 @@
 - Pi-image build/validation guidance lives in `infra/pi-image/pi-gen/README.md`.
 - Use `make test-ci-lite` (`python3 tools/tests/run_ci_parallel.py --ci-lite`) for the non-Docker blocking-CI subset.
 - Use `make test-all` (`python3 tools/tests/run_ci_parallel.py`) for the broader local runner.
+- Use `make benchmark-backend` for the explicit pytest-benchmark backend suite; pass `BENCHMARK_OPTS="--benchmark-save=<name>"` to save runs and `BACKEND_BENCHMARK_TARGETS=...` to focus one benchmark file.
+- Use `make benchmark-compare-backend` to compare saved runs from `apps/server/.benchmarks/`.
 - The full end-to-end verification runner is `make test-full-suite` (`python3 tools/tests/run_e2e_parallel.py --shards 1`), which starts an isolated direct server subprocess per shard from `apps/server/config.docker.yaml` with static UI serving disabled.
 - `tools/tests/run_backend_parallel.py` shards `apps/server/tests` by whole test file, using cached JUnit timings from `~/.cache/vibesensor/backend-duration-cache.json` to keep the backend CI shards balanced over time. It also accepts `--xdist-workers` / `VIBESENSOR_BACKEND_XDIST_WORKERS` for controlled intra-shard xdist; CI pins that to `2` because the repo's five-shard local CI-parallel benchmark beat `-n 0` (48.6s wall time) and still edged out the higher `-n 3` setting (41.5s) with `-n 2` (41.1s) while keeping the same shard contents.
 - `tools/tests/run_e2e_parallel.py` records observed shard test durations in `~/.cache/vibesensor/e2e-duration-cache.json` so later local or CI runs can rebalance without hand-maintained timing hints.
@@ -99,6 +101,10 @@ make test-ci-lite
 # Full local runner
 make test-all
 
+# Explicit backend benchmarks
+make benchmark-backend BENCHMARK_OPTS="--benchmark-save=baseline"
+make benchmark-compare-backend
+
 # Required pre-finalization gate — real GitHub workflow via act (requires Docker)
 act -W .github/workflows/ci.yml
 ```
@@ -112,6 +118,11 @@ pytest -q apps/server/tests/use_cases/updates/
 pytest -q apps/server/tests/integration/
 python3 tools/dev/fuzz_analysis_engine.py --duration-s 60 --batch-examples 100 --processes 16
 ```
+
+Explicit backend benchmark files stay out of default CI and normal pytest
+discovery so the blocking lanes do not turn noisy or hardware-sensitive.
+Run them on demand when you need regression evidence and save comparison data
+for later runs with `make benchmark-backend` / `make benchmark-compare-backend`.
 
 Focused CI job groups and full-stack validation:
 

--- a/tools/tests/benchmark_pipeline.py
+++ b/tools/tests/benchmark_pipeline.py
@@ -10,6 +10,11 @@ Usage::
     python tools/tests/benchmark_pipeline.py --sensors 8 --rounds 20
 
 Output is a plain-text table comparing sequential vs parallel execution.
+
+For repeatable regression comparisons, use
+``apps/server/tests/infra/workers/benchmark_compute_all.py`` through
+``make benchmark-backend``. This script remains the standalone
+human-readable throughput harness.
 """
 
 from __future__ import annotations

--- a/tools/tests/benchmark_update_status_codec.py
+++ b/tools/tests/benchmark_update_status_codec.py
@@ -9,6 +9,11 @@ Usage::
 Run this on a Raspberry Pi or similar low-power Linux host before copying the
 pattern to larger payload boundaries. Output reports payload bytes plus encode
 and decode latency in microseconds per operation.
+
+For repeatable regression comparisons, use
+``apps/server/tests/use_cases/updates/benchmark_update_status_codec.py``
+through ``make benchmark-backend``. This script remains the standalone
+single-shot timing harness.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## what changed
- add `pytest-benchmark` to backend dev deps and register explicit benchmark markers
- add two non-default benchmark files: worker-pool `SignalProcessor.compute_all()` and updater-status codec encode/decode
- add `make benchmark-backend` and `make benchmark-compare-backend` for save/compare flows
- update backend/testing/performance docs to point at the new benchmark path
- keep `tools/tests/benchmark_*.py` as standalone human-readable harnesses and link them to the canonical pytest-benchmark suite

## why
- repo already had ad hoc timing scripts, but not one repeatable compare flow for future regression work
- explicit benchmark files keep blocking CI quiet while still giving developers a real benchmark suite and saved-run comparison path

## validation
- `python3 -m py_compile apps/server/tests/infra/workers/benchmark_compute_all.py apps/server/tests/use_cases/updates/benchmark_update_status_codec.py tools/tests/benchmark_pipeline.py tools/tests/benchmark_update_status_codec.py`
- `/workspace/VibeSensor/.ai-temp/deptry-venv/bin/python -m ruff check apps/server/tests/infra/workers/benchmark_compute_all.py apps/server/tests/use_cases/updates/benchmark_update_status_codec.py tools/tests/benchmark_pipeline.py tools/tests/benchmark_update_status_codec.py`
- `/workspace/VibeSensor/.ai-temp/deptry-venv/bin/python -m ruff format --check apps/server/tests/infra/workers/benchmark_compute_all.py apps/server/tests/use_cases/updates/benchmark_update_status_codec.py tools/tests/benchmark_pipeline.py tools/tests/benchmark_update_status_codec.py`
- `python3 tools/dev/check_hygiene.py`
- `python3 tools/dev/docs_lint.py`
- `git diff --check`

## risks / tradeoffs / edge
- benchmark files are explicit-only, not part of default pytest discovery or blocking CI, to avoid noisy/flaky lanes
- this checkout still cannot execute the real backend benchmark suite locally because host Python is 3.11 while backend code is pinned to 3.13; the PR adds the runnable commands and CI-installed tooling, but the actual benchmark run stays for a 3.13 environment

Closes #2887
