### PR TITLE
refactor(history): remove HistoryDB facade

### DIFF
--- a/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
+++ b/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
@@ -267,12 +267,16 @@ async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected
     monkeypatch,
 ) -> None:
     from vibesensor.adapters.http.clients import create_client_routes
-    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
     from vibesensor.adapters.udp.protocol import HelloMessage
     from vibesensor.infra.runtime.registry import ClientRegistry
 
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db, live_ttl_seconds=5.0, retention_ttl_seconds=30.0)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(
+        db=db.client_name_repository,
+        live_ttl_seconds=5.0,
+        retention_ttl_seconds=30.0,
+    )
     hello = HelloMessage(
         client_id=bytes.fromhex("001122334455"),
         control_port=9010,
@@ -324,19 +328,19 @@ async def test_get_clients_overlays_canonical_settings_metadata_after_restart(
     from test_support.settings_services import build_settings_services
 
     from vibesensor.adapters.http.clients import create_client_routes
-    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
     from vibesensor.adapters.udp.protocol import HelloMessage
     from vibesensor.infra.runtime.registry import ClientRegistry
 
-    db = HistoryDB(tmp_path / "history.db")
-    initial_settings = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    initial_settings = build_settings_services(db=db.settings_snapshot_repository)
     initial_settings.sensor_settings.assign_sensor_location(
         "00:11:22:33:44:55",
         "rear_left_wheel",
     )
 
-    settings_store = build_settings_services(db=db).sensor_settings
-    registry = ClientRegistry(db=db)
+    settings_store = build_settings_services(db=db.settings_snapshot_repository).sensor_settings
+    registry = ClientRegistry(db=db.client_name_repository)
     registry.update_from_hello(
         HelloMessage(
             client_id=bytes.fromhex("001122334455"),

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_analysis_transitions.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_analysis_transitions.py
@@ -8,7 +8,10 @@ from pathlib import Path
 import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    HistoryPersistenceAdapters,
+    create_history_persistence_adapters,
+)
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.types.run_schema import RunMetadata
 
@@ -27,44 +30,48 @@ def _metadata(run_id: str, **overrides: object) -> RunMetadata:
 
 
 @pytest.fixture
-def history_db(tmp_path: Path) -> Iterator[HistoryDB]:
-    db = HistoryDB(tmp_path / "test.db")
+def history_db(tmp_path: Path) -> Iterator[HistoryPersistenceAdapters]:
+    db = create_history_persistence_adapters(tmp_path / "test.db")
     try:
         yield db
     finally:
-        db.close()
+        db.lifecycle.close()
 
 
 class TestHistoryDBAnalysisIdempotency:
     """Cover store_analysis idempotency, error transitions, and stored-analysis readback."""
 
-    def test_store_analysis_twice_keeps_first(self, history_db: HistoryDB) -> None:
-        history_db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
-        history_db.finalize_run("r1", "2026-01-01T00:05:00Z")
-        history_db.store_analysis("r1", make_persisted_analysis({"findings": ["a"]}))
-        history_db.store_analysis("r1", make_persisted_analysis({"findings": ["b"]}))
-        run = history_db.get_run("r1")
+    def test_store_analysis_twice_keeps_first(self, history_db: HistoryPersistenceAdapters) -> None:
+        history_db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        history_db.run_repository.finalize_run("r1", "2026-01-01T00:05:00Z")
+        history_db.run_repository.store_analysis("r1", make_persisted_analysis({"findings": ["a"]}))
+        history_db.run_repository.store_analysis("r1", make_persisted_analysis({"findings": ["b"]}))
+        run = history_db.run_repository.get_run("r1")
         assert run is not None
         assert run.analysis is not None
         assert run.analysis["findings"] == ["a"]
 
-    def test_store_analysis_error_transitions_to_error(self, history_db: HistoryDB) -> None:
-        history_db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
-        history_db.finalize_run("r1", "2026-01-01T00:05:00Z")
-        history_db.store_analysis_error("r1", "pipeline crash")
-        run = history_db.get_run("r1")
+    def test_store_analysis_error_transitions_to_error(
+        self, history_db: HistoryPersistenceAdapters
+    ) -> None:
+        history_db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        history_db.run_repository.finalize_run("r1", "2026-01-01T00:05:00Z")
+        history_db.run_repository.store_analysis_error("r1", "pipeline crash")
+        run = history_db.run_repository.get_run("r1")
         assert run is not None
         assert run.status.value == "error"
         assert run.error_message == "pipeline crash"
 
-    def test_get_run_analysis_returns_stored_analysis(self, history_db: HistoryDB) -> None:
-        history_db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
-        run = history_db.get_run("r1")
+    def test_get_run_analysis_returns_stored_analysis(
+        self, history_db: HistoryPersistenceAdapters
+    ) -> None:
+        history_db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        run = history_db.run_repository.get_run("r1")
         assert run is not None
         assert run.analysis is None
-        history_db.finalize_run("r1", "2026-01-01T00:05:00Z")
-        history_db.store_analysis("r1", make_persisted_analysis({"result": "ok"}))
-        run = history_db.get_run("r1")
+        history_db.run_repository.finalize_run("r1", "2026-01-01T00:05:00Z")
+        history_db.run_repository.store_analysis("r1", make_persisted_analysis({"result": "ok"}))
+        run = history_db.run_repository.get_run("r1")
         assert run is not None
         result = run.analysis
         assert result is not None
@@ -74,36 +81,40 @@ class TestHistoryDBAnalysisIdempotency:
 class TestHistoryDBFinalizeNoOp:
     """Cover finalize_run no-op behavior for complete, missing, and non-recording runs."""
 
-    def test_finalize_run_noop_on_already_complete(self, history_db: HistoryDB) -> None:
-        history_db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
-        history_db.finalize_run("r1", "2026-01-01T00:05:00Z")
-        history_db.store_analysis("r1", make_persisted_analysis({"ok": True}))
-        history_db.finalize_run("r1", "2026-01-01T00:10:00Z")
-        run = history_db.get_run("r1")
+    def test_finalize_run_noop_on_already_complete(
+        self, history_db: HistoryPersistenceAdapters
+    ) -> None:
+        history_db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        history_db.run_repository.finalize_run("r1", "2026-01-01T00:05:00Z")
+        history_db.run_repository.store_analysis("r1", make_persisted_analysis({"ok": True}))
+        history_db.run_repository.finalize_run("r1", "2026-01-01T00:10:00Z")
+        run = history_db.run_repository.get_run("r1")
         assert run is not None
         assert run.status.value == "complete"
 
-    def test_finalize_run_noop_on_missing_run(self, history_db: HistoryDB) -> None:
-        history_db.finalize_run("nonexistent", "2026-01-01T00:00:00Z")
-        assert history_db.get_run("nonexistent") is None
+    def test_finalize_run_noop_on_missing_run(self, history_db: HistoryPersistenceAdapters) -> None:
+        history_db.run_repository.finalize_run("nonexistent", "2026-01-01T00:00:00Z")
+        assert history_db.run_repository.get_run("nonexistent") is None
 
     def test_finalize_run_with_metadata_noop_when_not_recording(
         self,
-        history_db: HistoryDB,
+        history_db: HistoryPersistenceAdapters,
     ) -> None:
-        history_db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", v=1))
-        history_db.finalize_run("r1", "2026-01-01T00:05:00Z")
-        history_db.finalize_run("r1", "2026-01-01T00:10:00Z", metadata=_metadata("r1", v=2))
-        run = history_db.get_run("r1")
+        history_db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", v=1))
+        history_db.run_repository.finalize_run("r1", "2026-01-01T00:05:00Z")
+        history_db.run_repository.finalize_run(
+            "r1", "2026-01-01T00:10:00Z", metadata=_metadata("r1", v=2)
+        )
+        run = history_db.run_repository.get_run("r1")
         assert run is not None
         assert run.status.value == "analyzing"
 
-    def test_get_run_missing_returns_none(self, history_db: HistoryDB) -> None:
-        assert history_db.get_run("nonexistent") is None
+    def test_get_run_missing_returns_none(self, history_db: HistoryPersistenceAdapters) -> None:
+        assert history_db.run_repository.get_run("nonexistent") is None
 
-    def test_get_active_run_id(self, history_db: HistoryDB) -> None:
-        assert history_db.get_active_run_id() is None
-        history_db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
-        assert history_db.get_active_run_id() == "r1"
-        history_db.finalize_run("r1", "2026-01-01T00:05:00Z")
-        assert history_db.get_active_run_id() is None
+    def test_get_active_run_id(self, history_db: HistoryPersistenceAdapters) -> None:
+        assert history_db.run_repository.get_active_run_id() is None
+        history_db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        assert history_db.run_repository.get_active_run_id() == "r1"
+        history_db.run_repository.finalize_run("r1", "2026-01-01T00:05:00Z")
+        assert history_db.run_repository.get_active_run_id() is None

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_backup_and_indexes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 
 
 def _query_plan_details(db_path: Path, sql: str) -> list[str]:
@@ -18,8 +18,8 @@ def _query_plan_details(db_path: Path, sql: str) -> list[str]:
 
 def test_history_db_status_created_at_queries_use_composite_index(tmp_path: Path) -> None:
     db_path = tmp_path / "history.db"
-    db = HistoryDB(db_path)
-    db.close()
+    db = create_history_persistence_adapters(db_path)
+    db.lifecycle.close()
 
     latest_recording_plan = _query_plan_details(
         db_path,

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py
@@ -8,7 +8,7 @@ from threading import Event, Thread
 
 import pytest
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.types.run_schema import RunMetadata
 
@@ -32,84 +32,90 @@ def _metadata(run_id: str) -> RunMetadata:
 
 
 def test_history_db_read_connection_is_query_only(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
-        assert db._read_conn is not None
-        row = db._read_conn.execute("PRAGMA query_only").fetchone()
+        assert db.lifecycle._read_conn is not None
+        row = db.lifecycle._read_conn.execute("PRAGMA query_only").fetchone()
         assert row is not None
         assert int(row[0]) == 1
     finally:
-        db.close()
+        db.lifecycle.close()
 
 
 def test_history_db_read_errors_clear_read_transaction(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
-        assert db._read_conn is not None
+        assert db.lifecycle._read_conn is not None
         with pytest.raises(sqlite3.OperationalError):
-            with db._cursor(commit=False) as cur:
+            with db.lifecycle._cursor(commit=False) as cur:
                 cur.execute("SELECT * FROM missing_table")
-        assert not db._read_conn.in_transaction
+        assert not db.lifecycle._read_conn.in_transaction
     finally:
-        db.close()
+        db.lifecycle.close()
 
 
 def test_history_db_read_base_exception_clears_read_transaction(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
-        db.create_run("run-read-abort", "2026-01-01T00:00:00Z", _metadata("run-read-abort"))
-        assert db._read_conn is not None
+        db.run_repository.create_run(
+            "run-read-abort", "2026-01-01T00:00:00Z", _metadata("run-read-abort")
+        )
+        assert db.lifecycle._read_conn is not None
         with pytest.raises(_AbortTxn):
-            with db._cursor(commit=False) as cur:
+            with db.lifecycle._cursor(commit=False) as cur:
                 cur.execute("SELECT * FROM runs WHERE run_id = ?", ("run-read-abort",))
                 raise _AbortTxn
-        assert not db._read_conn.in_transaction
-        assert [run.run_id for run in db.list_runs()] == ["run-read-abort"]
+        assert not db.lifecycle._read_conn.in_transaction
+        assert [run.run_id for run in db.run_repository.list_runs()] == ["run-read-abort"]
     finally:
-        db.close()
+        db.lifecycle.close()
 
 
 def test_history_db_write_cursor_base_exception_rolls_back(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
-        db.create_run("run-write-cursor", "2026-01-01T00:00:00Z", _metadata("run-write-cursor"))
+        db.run_repository.create_run(
+            "run-write-cursor", "2026-01-01T00:00:00Z", _metadata("run-write-cursor")
+        )
         with pytest.raises(_AbortTxn):
-            with db._cursor() as cur:
+            with db.lifecycle._cursor() as cur:
                 cur.execute(
                     "UPDATE runs SET sample_count = 7 WHERE run_id = ?",
                     ("run-write-cursor",),
                 )
                 raise _AbortTxn
-        assert not db._conn.in_transaction
-        run = db.get_run("run-write-cursor")
+        assert not db.lifecycle._conn.in_transaction
+        run = db.run_repository.get_run("run-write-cursor")
         assert run is not None
         assert run.sample_count == 0
     finally:
-        db.close()
+        db.lifecycle.close()
 
 
 def test_history_db_write_transaction_base_exception_rolls_back(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
-        db.create_run("run-write-tx", "2026-01-01T00:00:00Z", _metadata("run-write-tx"))
+        db.run_repository.create_run(
+            "run-write-tx", "2026-01-01T00:00:00Z", _metadata("run-write-tx")
+        )
         with pytest.raises(_AbortTxn):
-            with db.write_transaction_cursor() as cur:
+            with db.lifecycle.write_transaction_cursor() as cur:
                 cur.execute(
                     "UPDATE runs SET sample_count = 9 WHERE run_id = ?",
                     ("run-write-tx",),
                 )
                 raise _AbortTxn
-        assert not db._conn.in_transaction
-        run = db.get_run("run-write-tx")
+        assert not db.lifecycle._conn.in_transaction
+        run = db.run_repository.get_run("run-write-tx")
         assert run is not None
         assert run.sample_count == 0
     finally:
-        db.close()
+        db.lifecycle.close()
 
 
 def test_history_db_allows_reads_during_write_transaction(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-read", "2026-01-01T00:00:00Z", _metadata("run-read"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-read", "2026-01-01T00:00:00Z", _metadata("run-read"))
     read_started = Event()
     read_finished = Event()
     errors: list[BaseException] = []
@@ -117,14 +123,14 @@ def test_history_db_allows_reads_during_write_transaction(tmp_path: Path) -> Non
     def _reader() -> None:
         read_started.set()
         try:
-            runs = db.list_runs()
+            runs = db.run_repository.list_runs()
             assert [run.run_id for run in runs] == ["run-read"]
         except BaseException as exc:  # pragma: no cover - re-raised in test thread
             errors.append(exc)
         finally:
             read_finished.set()
 
-    with db.write_transaction_cursor() as cur:
+    with db.lifecycle.write_transaction_cursor() as cur:
         cur.execute(
             "UPDATE runs SET error_message = ? WHERE run_id = ?",
             ("pending", "run-read"),
@@ -137,6 +143,6 @@ def test_history_db_allows_reads_during_write_transaction(tmp_path: Path) -> Non
         finally:
             thread.join(timeout=1.0)
 
-    db.close()
+    db.lifecycle.close()
     if errors:
         raise errors[0]

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -28,7 +28,10 @@ from test_support.history_db_lifecycle import (
 )
 from test_support.persisted_analysis import make_persisted_analysis
 
-from vibesensor.adapters.persistence.history_db import HistoryDB, SQLiteHistoryEngine
+from vibesensor.adapters.persistence.history_db import (
+    SQLiteHistoryEngine,
+    create_history_persistence_adapters,
+)
 from vibesensor.shared.boundaries.sensor_frames import sensor_frame_from_mapping
 
 
@@ -36,7 +39,7 @@ def test_append_samples_in_chunks(tmp_path: Path) -> None:
     db = build_history_db(tmp_path)
     create_recording_run(db, "run-1")
     calls: list[int] = []
-    original_write_tx = db.write_transaction_cursor
+    original_write_tx = db.run_repository._write_transaction_cursor_provider
 
     @contextmanager
     def _wrapped_write_transaction():
@@ -56,9 +59,9 @@ def test_append_samples_in_chunks(tmp_path: Path) -> None:
 
             yield _CursorProxy(cur)
 
-    db.write_transaction_cursor = _wrapped_write_transaction
+    db.run_repository._write_transaction_cursor_provider = _wrapped_write_transaction
     samples = [sensor_frame_from_mapping({"i": i, "x": 0.1}) for i in range(700)]
-    db.append_samples("run-1", samples)
+    db.run_repository.append_samples("run-1", samples)
     assert sum(calls) == 700
     assert max(calls) <= 256
     assert len(calls) >= 3
@@ -68,7 +71,7 @@ def test_list_runs_includes_recorded_car_name(tmp_path: Path) -> None:
     db = build_history_db(tmp_path)
     create_recording_run(db, "run-car", active_car_snapshot={"name": "Track Car"})
 
-    run = db.list_runs()[0]
+    run = db.run_repository.list_runs()[0]
 
     assert run.car_name == "Track Car"
 
@@ -79,35 +82,35 @@ def test_history_db_thread_safe_appends(tmp_path: Path) -> None:
 
     def _append(start: int) -> None:
         batch = [sensor_frame_from_mapping({"i": start + i}) for i in range(50)]
-        db.append_samples("run-2", batch)
+        db.run_repository.append_samples("run-2", batch)
 
     with ThreadPoolExecutor(max_workers=4) as pool:
         for offset in range(0, 400, 50):
             pool.submit(_append, offset)
 
-    assert len(db.get_run_samples("run-2")) == 400
+    assert len(db.run_repository.get_run_samples("run-2")) == 400
 
 
 def test_append_samples_rejects_non_recording_runs(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-guard", "2026-01-01T00:00:00Z", _metadata("run-guard"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-guard", "2026-01-01T00:00:00Z", _metadata("run-guard"))
 
-    written = db.append_samples("run-guard", [sensor_frame_from_mapping({"i": 1})])
+    written = db.run_repository.append_samples("run-guard", [sensor_frame_from_mapping({"i": 1})])
     assert written == 1
 
-    db.finalize_run("run-guard", "2026-01-01T00:10:00Z")
-    rejected = db.append_samples("run-guard", [sensor_frame_from_mapping({"i": 2})])
+    db.run_repository.finalize_run("run-guard", "2026-01-01T00:10:00Z")
+    rejected = db.run_repository.append_samples("run-guard", [sensor_frame_from_mapping({"i": 2})])
 
     assert rejected == 0
-    run = db.get_run("run-guard")
+    run = db.run_repository.get_run("run-guard")
     assert run is not None
     assert run.status.value == "analyzing"
     assert run.sample_count == 1
-    assert len(db.get_run_samples("run-guard")) == 1
+    assert len(db.run_repository.get_run_samples("run-guard")) == 1
 
 
 def test_close_uses_lock_and_clears_connection(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     events: list[str] = []
 
     class RecordingLock:
@@ -122,14 +125,14 @@ def test_close_uses_lock_and_clears_connection(tmp_path: Path) -> None:
             events.append(f"{self._label}-exit")
             return False
 
-    db._lock = RecordingLock("write")  # type: ignore[assignment]
-    db._read_lock = RecordingLock("read")  # type: ignore[assignment]
+    db.lifecycle._lock = RecordingLock("write")  # type: ignore[assignment]
+    db.lifecycle._read_lock = RecordingLock("read")  # type: ignore[assignment]
 
-    db.close()
+    db.lifecycle.close()
 
     assert events == ["write-enter", "write-exit", "read-enter", "read-exit"]
-    assert db._conn is None
-    assert db._read_conn is None
+    assert db.lifecycle._conn is None
+    assert db.lifecycle._read_conn is None
 
 
 def test_schema_version_ancient_no_migration_fails_fast(tmp_path: Path) -> None:
@@ -141,36 +144,38 @@ def test_schema_version_ancient_no_migration_fails_fast(tmp_path: Path) -> None:
     conn.close()
 
     with pytest.raises(RuntimeError, match="incompatible"):
-        HistoryDB(db_path)
+        create_history_persistence_adapters(db_path)
 
 
 def test_schema_version_future_fails_fast(tmp_path: Path) -> None:
     """A DB with a newer version than supported should raise (no downgrade)."""
     db_path = tmp_path / "history.db"
     # Create a valid current-version DB first so the physical schema is correct
-    db = HistoryDB(db_path)
-    db.close()
+    db = create_history_persistence_adapters(db_path)
+    db.lifecycle.close()
     conn = sqlite3.connect(str(db_path))
     conn.execute("PRAGMA user_version = 99")
     conn.commit()
     conn.close()
 
     with pytest.raises(RuntimeError, match="newer than supported"):
-        HistoryDB(db_path)
+        create_history_persistence_adapters(db_path)
 
 
 def test_iter_run_samples_batches(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-3", "2026-01-01T00:00:00Z", _metadata("run-3"))
-    db.append_samples("run-3", [sensor_frame_from_mapping({"i": i}) for i in range(11)])
-    batches = list(db.iter_run_samples("run-3", batch_size=4))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-3", "2026-01-01T00:00:00Z", _metadata("run-3"))
+    db.run_repository.append_samples(
+        "run-3", [sensor_frame_from_mapping({"i": i}) for i in range(11)]
+    )
+    batches = list(db.run_repository.iter_run_samples("run-3", batch_size=4))
     assert [len(batch) for batch in batches] == [4, 4, 3]
 
 
 def test_list_runs_uses_incremental_sample_count(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-4", "2026-01-01T00:00:00Z", _metadata("run-4"))
-    db.append_samples(
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-4", "2026-01-01T00:00:00Z", _metadata("run-4"))
+    db.run_repository.append_samples(
         "run-4",
         [
             sensor_frame_from_mapping({"i": 1}),
@@ -178,16 +183,16 @@ def test_list_runs_uses_incremental_sample_count(tmp_path: Path) -> None:
             sensor_frame_from_mapping({"i": 3}),
         ],
     )
-    run = db.list_runs()[0]
+    run = db.run_repository.list_runs()[0]
     assert run.sample_count == 3
 
 
 def test_recover_stale_recording_runs_marks_error(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-5", "2026-01-01T00:00:00Z", _metadata("run-5"))
-    recovered = db.recover_stale_recording_runs()
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-5", "2026-01-01T00:00:00Z", _metadata("run-5"))
+    recovered = db.run_repository.recover_stale_recording_runs()
     assert recovered == 1
-    run = db.get_run("run-5")
+    run = db.run_repository.get_run("run-5")
     assert run is not None
     assert run.status.value == "error"
     assert "Recovered stale recording during startup at" in str(run.error_message)
@@ -205,7 +210,7 @@ def test_prune_terminal_runs_older_than_days_deletes_only_old_terminal_runs(
 
     old_timestamp = (datetime.now(UTC) - timedelta(days=30)).isoformat()
     recent_timestamp = (datetime.now(UTC) - timedelta(days=2)).isoformat()
-    with db._cursor() as cur:
+    with db.lifecycle._cursor() as cur:
         cur.execute(
             "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
             (old_timestamp, old_timestamp, "run-old-complete"),
@@ -227,62 +232,66 @@ def test_prune_terminal_runs_older_than_days_deletes_only_old_terminal_runs(
             (old_timestamp, old_timestamp, "run-analyzing"),
         )
 
-    pruned = db.prune_terminal_runs_older_than_days(7)
+    pruned = db.run_repository.prune_terminal_runs_older_than_days(7)
 
     assert pruned == 2
-    assert db.get_run("run-old-complete") is None
-    assert db.get_run("run-old-error") is None
-    assert db.get_run("run-recent-complete") is not None
-    assert db.get_run("run-recording") is not None
-    assert db.get_run("run-analyzing") is not None
+    assert db.run_repository.get_run("run-old-complete") is None
+    assert db.run_repository.get_run("run-old-error") is None
+    assert db.run_repository.get_run("run-recent-complete") is not None
+    assert db.run_repository.get_run("run-recording") is not None
+    assert db.run_repository.get_run("run-analyzing") is not None
 
 
 def test_prune_terminal_runs_older_than_days_cascades_samples(tmp_path: Path) -> None:
     db = build_history_db(tmp_path)
     create_recording_run(db, "run-prune")
-    db.append_samples("run-prune", [sensor_frame_from_mapping({"i": i}) for i in range(3)])
-    db.store_analysis("run-prune", make_persisted_analysis(_analysis("run-prune", score=9)))
+    db.run_repository.append_samples(
+        "run-prune", [sensor_frame_from_mapping({"i": i}) for i in range(3)]
+    )
+    db.run_repository.store_analysis(
+        "run-prune", make_persisted_analysis(_analysis("run-prune", score=9))
+    )
 
     old_timestamp = (datetime.now(UTC) - timedelta(days=30)).isoformat()
-    with db._cursor() as cur:
+    with db.lifecycle._cursor() as cur:
         cur.execute(
             "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
             (old_timestamp, old_timestamp, "run-prune"),
         )
 
-    pruned = db.prune_terminal_runs_older_than_days(7)
+    pruned = db.run_repository.prune_terminal_runs_older_than_days(7)
 
     assert pruned == 1
-    assert db.get_run("run-prune") is None
-    with db._cursor() as cur:
+    assert db.run_repository.get_run("run-prune") is None
+    with db.lifecycle._cursor() as cur:
         cur.execute("SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?", ("run-prune",))
         assert cur.fetchone()[0] == 0
 
 
 def test_create_run_does_not_auto_recover_recording(tmp_path: Path) -> None:
     """create_run no longer auto-recovers stale recordings — startup does that."""
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-old", "2026-01-01T00:00:00Z", _metadata("run-old"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-old", "2026-01-01T00:00:00Z", _metadata("run-old"))
     # Second create should fail (unique constraint) — old run stays recording
     try:
-        db.create_run("run-old", "2026-01-01T00:01:00Z", _metadata("run-old"))
+        db.run_repository.create_run("run-old", "2026-01-01T00:01:00Z", _metadata("run-old"))
     except Exception:
         pass
-    old_run = db.get_run("run-old")
+    old_run = db.run_repository.get_run("run-old")
     assert old_run is not None and old_run.status.value == "recording"
 
 
 def test_create_run_persists_case_id(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
 
-    db.create_run(
+    db.run_repository.create_run(
         "run-case-create",
         "2026-01-01T00:00:00Z",
         _metadata("run-case-create"),
         case_id="case-123",
     )
 
-    run = db.get_run("run-case-create")
+    run = db.run_repository.get_run("run-case-create")
     assert run is not None
     assert run.case_id == "case-123"
 
@@ -290,12 +299,12 @@ def test_create_run_persists_case_id(tmp_path: Path) -> None:
 def test_recover_stale_recording_logs_warning(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-old", "2026-01-01T00:00:00Z", _metadata("run-old"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-old", "2026-01-01T00:00:00Z", _metadata("run-old"))
     with caplog.at_level(logging.WARNING):
-        recovered = db.recover_stale_recording_runs()
+        recovered = db.run_repository.recover_stale_recording_runs()
     assert recovered == 1
-    run = db.get_run("run-old")
+    run = db.run_repository.get_run("run-old")
     assert run is not None and run.status.value == "error"
 
 
@@ -311,11 +320,11 @@ def test_history_db_runs_startup_quick_check(
         original(self)
 
     monkeypatch.setattr(SQLiteHistoryEngine, "_run_startup_quick_check", _tracking)
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
         assert calls == [tmp_path / "history.db"]
     finally:
-        db.close()
+        db.lifecycle.close()
 
 
 def test_startup_quick_check_logs_corruption(
@@ -323,7 +332,7 @@ def test_startup_quick_check_logs_corruption(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
 
     class _FakeCursor:
         def execute(self, sql: str) -> None:
@@ -333,17 +342,17 @@ def test_startup_quick_check_logs_corruption(
             return [("row 7 missing from index",)]
 
     @contextmanager
-    def _fake_cursor(*, commit: bool = True):
+    def _fake_cursor(_self: SQLiteHistoryEngine, *, commit: bool = True):
         yield _FakeCursor()
 
-    monkeypatch.setattr(db, "_cursor", _fake_cursor)
+    monkeypatch.setattr(SQLiteHistoryEngine, "_cursor", _fake_cursor)
     with caplog.at_level(logging.CRITICAL):
-        db._run_startup_quick_check()
+        db.lifecycle._run_startup_quick_check()
     assert "quick_check reported corruption" in caplog.text
     assert "row 7 missing from index" in caplog.text
-    assert db.corruption_detected is True
-    assert db.corruption_details == "row 7 missing from index"
-    db.close()
+    assert db.lifecycle.corruption_detected is True
+    assert db.lifecycle.corruption_details == "row 7 missing from index"
+    db.lifecycle.close()
 
 
 def test_startup_quick_check_reports_corruption_via_callback(
@@ -351,7 +360,7 @@ def test_startup_quick_check_reports_corruption_via_callback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     reported: list[str] = []
-    db = HistoryDB(
+    db = create_history_persistence_adapters(
         tmp_path / "history.db",
         corruption_reporter=reported.append,
     )
@@ -364,22 +373,22 @@ def test_startup_quick_check_reports_corruption_via_callback(
             return [("row 7 missing from index",)]
 
     @contextmanager
-    def _fake_cursor(*, commit: bool = True):
+    def _fake_cursor(_self: SQLiteHistoryEngine, *, commit: bool = True):
         yield _FakeCursor()
 
-    monkeypatch.setattr(db, "_cursor", _fake_cursor)
-    db._run_startup_quick_check()
+    monkeypatch.setattr(SQLiteHistoryEngine, "_cursor", _fake_cursor)
+    db.lifecycle._run_startup_quick_check()
     assert reported == ["row 7 missing from index"]
-    assert db.corruption_detected is True
-    db.close()
+    assert db.lifecycle.corruption_detected is True
+    db.lifecycle.close()
 
 
 def test_startup_quick_check_blocks_future_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-corrupt", "2026-01-01T00:00:00Z", _metadata("run-corrupt"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-corrupt", "2026-01-01T00:00:00Z", _metadata("run-corrupt"))
 
     class _FakeCursor:
         def execute(self, sql: str) -> None:
@@ -388,77 +397,80 @@ def test_startup_quick_check_blocks_future_writes(
         def fetchall(self) -> list[tuple[str]]:
             return [("row 7 missing from index",)]
 
-    original_cursor = db._cursor
-
     @contextmanager
-    def _fake_cursor(*, commit: bool = True):
+    def _fake_cursor(_self: SQLiteHistoryEngine, *, commit: bool = True):
         yield _FakeCursor()
 
-    monkeypatch.setattr(db, "_cursor", _fake_cursor)
-    db._run_startup_quick_check()
-    monkeypatch.setattr(db, "_cursor", original_cursor)
+    monkeypatch.setattr(SQLiteHistoryEngine, "_cursor", _fake_cursor)
+    db.lifecycle._run_startup_quick_check()
 
     with pytest.raises(sqlite3.DatabaseError, match="Writes are disabled"):
-        db.append_samples("run-corrupt", [sensor_frame_from_mapping({"i": 1})])
+        db.run_repository.append_samples("run-corrupt", [sensor_frame_from_mapping({"i": 1})])
     with pytest.raises(sqlite3.DatabaseError, match="Writes are disabled"):
-        db.finalize_run("run-corrupt", "2026-01-01T00:10:00Z")
+        db.run_repository.finalize_run("run-corrupt", "2026-01-01T00:10:00Z")
 
-    run = db.get_run("run-corrupt")
+    run = db.run_repository.get_run("run-corrupt")
     assert run is not None
     assert run.sample_count == 0
     assert run.status.value == "recording"
-    db.close()
+    db.lifecycle.close()
 
 
 def test_delete_run_cascades_samples(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-del", "2026-01-01T00:00:00Z", _metadata("run-del"))
-    db.append_samples("run-del", [sensor_frame_from_mapping({"i": i}) for i in range(5)])
-    assert len(db.get_run_samples("run-del")) == 5
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-del", "2026-01-01T00:00:00Z", _metadata("run-del"))
+    db.run_repository.append_samples(
+        "run-del", [sensor_frame_from_mapping({"i": i}) for i in range(5)]
+    )
+    assert len(db.run_repository.get_run_samples("run-del")) == 5
 
-    db.delete_run("run-del")
+    db.run_repository.delete_run("run-del")
 
-    with db._cursor() as cur:
+    with db.lifecycle._cursor() as cur:
         cur.execute("SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?", ("run-del",))
         assert cur.fetchone()[0] == 0
 
 
 def test_run_status_transitions(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
 
-    db.create_run("run-st", "2026-01-01T00:00:00Z", _metadata("run-st"))
-    assert db.get_run("run-st").status.value == "recording"
+    db.run_repository.create_run("run-st", "2026-01-01T00:00:00Z", _metadata("run-st"))
+    assert db.run_repository.get_run("run-st").status.value == "recording"
 
-    db.finalize_run("run-st", "2026-01-01T00:10:00Z")
-    assert db.get_run("run-st").status.value == "analyzing"
+    db.run_repository.finalize_run("run-st", "2026-01-01T00:10:00Z")
+    assert db.run_repository.get_run("run-st").status.value == "analyzing"
 
-    db.store_analysis("run-st", make_persisted_analysis(_analysis("run-st", score=42)))
-    assert db.get_run("run-st").status.value == "complete"
+    db.run_repository.store_analysis(
+        "run-st", make_persisted_analysis(_analysis("run-st", score=42))
+    )
+    assert db.run_repository.get_run("run-st").status.value == "complete"
 
-    db.create_run("run-err", "2026-01-01T00:00:00Z", _metadata("run-err"))
-    db.finalize_run("run-err", "2026-01-01T00:10:00Z")
-    db.store_analysis_error("run-err", "something went wrong")
-    assert db.get_run("run-err").status.value == "error"
+    db.run_repository.create_run("run-err", "2026-01-01T00:00:00Z", _metadata("run-err"))
+    db.run_repository.finalize_run("run-err", "2026-01-01T00:10:00Z")
+    db.run_repository.store_analysis_error("run-err", "something went wrong")
+    assert db.run_repository.get_run("run-err").status.value == "error"
 
 
 def test_store_analysis_allows_direct_recording_to_complete(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-recording", "2026-01-01T00:00:00Z", _metadata("run-recording"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
+        "run-recording", "2026-01-01T00:00:00Z", _metadata("run-recording")
+    )
 
     analysis = _analysis("run-recording", score=42)
-    stored = db.store_analysis("run-recording", make_persisted_analysis(analysis))
+    stored = db.run_repository.store_analysis("run-recording", make_persisted_analysis(analysis))
 
     assert stored is True
-    run = db.get_run("run-recording")
+    run = db.run_repository.get_run("run-recording")
     assert run is not None
     assert run.status.value == "complete"
     assert run.analysis == analysis
 
 
 def test_append_samples_rolls_back_when_metadata_update_fails(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-rollback", "2026-01-01T00:00:00Z", _metadata("run-rollback"))
-    original_write_tx = db.write_transaction_cursor
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-rollback", "2026-01-01T00:00:00Z", _metadata("run-rollback"))
+    original_write_tx = db.run_repository._write_transaction_cursor_provider
 
     @contextmanager
     def _wrapped_write_transaction():
@@ -478,26 +490,26 @@ def test_append_samples_rolls_back_when_metadata_update_fails(tmp_path: Path) ->
 
             yield _CursorProxy(cur)
 
-    db.write_transaction_cursor = _wrapped_write_transaction
+    db.run_repository._write_transaction_cursor_provider = _wrapped_write_transaction
 
     with pytest.raises(sqlite3.OperationalError, match="simulated sample_count failure"):
-        db.append_samples(
+        db.run_repository.append_samples(
             "run-rollback",
             [sensor_frame_from_mapping({"i": 1}), sensor_frame_from_mapping({"i": 2})],
         )
 
-    run = db.get_run("run-rollback")
+    run = db.run_repository.get_run("run-rollback")
     assert run is not None
     assert run.sample_count == 0
-    assert db.get_run_samples("run-rollback") == []
+    assert db.run_repository.get_run_samples("run-rollback") == []
 
 
 def test_finalize_run_returns_false_when_already_analyzing(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-finalize", "2026-01-01T00:00:00Z", _metadata("run-finalize"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-finalize", "2026-01-01T00:00:00Z", _metadata("run-finalize"))
 
     assert (
-        db.finalize_run(
+        db.run_repository.finalize_run(
             "run-finalize",
             "2026-01-01T00:05:00Z",
             metadata=_metadata("run-finalize"),
@@ -505,7 +517,7 @@ def test_finalize_run_returns_false_when_already_analyzing(tmp_path: Path) -> No
         is True
     )
     assert (
-        db.finalize_run(
+        db.run_repository.finalize_run(
             "run-finalize",
             "2026-01-01T00:06:00Z",
             metadata=_metadata("run-finalize"),
@@ -515,11 +527,13 @@ def test_finalize_run_returns_false_when_already_analyzing(tmp_path: Path) -> No
 
 
 def test_finalize_run_persists_case_id(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-case-finalize", "2026-01-01T00:00:00Z", _metadata("run-case-finalize"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
+        "run-case-finalize", "2026-01-01T00:00:00Z", _metadata("run-case-finalize")
+    )
 
     assert (
-        db.finalize_run(
+        db.run_repository.finalize_run(
             "run-case-finalize",
             "2026-01-01T00:05:00Z",
             metadata=_metadata("run-case-finalize"),
@@ -528,7 +542,7 @@ def test_finalize_run_persists_case_id(tmp_path: Path) -> None:
         is True
     )
 
-    run = db.get_run("run-case-finalize")
+    run = db.run_repository.get_run("run-case-finalize")
     assert run is not None
     assert run.status.value == "analyzing"
     assert run.case_id == "case-456"
@@ -538,60 +552,67 @@ def test_analyzing_run_health_reports_oldest_age(tmp_path: Path) -> None:
     db = build_history_db(tmp_path)
     create_analyzing_run(db, "run-an")
 
-    health = db.analyzing_run_health()
+    health = db.run_repository.analyzing_run_health()
 
     assert health.analyzing_run_count == 1
     assert isinstance(health.analyzing_oldest_age_s, float)
 
 
 def test_update_run_metadata_overwrites_stored_metadata(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-meta", "2026-01-01T00:00:00Z", _metadata("run-meta", tire_width_mm=245.0))
-    assert db.update_run_metadata("run-meta", _metadata("run-meta", tire_width_mm=285.0)) is True
-    run = db.get_run("run-meta")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
+        "run-meta", "2026-01-01T00:00:00Z", _metadata("run-meta", tire_width_mm=245.0)
+    )
+    assert (
+        db.run_repository.update_run_metadata(
+            "run-meta", _metadata("run-meta", tire_width_mm=285.0)
+        )
+        is True
+    )
+    run = db.run_repository.get_run("run-meta")
     assert run is not None
     assert run.metadata.analysis_settings.tire_width_mm == 285.0
 
 
 def test_append_empty_samples_is_noop(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-empty", "2026-01-01T00:00:00Z", _metadata("run-empty"))
-    db.append_samples("run-empty", [sensor_frame_from_mapping({"i": 1})])
-    db.append_samples("run-empty", [])
-    run = db.list_runs()[0]
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-empty", "2026-01-01T00:00:00Z", _metadata("run-empty"))
+    db.run_repository.append_samples("run-empty", [sensor_frame_from_mapping({"i": 1})])
+    db.run_repository.append_samples("run-empty", [])
+    run = db.run_repository.list_runs()[0]
     assert run.sample_count == 1
 
 
 def test_client_names_crud(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
 
-    assert db.list_client_names() == {}
+    assert db.client_name_repository.list_client_names() == {}
 
-    db.upsert_client_name("client-1", "Alice")
-    db.upsert_client_name("client-2", "Bob")
-    names = db.list_client_names()
+    db.client_name_repository.upsert_client_name("client-1", "Alice")
+    db.client_name_repository.upsert_client_name("client-2", "Bob")
+    names = db.client_name_repository.list_client_names()
     assert names == {"client-1": "Alice", "client-2": "Bob"}
 
-    db.upsert_client_name("client-1", "Alice Updated")
-    assert db.list_client_names()["client-1"] == "Alice Updated"
+    db.client_name_repository.upsert_client_name("client-1", "Alice Updated")
+    assert db.client_name_repository.list_client_names()["client-1"] == "Alice Updated"
 
-    assert db.delete_client_name("client-2") is True
-    assert db.delete_client_name("client-2") is False
-    assert "client-2" not in db.list_client_names()
+    assert db.client_name_repository.delete_client_name("client-2") is True
+    assert db.client_name_repository.delete_client_name("client-2") is False
+    assert "client-2" not in db.client_name_repository.list_client_names()
 
 
 def test_read_only_operations_do_not_commit(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-ro", "2026-01-01T00:00:00Z", _metadata("run-ro"))
-    db.append_samples(
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-ro", "2026-01-01T00:00:00Z", _metadata("run-ro"))
+    db.run_repository.append_samples(
         "run-ro",
         [
             sensor_frame_from_mapping({"i": 1}),
             sensor_frame_from_mapping({"i": 2}),
         ],
     )
-    db.set_settings_snapshot(_settings_snapshot())
-    db.upsert_client_name("client-1", "Alice")
+    db.settings_snapshot_repository.set_settings_snapshot(_settings_snapshot())
+    db.client_name_repository.upsert_client_name("client-1", "Alice")
 
     class _ConnProxy:
         def __init__(self, conn):
@@ -605,22 +626,22 @@ def test_read_only_operations_do_not_commit(tmp_path: Path) -> None:
             self.commit_calls += 1
             return self._conn.commit()
 
-    proxy = _ConnProxy(db._conn)
-    db._conn = proxy
+    proxy = _ConnProxy(db.lifecycle._conn)
+    db.lifecycle._conn = proxy
 
-    _ = db.get_run("run-ro")
-    _ = db.list_runs()
-    _ = list(db.iter_run_samples("run-ro", batch_size=1))
-    _ = db.get_run_metadata("run-ro")
-    _ = db.get_run("run-ro").analysis
-    _ = db.get_run("run-ro").status
-    _ = db.get_active_run_id()
-    _ = db.get_settings_snapshot()
-    _ = db.list_client_names()
+    _ = db.run_repository.get_run("run-ro")
+    _ = db.run_repository.list_runs()
+    _ = list(db.run_repository.iter_run_samples("run-ro", batch_size=1))
+    _ = db.run_repository.get_run_metadata("run-ro")
+    _ = db.run_repository.get_run("run-ro").analysis
+    _ = db.run_repository.get_run("run-ro").status
+    _ = db.run_repository.get_active_run_id()
+    _ = db.settings_snapshot_repository.get_settings_snapshot()
+    _ = db.client_name_repository.list_client_names()
 
     assert proxy.commit_calls == 0
 
-    db.set_settings_snapshot(_settings_snapshot())
+    db.settings_snapshot_repository.set_settings_snapshot(_settings_snapshot())
     assert proxy.commit_calls == 1
 
 
@@ -628,16 +649,16 @@ def test_get_run_metadata_non_dict_json_returns_none_and_warns(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-bad-meta", "2026-01-01T00:00:00Z", _metadata("run-bad-meta"))
-    with db._cursor() as cur:
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-bad-meta", "2026-01-01T00:00:00Z", _metadata("run-bad-meta"))
+    with db.lifecycle._cursor() as cur:
         cur.execute(
             "UPDATE runs SET metadata_json = ? WHERE run_id = ?",
             ("[1, 2, 3]", "run-bad-meta"),
         )
 
     with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.persistence.history_db"):
-        result = db.get_run_metadata("run-bad-meta")
+        result = db.run_repository.get_run_metadata("run-bad-meta")
 
     assert result is None
     assert "run-bad-meta" in caplog.text
@@ -645,13 +666,13 @@ def test_get_run_metadata_non_dict_json_returns_none_and_warns(
 
 
 def test_close_is_idempotent(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.close()
-    db.close()
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.lifecycle.close()
+    db.lifecycle.close()
 
 
 def test_operations_after_close_raise(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.close()
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.lifecycle.close()
     with pytest.raises(RuntimeError, match="closed"):
-        db.create_run("run-x", "2026-01-01T00:00:00Z", _metadata("run-x"))
+        db.run_repository.create_run("run-x", "2026-01-01T00:00:00Z", _metadata("run-x"))

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
@@ -9,7 +9,7 @@ from typing import cast
 import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import (
     sensor_frame_from_mapping,
@@ -80,12 +80,14 @@ def _sensor_frame_dict(i: int, *, run_id: str = "run-v2") -> dict[str, object]:
 
 
 def test_v2_structured_roundtrip(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-v2", "2026-01-01T00:00:00Z", _metadata("run-v2"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-v2", "2026-01-01T00:00:00Z", _metadata("run-v2"))
     originals = [_sensor_frame_dict(i) for i in range(5)]
-    db.append_samples("run-v2", [sensor_frame_from_mapping(sample) for sample in originals])
+    db.run_repository.append_samples(
+        "run-v2", [sensor_frame_from_mapping(sample) for sample in originals]
+    )
 
-    retrieved = db.get_run_samples("run-v2")
+    retrieved = db.run_repository.get_run_samples("run-v2")
     assert len(retrieved) == 5
     for i, row in enumerate(retrieved):
         orig = originals[i]
@@ -98,12 +100,12 @@ def test_v2_structured_roundtrip(tmp_path: Path) -> None:
 
 
 def test_v2_nan_inf_sanitized(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-nan", "2026-01-01T00:00:00Z", _metadata("run-nan"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-nan", "2026-01-01T00:00:00Z", _metadata("run-nan"))
     sample = {"speed_kmh": float("nan"), "accel_x_g": float("inf"), "t_s": 1.0}
-    db.append_samples("run-nan", [sensor_frame_from_mapping(sample)])
+    db.run_repository.append_samples("run-nan", [sensor_frame_from_mapping(sample)])
 
-    rows = db.get_run_samples("run-nan")
+    rows = db.run_repository.get_run_samples("run-nan")
     assert len(rows) == 1
     assert rows[0].speed_kmh is None
     assert rows[0].accel_x_g is None
@@ -111,11 +113,13 @@ def test_v2_nan_inf_sanitized(tmp_path: Path) -> None:
 
 
 def test_v2_no_json_blobs_in_storage(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-check", "2026-01-01T00:00:00Z", _metadata("run-check"))
-    db.append_samples("run-check", [sensor_frame_from_mapping(_sensor_frame_dict(0))])
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-check", "2026-01-01T00:00:00Z", _metadata("run-check"))
+    db.run_repository.append_samples(
+        "run-check", [sensor_frame_from_mapping(_sensor_frame_dict(0))]
+    )
 
-    with db._cursor(commit=False) as cur:
+    with db.lifecycle._cursor(commit=False) as cur:
         cur.execute("PRAGMA table_info(samples_v2)")
         columns = {row[1] for row in cur.fetchall()}
 
@@ -167,17 +171,17 @@ def test_v4_db_rejected(tmp_path: Path) -> None:
 
     # No migrations are registered — opening a v4 database raises RuntimeError.
     with pytest.raises(RuntimeError, match="incompatible"):
-        HistoryDB(db_path)
+        create_history_persistence_adapters(db_path)
 
 
 def test_v2_sensor_frame_objects(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-sf", "2026-01-01T00:00:00Z", _metadata("run-sf"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-sf", "2026-01-01T00:00:00Z", _metadata("run-sf"))
 
     frame = sensor_frame_from_mapping(_sensor_frame_dict(0, run_id="run-sf"))
-    db.append_samples("run-sf", [frame])
+    db.run_repository.append_samples("run-sf", [frame])
 
-    rows = db.get_run_samples("run-sf")
+    rows = db.run_repository.get_run_samples("run-sf")
     assert len(rows) == 1
     assert rows[0].client_id == "aabbccddeeff"
     assert rows[0].speed_kmh == 60.0
@@ -185,87 +189,97 @@ def test_v2_sensor_frame_objects(tmp_path: Path) -> None:
 
 
 def test_v2_delete_cascades_legacy_and_v2(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-del2", "2026-01-01T00:00:00Z", _metadata("run-del2"))
-    db.append_samples(
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-del2", "2026-01-01T00:00:00Z", _metadata("run-del2"))
+    db.run_repository.append_samples(
         "run-del2",
         [sensor_frame_from_mapping(_sensor_frame_dict(i, run_id="run-del2")) for i in range(3)],
     )
 
-    assert len(db.get_run_samples("run-del2")) == 3
-    db.delete_run("run-del2")
+    assert len(db.run_repository.get_run_samples("run-del2")) == 3
+    db.run_repository.delete_run("run-del2")
 
-    with db._cursor(commit=False) as cur:
+    with db.lifecycle._cursor(commit=False) as cur:
         cur.execute("SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?", ("run-del2",))
         assert cur.fetchone()[0] == 0
 
 
 def test_v2_record_then_export_roundtrip(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-full", "2026-01-01T00:00:00Z", _metadata("run-full", source="roundtrip"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
+        "run-full", "2026-01-01T00:00:00Z", _metadata("run-full", source="roundtrip")
+    )
 
     for batch_start in range(0, 20, 5):
         batch = [
             _sensor_frame_dict(i, run_id="run-full") for i in range(batch_start, batch_start + 5)
         ]
-        db.append_samples("run-full", [sensor_frame_from_mapping(sample) for sample in batch])
+        db.run_repository.append_samples(
+            "run-full", [sensor_frame_from_mapping(sample) for sample in batch]
+        )
 
-    db.finalize_run("run-full", "2026-01-01T00:00:20Z")
-    assert db.get_run("run-full").status.value == "analyzing"
+    db.run_repository.finalize_run("run-full", "2026-01-01T00:00:20Z")
+    assert db.run_repository.get_run("run-full").status.value == "analyzing"
 
     analysis = _analysis("run-full", score=42)
-    db.store_analysis("run-full", make_persisted_analysis(analysis))
-    assert db.get_run("run-full").status.value == "complete"
+    db.run_repository.store_analysis("run-full", make_persisted_analysis(analysis))
+    assert db.run_repository.get_run("run-full").status.value == "complete"
 
-    all_samples = db.get_run_samples("run-full")
+    all_samples = db.run_repository.get_run_samples("run-full")
     assert len(all_samples) == 20
 
-    batched = list(db.iter_run_samples("run-full", batch_size=7))
+    batched = list(db.run_repository.iter_run_samples("run-full", batch_size=7))
     flat = [s for b in batched for s in b]
     assert len(flat) == 20
     assert [s.t_s for s in flat] == [float(i) for i in range(20)]
 
-    run = db.get_run("run-full")
+    run = db.run_repository.get_run("run-full")
     assert run is not None
     assert run.sample_count == 20
     assert run.status.value == "complete"
-    assert db.get_run("run-full").analysis == analysis
+    assert db.run_repository.get_run("run-full").analysis == analysis
 
 
 def test_v2_iter_with_offset(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-off", "2026-01-01T00:00:00Z", _metadata("run-off"))
-    db.append_samples("run-off", [sensor_frame_from_mapping({"t_s": float(i)}) for i in range(10)])
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-off", "2026-01-01T00:00:00Z", _metadata("run-off"))
+    db.run_repository.append_samples(
+        "run-off", [sensor_frame_from_mapping({"t_s": float(i)}) for i in range(10)]
+    )
 
-    rows0 = [s for b in db.iter_run_samples("run-off", offset=0) for s in b]
+    rows0 = [s for b in db.run_repository.iter_run_samples("run-off", offset=0) for s in b]
     assert [r.t_s for r in rows0] == [float(i) for i in range(10)]
 
-    rows1 = [s for b in db.iter_run_samples("run-off", offset=1) for s in b]
+    rows1 = [s for b in db.run_repository.iter_run_samples("run-off", offset=1) for s in b]
     assert [r.t_s for r in rows1] == [float(i) for i in range(1, 10)]
 
-    rows5 = [s for b in db.iter_run_samples("run-off", batch_size=3, offset=5) for s in b]
+    rows5 = [
+        s for b in db.run_repository.iter_run_samples("run-off", batch_size=3, offset=5) for s in b
+    ]
     assert [r.t_s for r in rows5] == [5.0, 6.0, 7.0, 8.0, 9.0]
 
-    rows_past = [s for b in db.iter_run_samples("run-off", offset=20) for s in b]
+    rows_past = [s for b in db.run_repository.iter_run_samples("run-off", offset=20) for s in b]
     assert rows_past == []
 
 
 def test_iter_run_samples_skips_corrupt_rows_and_continues(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-corrupt", "2026-01-01T00:00:00Z", _metadata("run-corrupt"))
-    db.append_samples(
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-corrupt", "2026-01-01T00:00:00Z", _metadata("run-corrupt"))
+    db.run_repository.append_samples(
         "run-corrupt",
         [sensor_frame_from_mapping({"t_s": 1.0}), sensor_frame_from_mapping({"t_s": 2.0})],
     )
-    with db._cursor() as cur:
+    with db.lifecycle._cursor() as cur:
         cur.execute(
             "INSERT INTO samples_v2 (run_id, top_peaks) VALUES (?, ?)",
             ("run-corrupt", "{bad"),
         )
-    db.append_samples("run-corrupt", [sensor_frame_from_mapping({"t_s": 3.0})])
+    db.run_repository.append_samples("run-corrupt", [sensor_frame_from_mapping({"t_s": 3.0})])
 
     rows = [
-        sample for batch in db.iter_run_samples("run-corrupt", batch_size=2) for sample in batch
+        sample
+        for batch in db.run_repository.iter_run_samples("run-corrupt", batch_size=2)
+        for sample in batch
     ]
     assert len(rows) == 3
     assert rows[0].t_s == 1.0
@@ -277,10 +291,12 @@ def test_v2_row_to_dict_non_list_peak_column_warns_and_skips_row(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-peak-warn", "2026-01-01T00:00:00Z", _metadata("run-peak-warn"))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
+        "run-peak-warn", "2026-01-01T00:00:00Z", _metadata("run-peak-warn")
+    )
 
-    with db._cursor() as cur:
+    with db.lifecycle._cursor() as cur:
         cur.execute(
             "INSERT INTO samples_v2 (run_id, top_peaks) VALUES (?, ?)",
             ("run-peak-warn", '{"unexpected": "dict"}'),
@@ -289,7 +305,7 @@ def test_v2_row_to_dict_non_list_peak_column_warns_and_skips_row(
     import logging
 
     with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.persistence.history_db"):
-        rows = db.get_run_samples("run-peak-warn")
+        rows = db.run_repository.get_run_samples("run-peak-warn")
 
     assert rows == []
     assert "top_peaks" in caplog.text

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py
@@ -9,7 +9,7 @@ from typing import cast
 import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frame_from_mapping
 from vibesensor.shared.json_utils import sanitize_value
@@ -43,56 +43,60 @@ def _analysis(run_id: str, **overrides: object) -> AnalysisSummary:
 
 
 def test_create_run_sanitizes_non_finite_metadata(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run(
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
         "run-nan",
         "2026-01-01T00:00:00Z",
         _metadata("run-nan", reference_context={"tire_circumference_m": float("nan")}),
     )
-    run = db.get_run("run-nan")
+    run = db.run_repository.get_run("run-nan")
     assert run is not None
     assert run.metadata.wheel_circumference_m is None
     assert run.metadata.tire_circumference_m is None
 
 
 def test_list_runs_clamps_negative_limit_to_all_rows(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     for i in range(5):
-        db.create_run(f"run-{i}", "2026-01-01T00:00:00Z", _metadata(f"run-{i}"))
-        db.finalize_run(f"run-{i}", "2026-01-01T00:10:00Z")
+        db.run_repository.create_run(f"run-{i}", "2026-01-01T00:00:00Z", _metadata(f"run-{i}"))
+        db.run_repository.finalize_run(f"run-{i}", "2026-01-01T00:10:00Z")
 
-    result = db.list_runs(limit=-1)
+    result = db.run_repository.list_runs(limit=-1)
     assert len(result) == 5
 
 
 def test_resolve_keyset_offset_rejects_invalid_table(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-guard", "2026-01-01T00:00:00Z", _metadata("run-guard"))
-    db.append_samples("run-guard", [sensor_frame_from_mapping({"i": i}) for i in range(3)])
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-guard", "2026-01-01T00:00:00Z", _metadata("run-guard"))
+    db.run_repository.append_samples(
+        "run-guard", [sensor_frame_from_mapping({"i": i}) for i in range(3)]
+    )
 
     with pytest.raises(ValueError, match="invalid table name"):
-        db._resolve_keyset_offset("injected_table", "run-guard", 1)
+        db.run_repository._resolve_keyset_offset("injected_table", "run-guard", 1)
 
 
 def test_append_samples_empty_run_id_raises(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     with pytest.raises(ValueError, match="run_id"):
-        db.append_samples("", [sensor_frame_from_mapping({"i": 1})])
+        db.run_repository.append_samples("", [sensor_frame_from_mapping({"i": 1})])
 
 
 def test_append_samples_whitespace_run_id_raises(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     with pytest.raises(ValueError, match="run_id"):
-        db.append_samples("   ", [sensor_frame_from_mapping({"i": 1})])
+        db.run_repository.append_samples("   ", [sensor_frame_from_mapping({"i": 1})])
 
 
 def test_iter_run_samples_negative_offset_raises(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("run-neg-off", "2026-01-01T00:00:00Z", _metadata("run-neg-off"))
-    db.append_samples("run-neg-off", [sensor_frame_from_mapping({"i": i}) for i in range(3)])
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("run-neg-off", "2026-01-01T00:00:00Z", _metadata("run-neg-off"))
+    db.run_repository.append_samples(
+        "run-neg-off", [sensor_frame_from_mapping({"i": i}) for i in range(3)]
+    )
 
     with pytest.raises(ValueError, match="offset"):
-        list(db.iter_run_samples("run-neg-off", offset=-1))
+        list(db.run_repository.iter_run_samples("run-neg-off", offset=-1))
 
 
 def test_sanitize_value_handles_numpy_scalars() -> None:
@@ -141,53 +145,57 @@ def test_sanitize_value_handles_numpy_arrays() -> None:
 
 
 def test_verify_run_integrity_clean_run(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run(
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
         "run-ok",
         "2026-01-01T00:00:00Z",
         _metadata("run-ok", sensor_model="a", sample_rate_hz=100),
     )
-    db.append_samples("run-ok", [sensor_frame_from_mapping({"i": i}) for i in range(5)])
-    db.finalize_run("run-ok", "2026-01-01T00:10:00Z")
-    db.store_analysis("run-ok", make_persisted_analysis(_analysis("run-ok")))
-    assert db.verify_run_integrity("run-ok") == []
+    db.run_repository.append_samples(
+        "run-ok", [sensor_frame_from_mapping({"i": i}) for i in range(5)]
+    )
+    db.run_repository.finalize_run("run-ok", "2026-01-01T00:10:00Z")
+    db.run_repository.store_analysis("run-ok", make_persisted_analysis(_analysis("run-ok")))
+    assert db.run_repository.verify_run_integrity("run-ok") == []
 
 
 def test_verify_run_integrity_sample_count_mismatch(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run(
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
         "run-m",
         "2026-01-01T00:00:00Z",
         _metadata("run-m", sensor_model="a", sample_rate_hz=100),
     )
-    db.append_samples("run-m", [sensor_frame_from_mapping({"i": i}) for i in range(5)])
-    db.finalize_run("run-m", "2026-01-01T00:10:00Z")
-    db.store_analysis("run-m", make_persisted_analysis(_analysis("run-m")))
+    db.run_repository.append_samples(
+        "run-m", [sensor_frame_from_mapping({"i": i}) for i in range(5)]
+    )
+    db.run_repository.finalize_run("run-m", "2026-01-01T00:10:00Z")
+    db.run_repository.store_analysis("run-m", make_persisted_analysis(_analysis("run-m")))
     # Manually corrupt sample_count
-    with db._cursor() as cur:
+    with db.lifecycle._cursor() as cur:
         cur.execute("UPDATE runs SET sample_count = 99 WHERE run_id = 'run-m'")
-    problems = db.verify_run_integrity("run-m")
+    problems = db.run_repository.verify_run_integrity("run-m")
     assert any("sample_count mismatch" in p for p in problems)
 
 
 def test_verify_run_integrity_complete_without_analysis(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run(
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
         "run-na",
         "2026-01-01T00:00:00Z",
         _metadata("run-na", sensor_model="a", sample_rate_hz=100),
     )
-    db.finalize_run("run-na", "2026-01-01T00:10:00Z")
+    db.run_repository.finalize_run("run-na", "2026-01-01T00:10:00Z")
     # Force status to complete without analysis
-    with db._cursor() as cur:
+    with db.lifecycle._cursor() as cur:
         cur.execute("UPDATE runs SET status = 'complete' WHERE run_id = 'run-na'")
-    problems = db.verify_run_integrity("run-na")
+    problems = db.run_repository.verify_run_integrity("run-na")
     assert any("missing analysis_json" in p for p in problems)
 
 
 def test_verify_run_integrity_run_not_found(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    assert db.verify_run_integrity("no-such-run") == ["run not found"]
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    assert db.run_repository.verify_run_integrity("no-such-run") == ["run not found"]
 
 
 # -- metadata validation warning tests ----------------------------------------
@@ -197,7 +205,7 @@ def test_create_run_warns_on_missing_metadata_keys(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     incomplete_meta = run_metadata_from_mapping(
         {
             "run_id": "run-w",
@@ -206,7 +214,7 @@ def test_create_run_warns_on_missing_metadata_keys(
         }
     )
     with caplog.at_level("WARNING"):
-        db.create_run("run-w", "2026-01-01T00:00:00Z", incomplete_meta)
+        db.run_repository.create_run("run-w", "2026-01-01T00:00:00Z", incomplete_meta)
     assert "missing recommended keys" in caplog.text
     assert "raw_sample_rate_hz" in caplog.text
 
@@ -215,10 +223,10 @@ def test_create_run_no_warning_when_metadata_complete(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     meta = _metadata("run-ok", sensor_model="a", raw_sample_rate_hz=100)
     with caplog.at_level("WARNING"):
-        db.create_run("run-ok", "2026-01-01T00:00:00Z", meta)
+        db.run_repository.create_run("run-ok", "2026-01-01T00:00:00Z", meta)
     assert "missing recommended keys" not in caplog.text
 
 
@@ -229,13 +237,13 @@ def test_store_analysis_warns_on_missing_summary_keys(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     meta = _metadata("run-w2", sensor_model="a", raw_sample_rate_hz=100)
-    db.create_run("run-w2", "2026-01-01T00:00:00Z", meta)
-    db.finalize_run("run-w2", "2026-01-01T00:10:00Z")
+    db.run_repository.create_run("run-w2", "2026-01-01T00:00:00Z", meta)
+    db.run_repository.finalize_run("run-w2", "2026-01-01T00:10:00Z")
     incomplete_summary = cast(AnalysisSummary, {"run_id": "run-w2", "score": 42})
     with caplog.at_level("WARNING"):
-        db.store_analysis("run-w2", make_persisted_analysis(incomplete_summary))
+        db.run_repository.store_analysis("run-w2", make_persisted_analysis(incomplete_summary))
     assert "missing expected keys" in caplog.text
 
 
@@ -243,17 +251,17 @@ def test_store_analysis_warns_on_missing_summary_keys(
 
 
 def test_store_analysis_rejects_terminal_status(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run(
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
         "run-t",
         "2026-01-01T00:00:00Z",
         _metadata("run-t", sensor_model="a", sample_rate_hz=100),
     )
-    db.finalize_run("run-t", "2026-01-01T00:10:00Z")
-    db.store_analysis("run-t", make_persisted_analysis(_analysis("run-t")))
+    db.run_repository.finalize_run("run-t", "2026-01-01T00:10:00Z")
+    db.run_repository.store_analysis("run-t", make_persisted_analysis(_analysis("run-t")))
     # Second store_analysis should return False (already complete)
     assert (
-        db.store_analysis(
+        db.run_repository.store_analysis(
             "run-t",
             make_persisted_analysis(_analysis("run-t", top_causes=["unexpected"])),
         )
@@ -262,13 +270,13 @@ def test_store_analysis_rejects_terminal_status(tmp_path: Path) -> None:
 
 
 def test_store_analysis_error_rejects_terminal_status(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run(
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run(
         "run-te",
         "2026-01-01T00:00:00Z",
         _metadata("run-te", sensor_model="a", sample_rate_hz=100),
     )
-    db.finalize_run("run-te", "2026-01-01T00:10:00Z")
-    db.store_analysis("run-te", make_persisted_analysis(_analysis("run-te")))
+    db.run_repository.finalize_run("run-te", "2026-01-01T00:10:00Z")
+    db.run_repository.store_analysis("run-te", make_persisted_analysis(_analysis("run-te")))
     # Error after complete should return False
-    assert db.store_analysis_error("run-te", "late failure") is False
+    assert db.run_repository.store_analysis_error("run-te", "late failure") is False

--- a/apps/server/tests/adapters/udp/test_reset_buffer_flush.py
+++ b/apps/server/tests/adapters/udp/test_reset_buffer_flush.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.adapters.udp.protocol import DataMessage, HelloMessage, pack_data
 from vibesensor.adapters.udp.udp_data_rx import DataDatagramProtocol
 from vibesensor.infra.processing import SignalProcessor
@@ -143,8 +143,8 @@ def _data_msg(seq: int, t0_us: int) -> DataMessage:
 @pytest.fixture
 def registry_ctx(tmp_path: Path) -> ClientRegistry:
     """Registry pre-registered with a single client."""
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     registry.update_from_hello(
         HelloMessage(
             client_id=_CLIENT_ID,

--- a/apps/server/tests/adapters/udp/test_udp_control_tx.py
+++ b/apps/server/tests/adapters/udp/test_udp_control_tx.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.adapters.udp.protocol import (
     HELLO_CAP_EXPLICIT_ACK,
     MSG_HELLO_ACK,
@@ -18,6 +18,11 @@ from vibesensor.adapters.udp.protocol import (
 )
 from vibesensor.adapters.udp.udp_control_tx import ControlDatagramProtocol, UDPControlPlane
 from vibesensor.infra.runtime.registry import ClientRegistry
+
+
+def _make_registry(tmp_path: Path) -> ClientRegistry:
+    adapters = create_history_persistence_adapters(tmp_path / "history.db")
+    return ClientRegistry(db=adapters.client_name_repository)
 
 
 @pytest.mark.parametrize(
@@ -33,7 +38,7 @@ def test_send_identify_accepts_hex_and_mac_client_ids(
     fake_transport,
 ) -> None:
     client_hex = "aabbccddeeff"
-    registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
+    registry = _make_registry(tmp_path)
     registry.update_from_hello(
         HelloMessage(
             client_id=bytes.fromhex(client_hex),
@@ -66,7 +71,7 @@ def test_control_datagram_programming_bug_propagates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client_hex = "aabbccddeeff"
-    registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
+    registry = _make_registry(tmp_path)
     protocol = ControlDatagramProtocol(registry)
     packet = pack_ack(bytes.fromhex(client_hex), cmd_seq=7, status=0)
 
@@ -87,7 +92,7 @@ def test_control_datagram_operational_error_is_logged_and_counted(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     client_hex = "aabbccddeeff"
-    registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
+    registry = _make_registry(tmp_path)
     registry.update_from_hello(
         HelloMessage(
             client_id=bytes.fromhex(client_hex),
@@ -120,7 +125,7 @@ def test_control_datagram_sends_hello_ack_for_capable_firmware(
     tmp_path: Path,
     fake_transport,
 ) -> None:
-    registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
+    registry = _make_registry(tmp_path)
     protocol = ControlDatagramProtocol(registry)
     protocol.transport = fake_transport
     packet = pack_hello(
@@ -145,7 +150,7 @@ def test_control_datagram_skips_hello_ack_for_legacy_firmware(
     tmp_path: Path,
     fake_transport,
 ) -> None:
-    registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
+    registry = _make_registry(tmp_path)
     protocol = ControlDatagramProtocol(registry)
     protocol.transport = fake_transport
     packet = pack_hello(
@@ -163,7 +168,7 @@ def test_control_datagram_skips_hello_ack_for_legacy_firmware(
 
 
 def test_close_closes_transport_once_and_clears_reference(tmp_path: Path, fake_transport) -> None:
-    registry = ClientRegistry(db=HistoryDB(tmp_path / "history.db"))
+    registry = _make_registry(tmp_path)
     plane = UDPControlPlane(registry=registry, bind_host="127.0.0.1", bind_port=9001)
     plane.transport = fake_transport
 

--- a/apps/server/tests/hygiene/test_history_db_mixins.py
+++ b/apps/server/tests/hygiene/test_history_db_mixins.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from vibesensor.adapters.persistence.history_db import (
     ClientNameRepository,
-    HistoryDB,
     RunHistoryRepository,
     SettingsSnapshotRepository,
     SQLiteHistoryEngine,
@@ -39,16 +38,6 @@ def test_run_history_repository_mixins_expose_disjoint_public_methods() -> None:
 
     overlaps = {name: owners for name, owners in owners_by_name.items() if len(owners) > 1}
     assert overlaps == {}, f"run-history mixins must keep disjoint public APIs: {overlaps}"
-
-
-def test_history_db_wrapper_is_no_longer_the_primary_mixin_stack() -> None:
-    history_db_members = set(HistoryDB.__dict__)
-
-    assert not issubclass(HistoryDB, _HistoryDBRunLifecycleMixin)
-    assert not issubclass(HistoryDB, _HistoryDBSampleIOMixin)
-    assert not issubclass(HistoryDB, _HistoryDBQueryMixin)
-    assert "__getattr__" in history_db_members
-    assert {"_cursor", "_cursor_connection", "write_transaction_cursor"} <= history_db_members
 
 
 def test_history_persistence_factory_returns_split_adapters(tmp_path: Path) -> None:

--- a/apps/server/tests/infra/config/test_sensor_settings.py
+++ b/apps/server/tests/infra/config/test_sensor_settings.py
@@ -8,7 +8,7 @@ from threading import RLock
 import pytest
 from test_support.settings_services import build_settings_services
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.infra.config.sensor_settings import (
     SensorSettingsService,
     SensorSettingsState,
@@ -89,12 +89,12 @@ def test_assign_sensor_location_rolls_back_new_sensor_on_persist_error() -> None
 
 
 def test_sensor_settings_round_trip_through_shared_snapshot(tmp_path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    services = build_settings_services(db=db.settings_snapshot_repository)
 
     services.sensor_settings.assign_sensor_location("aa:bb:cc:dd:ee:ff", "front_left_wheel")
 
-    reloaded = build_settings_services(db=db)
+    reloaded = build_settings_services(db=db.settings_snapshot_repository)
     sensors = reloaded.sensor_settings.get_sensors()
     assert "aabbccddeeff" in sensors
     assert sensors["aabbccddeeff"] == {

--- a/apps/server/tests/infra/config/test_settings_persistence.py
+++ b/apps/server/tests/infra/config/test_settings_persistence.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from test_support.settings_services import build_settings_services, write_raw_settings_snapshot
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.shared.exceptions import PersistenceError
 from vibesensor.shared.types.settings_snapshot import SettingsSnapshotPayload
 
@@ -25,13 +25,21 @@ class FakeSettingsSnapshotStore:
 
 
 def _sabotaged_services(tmp_path: Path):
-    db = HistoryDB(tmp_path / "history.db")
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    services = build_settings_services(db=db.settings_snapshot_repository)
+    original_repo = db.settings_snapshot_repository
 
     def _boom(payload: object) -> None:
         raise OSError("disk full")
 
-    db.set_settings_snapshot = _boom
+    class _SabotagedSettingsSnapshotStore:
+        def get_settings_snapshot(self) -> SettingsSnapshotPayload | None:
+            return original_repo.get_settings_snapshot()
+
+        def set_settings_snapshot(self, snapshot: SettingsSnapshotPayload) -> None:
+            _boom(snapshot)
+
+    services.coordinator._db = _SabotagedSettingsSnapshotStore()
     return services
 
 
@@ -47,8 +55,8 @@ def test_settings_snapshot_defaults_are_empty_and_gps() -> None:
 
 
 def test_settings_snapshot_persists_and_loads(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    services = build_settings_services(db=db.settings_snapshot_repository)
     added = services.car_settings.add_car({"name": "Persisted Car", "type": "suv"})
     services.car_settings.set_active_car(added.cars[0]["id"])
     services.speed_source_settings.update_speed_source(
@@ -63,7 +71,7 @@ def test_settings_snapshot_persists_and_loads(tmp_path: Path) -> None:
     services.ui_preferences.set_language("nl")
     services.ui_preferences.set_speed_unit("mps")
 
-    reloaded = build_settings_services(db=db)
+    reloaded = build_settings_services(db=db.settings_snapshot_repository)
     snapshot = reloaded.coordinator.snapshot()
     assert len(snapshot["cars"]) == 1
     assert snapshot["cars"][0]["name"] == "Persisted Car"
@@ -92,9 +100,9 @@ def test_settings_snapshot_persists_with_protocol_shaped_store() -> None:
 
 
 def test_settings_snapshot_corrupted_json_falls_back_to_defaults(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    write_raw_settings_snapshot(db, "not-valid-json{{{")
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    write_raw_settings_snapshot(db.lifecycle, "not-valid-json{{{")
+    services = build_settings_services(db=db.settings_snapshot_repository)
     snapshot = services.coordinator.snapshot()
     assert snapshot["cars"] == []
     assert snapshot["activeCarId"] is None
@@ -102,24 +110,24 @@ def test_settings_snapshot_corrupted_json_falls_back_to_defaults(tmp_path: Path)
 
 
 def test_settings_snapshot_with_empty_cars_stays_empty(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    write_raw_settings_snapshot(db, '{"cars": [], "activeCarId": ""}')
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    write_raw_settings_snapshot(db.lifecycle, '{"cars": [], "activeCarId": ""}')
+    services = build_settings_services(db=db.settings_snapshot_repository)
     snapshot = services.coordinator.snapshot()
     assert snapshot["cars"] == []
     assert snapshot["activeCarId"] is None
 
 
 def test_settings_snapshot_invalid_active_car_id_clears_selection(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     write_raw_settings_snapshot(
-        db,
+        db.lifecycle,
         (
             '{"cars": [{"id": "car-1", "name": "Only", "type": "sedan", "aspects": {}}], '
             '"activeCarId": "missing-car"}'
         ),
     )
-    services = build_settings_services(db=db)
+    services = build_settings_services(db=db.settings_snapshot_repository)
     snapshot = services.coordinator.snapshot()
     assert len(snapshot["cars"]) == 1
     assert snapshot["activeCarId"] is None

--- a/apps/server/tests/infra/config/test_ui_preferences.py
+++ b/apps/server/tests/infra/config/test_ui_preferences.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from test_support.settings_services import build_settings_services, write_raw_settings_snapshot
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 
 
 def test_ui_preferences_language_roundtrip() -> None:
@@ -18,29 +18,29 @@ def test_ui_preferences_language_roundtrip() -> None:
 
 
 def test_ui_preferences_speed_unit_roundtrip(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    services = build_settings_services(db=db.settings_snapshot_repository)
     assert services.ui_preferences.speed_unit == "kmh"
 
     services.ui_preferences.set_speed_unit("mps")
     assert services.ui_preferences.speed_unit == "mps"
 
-    reloaded = build_settings_services(db=db)
+    reloaded = build_settings_services(db=db.settings_snapshot_repository)
     assert reloaded.ui_preferences.speed_unit == "mps"
 
 
 def test_ui_preferences_load_normalizes_language_and_speed_unit(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    write_raw_settings_snapshot(db, '{"language": " NL ", "speedUnit": " MPS "}')
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    write_raw_settings_snapshot(db.lifecycle, '{"language": " NL ", "speedUnit": " MPS "}')
+    services = build_settings_services(db=db.settings_snapshot_repository)
     assert services.ui_preferences.language == "nl"
     assert services.ui_preferences.speed_unit == "mps"
 
 
 def test_ui_preferences_load_whitespace_only_values_default(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    write_raw_settings_snapshot(db, '{"language": "   ", "speedUnit": "   "}')
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    write_raw_settings_snapshot(db.lifecycle, '{"language": "   ", "speedUnit": "   "}')
+    services = build_settings_services(db=db.settings_snapshot_repository)
     assert services.ui_preferences.language == "en"
     assert services.ui_preferences.speed_unit == "kmh"
 

--- a/apps/server/tests/infra/runtime/test_client_metadata.py
+++ b/apps/server/tests/infra/runtime/test_client_metadata.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from threading import RLock
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.domain import normalize_sensor_id
 from vibesensor.infra.runtime.client_metadata import ClientMetadataManager
 from vibesensor.infra.runtime.registry import ClientRecord
@@ -25,13 +25,13 @@ def _build_manager(db_path: Path) -> tuple[ClientMetadataManager, dict[str, Clie
             records[normalized] = record
         return record
 
-    db = HistoryDB(db_path)
+    db = create_history_persistence_adapters(db_path)
     manager = ClientMetadataManager(
         lock=RLock(),
         get_or_create=_get_or_create,
-        list_client_names=db.list_client_names,
-        persist_client_name=db.upsert_client_name,
-        delete_client_name=db.delete_client_name,
+        list_client_names=db.client_name_repository.list_client_names,
+        persist_client_name=db.client_name_repository.upsert_client_name,
+        delete_client_name=db.client_name_repository.delete_client_name,
     )
     return manager, records
 

--- a/apps/server/tests/infra/runtime/test_registry.py
+++ b/apps/server/tests/infra/runtime/test_registry.py
@@ -33,7 +33,7 @@ from test_support.runtime_lifecycle import (
     make_hello_message as _make_hello_message,
 )
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.adapters.udp.protocol import DataMessage, HelloMessage
 from vibesensor.infra.runtime.registry import ClientRegistry
 from vibesensor.shared.boundaries.clients import snapshot_for_api
@@ -92,8 +92,8 @@ def test_registry_persists_names_with_protocol_shaped_store() -> None:
 
 
 def test_registry_sequence_gap(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     client_id = bytes.fromhex("aabbccddeeff")
 
     hello = HelloMessage(
@@ -118,8 +118,8 @@ def test_registry_sequence_gap(tmp_path: Path) -> None:
 
 
 def test_registry_rejects_far_behind_duplicate_without_clearing_dedup(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     client_id = bytes.fromhex("aabbccddeeff")
 
     hello = HelloMessage(
@@ -165,12 +165,12 @@ def test_registry_rejects_far_behind_duplicate_without_clearing_dedup(tmp_path: 
 
 
 def test_registry_rename_persist(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     client_id = "001122334455"
     registry.set_name(client_id, "rear")
 
-    registry2 = ClientRegistry(db=db)
+    registry2 = ClientRegistry(db=db.client_name_repository)
     hello = HelloMessage(
         client_id=bytes.fromhex(client_id),
         control_port=9011,
@@ -185,8 +185,8 @@ def test_registry_rename_persist(tmp_path: Path) -> None:
 
 
 def test_registry_rename_normalizes_client_id(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     lower_id = "001122334455"
     upper_id = lower_id.upper()
 
@@ -200,12 +200,12 @@ def test_registry_rename_normalizes_client_id(tmp_path: Path) -> None:
 
 
 def test_registry_snapshot_includes_persisted_offline_clients(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     offline_id = "001122334455"
     registry.set_name(offline_id, "rear-right-wheel")
 
-    registry2 = ClientRegistry(db=db)
+    registry2 = ClientRegistry(db=db.client_name_repository)
     rows = {row["id"]: row for row in snapshot_for_api(registry2, now=10.0)}
     assert rows[offline_id]["name"] == "rear-right-wheel"
     assert rows[offline_id]["connected"] is False
@@ -213,8 +213,8 @@ def test_registry_snapshot_includes_persisted_offline_clients(tmp_path: Path) ->
 
 
 def test_registry_persist_keeps_offline_names(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     offline_id = "001122334455"
     active_id = "aabbccddeeff"
 
@@ -228,7 +228,7 @@ def test_registry_persist_keeps_offline_names(tmp_path: Path) -> None:
     )
     registry.update_from_hello(hello, ("10.4.0.2", 9010), now=2.0)
 
-    registry2 = ClientRegistry(db=db)
+    registry2 = ClientRegistry(db=db.client_name_repository)
     registry2.update_from_hello(hello, ("10.4.0.2", 9010), now=3.0)
     registry2.update_from_hello(
         HelloMessage(
@@ -311,8 +311,12 @@ def test_registry_staleness_uses_monotonic_clock_when_now_not_provided(
 
 
 def test_registry_retains_stale_client_until_retention_ttl(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db, live_ttl_seconds=5.0, retention_ttl_seconds=30.0)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(
+        db=db.client_name_repository,
+        live_ttl_seconds=5.0,
+        retention_ttl_seconds=30.0,
+    )
     hello = HelloMessage(
         client_id=bytes.fromhex("001122334455"),
         control_port=9010,
@@ -334,8 +338,8 @@ def test_registry_retains_stale_client_until_retention_ttl(tmp_path: Path) -> No
 
 
 def test_registry_data_loss_snapshot_preserves_public_counter_shape(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     client_id = bytes.fromhex("001122334455")
     hello = HelloMessage(
         client_id=client_id,
@@ -372,22 +376,22 @@ def test_registry_data_loss_snapshot_preserves_public_counter_shape(tmp_path: Pa
 
 
 def test_registry_remove_client_clears_persisted_entry(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     client_id = "001122334455"
     registry.set_name(client_id, "front-left")
 
     assert registry.remove_client(client_id) is True
     assert registry.remove_client(client_id) is False
 
-    registry2 = ClientRegistry(db=db)
+    registry2 = ClientRegistry(db=db.client_name_repository)
     rows = snapshot_for_api(registry2, now=1.0)
     assert rows == []
 
 
 def test_registry_detects_sensor_reset_on_large_sequence_backstep(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     client_id = bytes.fromhex("aabbccddeeff")
     hello = HelloMessage(
         client_id=client_id,
@@ -426,8 +430,8 @@ def test_registry_detects_sensor_reset_on_large_sequence_backstep(tmp_path: Path
 
 
 def test_registry_exposes_timing_health_metrics(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     client_id = bytes.fromhex("001122334455")
     hello = HelloMessage(
         client_id=client_id,
@@ -456,8 +460,8 @@ def test_registry_exposes_timing_health_metrics(tmp_path: Path) -> None:
 
 def test_registry_clear_name_reverts_to_default(tmp_path: Path) -> None:
     """clear_name() should remove the user-assigned name and revert to default."""
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     client_id = "001122334455"
 
     # Assign a user name
@@ -471,7 +475,7 @@ def test_registry_clear_name_reverts_to_default(tmp_path: Path) -> None:
     assert cleared.name == f"client-{client_id[-4:]}"
 
     # Verify persistence: the cleared name should NOT come back after reload
-    registry2 = ClientRegistry(db=db)
+    registry2 = ClientRegistry(db=db.client_name_repository)
     rows = snapshot_for_api(registry2, now=1.0)
     names = [r["name"] for r in rows if r["id"] == client_id]
     # After clearing, the client may or may not appear in snapshot (depending on
@@ -482,8 +486,8 @@ def test_registry_clear_name_reverts_to_default(tmp_path: Path) -> None:
 
 def test_registry_clear_name_preserves_other_clients(tmp_path: Path) -> None:
     """Clearing one client's name should not affect other clients."""
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
 
     registry.set_name("001122334455", "Front Left Wheel")
     registry.set_name("aabbccddeeff", "Rear Right Wheel")
@@ -497,8 +501,8 @@ def test_registry_clear_name_preserves_other_clients(tmp_path: Path) -> None:
 
 def test_set_location_populates_client_record(tmp_path: Path) -> None:
     """set_location must write to ClientRecord so snapshot_for_api returns it."""
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     client_id = bytes.fromhex("aabbccddeeff")
 
     hello = HelloMessage(
@@ -525,8 +529,8 @@ def test_set_location_populates_client_record(tmp_path: Path) -> None:
 
 
 def test_set_location_trims_whitespace(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     hex_id = "001122334455"
     registry.set_location(hex_id, "  rear_axle  ")
     row = snapshot_for_api(registry, now=1.0)[0]

--- a/apps/server/tests/infra/runtime/test_registry_location_cap.py
+++ b/apps/server/tests/infra/runtime/test_registry_location_cap.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.infra.runtime.registry import ClientRegistry, _resolve_now_mono
 from vibesensor.shared.boundaries.clients import snapshot_for_api
 
@@ -19,8 +19,8 @@ _CLIENT_ID = "aabbccddeeff"
 
 
 def _make_registry(tmp_path: Path) -> ClientRegistry:
-    db = HistoryDB(tmp_path / "history.db")
-    return ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    return ClientRegistry(db=db.client_name_repository)
 
 
 # ── Location cap at 64 bytes ──────────────────────────────────────────────────

--- a/apps/server/tests/infra/runtime/test_ws_payload_projection.py
+++ b/apps/server/tests/infra/runtime/test_ws_payload_projection.py
@@ -105,12 +105,16 @@ def test_build_shared_payload_marks_retained_stale_clients_disconnected(
     tmp_path,
     monkeypatch,
 ) -> None:
-    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
     from vibesensor.adapters.udp.protocol import HelloMessage
     from vibesensor.infra.runtime.registry import ClientRegistry
 
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db, live_ttl_seconds=5.0, retention_ttl_seconds=30.0)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(
+        db=db.client_name_repository,
+        live_ttl_seconds=5.0,
+        retention_ttl_seconds=30.0,
+    )
     hello = HelloMessage(
         client_id=bytes.fromhex("001122334455"),
         control_port=9010,

--- a/apps/server/tests/integration/test_api_history_processing_regressions.py
+++ b/apps/server/tests/integration/test_api_history_processing_regressions.py
@@ -9,7 +9,10 @@ import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.http._helpers import safe_filename as _safe_filename
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    HistoryPersistenceAdapters,
+    create_history_persistence_adapters,
+)
 from vibesensor.infra.processing import SignalProcessor
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.types.run_schema import RunMetadata
@@ -78,27 +81,27 @@ class TestHistoryDBAnalysisValidation:
     """Analysis stored in history must be type-checked as dict."""
 
     @staticmethod
-    def _make_db(tmp_path: Path) -> HistoryDB:
-        db = HistoryDB(tmp_path / "history.db")
-        db.create_run("run-1", "2026-01-01T00:00:00Z", _metadata())
+    def _make_db(tmp_path: Path) -> HistoryPersistenceAdapters:
+        db = create_history_persistence_adapters(tmp_path / "history.db")
+        db.run_repository.create_run("run-1", "2026-01-01T00:00:00Z", _metadata())
         return db
 
     def test_rejects_non_dict_analysis(self, tmp_path: Path) -> None:
         db = self._make_db(tmp_path)
-        with db._cursor() as cur:
+        with db.lifecycle._cursor() as cur:
             cur.execute(
                 "UPDATE runs SET status='complete', analysis_json=? WHERE run_id=?",
                 ("[1,2,3]", "run-1"),
             )
-        run = db.get_run("run-1")
+        run = db.run_repository.get_run("run-1")
         assert run is not None
         assert run.analysis is None
         assert run.analysis_corrupt is True
 
     def test_accepts_dict_analysis(self, tmp_path: Path) -> None:
         db = self._make_db(tmp_path)
-        db.store_analysis("run-1", make_persisted_analysis({"findings": []}))
-        run = db.get_run("run-1")
+        db.run_repository.store_analysis("run-1", make_persisted_analysis({"findings": []}))
+        run = db.run_repository.get_run("run-1")
         assert run is not None
         assert run.analysis is not None
 

--- a/apps/server/tests/integration/test_concurrency_generation_guard_regressions.py
+++ b/apps/server/tests/integration/test_concurrency_generation_guard_regressions.py
@@ -17,7 +17,7 @@ import pytest
 from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.runtime.registry import ClientRegistry
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
@@ -27,8 +27,8 @@ from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
 
 def _make_logger(tmp_path: Path, **overrides):
     """Create a minimal RunRecorder + HistoryDB for concurrency tests."""
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     # Separate config fields from collaborator overrides.
     _CONFIG_FIELDS = frozenset(
         {
@@ -59,7 +59,7 @@ def _make_logger(tmp_path: Path, **overrides):
             fft_n=256,
             spectrum_max_hz=200,
         ),
-        "history_db": db,
+        "history_db": db.run_repository,
     }
     collab_defaults.update(overrides)
     return RunRecorder(config, **collab_defaults), db
@@ -106,7 +106,7 @@ class TestAutoStopGenerationGuard:
         # New session must still be alive
         assert logger.enabled is True
         assert logger._run_id == new_run_id
-        db.close()
+        db.lifecycle.close()
 
     def test_matching_run_id_does_stop(self, tmp_path: Path) -> None:
         logger, db = _make_logger(tmp_path)
@@ -117,7 +117,7 @@ class TestAutoStopGenerationGuard:
         logger.stop_recording(_only_if_run_id=run_id)
         assert logger.enabled is False
         assert logger._run_id is None
-        db.close()
+        db.lifecycle.close()
 
 
 # ---------------------------------------------------------------------------
@@ -129,49 +129,49 @@ class TestDeleteRunIfSafe:
     """Cover safe-delete outcomes for complete, active, analyzing, missing, and error runs."""
 
     def test_delete_complete_run(self, tmp_path: Path) -> None:
-        db = HistoryDB(tmp_path / "h.db")
-        db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
-        db.finalize_run("r1", "2026-01-01T00:05:00Z")
-        db.store_analysis("r1", make_persisted_analysis({"score": 1}))
-        deleted, reason = db.delete_run_if_safe("r1")
+        db = create_history_persistence_adapters(tmp_path / "h.db")
+        db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        db.run_repository.finalize_run("r1", "2026-01-01T00:05:00Z")
+        db.run_repository.store_analysis("r1", make_persisted_analysis({"score": 1}))
+        deleted, reason = db.run_repository.delete_run_if_safe("r1")
         assert deleted is True
         assert reason is None
-        assert db.get_run("r1") is None
-        db.close()
+        assert db.run_repository.get_run("r1") is None
+        db.lifecycle.close()
 
     def test_refuse_recording(self, tmp_path: Path) -> None:
-        db = HistoryDB(tmp_path / "h.db")
-        db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
-        deleted, reason = db.delete_run_if_safe("r1")
+        db = create_history_persistence_adapters(tmp_path / "h.db")
+        db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        deleted, reason = db.run_repository.delete_run_if_safe("r1")
         assert deleted is False
         assert reason == "active"
-        assert db.get_run("r1") is not None
-        db.close()
+        assert db.run_repository.get_run("r1") is not None
+        db.lifecycle.close()
 
     def test_refuse_analyzing(self, tmp_path: Path) -> None:
-        db = HistoryDB(tmp_path / "h.db")
-        db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
-        db.finalize_run("r1", "2026-01-01T00:05:00Z")
-        deleted, reason = db.delete_run_if_safe("r1")
+        db = create_history_persistence_adapters(tmp_path / "h.db")
+        db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        db.run_repository.finalize_run("r1", "2026-01-01T00:05:00Z")
+        deleted, reason = db.run_repository.delete_run_if_safe("r1")
         assert deleted is False
         assert reason == "analyzing"
-        db.close()
+        db.lifecycle.close()
 
     def test_not_found(self, tmp_path: Path) -> None:
-        db = HistoryDB(tmp_path / "h.db")
-        deleted, reason = db.delete_run_if_safe("nonexistent")
+        db = create_history_persistence_adapters(tmp_path / "h.db")
+        deleted, reason = db.run_repository.delete_run_if_safe("nonexistent")
         assert deleted is False
         assert reason == "not_found"
-        db.close()
+        db.lifecycle.close()
 
     def test_delete_error_run(self, tmp_path: Path) -> None:
-        db = HistoryDB(tmp_path / "h.db")
-        db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
-        db.store_analysis_error("r1", "boom")
-        deleted, reason = db.delete_run_if_safe("r1")
+        db = create_history_persistence_adapters(tmp_path / "h.db")
+        db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        db.run_repository.store_analysis_error("r1", "boom")
+        deleted, reason = db.run_repository.delete_run_if_safe("r1")
         assert deleted is True
         assert reason is None
-        db.close()
+        db.lifecycle.close()
 
 
 # ---------------------------------------------------------------------------
@@ -183,27 +183,27 @@ class TestFinalizeRunWithMetadata:
     """Cover metadata updates on finalize_run and the no-op path after status changes."""
 
     def test_atomic_metadata_and_status(self, tmp_path: Path) -> None:
-        db = HistoryDB(tmp_path / "h.db")
-        db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        db = create_history_persistence_adapters(tmp_path / "h.db")
+        db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
         new_meta = _metadata("r1", end_time_utc="2026-01-01T00:05:00Z")
-        db.finalize_run("r1", "2026-01-01T00:05:00Z", metadata=new_meta)
-        run = db.get_run("r1")
+        db.run_repository.finalize_run("r1", "2026-01-01T00:05:00Z", metadata=new_meta)
+        run = db.run_repository.get_run("r1")
         assert run is not None
         assert run.status.value == "analyzing"
         assert run.end_time_utc == "2026-01-01T00:05:00Z"
-        db.close()
+        db.lifecycle.close()
 
     def test_only_recording_transitions(self, tmp_path: Path) -> None:
-        db = HistoryDB(tmp_path / "h.db")
-        db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
-        db.finalize_run("r1", "2026-01-01T00:05:00Z")
+        db = create_history_persistence_adapters(tmp_path / "h.db")
+        db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1"))
+        db.run_repository.finalize_run("r1", "2026-01-01T00:05:00Z")
         # Already analyzing — second finalize with metadata should be no-op
-        db.finalize_run("r1", "2026-01-01T00:10:00Z", metadata=_metadata("r1"))
-        run = db.get_run("r1")
+        db.run_repository.finalize_run("r1", "2026-01-01T00:10:00Z", metadata=_metadata("r1"))
+        run = db.run_repository.get_run("r1")
         assert run is not None
         assert run.status.value == "analyzing"
         assert run.end_time_utc == "2026-01-01T00:05:00Z"
-        db.close()
+        db.lifecycle.close()
 
 
 # ---------------------------------------------------------------------------
@@ -234,15 +234,15 @@ class TestFinalizeReturnGatesAnalysis:
         assert isinstance(run_id, str) and len(run_id) > 0
 
         # Simulate a run that created history and wrote samples
-        db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id))
+        db.run_repository.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id))
         logger._persistence.history_run_created = True
         logger._persistence.written_sample_count = 5
 
         # Sabotage finalize_run to simulate a DB crash
         monkeypatch.setattr(
-            db,
+            type(db.run_repository),
             "finalize_run",
-            lambda *a, **kw: (_ for _ in ()).throw(sqlite3.OperationalError("disk gone")),
+            lambda _self, *a, **kw: (_ for _ in ()).throw(sqlite3.OperationalError("disk gone")),
         )
 
         schedule_calls: list[str] = []
@@ -258,4 +258,4 @@ class TestFinalizeReturnGatesAnalysis:
         assert schedule_calls == [run_id], (
             f"Expected analysis to be scheduled for {run_id}, got: {schedule_calls}"
         )
-        db.close()
+        db.lifecycle.close()

--- a/apps/server/tests/integration/test_contract_persistence_analysis.py
+++ b/apps/server/tests/integration/test_contract_persistence_analysis.py
@@ -19,7 +19,10 @@ from test_support import (
 )
 
 from vibesensor.adapters.analysis_summary import summarize_run_data
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    RunHistoryRepository,
+    create_history_persistence_adapters,
+)
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import (
     sensor_frame_from_mapping,
@@ -32,9 +35,9 @@ pytestmark = pytest.mark.smoke
 def _create_populated_db(
     meta: dict,
     samples: list[dict],
-) -> tuple[HistoryDB, str]:
+) -> tuple[RunHistoryRepository, str]:
     """Create an in-memory DB with a run containing *samples*."""
-    db = HistoryDB(Path(":memory:"))
+    db = create_history_persistence_adapters(Path(":memory:")).run_repository
     run_id = "contract-test-run"
     db.create_run(
         run_id,

--- a/apps/server/tests/integration/test_decode_project_roundtrip.py
+++ b/apps/server/tests/integration/test_decode_project_roundtrip.py
@@ -21,7 +21,7 @@ from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.analysis_summary import analysis_result_to_summary
 from vibesensor.adapters.history import build_projected_run_details_json
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.domain import DiagnosticCase, TestRun
 from vibesensor.shared.boundaries.analysis_payloads import project_analysis_summary
 from vibesensor.shared.boundaries.reporting import prepare_report_input
@@ -66,9 +66,9 @@ def _run_analysis() -> tuple[RunAnalysis, AnalysisResult]:
 
 def _persist_and_reload(tmp_path: Path, summary: dict[str, Any]) -> StoredHistoryRun:
     """Persist summary to HistoryDB and reload as a run payload."""
-    db = HistoryDB(tmp_path / "roundtrip.db")
+    db = create_history_persistence_adapters(tmp_path / "roundtrip.db")
     try:
-        db.create_run(
+        db.run_repository.create_run(
             _RUN_ID,
             "2026-01-01T00:00:00Z",
             run_metadata_from_mapping(
@@ -79,11 +79,11 @@ def _persist_and_reload(tmp_path: Path, summary: dict[str, Any]) -> StoredHistor
                 }
             ),
         )
-        db.finalize_run(_RUN_ID, "2026-01-01T00:01:00Z")
-        db.store_analysis(_RUN_ID, make_persisted_analysis(summary))
-        run = db.get_run(_RUN_ID)
+        db.run_repository.finalize_run(_RUN_ID, "2026-01-01T00:01:00Z")
+        db.run_repository.store_analysis(_RUN_ID, make_persisted_analysis(summary))
+        run = db.run_repository.get_run(_RUN_ID)
     finally:
-        db.close()
+        db.lifecycle.close()
     assert run is not None
     return run
 

--- a/apps/server/tests/integration/test_exception_discipline.py
+++ b/apps/server/tests/integration/test_exception_discipline.py
@@ -15,7 +15,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from test_support.settings_services import build_settings_services
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    ClientNameRepository,
+    create_history_persistence_adapters,
+)
 from vibesensor.infra.runtime.registry import ClientRegistry
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.exceptions import PersistenceError
@@ -37,7 +40,7 @@ def _metadata(run_id: str, **overrides: object) -> RunMetadata:
     return run_metadata_from_mapping(payload)
 
 
-def _assert_client_name_not_persisted(db: HistoryDB, client_id: str) -> None:
+def _assert_client_name_not_persisted(db: ClientNameRepository, client_id: str) -> None:
     assert db.list_client_names() == {}
     fresh_registry = ClientRegistry(db=db)
     assert fresh_registry.get(client_id) is None
@@ -48,40 +51,40 @@ class TestHistoryDBExceptionDiscipline:
 
     def test_sqlite_error_in_cursor_is_caught_and_rolled_back(self, tmp_path: Path) -> None:
         """sqlite3.IntegrityError (a sqlite3.Error subclass) is caught by _cursor."""
-        db = HistoryDB(tmp_path / "test.db")
+        db = create_history_persistence_adapters(tmp_path / "test.db")
         run_id = "run-exc-test"
-        db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="t"))
+        db.run_repository.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="t"))
 
         # Duplicate insert → IntegrityError, which is sqlite3.Error
         with pytest.raises(sqlite3.IntegrityError):
-            db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="t"))
+            db.run_repository.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="t"))
 
         # DB is still usable after IntegrityError (was rolled back)
-        runs = db.list_runs()
+        runs = db.run_repository.list_runs()
         assert any(r.run_id == run_id for r in runs)
-        db.close()
+        db.lifecycle.close()
 
     def test_type_error_in_write_tx_propagates(self, tmp_path: Path) -> None:
         """TypeError inside a write transaction must not be silently caught."""
-        db = HistoryDB(tmp_path / "test.db")
-        with pytest.raises(TypeError), db.write_transaction_cursor() as cur:
+        db = create_history_persistence_adapters(tmp_path / "test.db")
+        with pytest.raises(TypeError), db.lifecycle.write_transaction_cursor() as cur:
             cur.execute("SELECT 1")
             raise TypeError("simulated code bug")
         run_id = "run-after-type-error"
-        db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="t"))
-        assert any(run.run_id == run_id for run in db.list_runs())
-        db.close()
+        db.run_repository.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="t"))
+        assert any(run.run_id == run_id for run in db.run_repository.list_runs())
+        db.lifecycle.close()
 
     def test_attribute_error_in_cursor_propagates(self, tmp_path: Path) -> None:
         """AttributeError must not be silently caught."""
-        db = HistoryDB(tmp_path / "test.db")
-        with pytest.raises(AttributeError), db._cursor() as cur:
+        db = create_history_persistence_adapters(tmp_path / "test.db")
+        with pytest.raises(AttributeError), db.lifecycle._cursor() as cur:
             cur.execute("SELECT 1")
             raise AttributeError("simulated code bug")
         run_id = "run-after-attribute-error"
-        db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="t"))
-        assert any(run.run_id == run_id for run in db.list_runs())
-        db.close()
+        db.run_repository.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="t"))
+        assert any(run.run_id == run_id for run in db.run_repository.list_runs())
+        db.lifecycle.close()
 
 
 # ── SettingsStore — (sqlite3.Error, OSError) caught, bugs propagate ──────
@@ -92,8 +95,8 @@ class TestSettingsStoreExceptionDiscipline:
 
     def test_sqlite_error_wrapped_as_persistence_error(self, tmp_path: Path) -> None:
         """An sqlite3.OperationalError from the DB is wrapped as PersistenceError."""
-        db = HistoryDB(tmp_path / "test.db")
-        services = build_settings_services(db=db)
+        db = create_history_persistence_adapters(tmp_path / "test.db")
+        services = build_settings_services(db=db.settings_snapshot_repository)
         before = services.car_settings.get_cars()
         services.coordinator._db = MagicMock()
         services.coordinator._db.set_settings_snapshot.side_effect = sqlite3.OperationalError(
@@ -106,8 +109,8 @@ class TestSettingsStoreExceptionDiscipline:
 
     def test_os_error_wrapped_as_persistence_error(self, tmp_path: Path) -> None:
         """An OSError from the DB is wrapped as PersistenceError."""
-        db = HistoryDB(tmp_path / "test.db")
-        services = build_settings_services(db=db)
+        db = create_history_persistence_adapters(tmp_path / "test.db")
+        services = build_settings_services(db=db.settings_snapshot_repository)
         before = services.car_settings.get_cars()
         services.coordinator._db = MagicMock()
         services.coordinator._db.set_settings_snapshot.side_effect = OSError("disk full")
@@ -118,8 +121,8 @@ class TestSettingsStoreExceptionDiscipline:
 
     def test_type_error_propagates_through_persist(self, tmp_path: Path) -> None:
         """TypeError from the DB is NOT wrapped — it propagates as a code bug."""
-        db = HistoryDB(tmp_path / "test.db")
-        services = build_settings_services(db=db)
+        db = create_history_persistence_adapters(tmp_path / "test.db")
+        services = build_settings_services(db=db.settings_snapshot_repository)
         before = services.car_settings.get_cars()
         services.coordinator._db = MagicMock()
         services.coordinator._db.set_settings_snapshot.side_effect = TypeError("bad argument type")
@@ -130,8 +133,8 @@ class TestSettingsStoreExceptionDiscipline:
 
     def test_attribute_error_propagates_through_persist(self, tmp_path: Path) -> None:
         """AttributeError from the DB is NOT wrapped — it's a code bug."""
-        db = HistoryDB(tmp_path / "test.db")
-        services = build_settings_services(db=db)
+        db = create_history_persistence_adapters(tmp_path / "test.db")
+        services = build_settings_services(db=db.settings_snapshot_repository)
         before = services.car_settings.get_cars()
         services.coordinator._db = MagicMock()
         services.coordinator._db.set_settings_snapshot.side_effect = AttributeError(
@@ -151,12 +154,16 @@ class TestRegistryExceptionDiscipline:
 
     def test_sqlite_error_on_persist_name_is_swallowed(self, tmp_path: Path) -> None:
         """DB errors during name persistence are logged, not propagated."""
-        db = HistoryDB(tmp_path / "test.db")
-        registry = ClientRegistry(db=db)
+        db = create_history_persistence_adapters(tmp_path / "test.db")
+        registry = ClientRegistry(db=db.client_name_repository)
         client_id = "aabbccddeeff"
 
         # Sabotage the DB
-        with patch.object(db, "upsert_client_name", side_effect=sqlite3.OperationalError("locked")):
+        with patch.object(
+            ClientNameRepository,
+            "upsert_client_name",
+            side_effect=sqlite3.OperationalError("locked"),
+        ):
             # Should not raise — operational errors are tolerated for name persistence
             registry.set_name(client_id, "My Sensor")
 
@@ -164,15 +171,19 @@ class TestRegistryExceptionDiscipline:
         rec = registry.get(client_id)
         assert rec is not None
         assert rec.name == "My Sensor"
-        _assert_client_name_not_persisted(db, client_id)
+        _assert_client_name_not_persisted(db.client_name_repository, client_id)
 
     def test_type_error_on_persist_name_propagates(self, tmp_path: Path) -> None:
         """TypeError during name persistence indicates a code bug and must propagate."""
-        db = HistoryDB(tmp_path / "test.db")
-        registry = ClientRegistry(db=db)
+        db = create_history_persistence_adapters(tmp_path / "test.db")
+        registry = ClientRegistry(db=db.client_name_repository)
         client_id = "aabbccddeeff"
 
-        with patch.object(db, "upsert_client_name", side_effect=TypeError("wrong type")):
+        with patch.object(
+            ClientNameRepository,
+            "upsert_client_name",
+            side_effect=TypeError("wrong type"),
+        ):
             with pytest.raises(TypeError, match="wrong type"):
                 registry.set_name(client_id, "My Sensor")
-        _assert_client_name_not_persisted(db, client_id)
+        _assert_client_name_not_persisted(db.client_name_repository, client_id)

--- a/apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py
+++ b/apps/server/tests/integration/test_multi_sensor_e2e_pipeline.py
@@ -14,7 +14,10 @@ from pypdf import PdfReader
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    HistoryPersistenceAdapters,
+    create_history_persistence_adapters,
+)
 from vibesensor.adapters.udp.protocol import pack_data, pack_hello, parse_hello
 from vibesensor.adapters.udp.udp_data_rx import DataDatagramProtocol
 from vibesensor.domain import TireSpec
@@ -47,10 +50,10 @@ class _FakeTransport:
 
 
 @pytest.fixture
-def history_db(tmp_path: Path) -> Iterator[HistoryDB]:
-    db = HistoryDB(tmp_path / "history.db")
+def history_db(tmp_path: Path) -> Iterator[HistoryPersistenceAdapters]:
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     yield db
-    db.close()
+    db.lifecycle.close()
 
 
 def _register_sensors(registry: ClientRegistry) -> None:
@@ -95,9 +98,11 @@ def _build_sensor_packet(
     )
 
 
-def test_multi_sensor_udp_to_report_pipeline(history_db: HistoryDB, tmp_path: Path) -> None:
+def test_multi_sensor_udp_to_report_pipeline(
+    history_db: HistoryPersistenceAdapters, tmp_path: Path
+) -> None:
     """Exercise UDP parse/ingest → processing → recording → analysis → PDF for 4 sensors."""
-    registry = ClientRegistry(db=history_db)
+    registry = ClientRegistry(db=history_db.client_name_repository)
     processor = SignalProcessor(
         sample_rate_hz=_SAMPLE_RATE_HZ,
         waveform_seconds=4,
@@ -118,7 +123,7 @@ def test_multi_sensor_udp_to_report_pipeline(history_db: HistoryDB, tmp_path: Pa
         registry=registry,
         gps_monitor=gps_monitor,
         processor=processor,
-        history_db=history_db,
+        history_db=history_db.run_repository,
         language_reader=SimpleNamespace(language="en"),
     )
     proto = DataDatagramProtocol(registry=registry, processor=processor, queue_maxsize=256)
@@ -170,14 +175,14 @@ def test_multi_sensor_udp_to_report_pipeline(history_db: HistoryDB, tmp_path: Pa
     logger.stop_recording()
     assert logger.wait_for_post_analysis(timeout_s=20.0)
 
-    run = history_db.get_run(run_id)
+    run = history_db.run_repository.get_run(run_id)
     assert run is not None
     assert run.status.value == "complete"
     analysis = run.analysis
     assert analysis is not None
 
     rows = []
-    for batch in history_db.iter_run_samples(run_id, batch_size=512):
+    for batch in history_db.run_repository.iter_run_samples(run_id, batch_size=512):
         rows.extend(batch)
     assert rows
     assert {r.client_id for r in rows} == _SENSOR_IDS_HEX

--- a/apps/server/tests/integration/test_refactor_contract_regressions.py
+++ b/apps/server/tests/integration/test_refactor_contract_regressions.py
@@ -12,7 +12,10 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    HistoryPersistenceAdapters,
+    create_history_persistence_adapters,
+)
 from vibesensor.adapters.udp.protocol import DataMessage, HelloMessage
 from vibesensor.domain import RunStatus
 from vibesensor.infra.runtime.client_snapshot import ClientSnapshot
@@ -51,13 +54,13 @@ _SAMPLES_200X3 = np.zeros((200, 3), dtype=np.int16)
 
 
 @pytest.fixture
-def db(tmp_path: Path) -> HistoryDB:
-    return HistoryDB(tmp_path / "history.db")
+def db(tmp_path: Path) -> HistoryPersistenceAdapters:
+    return create_history_persistence_adapters(tmp_path / "history.db")
 
 
 @pytest.fixture
-def registry(db: HistoryDB) -> ClientRegistry:
-    return ClientRegistry(db=db)
+def registry(db: HistoryPersistenceAdapters) -> ClientRegistry:
+    return ClientRegistry(db=db.client_name_repository)
 
 
 def _hello(client_id: bytes = _CLIENT_ID, **overrides: object) -> HelloMessage:
@@ -172,11 +175,11 @@ class TestRunStatus:
     def test_status_value(self, attr: str, expected: str) -> None:
         assert getattr(RunStatus, attr) == expected
 
-    def test_history_db_uses_run_status(self, db: HistoryDB) -> None:
+    def test_history_db_uses_run_status(self, db: HistoryPersistenceAdapters) -> None:
         """delete_run_if_safe should return RunStatus.ANALYZING for analyzing runs."""
-        db.create_run("run-1", "2024-01-01T00:00:00Z", _metadata("run-1"))
-        db.finalize_run("run-1", "2024-01-01T00:01:00Z")
-        deleted, reason = db.delete_run_if_safe("run-1")
+        db.run_repository.create_run("run-1", "2024-01-01T00:00:00Z", _metadata("run-1"))
+        db.run_repository.finalize_run("run-1", "2024-01-01T00:01:00Z")
+        deleted, reason = db.run_repository.delete_run_if_safe("run-1")
         assert not deleted
         assert reason == RunStatus.ANALYZING
 

--- a/apps/server/tests/integration/test_runtime_fallbacks_regressions.py
+++ b/apps/server/tests/integration/test_runtime_fallbacks_regressions.py
@@ -13,7 +13,7 @@ import pytest
 from _paths import SERVER_ROOT
 from test_support.persisted_analysis import make_persisted_analysis
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.vibration_strength import (
@@ -91,19 +91,19 @@ class TestStoreAnalysisErrorGuard:
     """Regression: store_analysis_error must not overwrite a completed run."""
 
     def test_error_does_not_overwrite_complete(self, tmp_path: pytest.TempPathFactory) -> None:
-        db = HistoryDB(tmp_path / "test.db")
+        db = create_history_persistence_adapters(tmp_path / "test.db")
         run_id = "test-run-001"
-        db.create_run(run_id, "2024-01-01T00:00:00", _metadata(run_id, test=True))
+        db.run_repository.create_run(run_id, "2024-01-01T00:00:00", _metadata(run_id, test=True))
 
         # Complete the analysis
-        db.store_analysis(run_id, make_persisted_analysis({"result": "ok"}))
-        run_before = db.get_run(run_id)
+        db.run_repository.store_analysis(run_id, make_persisted_analysis({"result": "ok"}))
+        run_before = db.run_repository.get_run(run_id)
         assert run_before is not None
         assert run_before.status.value == "complete"
 
         # Try to overwrite with an error
-        db.store_analysis_error(run_id, "spurious error")
-        run_after = db.get_run(run_id)
+        db.run_repository.store_analysis_error(run_id, "spurious error")
+        run_after = db.run_repository.get_run(run_id)
         assert run_after is not None
         assert run_after.status.value == "complete", (
             "store_analysis_error must not overwrite a completed run"

--- a/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
+++ b/apps/server/tests/integration/test_runtime_quality_pass_regressions.py
@@ -18,7 +18,10 @@ import numpy as np
 import pytest
 from test_support.settings_services import build_settings_services
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    HistoryPersistenceAdapters,
+    create_history_persistence_adapters,
+)
 from vibesensor.infra.processing import SignalProcessor
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frame_from_mapping
@@ -29,8 +32,11 @@ from vibesensor.shared.types.sensor_frame import SensorFrame
 # -- shared helpers ----------------------------------------------------------
 
 
-def _make_history_db(tmp_path: Path, name: str = "history.db") -> HistoryDB:
-    return HistoryDB(tmp_path / name)
+def _make_history_db(
+    tmp_path: Path,
+    name: str = "history.db",
+) -> HistoryPersistenceAdapters:
+    return create_history_persistence_adapters(tmp_path / name)
 
 
 def _metadata(run_id: str, **overrides: object) -> RunMetadata:
@@ -52,11 +58,11 @@ def _seeded_history_db(
     n_samples: int,
     *,
     name: str = "history.db",
-) -> HistoryDB:
+) -> HistoryPersistenceAdapters:
     """Create a HistoryDB with one run containing *n_samples* rows."""
     db = _make_history_db(tmp_path, name)
-    db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="test"))
-    db.append_samples(
+    db.run_repository.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, src="test"))
+    db.run_repository.append_samples(
         run_id,
         [sensor_frame_from_mapping({"t_s": float(i)}) for i in range(n_samples)],
     )
@@ -169,7 +175,7 @@ class TestBoundedSample:
 
 def test_speed_unit_persists_and_round_trips(tmp_path: Path) -> None:
     db = _make_history_db(tmp_path, "settings.db")
-    services = build_settings_services(db=db)
+    services = build_settings_services(db=db.settings_snapshot_repository)
 
     # Default
     assert services.ui_preferences.speed_unit == "kmh"
@@ -179,7 +185,7 @@ def test_speed_unit_persists_and_round_trips(tmp_path: Path) -> None:
     assert services.ui_preferences.speed_unit == "mps"
 
     # Reload from DB
-    services2 = build_settings_services(db=db)
+    services2 = build_settings_services(db=db.settings_snapshot_repository)
     assert services2.ui_preferences.speed_unit == "mps"
 
     # Invalid falls back
@@ -197,7 +203,7 @@ def test_iter_run_samples_returns_all_rows(tmp_path: Path) -> None:
     db = _seeded_history_db(tmp_path, "r1", total)
 
     all_rows: list[SensorFrame] = []
-    for batch in db.iter_run_samples("r1", batch_size=10):
+    for batch in db.run_repository.iter_run_samples("r1", batch_size=10):
         all_rows.extend(batch)
     assert len(all_rows) == total
     assert [r.t_s for r in all_rows] == [float(i) for i in range(total)]
@@ -207,7 +213,7 @@ def test_iter_run_samples_offset(tmp_path: Path) -> None:
     db = _seeded_history_db(tmp_path, "r2", 20)
 
     all_rows: list[SensorFrame] = []
-    for batch in db.iter_run_samples("r2", batch_size=5, offset=10):
+    for batch in db.run_repository.iter_run_samples("r2", batch_size=5, offset=10):
         all_rows.extend(batch)
     assert len(all_rows) == 10
     assert all_rows[0].t_s == 10.0
@@ -248,4 +254,4 @@ CREATE TABLE samples (
     conn.close()
 
     with pytest.raises(RuntimeError, match="incompatible"):
-        HistoryDB(db_path)
+        create_history_persistence_adapters(db_path)

--- a/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
+++ b/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.infra.processing import SignalProcessor
 
 
@@ -16,13 +16,13 @@ class TestSQLiteBusyTimeout:
 
     def test_busy_timeout_is_set(self, tmp_path: Path) -> None:
         """HistoryDB must set PRAGMA busy_timeout to avoid immediate SQLITE_BUSY."""
-        db = HistoryDB(tmp_path / "test.db")
+        db = create_history_persistence_adapters(tmp_path / "test.db")
         try:
-            result = db._conn.execute("PRAGMA busy_timeout").fetchone()
+            result = db.lifecycle._conn.execute("PRAGMA busy_timeout").fetchone()
             assert result is not None
             assert result[0] == 5000
         finally:
-            db.close()
+            db.lifecycle.close()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py
+++ b/apps/server/tests/integration/test_runtime_validation_and_schema_regressions.py
@@ -19,7 +19,7 @@ from pydantic import ValidationError
 from test_support.settings_services import build_settings_services
 
 from vibesensor.adapters.http.models import CarUpsertRequest, SpeedSourceRequest
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.shared.exceptions import PersistenceError
 from vibesensor.shared.json_utils import sanitize_for_json
 from vibesensor.use_cases.diagnostics.math_utils import _corr_abs
@@ -99,10 +99,10 @@ class TestHistoryDbCorruptedSchemaVersion:
 
         # Legacy schema_meta databases are no longer supported
         with pytest.raises(RuntimeError, match="legacy"):
-            HistoryDB(db_path)
+            create_history_persistence_adapters(db_path)
 
     def test_valid_version_still_works(self, tmp_path) -> None:
-        assert HistoryDB(tmp_path / "test.db") is not None
+        assert create_history_persistence_adapters(tmp_path / "test.db") is not None
 
 
 # ------------------------------------------------------------------

--- a/apps/server/tests/test_support/history_db_lifecycle.py
+++ b/apps/server/tests/test_support/history_db_lifecycle.py
@@ -7,15 +7,18 @@ from typing import cast
 
 from test_support.core import canonicalize_run_context_metadata
 from test_support.persisted_analysis import make_persisted_analysis
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    HistoryPersistenceAdapters,
+    create_history_persistence_adapters,
+)
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.settings_snapshot import SettingsSnapshotPayload
 
 
-def build_history_db(tmp_path: Path) -> HistoryDB:
-    return HistoryDB(tmp_path / "history.db")
+def build_history_db(tmp_path: Path) -> HistoryPersistenceAdapters:
+    return create_history_persistence_adapters(tmp_path / "history.db")
 
 
 def make_run_metadata(run_id: str, **overrides: object) -> RunMetadata:
@@ -57,7 +60,7 @@ def make_settings_snapshot() -> SettingsSnapshotPayload:
 
 
 def create_recording_run(
-    db: HistoryDB,
+    db: HistoryPersistenceAdapters,
     run_id: str,
     *,
     started_at: str = "2026-01-01T00:00:00Z",
@@ -66,12 +69,12 @@ def create_recording_run(
     **metadata_overrides: object,
 ) -> RunMetadata:
     metadata_obj = metadata or make_run_metadata(run_id, **metadata_overrides)
-    db.create_run(run_id, started_at, metadata_obj, case_id=case_id)
+    db.run_repository.create_run(run_id, started_at, metadata_obj, case_id=case_id)
     return metadata_obj
 
 
 def create_analyzing_run(
-    db: HistoryDB,
+    db: HistoryPersistenceAdapters,
     run_id: str,
     *,
     started_at: str = "2026-01-01T00:00:00Z",
@@ -87,12 +90,12 @@ def create_analyzing_run(
         metadata=metadata,
         **metadata_overrides,
     )
-    db.finalize_run(run_id, finalized_at, metadata=metadata_obj, case_id=case_id)
+    db.run_repository.finalize_run(run_id, finalized_at, metadata=metadata_obj, case_id=case_id)
     return metadata_obj
 
 
 def create_completed_run(
-    db: HistoryDB,
+    db: HistoryPersistenceAdapters,
     run_id: str,
     *,
     started_at: str = "2026-01-01T00:00:00Z",
@@ -113,12 +116,12 @@ def create_completed_run(
         **(metadata_overrides or {}),
     )
     analysis_obj = analysis or make_analysis_summary(run_id, **(analysis_overrides or {}))
-    db.store_analysis(run_id, make_persisted_analysis(analysis_obj))
+    db.run_repository.store_analysis(run_id, make_persisted_analysis(analysis_obj))
     return analysis_obj
 
 
 def create_error_run(
-    db: HistoryDB,
+    db: HistoryPersistenceAdapters,
     run_id: str,
     *,
     started_at: str = "2026-01-01T00:00:00Z",
@@ -135,4 +138,4 @@ def create_error_run(
         metadata=metadata,
         **(metadata_overrides or {}),
     )
-    db.store_analysis_error(run_id, error_message)
+    db.run_repository.store_analysis_error(run_id, error_message)

--- a/apps/server/tests/test_support/runtime_lifecycle.py
+++ b/apps/server/tests/test_support/runtime_lifecycle.py
@@ -10,7 +10,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    HistoryPersistenceAdapters,
+    create_history_persistence_adapters,
+)
 from vibesensor.adapters.udp.protocol import DataMessage, HelloMessage
 from vibesensor.app.runtime_state import RuntimeState
 from vibesensor.infra.runtime.lifecycle import LifecycleManager, LifecycleRuntime
@@ -177,8 +180,8 @@ class StubWsPayloadSource:
         return payload
 
 
-def build_history_db(tmp_path: Path) -> HistoryDB:
-    return HistoryDB(tmp_path / "history.db")
+def build_history_db(tmp_path: Path) -> HistoryPersistenceAdapters:
+    return create_history_persistence_adapters(tmp_path / "history.db")
 
 
 def build_registry(
@@ -192,7 +195,9 @@ def build_registry(
         "retention_ttl_seconds": retention_ttl_seconds,
     }
     if db is not None:
-        kwargs["db"] = db
+        kwargs["db"] = (
+            db.client_name_repository if isinstance(db, HistoryPersistenceAdapters) else db
+        )
     return ClientRegistry(**kwargs)
 
 
@@ -239,7 +244,7 @@ def build_registry_with_hello(
     client_id_hex: str = "aabbccddeeff",
 ) -> tuple[ClientRegistry, bytes]:
     db = build_history_db(tmp_path)
-    registry = build_registry(db=db)
+    registry = build_registry(db=db.client_name_repository)
     hello = make_hello_message(client_id_hex)
     registry.update_from_hello(hello, ("10.4.0.2", hello.control_port), now=1.0)
     return registry, hello.client_id

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_golden_output.py
@@ -17,7 +17,7 @@ from vibesensor.adapters.analysis_summary import (
     analysis_result_to_summary,
     summarize_run_data,
 )
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.shared.boundaries.analysis_payloads import project_analysis_summary
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
@@ -76,10 +76,10 @@ def _action_ids(summary: dict[str, Any]) -> list[str]:
 
 
 def _persist_and_reload_summary(tmp_path: Path, summary: dict[str, Any]) -> dict[str, Any]:
-    db = HistoryDB(tmp_path / "history.db")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
     run: StoredHistoryRun | None = None
     try:
-        db.create_run(
+        db.run_repository.create_run(
             "characterization-roundtrip",
             "2026-01-01T00:00:00Z",
             run_metadata_from_mapping(
@@ -90,11 +90,13 @@ def _persist_and_reload_summary(tmp_path: Path, summary: dict[str, Any]) -> dict
                 }
             ),
         )
-        db.finalize_run("characterization-roundtrip", "2026-01-01T00:01:00Z")
-        db.store_analysis("characterization-roundtrip", make_persisted_analysis(summary))
-        run = db.get_run("characterization-roundtrip")
+        db.run_repository.finalize_run("characterization-roundtrip", "2026-01-01T00:01:00Z")
+        db.run_repository.store_analysis(
+            "characterization-roundtrip", make_persisted_analysis(summary)
+        )
+        run = db.run_repository.get_run("characterization-roundtrip")
     finally:
-        db.close()
+        db.lifecycle.close()
 
     assert run is not None
     analysis = run.analysis

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
@@ -12,7 +12,7 @@ from test_support import response_payload
 from test_support.persisted_analysis import make_persisted_analysis
 
 from tests.conftest import FakeState
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.domain.run_status import RunStatus
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frame_from_mapping
@@ -69,12 +69,12 @@ def _stored_run(
 
 def test_fresh_db_has_analysis_columns(tmp_path: Path) -> None:
     """Fresh DB should have analysis_started_at, analysis_completed_at."""
-    db = HistoryDB(tmp_path / "history.db")
-    cursor = db._conn.execute("PRAGMA table_info(runs)")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    cursor = db.lifecycle._conn.execute("PRAGMA table_info(runs)")
     columns = {row[1] for row in cursor.fetchall()}
     assert "analysis_started_at" in columns
     assert "analysis_completed_at" in columns
-    db.close()
+    db.lifecycle.close()
 
 
 def test_old_schema_version_raises_when_no_migration_registered(tmp_path: Path) -> None:
@@ -113,42 +113,42 @@ CREATE TABLE client_names (
     conn.close()
 
     with pytest.raises(RuntimeError, match="incompatible"):
-        HistoryDB(db_path)
+        create_history_persistence_adapters(db_path)
 
 
 # -- Analysis storage tests ---------------------------------------------------
 
 
 def test_store_analysis_sets_version_and_timestamps(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
-    db.finalize_run("r1", "2026-01-01T00:01:00Z")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
+    db.run_repository.finalize_run("r1", "2026-01-01T00:01:00Z")
 
     # Check analyzing state has analysis_started_at
-    run = db.get_run("r1")
+    run = db.run_repository.get_run("r1")
     assert run is not None
     assert run.status.value == "analyzing"
     assert run.analysis_started_at is not None
 
-    db.store_analysis("r1", make_persisted_analysis({"lang": "en", "findings": []}))
-    run = db.get_run("r1")
+    db.run_repository.store_analysis("r1", make_persisted_analysis({"lang": "en", "findings": []}))
+    run = db.run_repository.get_run("r1")
     assert run is not None
     assert run.status.value == "complete"
     assert run.analysis_completed_at is not None
     assert run.analysis == {"lang": "en", "findings": []}
-    db.close()
+    db.lifecycle.close()
 
 
 def test_store_analysis_persists_summary_directly(
     tmp_path: Path,
 ) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
-    db.finalize_run("r1", "2026-01-01T00:01:00Z")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
+    db.run_repository.finalize_run("r1", "2026-01-01T00:01:00Z")
 
-    db.store_analysis("r1", make_persisted_analysis({"lang": "en", "findings": []}))
+    db.run_repository.store_analysis("r1", make_persisted_analysis({"lang": "en", "findings": []}))
 
-    with db._cursor(commit=False) as cur:
+    with db.lifecycle._cursor(commit=False) as cur:
         cur.execute("SELECT analysis_json FROM runs WHERE run_id = ?", ("r1",))
         row = cur.fetchone()
     assert row is not None
@@ -157,53 +157,53 @@ def test_store_analysis_persists_summary_directly(
     assert '"summary"' not in raw
     assert '"_schema_version": 1' in raw
     assert '"lang"' in raw
-    run = db.get_run("r1")
+    run = db.run_repository.get_run("r1")
     assert run is not None
     assert run.analysis == {"lang": "en", "findings": []}
-    db.close()
+    db.lifecycle.close()
 
 
 def test_get_run_marks_unknown_analysis_storage_version_corrupt(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
-    db.finalize_run("r1", "2026-01-01T00:01:00Z")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
+    db.run_repository.finalize_run("r1", "2026-01-01T00:01:00Z")
 
-    with db._cursor() as cur:
+    with db.lifecycle._cursor() as cur:
         cur.execute(
             "UPDATE runs SET analysis_json = ? WHERE run_id = ?",
             ('{"_schema_version": 99, "findings": []}', "r1"),
         )
 
-    run = db.get_run("r1")
+    run = db.run_repository.get_run("r1")
     assert run is not None
     assert run.analysis is None
     assert run.analysis_corrupt is True
-    db.close()
+    db.lifecycle.close()
 
 
 def test_store_analysis_error_sets_completed_at(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
-    db.finalize_run("r1", "2026-01-01T00:01:00Z")
-    db.store_analysis_error("r1", "Test error")
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
+    db.run_repository.finalize_run("r1", "2026-01-01T00:01:00Z")
+    db.run_repository.store_analysis_error("r1", "Test error")
 
-    run = db.get_run("r1")
+    run = db.run_repository.get_run("r1")
     assert run is not None
     assert run.status.value == "error"
     assert run.error_message == "Test error"
     assert run.analysis_completed_at is not None
-    db.close()
+    db.lifecycle.close()
 
 
 def test_list_runs_includes_analysis_version(tmp_path: Path) -> None:
-    db = HistoryDB(tmp_path / "history.db")
-    db.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
-    db.finalize_run("r1", "2026-01-01T00:01:00Z")
-    db.store_analysis("r1", make_persisted_analysis({"lang": "en"}))
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    db.run_repository.create_run("r1", "2026-01-01T00:00:00Z", _metadata("r1", source="test"))
+    db.run_repository.finalize_run("r1", "2026-01-01T00:01:00Z")
+    db.run_repository.store_analysis("r1", make_persisted_analysis({"lang": "en"}))
 
-    runs = db.list_runs()
+    runs = db.run_repository.list_runs()
     assert len(runs) == 1
-    db.close()
+    db.lifecycle.close()
 
 
 # -- Post-analysis lifecycle tests (integration) ------------------------------
@@ -238,7 +238,11 @@ def _sample(i: int) -> dict[str, Any]:
 
 def _make_fake_state(history_db: Any) -> Any:
     """Build a minimal fake ``RuntimeState``-alike using shared FakeState."""
-    return FakeState(history_db=history_db)
+    return FakeState(
+        history_db=history_db.run_repository
+        if hasattr(history_db, "run_repository")
+        else history_db
+    )
 
 
 def _find_endpoint(router, path: str):
@@ -256,8 +260,8 @@ def test_stop_run_triggers_analysis_and_persists(tmp_path: Path, monkeypatch) ->
     from vibesensor.infra.runtime.registry import ClientRegistry
     from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
 
-    db = HistoryDB(tmp_path / "history.db")
-    registry = ClientRegistry(db=db)
+    db = create_history_persistence_adapters(tmp_path / "history.db")
+    registry = ClientRegistry(db=db.client_name_repository)
     gps_monitor = GPSSpeedMonitor(gps_enabled=False)
     processor = SignalProcessor(
         sample_rate_hz=800,
@@ -278,7 +282,7 @@ def test_stop_run_triggers_analysis_and_persists(tmp_path: Path, monkeypatch) ->
         registry=registry,
         gps_monitor=gps_monitor,
         processor=processor,
-        history_db=db,
+        history_db=db.run_repository,
         language_reader=SimpleNamespace(language="en"),
     )
 
@@ -288,10 +292,12 @@ def test_stop_run_triggers_analysis_and_persists(tmp_path: Path, monkeypatch) ->
     assert isinstance(run_id, str) and len(run_id) > 0
 
     # Manually create history and append samples (simulate the metrics loop)
-    db.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, language="en"))
+    db.run_repository.create_run(run_id, "2026-01-01T00:00:00Z", _metadata(run_id, language="en"))
     logger._persistence.history_run_created = True
     samples = [_sample(i) for i in range(20)]
-    db.append_samples(run_id, [sensor_frame_from_mapping(sample) for sample in samples])
+    db.run_repository.append_samples(
+        run_id, [sensor_frame_from_mapping(sample) for sample in samples]
+    )
     logger._persistence.written_sample_count = len(samples)
 
     # Monkeypatch the adapter summarize_run_data wrapper to a lightweight version for speed
@@ -310,14 +316,14 @@ def test_stop_run_triggers_analysis_and_persists(tmp_path: Path, monkeypatch) ->
     logger.wait_for_post_analysis(timeout_s=5.0)
 
     # Verify analysis is persisted
-    run = db.get_run(run_id)
+    run = db.run_repository.get_run(run_id)
     assert run is not None
     assert run.status.value == "complete"
     assert run.analysis is not None
     assert run.analysis["lang"] == "en"
     assert run.analysis_started_at is not None
     assert run.analysis_completed_at is not None
-    db.close()
+    db.lifecycle.close()
 
 
 # -- API endpoint reuse tests ------------------------------------------------

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py
@@ -13,7 +13,10 @@ from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.analysis_summary import build_findings_for_samples, summarize_run_data
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import (
+    RunHistoryRepository,
+    create_history_persistence_adapters,
+)
 from vibesensor.shared.boundaries.reporting import prepare_report_input
 from vibesensor.shared.boundaries.runs.log import normalize_sample_record
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
@@ -32,8 +35,12 @@ _END = "2026-01-01T00:05:00Z"
 
 
 @pytest.fixture
-def db(tmp_path: Path) -> HistoryDB:
-    return HistoryDB(tmp_path / "pipeline_test.db")
+def db(tmp_path: Path) -> RunHistoryRepository:
+    adapters = create_history_persistence_adapters(tmp_path / "pipeline_test.db")
+    try:
+        yield adapters.run_repository
+    finally:
+        adapters.lifecycle.close()
 
 
 def _simple_metadata(run_id: str = "test-run", lang: str = "en") -> dict[str, Any]:
@@ -206,7 +213,7 @@ class TestWorkerThreadRace:
 # ---------------------------------------------------------------------------
 
 
-def test_finalize_run_only_from_recording(db: HistoryDB) -> None:
+def test_finalize_run_only_from_recording(db: RunHistoryRepository) -> None:
     """Fix 7: finalize_run only transitions from 'recording' state."""
     db.create_run("r1", _START, _run_metadata("r1"))
     db.finalize_run("r1", _END)
@@ -221,7 +228,7 @@ def test_finalize_run_only_from_recording(db: HistoryDB) -> None:
     assert run.status.value == "analyzing"
 
 
-def test_store_analysis_idempotent(db: HistoryDB) -> None:
+def test_store_analysis_idempotent(db: RunHistoryRepository) -> None:
     """Fix 10: store_analysis skips already-complete runs."""
     db.create_run("r1", _START, _run_metadata("r1"))
     db.finalize_run("r1", _END)
@@ -295,7 +302,7 @@ def test_build_findings_uses_shared_speed_prep() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _setup_stale_pair(db: HistoryDB) -> None:
+def _setup_stale_pair(db: RunHistoryRepository) -> None:
     """Shared setup: r1 finalized (analyzing), r2 still recording."""
     db.create_run("r1", _START, _run_metadata("r1"))
     db.finalize_run("r1", _END)
@@ -306,13 +313,13 @@ def _setup_stale_pair(db: HistoryDB) -> None:
     )
 
 
-def test_stale_analyzing_run_ids(db: HistoryDB) -> None:
+def test_stale_analyzing_run_ids(db: RunHistoryRepository) -> None:
     """Fix 14: stale_analyzing_run_ids finds stuck runs."""
     _setup_stale_pair(db)
     assert db.stale_analyzing_run_ids() == ["r1"]
 
 
-def test_recover_stale_does_not_touch_analyzing(db: HistoryDB) -> None:
+def test_recover_stale_does_not_touch_analyzing(db: RunHistoryRepository) -> None:
     """Fix 14: recover_stale_recording_runs leaves 'analyzing' runs alone."""
     _setup_stale_pair(db)
     assert db.recover_stale_recording_runs() == 1  # only r2
@@ -372,7 +379,7 @@ def test_report_cli_summary_excludes_samples_for_pdf() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_end_to_end_pipeline(db: HistoryDB) -> None:
+def test_end_to_end_pipeline(db: RunHistoryRepository) -> None:
     """Full pipeline: create → record → finalize → analyze → persist → report."""
     run_id = "e2e-test-run"
     metadata = _simple_metadata(run_id)

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_settings.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_settings.py
@@ -147,10 +147,10 @@ def test_sanitize_rejects_non_finite_values() -> None:
 def test_snapshot_returns_copy_of_defaults(tmp_path) -> None:
     from test_support.settings_services import build_settings_services
 
-    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 
-    db = HistoryDB(tmp_path / "test.db")
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "test.db")
+    services = build_settings_services(db=db.settings_snapshot_repository)
     snap = services.analysis_settings.analysis_settings_snapshot()
     # Frozen dataclass — values match defaults and instance is immutable
     assert snap.tire_width_mm == DEFAULT_ANALYSIS_SETTINGS["tire_width_mm"]
@@ -160,10 +160,10 @@ def test_snapshot_returns_copy_of_defaults(tmp_path) -> None:
 def test_update_merges_valid_values(tmp_path) -> None:
     from test_support.settings_services import build_settings_services
 
-    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 
-    db = HistoryDB(tmp_path / "test.db")
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "test.db")
+    services = build_settings_services(db=db.settings_snapshot_repository)
     initial = services.car_settings.add_car({"name": "Test"})
     services.car_settings.set_active_car(initial.cars[0]["id"])
     services.analysis_settings.update_active_car_aspects({"tire_width_mm": 225.0})
@@ -175,10 +175,10 @@ def test_update_merges_valid_values(tmp_path) -> None:
 def test_update_rejects_invalid_and_keeps_old(tmp_path) -> None:
     from test_support.settings_services import build_settings_services
 
-    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 
-    db = HistoryDB(tmp_path / "test.db")
-    services = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "test.db")
+    services = build_settings_services(db=db.settings_snapshot_repository)
     initial = services.car_settings.add_car({"name": "Test"})
     services.car_settings.set_active_car(initial.cars[0]["id"])
     services.analysis_settings.update_active_car_aspects({"tire_width_mm": -5.0})

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_settings_source_of_truth.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_settings_source_of_truth.py
@@ -30,17 +30,17 @@ def _route(router, path: str, method: str = "GET"):
 @pytest.fixture
 def _wiring(tmp_path: Path):
     """Provide a wired (state, router) pair with one active car named 'Primary'."""
-    from vibesensor.adapters.persistence.history_db import HistoryDB
+    from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 
-    db = HistoryDB(tmp_path / "test.db")
-    settings = build_settings_services(db=db)
+    db = create_history_persistence_adapters(tmp_path / "test.db")
+    settings = build_settings_services(db=db.settings_snapshot_repository)
     initial = settings.car_settings.add_car({"name": "Primary"})
     settings.car_settings.set_active_car(initial.cars[0]["id"])
     state = FakeState(
         settings_reader=settings.settings_reader,
         car_settings=settings.car_settings,
         analysis_settings=settings.analysis_settings,
-        history_db=db,
+        history_db=db.run_repository,
     )
     app = FastAPI()
     router = create_router(state)

--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -10,7 +10,7 @@ import pytest
 from test_support.core import wait_until
 from test_support.persisted_analysis import make_persisted_analysis
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.domain import AnalysisSettingsSnapshot, CarSnapshot
 from vibesensor.shared.types.history_records import AnalyzingRunHealth
 from vibesensor.use_cases.run import _recorder_runtime
@@ -398,7 +398,7 @@ def test_stop_recording_does_not_block_on_post_analysis(
     promptly. This test simulates a slow summarizer and requires stop_recording to return quickly
     while analysis completes asynchronously afterward.
     """
-    history_db = HistoryDB(tmp_path / "history.db")
+    history_db = create_history_persistence_adapters(tmp_path / "history.db")
     summary_started = threading.Event()
     allow_summary_finish = threading.Event()
 
@@ -418,7 +418,7 @@ def test_stop_recording_does_not_block_on_post_analysis(
         "vibesensor.use_cases.run.logger.build_post_analysis_summary",
         _slow_analysis_runner,
     )
-    logger = make_logger(history_db=history_db)
+    logger = make_logger(history_db=history_db.run_repository)
 
     snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
@@ -437,7 +437,7 @@ def test_stop_recording_does_not_block_on_post_analysis(
     allow_summary_finish.set()
 
     def _status():
-        run = history_db.get_run(run_id)
+        run = history_db.run_repository.get_run(run_id)
         return run.status.value if run is not None else None
 
     assert wait_until(lambda: _status() == "complete", timeout_s=5.0)
@@ -448,7 +448,7 @@ def test_post_analysis_unexpected_failure_surfaces_worker_error_status(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    history_db = HistoryDB(tmp_path / "history.db")
+    history_db = create_history_persistence_adapters(tmp_path / "history.db")
 
     def _failing_analysis_runner(_run) -> dict[str, object]:
         raise RuntimeError("analysis exploded")
@@ -457,7 +457,7 @@ def test_post_analysis_unexpected_failure_surfaces_worker_error_status(
         "vibesensor.use_cases.run.logger.build_post_analysis_summary",
         _failing_analysis_runner,
     )
-    logger = make_logger(history_db=history_db)
+    logger = make_logger(history_db=history_db.run_repository)
 
     snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
@@ -475,7 +475,7 @@ def test_post_analysis_unexpected_failure_surfaces_worker_error_status(
     status = logger.status()
     assert status.last_completed_run_error == expected_worker_bug
     assert status.write_error == f"post-analysis worker bug for run {run_id}: analysis exploded"
-    run = history_db.get_run(run_id)
+    run = history_db.run_repository.get_run(run_id)
     assert run is not None
     assert run.analysis is None
     assert run.status.value == "error"
@@ -585,8 +585,11 @@ def test_post_analysis_uses_run_language_from_metadata(
     make_logger,
     tmp_path: Path,
 ) -> None:
-    history_db = HistoryDB(tmp_path / "history.db")
-    logger = make_logger(history_db=history_db, language_reader=SimpleNamespace(language="nl"))
+    history_db = create_history_persistence_adapters(tmp_path / "history.db")
+    logger = make_logger(
+        history_db=history_db.run_repository,
+        language_reader=SimpleNamespace(language="nl"),
+    )
 
     snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
@@ -617,11 +620,11 @@ def test_post_analysis_uses_run_language_from_metadata(
     logger.stop_recording()
 
     def _status():
-        run = history_db.get_run(run_id)
+        run = history_db.run_repository.get_run(run_id)
         return run.status.value if run is not None else None
 
     assert wait_until(lambda: _status() == "complete", timeout_s=2.0)
-    stored = history_db.get_run(run_id).analysis
+    stored = history_db.run_repository.get_run(run_id).analysis
     assert stored is not None
     assert stored["lang"] == "nl"
 
@@ -679,8 +682,8 @@ def test_run_metadata_captures_recorded_utc_offset(
 
 
 def test_db_persists_when_jsonl_disabled(make_logger, tmp_path: Path) -> None:
-    history_db = HistoryDB(tmp_path / "history.db")
-    logger = make_logger(history_db=history_db, persist_history_db=True)
+    history_db = create_history_persistence_adapters(tmp_path / "history.db")
+    logger = make_logger(history_db=history_db.run_repository, persist_history_db=True)
 
     snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
@@ -689,8 +692,8 @@ def test_db_persists_when_jsonl_disabled(make_logger, tmp_path: Path) -> None:
     logger._sample_flush.append_records(run_id, start_time_utc, start_mono)
     logger.stop_recording()
 
-    assert history_db.get_run(run_id) is not None
-    assert history_db.get_run_samples(run_id)
+    assert history_db.run_repository.get_run(run_id) is not None
+    assert history_db.run_repository.get_run_samples(run_id)
 
 
 def test_post_analysis_caps_sample_count_and_stores_sampling_metadata(
@@ -705,8 +708,8 @@ def test_post_analysis_caps_sample_count_and_stores_sampling_metadata(
         cap,
     )
 
-    history_db = HistoryDB(tmp_path / "history.db")
-    logger = make_logger(history_db=history_db)
+    history_db = create_history_persistence_adapters(tmp_path / "history.db")
+    logger = make_logger(history_db=history_db.run_repository)
 
     snapshot = _started_snapshot(logger)
     run_id = snapshot.run_id
@@ -744,11 +747,11 @@ def test_post_analysis_caps_sample_count_and_stores_sampling_metadata(
     logger.stop_recording()
 
     def _status():
-        run = history_db.get_run(run_id)
+        run = history_db.run_repository.get_run(run_id)
         return run.status.value if run is not None else None
 
     assert wait_until(lambda: _status() == "complete", timeout_s=3.0)
-    stored = history_db.get_run(run_id).analysis
+    stored = history_db.run_repository.get_run(run_id).analysis
     assert stored is not None
     assert stored["row_count"] <= cap
     assert stored["analysis_metadata"]["total_sample_count"] >= stored["row_count"]

--- a/apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py
+++ b/apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py
@@ -9,7 +9,7 @@ import pytest
 from test_support.core import wait_until
 from test_support.persisted_analysis import make_persisted_analysis
 
-from vibesensor.adapters.persistence.history_db import HistoryDB
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 
 # -- Test ----------------------------------------------------------------------
 
@@ -20,7 +20,7 @@ def test_start_append_stop_produces_complete_run_in_db(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Full lifecycle: start -> append -> stop -> analyze -> complete with a real DB."""
-    history_db = HistoryDB(tmp_path / "history.db")
+    history_db = create_history_persistence_adapters(tmp_path / "history.db")
     fake_analysis = {
         "findings": [],
         "top_causes": [],
@@ -38,7 +38,7 @@ def test_start_append_stop_produces_complete_run_in_db(
             }
         ),
     )
-    logger = make_logger(history_db=history_db)
+    logger = make_logger(history_db=history_db.run_repository)
 
     logger.start_recording()
     snapshot = logger._session_snapshot()
@@ -51,12 +51,12 @@ def test_start_append_stop_produces_complete_run_in_db(
     logger.stop_recording()
 
     def _status():
-        run = history_db.get_run(run_id)
+        run = history_db.run_repository.get_run(run_id)
         return run.status.value if run is not None else None
 
     assert wait_until(lambda: _status() == "complete", timeout_s=3.0)
 
-    stored = history_db.get_run(run_id).analysis
+    stored = history_db.run_repository.get_run(run_id).analysis
     assert stored is not None
     assert stored["score"] == 42
     assert stored["details"] == "looks good"

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -3,21 +3,14 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from threading import RLock
-from typing import Any
 
 from vibesensor.adapters.persistence.history_db._client_names_repository import (
     ClientNameRepository,
 )
-from vibesensor.adapters.persistence.history_db._engine import (
-    SQLiteHistoryEngine,
-    run_startup_quick_check,
-)
+from vibesensor.adapters.persistence.history_db._engine import SQLiteHistoryEngine
 from vibesensor.adapters.persistence.history_db._run_repository import RunHistoryRepository
 from vibesensor.adapters.persistence.history_db._settings_repository import (
     SettingsSnapshotRepository,
@@ -25,7 +18,6 @@ from vibesensor.adapters.persistence.history_db._settings_repository import (
 
 __all__ = [
     "ClientNameRepository",
-    "HistoryDB",
     "HistoryPersistenceAdapters",
     "RunHistoryRepository",
     "SQLiteHistoryEngine",
@@ -70,119 +62,3 @@ def create_history_persistence_adapters(
             cursor_provider=cursor_provider,
         ),
     )
-
-
-class HistoryDB:
-    """Compatibility facade over the split history persistence collaborators.
-
-    New production wiring should prefer the narrow repositories returned by
-    :func:`create_history_persistence_adapters`. This wrapper is retained so the
-    focused history-db tests and any remaining legacy call sites can continue to
-    exercise the same public surface while the app transitions to explicit
-    injection of narrower persistence capabilities.
-    """
-
-    def __init__(
-        self,
-        db_path: Path,
-        *,
-        corruption_reporter: Callable[[str], None] | None = None,
-    ) -> None:
-        self._engine = SQLiteHistoryEngine(
-            db_path,
-            corruption_reporter=corruption_reporter,
-        )
-        self._run_repository = RunHistoryRepository(
-            cursor_provider=lambda *, commit=True: self._cursor(commit=commit),
-            write_transaction_cursor_provider=lambda: self.write_transaction_cursor(),
-        )
-        self._settings_snapshot_repository = SettingsSnapshotRepository(
-            cursor_provider=lambda *, commit=True: self._cursor(commit=commit),
-        )
-        self._client_name_repository = ClientNameRepository(
-            cursor_provider=lambda *, commit=True: self._cursor(commit=commit),
-        )
-
-    def __getattr__(self, name: str) -> Any:
-        for delegate in (
-            self._run_repository,
-            self._settings_snapshot_repository,
-            self._client_name_repository,
-            self._engine,
-        ):
-            try:
-                return getattr(delegate, name)
-            except AttributeError:
-                continue
-        raise AttributeError(f"{self.__class__.__name__!s} object has no attribute {name!r}")
-
-    @property
-    def _conn(self) -> sqlite3.Connection | None:
-        return self._engine._conn
-
-    @_conn.setter
-    def _conn(self, value: sqlite3.Connection | None) -> None:
-        self._engine._conn = value
-
-    @property
-    def _read_conn(self) -> sqlite3.Connection | None:
-        return self._engine._read_conn
-
-    @_read_conn.setter
-    def _read_conn(self, value: sqlite3.Connection | None) -> None:
-        self._engine._read_conn = value
-
-    @property
-    def _lock(self) -> RLock:
-        return self._engine._lock
-
-    @_lock.setter
-    def _lock(self, value: RLock) -> None:
-        self._engine._lock = value
-
-    @property
-    def _read_lock(self) -> RLock:
-        return self._engine._read_lock
-
-    @_read_lock.setter
-    def _read_lock(self, value: RLock) -> None:
-        self._engine._read_lock = value
-
-    def close(self) -> None:
-        self._engine.close()
-
-    def _cursor_connection(
-        self,
-        *,
-        commit: bool,
-    ) -> tuple[sqlite3.Connection | None, RLock]:
-        return self._engine._cursor_connection(commit=commit)
-
-    @contextmanager
-    def _cursor(self, *, commit: bool = True) -> Iterator[sqlite3.Cursor]:
-        with self._engine._cursor(commit=commit) as cur:
-            yield cur
-
-    @contextmanager
-    def write_transaction_cursor(self) -> Iterator[sqlite3.Cursor]:
-        with self._engine.write_transaction_cursor() as cur:
-            yield cur
-
-    def _assert_write_allowed(self) -> None:
-        self._engine._assert_write_allowed()
-
-    def _mark_corrupted(self, details: str) -> None:
-        self._engine._mark_corrupted(details)
-
-    def _ensure_schema(self) -> None:
-        self._engine._ensure_schema()
-
-    def _schema_version(self) -> int:
-        return self._engine._schema_version()
-
-    def _run_startup_quick_check(self) -> None:
-        run_startup_quick_check(
-            cursor_provider=self._cursor,
-            db_path=self.db_path,
-            mark_corrupted=self._mark_corrupted,
-        )

--- a/tools/dev/verify_backend_static_guards.py
+++ b/tools/dev/verify_backend_static_guards.py
@@ -1877,6 +1877,34 @@ def _check_settings_facade_removed() -> list[str]:
     return violations
 
 
+def _check_history_db_facade_removed() -> list[str]:
+    history_init = (
+        VIBESENSOR_DIR / "adapters" / "persistence" / "history_db" / "__init__.py"
+    )
+    violations: list[str] = []
+    if "HistoryDB" in _read_text(history_init):
+        violations.append(
+            f"{history_init.relative_to(REPO_ROOT)} must not define or export HistoryDB"
+        )
+
+    for root in (SERVER_ROOT, REPO_ROOT / "tools"):
+        for path in _python_files(root):
+            if path == history_init:
+                continue
+            for lineno, module, names, level in _scan_imports(path):
+                if level > 0:
+                    continue
+                if (
+                    module == "vibesensor.adapters.persistence.history_db"
+                    and "HistoryDB" in names
+                ):
+                    violations.append(
+                        f"{path.relative_to(REPO_ROOT)}:{lineno}: imports HistoryDB from "
+                        "vibesensor.adapters.persistence.history_db; use explicit collaborators"
+                    )
+    return violations
+
+
 Check = tuple[str, Callable[[], list[str]]]
 CHECKS: tuple[Check, ...] = (
     (
@@ -2106,6 +2134,10 @@ CHECKS: tuple[Check, ...] = (
     (
         "Settings facade stays removed",
         _check_settings_facade_removed,
+    ),
+    (
+        "HistoryDB facade stays removed",
+        _check_history_db_facade_removed,
     ),
 )
 


### PR DESCRIPTION
## What changed
- delete the `HistoryDB` compatibility facade from `adapters/persistence/history_db/__init__.py`
- migrate shared test helpers and affected tests onto explicit `run_repository`, `settings_snapshot_repository`, `client_name_repository`, and `lifecycle` collaborators
- add a backend static guard so the facade class/import path does not come back

## Why
- the split history persistence layout already existed, but `HistoryDB` kept an old monolithic path alive
- repo owns all callers, so explicit collaborators are cleaner than keeping the compatibility wrapper

## Validation
- `make lint`
- `python3.14 tools/dev/verify_backend_static_guards.py`
- `make typecheck-backend`
- `pytest -q -n4 tests/infra/ tests/integration/ tests/adapters/ tests/use_cases/`

## Risks / tradeoffs
- broad test migration across history, runtime, settings, and integration coverage
- no intended production behavior change; app wiring already used `create_history_persistence_adapters()` before this refactor

## Follow-ups
- none

Closes #2920