### PR TITLE
refactor(updates): type sidecar state files

### DIFF
--- a/apps/server/tests/adapters/hotspot/test_hotspot_parsers.py
+++ b/apps/server/tests/adapters/hotspot/test_hotspot_parsers.py
@@ -270,3 +270,15 @@ class TestHealStateStore:
         assert store1.allow("restart", min_interval_s=9999) is True
         store2 = HealStateStore(state_path)
         assert store2.allow("restart", min_interval_s=9999) is False
+
+    def test_partial_state_file_keeps_numeric_entries(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "state.json"
+        state_path.write_text(
+            '{"restart": 9999999999, "reload": "bad", "reassociate": [1]}\n',
+            encoding="utf-8",
+        )
+        store = HealStateStore(state_path)
+
+        assert store.allow("restart", min_interval_s=9999) is False
+        assert store.allow("reload", min_interval_s=60) is True
+        assert store.allow("reassociate", min_interval_s=60) is True

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -352,6 +352,37 @@ class TestUpdateManagerAsync:
 
         assert details.version == "2026.3.29"
 
+    async def test_runtime_details_ignore_corrupt_ui_build_metadata(self, tmp_path) -> None:
+        manager, _runner, repo = setup_update_env(tmp_path)
+        seed_runtime_artifacts(repo, manager)
+        metadata_path = (
+            repo / "apps" / "server" / "vibesensor" / "static" / ".vibesensor-ui-build.json"
+        )
+        metadata_path.write_text("{not-json", encoding="utf-8")
+
+        details = collect_runtime_details(repo)
+
+        assert details.static_build_source_hash == ""
+        assert details.static_build_commit == ""
+        assert details.assets_verified is False
+
+    async def test_runtime_details_default_blank_for_missing_ui_build_metadata_fields(
+        self,
+        tmp_path,
+    ) -> None:
+        manager, _runner, repo = setup_update_env(tmp_path)
+        seed_runtime_artifacts(repo, manager)
+        metadata_path = (
+            repo / "apps" / "server" / "vibesensor" / "static" / ".vibesensor-ui-build.json"
+        )
+        metadata_path.write_text('{"static_assets_hash":"assets-only"}\n', encoding="utf-8")
+
+        details = collect_runtime_details(repo)
+
+        assert details.static_build_source_hash == ""
+        assert details.static_build_commit == ""
+        assert details.assets_verified is False
+
     async def test_usb_internet_happy_path_skips_hotspot_handover(self, tmp_path) -> None:
         usb_service = _StaticUsbInternetService(
             UsbInternetStatus(

--- a/apps/server/vibesensor/adapters/hotspot/parsers.py
+++ b/apps/server/vibesensor/adapters/hotspot/parsers.py
@@ -6,11 +6,12 @@ and have no dependencies on runner/subprocess infrastructure.
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 import time
 from pathlib import Path
+
+import msgspec
 
 LOGGER = logging.getLogger(__name__)
 
@@ -137,11 +138,13 @@ class HealStateStore:
         if not self._path.exists():
             return {}
         try:
-            data = json.loads(self._path.read_text(encoding="utf-8"))
-            if not isinstance(data, dict):
-                return {}
-            return {str(k): float(v) for k, v in data.items() if isinstance(v, (int, float))}
-        except (json.JSONDecodeError, OSError, ValueError):
+            data = msgspec.json.decode(self._path.read_bytes(), type=dict[str, object])
+            return {
+                key: float(value)
+                for key, value in data.items()
+                if isinstance(value, (int, float))
+            }
+        except (msgspec.DecodeError, msgspec.ValidationError, OSError, ValueError):
             LOGGER.warning(
                 "HealStateStore: ignoring corrupt state file %s",
                 self._path,
@@ -151,7 +154,7 @@ class HealStateStore:
 
     def _save(self, data: dict[str, float]) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+        self._path.write_bytes(msgspec.json.encode(data) + b"\n")
 
     def allow(self, key: str, min_interval_s: int) -> bool:
         """Return ``True`` and record the action timestamp if the cooldown has passed.

--- a/apps/server/vibesensor/adapters/hotspot/parsers.py
+++ b/apps/server/vibesensor/adapters/hotspot/parsers.py
@@ -140,9 +140,7 @@ class HealStateStore:
         try:
             data = msgspec.json.decode(self._path.read_bytes(), type=dict[str, object])
             return {
-                key: float(value)
-                for key, value in data.items()
-                if isinstance(value, (int, float))
+                key: float(value) for key, value in data.items() if isinstance(value, (int, float))
             }
         except (msgspec.DecodeError, msgspec.ValidationError, OSError, ValueError):
             LOGGER.warning(

--- a/apps/server/vibesensor/use_cases/updates/status/runtime_details.py
+++ b/apps/server/vibesensor/use_cases/updates/status/runtime_details.py
@@ -3,18 +3,39 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import subprocess
 from pathlib import Path
 
-from vibesensor.shared.types.json_types import JsonObject, is_json_object
+import msgspec
+
 from vibesensor.use_cases.updates.models import UpdateRuntimeDetails
 
 LOGGER = logging.getLogger(__name__)
 
 UI_BUILD_METADATA_FILE = ".vibesensor-ui-build.json"
 _PACKAGED_STATIC_DIR = Path(__file__).resolve().parents[3] / "static"
+
+
+class _UiBuildMetadataRecord(msgspec.Struct, kw_only=True, frozen=True):
+    """Typed runtime-details sidecar record stored beside built static assets."""
+
+    ui_source_hash: object = ""
+    static_assets_hash: object = ""
+    git_commit: object = ""
+
+
+def _ui_build_metadata_from_json(raw: bytes | str) -> _UiBuildMetadataRecord:
+    """Decode one UI build sidecar payload with current fallback semantics."""
+
+    try:
+        return msgspec.json.decode(raw, type=_UiBuildMetadataRecord)
+    except (msgspec.DecodeError, msgspec.ValidationError, TypeError):
+        return _UiBuildMetadataRecord()
+
+
+def _ui_build_metadata_text(value: object) -> str:
+    return str(value or "")
 
 
 def hash_tree(root: Path, *, ignore_names: set[str]) -> str:
@@ -77,17 +98,16 @@ def collect_runtime_details(repo: Path) -> UpdateRuntimeDetails:
     )
     static_assets_hash = hash_tree(static_root, ignore_names={UI_BUILD_METADATA_FILE})
 
-    metadata: JsonObject = {}
+    metadata = _UiBuildMetadataRecord()
     if metadata_path.is_file():
         try:
-            loaded = json.loads(metadata_path.read_text(encoding="utf-8"))
-            metadata = loaded if is_json_object(loaded) else {}
-        except (OSError, json.JSONDecodeError):
-            metadata = {}
+            metadata = _ui_build_metadata_from_json(metadata_path.read_bytes())
+        except OSError:
+            metadata = _UiBuildMetadataRecord()
 
-    static_build_source_hash = str(metadata.get("ui_source_hash") or "")
-    static_build_assets_hash = str(metadata.get("static_assets_hash") or "")
-    static_build_commit = str(metadata.get("git_commit") or "")
+    static_build_source_hash = _ui_build_metadata_text(metadata.ui_source_hash)
+    static_build_assets_hash = _ui_build_metadata_text(metadata.static_assets_hash)
+    static_build_commit = _ui_build_metadata_text(metadata.git_commit)
     has_repo_static = static_root.exists()
     assets_verified = (
         bool(ui_source_hash)

--- a/tools/build_ui_static.py
+++ b/tools/build_ui_static.py
@@ -10,13 +10,22 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 import shutil
 import subprocess
 from pathlib import Path
 
+import msgspec
+
 # Keep in sync with vibesensor.use_cases.updates.status.UI_BUILD_METADATA_FILE
 UI_BUILD_METADATA_FILE = ".vibesensor-ui-build.json"
+
+
+class _UiBuildMetadataRecord(msgspec.Struct, kw_only=True, frozen=True):
+    """Local copy of the updater UI build metadata sidecar contract."""
+
+    ui_source_hash: str
+    static_assets_hash: str
+    git_commit: str
 
 
 def _hash_tree(root: Path, *, ignore_names: set[str]) -> str:
@@ -122,17 +131,16 @@ def main(argv: list[str] | None = None) -> None:
     )
     static_assets_hash = _hash_tree(static_dir, ignore_names={UI_BUILD_METADATA_FILE})
     git_commit = _git_head_commit(repo_root)
-    (static_dir / UI_BUILD_METADATA_FILE).write_text(
-        json.dumps(
-            {
-                "ui_source_hash": ui_source_hash,
-                "static_assets_hash": static_assets_hash,
-                "git_commit": git_commit,
-            },
-            sort_keys=True,
+    # Keep this local codec in sync with updates.status.runtime_details.py.
+    (static_dir / UI_BUILD_METADATA_FILE).write_bytes(
+        msgspec.json.encode(
+            _UiBuildMetadataRecord(
+                ui_source_hash=ui_source_hash,
+                static_assets_hash=static_assets_hash,
+                git_commit=git_commit,
+            )
         )
-        + "\n",
-        encoding="utf-8",
+        + b"\n",
     )
     print(f"Synced {dist_dir} -> {static_dir}")
 


### PR DESCRIPTION
## What changed
- move updater runtime-details UI build sidecar decode onto a typed msgspec record
- switch `tools/build_ui_static.py` to write the same `.vibesensor-ui-build.json` contract via msgspec
- move hotspot `HealStateStore` load/save onto msgspec while keeping corrupt-file fallback and partial numeric-entry filtering
- add focused tests for corrupt/missing UI build metadata and partially invalid heal cooldown state

## Why
- issue #2897 targets two small internal sidecar files that are stable, repo-owned persistence edges
- this removes the remaining ad hoc JSON dict handling from those boundaries without changing file locations or operational behavior

## Validation
- `.venv-cto/bin/python -m ruff check apps/server/vibesensor/use_cases/updates/status/runtime_details.py apps/server/vibesensor/adapters/hotspot/parsers.py tools/build_ui_static.py apps/server/tests/use_cases/updates/test_update_manager_async.py apps/server/tests/adapters/hotspot/test_hotspot_parsers.py`
- `python3 -m py_compile apps/server/vibesensor/use_cases/updates/status/runtime_details.py apps/server/vibesensor/adapters/hotspot/parsers.py tools/build_ui_static.py apps/server/tests/use_cases/updates/test_update_manager_async.py apps/server/tests/adapters/hotspot/test_hotspot_parsers.py`
- `python3 -m pytest -q -o addopts='' apps/server/tests/use_cases/updates/test_update_manager_async.py apps/server/tests/adapters/hotspot/test_hotspot_parsers.py` *(blocked locally: repo tests import Python 3.13-only syntax while this host provides Python 3.11)*

## Risk / tradeoffs
- `.vibesensor-ui-build.json` now has one typed reader/writer contract across runtime and the standalone build tool
- heal cooldown files still ignore corrupt data and still drop invalid per-key values instead of failing the whole store

Closes #2897
