### PR TITLE
refactor(simulator): use shared httpx helper

### DIFF
--- a/apps/server/tests/adapters/simulator/test_scripted_speed_sync.py
+++ b/apps/server/tests/adapters/simulator/test_scripted_speed_sync.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from urllib.error import URLError
-
 import pytest
 
 from vibesensor.adapters.simulator.scripted_speed_sync import (
@@ -27,7 +25,7 @@ async def test_apply_scripted_speed_disables_sync_after_handled_http_error(
         speed_kmh: float,
         timeout_s: float,
     ) -> float:
-        raise URLError("connection refused")
+        raise OSError("connection refused")
 
     monkeypatch.setattr(
         "vibesensor.adapters.simulator.scripted_speed_sync.set_server_speed_override_kmh",
@@ -45,7 +43,7 @@ async def test_apply_scripted_speed_disables_sync_after_handled_http_error(
 
     assert clients[0].current_speed_kmh == 42.0
     assert result.server_speed_sync_enabled is False
-    assert result.failure_message == speed_sync_disable_message(URLError("connection refused"))
+    assert result.failure_message == speed_sync_disable_message(OSError("connection refused"))
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/adapters/simulator/test_server_http.py
+++ b/apps/server/tests/adapters/simulator/test_server_http.py
@@ -1,44 +1,78 @@
-"""Simulator HTTP helper coverage for speed-override requests."""
+"""Simulator HTTP helper coverage for health checks and speed overrides."""
 
 from __future__ import annotations
 
 import json
-from urllib.request import Request
 
-from vibesensor.adapters.simulator.server_http import set_server_speed_override_kmh
+import pytest
+
+from vibesensor.adapters.simulator.server_http import (
+    check_server_running,
+    set_server_speed_override_kmh,
+)
 
 
-class _FakeResponse:
-    def __init__(self, payload: dict[str, object]) -> None:
-        self._payload = payload
+def test_check_server_running_returns_true_on_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "vibesensor.adapters.simulator.server_http.read_text_response",
+        lambda url, *, timeout_s, context: (200, "application/json", "{}"),
+    )
 
-    def __enter__(self) -> _FakeResponse:
-        return self
+    assert check_server_running("127.0.0.1", 8000, timeout_s=0.5) is True
 
-    def __exit__(self, exc_type, exc, tb) -> bool:
-        return False
 
-    def read(self) -> bytes:
-        return json.dumps(self._payload).encode("utf-8")
+def test_check_server_running_returns_false_on_non_200(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "vibesensor.adapters.simulator.server_http.read_text_response",
+        lambda url, *, timeout_s, context: (503, "text/plain", "booting"),
+    )
+
+    assert check_server_running("127.0.0.1", 8000, timeout_s=0.5) is False
+
+
+def test_check_server_running_returns_false_on_network_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_read_text_response(url, *, timeout_s, context):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(
+        "vibesensor.adapters.simulator.server_http.read_text_response",
+        fake_read_text_response,
+    )
+
+    assert check_server_running("127.0.0.1", 8000, timeout_s=0.5) is False
 
 
 def test_set_server_speed_override_uses_http_api_snake_case(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    def fake_urlopen(req: Request, timeout: float) -> _FakeResponse:
-        captured["url"] = req.full_url
-        captured["method"] = req.get_method()
-        captured["timeout"] = timeout
-        captured["body"] = json.loads(req.data.decode("utf-8"))
-        return _FakeResponse(
-            {
-                "speed_source": "manual",
-                "manual_speed_kph": 55.0,
-                "stale_timeout_s": 10.0,
-            }
-        )
+    def fake_read_json_response(
+        url: str,
+        *,
+        method: str,
+        headers: dict[str, str],
+        content: bytes,
+        timeout_s: float,
+        context: str,
+    ) -> dict[str, object]:
+        captured["url"] = url
+        captured["method"] = method
+        captured["timeout"] = timeout_s
+        captured["context"] = context
+        captured["body"] = json.loads(content.decode("utf-8"))
+        return {
+            "speed_source": "manual",
+            "manual_speed_kph": 55.0,
+            "stale_timeout_s": 10.0,
+        }
 
-    monkeypatch.setattr("vibesensor.adapters.simulator.server_http.urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        "vibesensor.adapters.simulator.server_http.read_json_response",
+        fake_read_json_response,
+    )
 
     applied = set_server_speed_override_kmh("127.0.0.1", 8000, 55.0, 1.5)
 
@@ -46,6 +80,30 @@ def test_set_server_speed_override_uses_http_api_snake_case(monkeypatch) -> None
         "url": "http://127.0.0.1:8000/api/settings/speed-source",
         "method": "PUT",
         "timeout": 1.5,
+        "context": "simulator speed override",
         "body": {"speed_source": "manual", "manual_speed_kph": 55.0},
     }
     assert applied == 55.0
+
+
+def test_set_server_speed_override_propagates_http_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_read_json_response(
+        url: str,
+        *,
+        method: str,
+        headers: dict[str, str],
+        content: bytes,
+        timeout_s: float,
+        context: str,
+    ) -> dict[str, object]:
+        raise OSError("HTTP 503")
+
+    monkeypatch.setattr(
+        "vibesensor.adapters.simulator.server_http.read_json_response",
+        fake_read_json_response,
+    )
+
+    with pytest.raises(OSError, match="HTTP 503"):
+        set_server_speed_override_kmh("127.0.0.1", 8000, 55.0, 1.5)

--- a/apps/server/tests/use_cases/updates/test_http_client.py
+++ b/apps/server/tests/use_cases/updates/test_http_client.py
@@ -5,6 +5,7 @@ import pytest
 
 from vibesensor.use_cases.updates.http_client import (
     build_get_request,
+    build_request,
     read_text_response,
     stream_http_response,
 )
@@ -18,6 +19,21 @@ def test_build_get_request_rejects_non_https_when_required() -> None:
             context="release",
             require_https=True,
         )
+
+
+def test_build_request_keeps_method_and_body_for_json_puts() -> None:
+    request = build_request(
+        "put",
+        "http://127.0.0.1:8000/api/settings/speed-source",
+        headers={"Content-Type": "application/json"},
+        content=b'{"speed_source":"manual"}',
+        context="simulator speed override",
+    )
+
+    assert request.method == "PUT"
+    assert str(request.url) == "http://127.0.0.1:8000/api/settings/speed-source"
+    assert request.headers["Content-Type"] == "application/json"
+    assert request.content == b'{"speed_source":"manual"}'
 
 
 def test_github_api_client_get_json_decodes_payload() -> None:
@@ -70,6 +86,32 @@ def test_read_text_response_returns_status_and_body_for_local_smoke_checks() -> 
     assert status == 503
     assert content_type == "text/plain; charset=utf-8"
     assert body == "booting"
+
+
+def test_read_text_response_supports_put_with_request_body() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["body"] = request.content
+        return httpx.Response(200, text="ok", request=request)
+
+    status, _content_type, body = read_text_response(
+        "http://127.0.0.1:8000/api/settings/speed-source",
+        method="PUT",
+        headers={"Content-Type": "application/json"},
+        content=b'{"speed_source":"manual"}',
+        timeout_s=3.0,
+        context="simulator speed override",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert captured == {
+        "method": "PUT",
+        "body": b'{"speed_source":"manual"}',
+    }
+    assert status == 200
+    assert body == "ok"
 
 
 def test_stream_http_response_maps_timeout_to_oserror() -> None:

--- a/apps/server/vibesensor/adapters/simulator/server_http.py
+++ b/apps/server/vibesensor/adapters/simulator/server_http.py
@@ -6,8 +6,8 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from urllib.error import URLError
-from urllib.request import Request, urlopen
+
+from vibesensor.use_cases.updates.http_client import read_json_response, read_text_response
 
 LOCAL_SERVER_HOSTS = {"127.0.0.1", "localhost", "0.0.0.0"}
 
@@ -27,9 +27,13 @@ def _speed_source_url(host: str, port: int) -> str:
 def check_server_running(host: str, port: int, timeout_s: float = 1.0) -> bool:
     url = server_health_url(host, port)
     try:
-        with urlopen(url, timeout=timeout_s) as resp:
-            return bool(resp.status == 200)
-    except (URLError, OSError, TimeoutError):
+        status, _content_type, _body = read_text_response(
+            url,
+            timeout_s=timeout_s,
+            context="simulator health check",
+        )
+        return status == 200
+    except OSError:
         return False
 
 
@@ -39,16 +43,15 @@ def set_server_speed_override_kmh(
     payload = json.dumps({"speed_source": "manual", "manual_speed_kph": float(speed_kmh)}).encode(
         "utf-8"
     )
-    req = Request(
+    parsed = read_json_response(
         _speed_source_url(host, port),
-        data=payload,
         method="PUT",
         headers={"Content-Type": "application/json"},
+        content=payload,
+        timeout_s=timeout_s,
+        context="simulator speed override",
     )
-    with urlopen(req, timeout=timeout_s) as resp:
-        body = resp.read()
-    parsed = json.loads(body.decode("utf-8")) if body else {}
-    value = parsed.get("manual_speed_kph")
+    value = parsed.get("manual_speed_kph") if isinstance(parsed, dict) else None
     return float(value) if isinstance(value, (int, float)) else None
 
 

--- a/apps/server/vibesensor/use_cases/updates/http_client.py
+++ b/apps/server/vibesensor/use_cases/updates/http_client.py
@@ -16,11 +16,28 @@ import httpx
 from vibesensor.shared.types.json_types import JsonValue
 
 __all__ = [
+    "build_request",
     "build_get_request",
     "read_json_response",
     "read_text_response",
     "stream_http_response",
 ]
+
+
+def build_request(
+    method: str,
+    url: str,
+    *,
+    headers: Mapping[str, str] | None = None,
+    content: bytes | None = None,
+    context: str = "operation",
+    require_https: bool = False,
+) -> httpx.Request:
+    """Build a request after applying the shared runtime safety checks."""
+
+    if require_https and not url.startswith("https://"):
+        raise ValueError(f"Refusing non-HTTPS URL for {context}: {url}")
+    return httpx.Request(method.upper(), url, headers=dict(headers or {}), content=content)
 
 
 def build_get_request(
@@ -32,9 +49,13 @@ def build_get_request(
 ) -> httpx.Request:
     """Build a GET request after applying the shared runtime safety checks."""
 
-    if require_https and not url.startswith("https://"):
-        raise ValueError(f"Refusing non-HTTPS URL for {context}: {url}")
-    return httpx.Request("GET", url, headers=dict(headers or {}))
+    return build_request(
+        "GET",
+        url,
+        headers=headers,
+        context=context,
+        require_https=require_https,
+    )
 
 
 def _http_error_as_oserror(exc: httpx.HTTPError, *, context: str, url: str) -> OSError:
@@ -58,17 +79,21 @@ def _client(
 def read_json_response(
     url: str,
     *,
+    method: str = "GET",
     headers: Mapping[str, str] | None = None,
+    content: bytes | None = None,
     timeout_s: float,
     context: str,
     require_https: bool = False,
     transport: httpx.BaseTransport | None = None,
 ) -> JsonValue:
-    """GET *url* and decode the body as JSON."""
+    """Send a request and decode the response body as JSON."""
 
-    request = build_get_request(
+    request = build_request(
+        method,
         url,
         headers=headers,
+        content=content,
         context=context,
         require_https=require_https,
     )
@@ -89,17 +114,21 @@ def read_json_response(
 def read_text_response(
     url: str,
     *,
+    method: str = "GET",
     headers: Mapping[str, str] | None = None,
+    content: bytes | None = None,
     timeout_s: float,
     context: str,
     require_https: bool = False,
     transport: httpx.BaseTransport | None = None,
 ) -> tuple[int, str, str]:
-    """GET *url* and return status, content type, and decoded body text."""
+    """Send a request and return status, content type, and decoded body text."""
 
-    request = build_get_request(
+    request = build_request(
+        method,
         url,
         headers=headers,
+        content=content,
         context=context,
         require_https=require_https,
     )
@@ -115,23 +144,32 @@ def read_text_response(
 def stream_http_response(
     url: str,
     *,
+    method: str = "GET",
     headers: Mapping[str, str] | None = None,
+    content: bytes | None = None,
     timeout_s: float,
     context: str,
     require_https: bool = False,
     transport: httpx.BaseTransport | None = None,
 ) -> Iterator[httpx.Response]:
-    """Stream a successful GET response body for updater-owned callers."""
+    """Stream a successful response body for updater-owned callers."""
 
-    request = build_get_request(
+    request = build_request(
+        method,
         url,
         headers=headers,
+        content=content,
         context=context,
         require_https=require_https,
     )
     try:
         with _client(timeout_s=timeout_s, transport=transport) as client:
-            with client.stream("GET", request.url, headers=request.headers) as response:
+            with client.stream(
+                request.method,
+                request.url,
+                headers=request.headers,
+                content=request.content,
+            ) as response:
                 response.raise_for_status()
                 yield response
     except httpx.HTTPError as exc:


### PR DESCRIPTION
## What changed
- extend the shared outbound HTTP helper so it can send generic requests with request bodies instead of GET-only calls
- move simulator health checks and speed-override HTTP calls in `adapters/simulator/server_http.py` off `urllib.request` and onto that shared `httpx` helper
- update simulator tests to patch the shared helper seam and cover health-check success, non-200 responses, network failures, and speed-override HTTP failures

## Why
- issue #2901 is the simulator follow-up to the updater/release `httpx` migration from #2899
- this removes the last simulator-specific `urllib.request` plumbing and keeps outbound HTTP behavior on one repo-owned path

## Validation
- `.venv-cto/bin/python -m ruff check apps/server/vibesensor/use_cases/updates/http_client.py apps/server/vibesensor/adapters/simulator/server_http.py apps/server/tests/use_cases/updates/test_http_client.py apps/server/tests/adapters/simulator/test_server_http.py apps/server/tests/adapters/simulator/test_scripted_speed_sync.py`
- `python3 -m py_compile apps/server/vibesensor/use_cases/updates/http_client.py apps/server/vibesensor/adapters/simulator/server_http.py apps/server/tests/use_cases/updates/test_http_client.py apps/server/tests/adapters/simulator/test_server_http.py apps/server/tests/adapters/simulator/test_scripted_speed_sync.py`
- `cd apps/server && python3 -m pytest -q -o addopts="" tests/use_cases/updates/test_http_client.py tests/adapters/simulator/test_server_http.py tests/adapters/simulator/test_scripted_speed_sync.py` *(blocked locally: `tests/conftest.py` imports Python 3.13-only syntax while this host is Python 3.11)*

## Risk / tradeoffs
- simulator HTTP failures now surface through the same shared `OSError` mapping used by updater/release paths instead of raw `urllib` exception types
- the shared helper grew generic request-body support so simulator PUT requests can reuse it instead of creating a second outbound HTTP style
- follow-up issue #2904 can now add simulator-side `pytest-httpx` coverage on top of the same boundary

Closes #2901
