### PR TITLE
test(ui): share maintenance msw handlers

### DIFF
--- a/apps/ui/tests/esp_flash_feature_actions.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_actions.spec.ts
@@ -4,17 +4,24 @@ import {
   createDeferred,
   flushAsyncWork,
   installTimerHarness,
-  jsonResponse,
 } from "./async_test_helpers";
 import {
   createEspFlashFeatureHarness,
   createEspFlashPort,
   expectPollDelays,
-  installFeatureFetchMock,
   installMaintenanceFeatureGlobals,
 } from "./maintenance_feature_test_support";
+import {
+  buildEspFlashHandlers,
+  makeEspFlashHistoryPayload,
+  makeEspFlashLogsPayload,
+  makeEspFlashPortsPayload,
+  makeEspFlashStatusPayload,
+} from "./msw/handlers/maintenance";
+import { createUiMswTestServer } from "./msw/node";
 
 let restoreDomGlobals = () => undefined;
+const mswServer = createUiMswTestServer(test);
 
 test.beforeEach(() => {
   restoreDomGlobals = installMaintenanceFeatureGlobals();
@@ -28,24 +35,7 @@ test.afterEach(() => {
 test.describe("createEspFlashFeature actions", () => {
   test("start replaces the previous poll timeout instead of creating a second chain", async () => {
     const timers = installTimerHarness();
-    const restoreFetch = installFeatureFetchMock(async (url, method) => {
-      if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [createEspFlashPort()] });
-      }
-      if (url.pathname === "/api/esp-flash/start" && method === "POST") {
-        return jsonResponse({ status: "started", job_id: 1 });
-      }
-      if (url.pathname === "/api/esp-flash/status") {
-        return jsonResponse({ state: "idle", log_count: 0, error: null });
-      }
-      if (url.pathname === "/api/esp-flash/logs") {
-        return jsonResponse({ from_index: 0, next_index: 0, lines: [] });
-      }
-      if (url.pathname === "/api/esp-flash/history") {
-        return jsonResponse({ attempts: [] });
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(...buildEspFlashHandlers());
 
     try {
       const { deps, feature } = createEspFlashFeatureHarness();
@@ -56,17 +46,17 @@ test.describe("createEspFlashFeature actions", () => {
 
       deps.espFlashStartBtn.click();
       await expectPollDelays(timers, [4_000]);
+      feature.dispose();
     } finally {
-      restoreFetch();
       timers.restore();
     }
   });
 
   test("manual port selection is reflected in the flash start payload", async () => {
-    let startBody: Record<string, unknown> | null = null;
-    const restoreFetch = installFeatureFetchMock(async (url, method, body) => {
-      if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({
+    const startRequests: Array<{ auto_detect: boolean; port: string | null }> = [];
+    mswServer.use(
+      ...buildEspFlashHandlers({
+        ports: makeEspFlashPortsPayload({
           ports: [
             createEspFlashPort(),
             createEspFlashPort({
@@ -77,65 +67,39 @@ test.describe("createEspFlashFeature actions", () => {
               vid: 3,
             }),
           ],
-        });
-      }
-      if (url.pathname === "/api/esp-flash/start" && method === "POST") {
-        startBody = JSON.parse(body) as Record<string, unknown>;
-        return jsonResponse({ status: "started", job_id: 1 });
-      }
-      if (url.pathname === "/api/esp-flash/status") {
-        return jsonResponse({ state: "idle", log_count: 0, error: null });
-      }
-      if (url.pathname === "/api/esp-flash/logs") {
-        return jsonResponse({ from_index: 0, next_index: 0, lines: [] });
-      }
-      if (url.pathname === "/api/esp-flash/history") {
-        return jsonResponse({ attempts: [] });
-      }
-      return jsonResponse({});
-    });
+        }),
+        startRequests,
+      }),
+    );
 
-    try {
-      const { deps, feature } = createEspFlashFeatureHarness();
+    const { deps, feature } = createEspFlashFeatureHarness();
 
-      feature.bindHandlers();
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindHandlers();
+    feature.startPolling();
+    await flushAsyncWork();
 
-      deps.els.espFlashPortSelect.value = "/dev/ttyUSB1";
-      deps.els.espFlashPortSelect.dispatchEvent(new Event("change"));
-      deps.espFlashStartBtn.click();
-      await flushAsyncWork();
+    deps.els.espFlashPortSelect.value = "/dev/ttyUSB1";
+    deps.els.espFlashPortSelect.dispatchEvent(new Event("change"));
+    deps.espFlashStartBtn.click();
+    await flushAsyncWork();
 
-      expect(startBody).toEqual({
-        auto_detect: false,
-        port: "/dev/ttyUSB1",
-      });
-    } finally {
-      restoreFetch();
-    }
+    expect(startRequests).toEqual([{
+      auto_detect: false,
+      port: "/dev/ttyUSB1",
+    }]);
+    feature.dispose();
   });
 
   test("cancel replaces the previous poll timeout instead of creating a second chain", async () => {
     const timers = installTimerHarness();
-    const restoreFetch = installFeatureFetchMock(async (url, method) => {
-      if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [] });
-      }
-      if (url.pathname === "/api/esp-flash/cancel" && method === "POST") {
-        return jsonResponse({ status: "cancelled" });
-      }
-      if (url.pathname === "/api/esp-flash/status") {
-        return jsonResponse({ state: "idle", log_count: 0, error: null });
-      }
-      if (url.pathname === "/api/esp-flash/logs") {
-        return jsonResponse({ from_index: 0, next_index: 0, lines: [] });
-      }
-      if (url.pathname === "/api/esp-flash/history") {
-        return jsonResponse({ attempts: [] });
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(
+      ...buildEspFlashHandlers({
+        history: makeEspFlashHistoryPayload(),
+        logs: makeEspFlashLogsPayload(),
+        ports: makeEspFlashPortsPayload({ ports: [] }),
+        status: makeEspFlashStatusPayload(),
+      }),
+    );
 
     try {
       const { deps, feature } = createEspFlashFeatureHarness();
@@ -146,30 +110,24 @@ test.describe("createEspFlashFeature actions", () => {
 
       deps.espFlashCancelBtn.click();
       await expectPollDelays(timers, [4_000]);
+      feature.dispose();
     } finally {
-      restoreFetch();
       timers.restore();
     }
   });
 
   test("stopPolling prevents an in-flight poll from reviving the loop", async () => {
     const timers = installTimerHarness();
-    const deferredStatus = createDeferred<Response>();
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [] });
-      }
-      if (url.pathname === "/api/esp-flash/status") {
-        return deferredStatus.promise;
-      }
-      if (url.pathname === "/api/esp-flash/logs") {
-        return jsonResponse({ from_index: 0, next_index: 0, lines: [] });
-      }
-      if (url.pathname === "/api/esp-flash/history") {
-        return jsonResponse({ attempts: [] });
-      }
-      return jsonResponse({});
-    });
+    const deferredStatus = createDeferred<void>();
+    mswServer.use(
+      ...buildEspFlashHandlers({
+        ports: makeEspFlashPortsPayload({ ports: [] }),
+        status: async () => {
+          await deferredStatus.promise;
+          return makeEspFlashStatusPayload();
+        },
+      }),
+    );
 
     try {
       const { feature } = createEspFlashFeatureHarness();
@@ -182,16 +140,14 @@ test.describe("createEspFlashFeature actions", () => {
       );
 
       feature.stopPolling();
-      deferredStatus.resolve(
-        jsonResponse({ state: "idle", log_count: 0, error: null }),
-      );
+      deferredStatus.resolve();
       await flushAsyncWork();
 
       expect(timers.pendingDelays().filter((delay) => delay !== 10_000)).toEqual(
         [],
       );
+      feature.dispose();
     } finally {
-      restoreFetch();
       timers.restore();
     }
   });

--- a/apps/ui/tests/esp_flash_feature_polling.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_polling.spec.ts
@@ -7,8 +7,13 @@ import {
   installFeatureFetchMock,
   installMaintenanceFeatureGlobals,
 } from "./maintenance_feature_test_support";
+import {
+  buildEspFlashHandlers,
+} from "./msw/handlers/maintenance";
+import { createUiMswTestServer } from "./msw/node";
 
 let restoreDomGlobals = () => undefined;
+const mswServer = createUiMswTestServer(test);
 
 test.beforeEach(() => {
   restoreDomGlobals = installMaintenanceFeatureGlobals();
@@ -21,72 +26,47 @@ test.afterEach(() => {
 
 test.describe("createEspFlashFeature polling", () => {
   test("idle state renders readiness, empty log, and empty history context", async () => {
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [createEspFlashPort()] });
-      }
-      if (url.pathname === "/api/esp-flash/status") {
-        return jsonResponse({
-          state: "idle",
-          phase: "idle",
-          selected_port: null,
-          auto_detect: true,
-          last_success_at: null,
-          error: null,
-          log_count: 0,
-        });
-      }
-      if (url.pathname === "/api/esp-flash/history") {
-        return jsonResponse({ attempts: [] });
-      }
-      if (url.pathname === "/api/esp-flash/logs") {
-        return jsonResponse({ from_index: 0, next_index: 0, lines: [] });
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(...buildEspFlashHandlers());
 
-    try {
-      const { deps, feature } = createEspFlashFeatureHarness();
+    const { deps, feature } = createEspFlashFeatureHarness();
 
-      feature.bindHandlers();
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindHandlers();
+    feature.startPolling();
+    await flushAsyncWork();
 
-      expect(deps.espFlashStartSummary.innerHTML).toContain(
-        "settings.esp_flash.start_readiness.summary_ready",
-      );
-      expect(deps.espFlashStartSummary.innerHTML).toContain(
-        "settings.esp_flash.start_readiness.item.connection_ready",
-      );
-      expect(deps.espFlashStartBtn.disabled).toBe(false);
-      expect(deps.espFlashCancelBtn.hidden).toBe(true);
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain(
-        "settings.esp_flash.readiness.summary.ready_ports",
-      );
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain(
-        "settings.esp_flash.readiness.one_port",
-      );
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain(
-        "settings.esp_flash.auto_detect",
-      );
-      expect(deps.espFlashReadinessPanel.innerHTML).not.toContain(
-        "settings.esp_flash.journey_title",
-      );
-      expect(deps.espFlashReadinessPanel.innerHTML).not.toContain(
-        "settings.esp_flash.phase.validating",
-      );
-      expect(deps.espFlashJourneyPanel.innerHTML).toContain(
-        "settings.esp_flash.phase.validating",
-      );
-      expect((deps.els.espFlashLogPanel as HTMLElement).innerHTML).toContain(
-        "settings.esp_flash.logs_idle_title",
-      );
-      expect(
-        (deps.els.espFlashHistoryPanel as HTMLElement).innerHTML,
-      ).toContain("settings.esp_flash.history_empty_title");
-    } finally {
-      restoreFetch();
-    }
+    expect(deps.espFlashStartSummary.innerHTML).toContain(
+      "settings.esp_flash.start_readiness.summary_ready",
+    );
+    expect(deps.espFlashStartSummary.innerHTML).toContain(
+      "settings.esp_flash.start_readiness.item.connection_ready",
+    );
+    expect(deps.espFlashStartBtn.disabled).toBe(false);
+    expect(deps.espFlashCancelBtn.hidden).toBe(true);
+    expect(deps.espFlashReadinessPanel.innerHTML).toContain(
+      "settings.esp_flash.readiness.summary.ready_ports",
+    );
+    expect(deps.espFlashReadinessPanel.innerHTML).toContain(
+      "settings.esp_flash.readiness.one_port",
+    );
+    expect(deps.espFlashReadinessPanel.innerHTML).toContain(
+      "settings.esp_flash.auto_detect",
+    );
+    expect(deps.espFlashReadinessPanel.innerHTML).not.toContain(
+      "settings.esp_flash.journey_title",
+    );
+    expect(deps.espFlashReadinessPanel.innerHTML).not.toContain(
+      "settings.esp_flash.phase.validating",
+    );
+    expect(deps.espFlashJourneyPanel.innerHTML).toContain(
+      "settings.esp_flash.phase.validating",
+    );
+    expect((deps.els.espFlashLogPanel as HTMLElement).innerHTML).toContain(
+      "settings.esp_flash.logs_idle_title",
+    );
+    expect(
+      (deps.els.espFlashHistoryPanel as HTMLElement).innerHTML,
+    ).toContain("settings.esp_flash.history_empty_title");
+    feature.dispose();
   });
 
   test("no detected ports keep the flash action blocked until hardware is present", async () => {

--- a/apps/ui/tests/msw/handlers/maintenance.ts
+++ b/apps/ui/tests/msw/handlers/maintenance.ts
@@ -1,0 +1,227 @@
+import type {
+  EspFlashCancelPayload,
+  EspFlashHistoryPayload,
+  EspFlashLogsPayload,
+  EspFlashPortsPayload,
+  EspFlashStartPayload,
+  EspFlashStatusPayload,
+  HealthStatusPayload,
+  UpdateCancelPayload,
+  UpdateStartPayload,
+  UpdateStartRequestPayload,
+  UpdateStatusPayload,
+  UsbInternetStatusPayload,
+} from "../../../src/api/types";
+import {
+  createEspFlashPort,
+  createHealthyUpdateStatus,
+  createIdleUpdateStatus,
+  createUsbInternetStatus,
+} from "../../maintenance_feature_test_support";
+import { HttpResponse, http, uiTestUrl } from "../http";
+
+type ErrorResponse = {
+  detail: string;
+  status?: number;
+};
+
+type ScenarioValue<T> = T | ErrorResponse;
+type ScenarioInput<T> =
+  | ScenarioValue<T>
+  | readonly ScenarioValue<T>[]
+  | ((request: Request) => ScenarioValue<T> | Promise<ScenarioValue<T>>);
+
+export type EspFlashStartRequestPayload = {
+  auto_detect: boolean;
+  port: string | null;
+};
+
+function isErrorResponse(value: unknown): value is ErrorResponse {
+  return !!value && typeof value === "object" && "detail" in value;
+}
+
+function createScenarioResolver<T>(input: ScenarioInput<T>) {
+  let index = 0;
+  return async (request: Request): Promise<ScenarioValue<T>> => {
+    if (typeof input === "function") {
+      return await input(request);
+    }
+    if (Array.isArray(input)) {
+      const value = input[Math.min(index, input.length - 1)];
+      if (index < input.length - 1) {
+        index += 1;
+      }
+      return value;
+    }
+    return input;
+  };
+}
+
+async function resolveJsonScenario<T>(
+  request: Request,
+  resolve: (request: Request) => Promise<ScenarioValue<T>>,
+): Promise<HttpResponse> {
+  const resolved = await resolve(request);
+  if (isErrorResponse(resolved)) {
+    return HttpResponse.json(
+      { detail: resolved.detail },
+      { status: resolved.status ?? 400 },
+    );
+  }
+  return HttpResponse.json(resolved);
+}
+
+export function makeUpdateStartPayload(
+  overrides: Partial<UpdateStartPayload> = {},
+): UpdateStartPayload {
+  return {
+    status: "started",
+    transport: "wifi",
+    ssid: "MyWiFi",
+    ...overrides,
+  };
+}
+
+export function makeUpdateCancelPayload(
+  overrides: Partial<UpdateCancelPayload> = {},
+): UpdateCancelPayload {
+  return {
+    cancelled: true,
+    ...overrides,
+  };
+}
+
+export function makeEspFlashPortsPayload(
+  overrides: Partial<EspFlashPortsPayload> = {},
+): EspFlashPortsPayload {
+  return {
+    ports: [createEspFlashPort()],
+    ...overrides,
+  };
+}
+
+export function makeEspFlashStatusPayload(
+  overrides: Partial<EspFlashStatusPayload> = {},
+): EspFlashStatusPayload {
+  return {
+    state: "idle",
+    phase: "idle",
+    selected_port: null,
+    auto_detect: true,
+    last_success_at: null,
+    error: null,
+    log_count: 0,
+    job_id: null,
+    started_at: null,
+    finished_at: null,
+    exit_code: null,
+    ...overrides,
+  };
+}
+
+export function makeEspFlashLogsPayload(
+  overrides: Partial<EspFlashLogsPayload> = {},
+): EspFlashLogsPayload {
+  return {
+    from_index: 0,
+    next_index: 0,
+    lines: [],
+    ...overrides,
+  };
+}
+
+export function makeEspFlashHistoryPayload(
+  overrides: Partial<EspFlashHistoryPayload> = {},
+): EspFlashHistoryPayload {
+  return {
+    attempts: [],
+    ...overrides,
+  };
+}
+
+export function makeEspFlashStartPayload(
+  overrides: Partial<EspFlashStartPayload> = {},
+): EspFlashStartPayload {
+  return {
+    status: "started",
+    job_id: 1,
+    ...overrides,
+  };
+}
+
+export function makeEspFlashCancelPayload(
+  overrides: Partial<EspFlashCancelPayload> = {},
+): EspFlashCancelPayload {
+  return {
+    cancelled: true,
+    ...overrides,
+  };
+}
+
+export function buildUpdateHandlers(options: {
+  status?: ScenarioInput<UpdateStatusPayload>;
+  health?: ScenarioInput<HealthStatusPayload>;
+  internet?: ScenarioInput<UsbInternetStatusPayload>;
+  start?: ScenarioInput<UpdateStartPayload>;
+  cancel?: ScenarioInput<UpdateCancelPayload>;
+  startRequests?: UpdateStartRequestPayload[];
+  onStartRequest?: (payload: UpdateStartRequestPayload) => void;
+} = {}) {
+  const resolveStatus = createScenarioResolver(options.status ?? createIdleUpdateStatus());
+  const resolveHealth = createScenarioResolver(options.health ?? createHealthyUpdateStatus());
+  const resolveInternet = createScenarioResolver(options.internet ?? createUsbInternetStatus());
+  const resolveStart = createScenarioResolver(options.start ?? makeUpdateStartPayload());
+  const resolveCancel = createScenarioResolver(options.cancel ?? makeUpdateCancelPayload());
+  return [
+    http.get(uiTestUrl("/api/update/status"), async ({ request }) =>
+      await resolveJsonScenario(request, resolveStatus)),
+    http.get(uiTestUrl("/api/health"), async ({ request }) =>
+      await resolveJsonScenario(request, resolveHealth)),
+    http.get(uiTestUrl("/api/update/internet-status"), async ({ request }) =>
+      await resolveJsonScenario(request, resolveInternet)),
+    http.post(uiTestUrl("/api/update/start"), async ({ request }) => {
+      const payload = await request.json() as UpdateStartRequestPayload;
+      options.startRequests?.push(payload);
+      options.onStartRequest?.(payload);
+      return await resolveJsonScenario(request, resolveStart);
+    }),
+    http.post(uiTestUrl("/api/update/cancel"), async ({ request }) =>
+      await resolveJsonScenario(request, resolveCancel)),
+  ];
+}
+
+export function buildEspFlashHandlers(options: {
+  ports?: ScenarioInput<EspFlashPortsPayload>;
+  status?: ScenarioInput<EspFlashStatusPayload>;
+  logs?: ScenarioInput<EspFlashLogsPayload>;
+  history?: ScenarioInput<EspFlashHistoryPayload>;
+  start?: ScenarioInput<EspFlashStartPayload>;
+  cancel?: ScenarioInput<EspFlashCancelPayload>;
+  startRequests?: EspFlashStartRequestPayload[];
+  onStartRequest?: (payload: EspFlashStartRequestPayload) => void;
+} = {}) {
+  const resolvePorts = createScenarioResolver(options.ports ?? makeEspFlashPortsPayload());
+  const resolveStatus = createScenarioResolver(options.status ?? makeEspFlashStatusPayload());
+  const resolveLogs = createScenarioResolver(options.logs ?? makeEspFlashLogsPayload());
+  const resolveHistory = createScenarioResolver(options.history ?? makeEspFlashHistoryPayload());
+  const resolveStart = createScenarioResolver(options.start ?? makeEspFlashStartPayload());
+  const resolveCancel = createScenarioResolver(options.cancel ?? makeEspFlashCancelPayload());
+  return [
+    http.get(uiTestUrl("/api/esp-flash/ports"), async ({ request }) =>
+      await resolveJsonScenario(request, resolvePorts)),
+    http.get(uiTestUrl("/api/esp-flash/status"), async ({ request }) =>
+      await resolveJsonScenario(request, resolveStatus)),
+    http.get(uiTestUrl("/api/esp-flash/logs"), async ({ request }) =>
+      await resolveJsonScenario(request, resolveLogs)),
+    http.get(uiTestUrl("/api/esp-flash/history"), async ({ request }) =>
+      await resolveJsonScenario(request, resolveHistory)),
+    http.post(uiTestUrl("/api/esp-flash/start"), async ({ request }) => {
+      const payload = await request.json() as EspFlashStartRequestPayload;
+      options.startRequests?.push(payload);
+      options.onStartRequest?.(payload);
+      return await resolveJsonScenario(request, resolveStart);
+    }),
+    http.post(uiTestUrl("/api/esp-flash/cancel"), async ({ request }) =>
+      await resolveJsonScenario(request, resolveCancel)),
+  ];
+}

--- a/apps/ui/tests/update_feature_transport.spec.ts
+++ b/apps/ui/tests/update_feature_transport.spec.ts
@@ -3,19 +3,20 @@ import { expect, test } from "@playwright/test";
 import {
   flushAsyncWork,
   installTimerHarness,
-  jsonResponse,
 } from "./async_test_helpers";
 import {
+  createUsbInternetStatus,
   createHealthyUpdateStatus,
   createIdleUpdateStatus,
   createUpdateFeatureHarness,
-  createUsbInternetStatus,
   expectTimerDelays,
-  installFeatureFetchMock,
   installMaintenanceFeatureGlobals,
 } from "./maintenance_feature_test_support";
+import { buildUpdateHandlers, makeUpdateStartPayload } from "./msw/handlers/maintenance";
+import { createUiMswTestServer } from "./msw/node";
 
 let restoreDomGlobals = () => undefined;
+const mswServer = createUiMswTestServer(test);
 
 test.beforeEach(() => {
   restoreDomGlobals = installMaintenanceFeatureGlobals();
@@ -29,27 +30,23 @@ test.afterEach(() => {
 test.describe("createUpdateFeature transport", () => {
   test("start replaces the previous update poll timeout instead of creating a second chain", async () => {
     const timers = installTimerHarness();
-    let startBody = "";
-    const restoreFetch = installFeatureFetchMock(async (url, method, body) => {
-      if (url.pathname === "/api/update/start" && method === "POST") {
-        startBody = body;
-        return jsonResponse({
-          status: "started",
+    const startRequests: Array<{
+      password: string;
+      ssid?: string | null;
+      transport: string;
+    }> = [];
+    mswServer.use(
+      ...buildUpdateHandlers({
+        health: createHealthyUpdateStatus(),
+        internet: createUsbInternetStatus(),
+        start: makeUpdateStartPayload({
           transport: "wifi",
           ssid: "MyWiFi",
-        });
-      }
-      if (url.pathname === "/api/update/status") {
-        return jsonResponse(createIdleUpdateStatus());
-      }
-      if (url.pathname === "/api/health") {
-        return jsonResponse(createHealthyUpdateStatus());
-      }
-      if (url.pathname === "/api/update/internet-status") {
-        return jsonResponse(createUsbInternetStatus());
-      }
-      return jsonResponse({});
-    });
+        }),
+        startRequests,
+        status: createIdleUpdateStatus(),
+      }),
+    );
 
     try {
       const { deps, feature } = createUpdateFeatureHarness();
@@ -65,115 +62,106 @@ test.describe("createUpdateFeature transport", () => {
       deps.updateStartBtn.click();
       await expectTimerDelays(timers, [10_000]);
       expect(deps.updatePasswordInput.value).toBe("");
-      expect(JSON.parse(startBody)).toEqual({
+      expect(startRequests).toEqual([{
         transport: "wifi",
         ssid: "MyWiFi",
         password: "secret",
-      });
+      }]);
+      feature.dispose();
     } finally {
-      restoreFetch();
       timers.restore();
     }
   });
 
   test("usable USB internet shows the USB option and starts with the USB transport payload", async () => {
-    let startBody = "";
-    const restoreFetch = installFeatureFetchMock(async (url, method, body) => {
-      if (url.pathname === "/api/update/start" && method === "POST") {
-        startBody = body;
-        return jsonResponse({
-          status: "started",
+    const startRequests: Array<{
+      password: string;
+      ssid?: string | null;
+      transport: string;
+    }> = [];
+    mswServer.use(
+      ...buildUpdateHandlers({
+        health: createHealthyUpdateStatus(),
+        internet: createUsbInternetStatus({
+          detected: true,
+          usable: true,
+          interface_name: "usb0",
+          connection_name: "iPhone USB",
+          driver: "ipheth",
+          ipv4_addresses: ["172.20.10.2/28"],
+          gateway: "172.20.10.1",
+          has_default_route: true,
+          diagnostic: "USB internet is ready on 'usb0'.",
+        }),
+        start: makeUpdateStartPayload({
           transport: "usb_internet",
           ssid: null,
-        });
-      }
-      if (url.pathname === "/api/update/status") {
-        return jsonResponse(createIdleUpdateStatus());
-      }
-      if (url.pathname === "/api/health") {
-        return jsonResponse(createHealthyUpdateStatus());
-      }
-      if (url.pathname === "/api/update/internet-status") {
-        return jsonResponse(
-          createUsbInternetStatus({
-            detected: true,
-            usable: true,
-            interface_name: "usb0",
-            connection_name: "iPhone USB",
-            driver: "ipheth",
-            ipv4_addresses: ["172.20.10.2/28"],
-            gateway: "172.20.10.1",
-            has_default_route: true,
-            diagnostic: "USB internet is ready on 'usb0'.",
-          }),
-        );
-      }
-      return jsonResponse({});
-    });
+        }),
+        startRequests,
+        status: createIdleUpdateStatus(),
+      }),
+    );
 
-    try {
-      const { deps, feature } = createUpdateFeatureHarness();
-      deps.updateTransportWifiRadio.checked = false;
-      deps.updateTransportUsbRadio.checked = true;
+    const { deps, feature } = createUpdateFeatureHarness();
+    deps.updateTransportWifiRadio.checked = false;
+    deps.updateTransportUsbRadio.checked = true;
 
-      feature.bindUpdateHandlers();
-      feature.startPolling();
-      await flushAsyncWork();
-      deps.updatePasswordInput.value = "secret";
-      deps.updatePasswordInput.dispatchEvent(new Event("input"));
-      deps.updateTransportWifiRadio.checked = false;
-      deps.updateTransportUsbRadio.checked = true;
-      deps.updateTransportUsbRadio.dispatchEvent(new Event("change"));
+    feature.bindUpdateHandlers();
+    feature.startPolling();
+    await flushAsyncWork();
+    deps.updatePasswordInput.value = "secret";
+    deps.updatePasswordInput.dispatchEvent(new Event("input"));
+    deps.updateTransportWifiRadio.checked = false;
+    deps.updateTransportUsbRadio.checked = true;
+    deps.updateTransportUsbRadio.dispatchEvent(new Event("change"));
 
-      expect(deps.updateTransportOptions.hidden).toBe(false);
-      expect(deps.updateWifiFields.hidden).toBe(true);
-      expect(deps.updateStartBtn.disabled).toBe(false);
-      expect(deps.updateReadinessSummary.innerHTML).toContain(
-        "settings.update.readiness.item.connection_usb_ready",
-      );
-      expect(deps.updateDetailsCaption.textContent).toBe(
-        "settings.update.details_caption_usb",
-      );
-      expect(deps.updateTransportNote.textContent).toBe(
-        "settings.update.preflight_note_usb",
-      );
-      expect(deps.updateUsbTransportSummary.textContent).toBe(
-        "settings.update.transport.usb_summary_interface",
-      );
-      expect(
-        deps.updateTransportChoiceWifi.getAttribute("data-selected"),
-      ).toBeNull();
-      expect(
-        deps.updateTransportChoiceWifi.getAttribute("data-choice-state"),
-      ).toBeNull();
-      expect(
-        deps.updateTransportChoiceWifi.getAttribute("data-choice-badge"),
-      ).toBeNull();
-      expect(deps.updateTransportChoiceUsb.getAttribute("data-selected")).toBe(
-        "true",
-      );
-      expect(
-        deps.updateTransportChoiceUsb.getAttribute("data-choice-state"),
-      ).toBe("active");
-      expect(
-        deps.updateTransportChoiceUsb.getAttribute("data-choice-badge"),
-      ).toBe("settings.update.transport.selected_badge");
-      expect(
-        deps.updateTransportChoiceUsb.getAttribute("data-disabled"),
-      ).toBeNull();
-      expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain(
-        "usb0",
-      );
+    expect(deps.updateTransportOptions.hidden).toBe(false);
+    expect(deps.updateWifiFields.hidden).toBe(true);
+    expect(deps.updateStartBtn.disabled).toBe(false);
+    expect(deps.updateReadinessSummary.innerHTML).toContain(
+      "settings.update.readiness.item.connection_usb_ready",
+    );
+    expect(deps.updateDetailsCaption.textContent).toBe(
+      "settings.update.details_caption_usb",
+    );
+    expect(deps.updateTransportNote.textContent).toBe(
+      "settings.update.preflight_note_usb",
+    );
+    expect(deps.updateUsbTransportSummary.textContent).toBe(
+      "settings.update.transport.usb_summary_interface",
+    );
+    expect(
+      deps.updateTransportChoiceWifi.getAttribute("data-selected"),
+    ).toBeNull();
+    expect(
+      deps.updateTransportChoiceWifi.getAttribute("data-choice-state"),
+    ).toBeNull();
+    expect(
+      deps.updateTransportChoiceWifi.getAttribute("data-choice-badge"),
+    ).toBeNull();
+    expect(deps.updateTransportChoiceUsb.getAttribute("data-selected")).toBe(
+      "true",
+    );
+    expect(
+      deps.updateTransportChoiceUsb.getAttribute("data-choice-state"),
+    ).toBe("active");
+    expect(
+      deps.updateTransportChoiceUsb.getAttribute("data-choice-badge"),
+    ).toBe("settings.update.transport.selected_badge");
+    expect(
+      deps.updateTransportChoiceUsb.getAttribute("data-disabled"),
+    ).toBeNull();
+    expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain(
+      "usb0",
+    );
 
-      deps.updateStartBtn.click();
-      await flushAsyncWork();
+    deps.updateStartBtn.click();
+    await flushAsyncWork();
 
-      expect(JSON.parse(startBody)).toEqual({
-        transport: "usb_internet",
-        password: "",
-      });
-    } finally {
-      restoreFetch();
-    }
+    expect(startRequests).toEqual([{
+      transport: "usb_internet",
+      password: "",
+    }]);
+    feature.dispose();
   });
 });


### PR DESCRIPTION
## What changed
- add `apps/ui/tests/msw/handlers/maintenance.ts` for shared updater and ESP-flash HTTP handlers, typed defaults, per-endpoint scenario inputs, and start-request capture
- move updater transport tests and ESP-flash action tests onto that shared owner
- move one ESP-flash polling path onto the shared owner and keep the specialized last-running-phase regression on its existing targeted stub

## Why
- these maintenance specs still repeated verbose endpoint routers even after the shared MSW foundation landed
- one owner makes polling snapshots, action responses, and representative failure states cheaper to express without mock-only transport glue

## Validation
- `cd apps/ui && npm run lint:unused`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/update_feature_transport.spec.ts tests/esp_flash_feature_actions.spec.ts tests/esp_flash_feature_polling.spec.ts -c ../../.ai-temp/playwright.unit.local.config.ts`

## Risks / tradeoffs
- this PR migrates the first updater and ESP-flash consumers, not every maintenance test file
- the last-running-phase ESP-flash polling regression keeps its custom stub because its request timing is more specialized than the shared first-pass abstraction

Closes #2910