### PR TITLE
refactor(updates): type wheel snapshot IO

### DIFF
--- a/apps/server/tests/use_cases/updates/test_update_installer_verification.py
+++ b/apps/server/tests/use_cases/updates/test_update_installer_verification.py
@@ -481,6 +481,65 @@ async def test_install_release_rejects_incompatible_environment_before_pip_insta
 
 
 @pytest.mark.asyncio
+async def test_install_release_reports_malformed_dependency_snapshot_stdout(
+    tmp_path: Path,
+) -> None:
+    installer, commands, tracker = _make_installer(tmp_path)
+    wheel_path = tmp_path / "vibesensor-2025.6.15-py3-none-any.whl"
+    _build_fake_wheel(
+        wheel_path,
+        version="2025.6.15",
+        requires_dist=("missingdep>=1",),
+    )
+    commands.set_response("missingdep", 0, "{not-json", "")
+
+    result = await installer.install_release(wheel_path, "2025.6.15")
+
+    assert result == WheelInstallResult(succeeded=False, rollback_required=False)
+    assert tracker.status.state.value == "failed"
+    assert any(
+        issue.message == "Could not parse wheel dependency compatibility results"
+        and "{not-json" in issue.detail
+        for issue in tracker.status.issues
+    )
+    assert not any(
+        "pip install --force-reinstall --no-deps" in " ".join(call[0]) for call in commands.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_install_release_reports_wrong_shape_dependency_snapshot_stdout(
+    tmp_path: Path,
+) -> None:
+    installer, commands, tracker = _make_installer(tmp_path)
+    wheel_path = tmp_path / "vibesensor-2025.6.15-py3-none-any.whl"
+    _build_fake_wheel(
+        wheel_path,
+        version="2025.6.15",
+        requires_dist=("missingdep>=1",),
+    )
+    commands.set_response(
+        "missingdep",
+        0,
+        '{"python_full_version":"3.13.5","marker_environment":[],"installed_versions":{}}\n',
+        "",
+    )
+
+    result = await installer.install_release(wheel_path, "2025.6.15")
+
+    assert result == WheelInstallResult(succeeded=False, rollback_required=False)
+    assert tracker.status.state.value == "failed"
+    assert any(
+        issue.message == "Could not parse wheel dependency compatibility results"
+        and "marker_environment" in issue.detail
+        for issue in tracker.status.issues
+    )
+    assert not any(
+        "pip install --force-reinstall --no-deps" in " ".join(call[0]) for call in commands.calls
+    )
+
+
+@pytest.mark.asyncio
 async def test_wheel_install_executor_only_requests_rollback_after_mutating_failure(
     tmp_path: Path,
 ) -> None:

--- a/apps/server/vibesensor/use_cases/updates/wheel_installation.py
+++ b/apps/server/vibesensor/use_cases/updates/wheel_installation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -71,11 +72,11 @@ _TARGET_ENV_SNAPSHOT_SCRIPT = "\n".join(
 )
 
 
-def _target_environment_snapshot_request_json(distribution_names: list[str]) -> str:
+def _target_environment_snapshot_request_json(distribution_names: Sequence[str]) -> str:
     """Encode the target-environment snapshot request as one JSON CLI argument."""
 
     return msgspec.json.encode(
-        _TargetEnvironmentSnapshotRequest(distribution_names=distribution_names)
+        _TargetEnvironmentSnapshotRequest(distribution_names=list(distribution_names))
     ).decode("utf-8")
 
 

--- a/apps/server/vibesensor/use_cases/updates/wheel_installation.py
+++ b/apps/server/vibesensor/use_cases/updates/wheel_installation.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from pathlib import Path
 
+import msgspec
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
@@ -18,17 +18,38 @@ from vibesensor.use_cases.updates.runner import UpdateCommandExecutor
 from vibesensor.use_cases.updates.status import UpdateStatusTracker
 from vibesensor.use_cases.updates.venv_paths import reinstall_python_executable
 
+
+class _TargetEnvironmentSnapshotRequest(msgspec.Struct, kw_only=True, frozen=True):
+    """Typed request passed to the target-environment snapshot subprocess."""
+
+    distribution_names: list[str]
+
+
+class _TargetEnvironmentSnapshotResponse(msgspec.Struct, kw_only=True, frozen=True):
+    """Typed response returned by the target-environment snapshot subprocess."""
+
+    python_full_version: str
+    marker_environment: dict[str, str]
+    installed_versions: dict[str, str]
+
+
 _TARGET_ENV_SNAPSHOT_SCRIPT = "\n".join(
     [
         "import importlib.metadata as metadata",
-        "import json",
+        "import msgspec",
         "import sys",
         "from packaging.markers import default_environment",
         "from packaging.utils import canonicalize_name",
-        "payload = json.loads(sys.argv[1])",
+        "class TargetEnvironmentSnapshotRequest(msgspec.Struct, kw_only=True, frozen=True):",
+        "    distribution_names: list[str]",
+        "class TargetEnvironmentSnapshotResponse(msgspec.Struct, kw_only=True, frozen=True):",
+        "    python_full_version: str",
+        "    marker_environment: dict[str, str]",
+        "    installed_versions: dict[str, str]",
+        "payload = msgspec.json.decode(sys.argv[1], type=TargetEnvironmentSnapshotRequest)",
         "distribution_names = [",
         "    canonicalize_name(str(name))",
-        "    for name in payload.get('distribution_names', [])",
+        "    for name in payload.distribution_names",
         "]",
         "installed_versions = {}",
         "for distribution_name in distribution_names:",
@@ -37,13 +58,33 @@ _TARGET_ENV_SNAPSHOT_SCRIPT = "\n".join(
         "    except metadata.PackageNotFoundError:",
         "        installed_versions[distribution_name] = ''",
         "marker_environment = default_environment()",
-        "print(json.dumps({",
-        "    'python_full_version': marker_environment.get('python_full_version', ''),",
-        "    'marker_environment': marker_environment,",
-        "    'installed_versions': installed_versions,",
-        "}))",
+        "response = TargetEnvironmentSnapshotResponse(",
+        "    python_full_version=marker_environment.get('python_full_version', ''),",
+        "    marker_environment={",
+        "        str(key): str(value) for key, value in marker_environment.items()",
+        "    },",
+        "    installed_versions=installed_versions,",
+        ")",
+        "sys.stdout.buffer.write(msgspec.json.encode(response))",
+        "sys.stdout.buffer.write(b'\\n')",
     ],
 )
+
+
+def _target_environment_snapshot_request_json(distribution_names: list[str]) -> str:
+    """Encode the target-environment snapshot request as one JSON CLI argument."""
+
+    return msgspec.json.encode(
+        _TargetEnvironmentSnapshotRequest(distribution_names=distribution_names)
+    ).decode("utf-8")
+
+
+def _target_environment_snapshot_response_from_json(
+    raw: bytes | str,
+) -> _TargetEnvironmentSnapshotResponse:
+    """Decode one target-environment snapshot response from subprocess stdout."""
+
+    return msgspec.json.decode(raw, type=_TargetEnvironmentSnapshotResponse)
 
 
 @dataclass(frozen=True, slots=True)
@@ -201,7 +242,7 @@ class WheelInstallExecutor:
                 venv_python,
                 "-c",
                 _TARGET_ENV_SNAPSHOT_SCRIPT,
-                json.dumps({"distribution_names": requirement_names}),
+                _target_environment_snapshot_request_json(requirement_names),
             ],
             phase="installing",
             timeout=30,
@@ -219,22 +260,8 @@ class WheelInstallExecutor:
             self._status.mark_failed()
             return False
         try:
-            snapshot = json.loads(dependency_check.stdout or "{}")
-        except json.JSONDecodeError:
-            self._status.add_issue(
-                "installing",
-                "Could not parse wheel dependency compatibility results",
-                dependency_check.stdout or dependency_check.stderr,
-            )
-            self._status.mark_failed()
-            return False
-
-        marker_environment_raw = snapshot.get("marker_environment", {})
-        installed_versions_raw = snapshot.get("installed_versions", {})
-        if not isinstance(marker_environment_raw, dict) or not isinstance(
-            installed_versions_raw,
-            dict,
-        ):
+            snapshot = _target_environment_snapshot_response_from_json(dependency_check.stdout)
+        except (msgspec.DecodeError, msgspec.ValidationError):
             self._status.add_issue(
                 "installing",
                 "Could not parse wheel dependency compatibility results",
@@ -244,17 +271,9 @@ class WheelInstallExecutor:
             return False
         issues = wheel_dependency_issues(
             metadata,
-            python_full_version=str(snapshot.get("python_full_version") or ""),
-            marker_environment={
-                str(key): str(value)
-                for key, value in marker_environment_raw.items()
-                if isinstance(key, str)
-            },
-            installed_versions={
-                str(key): str(value)
-                for key, value in installed_versions_raw.items()
-                if isinstance(key, str)
-            },
+            python_full_version=snapshot.python_full_version,
+            marker_environment=snapshot.marker_environment,
+            installed_versions=snapshot.installed_versions,
         )
         if issues:
             self._status.add_issue(


### PR DESCRIPTION
## What changed
- replace the wheel-install target-environment subprocess request/response with typed msgspec structs
- switch the embedded snapshot helper script from `json.loads`/`json.dumps` to msgspec encode/decode
- remove the parent-side manual dict extraction for `python_full_version`, `marker_environment`, and `installed_versions`
- add updater verification tests for malformed snapshot stdout and wrong-shape snapshot stdout

## Why
- issue #2896 wants the wheel-install compatibility snapshot boundary to be msgspec-owned on both sides
- this keeps the subprocess flow but removes the loose post-decode dict handling from a tiny stable contract we fully own

## Validation
- `.venv-cto/bin/python -m ruff check apps/server/vibesensor/use_cases/updates/wheel_installation.py apps/server/tests/use_cases/updates/test_update_installer_verification.py`
- `python3 -m py_compile apps/server/vibesensor/use_cases/updates/wheel_installation.py apps/server/tests/use_cases/updates/test_update_installer_verification.py`
- `python3 -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/test_update_installer_verification.py` *(blocked locally: repo tests import Python 3.13-only syntax while this host provides Python 3.11)*

## Risk / tradeoffs
- wrong-shape snapshot stdout now fails at the msgspec boundary instead of drifting into loose dict defaults
- dependency compatibility policy and subprocess execution flow stay unchanged

Closes #2896
