### PR TITLE
refactor(updates): drop legacy status decode

### DIFF
--- a/apps/server/tests/use_cases/updates/test_update_models_roundtrip.py
+++ b/apps/server/tests/use_cases/updates/test_update_models_roundtrip.py
@@ -162,7 +162,7 @@ class TestUpdateJobStatusRoundTrip:
                     },
                 },
             )
- 
+
     def test_from_payload_accepts_canonical_runtime_flags(self) -> None:
         status = update_status_from_builtins(
             {

--- a/apps/server/tests/use_cases/updates/test_update_models_roundtrip.py
+++ b/apps/server/tests/use_cases/updates/test_update_models_roundtrip.py
@@ -122,65 +122,53 @@ class TestUpdateJobStatusRoundTrip:
                 finished_at=10.0,
             )
 
-    def test_from_payload_preserves_partial_valid_fields(self) -> None:
-        """Malformed nested fields must drop cleanly while valid pieces survive."""
-        status = update_status_from_builtins(
-            {
-                "state": "failed",
-                "phase": "installing",
-                "transport": "usb_internet",
-                "started_at": "10.5",
-                "finished_at": "20.5",
-                "last_success_at": "7",
-                "phase_started_at": "12.25",
-                "updated_at": "18",
-                "ssid": 123,
-                "uplink_interface": ["usb0"],
-                "issues": [
-                    "bad",
-                    {"phase": "downloading", "message": "warn", "detail": 99},
-                    {"phase": "installing", "message": "retry"},
-                ],
-                "log_tail": ["ok", 7, None],
-                "exit_code": "5",
-                "runtime": {
-                    "version": 9,
-                    "commit": None,
-                    "assets_verified": 1,
-                    "has_packaged_static": "true",
+    def test_from_payload_rejects_legacy_nested_shapes(self) -> None:
+        with pytest.raises(msgspec.ValidationError):
+            update_status_from_builtins(
+                {
+                    "state": "failed",
+                    "phase": "installing",
+                    "transport": "usb_internet",
+                    "started_at": "10.5",
+                    "finished_at": "20.5",
+                    "last_success_at": "7",
+                    "phase_started_at": "12.25",
+                    "updated_at": "18",
+                    "ssid": 123,
+                    "uplink_interface": ["usb0"],
+                    "issues": [
+                        "bad",
+                        {"phase": "downloading", "message": "warn", "detail": 99},
+                        {"phase": "installing", "message": "retry"},
+                    ],
+                    "log_tail": ["ok", 7, None],
+                    "exit_code": "5",
+                    "runtime": {
+                        "version": 9,
+                        "commit": None,
+                        "assets_verified": 1,
+                        "has_packaged_static": "true",
+                    },
                 },
-            },
-        )
+            )
 
-        assert status.state == UpdateState.failed
-        assert status.phase == UpdatePhase.installing
-        assert status.transport == UpdateTransport.usb_internet
-        assert status.started_at == 10.5
-        assert status.finished_at == 20.5
-        assert status.last_success_at == 7.0
-        assert status.phase_started_at == 12.25
-        assert status.updated_at == 18.0
-        assert status.ssid is None
-        assert status.uplink_interface is None
-        assert status.log_tail == ["ok", "7", "None"]
-        assert status.exit_code == 5
-        assert status.issues == [
-            UpdateIssue(phase="downloading", message="warn", detail="99"),
-            UpdateIssue(phase="installing", message="retry", detail=""),
-        ]
-        assert status.runtime == UpdateRuntimeDetails(
-            version="9",
-            commit="",
-            assets_verified=True,
-            has_packaged_static=True,
-        )
-
-    def test_from_payload_coerces_legacy_boolish_runtime_flags(self) -> None:
+    def test_from_payload_rejects_legacy_boolish_runtime_flags(self) -> None:
+        with pytest.raises(msgspec.ValidationError):
+            update_status_from_builtins(
+                {
+                    "runtime": {
+                        "assets_verified": 1,
+                        "has_packaged_static": "true",
+                    },
+                },
+            )
+ 
+    def test_from_payload_accepts_canonical_runtime_flags(self) -> None:
         status = update_status_from_builtins(
             {
                 "runtime": {
-                    "assets_verified": 1,
-                    "has_packaged_static": "true",
+                    "assets_verified": True,
+                    "has_packaged_static": True,
                 },
             },
         )

--- a/apps/server/tests/use_cases/updates/test_update_state_persistence.py
+++ b/apps/server/tests/use_cases/updates/test_update_state_persistence.py
@@ -206,7 +206,7 @@ class TestUpdateStateStore:
         assert loaded.issues[0].message == "ok"
         assert loaded.log_tail == ["log entry 1"]
 
-    def test_load_accepts_backward_compatible_legacy_payload(self, tmp_path: Path) -> None:
+    def test_load_rejects_legacy_payload_shape(self, tmp_path: Path) -> None:
         path = tmp_path / "state.json"
         path.write_text(
             """
@@ -233,20 +233,7 @@ class TestUpdateStateStore:
 
         loaded = store.load()
 
-        assert loaded is not None
-        assert loaded.state == UpdateState.failed
-        assert loaded.phase == UpdatePhase.installing
-        assert loaded.transport == UpdateTransport.usb_internet
-        assert loaded.started_at == 10.5
-        assert loaded.issues == [
-            UpdateIssue(phase="downloading", message="warn", detail="99"),
-        ]
-        assert loaded.log_tail == ["ok", "7", "None"]
-        assert loaded.runtime == UpdateRuntimeDetails(
-            version="9",
-            assets_verified=True,
-            has_packaged_static=True,
-        )
+        assert loaded is None
 
     @pytest.mark.parametrize(
         "file_content",

--- a/apps/server/vibesensor/use_cases/updates/status/payload_codec.py
+++ b/apps/server/vibesensor/use_cases/updates/status/payload_codec.py
@@ -7,9 +7,7 @@ import time
 import msgspec
 
 from vibesensor.shared.types.json_types import (
-    JsonArray,
     JsonObject,
-    is_json_array,
     is_json_object,
 )
 from vibesensor.use_cases.updates.models import (
@@ -125,10 +123,7 @@ def update_status_from_builtins(data: object) -> UpdateJobStatus:
 def update_status_from_json(raw: bytes | str) -> UpdateJobStatus:
     """Decode persisted updater status JSON into the domain status model."""
 
-    try:
-        payload = msgspec.json.decode(raw, type=UpdateJobStatusPayload)
-    except msgspec.ValidationError:
-        payload = _convert_status_payload_object(msgspec.json.decode(raw))
+    payload = msgspec.json.decode(raw, type=UpdateJobStatusPayload)
     return _status_from_payload(payload)
 
 
@@ -143,73 +138,7 @@ def _status_from_payload(payload: UpdateJobStatusPayload) -> UpdateJobStatus:
 
 
 def _convert_status_payload_object(data: object) -> UpdateJobStatusPayload:
-    try:
-        return msgspec.convert(data, type=UpdateJobStatusPayload, strict=False)
-    except msgspec.ValidationError:
-        if not is_json_object(data):
-            raise
-        # Legacy persisted updater status files allowed loose nested values.
-        normalized = dict(data)
-        normalized["issues"] = _normalize_legacy_issues(data.get("issues"))
-        normalized["log_tail"] = _normalize_legacy_log_tail(data.get("log_tail"))
-        normalized["runtime"] = _normalize_legacy_runtime(data.get("runtime"))
-        normalized["ssid"] = data.get("ssid") if isinstance(data.get("ssid"), str) else None
-        normalized["uplink_interface"] = (
-            data.get("uplink_interface") if isinstance(data.get("uplink_interface"), str) else None
-        )
-        return msgspec.convert(normalized, type=UpdateJobStatusPayload, strict=False)
-
-
-def _normalize_legacy_issues(value: object) -> JsonArray:
-    if not is_json_array(value):
-        return []
-    issues: JsonArray = []
-    for issue in value:
-        if not is_json_object(issue):
-            continue
-        issues.append(
-            {
-                "phase": str(issue.get("phase", "")),
-                "message": str(issue.get("message", "")),
-                "detail": str(issue.get("detail", "")),
-            }
-        )
-    return issues
-
-
-def _normalize_legacy_log_tail(value: object) -> JsonArray:
-    if not is_json_array(value):
-        return []
-    return [str(line) for line in value[-UPDATE_STATUS_LOG_TAIL_LIMIT:]]
-
-
-def _normalize_legacy_runtime(value: object) -> JsonObject:
-    if not is_json_object(value):
-        return {}
-    return {
-        "version": _legacy_text(value.get("version")),
-        "commit": _legacy_text(value.get("commit")),
-        "ui_source_hash": _legacy_text(value.get("ui_source_hash")),
-        "static_assets_hash": _legacy_text(value.get("static_assets_hash")),
-        "static_build_source_hash": _legacy_text(value.get("static_build_source_hash")),
-        "static_build_commit": _legacy_text(value.get("static_build_commit")),
-        "assets_verified": _coerce_legacy_bool(value.get("assets_verified")),
-        "has_packaged_static": _coerce_legacy_bool(value.get("has_packaged_static")),
-    }
-
-
-def _legacy_text(value: object) -> str:
-    return "" if value is None else str(value)
-
-
-def _coerce_legacy_bool(value: object) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return value != 0
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return False
+    return msgspec.convert(data, type=UpdateJobStatusPayload, strict=True)
 
 
 def _phase_elapsed_s(status: UpdateJobStatus, *, now_s: float | None) -> float | None:

--- a/tools/dev/verify_backend_static_guards.py
+++ b/tools/dev/verify_backend_static_guards.py
@@ -1905,6 +1905,27 @@ def _check_history_db_facade_removed() -> list[str]:
     return violations
 
 
+def _check_update_status_legacy_decode_removed() -> list[str]:
+    codec_path = (
+        VIBESENSOR_DIR / "use_cases" / "updates" / "status" / "payload_codec.py"
+    )
+    text = _read_text(codec_path)
+    violations: list[str] = []
+    for legacy_name in (
+        "_normalize_legacy_issues",
+        "_normalize_legacy_log_tail",
+        "_normalize_legacy_runtime",
+        "_legacy_text",
+        "_coerce_legacy_bool",
+    ):
+        if legacy_name in text:
+            violations.append(
+                f"{codec_path.relative_to(REPO_ROOT)} must not define {legacy_name}; "
+                "require the canonical UpdateJobStatusPayload shape instead"
+            )
+    return violations
+
+
 Check = tuple[str, Callable[[], list[str]]]
 CHECKS: tuple[Check, ...] = (
     (
@@ -2138,6 +2159,10 @@ CHECKS: tuple[Check, ...] = (
     (
         "HistoryDB facade stays removed",
         _check_history_db_facade_removed,
+    ),
+    (
+        "Updater status legacy decode stays removed",
+        _check_update_status_legacy_decode_removed,
     ),
 )
 


### PR DESCRIPTION
## What changed
- remove the legacy updater-status decode normalization helpers from `payload_codec.py`
- require canonical `UpdateJobStatusPayload` input for builtins and persisted JSON decode
- update updater-status tests so old loose payload shapes now fail clearly instead of being normalized
- add a static guard so the legacy helper path does not come back

## Why
- updater status writer, reader, store, and tests all live in this repo
- keeping loose legacy normalization after the canonical msgspec payload exists is just compatibility residue

## Validation
- `pytest -q tests/use_cases/updates/test_update_models_roundtrip.py tests/use_cases/updates/test_update_state_persistence.py`
- `python3.14 tools/dev/verify_backend_static_guards.py`
- `make typecheck-backend`

## Risks / tradeoffs
- old loose updater-status JSON now fails instead of being coerced
- canonical payload shape is unchanged; only the fallback path is removed

## Follow-ups
- none

Closes #2921