### PR TITLE
refactor(updates): use msgspec rollback metadata

### DIFF
--- a/apps/server/tests/use_cases/updates/test_rollback_snapshot.py
+++ b/apps/server/tests/use_cases/updates/test_rollback_snapshot.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from test_support.update_status import build_update_status_harness
+
+from vibesensor.use_cases.updates.rollback_snapshot import (
+    RollbackSnapshotMetadata,
+    RollbackSnapshotStore,
+)
+from vibesensor.use_cases.updates.status import UpdateStatusTracker
+
+
+def _make_store(tmp_path: Path) -> tuple[RollbackSnapshotStore, UpdateStatusTracker, Path]:
+    rollback_dir = tmp_path / "rollback"
+    tracker = build_update_status_harness(tmp_path / "update_status.json")
+    return RollbackSnapshotStore(rollback_dir, tracker), tracker, rollback_dir
+
+
+def test_rollback_snapshot_metadata_round_trips(tmp_path: Path) -> None:
+    store, tracker, _rollback_dir = _make_store(tmp_path)
+    metadata = RollbackSnapshotMetadata(version="2025.6.14", sha256="a" * 64)
+
+    store.write_metadata(metadata)
+
+    assert store._load_metadata(report_issues=True) == metadata
+    assert tracker.status.issues == []
+
+
+def test_rollback_snapshot_metadata_reports_unreadable_json(tmp_path: Path) -> None:
+    store, tracker, rollback_dir = _make_store(tmp_path)
+    rollback_dir.mkdir()
+    (rollback_dir / "rollback_snapshot.json").write_text("{not-json\n", encoding="utf-8")
+
+    assert store._load_metadata(report_issues=True) is None
+    assert any(
+        issue.message == "Rollback snapshot metadata is unreadable"
+        for issue in tracker.status.issues
+    )
+
+
+def test_rollback_snapshot_metadata_reports_incomplete_payload(tmp_path: Path) -> None:
+    store, tracker, rollback_dir = _make_store(tmp_path)
+    rollback_dir.mkdir()
+    (rollback_dir / "rollback_snapshot.json").write_text(
+        '{"version":"2025.6.14"}\n',
+        encoding="utf-8",
+    )
+
+    assert store._load_metadata(report_issues=True) is None
+    assert any(
+        issue.message == "Rollback snapshot metadata is incomplete"
+        for issue in tracker.status.issues
+    )
+
+
+def test_rollback_snapshot_metadata_coerces_legacy_non_string_values(tmp_path: Path) -> None:
+    store, tracker, rollback_dir = _make_store(tmp_path)
+    rollback_dir.mkdir()
+    (rollback_dir / "rollback_snapshot.json").write_text(
+        '{"version":2025.614,"sha256":12345}\n',
+        encoding="utf-8",
+    )
+
+    assert store._load_metadata(report_issues=False) == RollbackSnapshotMetadata(
+        version="2025.614",
+        sha256="12345",
+    )
+    assert tracker.status.issues == []

--- a/apps/server/vibesensor/use_cases/updates/rollback_snapshot.py
+++ b/apps/server/vibesensor/use_cases/updates/rollback_snapshot.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-import json
 import os
 import tempfile
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+
+import msgspec
 
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 
@@ -15,6 +17,11 @@ __all__ = ["RollbackSnapshot", "RollbackSnapshotMetadata", "RollbackSnapshotStor
 _ROLLBACK_METADATA_FILE = "rollback_snapshot.json"
 _ROLLBACK_WHEEL_FILE = "rollback_snapshot.whl"
 _ROLLBACK_BACKUP_WHEEL_FILE = ".rollback_snapshot.previous.whl"
+
+
+class _RollbackSnapshotMetadataRecord(msgspec.Struct, kw_only=True, frozen=True):
+    version: str = ""
+    sha256: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,6 +41,43 @@ class RollbackSnapshotPromotion:
     wheel_path: Path
     backup_path: Path | None
     moved_new_wheel: bool
+
+
+def _rollback_snapshot_metadata_to_json(metadata: RollbackSnapshotMetadata) -> bytes:
+    return (
+        msgspec.json.encode(
+            _RollbackSnapshotMetadataRecord(version=metadata.version, sha256=metadata.sha256)
+        )
+        + b"\n"
+    )
+
+
+def _rollback_snapshot_metadata_from_json(raw: bytes | str) -> RollbackSnapshotMetadata:
+    record = _decode_rollback_snapshot_metadata_record(raw)
+    return RollbackSnapshotMetadata(version=record.version, sha256=record.sha256)
+
+
+def _decode_rollback_snapshot_metadata_record(raw: bytes | str) -> _RollbackSnapshotMetadataRecord:
+    try:
+        return msgspec.json.decode(raw, type=_RollbackSnapshotMetadataRecord)
+    except msgspec.ValidationError:
+        decoded = msgspec.json.decode(raw)
+        if not isinstance(decoded, Mapping):
+            raise
+        return _rollback_snapshot_metadata_record_from_object(decoded)
+
+
+def _rollback_snapshot_metadata_record_from_object(
+    payload: Mapping[str, object],
+) -> _RollbackSnapshotMetadataRecord:
+    return _RollbackSnapshotMetadataRecord(
+        version=_rollback_snapshot_metadata_text(payload.get("version")),
+        sha256=_rollback_snapshot_metadata_text(payload.get("sha256")),
+    )
+
+
+def _rollback_snapshot_metadata_text(value: object) -> str:
+    return str(value or "")
 
 
 class RollbackSnapshotStore:
@@ -59,25 +103,15 @@ class RollbackSnapshotStore:
         """Atomically persist rollback metadata alongside stored wheels."""
 
         self._rollback_dir.mkdir(parents=True, exist_ok=True)
-        payload = (
-            json.dumps(
-                {
-                    "version": metadata.version,
-                    "sha256": metadata.sha256,
-                },
-                indent=2,
-            )
-            + "\n"
-        )
+        payload = _rollback_snapshot_metadata_to_json(metadata)
         fd, temp_path_text = tempfile.mkstemp(
             prefix=".rollback_snapshot.",
             suffix=".tmp",
             dir=self._rollback_dir,
-            text=True,
         )
         temp_path = Path(temp_path_text)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            with os.fdopen(fd, "wb") as handle:
                 handle.write(payload)
                 handle.flush()
                 os.fsync(handle.fileno())
@@ -155,8 +189,8 @@ class RollbackSnapshotStore:
                 )
             return None
         try:
-            raw = json.loads(metadata_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
+            metadata = _rollback_snapshot_metadata_from_json(metadata_path.read_bytes())
+        except (msgspec.DecodeError, msgspec.ValidationError, OSError) as exc:
             if report_issues:
                 self._status.add_issue(
                     "installing",
@@ -164,9 +198,7 @@ class RollbackSnapshotStore:
                     f"{metadata_path}: {exc}",
                 )
             return None
-        version = str(raw.get("version") or "")
-        sha256 = str(raw.get("sha256") or "")
-        if not version or not sha256:
+        if not metadata.version or not metadata.sha256:
             if report_issues:
                 self._status.add_issue(
                     "installing",
@@ -174,4 +206,4 @@ class RollbackSnapshotStore:
                     f"{metadata_path} is missing version or sha256",
                 )
             return None
-        return RollbackSnapshotMetadata(version=version, sha256=sha256)
+        return metadata


### PR DESCRIPTION
small

## what changed
- replace rollback snapshot metadata json encode/decode with a msgspec record codec
- keep missing, unreadable, and incomplete updater issue paths intact
- add focused rollback snapshot tests for round-trip, corrupt json, partial payload, and legacy-like coercion

## why
- this file is a tiny repo-owned persistence boundary
- msgspec removes handwritten field walking from the main load path
- narrow fallback normalization keeps current behavior for partial legacy-like payloads

## validation
- ruff check + format check on touched files
- local backend execution blocked here: host lacks python 3.13 and docker daemon access
- PR CI is the real 3.13 execution gate

## risks tradeoffs edge
- persisted json formatting becomes compact msgspec output
- non-object payloads stay unreadable; legacy-like object values still coerce through the fallback path

Closes #2893