### PR TITLE
refactor(report): drop active location fallback

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_metrics_consistency.py
+++ b/apps/server/tests/adapters/pdf/test_report_metrics_consistency.py
@@ -431,10 +431,9 @@ class TestScenario5SparseSensors:
 
     def test_sensor_count_accurate(self, scenario: ScenarioPair) -> None:
         summary, rd = scenario
-        connected = summary.get("sensor_locations_connected_throughout") or summary.get(
-            "sensor_locations",
-        )
-        assert rd.sensor_count == len(connected or [])
+        connected = summary.get("sensor_locations_connected_throughout")
+        assert isinstance(connected, list)
+        assert rd.sensor_count == len(connected)
 
     def test_sparse_sensor_contract_degrades_location_granularity(
         self,

--- a/apps/server/tests/adapters/pdf/test_report_pdf_diagram_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_diagram_rendering.py
@@ -277,6 +277,7 @@ def test_build_report_pdf_hotspot_panel_explains_intensity_and_certainty() -> No
             }
         ],
         sensor_locations=["front-left wheel", "front-right wheel"],
+        sensor_locations_connected_throughout=["front-left wheel", "front-right wheel"],
         sensor_intensity_by_location=[
             LocationIntensitySummary(location="front-left wheel", p95_intensity_db=32.0),
             LocationIntensitySummary(location="front-right wheel", p95_intensity_db=18.0),

--- a/apps/server/tests/adapters/pdf/test_summary_view.py
+++ b/apps/server/tests/adapters/pdf/test_summary_view.py
@@ -274,11 +274,11 @@ class TestSummaryHelpers:
         assert prepared.report_facts is not None
         assert prepared.report_facts.sensor.active_locations == ("front_left",)
 
-    def test_sensor_locations_active_fallback(self) -> None:
+    def test_sensor_locations_active_requires_connected_throughout(self) -> None:
         prepared = prepare_report_input(_minimal_summary(sensor_locations_connected_throughout=[]))
         assert prepared.domain_test_run is not None
         assert prepared.report_facts is not None
-        assert "front_left" in prepared.report_facts.sensor.active_locations
+        assert prepared.report_facts.sensor.active_locations == ()
 
     def test_boundary_test_plan_payload_projects_semantic_action_fields(self) -> None:
         projected = step_payloads_from_plan(

--- a/apps/server/tests/shared/boundaries/test_report_payload.py
+++ b/apps/server/tests/shared/boundaries/test_report_payload.py
@@ -101,6 +101,16 @@ def test_report_summary_from_mapping_projects_canonical_metadata_and_rows() -> N
     assert summary.timeline_intervals[0].speed_min_kmh == 58.0
 
 
+def test_report_summary_from_mapping_ignores_sensor_locations_without_connected_throughout() -> None:
+    summary = report_summary_from_mapping(
+        {
+            "sensor_locations": ["front-left", "rear-right"],
+        }
+    )
+
+    assert summary.active_sensor_locations == ()
+
+
 def test_report_summary_from_mapping_drops_non_finite_summary_scalars() -> None:
     summary = report_summary_from_mapping(
         {

--- a/apps/server/tests/shared/boundaries/test_report_payload.py
+++ b/apps/server/tests/shared/boundaries/test_report_payload.py
@@ -101,7 +101,7 @@ def test_report_summary_from_mapping_projects_canonical_metadata_and_rows() -> N
     assert summary.timeline_intervals[0].speed_min_kmh == 58.0
 
 
-def test_report_summary_from_mapping_ignores_sensor_locations_without_connected_throughout() -> None:
+def test_report_summary_requires_connected_active_locations() -> None:
     summary = report_summary_from_mapping(
         {
             "sensor_locations": ["front-left", "rear-right"],

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -116,14 +116,7 @@ class ReportSummaryNormalizer:
     def _active_sensor_locations(self) -> tuple[str, ...]:
         connected = self._payload.get("sensor_locations_connected_throughout")
         locations = connected if isinstance(connected, list) else []
-        active = tuple(str(location).strip() for location in locations if str(location).strip())
-        if active:
-            return active
-        fallback = self._payload.get("sensor_locations")
-        fallback_locations = fallback if isinstance(fallback, list) else []
-        return tuple(
-            str(location).strip() for location in fallback_locations if str(location).strip()
-        )
+        return tuple(str(location).strip() for location in locations if str(location).strip())
 
     def _sensor_intensity_rows(self) -> tuple[LocationIntensitySummary, ...]:
         raw_rows = self._payload.get("sensor_intensity_by_location")


### PR DESCRIPTION
## What changed
- remove the report-side fallback from `sensor_locations_connected_throughout` to `sensor_locations` in `apps/server/vibesensor/shared/boundaries/reporting/summary.py`
- update focused report boundary and PDF tests so active locations only come from the canonical field
- keep `sensor_locations` itself intact where it remains semantically distinct

## Why
- `#2932` is the last report-side active-location compatibility path
- report decoding should stop accepting the older fallback shape

## Validation
- `cd apps/server && ../../.venv/bin/python -m pytest -q --noconftest tests/shared/boundaries/test_report_payload.py tests/adapters/pdf/test_summary_view.py tests/use_cases/history/test_report_preparation_contract.py tests/adapters/pdf/test_report_metrics_consistency.py`

## Risks / tradeoffs
- report-side active locations are empty when the canonical connected-throughout field is missing
- `sensor_locations` remains available for its separate meaning

Closes #2932