### PR TITLE
refactor(car-library): drop CAR_LIBRARY alias

### DIFF
--- a/apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py
+++ b/apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py
@@ -6,14 +6,18 @@ import json
 
 import pytest
 
-from vibesensor.adapters.persistence.car_library import _DATA_FILE, CAR_LIBRARY, resolve_variant
+from vibesensor.adapters.persistence.car_library import (
+    _DATA_FILE,
+    load_car_library,
+    resolve_variant,
+)
 
 _RATIO_SOURCES_FILE = _DATA_FILE.with_name("car_library_ratio_sources.json")
 _VARIANT_SOURCES_FILE = _DATA_FILE.with_name("CAR_VARIANT_SOURCES.md")
 
 
 def _entry_for(model: str) -> dict[str, object]:
-    for entry in CAR_LIBRARY:
+    for entry in load_car_library():
         if entry["brand"] == "BMW" and entry["model"] == model:
             return entry
     raise AssertionError(f"BMW model not found: {model}")

--- a/apps/server/tests/adapters/persistence/test_car_library.py
+++ b/apps/server/tests/adapters/persistence/test_car_library.py
@@ -7,15 +7,21 @@ from pathlib import Path
 import pytest
 
 from vibesensor.adapters.persistence.car_library import (
-    CAR_LIBRARY,
     get_brands,
     get_models_for_brand_type,
     get_types_for_brand,
+    load_car_library,
 )
 
 
 def test_car_library_has_entries() -> None:
-    assert len(CAR_LIBRARY) > 50
+    assert len(load_car_library()) > 50
+
+
+def test_car_library_module_no_longer_exports_compat_alias() -> None:
+    import vibesensor.adapters.persistence.car_library as car_library_module
+
+    assert not hasattr(car_library_module, "CAR_LIBRARY")
 
 
 def test_get_brands_returns_bmw_and_audi() -> None:
@@ -45,7 +51,7 @@ def test_get_models_for_brand_type() -> None:
 
 
 def test_every_entry_has_required_fields() -> None:
-    for entry in CAR_LIBRARY:
+    for entry in load_car_library():
         assert "brand" in entry
         assert "type" in entry
         assert "model" in entry
@@ -72,7 +78,7 @@ def test_every_entry_has_required_fields() -> None:
 
 
 def test_tire_specs_reasonable() -> None:
-    for entry in CAR_LIBRARY:
+    for entry in load_car_library():
         assert entry["tire_width_mm"] >= 175, f"{entry['model']} tire too narrow"
         assert entry["tire_width_mm"] <= 335, f"{entry['model']} tire too wide"
         assert entry["tire_aspect_pct"] >= 20, f"{entry['model']} aspect too low"
@@ -82,7 +88,7 @@ def test_tire_specs_reasonable() -> None:
 
 
 def test_tire_options_specs_within_bounds() -> None:
-    for entry in CAR_LIBRARY:
+    for entry in load_car_library():
         for opt in entry["tire_options"]:
             label = f"{entry['model']} / {opt['name']}"
             assert opt["tire_width_mm"] <= 335, f"{label} width too large"
@@ -93,7 +99,7 @@ def test_tire_options_specs_within_bounds() -> None:
 
 def test_tire_options_standard_matches_base() -> None:
     """The first tire option (Standard) should match the car's base tire specs."""
-    for entry in CAR_LIBRARY:
+    for entry in load_car_library():
         std = entry["tire_options"][0]
         assert std["tire_width_mm"] == entry["tire_width_mm"], entry["model"]
         assert std["tire_aspect_pct"] == entry["tire_aspect_pct"], entry["model"]
@@ -110,7 +116,7 @@ def test_tire_options_count_by_category() -> None:
     perf = ["M3", "M4", "M5", "RS 3", "RS 4", "RS 5", "RS 6", "RS 7", "RS Q8", "R8"]
     ev = ["iX", "i4", "e-tron GT", "Q4 e-tron"]
 
-    for entry in CAR_LIBRARY:
+    for entry in load_car_library():
         model = entry["model"]
         if _matches_prefix(model, perf) or _matches_prefix(model, ev):
             assert len(entry["tire_options"]) == 2, f"{model} should have 2 options"
@@ -122,7 +128,7 @@ def test_tire_option_name_format() -> None:
     """Each option name should end with a rim size in inches."""
     import re
 
-    for entry in CAR_LIBRARY:
+    for entry in load_car_library():
         for opt in entry["tire_options"]:
             assert re.search(r'\d+"$', opt["name"]), f"Bad name format: {opt['name']}"
 
@@ -168,12 +174,10 @@ def _make_bad_data_file(tmp_path: Path, kind: str) -> Path:
 
 @pytest.mark.parametrize("kind", ["missing", "invalid_json", "schema_drift"])
 def test_load_library_handles_bad_data(tmp_path: Path, kind: str) -> None:
-    """_load_library gracefully returns [] when the data file is missing or malformed."""
+    """load_car_library gracefully returns [] when the data file is missing or malformed."""
     from unittest.mock import patch
-
-    from vibesensor.adapters.persistence.car_library import _load_library
 
     fake_path = _make_bad_data_file(tmp_path, kind)
     with patch("vibesensor.adapters.persistence.car_library._DATA_FILE", fake_path):
-        result = _load_library()
+        result = load_car_library()
     assert result == []

--- a/apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py
+++ b/apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator
 
-from vibesensor.adapters.persistence.car_library import _DATA_FILE, CAR_LIBRARY
+from vibesensor.adapters.persistence.car_library import _DATA_FILE, load_car_library
 
 _RATIO_SOURCES_FILE = _DATA_FILE.with_name("car_library_ratio_sources.json")
 _PLACEHOLDER_PHRASE = "preserved pending official-source confirmation"
@@ -153,7 +153,7 @@ def test_ratio_sources_do_not_contain_legacy_audit_wording_or_keys() -> None:
 
 def test_ratio_sources_cover_every_car_library_row() -> None:
     ratio_source_keys = set(_load_ratio_sources())
-    library_keys = {_car_key(entry) for entry in CAR_LIBRARY}
+    library_keys = {_car_key(entry) for entry in load_car_library()}
     assert ratio_source_keys == library_keys
 
 

--- a/apps/server/tests/adapters/persistence/test_car_variants.py
+++ b/apps/server/tests/adapters/persistence/test_car_variants.py
@@ -7,9 +7,9 @@ import json
 import pytest
 
 from vibesensor.adapters.persistence.car_library import (
-    CAR_LIBRARY,
     get_models_for_brand_type,
     get_variants_for_model,
+    load_car_library,
     resolve_variant,
 )
 from vibesensor.shared.types.car_config import car_from_persistence_dict, car_to_persistence_dict
@@ -20,6 +20,10 @@ def _variant_label(entry: dict[str, object], variant: dict[str, object]) -> str:
     return f"{entry['model']} / {variant.get('name', '?')}"
 
 
+def _library_entries() -> list[dict[str, object]]:
+    return load_car_library()
+
+
 # ---------------------------------------------------------------------------
 # Car library JSON structure tests
 # ---------------------------------------------------------------------------
@@ -27,7 +31,7 @@ def _variant_label(entry: dict[str, object], variant: dict[str, object]) -> str:
 
 def test_every_model_has_variants() -> None:
     """Every car library entry must have at least one variant."""
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         assert "variants" in entry, f"{entry['model']} missing variants"
         assert isinstance(entry["variants"], list), f"{entry['model']} variants not a list"
         assert len(entry["variants"]) >= 1, f"{entry['model']} has no variants"
@@ -35,7 +39,7 @@ def test_every_model_has_variants() -> None:
 
 def test_every_variant_has_required_fields() -> None:
     """Each variant must have name and drivetrain."""
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         for v in entry["variants"]:
             label = _variant_label(entry, v)
             assert "name" in v, f"{label} missing name"
@@ -49,7 +53,7 @@ def test_every_variant_has_required_fields() -> None:
 
 def test_variant_names_unique_within_model() -> None:
     """Variant names must be unique within each model."""
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         names = [v["name"] for v in entry["variants"]]
         assert len(names) == len(set(names)), (
             f"{entry['model']} has duplicate variant names: {names}"
@@ -58,7 +62,7 @@ def test_variant_names_unique_within_model() -> None:
 
 def test_variant_gearbox_overrides_valid() -> None:
     """Variant gearbox overrides must be valid (positive ratios)."""
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         for v in entry["variants"]:
             gbs = v.get("gearboxes")
             if not gbs:
@@ -74,7 +78,7 @@ def test_variant_gearbox_overrides_valid() -> None:
 
 def test_variant_tire_overrides_valid() -> None:
     """Variant tire overrides must be within reasonable bounds."""
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         for v in entry["variants"]:
             label = _variant_label(entry, v)
             if "tire_width_mm" in v and v["tire_width_mm"] is not None:
@@ -106,7 +110,7 @@ def test_get_variants_for_model_unknown_returns_empty() -> None:
 
 def test_resolve_variant_no_variant() -> None:
     """resolve_variant with None returns base entry."""
-    base = CAR_LIBRARY[0]
+    base = _library_entries()[0]
     resolved = resolve_variant(base, None)
     assert resolved["gearboxes"] == base["gearboxes"]
     assert resolved["tire_options"] == base["tire_options"]
@@ -115,7 +119,7 @@ def test_resolve_variant_no_variant() -> None:
 def test_resolve_variant_inherits_base_gearboxes() -> None:
     """Variant without gearbox override inherits base gearboxes."""
     # Find a model where first variant has no gearbox override
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         first_v = entry["variants"][0]
         if not first_v.get("gearboxes"):
             resolved = resolve_variant(entry, first_v["name"])
@@ -126,7 +130,7 @@ def test_resolve_variant_inherits_base_gearboxes() -> None:
 def test_resolve_variant_overrides_gearboxes() -> None:
     """Variant with gearbox override replaces base gearboxes."""
     # BMW M3 G80 variants have gearbox overrides
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         if entry["model"] == "M3 (G80, 2021-2026)":
             # "M3 Competition" has only automatic
             resolved = resolve_variant(entry, "M3 Competition")
@@ -139,7 +143,7 @@ def test_resolve_variant_overrides_gearboxes() -> None:
 
 def test_resolve_variant_g20_330i_xdrive_uses_verified_automatic_ratio() -> None:
     """G20 330i xDrive keeps the automatic-only gearbox override with the verified ratio."""
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         if entry["brand"] == "BMW" and entry["model"] == "3 Series (G20, 2019-2025)":
             resolved = resolve_variant(entry, "330i xDrive")
             assert resolved["gearboxes"] == [
@@ -171,7 +175,7 @@ def test_resolve_variant_audi_b9_fy_s_tronic_uses_verified_final_drives(
     model: str, variant: str, expected_final_drive_ratio: float
 ) -> None:
     """Audi B9/FY S tronic entries keep the verified final-drive ratios from Audi docs."""
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         if entry["brand"] == "Audi" and entry["model"] == model:
             resolved = resolve_variant(entry, variant)
             s_tronic = next(
@@ -210,7 +214,7 @@ def test_audi_models_include_verified_tdi_variants(
     model: str, variant: str, expected_engine: str, expected_drivetrain: str
 ) -> None:
     """Audi core European-market models keep the verified TDI coverage added for #974."""
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         if entry["brand"] == "Audi" and entry["model"] == model:
             variant_entry = next(
                 candidate for candidate in entry["variants"] if candidate["name"] == variant
@@ -286,7 +290,7 @@ def test_bev_models_match_verified_motor_layouts(
     model: str, expected_electric_variants: dict[str, tuple[str, str]]
 ) -> None:
     """Supported BEV entries keep the verified motor-layout variants from issue #975."""
-    for entry in CAR_LIBRARY:
+    for entry in _library_entries():
         if entry["model"] == model:
             actual_electric_variants = {
                 variant["name"]: (variant["engine"], variant["drivetrain"])
@@ -301,7 +305,7 @@ def test_bev_models_match_verified_motor_layouts(
 
 def test_resolve_variant_unknown_name_returns_base() -> None:
     """resolve_variant with unknown name returns base entry unchanged."""
-    base = CAR_LIBRARY[0]
+    base = _library_entries()[0]
     resolved = resolve_variant(base, "nonexistent_variant")
     assert resolved["gearboxes"] == base["gearboxes"]
 
@@ -391,5 +395,5 @@ def test_car_library_json_parseable() -> None:
 
 def test_total_variant_count() -> None:
     """Sanity check: the library has a reasonable number of variants."""
-    total = sum(len(e.get("variants", [])) for e in CAR_LIBRARY)
+    total = sum(len(e.get("variants", [])) for e in _library_entries())
     assert total >= 150, f"Only {total} variants total, expected >=150"

--- a/apps/server/tests/hygiene/test_car_library_artifact_sync.py
+++ b/apps/server/tests/hygiene/test_car_library_artifact_sync.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from vibesensor.adapters.persistence.car_library import _DATA_FILE, CAR_LIBRARY
+from vibesensor.adapters.persistence.car_library import _DATA_FILE, load_car_library
 
 _RATIO_SOURCES_FILE = _DATA_FILE.with_name("car_library_ratio_sources.json")
 _VARIANT_SOURCES_FILE = _DATA_FILE.with_name("CAR_VARIANT_SOURCES.md")
@@ -60,7 +60,7 @@ def _variant_rows_from_docs() -> dict[str, list[tuple[str, str, str]]]:
 
 def _variant_rows_from_library() -> dict[str, list[tuple[str, str, str]]]:
     rows: dict[str, list[tuple[str, str, str]]] = {}
-    for entry in CAR_LIBRARY:
+    for entry in load_car_library():
         rows[_car_key(entry)] = [
             (variant["name"], variant["engine"], variant["drivetrain"])
             for variant in entry["variants"]

--- a/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
+++ b/apps/server/tests/integration/test_review_guardrails_extended_regressions.py
@@ -17,9 +17,9 @@ import vibesensor.adapters.udp.udp_control_tx as udp_control_tx_mod
 import vibesensor.shared.locations as locations_mod
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 from vibesensor.adapters.persistence.car_library import (
-    CAR_LIBRARY,
     get_models_for_brand_type,
     get_variants_for_model,
+    load_car_library,
 )
 from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
 from vibesensor.adapters.websocket.hub import _ws_debug_enabled
@@ -116,23 +116,25 @@ class TestCarLibraryCopies:
     """Verify car-library query helpers return copies rather than mutable internals."""
 
     def test_get_models_returns_copies(self) -> None:
-        if not CAR_LIBRARY:
+        library = load_car_library()
+        if not library:
             pytest.skip("No car library data loaded")
-        brand = CAR_LIBRARY[0].get("brand")
-        car_type = CAR_LIBRARY[0].get("type")
+        brand = library[0].get("brand")
+        car_type = library[0].get("type")
         models = get_models_for_brand_type(brand, car_type)
         if not models:
             pytest.skip("No models found")
         # Mutate the returned dict
         models[0]["MUTATED"] = True
         # Original library should NOT be mutated
-        for entry in CAR_LIBRARY:
+        for entry in load_car_library():
             assert "MUTATED" not in entry
 
     def test_get_variants_returns_copies(self) -> None:
-        if not CAR_LIBRARY:
+        library = load_car_library()
+        if not library:
             pytest.skip("No car library data loaded")
-        for entry in CAR_LIBRARY:
+        for entry in library:
             variants = entry.get("variants") or []
             if variants:
                 result = get_variants_for_model(entry["brand"], entry["type"], entry["model"])

--- a/apps/server/vibesensor/adapters/persistence/car_library.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library.py
@@ -19,11 +19,11 @@ from vibesensor.shared._data_files import resolve_static_data_file
 LOGGER = logging.getLogger(__name__)
 
 __all__ = [
-    "CAR_LIBRARY",
     "CarLibraryEntry",
     "get_brands",
     "get_models_for_brand_type",
     "get_types_for_brand",
+    "load_car_library",
     "get_variants_for_model",
     "resolve_variant",
 ]
@@ -116,23 +116,25 @@ def _load_library() -> list[CarLibraryEntry]:
         return []
 
 
-# Eagerly loaded; on transient failures the module-level list stays empty
-# but callers can call ``_load_library()`` again to retry.
+# Query helpers reuse one import-time snapshot; explicit loaders can call
+# ``load_car_library()`` when they need a fresh validated read from disk.
+_CAR_LIBRARY: list[CarLibraryEntry] = _load_library()
 
 
-# Module-level alias keeps
-# ``from vibesensor.adapters.persistence.car_library import CAR_LIBRARY`` working.
-CAR_LIBRARY: list[CarLibraryEntry] = _load_library()
+def load_car_library() -> list[CarLibraryEntry]:
+    """Load and return a fresh validated car-library snapshot."""
+
+    return _load_library()
 
 
 def get_brands() -> list[str]:
     """Return sorted list of unique brands in the library."""
-    return sorted({entry["brand"] for entry in CAR_LIBRARY})
+    return sorted({entry["brand"] for entry in _CAR_LIBRARY})
 
 
 def get_types_for_brand(brand: str) -> list[str]:
     """Return sorted body types available for *brand*."""
-    return sorted({entry["type"] for entry in CAR_LIBRARY if entry["brand"] == brand})
+    return sorted({entry["type"] for entry in _CAR_LIBRARY if entry["brand"] == brand})
 
 
 def get_models_for_brand_type(brand: str, car_type: str) -> list[CarLibraryEntry]:
@@ -142,7 +144,7 @@ def get_models_for_brand_type(brand: str, car_type: str) -> list[CarLibraryEntry
     """
     return [
         _deep_copy_entry(entry)
-        for entry in CAR_LIBRARY
+        for entry in _CAR_LIBRARY
         if entry["brand"] == brand and entry["type"] == car_type
     ]
 
@@ -152,7 +154,7 @@ def get_variants_for_model(brand: str, car_type: str, model: str) -> list[CarLib
 
     Returns deep copies so callers cannot corrupt the cached library.
     """
-    for entry in CAR_LIBRARY:
+    for entry in _CAR_LIBRARY:
         if _entry_matches_identity(entry, brand=brand, car_type=car_type, model=model):
             return _deep_copy_variants(entry["variants"])
     return []


### PR DESCRIPTION
## What change
- remove exported `CAR_LIBRARY` compatibility alias from `car_library.py`
- add explicit `load_car_library()` API for fresh raw-list reads
- keep query helpers on private cached `_CAR_LIBRARY`
- migrate focused backend car-library tests off the alias
- add guard that the module no longer exports `CAR_LIBRARY`

## Why
- alias was repo-local compatibility code only
- all callers live in this repo, so explicit loader/query APIs are cleaner than preserving the old import path

## Validation
- `cd apps/server && ../../.venv/bin/python -m ruff check vibesensor/adapters/persistence/car_library.py tests/adapters/persistence/test_car_library.py tests/adapters/persistence/test_car_variants.py tests/adapters/persistence/test_car_library_ratio_sources.py tests/adapters/persistence/test_bmw_car_library_mismatches.py tests/hygiene/test_car_library_artifact_sync.py tests/integration/test_review_guardrails_extended_regressions.py`
- `cd apps/server && ../../.venv/bin/python -m pytest -q --noconftest tests/adapters/persistence/test_car_library.py tests/adapters/persistence/test_car_variants.py tests/adapters/persistence/test_car_library_ratio_sources.py tests/adapters/persistence/test_bmw_car_library_mismatches.py tests/hygiene/test_car_library_artifact_sync.py tests/integration/test_review_guardrails_extended_regressions.py` (`110 passed`)

## Risk / tradeoffs
- small intentional repo-local breaking change: direct `CAR_LIBRARY` imports now fail
- query semantics and car-library JSON schema stay unchanged
- raw-list callers now do explicit loads instead of sharing the old module alias

Closes #2933