### PR TITLE
build(ui): remove legacy peer workaround

### DIFF
--- a/apps/ui/.npmrc
+++ b/apps/ui/.npmrc
@@ -1,3 +1,0 @@
-# openapi-typescript 7.13.0 still declares a TypeScript 5 peer range,
-# but the generator and UI build work with TypeScript 6 in this repo.
-legacy-peer-deps=true

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -24,7 +24,7 @@
         "openapi-typescript": "^7.13.0",
         "rollup-plugin-visualizer": "^7.0.1",
         "tsx": "^4.21.0",
-        "typescript": "^6.0.3",
+        "typescript": "^5.9.3",
         "vite": "^8.0.8"
       }
     },
@@ -5241,10 +5241,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -50,7 +50,7 @@
     "openapi-typescript": "^7.13.0",
     "rollup-plugin-visualizer": "^7.0.1",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.3",
+    "typescript": "^5.9.3",
     "vite": "^8.0.8"
   }
 }


### PR DESCRIPTION
## Why
- UI install was relying on `.npmrc` `legacy-peer-deps=true` to hide a real peer mismatch.
- `openapi-typescript@7.13.0` still peers on `typescript ^5.x`, but the repo had pinned `typescript ^6.0.3`.

## What changed
- delete `apps/ui/.npmrc`
- pin UI `typescript` to `^5.9.3`
- refresh `apps/ui/package-lock.json`

## Validation
- `cd apps/ui && npm install`
- `cd apps/ui && rm -rf node_modules && npm ci`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## Risk / tradeoffs
- keeps the existing generator/tooling set; no broad frontend dependency churn
- standardizes the UI toolchain on the peer-compatible TypeScript 5 line until upstream widens its peer range
