### PR TITLE
refactor(updates): share firmware bundle codecs

### DIFF
--- a/apps/server/tests/use_cases/updates/firmware/test_firmware_bundle.py
+++ b/apps/server/tests/use_cases/updates/firmware/test_firmware_bundle.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vibesensor.use_cases.updates.firmware.firmware_bundle import (
+    flash_manifest_record_from_json,
+    flash_manifest_record_to_json,
+    parse_manifest,
+    read_meta,
+    validate_bundle,
+    write_meta,
+)
+from vibesensor.use_cases.updates.firmware.firmware_types import (
+    BundleMeta,
+    FlashManifestRecord,
+    ManifestEnvironmentRecord,
+    ManifestSegmentRecord,
+)
+
+
+def test_flash_manifest_record_round_trips_and_parses_domain() -> None:
+    record = FlashManifestRecord(
+        generated_from="deadbeef",
+        environments=[
+            ManifestEnvironmentRecord(
+                name="esp32dev",
+                segments=[
+                    ManifestSegmentRecord(
+                        file="esp32dev/firmware.bin",
+                        offset="0x10000",
+                        sha256="a" * 64,
+                    )
+                ],
+            )
+        ],
+    )
+
+    decoded = flash_manifest_record_from_json(flash_manifest_record_to_json(record))
+    manifest = parse_manifest(decoded)
+
+    assert decoded == record
+    assert manifest.generated_from == "deadbeef"
+    assert manifest.environments[0].name == "esp32dev"
+    assert manifest.environments[0].segments[0].file == "esp32dev/firmware.bin"
+
+
+def test_write_meta_round_trips_with_read_meta(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    meta = BundleMeta(
+        tag="fw-main-abc1234",
+        asset="vibesensor-fw-main-abc1234.zip",
+        timestamp="2026-01-01T00:00:00+00:00",
+        sha256="a" * 64,
+        source="downloaded",
+    )
+
+    write_meta(bundle_dir, meta)
+
+    assert read_meta(bundle_dir) == meta
+
+
+def test_read_meta_rejects_corrupt_json(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "_meta.json").write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="metadata is corrupt"):
+        read_meta(bundle_dir)
+
+
+def test_validate_bundle_rejects_corrupt_manifest_json(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "flash.json").write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Firmware manifest is corrupt"):
+        validate_bundle(bundle_dir)

--- a/apps/server/tests/use_cases/updates/releases/test_release_validation.py
+++ b/apps/server/tests/use_cases/updates/releases/test_release_validation.py
@@ -86,6 +86,69 @@ def test_validate_firmware_dist_reports_missing_firmware_bin(tmp_path: Path) -> 
     assert any("must contain at least one segment" in error for error in errors)
 
 
+def test_validate_firmware_dist_reports_invalid_manifest_json(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir(parents=True)
+    (dist_dir / "flash.json").write_text("{not-json", encoding="utf-8")
+
+    errors = validate_firmware_dist(dist_dir)
+
+    assert any("Invalid firmware manifest JSON" in error for error in errors)
+
+
+def test_validate_firmware_dist_reports_missing_environment_name(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    env_dir = dist_dir / "esp32dev"
+    env_dir.mkdir(parents=True)
+    (env_dir / "firmware.bin").write_bytes(b"firmware")
+    manifest = {
+        "generated_from": "deadbeef",
+        "environments": [
+            {
+                "segments": [
+                    {
+                        "file": "esp32dev/firmware.bin",
+                        "offset": "0x10000",
+                        "sha256": hashlib.sha256(b"firmware").hexdigest(),
+                    },
+                ],
+            },
+        ],
+    }
+    (dist_dir / "flash.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    errors = validate_firmware_dist(dist_dir)
+
+    assert "environments[0].name must be a non-empty string" in errors
+
+
+def test_validate_firmware_dist_reports_checksum_mismatch(tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    env_dir = dist_dir / "esp32dev"
+    env_dir.mkdir(parents=True)
+    (env_dir / "firmware.bin").write_bytes(b"firmware")
+    manifest = {
+        "generated_from": "deadbeef",
+        "environments": [
+            {
+                "name": "esp32dev",
+                "segments": [
+                    {
+                        "file": "esp32dev/firmware.bin",
+                        "offset": "0x10000",
+                        "sha256": "0" * 64,
+                    },
+                ],
+            },
+        ],
+    }
+    (dist_dir / "flash.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    errors = validate_firmware_dist(dist_dir)
+
+    assert any("sha256 mismatch for esp32dev/firmware.bin" in error for error in errors)
+
+
 def _build_fake_release_wheel(
     path: Path,
     *,

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_bundle.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_bundle.py
@@ -248,10 +248,12 @@ def _manifest_environment_record_from_object(
 
 
 def _manifest_segment_record_from_object(payload: Mapping[str, object]) -> ManifestSegmentRecord:
+    file_name = payload.get("file")
+    offset = payload.get("offset")
     sha256 = payload.get("sha256", "")
     return ManifestSegmentRecord(
-        file=payload.get("file") if isinstance(payload.get("file"), str) else "",
-        offset=payload.get("offset") if isinstance(payload.get("offset"), str) else "",
+        file=file_name if isinstance(file_name, str) else "",
+        offset=offset if isinstance(offset, str) else "",
         sha256=sha256 if isinstance(sha256, str) else "",
     )
 

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_bundle.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_bundle.py
@@ -3,23 +3,33 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import os
 import tempfile
 import zipfile
+from collections.abc import Mapping
 from pathlib import Path
 
-from vibesensor.shared.types.json_types import JsonObject, is_json_array, is_json_object
+import msgspec
+
+from vibesensor.shared.types.json_types import is_json_array, is_json_object
 from vibesensor.use_cases.updates.firmware.firmware_types import (
     BundleMeta,
+    BundleMetaRecord,
     FlashManifest,
+    FlashManifestRecord,
     ManifestEnvironment,
+    ManifestEnvironmentRecord,
     ManifestSegment,
+    ManifestSegmentRecord,
 )
 
 __all__ = [
+    "bundle_meta_record_from_json",
+    "bundle_meta_record_to_json",
     "dir_sha256",
     "extract_bundle_archive",
+    "flash_manifest_record_from_json",
+    "flash_manifest_record_to_json",
     "parse_manifest",
     "read_meta",
     "safe_extractall",
@@ -31,12 +41,32 @@ _META_FILE = "_meta.json"
 _MANIFEST_FILE = "flash.json"
 
 
-def _read_json_file(path: Path) -> JsonObject:
-    """Read and parse a JSON file. Raises JSONDecodeError or OSError on failure."""
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not is_json_object(payload):
-        raise ValueError(f"Expected JSON object in {path}, got {type(payload).__name__}")
-    return payload
+def flash_manifest_record_from_json(raw: bytes | str) -> FlashManifestRecord:
+    try:
+        return msgspec.json.decode(raw, type=FlashManifestRecord)
+    except msgspec.ValidationError as exc:
+        decoded = msgspec.json.decode(raw)
+        if not is_json_object(decoded):
+            raise ValueError("Firmware manifest root must be a JSON object") from exc
+        return _flash_manifest_record_from_object(decoded)
+
+
+def flash_manifest_record_to_json(record: FlashManifestRecord) -> bytes:
+    return msgspec.json.encode(record) + b"\n"
+
+
+def bundle_meta_record_from_json(raw: bytes | str) -> BundleMetaRecord:
+    try:
+        return msgspec.json.decode(raw, type=BundleMetaRecord)
+    except msgspec.ValidationError as exc:
+        decoded = msgspec.json.decode(raw)
+        if not is_json_object(decoded):
+            raise ValueError("Firmware bundle metadata root must be a JSON object") from exc
+        return _bundle_meta_record_from_object(decoded)
+
+
+def bundle_meta_record_to_json(record: BundleMetaRecord) -> bytes:
+    return msgspec.json.encode(record) + b"\n"
 
 
 def safe_extractall(zf: zipfile.ZipFile, dest: Path) -> None:
@@ -60,37 +90,30 @@ def extract_bundle_archive(zip_path: Path, dest_dir: Path) -> Path:
     return dest_dir
 
 
-def parse_manifest(data: JsonObject) -> FlashManifest:
-    """Parse a flash.json manifest dict into a FlashManifest."""
+def parse_manifest(data: FlashManifestRecord | object) -> FlashManifest:
+    """Parse a flash.json manifest record or JSON-like object into a FlashManifest."""
+
+    record = _coerce_flash_manifest_record(data)
     envs: list[ManifestEnvironment] = []
-    environments = data.get("environments", [])
-    if is_json_array(environments):
-        for env_data in environments:
-            if not is_json_object(env_data):
-                continue
-            segments_raw = env_data.get("segments", [])
-            segs: list[ManifestSegment] = []
-            if is_json_array(segments_raw):
-                for segment in segments_raw:
-                    if not is_json_object(segment):
-                        continue
-                    file_name = segment.get("file")
-                    offset = segment.get("offset")
-                    if not isinstance(file_name, str) or not isinstance(offset, str):
-                        continue
-                    sha256 = segment.get("sha256", "")
-                    segs.append(
-                        ManifestSegment(
-                            file=file_name,
-                            offset=offset,
-                            sha256=str(sha256) if isinstance(sha256, str) else "",
-                        ),
+    for env_record in record.environments:
+        if not env_record.name:
+            continue
+        envs.append(
+            ManifestEnvironment(
+                name=env_record.name,
+                segments=[
+                    ManifestSegment(
+                        file=segment.file,
+                        offset=segment.offset,
+                        sha256=segment.sha256,
                     )
-            name = env_data.get("name")
-            if isinstance(name, str) and name:
-                envs.append(ManifestEnvironment(name=name, segments=segs))
+                    for segment in env_record.segments
+                    if segment.file and segment.offset
+                ],
+            )
+        )
     return FlashManifest(
-        generated_from=str(data.get("generated_from", "")),
+        generated_from=record.generated_from,
         environments=envs,
     )
 
@@ -108,11 +131,11 @@ def validate_bundle(bundle_dir: Path) -> FlashManifest:
             "Run the updater while online or reinstall the Pi image.",
         )
     try:
-        manifest_data = _read_json_file(manifest_path)
-    except (json.JSONDecodeError, OSError) as exc:
+        manifest_record = flash_manifest_record_from_json(manifest_path.read_bytes())
+    except (msgspec.DecodeError, OSError, ValueError) as exc:
         raise ValueError(f"Firmware manifest is corrupt in {bundle_dir}: {exc}") from exc
 
-    manifest = parse_manifest(manifest_data)
+    manifest = parse_manifest(manifest_record)
     if not manifest.environments:
         raise ValueError(
             f"Firmware manifest in {bundle_dir} has no environments. The bundle may be incomplete.",
@@ -142,15 +165,15 @@ def read_meta(bundle_dir: Path) -> BundleMeta | None:
     if not meta_path.is_file():
         return None
     try:
-        data = _read_json_file(meta_path)
-    except (json.JSONDecodeError, OSError) as exc:
+        record = bundle_meta_record_from_json(meta_path.read_bytes())
+    except (msgspec.DecodeError, OSError, ValueError) as exc:
         raise ValueError(f"Firmware bundle metadata is corrupt in {bundle_dir}: {exc}") from exc
     return BundleMeta(
-        tag=str(data.get("tag", "")),
-        asset=str(data.get("asset", "")),
-        timestamp=str(data.get("timestamp", "")),
-        sha256=str(data.get("sha256", "")),
-        source=str(data.get("source", "")),
+        tag=record.tag,
+        asset=record.asset,
+        timestamp=record.timestamp,
+        sha256=record.sha256,
+        source=record.source,
     )
 
 
@@ -161,18 +184,86 @@ def write_meta(bundle_dir: Path, meta: BundleMeta) -> None:
     a truncated ``_meta.json``.
     """
     meta_path = bundle_dir / _META_FILE
-    payload = json.dumps(meta.to_dict(), indent=2) + "\n"
+    payload = bundle_meta_record_to_json(
+        BundleMetaRecord(
+            tag=meta.tag,
+            asset=meta.asset,
+            timestamp=meta.timestamp,
+            sha256=meta.sha256,
+            source=meta.source,
+        )
+    )
     fd, tmp = tempfile.mkstemp(
         dir=str(bundle_dir),
         prefix="._meta_",
         suffix=".tmp",
     )
     try:
-        os.write(fd, payload.encode("utf-8"))
+        os.write(fd, payload)
         os.fsync(fd)
     finally:
         os.close(fd)
     Path(tmp).replace(meta_path)
+
+
+def _coerce_flash_manifest_record(data: FlashManifestRecord | object) -> FlashManifestRecord:
+    if isinstance(data, FlashManifestRecord):
+        return data
+    if not is_json_object(data):
+        return FlashManifestRecord()
+    return _flash_manifest_record_from_object(data)
+
+
+def _flash_manifest_record_from_object(payload: Mapping[str, object]) -> FlashManifestRecord:
+    environments: list[ManifestEnvironmentRecord] = []
+    raw_environments = payload.get("environments")
+    if is_json_array(raw_environments):
+        for raw_environment in raw_environments:
+            if is_json_object(raw_environment):
+                environments.append(_manifest_environment_record_from_object(raw_environment))
+            else:
+                environments.append(ManifestEnvironmentRecord())
+    return FlashManifestRecord(
+        generated_from=str(payload.get("generated_from", "")),
+        environments=environments,
+    )
+
+
+def _manifest_environment_record_from_object(
+    payload: Mapping[str, object],
+) -> ManifestEnvironmentRecord:
+    segments: list[ManifestSegmentRecord] = []
+    raw_segments = payload.get("segments")
+    if is_json_array(raw_segments):
+        for raw_segment in raw_segments:
+            if is_json_object(raw_segment):
+                segments.append(_manifest_segment_record_from_object(raw_segment))
+            else:
+                segments.append(ManifestSegmentRecord())
+    name = payload.get("name")
+    return ManifestEnvironmentRecord(
+        name=name if isinstance(name, str) else "",
+        segments=segments,
+    )
+
+
+def _manifest_segment_record_from_object(payload: Mapping[str, object]) -> ManifestSegmentRecord:
+    sha256 = payload.get("sha256", "")
+    return ManifestSegmentRecord(
+        file=payload.get("file") if isinstance(payload.get("file"), str) else "",
+        offset=payload.get("offset") if isinstance(payload.get("offset"), str) else "",
+        sha256=sha256 if isinstance(sha256, str) else "",
+    )
+
+
+def _bundle_meta_record_from_object(payload: Mapping[str, object]) -> BundleMetaRecord:
+    return BundleMetaRecord(
+        tag=str(payload.get("tag", "")),
+        asset=str(payload.get("asset", "")),
+        timestamp=str(payload.get("timestamp", "")),
+        sha256=str(payload.get("sha256", "")),
+        source=str(payload.get("source", "")),
+    )
 
 
 def dir_sha256(directory: Path) -> str:

--- a/apps/server/vibesensor/use_cases/updates/firmware/firmware_types.py
+++ b/apps/server/vibesensor/use_cases/updates/firmware/firmware_types.py
@@ -4,6 +4,8 @@ import os
 from dataclasses import dataclass, field
 from typing import TypedDict
 
+import msgspec
+
 from vibesensor.shared.constants.github import GITHUB_REPO
 from vibesensor.shared.process_settings import (
     DEFAULT_FIRMWARE_CACHE_DIR,
@@ -13,15 +15,19 @@ from vibesensor.shared.process_settings import (
 
 __all__ = [
     "BundleMeta",
+    "BundleMetaRecord",
     "FirmwareCacheConfig",
     "FirmwareCacheInfoPayload",
     "FlashManifest",
+    "FlashManifestRecord",
     "GitHubReleaseAssetPayload",
     "GitHubReleasePayload",
     "ManifestEnvironment",
     "ManifestEnvironmentPayload",
+    "ManifestEnvironmentRecord",
     "ManifestSegment",
     "ManifestSegmentPayload",
+    "ManifestSegmentRecord",
 ]
 
 _DEFAULT_CACHE_DIR = str(DEFAULT_FIRMWARE_CACHE_DIR)
@@ -62,6 +68,30 @@ class FirmwareCacheInfoPayload(TypedDict, total=False):
     bundle_path: str
 
 
+class BundleMetaRecord(msgspec.Struct, kw_only=True, frozen=True):
+    tag: str = ""
+    asset: str = ""
+    timestamp: str = ""
+    sha256: str = ""
+    source: str = ""
+
+
+class ManifestSegmentRecord(msgspec.Struct, kw_only=True, frozen=True):
+    file: str = ""
+    offset: str = ""
+    sha256: str = ""
+
+
+class ManifestEnvironmentRecord(msgspec.Struct, kw_only=True, frozen=True):
+    name: str = ""
+    segments: list[ManifestSegmentRecord] = msgspec.field(default_factory=list)
+
+
+class FlashManifestRecord(msgspec.Struct, kw_only=True, frozen=True):
+    generated_from: str = ""
+    environments: list[ManifestEnvironmentRecord] = msgspec.field(default_factory=list)
+
+
 @dataclass
 class FirmwareCacheConfig:
     """Configuration for the local ESP32 firmware download cache."""
@@ -95,15 +125,6 @@ class BundleMeta:
     timestamp: str = ""
     sha256: str = ""
     source: str = ""  # "downloaded" or "baseline"
-
-    def to_dict(self) -> dict[str, str]:
-        return {
-            "tag": self.tag,
-            "asset": self.asset,
-            "timestamp": self.timestamp,
-            "sha256": self.sha256,
-            "source": self.source,
-        }
 
 
 @dataclass

--- a/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
@@ -17,7 +17,6 @@ import msgspec
 from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
 from vibesensor.use_cases.updates.artifact_validation import wheel_metadata_validation_errors
-from vibesensor.use_cases.updates.firmware.firmware_bundle import flash_manifest_record_from_json
 
 _RELEASE_SMOKE_RETRY_WAIT_S = 0.5
 
@@ -59,6 +58,10 @@ def build_release_smoke_config(
 
 
 def validate_firmware_dist(dist_dir: Path) -> list[str]:
+    from vibesensor.use_cases.updates.firmware.firmware_bundle import (
+        flash_manifest_record_from_json,
+    )
+
     errors: list[str] = []
     manifest_path = dist_dir / "flash.json"
     if not manifest_path.is_file():

--- a/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
@@ -13,9 +13,11 @@ import urllib.request
 from collections.abc import Sequence
 from pathlib import Path
 
+import msgspec
 from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
 from vibesensor.use_cases.updates.artifact_validation import wheel_metadata_validation_errors
+from vibesensor.use_cases.updates.firmware.firmware_bundle import flash_manifest_record_from_json
 
 _RELEASE_SMOKE_RETRY_WAIT_S = 0.5
 
@@ -63,53 +65,43 @@ def validate_firmware_dist(dist_dir: Path) -> list[str]:
         return [f"Missing firmware manifest: {manifest_path}"]
 
     try:
-        manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
+        manifest = flash_manifest_record_from_json(manifest_path.read_bytes())
+    except msgspec.DecodeError as exc:
         return [f"Invalid firmware manifest JSON: {exc}"]
+    except (OSError, ValueError) as exc:
+        return [str(exc)]
 
-    if not isinstance(manifest_data, dict):
-        return ["Firmware manifest root must be a JSON object"]
-
-    environments = manifest_data.get("environments")
-    if not isinstance(environments, list) or not environments:
+    if not manifest.environments:
         return ["Firmware manifest must contain at least one environment"]
 
     seen_names: set[str] = set()
-    for index, raw_environment in enumerate(environments):
+    for index, environment in enumerate(manifest.environments):
         prefix = f"environments[{index}]"
-        if not isinstance(raw_environment, dict):
-            errors.append(f"{prefix} must be an object")
-            continue
-
-        env_name = raw_environment.get("name")
-        if not isinstance(env_name, str) or not env_name:
+        env_name = environment.name
+        if not env_name:
             errors.append(f"{prefix}.name must be a non-empty string")
             continue
         if env_name in seen_names:
             errors.append(f"Duplicate firmware environment name: {env_name}")
         seen_names.add(env_name)
 
-        segments = raw_environment.get("segments")
-        if not isinstance(segments, list) or not segments:
+        segments = environment.segments
+        if not segments:
             errors.append(f"{prefix}.segments must contain at least one segment")
             continue
 
         firmware_seen = False
-        for seg_index, raw_segment in enumerate(segments):
+        for seg_index, segment in enumerate(segments):
             seg_prefix = f"{prefix}.segments[{seg_index}]"
-            if not isinstance(raw_segment, dict):
-                errors.append(f"{seg_prefix} must be an object")
-                continue
-
-            file_name = raw_segment.get("file")
-            offset = raw_segment.get("offset")
-            sha256 = raw_segment.get("sha256")
-            if not isinstance(file_name, str) or not file_name:
+            file_name = segment.file
+            offset = segment.offset
+            sha256 = segment.sha256
+            if not file_name:
                 errors.append(f"{seg_prefix}.file must be a non-empty string")
                 continue
-            if not isinstance(offset, str) or not offset.startswith("0x"):
+            if not offset.startswith("0x"):
                 errors.append(f"{seg_prefix}.offset must be a hex string")
-            if not isinstance(sha256, str) or len(sha256) != 64:
+            if len(sha256) != 64:
                 errors.append(f"{seg_prefix}.sha256 must be a 64-character hex digest")
 
             artifact_path = dist_dir / file_name


### PR DESCRIPTION
medium

## what changed
- add shared msgspec record types for firmware manifest and bundle metadata
- move runtime bundle manifest/meta reads onto one canonical msgspec decode path
- make release validation reuse the same manifest boundary instead of hand-walking json
- add focused firmware bundle tests plus release-validation cases for malformed json, missing required fields, and checksum mismatch

## why
- flash.json and _meta.json are repo-owned stable file boundaries
- runtime bundle loading and release validation had drifted into separate json parsing rules
- one typed boundary cuts duplicate field walking and keeps boundary changes in one place

## validation
- ruff check + format check on touched files
- python3 -m py_compile on touched files
- local backend execution blocked here: host lacks python 3.13 and docker daemon access
- PR CI is the real 3.13 execution gate

## risks tradeoffs edge
- runtime bundle parsing still filters invalid envs and segments like before; strict field errors stay in release validation
- malformed non-object manifest/meta roots surface as explicit boundary errors
- flash.json gets a symmetric msgspec encode helper even though runtime only reads it today

Closes #2894