### PR TITLE
test(ui): add shared msw layer

### DIFF
--- a/apps/server/tests/hygiene/test_build_ui_static.py
+++ b/apps/server/tests/hygiene/test_build_ui_static.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import hashlib
 import importlib.util
 import sys
@@ -151,3 +152,21 @@ def test_build_ui_static_rejects_prevalidated_contracts_without_skip_typecheck(
         module.main(["--assume-prevalidated-contracts"])
 
     assert exc_info.value.code == 2
+
+
+def test_build_ui_static_stays_importable_without_msgspec(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def _guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "msgspec":
+            raise ModuleNotFoundError(name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _guarded_import)
+
+    module, _repo, _ui_dir = _load_temp_build_ui_static(tmp_path)
+
+    assert module.UI_BUILD_METADATA_FILE == ".vibesensor-ui-build.json"

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -89,6 +89,20 @@ The release-smoke artifact helper is the intentional narrow exception: after the
 Generated contract artifacts stay out of the lint/format path on purpose so the
 source-of-truth export commands remain the only writers for those files.
 
+## HTTP boundary tests with MSW
+
+Use `msw` as the shared HTTP mocking layer for UI tests that exercise the real
+browser-side fetch boundary.
+
+- Node-side Playwright specs should install the shared lifecycle from
+  `tests/msw/node.ts`; it normalizes relative `/api/...` requests onto the
+  test origin and fails unhandled HTTP requests loudly by default.
+- Feature-specific reusable handlers belong under `tests/msw/handlers/` as they
+  appear. Keep cross-feature primitives in `tests/msw/http.ts`, and name
+  scenario factories `build<Feature><Scenario>Handlers(...)`.
+- `tests/msw/browser.ts` is the shared entrypoint for future browser-worker
+  flows; keep WebSocket mocking out of that layer.
+
 ## Bundle analysis
 
 Run `npm run analyze` to build the production bundle and emit

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -100,8 +100,8 @@ browser-side fetch boundary.
 - Feature-specific reusable handlers belong under `tests/msw/handlers/` as they
   appear. Keep cross-feature primitives in `tests/msw/http.ts`, and name
   scenario factories `build<Feature><Scenario>Handlers(...)`.
-- `tests/msw/browser.ts` is the shared entrypoint for future browser-worker
-  flows; keep WebSocket mocking out of that layer.
+- Browser-worker wiring for optional local backend-free flows stays with the
+  later MSW follow-up issues; keep WebSocket mocking out of that layer.
 
 ## Bundle analysis
 

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -20,6 +20,7 @@
         "dependency-cruiser": "^17.3.10",
         "knip": "^6.4.1",
         "linkedom": "^0.18.12",
+        "msw": "^2.13.4",
         "openapi-typescript": "^7.13.0",
         "rollup-plugin-visualizer": "^7.0.1",
         "tsx": "^4.21.0",
@@ -981,6 +982,93 @@
         "node": ">=18"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
+      "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+      "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1030,6 +1118,31 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.4",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.4.tgz",
+      "integrity": "sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.3",
@@ -1087,6 +1200,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
       "version": "0.121.0",
@@ -2206,6 +2344,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2498,6 +2663,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/cliui": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -2556,6 +2731,20 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -2908,6 +3097,33 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3082,6 +3298,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3113,6 +3339,17 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
       }
     },
     "node_modules/html-escaper": {
@@ -3254,6 +3491,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3315,6 +3562,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -3871,6 +4125,190 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.4.tgz",
+      "integrity": "sha512-fPlKBeFe+8rpcyR3umUmmHuNwu6gc6T3STvkgEa9WDX/HEgal9wDeflpCUAIRtmvaLZM2igfI5y1bZ9G5J26KA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.7",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3962,6 +4400,13 @@
       "peerDependencies": {
         "typescript": "^5.x"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/oxc-parser": {
       "version": "0.121.0",
@@ -4065,6 +4510,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4255,6 +4707,16 @@
         "regexp-tree": "bin/regexp-tree"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4295,6 +4757,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.8.tgz",
+      "integrity": "sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -4429,6 +4898,26 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-code-frame": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/simple-code-frame/-/simple-code-frame-1.3.0.tgz",
@@ -4488,6 +4977,23 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -4572,6 +5078,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
@@ -4603,6 +5122,26 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4614,6 +5153,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -4717,6 +5269,23 @@
       "license": "ISC",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -44,6 +44,7 @@
     "dependency-cruiser": "^17.3.10",
     "knip": "^6.4.1",
     "linkedom": "^0.18.12",
+    "msw": "^2.13.4",
     "openapi-typescript": "^7.13.0",
     "rollup-plugin-visualizer": "^7.0.1",
     "tsx": "^4.21.0",

--- a/apps/ui/tests/maintenance_feature_test_support.ts
+++ b/apps/ui/tests/maintenance_feature_test_support.ts
@@ -25,6 +25,8 @@ import type {
 import { flushAsyncWork, installWindowGlobal } from "./async_test_helpers";
 import type { TimerHarness } from "./async_test_helpers";
 import { createPanel, installFakeDomGlobals } from "./dom_render_test_support";
+import { http } from "./msw/http";
+import { createUiMswTestScope } from "./msw/node";
 
 type ClickListener = (() => void) | null;
 
@@ -80,30 +82,19 @@ export function installFeatureFetchMock(
     body: string,
   ) => Promise<Response> | Response,
 ): () => void {
-  const originalFetch = globalThis.fetch;
-
-  globalThis.fetch = (async (
-    input: string | URL | RequestInfo,
-    init?: RequestInit,
-  ) => {
-    const requestUrl =
-      typeof input === "string"
-        ? input
-        : input instanceof URL
-          ? input.toString()
-          : input.url;
-    const requestMethod =
-      init?.method ?? (input instanceof Request ? input.method : "GET");
-    const requestBody = typeof init?.body === "string" ? init.body : "";
-    return handler(
-      new URL(requestUrl, "http://vibesensor.test"),
-      requestMethod,
-      requestBody,
-    );
-  }) as typeof fetch;
+  const scope = createUiMswTestScope();
+  scope.server.use(
+    http.all("*", async ({ request }) => {
+      const requestBody =
+        request.method === "GET" || request.method === "HEAD"
+          ? ""
+          : await request.text();
+      return await handler(new URL(request.url), request.method, requestBody);
+    }),
+  );
 
   return () => {
-    globalThis.fetch = originalFetch;
+    scope.close();
   };
 }
 

--- a/apps/ui/tests/msw/browser.ts
+++ b/apps/ui/tests/msw/browser.ts
@@ -1,6 +1,0 @@
-import type { RequestHandler } from "msw";
-import { setupWorker } from "msw/browser";
-
-export function createUiMswWorker(...handlers: RequestHandler[]) {
-  return setupWorker(...handlers);
-}

--- a/apps/ui/tests/msw/browser.ts
+++ b/apps/ui/tests/msw/browser.ts
@@ -1,0 +1,6 @@
+import type { RequestHandler } from "msw";
+import { setupWorker } from "msw/browser";
+
+export function createUiMswWorker(...handlers: RequestHandler[]) {
+  return setupWorker(...handlers);
+}

--- a/apps/ui/tests/msw/http.ts
+++ b/apps/ui/tests/msw/http.ts
@@ -1,0 +1,9 @@
+import { HttpResponse, http } from "msw";
+
+export const UI_MSW_ORIGIN = "http://vibesensor.test";
+
+export function uiTestUrl(path: string): string {
+  return new URL(path, UI_MSW_ORIGIN).toString();
+}
+
+export { http, HttpResponse };

--- a/apps/ui/tests/msw/node.ts
+++ b/apps/ui/tests/msw/node.ts
@@ -1,0 +1,73 @@
+import type { test as playwrightTest } from "@playwright/test";
+import { setupServer } from "msw/node";
+
+import { UI_MSW_ORIGIN } from "./http";
+
+type PlaywrightTestHooks = Pick<
+  typeof playwrightTest,
+  "afterAll" | "afterEach" | "beforeAll"
+>;
+
+function installUiMswInterception(server: ReturnType<typeof setupServer>): () => void {
+  const originalFetch = globalThis.fetch;
+  if (!originalFetch) {
+    throw new Error("MSW test server requires global fetch");
+  }
+  server.listen({
+    onUnhandledRequest({ method, url }) {
+      throw new Error(`Unhandled MSW request: ${method} ${url}`);
+    },
+  });
+  const interceptedFetch = globalThis.fetch;
+  if (!interceptedFetch) {
+    throw new Error("MSW test server failed to install fetch interception");
+  }
+  globalThis.fetch = ((input: URL | RequestInfo, init?: RequestInit) =>
+    interceptedFetch(resolveFetchInput(input), init)) as typeof fetch;
+  return () => {
+    server.close();
+    globalThis.fetch = originalFetch;
+  };
+}
+
+function resolveFetchInput(input: URL | RequestInfo): URL | Request {
+  if (typeof input === "string") {
+    return new URL(input, UI_MSW_ORIGIN);
+  }
+  if (input instanceof URL) {
+    return new URL(input.toString(), UI_MSW_ORIGIN);
+  }
+  return new Request(new URL(input.url, UI_MSW_ORIGIN), input);
+}
+
+export function createUiMswTestServer(testHooks: PlaywrightTestHooks) {
+  const server = setupServer();
+  let restoreInterception = () => undefined;
+
+  testHooks.beforeAll(() => {
+    restoreInterception = installUiMswInterception(server);
+  });
+
+  testHooks.afterEach(() => {
+    server.resetHandlers();
+  });
+
+  testHooks.afterAll(() => {
+    restoreInterception();
+  });
+
+  return server;
+}
+
+export function createUiMswTestScope() {
+  const server = setupServer();
+  const restoreInterception = installUiMswInterception(server);
+
+  return {
+    server,
+    close(): void {
+      server.resetHandlers();
+      restoreInterception();
+    },
+  };
+}

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { HttpResponse, http, uiTestUrl } from "./msw/http";
+import { createUiMswTestServer } from "./msw/node";
 import { createAppState } from "../src/app/ui_app_state";
 import { UiShellController } from "../src/app/runtime/ui_shell_controller";
 import {
@@ -20,31 +22,7 @@ import { createUiShellStatusModule } from "../src/app/runtime/ui_shell_status_mo
 import { signal, type ReadonlySignal } from "../src/app/ui_signals";
 import { installDocumentStub } from "./spectrum_test_support";
 
-function jsonResponse(body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    headers: { "content-type": "application/json" },
-    status: 200,
-  });
-}
-
-function requestUrl(input: string | URL | RequestInfo): string {
-  return String(
-    typeof input === "string" ? input : input instanceof URL ? input : input.url,
-  );
-}
-
-async function withMockFetch(
-  mockFetch: typeof fetch,
-  run: () => Promise<void>,
-): Promise<void> {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = mockFetch;
-  try {
-    await run();
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-}
+const mswServer = createUiMswTestServer(test);
 
 function testTranslation(key: string, vars?: Record<string, unknown>): string {
   return vars ? `${key}:${JSON.stringify(vars)}` : key;
@@ -360,22 +338,18 @@ test.describe("createUiShellPreferencesModule", () => {
       normalizeLanguage: (lang) => String(lang),
     });
 
-    await withMockFetch(
-      (async (input: string | URL | RequestInfo) => {
-        const url = requestUrl(input);
-        requests.push(url);
-        if (url.endsWith("/api/settings/language")) {
-          return jsonResponse({ language: "nl" });
-        }
-        if (url.endsWith("/api/settings/speed-unit")) {
-          return jsonResponse({ speed_unit: "mps" });
-        }
-        throw new Error(`Unexpected request: ${url}`);
-      }) as typeof fetch,
-      async () => {
-        await module.hydratePersistedPreferences();
-      },
+    mswServer.use(
+      http.get(uiTestUrl("/api/settings/language"), ({ request }) => {
+        requests.push(new URL(request.url).pathname);
+        return HttpResponse.json({ language: "nl" });
+      }),
+      http.get(uiTestUrl("/api/settings/speed-unit"), ({ request }) => {
+        requests.push(new URL(request.url).pathname);
+        return HttpResponse.json({ speed_unit: "mps" });
+      }),
     );
+
+    await module.hydratePersistedPreferences();
 
     expect(requests).toEqual([
       "/api/settings/language",
@@ -397,19 +371,20 @@ test.describe("createUiShellPreferencesModule", () => {
       normalizeLanguage: (lang) => String(lang),
     });
 
-    await withMockFetch(
-      (async () =>
-        new Promise<Response>((resolve) => {
+    mswServer.use(
+      http.put(uiTestUrl("/api/settings/language"), () => {
+        return new Promise<Response>((resolve) => {
           resolveResponse = resolve;
-        })) as typeof fetch,
-      async () => {
-        const savePromise = module.saveLanguage("nl");
-        expect(module.selectedLanguage.value).toBe("nl");
-        expect(state.shell.lang.value).toBe("en");
-        resolveResponse?.(jsonResponse({ language: "nl" }));
-        await savePromise;
-      },
+        });
+      }),
     );
+
+    const savePromise = module.saveLanguage("nl");
+    expect(module.selectedLanguage.value).toBe("nl");
+    expect(state.shell.lang.value).toBe("en");
+    await expect.poll(() => resolveResponse !== null).toBe(true);
+    resolveResponse?.(HttpResponse.json({ language: "nl" }));
+    await savePromise;
 
     expect(state.shell.lang.value).toBe("nl");
     expect(module.selectedLanguage.value).toBe("nl");
@@ -424,14 +399,14 @@ test.describe("createUiShellPreferencesModule", () => {
       normalizeLanguage: (lang) => String(lang),
     });
 
-    await withMockFetch(
-      (async () => {
-        throw new Error("save failed");
-      }) as typeof fetch,
-      async () => {
-        await module.saveSpeedUnit("mps");
-      },
+    mswServer.use(
+      http.put(
+        uiTestUrl("/api/settings/speed-unit"),
+        () => HttpResponse.json({ detail: "save failed" }, { status: 500 }),
+      ),
     );
+
+    await module.saveSpeedUnit("mps");
 
     expect(state.shell.speedUnit.value).toBe("kmh");
     expect(module.selectedSpeedUnit.value).toBe("kmh");

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,6 +15,7 @@
 - `tools/tests/run_e2e_parallel.py` records observed shard test durations in `~/.cache/vibesensor/e2e-duration-cache.json` so later local or CI runs can rebalance without hand-maintained timing hints.
 - Python test configuration lives in `apps/server/pyproject.toml`.
 - Use `pytest-httpx` for backend outbound HTTP boundary tests around `httpx` clients; prefer it over monkeypatching low-level request functions when the goal is to assert request URLs, methods, payloads, status codes, and transport failures.
+- Use the shared MSW helpers under `apps/ui/tests/msw/` for frontend HTTP-boundary tests; they normalize relative `/api/...` requests onto the test origin and fail unhandled requests loudly by default.
 - Backend structural AST/import guards live in `tools/dev/verify_backend_static_guards.py`, and repo/frontend hygiene guards live in `tools/dev/check_hygiene.py`; both run via `make lint`.
 - Oversized tracked test/spec files are guarded in `tools/dev/check_hygiene.py` with the allowlist at `tools/dev/oversized_test_allowlist.yml`. Files at or above the shared threshold must either be split or carry an explicit allowlist reason, and the hygiene output always prints the current largest tracked test/spec files.
 - `make sync-contracts` is the authoritative contract/doc regeneration path; `make lint` and the `backend-contract-drift` CI job run it in `--check` mode.

--- a/tools/build_ui_static.py
+++ b/tools/build_ui_static.py
@@ -10,22 +10,13 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import shutil
 import subprocess
 from pathlib import Path
 
-import msgspec
-
 # Keep in sync with vibesensor.use_cases.updates.status.UI_BUILD_METADATA_FILE
 UI_BUILD_METADATA_FILE = ".vibesensor-ui-build.json"
-
-
-class _UiBuildMetadataRecord(msgspec.Struct, kw_only=True, frozen=True):
-    """Local copy of the updater UI build metadata sidecar contract."""
-
-    ui_source_hash: str
-    static_assets_hash: str
-    git_commit: str
 
 
 def _hash_tree(root: Path, *, ignore_names: set[str]) -> str:
@@ -131,16 +122,19 @@ def main(argv: list[str] | None = None) -> None:
     )
     static_assets_hash = _hash_tree(static_dir, ignore_names={UI_BUILD_METADATA_FILE})
     git_commit = _git_head_commit(repo_root)
-    # Keep this local codec in sync with updates.status.runtime_details.py.
+    # Keep this local payload shape in sync with updates.status.runtime_details.py.
     (static_dir / UI_BUILD_METADATA_FILE).write_bytes(
-        msgspec.json.encode(
-            _UiBuildMetadataRecord(
-                ui_source_hash=ui_source_hash,
-                static_assets_hash=static_assets_hash,
-                git_commit=git_commit,
-            )
+        (
+            json.dumps(
+                {
+                    "ui_source_hash": ui_source_hash,
+                    "static_assets_hash": static_assets_hash,
+                    "git_commit": git_commit,
+                },
+                sort_keys=True,
+            ).encode("utf-8")
+            + b"\n"
         )
-        + b"\n",
     )
     print(f"Synced {dist_dir} -> {static_dir}")
 


### PR DESCRIPTION
## What changed
- add `msw` to `apps/ui` and introduce shared frontend HTTP mocking helpers under `apps/ui/tests/msw/` for node-side tests plus the future browser-worker entrypoint
- normalize relative `/api/...` requests onto a fixed test origin in the shared node helper and fail unhandled HTTP requests loudly by default
- move the existing maintenance feature fetch helper onto per-test MSW scopes so update/ESP feature specs keep one canonical HTTP mocking path
- migrate the shell preferences runtime tests off direct `globalThis.fetch` swaps and onto explicit MSW handlers
- document initial MSW handler/scenario conventions in `apps/ui/README.md` and `docs/testing.md`

## Why
- #2906 is the foundation issue for the UI HTTP mocking cleanup: one shared MSW path first, then follow-up issues can move more feature tests and browser flows onto it
- the new helper keeps the current UI tests working without rewriting every spec in one PR while still moving real UI fetch paths off direct monkeypatching

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=../../.ai-temp/playwright.unit.local.config.ts tests/ui_shell_runtime_modules.spec.ts tests/update_feature_transport.spec.ts tests/update_feature_polling.spec.ts tests/esp_flash_feature_actions.spec.ts tests/esp_flash_feature_polling.spec.ts`
- `cd apps/ui && npm run lint` *(pre-existing warnings only: Biome schema-version info plus untouched warnings in `src/app/features/realtime_feature_workflow.ts`, `src/app/views/esp_flash_journey_presenter.ts`, `src/app/views/history_detail_presenter.ts`, and `tests/realtime_feature_workflow.spec.ts`)*

## Risk / tradeoffs
- browser-worker usage is only scaffolded here; follow-up issue #2915 still owns wiring optional local browser mode into smoke/dev flows
- most UI fetch-heavy specs still use existing helpers today, but those helpers now sit on the shared MSW layer instead of direct `fetch` swapping
- the temporary `.ai-temp/playwright.unit.local.config.ts` file is local-only validation scaffolding and is not part of the commit

Closes #2906
