### PR TITLE
test(simulator): use pytest-httpx

### DIFF
--- a/apps/server/tests/adapters/simulator/test_server_http.py
+++ b/apps/server/tests/adapters/simulator/test_server_http.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 
+import httpx
 import pytest
+from pytest_httpx import HTTPXMock
+from test_support.httpx import add_httpx_exception, add_json_response, add_text_response
 
 from vibesensor.adapters.simulator.server_http import (
     check_server_running,
@@ -12,98 +15,97 @@ from vibesensor.adapters.simulator.server_http import (
 )
 
 
-def test_check_server_running_returns_true_on_200(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "vibesensor.adapters.simulator.server_http.read_text_response",
-        lambda url, *, timeout_s, context: (200, "application/json", "{}"),
-    )
+def test_check_server_running_returns_true_on_200(httpx_mock: HTTPXMock) -> None:
+    url = "http://127.0.0.1:8000/api/clients"
+    add_text_response(httpx_mock, url=url, text="{}", headers={"Content-Type": "application/json"})
 
     assert check_server_running("127.0.0.1", 8000, timeout_s=0.5) is True
 
 
-def test_check_server_running_returns_false_on_non_200(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "vibesensor.adapters.simulator.server_http.read_text_response",
-        lambda url, *, timeout_s, context: (503, "text/plain", "booting"),
-    )
+def test_check_server_running_returns_false_on_non_200(httpx_mock: HTTPXMock) -> None:
+    url = "http://127.0.0.1:8000/api/clients"
+    add_text_response(httpx_mock, url=url, text="booting", status_code=503)
 
     assert check_server_running("127.0.0.1", 8000, timeout_s=0.5) is False
 
 
-def test_check_server_running_returns_false_on_network_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def fake_read_text_response(url, *, timeout_s, context):
-        raise OSError("connection refused")
-
-    monkeypatch.setattr(
-        "vibesensor.adapters.simulator.server_http.read_text_response",
-        fake_read_text_response,
-    )
+def test_check_server_running_returns_false_on_timeout(httpx_mock: HTTPXMock) -> None:
+    url = "http://127.0.0.1:8000/api/clients"
+    add_httpx_exception(httpx_mock, url=url, exception=httpx.ReadTimeout("timed out"))
 
     assert check_server_running("127.0.0.1", 8000, timeout_s=0.5) is False
 
 
-def test_set_server_speed_override_uses_http_api_snake_case(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+def test_check_server_running_returns_false_on_connection_failure(httpx_mock: HTTPXMock) -> None:
+    url = "http://127.0.0.1:8000/api/clients"
+    add_httpx_exception(httpx_mock, url=url, exception=httpx.ConnectError("connection refused"))
 
-    def fake_read_json_response(
-        url: str,
-        *,
-        method: str,
-        headers: dict[str, str],
-        content: bytes,
-        timeout_s: float,
-        context: str,
-    ) -> dict[str, object]:
-        captured["url"] = url
-        captured["method"] = method
-        captured["timeout"] = timeout_s
-        captured["context"] = context
-        captured["body"] = json.loads(content.decode("utf-8"))
-        return {
+    assert check_server_running("127.0.0.1", 8000, timeout_s=0.5) is False
+
+
+def test_set_server_speed_override_uses_http_api_snake_case(httpx_mock: HTTPXMock) -> None:
+    url = "http://127.0.0.1:8000/api/settings/speed-source"
+    add_json_response(
+        httpx_mock,
+        url=url,
+        method="PUT",
+        payload={
             "speed_source": "manual",
             "manual_speed_kph": 55.0,
             "stale_timeout_s": 10.0,
-        }
-
-    monkeypatch.setattr(
-        "vibesensor.adapters.simulator.server_http.read_json_response",
-        fake_read_json_response,
+        },
     )
 
     applied = set_server_speed_override_kmh("127.0.0.1", 8000, 55.0, 1.5)
 
-    assert captured == {
-        "url": "http://127.0.0.1:8000/api/settings/speed-source",
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1
+    assert {
+        "url": str(requests[0].url),
+        "method": requests[0].method,
+        "content_type": requests[0].headers["Content-Type"],
+        "body": json.loads(requests[0].content.decode("utf-8")),
+    } == {
+        "url": url,
         "method": "PUT",
-        "timeout": 1.5,
-        "context": "simulator speed override",
+        "content_type": "application/json",
         "body": {"speed_source": "manual", "manual_speed_kph": 55.0},
     }
     assert applied == 55.0
 
 
-def test_set_server_speed_override_propagates_http_failures(
-    monkeypatch: pytest.MonkeyPatch,
+def test_set_server_speed_override_returns_none_for_malformed_response_payload(
+    httpx_mock: HTTPXMock,
 ) -> None:
-    def fake_read_json_response(
-        url: str,
-        *,
-        method: str,
-        headers: dict[str, str],
-        content: bytes,
-        timeout_s: float,
-        context: str,
-    ) -> dict[str, object]:
-        raise OSError("HTTP 503")
-
-    monkeypatch.setattr(
-        "vibesensor.adapters.simulator.server_http.read_json_response",
-        fake_read_json_response,
+    url = "http://127.0.0.1:8000/api/settings/speed-source"
+    add_json_response(
+        httpx_mock,
+        url=url,
+        method="PUT",
+        payload={"speed_source": "manual", "manual_speed_kph": "55.0"},
     )
 
+    assert set_server_speed_override_kmh("127.0.0.1", 8000, 55.0, 1.5) is None
+
+
+def test_set_server_speed_override_propagates_status_failures(httpx_mock: HTTPXMock) -> None:
+    url = "http://127.0.0.1:8000/api/settings/speed-source"
+    add_text_response(httpx_mock, url=url, text="busy", status_code=503, method="PUT")
+
     with pytest.raises(OSError, match="HTTP 503"):
+        set_server_speed_override_kmh("127.0.0.1", 8000, 55.0, 1.5)
+
+
+def test_set_server_speed_override_propagates_connection_failures(
+    httpx_mock: HTTPXMock,
+) -> None:
+    url = "http://127.0.0.1:8000/api/settings/speed-source"
+    add_httpx_exception(
+        httpx_mock,
+        url=url,
+        method="PUT",
+        exception=httpx.ConnectError("connection refused"),
+    )
+
+    with pytest.raises(OSError, match="connection refused"):
         set_server_speed_override_kmh("127.0.0.1", 8000, 55.0, 1.5)


### PR DESCRIPTION
## What changed
- move `apps/server/tests/adapters/simulator/test_server_http.py` off direct monkeypatching of `read_text_response` / `read_json_response` and onto `pytest-httpx`
- reuse the shared `tests/test_support/httpx.py` helpers from #2902 instead of adding simulator-specific transport stubs
- cover simulator health success, non-200, timeout, and connection failure cases at the real outbound HTTP boundary
- cover speed-override success, malformed response payloads, status failures, and connection failures while still asserting the PUT request body sent to the server

## Why
- #2904 follows #2899, #2901, and #2902: simulator outbound HTTP should use the same preferred request-boundary test style as the updater/release paths
- this removes most bespoke monkeypatching from the simulator HTTP owner without changing simulator behavior

## Validation
- `.venv-cto/bin/python -m ruff check apps/server/tests/adapters/simulator/test_server_http.py`
- `python3 -m py_compile apps/server/tests/adapters/simulator/test_server_http.py`
- `cd apps/server && python3 -m pytest -q -o addopts="" tests/adapters/simulator/test_server_http.py` *(blocked locally: `tests/conftest.py` imports Python 3.13-only syntax while this host is Python 3.11)*

## Risk / tradeoffs
- this only changes the focused simulator outbound HTTP boundary suite; non-HTTP simulator tests stay on their existing seams
- CI is the first full execution gate for the new simulator `pytest-httpx` assertions on this host because local pytest still cannot collect backend tests
- request assertions intentionally stay on stable boundary details (URL, method, headers, body, response/error mapping) instead of inspecting deeper `httpx` internals

Closes #2904
