### PR TITLE
refactor(dev): require docker compose v2

### DIFF
--- a/apps/server/tests/hygiene/test_check_prerequisites.py
+++ b/apps/server/tests/hygiene/test_check_prerequisites.py
@@ -15,9 +15,7 @@ def _load_module():
         "check_prerequisites_for_tests",
         _CHECK_PREREQUISITES,
     )
-    assert spec is not None and spec.loader is not None, (
-        f"Unable to load {_CHECK_PREREQUISITES}"
-    )
+    assert spec is not None and spec.loader is not None, f"Unable to load {_CHECK_PREREQUISITES}"
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)

--- a/apps/server/tests/hygiene/test_check_prerequisites.py
+++ b/apps/server/tests/hygiene/test_check_prerequisites.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib.util
 import sys
-from pathlib import Path
 
 from tests._paths import REPO_ROOT
 
@@ -16,7 +15,9 @@ def _load_module():
         "check_prerequisites_for_tests",
         _CHECK_PREREQUISITES,
     )
-    assert spec is not None and spec.loader is not None, f"Unable to load {_CHECK_PREREQUISITES}"
+    assert spec is not None and spec.loader is not None, (
+        f"Unable to load {_CHECK_PREREQUISITES}"
+    )
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
@@ -26,7 +27,10 @@ def _load_module():
 def test_check_docker_accepts_compose_v2_and_keeps_daemon_check(monkeypatch) -> None:
     module = _load_module()
 
-    monkeypatch.setattr(module, "_which", lambda command: "/usr/bin/docker" if command == "docker" else None)
+    def _docker_only(command: str) -> str | None:
+        return "/usr/bin/docker" if command == "docker" else None
+
+    monkeypatch.setattr(module, "_which", _docker_only)
 
     def _fake_run(command: list[str]) -> tuple[bool, str]:
         if command == ["docker", "compose", "version"]:
@@ -76,6 +80,10 @@ def test_check_docker_requires_compose_v2_even_if_legacy_binary_exists(monkeypat
 
     assert [(item.name, item.status, item.message) for item in results] == [
         ("docker", "OK", "installed"),
-        ("docker compose", "WARN", "v2 unavailable: docker: 'compose' is not a docker command."),
+        (
+            "docker compose",
+            "WARN",
+            "v2 unavailable: docker: 'compose' is not a docker command.",
+        ),
         ("docker daemon", "OK", "reachable"),
     ]

--- a/apps/server/tests/hygiene/test_check_prerequisites.py
+++ b/apps/server/tests/hygiene/test_check_prerequisites.py
@@ -1,0 +1,81 @@
+"""Guards for the native prerequisite checker."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from tests._paths import REPO_ROOT
+
+_CHECK_PREREQUISITES = REPO_ROOT / "tools" / "dev" / "check_prerequisites.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_prerequisites_for_tests",
+        _CHECK_PREREQUISITES,
+    )
+    assert spec is not None and spec.loader is not None, f"Unable to load {_CHECK_PREREQUISITES}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_docker_accepts_compose_v2_and_keeps_daemon_check(monkeypatch) -> None:
+    module = _load_module()
+
+    monkeypatch.setattr(module, "_which", lambda command: "/usr/bin/docker" if command == "docker" else None)
+
+    def _fake_run(command: list[str]) -> tuple[bool, str]:
+        if command == ["docker", "compose", "version"]:
+            return True, "Docker Compose version v2.39.4\n"
+        if command == ["docker", "info"]:
+            return False, "Cannot connect to the Docker daemon at unix:///var/run/docker.sock\n"
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(module, "_run", _fake_run)
+
+    results = module._check_docker()
+
+    assert [(item.name, item.status, item.message) for item in results] == [
+        ("docker", "OK", "installed"),
+        ("docker compose", "OK", "Docker Compose version v2.39.4"),
+        (
+            "docker daemon",
+            "WARN",
+            "not reachable: Cannot connect to the Docker daemon at unix:///var/run/docker.sock",
+        ),
+    ]
+
+
+def test_check_docker_requires_compose_v2_even_if_legacy_binary_exists(monkeypatch) -> None:
+    module = _load_module()
+
+    def _fake_which(command: str) -> str | None:
+        if command == "docker":
+            return "/usr/bin/docker"
+        if command == "docker-compose":
+            return "/usr/bin/docker-compose"
+        return None
+
+    def _fake_run(command: list[str]) -> tuple[bool, str]:
+        if command == ["docker", "compose", "version"]:
+            return False, "docker: 'compose' is not a docker command.\n"
+        if command == ["docker", "info"]:
+            return True, "Server Version: 28.0.0\n"
+        if command == ["docker-compose", "version"]:
+            raise AssertionError("legacy docker-compose should not be probed")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(module, "_which", _fake_which)
+    monkeypatch.setattr(module, "_run", _fake_run)
+
+    results = module._check_docker()
+
+    assert [(item.name, item.status, item.message) for item in results] == [
+        ("docker", "OK", "installed"),
+        ("docker compose", "WARN", "v2 unavailable: docker: 'compose' is not a docker command."),
+        ("docker daemon", "OK", "reachable"),
+    ]

--- a/tools/dev/check_prerequisites.py
+++ b/tools/dev/check_prerequisites.py
@@ -157,19 +157,13 @@ def _check_docker() -> list[CheckResult]:
     if compose_ok:
         results.append(CheckResult("docker compose", "OK", _first_line(compose_output)))
     else:
-        legacy_ok, legacy_output = _run(["docker-compose", "version"])
-        if legacy_ok:
-            results.append(
-                CheckResult("docker compose", "OK", _first_line(legacy_output))
+        results.append(
+            CheckResult(
+                "docker compose",
+                "WARN",
+                f"v2 unavailable: {_first_line(compose_output)}",
             )
-        else:
-            results.append(
-                CheckResult(
-                    "docker compose",
-                    "WARN",
-                    f"unavailable: {_first_line(compose_output or legacy_output)}",
-                )
-            )
+        )
 
     daemon_ok, daemon_output = _run(["docker", "info"])
     if daemon_ok:


### PR DESCRIPTION
## Size
small

## What changed
- remove the `docker-compose` fallback branch from `_check_docker()` in `tools/dev/check_prerequisites.py`
- change the warning text so the checker explicitly reports `docker compose` v2 as unavailable instead of silently treating the legacy binary as supported
- add focused hygiene coverage for the compose-v2 success path and the legacy-binary-only path

## Why
- the repo documents and validates `docker compose` as the canonical workflow already
- keeping `docker-compose` as an accepted fallback is compatibility residue in repo-owned developer tooling

## Validation
- `cd apps/server && pytest -q --noconftest -o addopts='' tests/hygiene/test_check_prerequisites.py`
- `python3 tools/dev/check_hygiene.py`
- repo search for `docker-compose version`

## Risks / tradeoffs
- environments that only provide the old `docker-compose` binary now get a warning until they install Docker Compose v2
- Docker daemon reachability checks stay unchanged

Closes #2927