### PR TITLE
docs(ui): clarify msw test rules

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -94,12 +94,39 @@ source-of-truth export commands remain the only writers for those files.
 Use `msw` as the shared HTTP mocking layer for UI tests that exercise the real
 browser-side fetch boundary.
 
-- Node-side Playwright specs should install the shared lifecycle from
-  `tests/msw/node.ts`; it normalizes relative `/api/...` requests onto the
-  test origin and fails unhandled HTTP requests loudly by default.
-- Feature-specific reusable handlers belong under `tests/msw/handlers/` as they
-  appear. Keep cross-feature primitives in `tests/msw/http.ts`, and name
-  scenario factories `build<Feature><Scenario>Handlers(...)`.
+- Install the shared Node-side lifecycle from `tests/msw/node.ts` whenever the
+  spec calls the real UI HTTP client or otherwise exercises the fetch boundary.
+  The harness normalizes relative `/api/...` requests onto the test origin and
+  fails unhandled HTTP requests loudly by default, so missing handlers stay
+  obvious instead of silently falling through.
+- Keep reusable feature-area handlers under `tests/msw/handlers/`. Organize
+  them by the feature that owns the HTTP surface (`history.ts`, `settings.ts`,
+  `maintenance.ts`) instead of by individual spec files.
+- Keep cross-feature HTTP primitives in `tests/msw/http.ts`. That file owns the
+  shared origin, route helpers, and any low-level helpers that are reused across
+  multiple feature handler modules.
+- Name reusable handler composition helpers `build<Feature>Handlers(...)` or
+  `build<Feature><Scenario>Handlers(...)` when a feature needs a narrower
+  scenario bundle. Name payload builders `make<Feature><Thing>Payload(...)` so
+  handlers and callers read consistently.
+- Prefer composing a realistic scenario from those shared builders over
+  redefining ad hoc `fetch` replacements inside one spec. Reuse existing
+  contract-shaped payload builders instead of inventing mock-only response
+  shapes.
+
+Use MSW when the behavior under test depends on the real HTTP boundary:
+
+- request URLs, methods, payloads, or status handling matter
+- the feature should exercise the actual `fetch`/API wrapper path end to end
+- one shared handler can serve multiple specs in the same feature area
+
+Do **not** use MSW when the test is already below the network seam:
+
+- pure presenters, state derivations, and DOM-only views should stay network-free
+- workflow/controller tests with injected transport ports should keep those
+  focused fakes instead of layering on MSW unnecessarily
+- WebSocket behavior is separate; keep using the existing fake WebSocket helpers
+  for live-session flows instead of trying to route WS traffic through MSW
 
 ## Optional browser MSW mock mode
 
@@ -117,6 +144,8 @@ npm run dev:mock
 - Browser mock mode starts the app with `msw/browser` before `startUiApp()`,
   serves a checked-in `mockServiceWorker.js`, and bypasses any HTTP requests
   that do not have an explicit mock handler.
+- Browser mock mode should reuse the same shared handler owners under
+  `tests/msw/handlers/` rather than growing a second browser-only mock universe.
 - The mode currently reuses the shared history and settings MSW handler owners
   plus lightweight startup/update defaults so local settings and history flows
   can load without the backend.

--- a/apps/ui/tests/msw/node.ts
+++ b/apps/ui/tests/msw/node.ts
@@ -44,6 +44,8 @@ export function createUiMswTestServer(testHooks: PlaywrightTestHooks) {
   const server = setupServer();
   let restoreInterception = () => undefined;
 
+  // Use this shared lifecycle only for tests that cross the real HTTP/fetch
+  // boundary. Transport-injected or pure view/state tests should stay below it.
   testHooks.beforeAll(() => {
     restoreInterception = installUiMswInterception(server);
   });

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,6 +21,26 @@
 - Oversized tracked test/spec files are guarded in `tools/dev/check_hygiene.py` with the allowlist at `tools/dev/oversized_test_allowlist.yml`. Files at or above the shared threshold must either be split or carry an explicit allowlist reason, and the hygiene output always prints the current largest tracked test/spec files.
 - `make sync-contracts` is the authoritative contract/doc regeneration path; `make lint` and the `backend-contract-drift` CI job run it in `--check` mode.
 
+### Frontend HTTP tests with MSW
+
+Use MSW only for frontend tests that intentionally cross the real HTTP boundary.
+
+- Install the shared lifecycle from `apps/ui/tests/msw/node.ts` for Playwright
+  specs that call the real UI HTTP client. It rewrites relative `/api/...`
+  requests onto the test origin and throws on unhandled requests so missing
+  handlers fail loudly.
+- Keep reusable feature handlers in `apps/ui/tests/msw/handlers/` and cross-feature
+  primitives in `apps/ui/tests/msw/http.ts`. Follow the existing naming pattern:
+  `build<Feature>Handlers(...)`, `build<Feature><Scenario>Handlers(...)`, and
+  `make<Feature><Thing>Payload(...)`.
+- Prefer those shared scenario helpers over ad hoc `globalThis.fetch`
+  replacement when multiple specs in the same feature area need the same HTTP
+  behavior.
+- Do not add MSW to tests that already inject transport ports or stay inside
+  pure presenter/view/state seams. Those tests should remain network-free.
+- WebSocket mocking is outside the MSW boundary here; keep using the dedicated
+  fake WebSocket helpers for live-session flows.
+
 ## Layout
 
 The test tree is feature-based. Most directories mirror the backend package or module they cover.


### PR DESCRIPTION
## What
- document the shared MSW handler ownership and scenario naming rules in `apps/ui/README.md`
- add a matching frontend HTTP/MSW guide to `docs/testing.md`
- clarify in `apps/ui/tests/msw/node.ts` that the shared MSW lifecycle is only for real HTTP-boundary tests

## Why
- keep new UI tests on one MSW pattern instead of growing a second mock style
- make it explicit when a test should stay transport-injected or WebSocket-specific instead of reaching for MSW

## Validation
- `cd /workspace/VibeSensor && make docs-lint`

## Risk / edges
- docs only; no runtime behavior changes

Closes #2916