### PR TITLE
refactor(updates): share runtime httpx client

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
   "fastapi>=0.111,<1",
+  "httpx>=0.27,<1",
   "msgspec>=0.19,<1",
   "pydantic>=2.7,<3",
   "pydantic-settings>=2.10,<3",
@@ -32,7 +33,6 @@ esp = [
 dev = [
   "deptry>=0.25,<0.26",
   "hypothesis>=6.131,<7",
-  "httpx>=0.27,<1",
   "import-linter>=2.11,<3",
   "mypy>=1.19,<2",
   "pypdf>=5,<7",

--- a/apps/server/tests/integration/test_io_and_time_guard_regressions.py
+++ b/apps/server/tests/integration/test_io_and_time_guard_regressions.py
@@ -11,6 +11,7 @@ Covers:
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -98,16 +99,15 @@ class TestDownloadAssetFdLeakGuard:
 
         dest = tmp_path / "firmware.bin"
 
-        # Patch urlopen to provide a fake response, and os.fdopen to fail
+        # Patch the shared streaming helper to provide a fake response, and
+        # os.fdopen to fail.
         fake_resp = MagicMock()
-        fake_resp.read.return_value = b"data"
-        fake_resp.__enter__ = lambda s: s
-        fake_resp.__exit__ = lambda s, *a: None
+        fake_resp.iter_bytes.return_value = iter([b"data"])
 
         with (
             patch(
-                "vibesensor.use_cases.updates.asset_download.urlopen",
-                return_value=fake_resp,
+                "vibesensor.use_cases.updates.asset_download.stream_http_response",
+                return_value=nullcontext(fake_resp),
             ),
             patch("os.fdopen", side_effect=OSError("mock fdopen failure")),
             patch("os.close") as mock_close,

--- a/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
+++ b/apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -142,15 +143,13 @@ class TestFirmwareCacheStreamingDownload:
         dest = tmp_path / "firmware.bin"
         test_data = b"firmware_content_bytes_here"
 
-        # Mock urlopen to return test data
+        # Mock the shared streaming helper to return test data.
         mock_resp = MagicMock()
-        mock_resp.read.side_effect = [test_data, b""]
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = lambda s, *a: None
+        mock_resp.iter_bytes.return_value = iter([test_data])
 
         with patch(
-            "vibesensor.use_cases.updates.asset_download.urlopen",
-            return_value=mock_resp,
+            "vibesensor.use_cases.updates.asset_download.stream_http_response",
+            return_value=nullcontext(mock_resp),
         ):
             fetcher._download_asset("https://example.com/fw.bin", dest)
 

--- a/apps/server/tests/use_cases/updates/test_http_client.py
+++ b/apps/server/tests/use_cases/updates/test_http_client.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from vibesensor.use_cases.updates.http_client import (
+    build_get_request,
+    read_text_response,
+    stream_http_response,
+)
+from vibesensor.use_cases.updates.releases.github_api import GitHubApiClient
+
+
+def test_build_get_request_rejects_non_https_when_required() -> None:
+    with pytest.raises(ValueError, match="non-HTTPS"):
+        build_get_request(
+            "http://example.com/releases",
+            context="release",
+            require_https=True,
+        )
+
+
+def test_github_api_client_get_json_decodes_payload() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Accept"] == "application/vnd.github+json"
+        return httpx.Response(200, json={"ok": True}, request=request)
+
+    client = GitHubApiClient(transport=httpx.MockTransport(handler))
+
+    assert client.get_json("https://api.github.com/repos/owner/repo/releases") == {"ok": True}
+
+
+def test_github_api_client_get_json_maps_non_200_to_oserror() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="busy", request=request)
+
+    client = GitHubApiClient(transport=httpx.MockTransport(handler))
+
+    with pytest.raises(OSError, match="HTTP 503"):
+        client.get_json("https://api.github.com/repos/owner/repo/releases")
+
+
+def test_github_api_client_get_json_rejects_invalid_json() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"{not-json", request=request)
+
+    client = GitHubApiClient(transport=httpx.MockTransport(handler))
+
+    with pytest.raises(ValueError, match="invalid JSON"):
+        client.get_json("https://api.github.com/repos/owner/repo/releases")
+
+
+def test_read_text_response_returns_status_and_body_for_local_smoke_checks() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "http://127.0.0.1:8000/api/health"
+        return httpx.Response(
+            503,
+            headers={"Content-Type": "text/plain; charset=utf-8"},
+            text="booting",
+            request=request,
+        )
+
+    status, content_type, body = read_text_response(
+        "http://127.0.0.1:8000/api/health",
+        timeout_s=3.0,
+        context="release smoke",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert status == 503
+    assert content_type == "text/plain; charset=utf-8"
+    assert body == "booting"
+
+
+def test_stream_http_response_maps_timeout_to_oserror() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out", request=request)
+
+    with pytest.raises(OSError, match="timed out"):
+        with stream_http_response(
+            "https://api.github.com/repos/owner/repo/releases/assets/1",
+            timeout_s=30,
+            context="release asset",
+            require_https=True,
+            transport=httpx.MockTransport(handler),
+        ):
+            pytest.fail("stream should not succeed")

--- a/apps/server/vibesensor/use_cases/updates/asset_download.py
+++ b/apps/server/vibesensor/use_cases/updates/asset_download.py
@@ -7,18 +7,19 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Protocol
-from urllib.request import Request, urlopen
+
+from vibesensor.use_cases.updates.http_client import stream_http_response
 
 __all__ = ["download_release_asset"]
 
 
-class GitHubAssetRequestBuilder(Protocol):
-    def build_request(self, url: str, *, accept: str = "") -> Request: ...
+class GitHubAssetHeadersClient(Protocol):
+    def api_headers(self, *, accept: str = "") -> dict[str, str]: ...
 
 
 def download_release_asset(
     *,
-    client: GitHubAssetRequestBuilder,
+    client: GitHubAssetHeadersClient,
     url: str,
     dest: Path,
     timeout_s: float,
@@ -29,9 +30,14 @@ def download_release_asset(
 ) -> None:
     """Stream a GitHub release asset to *dest* with temp-file cleanup and a size bound."""
 
-    req = client.build_request(url, accept="application/octet-stream")
     dest.parent.mkdir(parents=True, exist_ok=True)
-    with urlopen(req, timeout=timeout_s) as resp:
+    with stream_http_response(
+        url,
+        headers=client.api_headers(accept="application/octet-stream"),
+        timeout_s=timeout_s,
+        context="release asset",
+        require_https=True,
+    ) as resp:
         tmp_fd, tmp_path = tempfile.mkstemp(dir=str(dest.parent), suffix=temp_suffix)
         fdopen_ok = False
         downloaded = False
@@ -39,10 +45,7 @@ def download_release_asset(
             total = 0
             with os.fdopen(tmp_fd, "wb") as tmp_f:
                 fdopen_ok = True
-                while True:
-                    chunk = resp.read(chunk_size)
-                    if not chunk:
-                        break
+                for chunk in resp.iter_bytes(chunk_size=chunk_size):
                     total += len(chunk)
                     if total > max_bytes:
                         raise ValueError(size_limit_message)

--- a/apps/server/vibesensor/use_cases/updates/http_client.py
+++ b/apps/server/vibesensor/use_cases/updates/http_client.py
@@ -1,0 +1,138 @@
+"""Canonical outbound HTTP helpers for updater and release runtime flows.
+
+Keep updater-owned HTTP call sites on these helpers so timeout, redirect,
+status, and error mapping stay consistent instead of re-creating low-level
+client plumbing at each boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+
+import httpx
+
+from vibesensor.shared.types.json_types import JsonValue
+
+__all__ = [
+    "build_get_request",
+    "read_json_response",
+    "read_text_response",
+    "stream_http_response",
+]
+
+
+def build_get_request(
+    url: str,
+    *,
+    headers: Mapping[str, str] | None = None,
+    context: str = "operation",
+    require_https: bool = False,
+) -> httpx.Request:
+    """Build a GET request after applying the shared runtime safety checks."""
+
+    if require_https and not url.startswith("https://"):
+        raise ValueError(f"Refusing non-HTTPS URL for {context}: {url}")
+    return httpx.Request("GET", url, headers=dict(headers or {}))
+
+
+def _http_error_as_oserror(exc: httpx.HTTPError, *, context: str, url: str) -> OSError:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return OSError(f"{context} request failed with HTTP {exc.response.status_code}: {url}")
+    return OSError(f"{context} request failed for {url}: {exc}")
+
+
+def _client(
+    *,
+    timeout_s: float,
+    transport: httpx.BaseTransport | None,
+) -> httpx.Client:
+    return httpx.Client(
+        follow_redirects=True,
+        timeout=timeout_s,
+        transport=transport,
+    )
+
+
+def read_json_response(
+    url: str,
+    *,
+    headers: Mapping[str, str] | None = None,
+    timeout_s: float,
+    context: str,
+    require_https: bool = False,
+    transport: httpx.BaseTransport | None = None,
+) -> JsonValue:
+    """GET *url* and decode the body as JSON."""
+
+    request = build_get_request(
+        url,
+        headers=headers,
+        context=context,
+        require_https=require_https,
+    )
+    try:
+        with _client(timeout_s=timeout_s, transport=transport) as client:
+            response = client.send(request)
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise _http_error_as_oserror(exc, context=context, url=url) from exc
+
+    try:
+        payload: JsonValue = json.loads(response.content)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{context} returned invalid JSON: {exc}") from exc
+    return payload
+
+
+def read_text_response(
+    url: str,
+    *,
+    headers: Mapping[str, str] | None = None,
+    timeout_s: float,
+    context: str,
+    require_https: bool = False,
+    transport: httpx.BaseTransport | None = None,
+) -> tuple[int, str, str]:
+    """GET *url* and return status, content type, and decoded body text."""
+
+    request = build_get_request(
+        url,
+        headers=headers,
+        context=context,
+        require_https=require_https,
+    )
+    try:
+        with _client(timeout_s=timeout_s, transport=transport) as client:
+            response = client.send(request)
+    except httpx.HTTPError as exc:
+        raise _http_error_as_oserror(exc, context=context, url=url) from exc
+    return response.status_code, response.headers.get("Content-Type", ""), response.text
+
+
+@contextmanager
+def stream_http_response(
+    url: str,
+    *,
+    headers: Mapping[str, str] | None = None,
+    timeout_s: float,
+    context: str,
+    require_https: bool = False,
+    transport: httpx.BaseTransport | None = None,
+) -> Iterator[httpx.Response]:
+    """Stream a successful GET response body for updater-owned callers."""
+
+    request = build_get_request(
+        url,
+        headers=headers,
+        context=context,
+        require_https=require_https,
+    )
+    try:
+        with _client(timeout_s=timeout_s, transport=transport) as client:
+            with client.stream("GET", request.url, headers=request.headers) as response:
+                response.raise_for_status()
+                yield response
+    except httpx.HTTPError as exc:
+        raise _http_error_as_oserror(exc, context=context, url=url) from exc

--- a/apps/server/vibesensor/use_cases/updates/releases/github_api.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/github_api.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
-from urllib.request import Request, urlopen
+
+import httpx
 
 from vibesensor.shared.types.json_types import JsonValue
+from vibesensor.use_cases.updates.http_client import build_get_request, read_json_response
 
 DOWNLOAD_CHUNK_BYTES = 1024 * 1024  # 1 MB per read()
 
@@ -21,8 +22,7 @@ __all__ = [
 def validate_https_url(url: str, *, context: str = "operation") -> None:
     """Raise ``ValueError`` if *url* does not use the HTTPS scheme."""
 
-    if not url.startswith("https://"):
-        raise ValueError(f"Refusing non-HTTPS URL for {context}: {url}")
+    build_get_request(url, context=context, require_https=True)
 
 
 def github_api_headers(
@@ -44,6 +44,7 @@ class GitHubApiClient:
 
     token: str = ""
     context: str = "github"
+    transport: httpx.BaseTransport | None = None
 
     def api_headers(self, *, accept: str = "application/vnd.github+json") -> dict[str, str]:
         return github_api_headers(self.token, accept=accept)
@@ -53,13 +54,22 @@ class GitHubApiClient:
         url: str,
         *,
         accept: str = "application/vnd.github+json",
-    ) -> Request:
-        validate_https_url(url, context=self.context)
-        return Request(url, headers=self.api_headers(accept=accept))
+    ) -> httpx.Request:
+        return build_get_request(
+            url,
+            headers=self.api_headers(accept=accept),
+            context=self.context,
+            require_https=True,
+        )
 
     def get_json(self, url: str) -> JsonValue:
         """GET *url* and return the parsed JSON response."""
 
-        with urlopen(self.build_request(url), timeout=30) as resp:
-            result: JsonValue = json.loads(resp.read().decode("utf-8"))
-            return result
+        return read_json_response(
+            url,
+            headers=self.api_headers(),
+            timeout_s=30,
+            context=self.context,
+            require_https=True,
+            transport=self.transport,
+        )

--- a/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
@@ -8,8 +8,6 @@ import json
 import subprocess
 import sys
 import tempfile
-import urllib.error
-import urllib.request
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -17,6 +15,7 @@ import msgspec
 from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
 from vibesensor.use_cases.updates.artifact_validation import wheel_metadata_validation_errors
+from vibesensor.use_cases.updates.http_client import read_text_response
 
 _RELEASE_SMOKE_RETRY_WAIT_S = 0.5
 
@@ -145,11 +144,12 @@ def validate_release_wheel_metadata(
 def _read_http(url: str) -> tuple[int, str, str]:
     """Fetch a URL and return status, content type, and decoded body text."""
 
-    request = urllib.request.Request(url, headers={"Connection": "close"})
-    with urllib.request.urlopen(request, timeout=3.0) as response:
-        body = response.read().decode("utf-8", errors="replace")
-        content_type = response.headers.get("Content-Type", "")
-        return response.status, content_type, body
+    return read_text_response(
+        url,
+        headers={"Connection": "close"},
+        timeout_s=3.0,
+        context="release smoke",
+    )
 
 
 def packaged_static_index_path() -> Path:
@@ -245,7 +245,6 @@ def run_server_smoke(
                         except (
                             OSError,
                             RuntimeError,
-                            urllib.error.URLError,
                             json.JSONDecodeError,
                         ) as exc:
                             last_error = exc


### PR DESCRIPTION
## What changed
- add a shared updater-owned `httpx` boundary in `use_cases/updates/http_client.py`
- move GitHub release JSON fetches, asset streaming, and release-smoke HTTP probes onto that boundary
- promote `httpx` from dev-only to a runtime dependency in `apps/server/pyproject.toml`
- add focused outbound-HTTP tests and update the asset-download regression seams to patch the shared helper instead of raw `urlopen`

## Why
- issue #2899 is about one repo-owned outbound HTTP client path for updater and release flows
- this removes repeated `urllib.request` plumbing and keeps timeout, redirect, and error mapping behavior in one owner

## Validation
- `.venv-cto/bin/python -m ruff check apps/server/vibesensor/use_cases/updates/http_client.py apps/server/vibesensor/use_cases/updates/releases/github_api.py apps/server/vibesensor/use_cases/updates/asset_download.py apps/server/vibesensor/use_cases/updates/releases/release_validation.py apps/server/tests/use_cases/updates/test_http_client.py apps/server/tests/integration/test_io_and_time_guard_regressions.py apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py apps/server/pyproject.toml`
- `python3 -m py_compile apps/server/vibesensor/use_cases/updates/http_client.py apps/server/vibesensor/use_cases/updates/releases/github_api.py apps/server/vibesensor/use_cases/updates/asset_download.py apps/server/vibesensor/use_cases/updates/releases/release_validation.py apps/server/tests/use_cases/updates/test_http_client.py apps/server/tests/integration/test_io_and_time_guard_regressions.py apps/server/tests/integration/test_runtime_nan_and_update_guard_regressions.py`
- `cd apps/server && python3 -m pytest -q -o addopts="" tests/use_cases/updates/test_http_client.py tests/use_cases/updates/releases/test_release_fetcher.py tests/use_cases/updates/releases/test_release_validation.py` *(blocked locally: `tests/conftest.py` imports Python 3.13-only syntax while this host is Python 3.11)*

## Risk / tradeoffs
- GitHub/update HTTP failures now flow through one shared `OSError` mapping instead of raw `urllib` exception types
- release-smoke still handles non-200 responses explicitly and still treats startup network failures as retryable
- follow-up issues #2900 and #2902 can now build on this shared boundary instead of repeating transport setup

Closes #2899
