### PR TITLE
refactor(summary): drop phase fallback

### DIFF
--- a/apps/server/tests/domain/test_snapshots.py
+++ b/apps/server/tests/domain/test_snapshots.py
@@ -305,7 +305,7 @@ class TestSpeedProfileSummaryFromDict:
 class TestDrivingPhaseSummaryFromDict:
     """from_dict() constructor tests."""
 
-    def test_counts_percentages_and_flags_fall_back_consistently(self) -> None:
+    def test_counts_percentages_and_flags_derive_from_canonical_fields(self) -> None:
         snap = driving_phase_summary_from_mapping(
             {
                 "phase_counts": {"cruise": "100", "acceleration": 50, "idle": "bad"},
@@ -325,7 +325,7 @@ class TestDrivingPhaseSummaryFromDict:
         assert snap.idle_pct == pytest.approx(0.10)
         assert snap.speed_unknown_pct == 0.0
 
-    def test_explicit_flags_and_percentages_override_count_fallbacks(self) -> None:
+    def test_legacy_flat_fields_do_not_override_canonical_phase_fields(self) -> None:
         snap = driving_phase_summary_from_mapping(
             {
                 "phase_counts": {"cruise": 10, "acceleration": 3},
@@ -336,9 +336,9 @@ class TestDrivingPhaseSummaryFromDict:
             }
         )
 
-        assert snap.has_cruise is False
-        assert snap.has_acceleration is False
-        assert snap.cruise_pct == 0.0
+        assert snap.has_cruise is True
+        assert snap.has_acceleration is True
+        assert snap.cruise_pct == pytest.approx(0.9)
 
     def test_invalid_phase_counts_skipped(self) -> None:
         snap = driving_phase_summary_from_mapping({"phase_counts": {"cruise": "bad", "accel": 10}})

--- a/apps/server/tests/domain/test_test_run_value_objects.py
+++ b/apps/server/tests/domain/test_test_run_value_objects.py
@@ -290,7 +290,10 @@ class TestTestRunWithValueObjects:
                 "steady_speed": True,
                 "sample_count": 500,
             },
-            "phase_summary": {"has_cruise": True, "cruise_pct": 65.0},
+            "phase_summary": {
+                "phase_counts": {"cruise": 325},
+                "phase_pcts": {"cruise": 65.0},
+            },
         }
         result = reconstruct_test_run_from_summary(summary)
         assert result.speed_profile is not None

--- a/apps/server/tests/shared/boundaries/test_golden_file_reconstruction.py
+++ b/apps/server/tests/shared/boundaries/test_golden_file_reconstruction.py
@@ -95,20 +95,36 @@ class TestRoundTripParity:
         assert snap.has_acceleration is False
         assert snap.cruise_pct == 0.0
 
-    def test_phase_summary_fallback_to_phase_counts(self) -> None:
+    def test_phase_summary_derives_flags_from_phase_counts(self) -> None:
         snap = driving_phase_summary_from_mapping(
             {"phase_counts": {"cruise": 10, "acceleration": 5}}
         )
         assert snap.has_cruise is True
         assert snap.has_acceleration is True
 
-    def test_phase_summary_fallback_to_phase_pcts(self) -> None:
+    def test_phase_summary_derives_percentages_from_phase_pcts(self) -> None:
         snap = driving_phase_summary_from_mapping(
             {"phase_pcts": {"cruise": 45.0, "idle": 12.0, "speed_unknown": 8.0}}
         )
         assert snap.cruise_pct == pytest.approx(45.0)
         assert snap.idle_pct == pytest.approx(12.0)
         assert snap.speed_unknown_pct == pytest.approx(8.0)
+
+    def test_phase_summary_ignores_legacy_flat_fields_without_canonical_values(self) -> None:
+        snap = driving_phase_summary_from_mapping(
+            {
+                "has_cruise": True,
+                "has_acceleration": True,
+                "cruise_pct": 45.0,
+                "idle_pct": 12.0,
+                "speed_unknown_pct": 8.0,
+            }
+        )
+        assert snap.has_cruise is False
+        assert snap.has_acceleration is False
+        assert snap.cruise_pct == 0.0
+        assert snap.idle_pct == 0.0
+        assert snap.speed_unknown_pct == 0.0
 
     def test_speed_profile_from_typed_snapshots_with_empty_inputs(self) -> None:
         speed_profile = SpeedProfile.from_stats(speed_profile_summary_from_mapping({}))

--- a/apps/server/vibesensor/shared/boundaries/codecs/summaries.py
+++ b/apps/server/vibesensor/shared/boundaries/codecs/summaries.py
@@ -63,30 +63,16 @@ def driving_phase_summary_from_mapping(payload: object) -> DrivingPhaseSummary:
             if isinstance(key, str) and (parsed_pct := _float_from(value)) is not None:
                 phase_pcts[key] = parsed_pct
 
-    def _flag_fallback(key: str, phase_key: str) -> bool:
-        value = payload.get(key)
-        if isinstance(value, bool):
-            return value
-        if value is not None:
-            return bool(value)
-        return phase_counts.get(phase_key, 0) > 0
-
-    def _pct_fallback(key: str, phase_key: str) -> float:
-        value = optional_float(payload.get(key))
-        if value is not None or key in payload:
-            return value or 0.0
-        return phase_pcts.get(phase_key, 0.0)
-
     return DrivingPhaseSummary(
         phase_counts=phase_counts,
         phase_pcts=phase_pcts,
         total_samples=_int_or(payload.get("total_samples")),
         segment_count=_int_or(payload.get("segment_count")),
-        has_cruise=_flag_fallback("has_cruise", "cruise"),
-        has_acceleration=_flag_fallback("has_acceleration", "acceleration"),
-        cruise_pct=_pct_fallback("cruise_pct", "cruise"),
-        idle_pct=_pct_fallback("idle_pct", "idle"),
-        speed_unknown_pct=_pct_fallback("speed_unknown_pct", "speed_unknown"),
+        has_cruise=phase_counts.get("cruise", 0) > 0,
+        has_acceleration=phase_counts.get("acceleration", 0) > 0,
+        cruise_pct=phase_pcts.get("cruise", 0.0),
+        idle_pct=phase_pcts.get("idle", 0.0),
+        speed_unknown_pct=phase_pcts.get("speed_unknown", 0.0),
     )
 
 


### PR DESCRIPTION
## What changed
- remove flat legacy phase-summary fallback helpers from `apps/server/vibesensor/shared/boundaries/codecs/summaries.py`
- derive `DrivingPhaseSummary` flags and percentages only from canonical `phase_counts` / `phase_pcts`
- update focused boundary/domain fixtures so they use or assert the canonical nested shape

## Why
- `#2931` is the last half-migrated phase-summary decode path
- decoder should stop accepting the old flat compatibility shape

## Validation
- `cd apps/server && ../../.venv/bin/python -m pytest -q --noconftest tests/shared/boundaries/test_golden_file_reconstruction.py tests/domain/test_snapshots.py tests/domain/test_test_run_value_objects.py`

## Risks / tradeoffs
- flat-only phase-summary payloads no longer populate flags or percentages
- canonical serialized output stays unchanged

Closes #2931