### PR TITLE
refactor(runs): use msgspec run-log codecs

### DIFF
--- a/apps/server/tests/shared/boundaries/test_run_metadata_codec.py
+++ b/apps/server/tests/shared/boundaries/test_run_metadata_codec.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import msgspec
+
 from vibesensor.shared.boundaries.runs.metadata import (
+    run_metadata_from_json,
     run_metadata_from_mapping,
+    run_metadata_to_json_bytes,
     run_metadata_to_json_object,
 )
 
@@ -38,3 +42,45 @@ def test_run_metadata_codec_roundtrip_uses_nested_symptom_and_reference_context(
     assert "symptom_onset" not in payload
     assert "symptom_context" not in payload
     assert "tire_circumference_m" not in payload
+
+
+def test_run_metadata_msgspec_codec_roundtrip_preserves_nested_fields() -> None:
+    metadata = run_metadata_from_mapping(
+        {
+            "run_id": "run-msgspec",
+            "start_time_utc": "2026-01-01T00:00:00Z",
+            "sensor_model": "ADXL345",
+            "symptom": {
+                "description": "whine under load",
+                "onset": "after 60 km/h",
+                "context": "during acceleration",
+            },
+            "reference_context": {"tire_circumference_m": 2.2},
+        }
+    )
+
+    decoded = run_metadata_from_json(run_metadata_to_json_bytes(metadata))
+
+    assert decoded.run_id == "run-msgspec"
+    assert decoded.symptom is not None
+    assert decoded.symptom.description == "whine under load"
+    assert decoded.symptom.onset == "after 60 km/h"
+    assert decoded.symptom.context == "during acceleration"
+    assert decoded.wheel_circumference_m == 2.2
+
+
+def test_run_metadata_from_json_tolerates_legacy_non_string_record_type() -> None:
+    decoded = run_metadata_from_json(
+        msgspec.json.encode(
+            {
+                "record_type": 123,
+                "schema_version": "v2-jsonl",
+                "run_id": "legacy-run",
+                "start_time_utc": "2026-01-01T00:00:00Z",
+                "sensor_model": "ADXL345",
+            }
+        )
+    )
+
+    assert decoded.record_type == "run_metadata"
+    assert decoded.run_id == "legacy-run"

--- a/apps/server/vibesensor/shared/boundaries/runs/log.py
+++ b/apps/server/vibesensor/shared/boundaries/runs/log.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -49,7 +50,7 @@ class RunData:
     source_path: Path
 
 
-def normalize_sample_record(record: dict[str, object]) -> SensorFrame:
+def normalize_sample_record(record: Mapping[str, object]) -> SensorFrame:
     """Normalize a raw sample payload into the canonical typed sample object."""
 
     return sensor_frame_from_mapping(record, strict=True, source="jsonl sample")

--- a/apps/server/vibesensor/shared/boundaries/runs/log.py
+++ b/apps/server/vibesensor/shared/boundaries/runs/log.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
 
-from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+import msgspec
+
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_json
 from vibesensor.shared.boundaries.sensor_frames import (
     SensorFrameDecodeError,
     sensor_frame_from_mapping,
 )
+from vibesensor.shared.types.json_types import is_json_object
 from vibesensor.shared.types.run_schema import (
     RUN_END_TYPE,
     RUN_METADATA_TYPE,
@@ -31,6 +33,13 @@ __all__ = [
 LOGGER = logging.getLogger(__name__)
 
 
+class _RunEndRecord(msgspec.Struct, kw_only=True, frozen=True):
+    """Typed run-end record used for tolerant end-time backfill."""
+
+    record_type: str = RUN_END_TYPE
+    end_time_utc: object = None
+
+
 @dataclass(slots=True)
 class RunData:
     """Parsed contents of a JSONL run file: metadata, samples, and source path."""
@@ -46,16 +55,28 @@ def normalize_sample_record(record: dict[str, object]) -> SensorFrame:
     return sensor_frame_from_mapping(record, strict=True, source="jsonl sample")
 
 
+def _run_end_record_from_json(data: str | bytes | bytearray) -> _RunEndRecord:
+    """Decode a run-end record through msgspec while tolerating legacy-like shapes."""
+
+    try:
+        return msgspec.json.decode(data, type=_RunEndRecord)
+    except msgspec.ValidationError:
+        payload = msgspec.json.decode(data)
+    if not is_json_object(payload):
+        raise TypeError("run end JSON must decode to an object")
+    return _RunEndRecord(end_time_utc=payload.get("end_time_utc"))
+
+
 def read_jsonl_run(path: Path) -> RunData:
     """Read a JSONL run file and return parsed metadata and sample records."""
     if not path.exists():
         raise FileNotFoundError(path)
 
     metadata: RunMetadata | None = None
-    end_record: dict[str, object] | None = None
+    end_record: _RunEndRecord | None = None
     samples: list[SensorFrame] = []
     skipped = 0
-    _loads = json.loads
+    _decode = msgspec.json.decode
     _meta_type = RUN_METADATA_TYPE
     _sample_type = RUN_SAMPLE_TYPE
     _end_type = RUN_END_TYPE
@@ -66,8 +87,8 @@ def read_jsonl_run(path: Path) -> RunData:
             if not text:
                 continue
             try:
-                payload = _loads(text)
-            except json.JSONDecodeError as exc:
+                payload = _decode(text)
+            except msgspec.DecodeError as exc:
                 LOGGER.warning(
                     "Skipping corrupt JSONL line %d in %s: %s",
                     line_no,
@@ -76,11 +97,11 @@ def read_jsonl_run(path: Path) -> RunData:
                 )
                 skipped += 1
                 continue
-            if not isinstance(payload, dict):
+            if not is_json_object(payload):
                 continue
             record_type = str(payload.get("record_type", ""))
             if record_type == _meta_type and metadata is None:
-                metadata = run_metadata_from_mapping(payload)
+                metadata = run_metadata_from_json(text)
             elif record_type == _meta_type:
                 LOGGER.warning(
                     "Duplicate metadata record at line %d in %s; ignoring",
@@ -100,7 +121,7 @@ def read_jsonl_run(path: Path) -> RunData:
                     )
                     skipped += 1
             elif record_type == _end_type:
-                end_record = payload
+                end_record = _run_end_record_from_json(text)
 
     if skipped:
         LOGGER.warning("Skipped %d corrupt line(s) while reading %s", skipped, path)
@@ -109,7 +130,7 @@ def read_jsonl_run(path: Path) -> RunData:
     if not metadata.run_id:
         raise ValueError(f"Run metadata in {path} is missing required 'run_id' field")
     if end_record and not metadata.end_time_utc:
-        end_time = end_record.get("end_time_utc")
+        end_time = end_record.end_time_utc
         if end_time:
             metadata.end_time_utc = str(end_time)
         else:

--- a/apps/server/vibesensor/shared/boundaries/runs/metadata.py
+++ b/apps/server/vibesensor/shared/boundaries/runs/metadata.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 
+import msgspec
+
 from vibesensor.domain import Symptom
 from vibesensor.shared.boundaries.codecs import (
     analysis_settings_snapshot_from_mapping,
@@ -17,7 +19,7 @@ from vibesensor.shared.boundaries.runs.car import (
 )
 from vibesensor.shared.json_utils import as_float_or_none, as_int_or_none
 from vibesensor.shared.time_utils import coerce_utc_offset_seconds
-from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.json_types import JsonObject, is_json_object
 from vibesensor.shared.types.run_schema import (
     PEAK_PICKER_METHOD,
     RUN_METADATA_TYPE,
@@ -26,11 +28,53 @@ from vibesensor.shared.types.run_schema import (
 )
 
 __all__ = [
+    "run_metadata_from_json",
     "run_metadata_from_mapping",
+    "run_metadata_to_json_bytes",
     "run_metadata_to_json_object",
 ]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _RunMetadataRecord(msgspec.Struct, kw_only=True, frozen=True):
+    """Msgspec-owned run metadata record for persisted JSONL envelopes."""
+
+    record_type: str = RUN_METADATA_TYPE
+    schema_version: str = RUN_SCHEMA_VERSION
+    run_id: object = ""
+    start_time_utc: object = ""
+    end_time_utc: object = None
+    sensor_model: object = "unknown"
+    firmware_version: object = None
+    raw_sample_rate_hz: object = None
+    feature_interval_s: object = None
+    fft_window_size_samples: object = None
+    fft_window_type: object = None
+    peak_picker_method: object = PEAK_PICKER_METHOD
+    accel_scale_g_per_lsb: object = None
+    incomplete_for_order_analysis: object = False
+    analysis_settings_snapshot: object = None
+    active_car_snapshot: object = None
+    case_id: object = ""
+    sensor_mac: object = None
+    symptom: object = None
+    report_date: object = None
+    language: object = "en"
+    reference_context: object = None
+    recorded_utc_offset_seconds: object = None
+
+
+def run_metadata_from_json(data: str | bytes | bytearray) -> RunMetadata:
+    """Decode persisted metadata JSON through the canonical msgspec boundary."""
+
+    try:
+        payload = msgspec.to_builtins(msgspec.json.decode(data, type=_RunMetadataRecord))
+    except msgspec.ValidationError:
+        payload = msgspec.json.decode(data)
+    if not is_json_object(payload):
+        raise TypeError("run metadata JSON must decode to an object")
+    return run_metadata_from_mapping(payload)
 
 
 def run_metadata_from_mapping(data: Mapping[str, object]) -> RunMetadata:
@@ -105,6 +149,17 @@ def run_metadata_to_json_object(metadata: RunMetadata) -> JsonObject:
     if metadata.recorded_utc_offset_seconds is not None:
         payload["recorded_utc_offset_seconds"] = metadata.recorded_utc_offset_seconds
     return payload
+
+
+def run_metadata_to_json_bytes(metadata: RunMetadata) -> bytes:
+    """Encode typed run metadata through the canonical msgspec boundary."""
+
+    record = msgspec.convert(
+        run_metadata_to_json_object(metadata),
+        type=_RunMetadataRecord,
+        strict=False,
+    )
+    return msgspec.json.encode(record)
 
 
 def _normalized_language(value: object) -> str:


### PR DESCRIPTION
## What changed
- move JSONL line parsing in `read_jsonl_run()` from `json.loads()` to msgspec decode
- add msgspec-owned metadata codecs in `runs/metadata.py` and a typed run-end record helper
- keep sample normalization on `sensor_frame_from_mapping(..., strict=True)` so the numeric sample path and file format stay unchanged

## Why
- issue #2895 wants the run-log boundary to own typed msgspec decoding for structured records
- this cuts loose dict parsing without making historical run loading less tolerant

## Validation
- `.venv-cto/bin/python -m ruff check apps/server/vibesensor/shared/boundaries/runs/log.py apps/server/vibesensor/shared/boundaries/runs/metadata.py apps/server/tests/shared/boundaries/test_run_metadata_codec.py`
- `python3 -m py_compile apps/server/vibesensor/shared/boundaries/runs/log.py apps/server/vibesensor/shared/boundaries/runs/metadata.py apps/server/tests/shared/boundaries/test_run_metadata_codec.py`
- `python3 -m pytest -q -o addopts='' apps/server/tests/shared/boundaries/test_run_metadata_codec.py apps/server/tests/shared/boundaries/test_run_log.py` *(blocked locally: repo imports Python 3.13-only syntax while this host provides Python 3.11)*

## Risk / tradeoffs
- metadata and end records now get a typed msgspec decode when encountered, while the hot sample path stays on the existing sample boundary for clarity and compatibility
- legacy-like metadata with non-string `record_type` still falls back to the existing mapping normalization path

Closes #2895
