### PR TITLE
refactor(app): drop process settings shim

### DIFF
--- a/apps/server/vibesensor/app/process_settings.py
+++ b/apps/server/vibesensor/app/process_settings.py
@@ -1,5 +1,0 @@
-"""Backward-compatible app-layer re-export for process env settings."""
-
-from __future__ import annotations
-
-from vibesensor.shared.process_settings import *  # noqa: F403

--- a/tools/dev/verify_backend_static_guards.py
+++ b/tools/dev/verify_backend_static_guards.py
@@ -1821,6 +1821,35 @@ def _check_run_lifecycle_only() -> list[str]:
     return violations
 
 
+def _check_process_settings_shim_removed() -> list[str]:
+    legacy_path = VIBESENSOR_DIR / "app" / "process_settings.py"
+    violations: list[str] = []
+    if legacy_path.exists():
+        violations.append(
+            f"{legacy_path.relative_to(REPO_ROOT)} should stay removed; use "
+            "vibesensor.shared.process_settings directly"
+        )
+
+    for root in (SERVER_ROOT, REPO_ROOT / "tools"):
+        for path in _python_files(root):
+            for lineno, module, names, level in _scan_imports(path):
+                if level > 0:
+                    continue
+                if module == "vibesensor.app.process_settings":
+                    violations.append(
+                        f"{path.relative_to(REPO_ROOT)}:{lineno}: imports from "
+                        "vibesensor.app.process_settings; use "
+                        "vibesensor.shared.process_settings directly"
+                    )
+                if module == "vibesensor.app" and "process_settings" in names:
+                    violations.append(
+                        f"{path.relative_to(REPO_ROOT)}:{lineno}: imports "
+                        "process_settings from vibesensor.app; use "
+                        "vibesensor.shared.process_settings directly"
+                    )
+    return violations
+
+
 Check = tuple[str, Callable[[], list[str]]]
 CHECKS: tuple[Check, ...] = (
     (
@@ -2042,6 +2071,10 @@ CHECKS: tuple[Check, ...] = (
     (
         "Run lifecycle class stays out of analysis/report code",
         _check_run_lifecycle_only,
+    ),
+    (
+        "Process settings shim stays removed",
+        _check_process_settings_shim_removed,
     ),
 )
 


### PR DESCRIPTION
## What
- delete `apps/server/vibesensor/app/process_settings.py`, which was only a dead re-export of `vibesensor.shared.process_settings`
- add a backend static guard that fails if the old module file or import path comes back

## Why
- repo search shows no remaining imports of the app-layer shim
- keep `vibesensor.shared.process_settings` as the single owner instead of preserving unused compatibility code

## Validation
- `cd /workspace/VibeSensor && python3 tools/dev/check_hygiene.py`
- direct `_check_process_settings_shim_removed()` execution from `tools/dev/verify_backend_static_guards.py` returned `OK`
- `rg "vibesensor\.app\.process_settings" /workspace/VibeSensor` only matches the new static guard text

## Risk / edges
- local `make lint` is blocked in this checkout because `.venv` is missing `ruff`
- the full backend static-guard suite is host-blocked on Python 3.13-only backend syntax, so CI is the full package/runtime gate here

Closes #2917
