### PR TITLE
refactor(release): drop legacy title prefix

### DIFF
--- a/apps/server/tests/hygiene/test_main_release_scripts.py
+++ b/apps/server/tests/hygiene/test_main_release_scripts.py
@@ -171,12 +171,9 @@ def test_cleanup_superseded_releases_keeps_current_and_ignores_missing_tags(monk
 
     assert removed == [
         module.ReleaseSummary(id=2, tag="server-v2026.4.5", title="Wheel / ESP release 2026.4.5"),
-        module.ReleaseSummary(id=3, tag="server-v2026.4.4", title="Release 2026.4.4"),
     ]
     assert calls == [
         ("GET", "Skamba/VibeSensor", "releases?per_page=100&page=1"),
         ("DELETE", "Skamba/VibeSensor", "releases/2"),
         ("DELETE", "Skamba/VibeSensor", "git/refs/tags/server-v2026.4.5"),
-        ("DELETE", "Skamba/VibeSensor", "releases/3"),
-        ("DELETE", "Skamba/VibeSensor", "git/refs/tags/server-v2026.4.4"),
     ]

--- a/apps/server/tests/infra/processing/benchmark_rfft_backend.py
+++ b/apps/server/tests/infra/processing/benchmark_rfft_backend.py
@@ -46,8 +46,8 @@ def _numpy_rfft_call(block: np.ndarray, window: np.ndarray) -> Callable[[], np.n
 
 def _pyfftw_rfft_call(block: np.ndarray, window: np.ndarray) -> Callable[[], np.ndarray]:
     plan = _get_rfft_plan(_AXES_COUNT, block.shape[1])
-    # Warm the plan/output buffer so the first measured iteration doesn't pay
-    # one-time FFTW_MEASURE cost.
+    # Warm the plan/output buffer so the benchmarked iterations don't include
+    # one-time plan setup / first-call buffer effects.
     np.multiply(block, window, out=plan.input_array)
     plan()
 

--- a/apps/server/tests/infra/processing/test_processing_fft.py
+++ b/apps/server/tests/infra/processing/test_processing_fft.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+import vibesensor.infra.processing.fft as fft_module
 from vibesensor.infra.processing.fft import (
     compute_fft_spectrum,
     float_list,
@@ -256,6 +257,57 @@ class TestComputeFftSpectrum:
         assert result["freq_slice"][0] == pytest.approx(6.0)
         assert float(result["spectrum_by_axis"]["x"]["amp"][0]) > 0.0
         assert float(result["combined_amp"][0]) > 0.0
+
+    def test_get_rfft_plan_uses_estimate_planning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, object] = {}
+        original_cache = fft_module._PLAN_CACHE.copy()
+
+        class FakePlan:
+            def __init__(self, input_array: np.ndarray, output_array: np.ndarray) -> None:
+                self.input_array = input_array
+                self.output_array = output_array
+
+            def __call__(self) -> np.ndarray:
+                return self.output_array
+
+        def _fake_empty_aligned(
+            shape: tuple[int, ...],
+            *,
+            dtype: np.dtype[np.generic],
+        ) -> np.ndarray:
+            return np.empty(shape, dtype=dtype)
+
+        def _fake_fftw(
+            input_array: np.ndarray,
+            output_array: np.ndarray,
+            *,
+            axes: tuple[int, ...],
+            direction: str,
+            flags: tuple[str, ...],
+            threads: int,
+        ) -> FakePlan:
+            captured["axes"] = axes
+            captured["direction"] = direction
+            captured["flags"] = flags
+            captured["threads"] = threads
+            return FakePlan(input_array, output_array)
+
+        fft_module._PLAN_CACHE.clear()
+        monkeypatch.setattr(fft_module.pyfftw, "empty_aligned", _fake_empty_aligned)
+        monkeypatch.setattr(fft_module.pyfftw, "FFTW", _fake_fftw)
+        try:
+            plan = fft_module._get_rfft_plan(3, 256)
+        finally:
+            fft_module._PLAN_CACHE.clear()
+            fft_module._PLAN_CACHE.update(original_cache)
+
+        assert isinstance(plan, FakePlan)
+        assert captured == {
+            "axes": (1,),
+            "direction": "FFTW_FORWARD",
+            "flags": ("FFTW_ESTIMATE",),
+            "threads": 1,
+        }
 
     @pytest.mark.parametrize(
         ("block", "sample_rate_hz", "params", "expect_empty"),

--- a/apps/server/vibesensor/infra/processing/fft.py
+++ b/apps/server/vibesensor/infra/processing/fft.py
@@ -43,6 +43,7 @@ type IntIndexArray = npt.NDArray[np.intp]
 # itself is guarded by a lock; plan construction is lazy on first use.
 _PLAN_CACHE_LOCK = threading.Lock()
 _PLAN_CACHE: dict[tuple[int, int], threading.local] = {}
+_RFFT_PLAN_FLAGS = ("FFTW_ESTIMATE",)
 
 
 def _get_rfft_plan(axes_count: int, fft_n: int) -> pyfftw.FFTW:
@@ -79,7 +80,9 @@ def _get_rfft_plan(axes_count: int, fft_n: int) -> pyfftw.FFTW:
             output_array,
             axes=(1,),
             direction="FFTW_FORWARD",
-            flags=("FFTW_MEASURE",),
+            # Short live runs need their first FFT immediately; avoid expensive
+            # runtime planning work on the hot path.
+            flags=_RFFT_PLAN_FLAGS,
             threads=1,
         )
         tls.plan = plan

--- a/tools/release/main_release.py
+++ b/tools/release/main_release.py
@@ -205,7 +205,6 @@ def select_superseded_releases(
     *,
     current_tag: str,
     release_title_prefix: str,
-    legacy_title_prefix: str = "Release ",
 ) -> list[ReleaseSummary]:
     title_prefix = f"{release_title_prefix} "
     selected: list[ReleaseSummary] = []
@@ -217,9 +216,7 @@ def select_superseded_releases(
         title = str(release.get("name") or "")
         if tag == current_tag or not tag.startswith("server-v"):
             continue
-        if not title.startswith(title_prefix) and not title.startswith(
-            legacy_title_prefix
-        ):
+        if not title.startswith(title_prefix):
             continue
         selected.append(ReleaseSummary(id=release_id, tag=tag, title=title))
     return selected
@@ -270,13 +267,11 @@ def cleanup_superseded_releases(
     *,
     current_tag: str,
     release_title_prefix: str,
-    legacy_title_prefix: str = "Release ",
 ) -> list[ReleaseSummary]:
     removed = select_superseded_releases(
         _list_releases(repo),
         current_tag=current_tag,
         release_title_prefix=release_title_prefix,
-        legacy_title_prefix=legacy_title_prefix,
     )
     for release in removed:
         print(f"Deleting superseded Wheel / ESP release {release.tag}", flush=True)
@@ -315,10 +310,6 @@ def main(argv: list[str] | None = None) -> int:
         "--release-title-prefix",
         default="Wheel / ESP release",
     )
-    cleanup_parser.add_argument(
-        "--legacy-title-prefix",
-        default="Release ",
-    )
     cleanup_parser.add_argument("--dry-run", action="store_true")
 
     args = parser.parse_args(argv)
@@ -347,7 +338,6 @@ def main(argv: list[str] | None = None) -> int:
         _list_releases(args.repo),
         current_tag=args.current_tag,
         release_title_prefix=args.release_title_prefix,
-        legacy_title_prefix=args.legacy_title_prefix,
     )
     if args.dry_run:
         print(json.dumps([asdict(release) for release in selected], indent=2))
@@ -356,7 +346,6 @@ def main(argv: list[str] | None = None) -> int:
         args.repo,
         current_tag=args.current_tag,
         release_title_prefix=args.release_title_prefix,
-        legacy_title_prefix=args.legacy_title_prefix,
     )
     return 0
 


### PR DESCRIPTION
## Size
medium

## What changed
- remove `legacy_title_prefix` matching from the release cleanup selector and cleanup wrapper
- delete the `--legacy-title-prefix` CLI option from `tools/release/main_release.py`
- tighten the focused release-script hygiene test so cleanup ignores old `Release ...` titles
- switch runtime pyFFTW plan creation from `FFTW_MEASURE` to `FFTW_ESTIMATE` so short live runs do not stall their first FFT-derived strength metrics
- add a focused FFT planner regression test and update the benchmark note to match the runtime planning mode

## Why
- the repo only produces the canonical `Wheel / ESP release ...` title scheme now; the older `Release ...` cleanup path was dead compatibility residue
- rerun CI on this branch exposed an unrelated fresh-`main` backend regression: short E2E runs were failing post-analysis with `Missing required precomputed strength metrics in sample index 0: vibration_strength_db` after the pyFFTW hot-path switch
- fixing that regression on-branch is the smallest clean path to get this issue landed without leaving PR `#2977` red on unrelated backend breakage

## Validation
- `cd apps/server && pytest -q --noconftest tests/hygiene/test_main_release_scripts.py`
- `python3 tools/dev/check_hygiene.py`
- repo search for `legacy_title_prefix` / `--legacy-title-prefix`
- targeted executable FFT test remains host-blocked locally because the touched backend package uses Python 3.13-only syntax while this host is Python 3.11; PR CI is the execution gate for that seam

## Risks / tradeoffs
- cleanup no longer deletes old GitHub releases whose titles still use the legacy `Release ...` prefix
- `FFTW_ESTIMATE` trades some potential peak plan quality for predictable first-FFT latency, which is the better runtime default for short recordings and live processing
- if a future benchmark proves a better planning strategy, it should land with runtime and short-run coverage together

Closes #2926