### PR TITLE
refactor(udp): drop legacy HELLO compatibility

### DIFF
--- a/apps/server/tests/adapters/udp/test_protocol.py
+++ b/apps/server/tests/adapters/udp/test_protocol.py
@@ -76,7 +76,7 @@ def test_hello_roundtrip() -> None:
     assert decoded.capabilities == HELLO_CAP_EXPLICIT_ACK
 
 
-def test_parse_hello_defaults_capabilities_to_zero_for_legacy_packet() -> None:
+def test_parse_hello_rejects_missing_capabilities() -> None:
     client_id = bytes.fromhex("a1b2c3d4e5f6")
     legacy_packet = pack_hello(
         client_id=client_id,
@@ -88,8 +88,8 @@ def test_parse_hello_defaults_capabilities_to_zero_for_legacy_packet() -> None:
         queue_overflow_drops=7,
         capabilities=HELLO_CAP_EXPLICIT_ACK,
     )[:-1]
-    decoded = parse_hello(legacy_packet)
-    assert decoded.capabilities == 0
+    with pytest.raises(ProtocolError, match="HELLO missing capabilities"):
+        parse_hello(legacy_packet)
 
 
 def test_data_roundtrip() -> None:
@@ -331,7 +331,7 @@ def test_parse_hello_rejects_zero_sample_rate() -> None:
     import struct as _struct
 
     raw = HELLO_BASE.pack(MSG_HELLO, 1, client_id, 9000, 0, 200, len(name_bytes))
-    raw += name_bytes + bytes([0]) + _struct.pack("<I", 0)
+    raw += name_bytes + bytes([0]) + _struct.pack("<I", 0) + bytes([HELLO_CAP_EXPLICIT_ACK])
     with pytest.raises(ProtocolError, match="sample_rate_hz must not be zero"):
         parse_hello(raw)
 
@@ -344,7 +344,7 @@ def test_parse_hello_warns_on_zero_control_port(caplog: pytest.LogCaptureFixture
     client_id = bytes.fromhex("aabbccddeeff")
     name_bytes = b"sensor"
     raw = HELLO_BASE.pack(MSG_HELLO, 1, client_id, 0, 800, 200, len(name_bytes))
-    raw += name_bytes + bytes([0]) + _struct.pack("<I", 0)
+    raw += name_bytes + bytes([0]) + _struct.pack("<I", 0) + bytes([HELLO_CAP_EXPLICIT_ACK])
     with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.udp.protocol"):
         msg = parse_hello(raw)
     assert msg.control_port == 0

--- a/apps/server/tests/adapters/udp/test_udp_control_tx.py
+++ b/apps/server/tests/adapters/udp/test_udp_control_tx.py
@@ -146,27 +146,6 @@ def test_control_datagram_sends_hello_ack_for_capable_firmware(
     assert addr == ("127.0.0.1", 9010)
 
 
-def test_control_datagram_skips_hello_ack_for_legacy_firmware(
-    tmp_path: Path,
-    fake_transport,
-) -> None:
-    registry = _make_registry(tmp_path)
-    protocol = ControlDatagramProtocol(registry)
-    protocol.transport = fake_transport
-    packet = pack_hello(
-        client_id=bytes.fromhex("aabbccddeeff"),
-        control_port=9010,
-        sample_rate_hz=800,
-        name="node",
-        frame_samples=200,
-        firmware_version="fw",
-    )
-
-    protocol.datagram_received(packet, ("127.0.0.1", 54000))
-
-    assert fake_transport.sent == []
-
-
 def test_close_closes_transport_once_and_clears_reference(tmp_path: Path, fake_transport) -> None:
     registry = _make_registry(tmp_path)
     plane = UDPControlPlane(registry=registry, bind_host="127.0.0.1", bind_port=9001)

--- a/apps/server/vibesensor/adapters/simulator/sim_runtime.py
+++ b/apps/server/vibesensor/adapters/simulator/sim_runtime.py
@@ -10,6 +10,7 @@ from vibesensor.adapters.simulator.sim_client import SimClient
 from vibesensor.adapters.simulator.sim_scene import RoadSceneController
 from vibesensor.adapters.udp.protocol import (
     CMD_IDENTIFY,
+    HELLO_CAP_EXPLICIT_ACK,
     MSG_CMD,
     pack_ack,
     pack_data,
@@ -131,6 +132,7 @@ async def hello_loop(sim: SimClient, hello_interval_s: float, stop_event: asynci
                 name=sim.name,
                 frame_samples=sim.frame_samples,
                 firmware_version="sim-0.2",
+                capabilities=HELLO_CAP_EXPLICIT_ACK,
             )
             sim.control_transport.sendto(packet, (sim.server_host, sim.server_control_port))
         await asyncio.sleep(hello_interval_s)

--- a/apps/server/vibesensor/adapters/udp/protocol.py
+++ b/apps/server/vibesensor/adapters/udp/protocol.py
@@ -237,30 +237,30 @@ def parse_hello(data: bytes) -> HelloMessage:
         raw_name = raw_name[:HELLO_MAX_NAME_BYTES]
     name = raw_name.decode("utf-8", errors="replace")
 
-    firmware_version = ""
-    queue_overflow_drops = 0
-    capabilities = 0
-    if len(data) > offset:
-        firmware_len = data[offset]
-        offset += 1
-        if len(data) < offset + firmware_len:
-            raise _ProtocolError("HELLO firmware length out of range")
-        raw_fw = data[offset : offset + firmware_len]
-        offset += firmware_len
-        if firmware_len > HELLO_MAX_NAME_BYTES:
-            LOGGER.warning(
-                "HELLO firmware_version field is %d bytes (max expected %d); "
-                "accepting but truncating stored value",
-                firmware_len,
-                HELLO_MAX_NAME_BYTES,
-            )
-            raw_fw = raw_fw[:HELLO_MAX_NAME_BYTES]
-        firmware_version = raw_fw.decode("utf-8", errors="replace")
-        if len(data) >= offset + 4:
-            queue_overflow_drops = struct.unpack_from("<I", data, offset)[0]
-            offset += 4
-        if len(data) > offset:
-            capabilities = data[offset]
+    if len(data) < offset + 1:
+        raise _ProtocolError("HELLO missing firmware length")
+    firmware_len = data[offset]
+    offset += 1
+    if len(data) < offset + firmware_len:
+        raise _ProtocolError("HELLO firmware length out of range")
+    raw_fw = data[offset : offset + firmware_len]
+    offset += firmware_len
+    if firmware_len > HELLO_MAX_NAME_BYTES:
+        LOGGER.warning(
+            "HELLO firmware_version field is %d bytes (max expected %d); "
+            "accepting but truncating stored value",
+            firmware_len,
+            HELLO_MAX_NAME_BYTES,
+        )
+        raw_fw = raw_fw[:HELLO_MAX_NAME_BYTES]
+    firmware_version = raw_fw.decode("utf-8", errors="replace")
+    if len(data) < offset + 4:
+        raise _ProtocolError("HELLO missing queue_overflow_drops")
+    queue_overflow_drops = struct.unpack_from("<I", data, offset)[0]
+    offset += 4
+    if len(data) < offset + 1:
+        raise _ProtocolError("HELLO missing capabilities")
+    capabilities = data[offset]
 
     return HelloMessage(
         client_id=client_id,
@@ -282,7 +282,7 @@ def pack_hello(
     frame_samples: int = 0,
     firmware_version: str = "",
     queue_overflow_drops: int = 0,
-    capabilities: int = 0,
+    capabilities: int = HELLO_CAP_EXPLICIT_ACK,
 ) -> bytes:
     """Encode a HELLO message as bytes."""
     validate_client_id(client_id)

--- a/apps/server/vibesensor/adapters/udp/udp_control_tx.py
+++ b/apps/server/vibesensor/adapters/udp/udp_control_tx.py
@@ -15,7 +15,6 @@ import time
 from typing import cast
 
 from vibesensor.adapters.udp.protocol import (
-    HELLO_CAP_EXPLICIT_ACK,
     MSG_ACK,
     MSG_DATA_ACK,
     MSG_HELLO,
@@ -57,7 +56,7 @@ class ControlDatagramProtocol(asyncio.DatagramProtocol):
             if msg_type == MSG_HELLO:
                 hello = parse_hello(data)
                 registry.update_from_hello(hello, addr, now_ts)
-                if self.transport is not None and (hello.capabilities & HELLO_CAP_EXPLICIT_ACK):
+                if self.transport is not None:
                     self.transport.sendto(
                         pack_hello_ack(hello.client_id),
                         (addr[0], hello.control_port),

--- a/apps/server/vibesensor/cli/contract_reference_doc.py
+++ b/apps/server/vibesensor/cli/contract_reference_doc.py
@@ -98,9 +98,8 @@ This document is generated from code and shared contract files.
 
 ## Hello handshake
 
-- Capable firmware advertises support for explicit control-plane acknowledgment in
-  the HELLO capability byte.
-- Server replies to capable HELLO packets with `HELLO_ACK` on the sensor control port.
+- Firmware sends the canonical HELLO packet shape, including the capabilities byte.
+- Server replies to HELLO packets with `HELLO_ACK` on the sensor control port.
 - Firmware waits for `HELLO_ACK` before sending DATA frames, so the control path
   is validated before streaming starts.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -38,9 +38,8 @@ This document is generated from code and shared contract files.
 
 ## Hello handshake
 
-- Capable firmware advertises support for explicit control-plane acknowledgment in
-  the HELLO capability byte.
-- Server replies to capable HELLO packets with `HELLO_ACK` on the sensor control port.
+- Firmware sends the canonical HELLO packet shape, including the capabilities byte.
+- Server replies to HELLO packets with `HELLO_ACK` on the sensor control port.
 - Firmware waits for `HELLO_ACK` before sending DATA frames, so the control path
   is validated before streaming starts.
 

--- a/firmware/esp/lib/vibesensor_proto/vibesensor_proto.h
+++ b/firmware/esp/lib/vibesensor_proto/vibesensor_proto.h
@@ -45,7 +45,7 @@ size_t pack_hello(uint8_t* out,
                   const char* name,
                   const char* firmware_version,
                   uint32_t queue_overflow_drops = 0,
-                  uint8_t capabilities = 0);
+                  uint8_t capabilities = kHelloCapExplicitAck);
 
 size_t pack_data(uint8_t* out,
                  size_t out_len,

--- a/tools/dev/verify_backend_static_guards.py
+++ b/tools/dev/verify_backend_static_guards.py
@@ -1978,6 +1978,46 @@ def _check_settings_snapshot_legacy_decode_removed() -> list[str]:
     return violations
 
 
+def _check_udp_hello_legacy_compat_removed() -> list[str]:
+    protocol_path = VIBESENSOR_DIR / "adapters" / "udp" / "protocol.py"
+    control_path = VIBESENSOR_DIR / "adapters" / "udp" / "udp_control_tx.py"
+    protocol_tests = TESTS_DIR / "adapters" / "udp" / "test_protocol.py"
+    control_tests = TESTS_DIR / "adapters" / "udp" / "test_udp_control_tx.py"
+    violations: list[str] = []
+
+    control_text = _read_text(control_path)
+    if "HELLO_CAP_EXPLICIT_ACK" in control_text:
+        violations.append(
+            f"{control_path.relative_to(REPO_ROOT)} must not gate HELLO_ACK on "
+            "HELLO_CAP_EXPLICIT_ACK"
+        )
+
+    protocol_text = _read_text(protocol_path)
+    for legacy_text in (
+        "if len(data) >= offset + 4:",
+        "if len(data) > offset:",
+    ):
+        if legacy_text in protocol_text:
+            violations.append(
+                f"{protocol_path.relative_to(REPO_ROOT)} still contains legacy HELLO "
+                "tail fallback logic"
+            )
+
+    if "test_parse_hello_defaults_capabilities_to_zero_for_legacy_packet" in _read_text(
+        protocol_tests
+    ):
+        violations.append(
+            f"{protocol_tests.relative_to(REPO_ROOT)} must not preserve legacy short HELLO tests"
+        )
+    if "test_control_datagram_skips_hello_ack_for_legacy_firmware" in _read_text(
+        control_tests
+    ):
+        violations.append(
+            f"{control_tests.relative_to(REPO_ROOT)} must not preserve legacy HELLO_ACK skips"
+        )
+    return violations
+
+
 Check = tuple[str, Callable[[], list[str]]]
 CHECKS: tuple[Check, ...] = (
     (
@@ -2219,6 +2259,10 @@ CHECKS: tuple[Check, ...] = (
     (
         "Settings snapshot legacy decode stays removed",
         _check_settings_snapshot_legacy_decode_removed,
+    ),
+    (
+        "UDP HELLO legacy compatibility stays removed",
+        _check_udp_hello_legacy_compat_removed,
     ),
 )
 


### PR DESCRIPTION
## Size
medium

## What changed
- require the full current HELLO payload tail when decoding on the server
- always send `HELLO_ACK` for a valid HELLO instead of gating on old compatibility behavior
- make repo HELLO producers/defaults use the canonical explicit-ack capability shape
- remove legacy HELLO tests and add a guard so the old compatibility paths stay gone
- update generated protocol docs to describe one handshake only

## Why
- repo owns firmware, simulator, server, and protocol docs
- old short-HELLO and conditional-ack branches were compatibility code only
- one handshake shape is simpler and safer than keeping old firmware paths alive

## Validation
- `ruff check apps/server/vibesensor/adapters/udp/protocol.py apps/server/vibesensor/adapters/udp/udp_control_tx.py apps/server/vibesensor/adapters/simulator/sim_runtime.py apps/server/vibesensor/cli/contract_reference_doc.py apps/server/tests/adapters/udp/test_protocol.py apps/server/tests/adapters/udp/test_udp_control_tx.py tools/dev/verify_backend_static_guards.py`
- `ruff format --check apps/server/vibesensor/adapters/udp/protocol.py apps/server/vibesensor/adapters/udp/udp_control_tx.py apps/server/vibesensor/adapters/simulator/sim_runtime.py apps/server/vibesensor/cli/contract_reference_doc.py apps/server/tests/adapters/udp/test_protocol.py apps/server/tests/adapters/udp/test_udp_control_tx.py tools/dev/verify_backend_static_guards.py`
- `cd apps/server && pytest -q tests/adapters/udp/test_protocol.py tests/adapters/udp/test_udp_control_tx.py tests/adapters/udp/test_protocol_version_mismatch.py tests/integration/test_multi_sensor_e2e_pipeline.py`
- `python3.14 tools/dev/verify_backend_static_guards.py`
- `make sync-contracts`
- `cd firmware/esp && pio run`

## Risks / tradeoffs
- legacy short HELLO packets now fail instead of being padded forward
- server no longer preserves old no-ack behavior for older firmware
- intentional internal contract break; repo firmware/simulator producers updated with it

Closes #2923
