### PR TITLE
test(ui): move node specs onto msw

### DIFF
--- a/apps/ui/tests/api_clone_usage.spec.ts
+++ b/apps/ui/tests/api_clone_usage.spec.ts
@@ -9,7 +9,11 @@ import type {
   HistoryInsightsAnalyzingPayload,
   LoggingStatusPayload,
 } from "../src/api/types";
-import { installWindowGlobal, jsonResponse } from "./async_test_helpers";
+import { installWindowGlobal } from "./async_test_helpers";
+import { HttpResponse, http, uiTestUrl } from "./msw/http";
+import { createUiMswTestServer } from "./msw/node";
+
+const mswServer = createUiMswTestServer(test);
 
 test.describe("API adapter clone usage", () => {
   test.beforeEach(() => {
@@ -17,7 +21,6 @@ test.describe("API adapter clone usage", () => {
   });
 
   test("returns logging status without structuredClone", async () => {
-    const originalFetch = globalThis.fetch;
     const originalStructuredClone = globalThis.structuredClone;
     const payload: LoggingStatusPayload = {
       enabled: false,
@@ -37,19 +40,17 @@ test.describe("API adapter clone usage", () => {
       structuredCloneCalls += 1;
       return originalStructuredClone(value);
     }) as typeof structuredClone;
-    globalThis.fetch = (async () => jsonResponse(payload)) as typeof fetch;
+    mswServer.use(http.get(uiTestUrl("/api/recording/status"), () => HttpResponse.json(payload)));
 
     try {
       await expect(getLoggingStatus()).resolves.toEqual(payload);
       expect(structuredCloneCalls).toBe(0);
     } finally {
-      globalThis.fetch = originalFetch;
       globalThis.structuredClone = originalStructuredClone;
     }
   });
 
   test("serializes car payloads without structuredClone", async () => {
-    const originalFetch = globalThis.fetch;
     const originalStructuredClone = globalThis.structuredClone;
     const requestPayload: CarUpsertRequest = {
       name: "Project Car",
@@ -71,23 +72,23 @@ test.describe("API adapter clone usage", () => {
       structuredCloneCalls += 1;
       return originalStructuredClone(value);
     }) as typeof structuredClone;
-    globalThis.fetch = (async (_input: string | URL | RequestInfo, init?: RequestInit) => {
-      requestBody = String(init?.body ?? "");
-      return jsonResponse(responsePayload);
-    }) as typeof fetch;
+    mswServer.use(
+      http.post(uiTestUrl("/api/settings/cars"), async ({ request }) => {
+        requestBody = await request.text();
+        return HttpResponse.json(responsePayload);
+      }),
+    );
 
     try {
       await expect(addSettingsCar(requestPayload)).resolves.toEqual(responsePayload);
       expect(JSON.parse(requestBody)).toEqual(requestPayload);
       expect(structuredCloneCalls).toBe(0);
     } finally {
-      globalThis.fetch = originalFetch;
       globalThis.structuredClone = originalStructuredClone;
     }
   });
 
   test("returns history insights bodies without structuredClone", async () => {
-    const originalFetch = globalThis.fetch;
     const originalStructuredClone = globalThis.structuredClone;
     const payload: HistoryInsightsAnalyzingPayload = {
       status: "analyzing",
@@ -99,13 +100,16 @@ test.describe("API adapter clone usage", () => {
       structuredCloneCalls += 1;
       return originalStructuredClone(value);
     }) as typeof structuredClone;
-    globalThis.fetch = (async () => jsonResponse(payload, { status: 202 })) as typeof fetch;
+    mswServer.use(
+      http.get(uiTestUrl("/api/history/run-001/insights"), () =>
+        HttpResponse.json(payload, { status: 202 }),
+      ),
+    );
 
     try {
       await expect(getHistoryInsights("run-001", "en")).resolves.toEqual(payload);
       expect(structuredCloneCalls).toBe(0);
     } finally {
-      globalThis.fetch = originalFetch;
       globalThis.structuredClone = originalStructuredClone;
     }
   });

--- a/apps/ui/tests/api_http.spec.ts
+++ b/apps/ui/tests/api_http.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "@playwright/test";
 import { apiJson } from "../src/api/http";
-import { createDeferred, installTimerHarness, installWindowGlobal, jsonResponse } from "./async_test_helpers";
+import { createDeferred, installTimerHarness, installWindowGlobal } from "./async_test_helpers";
+import { HttpResponse, http, uiTestUrl } from "./msw/http";
+import { createUiMswTestServer } from "./msw/node";
+
+const mswServer = createUiMswTestServer(test);
 
 test.describe("apiJson", () => {
   test.beforeEach(() => {
@@ -8,24 +12,19 @@ test.describe("apiJson", () => {
   });
 
   test("timeout aborts with and without provided AbortSignal", async () => {
-    const originalFetch = globalThis.fetch;
     const originalSetTimeout = globalThis.setTimeout;
     const originalClearTimeout = globalThis.clearTimeout;
     const externalController = new AbortController();
 
+    mswServer.use(
+      http.get(uiTestUrl("/timeout/no-signal"), async () => await new Promise<HttpResponse>(() => undefined)),
+      http.get(uiTestUrl("/timeout/with-signal"), async () => await new Promise<HttpResponse>(() => undefined)),
+    );
     globalThis.setTimeout = ((handler: TimerHandler) => {
       if (typeof handler === "function") handler();
       return 1 as unknown as ReturnType<typeof setTimeout>;
     }) as typeof setTimeout;
     globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
-    globalThis.fetch = ((_: string | URL | Request, init?: RequestInit) =>
-      new Promise((_, reject) => {
-        if (init?.signal?.aborted) {
-          reject(new DOMException("Aborted", "AbortError"));
-          return;
-        }
-        init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
-      })) as typeof fetch;
 
     try {
       const outcomes = await Promise.all([
@@ -38,23 +37,23 @@ test.describe("apiJson", () => {
       ]);
       expect(outcomes).toEqual(["AbortError", "AbortError"]);
     } finally {
-      globalThis.fetch = originalFetch;
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;
     }
   });
 
   test("supports custom timeout overrides and clears their timers after a successful response", async () => {
-    const originalFetch = globalThis.fetch;
     const timerHarness = installTimerHarness();
-    const response = createDeferred<Response>();
+    const response = createDeferred<HttpResponse>();
     let requestedPath = "";
     let requestedMethod = "";
-    globalThis.fetch = ((path: string | URL | RequestInfo, init?: RequestInit) => {
-      requestedPath = String(path);
-      requestedMethod = init?.method ?? "GET";
-      return response.promise;
-    }) as typeof fetch;
+    mswServer.use(
+      http.post(uiTestUrl("/timeout/custom"), async ({ request }) => {
+        requestedPath = new URL(request.url).pathname;
+        requestedMethod = request.method;
+        return await response.promise;
+      }),
+    );
 
     try {
       const request = apiJson<{ ok: boolean }>("/timeout/custom", {
@@ -63,46 +62,38 @@ test.describe("apiJson", () => {
       });
 
       expect(timerHarness.pendingDelays()).toEqual([20_000]);
-      expect(requestedPath).toContain("/timeout/custom");
-      expect(requestedMethod).toBe("POST");
 
-      response.resolve(jsonResponse({ ok: true }));
+      response.resolve(HttpResponse.json({ ok: true }));
       await expect(request).resolves.toEqual({ ok: true });
+      expect(requestedPath).toBe("/timeout/custom");
+      expect(requestedMethod).toBe("POST");
       expect(timerHarness.pendingDelays()).toEqual([]);
     } finally {
-      globalThis.fetch = originalFetch;
       timerHarness.restore();
     }
   });
 
   test("handles 204, text response, invalid JSON and non-2xx JSON detail", async () => {
-    const originalFetch = globalThis.fetch;
-    const mkResponse = (
-      body: string | null,
-      status: number,
-      statusText: string,
-      contentType: string,
-    ) => new Response(body, { status, statusText, headers: { "content-type": contentType } });
-    globalThis.fetch = (async (path: string | URL | RequestInfo) => {
-      const value = String(path);
-      if (value.includes("status204")) return mkResponse(null, 204, "No Content", "application/json");
-      if (value.includes("text-ok")) return mkResponse("plain-text", 200, "OK", "text/plain");
-      if (value.includes("invalid-json")) return mkResponse("{nope", 200, "OK", "application/json");
-      if (value.includes("error-json")) {
-        return mkResponse(JSON.stringify({ detail: "bad request detail" }), 400, "Bad Request", "application/json");
-      }
-      return mkResponse("unknown", 500, "Unknown", "text/plain");
-    }) as typeof fetch;
+    mswServer.use(
+      http.get(uiTestUrl("/status204"), () => new HttpResponse(null, { status: 204, statusText: "No Content" })),
+      http.get(uiTestUrl("/text-ok"), () => new HttpResponse("plain-text", { status: 200, statusText: "OK" })),
+      http.get(uiTestUrl("/invalid-json"), () =>
+        new HttpResponse("{nope", {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+      http.get(uiTestUrl("/error-json"), () =>
+        HttpResponse.json({ detail: "bad request detail" }, { status: 400, statusText: "Bad Request" }),
+      ),
+    );
 
-    try {
-      const payload204 = await apiJson("/status204");
-      const payloadText = await apiJson("/text-ok");
-      await expect(apiJson("/invalid-json")).rejects.toThrow(/Invalid JSON response \(200 OK\)/);
-      await expect(apiJson("/error-json")).rejects.toThrow("bad request detail");
-      expect(payload204).toBeUndefined();
-      expect(payloadText).toBe("plain-text");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    const payload204 = await apiJson("/status204");
+    const payloadText = await apiJson("/text-ok");
+    await expect(apiJson("/invalid-json")).rejects.toThrow(/Invalid JSON response \(200 OK\)/);
+    await expect(apiJson("/error-json")).rejects.toThrow("bad request detail");
+    expect(payload204).toBeUndefined();
+    expect(payloadText).toBe("plain-text");
   });
 });

--- a/apps/ui/tests/history_download.spec.ts
+++ b/apps/ui/tests/history_download.spec.ts
@@ -4,6 +4,10 @@ import {
   downloadBlobFile,
   filenameFromDisposition,
 } from "../src/app/features/history_download";
+import { HttpResponse, http, uiTestUrl } from "./msw/http";
+import { createUiMswTestServer } from "./msw/node";
+
+const mswServer = createUiMswTestServer(test);
 
 test("filenameFromDisposition decodes UTF-8 and falls back when needed", () => {
   expect(
@@ -20,7 +24,6 @@ test("filenameFromDisposition decodes UTF-8 and falls back when needed", () => {
 });
 
 test("downloadBlobFile downloads with decoded filename and revokes the blob URL", async () => {
-  const originalFetch = globalThis.fetch;
   const originalDocument = (globalThis as { document?: Document }).document;
   const originalCreateObjectURL = URL.createObjectURL;
   const originalRevokeObjectURL = URL.revokeObjectURL;
@@ -28,14 +31,17 @@ test("downloadBlobFile downloads with decoded filename and revokes the blob URL"
   const anchorState = { href: "", download: "", clicks: 0, removed: 0 };
   const revoked: string[] = [];
 
-  globalThis.fetch = (async () =>
-    new Response("PDF", {
-      status: 200,
-      headers: {
-        "content-type": "application/pdf",
-        "content-disposition": "attachment; filename*=UTF-8''run%20%C3%BC.pdf",
-      },
-    })) as typeof fetch;
+  mswServer.use(
+    http.get(uiTestUrl("/api/history/run-001/report.pdf"), () =>
+      new HttpResponse("PDF", {
+        status: 200,
+        headers: {
+          "content-type": "application/pdf",
+          "content-disposition": "attachment; filename*=UTF-8''run%20%C3%BC.pdf",
+        },
+      }),
+    ),
+  );
   (globalThis as { document?: Document }).document = {
     body: {
       appendChild() {
@@ -80,7 +86,6 @@ test("downloadBlobFile downloads with decoded filename and revokes the blob URL"
   try {
     await downloadBlobFile("/api/history/run-001/report.pdf", "fallback.pdf");
   } finally {
-    globalThis.fetch = originalFetch;
     (globalThis as { document?: Document }).document = originalDocument;
     URL.createObjectURL = originalCreateObjectURL;
     URL.revokeObjectURL = originalRevokeObjectURL;


### PR DESCRIPTION
## What changed
- move `api_http.spec.ts`, `history_download.spec.ts`, and `api_clone_usage.spec.ts` onto the shared Node-side MSW harness
- register per-test handlers with `mswServer.use(...)` instead of swapping `globalThis.fetch`
- keep strict unhandled-request failures from `tests/msw/node.ts`

## Why
- `#2907` wants one shared Node-side MSW path for low-level UI HTTP specs
- this keeps the real fetch boundary while removing per-file fetch lifecycle stubs

## Validation
- `cd apps/ui && npx playwright test --config ../../.ai-temp/playwright.unit.local.config.ts tests/api_http.spec.ts tests/history_download.spec.ts tests/api_clone_usage.spec.ts`
- `cd apps/ui && npm run lint:unused && npm run typecheck`

## Risks / edge
- browser-worker mode is still out of scope here
- broader workflow/spec migrations stay with the later MSW follow-up issues

Closes #2907
