### PR TITLE
test(maintenance): share polling msw scenarios

### DIFF
--- a/apps/ui/tests/esp_flash_feature_polling.spec.ts
+++ b/apps/ui/tests/esp_flash_feature_polling.spec.ts
@@ -1,10 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { flushAsyncWork, jsonResponse } from "./async_test_helpers";
+import { flushAsyncWork } from "./async_test_helpers";
 import {
   createEspFlashFeatureHarness,
   createEspFlashPort,
-  installFeatureFetchMock,
   installMaintenanceFeatureGlobals,
 } from "./maintenance_feature_test_support";
 import {
@@ -70,57 +69,34 @@ test.describe("createEspFlashFeature polling", () => {
   });
 
   test("no detected ports keep the flash action blocked until hardware is present", async () => {
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [] });
-      }
-      if (url.pathname === "/api/esp-flash/status") {
-        return jsonResponse({
-          state: "idle",
-          phase: "idle",
-          selected_port: null,
-          auto_detect: true,
-          last_success_at: null,
-          error: null,
-          log_count: 0,
-        });
-      }
-      if (url.pathname === "/api/esp-flash/history") {
-        return jsonResponse({ attempts: [] });
-      }
-      if (url.pathname === "/api/esp-flash/logs") {
-        return jsonResponse({ from_index: 0, next_index: 0, lines: [] });
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(
+      ...buildEspFlashHandlers({
+        ports: { ports: [] },
+      }),
+    );
 
-    try {
-      const { deps, feature } = createEspFlashFeatureHarness();
+    const { deps, feature } = createEspFlashFeatureHarness();
 
-      feature.bindHandlers();
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindHandlers();
+    feature.startPolling();
+    await flushAsyncWork();
 
-      expect(deps.espFlashStartSummary.innerHTML).toContain(
-        "settings.esp_flash.start_readiness.summary_blocked",
-      );
-      expect(deps.espFlashStartSummary.innerHTML).toContain(
-        "settings.esp_flash.start_readiness.item.connection_blocked",
-      );
-      expect(deps.espFlashStartBtn.disabled).toBe(true);
-      expect(deps.espFlashCancelBtn.hidden).toBe(true);
-    } finally {
-      restoreFetch();
-    }
+    expect(deps.espFlashStartSummary.innerHTML).toContain(
+      "settings.esp_flash.start_readiness.summary_blocked",
+    );
+    expect(deps.espFlashStartSummary.innerHTML).toContain(
+      "settings.esp_flash.start_readiness.item.connection_blocked",
+    );
+    expect(deps.espFlashStartBtn.disabled).toBe(true);
+    expect(deps.espFlashCancelBtn.hidden).toBe(true);
+    feature.dispose();
   });
 
   test("running state highlights the active stage and marks completed stages done", async () => {
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [createEspFlashPort()] });
-      }
-      if (url.pathname === "/api/esp-flash/status") {
-        return jsonResponse({
+    mswServer.use(
+      ...buildEspFlashHandlers({
+        ports: { ports: [createEspFlashPort()] },
+        status: {
           state: "running",
           phase: "flashing",
           selected_port: "/dev/ttyUSB0",
@@ -128,46 +104,36 @@ test.describe("createEspFlashFeature polling", () => {
           last_success_at: null,
           error: null,
           log_count: 0,
-        });
-      }
-      if (url.pathname === "/api/esp-flash/history") {
-        return jsonResponse({ attempts: [] });
-      }
-      if (url.pathname === "/api/esp-flash/logs") {
-        return jsonResponse({ from_index: 0, next_index: 0, lines: [] });
-      }
-      return jsonResponse({});
-    });
+        },
+      }),
+    );
 
-    try {
-      const { deps, feature } = createEspFlashFeatureHarness();
+    const { deps, feature } = createEspFlashFeatureHarness();
 
-      feature.bindHandlers();
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindHandlers();
+    feature.startPolling();
+    await flushAsyncWork();
 
-      expect(deps.espFlashStartSummary.innerHTML).toContain(
-        "settings.esp_flash.start_readiness.summary_running",
-      );
-      expect(deps.espFlashStartBtn.hidden).toBe(true);
-      expect(deps.espFlashCancelBtn.hidden).toBe(false);
-      expect((deps.els.espFlashLogPanel as HTMLElement).innerHTML).toContain(
-        "settings.esp_flash.logs_running_title",
-      );
-      const html = deps.espFlashJourneyPanel.innerHTML;
-      expect(html).toMatch(
-        /data-stage-phase="flashing" data-stage-state="active" aria-current="step"/,
-      );
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain(
-        "settings.esp_flash.readiness.current_step",
-      );
-      expect(html.match(/data-stage-state="done"/g)).toHaveLength(3);
-      expect(
-        html.match(/<span class="maintenance-stage__marker">✓<\/span>/g),
-      ).toHaveLength(3);
-    } finally {
-      restoreFetch();
-    }
+    expect(deps.espFlashStartSummary.innerHTML).toContain(
+      "settings.esp_flash.start_readiness.summary_running",
+    );
+    expect(deps.espFlashStartBtn.hidden).toBe(true);
+    expect(deps.espFlashCancelBtn.hidden).toBe(false);
+    expect((deps.els.espFlashLogPanel as HTMLElement).innerHTML).toContain(
+      "settings.esp_flash.logs_running_title",
+    );
+    const html = deps.espFlashJourneyPanel.innerHTML;
+    expect(html).toMatch(
+      /data-stage-phase="flashing" data-stage-state="active" aria-current="step"/,
+    );
+    expect(deps.espFlashReadinessPanel.innerHTML).toContain(
+      "settings.esp_flash.readiness.current_step",
+    );
+    expect(html.match(/data-stage-state="done"/g)).toHaveLength(3);
+    expect(
+      html.match(/<span class="maintenance-stage__marker">✓<\/span>/g),
+    ).toHaveLength(3);
+    feature.dispose();
   });
 
   test("failed refresh keeps the last running stage marked as stopped here", async () => {
@@ -180,64 +146,52 @@ test.describe("createEspFlashFeature polling", () => {
       error: null,
       log_count: 0,
     };
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/esp-flash/ports") {
-        return jsonResponse({ ports: [createEspFlashPort()] });
-      }
-      if (url.pathname === "/api/esp-flash/status") {
-        return jsonResponse(status);
-      }
-      if (url.pathname === "/api/esp-flash/history") {
-        return jsonResponse({ attempts: [] });
-      }
-      if (url.pathname === "/api/esp-flash/logs") {
-        return jsonResponse({ from_index: 0, next_index: 0, lines: [] });
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(
+      ...buildEspFlashHandlers({
+        ports: { ports: [createEspFlashPort()] },
+        status: () => status,
+      }),
+    );
 
-    try {
-      const { deps, feature } = createEspFlashFeatureHarness();
+    const { deps, feature } = createEspFlashFeatureHarness();
 
-      feature.bindHandlers();
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindHandlers();
+    feature.startPolling();
+    await flushAsyncWork();
 
-      status = {
-        ...status,
-        state: "failed",
-        phase: "failed",
-        error: "serial port disconnected",
-      };
-      feature.stopPolling();
-      feature.startPolling();
-      await flushAsyncWork();
+    status = {
+      ...status,
+      state: "failed",
+      phase: "failed",
+      error: "serial port disconnected",
+    };
+    feature.stopPolling();
+    feature.startPolling();
+    await flushAsyncWork();
 
-      const html = deps.espFlashJourneyPanel.innerHTML;
-      expect(html).toMatch(
-        /data-stage-phase="flashing" data-stage-state="attention"/,
-      );
-      expect(deps.espFlashStartSummary.innerHTML).toContain(
-        "settings.esp_flash.recovery.title",
-      );
-      expect(deps.espFlashStartSummary.innerHTML).toContain(
-        "settings.esp_flash.recovery.flashing.detail",
-      );
-      expect(deps.espFlashStartBtn.textContent).toBe(
-        "settings.esp_flash.retry",
-      );
-      expect((deps.els.espFlashLogPanel as HTMLElement).innerHTML).toContain(
-        "settings.esp_flash.logs_failed_title",
-      );
-      expect(
-        (deps.els.espFlashHistoryPanel as HTMLElement).innerHTML,
-      ).toContain("serial port disconnected");
-      expect(html.match(/data-stage-state="done"/g)).toHaveLength(3);
-      expect(deps.espFlashReadinessPanel.innerHTML).toContain(
-        "serial port disconnected",
-      );
-    } finally {
-      restoreFetch();
-    }
+    const html = deps.espFlashJourneyPanel.innerHTML;
+    expect(html).toMatch(
+      /data-stage-phase="flashing" data-stage-state="attention"/,
+    );
+    expect(deps.espFlashStartSummary.innerHTML).toContain(
+      "settings.esp_flash.recovery.title",
+    );
+    expect(deps.espFlashStartSummary.innerHTML).toContain(
+      "settings.esp_flash.recovery.flashing.detail",
+    );
+    expect(deps.espFlashStartBtn.textContent).toBe(
+      "settings.esp_flash.retry",
+    );
+    expect((deps.els.espFlashLogPanel as HTMLElement).innerHTML).toContain(
+      "settings.esp_flash.logs_failed_title",
+    );
+    expect(
+      (deps.els.espFlashHistoryPanel as HTMLElement).innerHTML,
+    ).toContain("serial port disconnected");
+    expect(html.match(/data-stage-state="done"/g)).toHaveLength(3);
+    expect(deps.espFlashReadinessPanel.innerHTML).toContain(
+      "serial port disconnected",
+    );
+    feature.dispose();
   });
 });

--- a/apps/ui/tests/update_feature_polling.spec.ts
+++ b/apps/ui/tests/update_feature_polling.spec.ts
@@ -4,7 +4,6 @@ import {
   createDeferred,
   flushAsyncWork,
   installTimerHarness,
-  jsonResponse,
 } from "./async_test_helpers";
 import {
   createHealthyUpdateStatus,
@@ -12,11 +11,13 @@ import {
   createUpdateFeatureHarness,
   createUsbInternetStatus,
   expectTimerDelays,
-  installFeatureFetchMock,
   installMaintenanceFeatureGlobals,
 } from "./maintenance_feature_test_support";
+import { buildUpdateHandlers } from "./msw/handlers/maintenance";
+import { createUiMswTestServer } from "./msw/node";
 
 let restoreDomGlobals = () => undefined;
+const mswServer = createUiMswTestServer(test);
 
 test.beforeEach(() => {
   restoreDomGlobals = installMaintenanceFeatureGlobals();
@@ -29,98 +30,81 @@ test.afterEach(() => {
 
 test.describe("createUpdateFeature polling", () => {
   test("idle update status renders readiness and the expected journey", async () => {
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/update/status") {
-        return jsonResponse(createIdleUpdateStatus());
-      }
-      if (url.pathname === "/api/health") {
-        return jsonResponse(createHealthyUpdateStatus());
-      }
-      if (url.pathname === "/api/update/internet-status") {
-        return jsonResponse(createUsbInternetStatus());
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(...buildUpdateHandlers());
 
-    try {
-      const { deps, feature } = createUpdateFeatureHarness();
+    const { deps, feature } = createUpdateFeatureHarness();
 
-      feature.bindUpdateHandlers();
-      deps.updateSsidInput.value = "MyWiFi";
-      deps.updateSsidInput.dispatchEvent(new Event("input"));
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindUpdateHandlers();
+    deps.updateSsidInput.value = "MyWiFi";
+    deps.updateSsidInput.dispatchEvent(new Event("input"));
+    feature.startPolling();
+    await flushAsyncWork();
 
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
-        "settings.update.journey_title",
-      );
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
-        "settings.update.phase.validating",
-      );
-      expect(
-        (deps.els.updateStatusPanel as HTMLElement).innerHTML,
-      ).not.toContain("settings.update.issues_empty_title");
-      expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
-        "settings.update.log_empty_title",
-      );
-      expect((deps.els.updateOverviewPanel as HTMLElement).innerHTML).toContain(
-        "settings.update.current_status_title",
-      );
-      expect((deps.els.updateOverviewPanel as HTMLElement).innerHTML).toContain(
-        "settings.update.current_status_summary.ready",
-      );
-      expect((deps.els.updateOverviewPanel as HTMLElement).innerHTML).toContain(
-        "1.2.3",
-      );
-      expect((deps.els.updateOverviewPanel as HTMLElement).innerHTML).toContain(
-        "settings.update.health_card_title",
-      );
-      expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain(
-        "settings.internet.card_title",
-      );
-      expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain(
-        "settings.internet.summary.not_detected",
-      );
-      expect(deps.updateTransportOptions.hidden).toBe(false);
-      expect(deps.updateTransportChoiceWifi.getAttribute("data-selected")).toBe(
-        "true",
-      );
-      expect(
-        deps.updateTransportChoiceWifi.getAttribute("data-choice-state"),
-      ).toBe("active");
-      expect(
-        deps.updateTransportChoiceWifi.getAttribute("data-choice-badge"),
-      ).toBe("settings.update.transport.selected_badge");
-      expect(deps.updateTransportChoiceUsb.getAttribute("data-disabled")).toBe(
-        "true",
-      );
-      expect(deps.updateTransportUsbRadio.disabled).toBe(true);
-      expect(deps.updateReadinessSummary.innerHTML).toContain(
-        "settings.update.readiness.summary_ready",
-      );
-      expect(deps.updateReadinessSummary.innerHTML).toContain(
-        "settings.update.readiness.item.connection_wifi_ready",
-      );
-      expect(deps.updateDetailsCaption.textContent).toBe(
-        "settings.update.details_caption_wifi",
-      );
-      expect(deps.updateStartBtn.disabled).toBe(false);
-      expect(deps.updateUsbTransportSummary.textContent).toBe(
-        "settings.update.transport.usb_summary_unavailable",
-      );
-    } finally {
-      restoreFetch();
-    }
+    expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
+      "settings.update.journey_title",
+    );
+    expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
+      "settings.update.phase.validating",
+    );
+    expect(
+      (deps.els.updateStatusPanel as HTMLElement).innerHTML,
+    ).not.toContain("settings.update.issues_empty_title");
+    expect((deps.els.updateStatusPanel as HTMLElement).innerHTML).toContain(
+      "settings.update.log_empty_title",
+    );
+    expect((deps.els.updateOverviewPanel as HTMLElement).innerHTML).toContain(
+      "settings.update.current_status_title",
+    );
+    expect((deps.els.updateOverviewPanel as HTMLElement).innerHTML).toContain(
+      "settings.update.current_status_summary.ready",
+    );
+    expect((deps.els.updateOverviewPanel as HTMLElement).innerHTML).toContain(
+      "1.2.3",
+    );
+    expect((deps.els.updateOverviewPanel as HTMLElement).innerHTML).toContain(
+      "settings.update.health_card_title",
+    );
+    expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain(
+      "settings.internet.card_title",
+    );
+    expect((deps.internetStatusPanel as HTMLElement).innerHTML).toContain(
+      "settings.internet.summary.not_detected",
+    );
+    expect(deps.updateTransportOptions.hidden).toBe(false);
+    expect(deps.updateTransportChoiceWifi.getAttribute("data-selected")).toBe(
+      "true",
+    );
+    expect(
+      deps.updateTransportChoiceWifi.getAttribute("data-choice-state"),
+    ).toBe("active");
+    expect(
+      deps.updateTransportChoiceWifi.getAttribute("data-choice-badge"),
+    ).toBe("settings.update.transport.selected_badge");
+    expect(deps.updateTransportChoiceUsb.getAttribute("data-disabled")).toBe(
+      "true",
+    );
+    expect(deps.updateTransportUsbRadio.disabled).toBe(true);
+    expect(deps.updateReadinessSummary.innerHTML).toContain(
+      "settings.update.readiness.summary_ready",
+    );
+    expect(deps.updateReadinessSummary.innerHTML).toContain(
+      "settings.update.readiness.item.connection_wifi_ready",
+    );
+    expect(deps.updateDetailsCaption.textContent).toBe(
+      "settings.update.details_caption_wifi",
+    );
+    expect(deps.updateStartBtn.disabled).toBe(false);
+    expect(deps.updateUsbTransportSummary.textContent).toBe(
+      "settings.update.transport.usb_summary_unavailable",
+    );
+    feature.dispose();
   });
 
   test("degraded health blocks update start until maintenance issues are resolved", async () => {
     const healthy = createHealthyUpdateStatus();
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/update/status") {
-        return jsonResponse(createIdleUpdateStatus());
-      }
-      if (url.pathname === "/api/health") {
-        return jsonResponse({
+    mswServer.use(
+      ...buildUpdateHandlers({
+        health: {
           ...healthy,
           status: "degraded",
           degradation_reasons: ["persistence_write_error"],
@@ -128,269 +112,187 @@ test.describe("createUpdateFeature polling", () => {
             ...healthy.persistence,
             write_error: "database locked",
           },
-        });
-      }
-      if (url.pathname === "/api/update/internet-status") {
-        return jsonResponse(createUsbInternetStatus());
-      }
-      return jsonResponse({});
-    });
+        },
+      }),
+    );
 
-    try {
-      const { deps, feature } = createUpdateFeatureHarness();
+    const { deps, feature } = createUpdateFeatureHarness();
 
-      feature.bindUpdateHandlers();
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindUpdateHandlers();
+    feature.startPolling();
+    await flushAsyncWork();
 
-      expect(deps.updateReadinessSummary.innerHTML).toContain(
-        "settings.update.readiness.item.health_blocked",
-      );
-      expect(deps.updateStartBtn.disabled).toBe(true);
-    } finally {
-      restoreFetch();
-    }
+    expect(deps.updateReadinessSummary.innerHTML).toContain(
+      "settings.update.readiness.item.health_blocked",
+    );
+    expect(deps.updateStartBtn.disabled).toBe(true);
+    feature.dispose();
   });
 
   test("running update state highlights the active journey stage", async () => {
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/update/status") {
-        return jsonResponse(
-          createIdleUpdateStatus({
-            state: "running",
-            phase: "installing",
-            transport: "wifi",
-            ssid: "MyWiFi",
-          }),
-        );
-      }
-      if (url.pathname === "/api/health") {
-        return jsonResponse(createHealthyUpdateStatus());
-      }
-      if (url.pathname === "/api/update/internet-status") {
-        return jsonResponse(createUsbInternetStatus());
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(
+      ...buildUpdateHandlers({
+        status: createIdleUpdateStatus({
+          state: "running",
+          phase: "installing",
+          transport: "wifi",
+          ssid: "MyWiFi",
+        }),
+      }),
+    );
 
-    try {
-      const { deps, feature } = createUpdateFeatureHarness();
+    const { deps, feature } = createUpdateFeatureHarness();
 
-      feature.bindUpdateHandlers();
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindUpdateHandlers();
+    feature.startPolling();
+    await flushAsyncWork();
 
-      const html = (deps.els.updateStatusPanel as HTMLElement).innerHTML;
-      expect(html).toContain("settings.update.log_running_title");
-      expect(html).toMatch(
-        /data-stage-phase="installing" data-stage-state="active" aria-current="step"/,
-      );
-      expect(html.match(/data-stage-state="done"/g)).toHaveLength(5);
-      expect(
-        html.match(/<span class="maintenance-stage__marker">✓<\/span>/g),
-      ).toHaveLength(5);
-    } finally {
-      restoreFetch();
-    }
+    const html = (deps.els.updateStatusPanel as HTMLElement).innerHTML;
+    expect(html).toContain("settings.update.log_running_title");
+    expect(html).toMatch(
+      /data-stage-phase="installing" data-stage-state="active" aria-current="step"/,
+    );
+    expect(html.match(/data-stage-state="done"/g)).toHaveLength(5);
+    expect(
+      html.match(/<span class="maintenance-stage__marker">✓<\/span>/g),
+    ).toHaveLength(5);
+    feature.dispose();
   });
 
   test("persisted Wi-Fi ssid rehydrates the update input after startup", async () => {
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/update/status") {
-        return jsonResponse(
-          createIdleUpdateStatus({
-            ssid: "Workshop Wi-Fi",
-            updated_at: 123,
-            last_success_at: 123,
-          }),
-        );
-      }
-      if (url.pathname === "/api/health") {
-        return jsonResponse(createHealthyUpdateStatus());
-      }
-      if (url.pathname === "/api/update/internet-status") {
-        return jsonResponse(createUsbInternetStatus());
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(
+      ...buildUpdateHandlers({
+        status: createIdleUpdateStatus({
+          ssid: "Workshop Wi-Fi",
+          updated_at: 123,
+          last_success_at: 123,
+        }),
+      }),
+    );
 
-    try {
-      const { deps, feature } = createUpdateFeatureHarness();
-      deps.updateSsidInput.value = "";
+    const { deps, feature } = createUpdateFeatureHarness();
+    deps.updateSsidInput.value = "";
 
-      feature.bindUpdateHandlers();
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindUpdateHandlers();
+    feature.startPolling();
+    await flushAsyncWork();
 
-      expect(deps.updateSsidInput.value).toBe("Workshop Wi-Fi");
-      expect(deps.updateReadinessSummary.innerHTML).toContain(
-        "settings.update.readiness.summary_ready",
-      );
-      expect(deps.updateStartBtn.disabled).toBe(false);
-    } finally {
-      restoreFetch();
-    }
+    expect(deps.updateSsidInput.value).toBe("Workshop Wi-Fi");
+    expect(deps.updateReadinessSummary.innerHTML).toContain(
+      "settings.update.readiness.summary_ready",
+    );
+    expect(deps.updateStartBtn.disabled).toBe(false);
+    feature.dispose();
   });
 
   test("persisted Wi-Fi ssid does not overwrite a user edit already in progress", async () => {
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/update/status") {
-        return jsonResponse(
-          createIdleUpdateStatus({
-            ssid: "Workshop Wi-Fi",
-            updated_at: 123,
-            last_success_at: 123,
-          }),
-        );
-      }
-      if (url.pathname === "/api/health") {
-        return jsonResponse(createHealthyUpdateStatus());
-      }
-      if (url.pathname === "/api/update/internet-status") {
-        return jsonResponse(createUsbInternetStatus());
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(
+      ...buildUpdateHandlers({
+        status: createIdleUpdateStatus({
+          ssid: "Workshop Wi-Fi",
+          updated_at: 123,
+          last_success_at: 123,
+        }),
+      }),
+    );
 
-    try {
-      const { deps, feature } = createUpdateFeatureHarness();
+    const { deps, feature } = createUpdateFeatureHarness();
 
-      feature.bindUpdateHandlers();
-      deps.updateSsidInput.value = "Driver-entered Wi-Fi";
-      deps.updateSsidInput.dispatchEvent(new Event("input"));
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindUpdateHandlers();
+    deps.updateSsidInput.value = "Driver-entered Wi-Fi";
+    deps.updateSsidInput.dispatchEvent(new Event("input"));
+    feature.startPolling();
+    await flushAsyncWork();
 
-      expect(deps.updateSsidInput.value).toBe("Driver-entered Wi-Fi");
-    } finally {
-      restoreFetch();
-    }
+    expect(deps.updateSsidInput.value).toBe("Driver-entered Wi-Fi");
+    feature.dispose();
   });
 
   test("failed update state surfaces the failed stage and issue details", async () => {
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/update/status") {
-        return jsonResponse(
-          createIdleUpdateStatus({
-            state: "failed",
-            phase: "restoring_hotspot",
-            transport: "wifi",
-            issues: [
-              {
-                phase: "restoring_hotspot",
-                message: "Hotspot restart timed out",
-                detail: "NetworkManager is still reconnecting to the uplink.",
-              },
-            ],
-          }),
-        );
-      }
-      if (url.pathname === "/api/health") {
-        return jsonResponse(createHealthyUpdateStatus());
-      }
-      if (url.pathname === "/api/update/internet-status") {
-        return jsonResponse(createUsbInternetStatus());
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(
+      ...buildUpdateHandlers({
+        status: createIdleUpdateStatus({
+          state: "failed",
+          phase: "restoring_hotspot",
+          transport: "wifi",
+          issues: [
+            {
+              phase: "restoring_hotspot",
+              message: "Hotspot restart timed out",
+              detail: "NetworkManager is still reconnecting to the uplink.",
+            },
+          ],
+        }),
+      }),
+    );
 
-    try {
-      const { deps, feature } = createUpdateFeatureHarness();
+    const { deps, feature } = createUpdateFeatureHarness();
 
-      feature.bindUpdateHandlers();
-      deps.updateSsidInput.value = "MyWiFi";
-      deps.updateSsidInput.dispatchEvent(new Event("input"));
-      feature.startPolling();
-      await flushAsyncWork();
+    feature.bindUpdateHandlers();
+    deps.updateSsidInput.value = "MyWiFi";
+    deps.updateSsidInput.dispatchEvent(new Event("input"));
+    feature.startPolling();
+    await flushAsyncWork();
 
-      const html = (deps.els.updateStatusPanel as HTMLElement).innerHTML;
-      expect(deps.updateReadinessSummary.innerHTML).toContain(
-        "settings.update.recovery.title",
-      );
-      expect(deps.updateReadinessSummary.innerHTML).toContain(
-        "settings.update.recovery.wifi.title",
-      );
-      expect(deps.updateReadinessSummary.innerHTML).toContain(
-        "settings.update.recovery.wifi.detail",
-      );
-      expect(deps.updateStartBtn.textContent).toBe("settings.update.retry");
-      expect(html).toContain("settings.update.issues");
-      expect(html).toContain("settings.update.attempt_title");
-      expect(html).toContain("settings.update.log_failed_title");
-      expect(html).toContain("Hotspot restart timed out");
-      expect(html).toContain(
-        "NetworkManager is still reconnecting to the uplink.",
-      );
-      expect(html).toMatch(
-        /data-stage-phase="restoring_hotspot" data-stage-state="attention"/,
-      );
-    } finally {
-      restoreFetch();
-    }
+    const html = (deps.els.updateStatusPanel as HTMLElement).innerHTML;
+    expect(deps.updateReadinessSummary.innerHTML).toContain(
+      "settings.update.recovery.title",
+    );
+    expect(deps.updateReadinessSummary.innerHTML).toContain(
+      "settings.update.recovery.wifi.title",
+    );
+    expect(deps.updateReadinessSummary.innerHTML).toContain(
+      "settings.update.recovery.wifi.detail",
+    );
+    expect(deps.updateStartBtn.textContent).toBe("settings.update.retry");
+    expect(html).toContain("settings.update.issues");
+    expect(html).toContain("settings.update.attempt_title");
+    expect(html).toContain("settings.update.log_failed_title");
+    expect(html).toContain("Hotspot restart timed out");
+    expect(html).toContain(
+      "NetworkManager is still reconnecting to the uplink.",
+    );
+    expect(html).toMatch(
+      /data-stage-phase="restoring_hotspot" data-stage-state="attention"/,
+    );
+    feature.dispose();
   });
 
   test("cancel replaces the previous update poll timeout instead of creating a second chain", async () => {
     const timers = installTimerHarness();
-    const restoreFetch = installFeatureFetchMock(async (url, method) => {
-      if (url.pathname === "/api/update/cancel" && method === "POST") {
-        return jsonResponse({ status: "cancelled" });
-      }
-      if (url.pathname === "/api/update/status") {
-        return jsonResponse(createIdleUpdateStatus());
-      }
-      if (url.pathname === "/api/health") {
-        return jsonResponse(createHealthyUpdateStatus());
-      }
-      if (url.pathname === "/api/update/internet-status") {
-        return jsonResponse(createUsbInternetStatus());
-      }
-      return jsonResponse({});
-    });
+    mswServer.use(...buildUpdateHandlers());
 
-    try {
-      const { deps, feature } = createUpdateFeatureHarness();
+    const { deps, feature } = createUpdateFeatureHarness();
 
-      feature.bindUpdateHandlers();
-      feature.startPolling();
-      await expectTimerDelays(timers, [10_000]);
+    feature.bindUpdateHandlers();
+    feature.startPolling();
+    await expectTimerDelays(timers, [10_000]);
 
-      deps.updateCancelBtn.click();
-      await expectTimerDelays(timers, [10_000]);
-    } finally {
-      restoreFetch();
-      timers.restore();
-    }
+    deps.updateCancelBtn.click();
+    await expectTimerDelays(timers, [10_000]);
+    feature.dispose();
+    timers.restore();
   });
 
   test("stopPolling prevents an in-flight update poll from reviving the loop", async () => {
     const timers = installTimerHarness();
-    const deferredStatus = createDeferred<Response>();
-    const restoreFetch = installFeatureFetchMock(async (url) => {
-      if (url.pathname === "/api/update/status") {
-        return deferredStatus.promise;
-      }
-      if (url.pathname === "/api/health") {
-        return jsonResponse(createHealthyUpdateStatus());
-      }
-      if (url.pathname === "/api/update/internet-status") {
-        return jsonResponse(createUsbInternetStatus());
-      }
-      return jsonResponse({});
-    });
+    const deferredStatus = createDeferred<ReturnType<typeof createIdleUpdateStatus>>();
+    mswServer.use(
+      ...buildUpdateHandlers({
+        status: async () => await deferredStatus.promise,
+      }),
+    );
 
-    try {
-      const { feature } = createUpdateFeatureHarness();
+    const { feature } = createUpdateFeatureHarness();
 
-      feature.bindUpdateHandlers();
-      feature.startPolling();
-      await expectTimerDelays(timers, [10_000]);
+    feature.bindUpdateHandlers();
+    feature.startPolling();
+    await expectTimerDelays(timers, [10_000]);
 
-      feature.stopPolling();
-      deferredStatus.resolve(jsonResponse(createIdleUpdateStatus()));
-      await expectTimerDelays(timers, []);
-    } finally {
-      restoreFetch();
-      timers.restore();
-    }
+    feature.stopPolling();
+    deferredStatus.resolve(createIdleUpdateStatus());
+    await expectTimerDelays(timers, []);
+    feature.dispose();
+    timers.restore();
   });
 });


### PR DESCRIPTION
## What
- move the remaining HTTP-facing polling cases in `tests/update_feature_polling.spec.ts` onto `buildUpdateHandlers(...)`
- move the remaining direct-fetch polling cases in `tests/esp_flash_feature_polling.spec.ts` onto `buildEspFlashHandlers(...)`
- leave `update_feature_workflow.spec.ts` and `esp_flash_feature_workflow.spec.ts` alone because they stay on the pure API-injected seam

## Why
- remove the last ad hoc fetch routers from representative updater and firmware-installer polling coverage
- prove the shared maintenance handlers from #2910 cover real polling state transitions cleanly
- keep pure non-HTTP workflow tests lightweight

## Validation
- `cd apps/ui && npm run lint:unused`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/update_feature_polling.spec.ts tests/esp_flash_feature_polling.spec.ts -c ../../.ai-temp/playwright.unit.local.config.ts`

## Risk / edges
- update polling keeps the deferred stop-polling case by resolving the shared status scenario from a promise-backed function
- ESP-flash polling keeps the failure-after-running regression through a mutable shared status resolver instead of a bespoke fetch stub

Closes #2914