### PR TITLE
test(ui): share history msw handlers

### DIFF
--- a/apps/ui/tests/history_download.spec.ts
+++ b/apps/ui/tests/history_download.spec.ts
@@ -4,7 +4,10 @@ import {
   downloadBlobFile,
   filenameFromDisposition,
 } from "../src/app/features/history_download";
-import { HttpResponse, http, uiTestUrl } from "./msw/http";
+import {
+  buildHistoryDownloadHandlers,
+  makeHistoryBinaryDownloadResponse,
+} from "./msw/handlers/history";
 import { createUiMswTestServer } from "./msw/node";
 
 const mswServer = createUiMswTestServer(test);
@@ -32,15 +35,13 @@ test("downloadBlobFile downloads with decoded filename and revokes the blob URL"
   const revoked: string[] = [];
 
   mswServer.use(
-    http.get(uiTestUrl("/api/history/run-001/report.pdf"), () =>
-      new HttpResponse("PDF", {
-        status: 200,
-        headers: {
-          "content-type": "application/pdf",
-          "content-disposition": "attachment; filename*=UTF-8''run%20%C3%BC.pdf",
-        },
+    ...buildHistoryDownloadHandlers({
+      reportPdf: makeHistoryBinaryDownloadResponse({
+        body: "PDF",
+        contentType: "application/pdf",
+        filename: "run ü.pdf",
       }),
-    ),
+    }),
   );
   (globalThis as { document?: Document }).document = {
     body: {

--- a/apps/ui/tests/history_feature_modules.spec.ts
+++ b/apps/ui/tests/history_feature_modules.spec.ts
@@ -9,6 +9,14 @@ import type {
   HistoryPanelView,
 } from "../src/app/views/history_table_view";
 import { installWindowGlobal, jsonResponse } from "./async_test_helpers";
+import {
+  buildHistoryHandlers,
+  makeDeleteHistoryRunPayload,
+  makeHistoryListPayload,
+} from "./msw/handlers/history";
+import { createUiMswTestServer } from "./msw/node";
+
+const mswServer = createUiMswTestServer(test);
 
 type ButtonStub = HTMLButtonElement & {
   disabled: boolean;
@@ -274,20 +282,13 @@ test("history feature skips deletion when confirmation is declined", async () =>
 
 test("history feature refreshes runs and renders an empty-state model when no runs exist", async () => {
   const { feature, historySummary, deleteAllRunsBtn, getLatestModel } = createFeatureHarness();
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async (input: string | URL | RequestInfo) => {
-    const url = String(typeof input === "string" ? input : input instanceof URL ? input : input.url);
-    if (url === "/api/history") {
-      return jsonResponse({ runs: [] });
-    }
-    throw new Error(`Unexpected request: ${url}`);
-  }) as typeof fetch;
+  mswServer.use(
+    ...buildHistoryHandlers({
+      list: makeHistoryListPayload({ runs: [] }),
+    }),
+  );
 
-  try {
-    await feature.refreshHistory();
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+  await feature.refreshHistory();
 
   const model = getLatestModel();
   expect(historySummary.textContent).toBe("history.none");
@@ -301,22 +302,15 @@ test("history feature refreshes runs and renders an empty-state model when no ru
 test("history feature refreshes runs and renders table state through one owner", async () => {
   const state = createAppState();
   const { feature, historySummary, deleteAllRunsBtn, getLatestModel } = createFeatureHarness(state);
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async (input: string | URL | RequestInfo) => {
-    const url = String(typeof input === "string" ? input : input instanceof URL ? input : input.url);
-    if (url === "/api/history") {
-      return jsonResponse({
+  mswServer.use(
+    ...buildHistoryHandlers({
+      list: makeHistoryListPayload({
         runs: [historyListRun("run-001", { status: "analyzing" })],
-      });
-    }
-    throw new Error(`Unexpected request: ${url}`);
-  }) as typeof fetch;
+      }),
+    }),
+  );
 
-  try {
-    await feature.refreshHistory();
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+  await feature.refreshHistory();
 
   expect(state.history.runs.value).toHaveLength(1);
   expect(historySummary.textContent).toContain("history.available_count");
@@ -557,32 +551,27 @@ test("history feature reports partial delete failures without splitting render o
   ensureRunDetail(state, "run-002");
 
   const { feature, errors, getRenderCount, getLatestModel } = createFeatureHarness(state);
-  const originalFetch = globalThis.fetch;
   const deleteRequests: string[] = [];
-
-  globalThis.fetch = (async (input: string | URL | RequestInfo, init?: RequestInit) => {
-    const url = String(typeof input === "string" ? input : input instanceof URL ? input : input.url);
-    if (init?.method === "DELETE" && url === "/api/history/run-001") {
-      deleteRequests.push(url);
-      return jsonResponse({ ok: true });
-    }
-    if (init?.method === "DELETE" && url === "/api/history/run-002") {
-      deleteRequests.push(url);
-      return jsonResponse({ detail: "delete failed" }, { status: 500 });
-    }
-    if (url === "/api/history") {
-      return jsonResponse({
+  mswServer.use(
+    ...buildHistoryHandlers({
+      list: makeHistoryListPayload({
         runs: [historyListRun("run-002", { status: "analyzing" })],
-      });
-    }
-    throw new Error(`Unexpected request: ${url}`);
-  }) as typeof fetch;
+      }),
+      deleteRun: (request) => {
+        const url = new URL(request.url);
+        deleteRequests.push(url.pathname);
+        if (url.pathname === "/api/history/run-001") {
+          return makeDeleteHistoryRunPayload({ run_id: "run-001" });
+        }
+        if (url.pathname === "/api/history/run-002") {
+          return { detail: "delete failed", status: 500 };
+        }
+        return { detail: `Unexpected request: ${url.pathname}`, status: 500 };
+      },
+    }),
+  );
 
-  try {
-    await feature.deleteAllRuns();
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+  await feature.deleteAllRuns();
 
   expect(deleteRequests).toEqual(["/api/history/run-001", "/api/history/run-002"]);
   expect(state.history.deleteAllRunsInFlight.value).toBe(false);

--- a/apps/ui/tests/msw/handlers/history.ts
+++ b/apps/ui/tests/msw/handlers/history.ts
@@ -1,0 +1,185 @@
+import type {
+  DeleteHistoryRunPayload,
+  HistoryEntry,
+  HistoryListPayload,
+  HistoryRunPayload,
+} from "../../../src/api/types";
+import { HttpResponse, http, uiTestUrl } from "../http";
+
+type ErrorResponse = {
+  detail: string;
+  status?: number;
+};
+
+type JsonHandlerResult<T> = T | ErrorResponse | ((request: Request) => T | ErrorResponse | Promise<T | ErrorResponse>);
+type BinaryResponseInit = {
+  body?: BodyInit | null;
+  contentType?: string;
+  filename?: string | null;
+  headers?: HeadersInit;
+  status?: number;
+  statusText?: string;
+};
+type BinaryHandlerResult =
+  | BinaryResponseInit
+  | ErrorResponse
+  | ((request: Request) => BinaryResponseInit | ErrorResponse | Promise<BinaryResponseInit | ErrorResponse>);
+
+type HistoryInsightsLike = ErrorResponse | {
+  run_id: string;
+  status: "analyzing" | "complete";
+  [key: string]: unknown;
+};
+
+function isErrorResponse(value: unknown): value is ErrorResponse {
+  return !!value && typeof value === "object" && "detail" in value;
+}
+
+async function resolveJsonResult<T>(
+  request: Request,
+  result: JsonHandlerResult<T>,
+): Promise<HttpResponse> {
+  const resolved = typeof result === "function" ? await result(request) : result;
+  if (isErrorResponse(resolved)) {
+    return HttpResponse.json(
+      { detail: resolved.detail },
+      { status: resolved.status ?? 400 },
+    );
+  }
+  return HttpResponse.json(resolved);
+}
+
+async function resolveBinaryResult(
+  request: Request,
+  result: BinaryHandlerResult,
+): Promise<HttpResponse> {
+  const resolved = typeof result === "function" ? await result(request) : result;
+  if (isErrorResponse(resolved)) {
+    return HttpResponse.json(
+      { detail: resolved.detail },
+      { status: resolved.status ?? 400 },
+    );
+  }
+  const headers = new Headers(resolved.headers);
+  headers.set("content-type", resolved.contentType ?? "application/octet-stream");
+  if (resolved.filename) {
+    headers.set(
+      "content-disposition",
+      `attachment; filename*=UTF-8''${encodeURIComponent(resolved.filename)}`,
+    );
+  }
+  return new HttpResponse(resolved.body ?? "", {
+    status: resolved.status ?? 200,
+    statusText: resolved.statusText,
+    headers,
+  });
+}
+
+export function makeHistoryListRun(
+  runId: string,
+  overrides: Partial<HistoryEntry> = {},
+): HistoryEntry {
+  return {
+    run_id: runId,
+    status: "complete",
+    start_time_utc: "2026-01-01T00:00:00Z",
+    end_time_utc: "2026-01-01T00:00:12Z",
+    created_at: "2026-01-01T00:00:00Z",
+    sample_count: 42,
+    car_name: "Track Car",
+    error_message: null,
+    ...overrides,
+  };
+}
+
+export function makeHistoryListPayload(
+  overrides: Partial<HistoryListPayload> = {},
+): HistoryListPayload {
+  return {
+    runs: [makeHistoryListRun("run-001")],
+    ...overrides,
+  };
+}
+
+export function makeDeleteHistoryRunPayload(
+  overrides: Partial<DeleteHistoryRunPayload> = {},
+): DeleteHistoryRunPayload {
+  return {
+    run_id: "run-001",
+    status: "deleted",
+    ...overrides,
+  };
+}
+
+export function makeHistoryRunPayload(
+  overrides: Partial<HistoryRunPayload> = {},
+): HistoryRunPayload {
+  return {
+    analysis: null,
+    error_message: null,
+    metadata: undefined,
+    run_id: "run-001",
+    sample_count: 42,
+    status: "complete",
+    ...overrides,
+  };
+}
+
+export function makeHistoryInsightsAnalyzingPayload(runId: string): HistoryInsightsLike {
+  return {
+    run_id: runId,
+    status: "analyzing",
+  };
+}
+
+export function makeHistoryBinaryDownloadResponse(
+  overrides: Partial<BinaryResponseInit> = {},
+): BinaryResponseInit {
+  return {
+    body: "PDF",
+    contentType: "application/pdf",
+    filename: "run-001_report.pdf",
+    status: 200,
+    ...overrides,
+  };
+}
+
+export function buildHistoryHandlers(options: {
+  list?: JsonHandlerResult<HistoryListPayload>;
+  deleteRun?: JsonHandlerResult<DeleteHistoryRunPayload>;
+  runDetail?: JsonHandlerResult<HistoryRunPayload>;
+  insights?: JsonHandlerResult<HistoryInsightsLike>;
+} = {}) {
+  const list = options.list ?? makeHistoryListPayload();
+  const deleteRun = options.deleteRun ?? makeDeleteHistoryRunPayload();
+  const runDetail = options.runDetail ?? makeHistoryRunPayload();
+  const insights = options.insights ?? makeHistoryInsightsAnalyzingPayload("run-001");
+  return [
+    http.get(uiTestUrl("/api/history"), async ({ request }) =>
+      await resolveJsonResult(request, list)),
+    http.delete(uiTestUrl("/api/history/:runId"), async ({ request }) =>
+      await resolveJsonResult(request, deleteRun)),
+    http.get(uiTestUrl("/api/history/:runId"), async ({ request }) =>
+      await resolveJsonResult(request, runDetail)),
+    http.get(uiTestUrl("/api/history/:runId/insights"), async ({ request }) =>
+      await resolveJsonResult(request, insights)),
+  ];
+}
+
+export function buildHistoryDownloadHandlers(options: {
+  reportPdf?: BinaryHandlerResult;
+  exportArchive?: BinaryHandlerResult;
+} = {}) {
+  const reportPdf = options.reportPdf ?? makeHistoryBinaryDownloadResponse();
+  const exportArchive = options.exportArchive ?? makeHistoryBinaryDownloadResponse({
+    body: "ZIP",
+    contentType: "application/zip",
+    filename: "run-001_export.zip",
+  });
+  return [
+    http.get(uiTestUrl("/api/history/:runId/report.pdf"), async ({ request }) =>
+      await resolveBinaryResult(request, reportPdf)),
+    http.get(uiTestUrl("/api/history/:runId/export"), async ({ request }) =>
+      await resolveBinaryResult(request, exportArchive)),
+  ];
+}


### PR DESCRIPTION
## What changed
- add `apps/ui/tests/msw/handlers/history.ts` for reusable history list/delete/detail/insights and blob download responses
- move `tests/history_download.spec.ts` onto shared history download handlers
- move straightforward history feature empty/table/delete paths onto shared MSW handlers instead of direct fetch replacement

## Why
- history tests still hand-rolled fetch and blob responses after the shared MSW foundation landed
- shared handlers make empty-state, error, and download cases cheaper to express without mock-only wiring

## Validation
- `cd apps/ui && npm run lint:unused`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/history_download.spec.ts tests/history_feature_modules.spec.ts -c ../../.ai-temp/playwright.unit.local.config.ts`

## Risks / tradeoffs
- detail and insights endpoints are wired in the shared owner, but this PR only migrates the first list/delete/download consumers
- deeper history workflow migrations stay for follow-up issues instead of widening this PR

Closes #2909