### PR TITLE
refactor(ui): drop freshness fallback

### DIFF
--- a/apps/ui/src/app/features/data_freshness.ts
+++ b/apps/ui/src/app/features/data_freshness.ts
@@ -1,10 +1,8 @@
 export interface FreshnessClient {
-  sample_rate_hz?: number | null;
+  sample_rate_hz: number;
   frame_samples: number;
 }
 
-const LEGACY_FRESH_THRESHOLD_MS = 250;
-const LEGACY_DELAYED_THRESHOLD_MS = 1000;
 const FRESH_CADENCE_MULTIPLIER = 1.25;
 const DELAYED_CADENCE_MULTIPLIER = 2.5;
 
@@ -13,33 +11,14 @@ export function deriveDataFreshnessThresholds(
 ): { freshMs: number; delayedMs: number } {
   let slowestCadenceMs = 0;
   for (const client of clients) {
-    const sampleRateHz = Number(client.sample_rate_hz);
-    const frameSamples = Number(client.frame_samples);
-    if (
-      !Number.isFinite(sampleRateHz) ||
-      !Number.isFinite(frameSamples) ||
-      sampleRateHz <= 0 ||
-      frameSamples <= 0
-    ) {
-      continue;
-    }
-    slowestCadenceMs = Math.max(slowestCadenceMs, (frameSamples * 1000) / sampleRateHz);
-  }
-  if (slowestCadenceMs <= 0) {
-    return {
-      freshMs: LEGACY_FRESH_THRESHOLD_MS,
-      delayedMs: LEGACY_DELAYED_THRESHOLD_MS,
-    };
+    slowestCadenceMs = Math.max(
+      slowestCadenceMs,
+      (client.frame_samples * 1000) / client.sample_rate_hz,
+    );
   }
   return {
-    freshMs: Math.max(
-      LEGACY_FRESH_THRESHOLD_MS,
-      Math.ceil(slowestCadenceMs * FRESH_CADENCE_MULTIPLIER),
-    ),
-    delayedMs: Math.max(
-      LEGACY_DELAYED_THRESHOLD_MS,
-      Math.ceil(slowestCadenceMs * DELAYED_CADENCE_MULTIPLIER),
-    ),
+    freshMs: Math.ceil(slowestCadenceMs * FRESH_CADENCE_MULTIPLIER),
+    delayedMs: Math.ceil(slowestCadenceMs * DELAYED_CADENCE_MULTIPLIER),
   };
 }
 

--- a/apps/ui/tests/realtime_feature_freshness.spec.ts
+++ b/apps/ui/tests/realtime_feature_freshness.spec.ts
@@ -14,10 +14,10 @@ function makeClient(overrides: Partial<{ sample_rate_hz: number; frame_samples: 
 }
 
 test.describe("realtime freshness thresholds", () => {
-  test("falls back to legacy thresholds when cadence metadata is missing", () => {
-    expect(deriveDataFreshnessThresholds([makeClient({ frame_samples: 0 })])).toEqual({
-      freshMs: 250,
-      delayedMs: 1000,
+  test("derives thresholds directly from cadence without legacy minimums", () => {
+    expect(deriveDataFreshnessThresholds([makeClient({ sample_rate_hz: 1600, frame_samples: 100 })])).toEqual({
+      freshMs: 79,
+      delayedMs: 157,
     });
   });
 


### PR DESCRIPTION
## What changed
- remove legacy freshness-threshold fallback and minimum clamps from `apps/ui/src/app/features/data_freshness.ts`
- require cadence metadata in the local `FreshnessClient` shape
- update the focused freshness spec to lock cadence-only thresholds

## Why
- `#2929` made cadence metadata mandatory in client payloads
- UI should stop preserving older-producer compatibility logic

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npx playwright test tests/realtime_feature_freshness.spec.ts -c ../../.ai-temp/playwright.unit.local.config.ts`

## Risks / tradeoffs
- invalid cadence metadata no longer falls back to 250/1000 ms legacy thresholds
- freshness now derives only from canonical payload cadence

Closes #2930