### PR TITLE
refactor(ui): drop CSS alias tokens

### DIFF
--- a/apps/ui/src/styles/components.css
+++ b/apps/ui/src/styles/components.css
@@ -4,15 +4,15 @@ button,
 .btn {
   height: 38px;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--md-sys-color-outline);
   padding: 0 var(--space-3);
   font-size: 0.93rem;
 }
 
 select,
 input {
-  background: var(--surface);
-  color: var(--text);
+  background: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
 }
 
 .lang-picker,
@@ -21,8 +21,8 @@ input {
 .menu {
   margin: 0;
   display: inline-flex;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
+  background: var(--md-sys-color-surface-container-high);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: 999px;
   padding: 4px;
   gap: 4px;
@@ -32,7 +32,7 @@ input {
   border: 0;
   border-radius: 999px;
   background: transparent;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   padding: 0.5rem 1rem;
   font-weight: 600;
   cursor: pointer;
@@ -41,11 +41,11 @@ input {
 
 .menu-btn:hover {
   background: var(--menu-hover);
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
 }
 
 .menu-btn[aria-selected="true"] {
-  background: var(--brand-500);
+  background: var(--md-sys-color-primary);
   color: var(--on-fill);
   box-shadow: none;
 }
@@ -58,7 +58,7 @@ button,
   font-weight: 700;
   letter-spacing: 0.01em;
   cursor: pointer;
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   color: var(--md-sys-color-on-surface);
   border-color: var(--md-sys-color-outline);
   box-shadow: none;
@@ -67,9 +67,9 @@ button,
 
 button:hover,
 .btn:hover {
-  border-color: var(--border-strong);
+  border-color: var(--md-sys-color-outline);
   box-shadow: none;
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   transform: none;
 }
 button:active,
@@ -81,7 +81,7 @@ button:active,
 
 .btn--primary,
 button.primary {
-  background: var(--brand-500);
+  background: var(--md-sys-color-primary);
   border-color: var(--brand-600);
   color: var(--on-fill);
 }
@@ -93,14 +93,14 @@ button.primary:hover {
 
 .btn--success,
 button.success {
-  background: var(--success);
+  background: var(--md-sys-color-tertiary);
   border-color: var(--success-700);
   color: var(--on-fill);
 }
 
 .btn--danger,
 button.warn {
-  background: var(--danger);
+  background: var(--md-sys-color-error);
   border-color: var(--danger-700);
   color: var(--on-fill);
 }
@@ -129,7 +129,7 @@ button:focus-visible,
 select:focus-visible,
 input:focus-visible,
 .menu-btn:focus-visible {
-  outline: 2px solid var(--focus);
+  outline: 2px solid var(--md-sys-color-focus);
   outline-offset: 2px;
 }
 
@@ -162,9 +162,9 @@ button[hidden],
 
 .card,
 .panel {
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-md);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   box-shadow: none;
   padding: var(--space-4);
 }
@@ -182,7 +182,7 @@ button[hidden],
 .card__title { margin: 0; font-size: 1rem; font-weight: 700; }
 .card__subtle,
 .subtle,
-.mini-label { color: var(--muted); font-size: 0.86rem; }
+.mini-label { color: var(--md-sys-color-on-surface-variant); font-size: 0.86rem; }
 
 .empty-state {
   position: absolute;
@@ -193,10 +193,10 @@ button[hidden],
   justify-content: center;
   text-align: center;
   gap: var(--space-1);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
   background: rgba(248, 249, 251, 0.94);
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   padding: var(--space-4);
 }
 .empty-state::before {
@@ -213,22 +213,22 @@ button[hidden],
   justify-content: flex-start;
   text-align: left;
   margin: var(--space-3) 0;
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
 }
 .empty-state--actionable {
   gap: var(--space-2);
 }
 .empty-state__title {
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
   font-size: 0.95rem;
   line-height: 1.35;
 }
 .empty-state__body {
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
   line-height: 1.45;
 }
 .empty-state__detail {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.82rem;
   line-height: 1.45;
 }
@@ -252,7 +252,7 @@ button[hidden],
 }
 
 .stat { min-height: 72px; }
-.stat__label { font-size: 0.76rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted); }
+.stat__label { font-size: 0.76rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--md-sys-color-on-surface-variant); }
 .stat__value { margin-top: var(--space-1); font-size: 1.1rem; font-weight: 700; overflow-wrap: anywhere; }
 .stat__value[data-variant] { color: var(--variant-text); }
 .stat__value[data-has-icon="true"] {
@@ -303,7 +303,7 @@ button[hidden],
   width: min(520px, calc(100vw - 2rem));
   display: grid;
   gap: var(--space-3);
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--md-sys-color-outline);
   box-shadow: 0 28px 80px rgba(15, 23, 42, 0.24);
 }
 
@@ -318,7 +318,7 @@ button[hidden],
 
 .confirmation-dialog__message {
   margin: 0;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
   white-space: pre-wrap;
 }
 
@@ -329,11 +329,11 @@ button[hidden],
   gap: var(--space-2);
 }
 
-.uplot { color: var(--text); font-family: inherit; }
+.uplot { color: var(--md-sys-color-on-surface); font-family: inherit; }
 .uplot .u-title,
 .uplot .u-label,
-.uplot .u-legend { color: var(--muted); }
-.uplot .u-axis text { fill: var(--muted); }
+.uplot .u-legend { color: var(--md-sys-color-on-surface-variant); }
+.uplot .u-axis text { fill: var(--md-sys-color-on-surface-variant); }
 .uplot .u-axis line,
 .uplot .u-grid line { stroke: var(--chart-grid); }
 .uplot .u-select { background: rgba(124, 58, 237, 0.12); }

--- a/apps/ui/src/styles/history-adaptive.css
+++ b/apps/ui/src/styles/history-adaptive.css
@@ -37,9 +37,9 @@
       "started samples"
       "actions actions";
     gap: var(--space-2);
-    border: 1px solid var(--border);
+    border: 1px solid var(--md-sys-color-outline-variant);
     border-radius: var(--radius-sm);
-    background: var(--surface);
+    background: var(--md-sys-color-surface-container);
     padding: var(--space-3);
     cursor: default;
   }
@@ -74,7 +74,7 @@
 
   .history-row__run-id {
     font-size: 0.76rem;
-    color: var(--muted);
+    color: var(--md-sys-color-on-surface-variant);
     font-weight: 600;
   }
 
@@ -98,7 +98,7 @@
     justify-content: flex-start;
     padding: 0.45rem 0.75rem;
     border: 1px solid var(--brand-400);
-    background: linear-gradient(180deg, rgba(139, 92, 246, 0.08), var(--surface));
+    background: linear-gradient(180deg, rgba(139, 92, 246, 0.08), var(--md-sys-color-surface-container));
     white-space: normal;
   }
 
@@ -115,9 +115,9 @@
     gap: 0.35rem;
     align-content: start;
     padding: var(--space-2) var(--space-3);
-    border: 1px solid var(--border);
+    border: 1px solid var(--md-sys-color-outline-variant);
     border-radius: var(--radius-sm);
-    background: var(--surface-2);
+    background: var(--md-sys-color-surface-container-high);
   }
 
   .history-row__meta-cell.numeric {
@@ -130,7 +130,7 @@
     font-weight: 700;
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: var(--muted);
+    color: var(--md-sys-color-on-surface-variant);
   }
 
   .history-row__meta-value {

--- a/apps/ui/src/styles/history-detail.css
+++ b/apps/ui/src/styles/history-detail.css
@@ -6,9 +6,9 @@
 
 .history-details-card {
   margin: var(--space-2) 0 var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   padding: var(--space-4);
   display: grid;
   gap: var(--space-3);
@@ -38,7 +38,7 @@
 .history-details-header__title {
   font-size: 1.02rem;
   font-weight: 700;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
 }
 
 .history-details-header__actions {
@@ -48,14 +48,14 @@
 }
 
 .history-details-header__status {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.84rem;
   line-height: 1.45;
   text-align: right;
 }
 
 .history-run-summary {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.82rem;
   line-height: 1.45;
 }
@@ -66,9 +66,9 @@
   gap: var(--space-3);
   align-items: start;
   padding: var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-md);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
 }
 
 .history-details-footer__copy {
@@ -82,11 +82,11 @@
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .history-details-footer__body {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.84rem;
   line-height: 1.45;
   max-width: 34rem;
@@ -144,9 +144,9 @@
 
 .history-evidence-panel,
 .history-insights-block {
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-md);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   padding: var(--space-3);
 }
 
@@ -170,7 +170,7 @@
 
 .history-heatmap__title {
   font-weight: 600;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.82rem;
 }
 
@@ -185,16 +185,16 @@
 }
 
 .history-heatmap__zone {
-  --history-heatmap-accent: var(--border);
+  --history-heatmap-accent: var(--md-sys-color-outline-variant);
   --history-heatmap-fill: 0%;
   display: grid;
   gap: 0.55rem;
   align-content: start;
   min-height: 5.75rem;
   padding: var(--space-2);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
@@ -207,12 +207,12 @@
 }
 
 .history-heatmap__zone--empty {
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   border-style: dashed;
 }
 
 .history-heatmap__zone--empty::before {
-  background: var(--border);
+  background: var(--md-sys-color-outline-variant);
   opacity: 0.7;
 }
 
@@ -227,19 +227,19 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   line-height: 1.3;
 }
 
 .history-heatmap__zone-value {
   font-size: 1rem;
   font-weight: 700;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
   font-variant-numeric: tabular-nums;
 }
 
 .history-heatmap__zone-value--empty {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.88rem;
   font-weight: 600;
 }
@@ -247,7 +247,7 @@
 .history-heatmap__zone-meter {
   height: 0.4rem;
   border-radius: 999px;
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   overflow: hidden;
 }
 
@@ -269,11 +269,11 @@
   display: inline-flex;
   align-items: center;
   padding: 0.35rem 0.65rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: 999px;
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   font-size: 0.78rem;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .history-panel-header {
@@ -293,10 +293,10 @@
 .history-panel-state {
   margin-top: var(--space-3);
   padding: var(--space-3);
-  border: 1px dashed var(--border);
+  border: 1px dashed var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
-  color: var(--muted);
+  background: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.88rem;
   line-height: 1.45;
 }
@@ -320,22 +320,22 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .history-findings-overview__headline {
   font-size: 1.15rem;
   font-weight: 700;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
 }
 
 .history-diagnosis-card {
   display: grid;
   gap: var(--space-3);
   padding: var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-md);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
 }
 
 .history-diagnosis-card--success {
@@ -363,7 +363,7 @@
 }
 
 .history-diagnosis-card__signature {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.88rem;
   font-weight: 600;
 }
@@ -391,7 +391,7 @@
 
 .history-findings-overview__explanation {
   margin: 0;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   line-height: 1.45;
 }
 
@@ -406,13 +406,13 @@
   gap: 0.25rem;
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
 }
 
 .history-findings-chip__label {
   font-size: 0.76rem;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -440,20 +440,20 @@
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .history-secondary-findings__more {
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   padding: var(--space-2) var(--space-3);
 }
 
 .history-secondary-findings__more summary {
   cursor: pointer;
   font-weight: 600;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
 }
 
 .history-secondary-findings__more[open] {
@@ -469,12 +469,12 @@
   gap: var(--space-2);
   padding: var(--space-3);
   border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  background: var(--surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface-container);
 }
 
 .history-finding-card--secondary {
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
 }
 
 .history-finding-card--success {
@@ -486,7 +486,7 @@
 }
 
 .history-finding-card--empty {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .history-finding-card__header {
@@ -508,7 +508,7 @@
 }
 
 .history-finding-card__signal {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.82rem;
   font-weight: 600;
 }
@@ -544,14 +544,14 @@
   display: grid;
   gap: 0.2rem;
   padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
 }
 
 .history-finding-card__label {
   font-size: 0.74rem;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }

--- a/apps/ui/src/styles/history-table.css
+++ b/apps/ui/src/styles/history-table.css
@@ -6,7 +6,7 @@
 
 .history-table th,
 .history-table td {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
   padding: 0.6rem;
   text-align: left;
   vertical-align: middle;
@@ -19,8 +19,8 @@
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--muted);
-  background: var(--surface-2);
+  color: var(--md-sys-color-on-surface-variant);
+  background: var(--md-sys-color-surface-container-high);
 }
 
 .history-table tbody tr:nth-child(even) td { background: var(--row-even); }
@@ -46,7 +46,7 @@
 
 .history-row__run-id {
   font-size: 0.78rem;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-weight: 600;
   overflow-wrap: anywhere;
 }
@@ -61,13 +61,13 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .history-row__car-name {
   font-size: 1rem;
   font-weight: 700;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
   overflow-wrap: anywhere;
 }
 
@@ -80,10 +80,10 @@
 .history-row__summary-chip {
   display: inline-flex;
   align-items: center;
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: 999px;
-  background: var(--surface);
-  color: var(--text);
+  background: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
   padding: 0.14rem 0.5rem;
   font-size: 0.74rem;
   line-height: 1.35;
@@ -108,8 +108,8 @@
 }
 
 .history-row__summary-chip--muted {
-  color: var(--muted);
-  background: var(--surface-2);
+  color: var(--md-sys-color-on-surface-variant);
+  background: var(--md-sys-color-surface-container-high);
 }
 
 .history-row__summary-chip--source {
@@ -138,12 +138,12 @@
 .history-row__diagnosis-title {
   font-size: 0.92rem;
   font-weight: 700;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
   overflow-wrap: anywhere;
 }
 
 .history-row__diagnosis-meta {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.8rem;
   line-height: 1.4;
   overflow-wrap: anywhere;
@@ -179,7 +179,7 @@
 }
 
 .history-row__toggle:focus-visible {
-  outline: 2px solid var(--focus);
+  outline: 2px solid var(--md-sys-color-focus);
   outline-offset: 2px;
 }
 
@@ -237,7 +237,7 @@
 }
 
 .history-row__action-hint {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.76rem;
   line-height: 1.45;
   text-align: right;
@@ -257,11 +257,11 @@
   margin-top: var(--space-2);
 }
 
-.history-row[data-expanded="true"] td { background: var(--surface-2) !important; }
+.history-row[data-expanded="true"] td { background: var(--md-sys-color-surface-container-high) !important; }
 
 .history-inline-error {
   display: inline-flex;
-  color: var(--danger);
+  color: var(--md-sys-color-error);
   font-size: 0.82rem;
 }
 
@@ -285,7 +285,7 @@
 }
 
 .history-toolbar__summary {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.9rem;
   line-height: 1.45;
 }

--- a/apps/ui/src/styles/maintenance-cards.css
+++ b/apps/ui/src/styles/maintenance-cards.css
@@ -1,16 +1,16 @@
 .maintenance-card {
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   padding: var(--space-3);
 }
 
 .maintenance-card--hero {
-  border-color: color-mix(in srgb, var(--brand-400) 24%, var(--border));
+  border-color: color-mix(in srgb, var(--brand-400) 24%, var(--md-sys-color-outline-variant));
   background: linear-gradient(
     180deg,
-    color-mix(in srgb, var(--menu-hover) 42%, var(--surface-2)),
-    var(--surface-2)
+    color-mix(in srgb, var(--menu-hover) 42%, var(--md-sys-color-surface-container-high)),
+    var(--md-sys-color-surface-container-high)
   );
 }
 
@@ -40,10 +40,10 @@
 .status-grid {
   display: grid;
   gap: 1px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
   overflow: hidden;
-  background: var(--border);
+  background: var(--md-sys-color-outline-variant);
 }
 
 .status-grid__row {
@@ -52,19 +52,19 @@
   justify-content: space-between;
   gap: var(--space-3);
   padding: var(--space-2) var(--space-3);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
 }
 
 .status-grid__label {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-weight: 600;
 }
 
 .maintenance-note {
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface);
-  color: var(--muted);
+  background: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface-variant);
   padding: var(--space-2) var(--space-3);
 }
 

--- a/apps/ui/src/styles/maintenance-details.css
+++ b/apps/ui/src/styles/maintenance-details.css
@@ -8,9 +8,9 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.78rem;
   line-height: 1.45;
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   padding: var(--space-3);
 }
 
@@ -25,9 +25,9 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.78rem;
   line-height: 1.45;
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   padding: var(--space-3);
   white-space: pre-wrap;
 }
@@ -54,14 +54,14 @@
 .maintenance-attempt {
   display: grid;
   gap: var(--space-2);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   padding: var(--space-2) var(--space-3);
 }
 
 .issue-phase {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-weight: 700;
 }
 

--- a/apps/ui/src/styles/maintenance-journey.css
+++ b/apps/ui/src/styles/maintenance-journey.css
@@ -2,9 +2,9 @@
   display: grid;
   gap: var(--space-2);
   padding: var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
 }
 
 .maintenance-stage-list {
@@ -22,8 +22,8 @@
   align-items: start;
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  background: var(--surface-2);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface-container-high);
   transition:
     border-color 180ms ease,
     background-color 180ms ease,
@@ -75,7 +75,7 @@
 }
 
 .maintenance-stage__detail {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.84rem;
   line-height: 1.45;
   transition: color 180ms ease;
@@ -83,11 +83,11 @@
 
 @keyframes maintenance-stage-live-pulse {
   0%, 100% {
-    box-shadow: inset 0 0 0 1px var(--brand-500);
+    box-shadow: inset 0 0 0 1px var(--md-sys-color-primary);
   }
   50% {
     box-shadow:
-      inset 0 0 0 1px var(--brand-500),
+      inset 0 0 0 1px var(--md-sys-color-primary),
       0 0 0 0.22rem rgba(139, 92, 246, 0.12);
   }
 }
@@ -104,20 +104,20 @@
 }
 
 .maintenance-stage[data-stage-state="active"] {
-  border-color: var(--brand-500);
+  border-color: var(--md-sys-color-primary);
   background: var(--menu-hover);
-  box-shadow: inset 0 0 0 1px var(--brand-500);
+  box-shadow: inset 0 0 0 1px var(--md-sys-color-primary);
   animation: maintenance-stage-live-pulse 1.6s ease-in-out infinite;
 }
 
 .maintenance-stage[data-stage-state="active"] .maintenance-stage__marker {
-  background: var(--brand-500);
+  background: var(--md-sys-color-primary);
   color: var(--on-fill);
   animation: maintenance-stage-marker-pulse 1.6s ease-in-out infinite;
 }
 
 .maintenance-stage[data-stage-state="active"] .maintenance-stage__state {
-  background: var(--brand-500);
+  background: var(--md-sys-color-primary);
   color: var(--on-fill);
 }
 
@@ -128,7 +128,7 @@
 
 .maintenance-stage[data-stage-state="done"] .maintenance-stage__marker,
 .maintenance-stage[data-stage-state="done"] .maintenance-stage__state {
-  background: var(--success);
+  background: var(--md-sys-color-tertiary);
   color: var(--on-fill);
 }
 
@@ -143,6 +143,6 @@
 
 .maintenance-stage[data-stage-state="attention"] .maintenance-stage__marker,
 .maintenance-stage[data-stage-state="attention"] .maintenance-stage__state {
-  background: var(--danger);
+  background: var(--md-sys-color-error);
   color: var(--on-fill);
 }

--- a/apps/ui/src/styles/maintenance-readiness.css
+++ b/apps/ui/src/styles/maintenance-readiness.css
@@ -1,9 +1,9 @@
 .maintenance-readiness {
   display: grid;
   gap: var(--space-2);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   padding: var(--space-3);
 }
 
@@ -26,11 +26,11 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .maintenance-readiness__summary {
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
   font-size: 0.92rem;
   font-weight: 600;
 }
@@ -49,9 +49,9 @@
   gap: var(--space-2);
   align-items: flex-start;
   padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
 }
 
 .maintenance-readiness__marker {
@@ -80,7 +80,7 @@
 }
 
 .maintenance-readiness__detail {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.84rem;
   line-height: 1.45;
 }

--- a/apps/ui/src/styles/realtime-logging.css
+++ b/apps/ui/src/styles/realtime-logging.css
@@ -26,9 +26,9 @@
 
 .capture-readiness {
   margin-top: var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-md);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   padding: var(--space-3);
 }
 
@@ -38,7 +38,7 @@
 
 .capture-readiness__title {
   margin-bottom: var(--space-2);
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -51,9 +51,9 @@
 }
 
 .capture-readiness__item {
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   padding: var(--space-2) var(--space-3);
 }
 
@@ -102,7 +102,7 @@
 
 .capture-readiness__detail {
   margin-top: 4px;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.9rem;
   line-height: 1.45;
 }
@@ -134,9 +134,9 @@
 
 .stat--compact {
   min-height: 0;
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   padding: var(--space-3);
 }
 

--- a/apps/ui/src/styles/realtime-overview.css
+++ b/apps/ui/src/styles/realtime-overview.css
@@ -54,9 +54,9 @@
   min-width: 0;
   display: grid;
   gap: var(--space-1);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   padding: var(--space-3);
 }
 
@@ -93,7 +93,7 @@
 
 .live-sensor-card[data-strongest="true"] {
   border-color: rgba(124, 58, 237, 0.35);
-  background: linear-gradient(180deg, rgba(139, 92, 246, 0.08), var(--surface-2));
+  background: linear-gradient(180deg, rgba(139, 92, 246, 0.08), var(--md-sys-color-surface-container-high));
 }
 
 .live-sensor-card[data-strongest="true"]::before {
@@ -102,7 +102,7 @@
   inset: 0 auto 0 0;
   width: 4px;
   border-radius: var(--radius-sm) 0 0 var(--radius-sm);
-  background: var(--brand-500);
+  background: var(--md-sys-color-primary);
 }
 
 .live-sensor-card[data-strongest="true"] .live-sensor-card__header strong {

--- a/apps/ui/src/styles/realtime-spectrum.css
+++ b/apps/ui/src/styles/realtime-spectrum.css
@@ -18,9 +18,9 @@
   margin-top: var(--space-3);
   display: grid;
   gap: var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   padding: var(--space-3);
   scroll-margin-top: calc((var(--space-6) * 2) + var(--space-4));
 }
@@ -36,18 +36,18 @@
   scroll-margin-top: calc((var(--space-6) * 2) + var(--space-4));
 }
 #specChart {
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   overflow: hidden;
   scroll-margin-top: calc((var(--space-6) * 2) + var(--space-4));
 }
 .spectrum-inspector {
   margin-top: 0;
-  color: var(--text);
-  border: 1px solid var(--border);
+  color: var(--md-sys-color-on-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   padding: var(--space-2) var(--space-3);
   font-size: 0.88rem;
   line-height: 1.45;
@@ -86,9 +86,9 @@
   min-height: 44px;
   display: inline-flex;
   align-items: center;
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   color: inherit;
   padding: var(--space-2) var(--space-3);
   font: inherit;
@@ -103,13 +103,13 @@
 .legend-item--interactive[data-legend-state="active"] {
   border-color: var(--brand-600);
   box-shadow: inset 0 0 0 1px var(--brand-600);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
 }
 .legend-item--interactive[data-legend-state="muted"] {
   opacity: 1;
   border-style: dashed;
-  background: var(--surface);
-  color: var(--text);
+  background: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
 }
 .legend-item--reset {
   justify-content: center;
@@ -124,14 +124,14 @@
   overflow-wrap: anywhere;
 }
 .legend-item__meta {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.74rem;
   line-height: 1.4;
 }
 .legend-item--band {
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: 999px;
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   padding: 0.35rem 0.65rem;
 }
 .legend-item--band[data-band-state="active"] {
@@ -139,8 +139,8 @@
   box-shadow: inset 0 0 0 1px var(--band-color, var(--brand-600));
 }
 .legend-item--band[data-band-state="empty"] {
-  color: var(--muted);
-  background: var(--surface);
+  color: var(--md-sys-color-on-surface-variant);
+  background: var(--md-sys-color-surface-container);
 }
 .swatch {
   width: 12px;

--- a/apps/ui/src/styles/settings-cars-wizard.css
+++ b/apps/ui/src/styles/settings-cars-wizard.css
@@ -20,7 +20,7 @@
   max-height: calc(100vh - 2rem);
   margin: clamp(1rem, 3vw, 2rem) auto;
   overflow: auto;
-  border: 1px solid var(--border-strong);
+  border: 1px solid var(--md-sys-color-outline);
   box-shadow: 0 28px 80px rgba(15, 23, 42, 0.24);
 }
 .wizard-header {
@@ -43,7 +43,7 @@
   border-radius: 999px;
   border: 1px solid rgba(139, 92, 246, 0.2);
   background: rgba(139, 92, 246, 0.08);
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
   font-size: 0.88rem;
   font-weight: 600;
 }
@@ -54,13 +54,13 @@
   font-size: 1.4rem;
   cursor: pointer;
   padding: 0 8px;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   min-width: 2.5rem;
   min-height: 2.5rem;
 }
 .wizard-close:hover {
-  color: var(--text);
-  background: var(--surface-2);
+  color: var(--md-sys-color-on-surface);
+  background: var(--md-sys-color-surface-container-high);
 }
 .wizard-shell {
   display: grid;
@@ -97,9 +97,9 @@
   padding: 0.7rem 1rem;
   font-size: 0.85rem;
   font-weight: 600;
-  background: var(--surface-2);
-  color: var(--muted);
-  border: 1px solid var(--border);
+  background: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface-variant);
+  border: 1px solid var(--md-sys-color-outline-variant);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
 .wizard-step-dot__number {
@@ -118,13 +118,13 @@
   line-height: 1.2;
 }
 .wizard-step-dot[data-step-state="active"] {
-  border-color: var(--brand-500);
+  border-color: var(--md-sys-color-primary);
   background: var(--menu-hover);
-  color: var(--text);
-  box-shadow: inset 0 0 0 1px var(--brand-500);
+  color: var(--md-sys-color-on-surface);
+  box-shadow: inset 0 0 0 1px var(--md-sys-color-primary);
 }
 .wizard-step-dot[data-step-state="active"] .wizard-step-dot__number {
-  background: var(--brand-500);
+  background: var(--md-sys-color-primary);
   color: var(--on-fill);
 }
 .wizard-step-dot[data-step-state="done"] {
@@ -133,44 +133,44 @@
   color: var(--pill-ok-text);
 }
 .wizard-step-dot[data-step-state="done"] .wizard-step-dot__number {
-  background: var(--success);
+  background: var(--md-sys-color-tertiary);
   color: var(--on-fill);
 }
 .wizard-step[hidden] { display: none !important; }
 .wizard-step > h3 { margin-bottom: var(--space-2); }
-.wizard-section-title { margin-top: var(--space-3); padding-top: var(--space-2); border-top: 1px solid var(--border); }
+.wizard-section-title { margin-top: var(--space-3); padding-top: var(--space-2); border-top: 1px solid var(--md-sys-color-outline-variant); }
 .wizard-options { display: flex; flex-wrap: wrap; gap: var(--space-2); margin: var(--space-3) 0 0; }
 .wizard-options .wiz-opt {
   min-width: min(260px, 100%);
   padding: var(--space-2) var(--space-3);
-  border: 2px solid var(--border);
+  border: 2px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 0.95rem;
   transition: border-color .15s, background .15s, box-shadow .15s;
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
   text-align: left;
 }
 .wizard-options .wiz-opt:hover { border-color: var(--brand-400); background: var(--menu-hover); }
 .wizard-options .wiz-opt:focus-visible {
   outline: none;
-  border-color: var(--brand-500);
+  border-color: var(--md-sys-color-primary);
   box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.18);
 }
-.wizard-options .wiz-opt[data-selected="true"] { border-color: var(--brand-500); background: var(--md-sys-color-primary-container); color: var(--md-sys-color-on-primary-container); font-weight: 600; }
+.wizard-options .wiz-opt[data-selected="true"] { border-color: var(--md-sys-color-primary); background: var(--md-sys-color-primary-container); color: var(--md-sys-color-on-primary-container); font-weight: 600; }
 .wizard-options--list { flex-direction: column; }
 .wizard-options--list .wiz-opt { width: 100%; display: flex; justify-content: space-between; align-items: center; gap: var(--space-2); }
-.wizard-options--list .wiz-opt .wiz-opt-detail { font-size: 0.8rem; color: var(--muted); }
-.wizard-custom, .wizard-custom-specs { margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--border); display: flex; flex-wrap: wrap; gap: var(--space-2); align-items: flex-end; }
+.wizard-options--list .wiz-opt .wiz-opt-detail { font-size: 0.8rem; color: var(--md-sys-color-on-surface-variant); }
+.wizard-custom, .wizard-custom-specs { margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--md-sys-color-outline-variant); display: flex; flex-wrap: wrap; gap: var(--space-2); align-items: flex-end; }
 .wizard-custom label { flex-basis: 100%; }
 .wizard-custom input { flex: 1; min-width: 150px; }
 .wizard-custom--branch {
   align-items: stretch;
   padding-top: var(--space-3);
   border-top: none;
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-md);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   padding: var(--space-3);
 }
 .wizard-custom-specs {
@@ -185,9 +185,9 @@
   display: grid;
   gap: var(--space-3);
   padding: var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-md);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
 }
 .wizard-branch-card__header {
   display: grid;
@@ -198,7 +198,7 @@
   font-size: 0.82rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-weight: 700;
 }
 .wizard-branch-note {
@@ -209,7 +209,7 @@
   align-items: center;
   gap: var(--space-2);
   margin: var(--space-1) 0;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.85rem;
   font-weight: 600;
 }
@@ -218,12 +218,12 @@
   content: "";
   flex: 1;
   height: 1px;
-  background: var(--border);
+  background: var(--md-sys-color-outline-variant);
 }
 .add-car-wizard[data-spec-branch="library"] .wizard-branch-card--library,
 .add-car-wizard[data-spec-branch="manual"] .wizard-branch-card--manual {
-  border-color: var(--brand-500);
-  box-shadow: inset 0 0 0 1px var(--brand-500);
+  border-color: var(--md-sys-color-primary);
+  box-shadow: inset 0 0 0 1px var(--md-sys-color-primary);
   background: var(--menu-hover);
 }
 .wizard-custom-specs__note { margin-top: 0; }
@@ -234,8 +234,8 @@
   gap: var(--space-2);
   margin-top: var(--space-4);
   padding-top: var(--space-3);
-  border-top: 1px solid var(--border);
-  background: linear-gradient(180deg, rgba(248, 250, 252, 0) 0%, var(--surface) 28%);
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0) 0%, var(--md-sys-color-surface-container) 28%);
   z-index: 2;
 }
 .wizard-nav__status {
@@ -252,9 +252,9 @@
 .wizard-summary-card {
   display: grid;
   gap: var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-md);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   padding: var(--space-3);
   position: sticky;
   top: 0;
@@ -263,7 +263,7 @@
   font-size: 0.82rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-weight: 700;
 }
 .wizard-task-callout {
@@ -279,14 +279,14 @@
   gap: 0.35rem;
   padding: var(--space-3);
   border-radius: var(--radius-sm);
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
 }
 .wizard-summary-preview__label {
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-weight: 600;
 }
 .wizard-summary-preview__value {
@@ -304,15 +304,15 @@
   gap: 0.2rem;
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
-  background: var(--surface);
-  border: 1px solid var(--border);
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
 }
 .wizard-summary-item dt {
   margin: 0;
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 .wizard-summary-item dd {
   margin: 0;
@@ -377,7 +377,7 @@
     position: static;
     margin-top: var(--space-3);
     padding-top: var(--space-2);
-    background: var(--surface);
+    background: var(--md-sys-color-surface-container);
   }
   .wizard-options .wiz-opt,
   .wizard-custom input,

--- a/apps/ui/src/styles/settings-cars.css
+++ b/apps/ui/src/styles/settings-cars.css
@@ -1,8 +1,8 @@
 /* Car list table */
 .car-tab-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: var(--space-2); }
 .car-list-table { width: 100%; border-collapse: collapse; margin-top: 0; font-size: 0.88rem; }
-.car-list-table th { text-align: left; padding: var(--space-2); border-bottom: 2px solid var(--border); font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
-.car-list-table td { padding: var(--space-2); border-bottom: 1px solid var(--border); vertical-align: middle; }
+.car-list-table th { text-align: left; padding: var(--space-2); border-bottom: 2px solid var(--md-sys-color-outline-variant); font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--md-sys-color-on-surface-variant); }
+.car-list-table td { padding: var(--space-2); border-bottom: 1px solid var(--md-sys-color-outline-variant); vertical-align: middle; }
 .car-list-table tr:last-child td { border-bottom: none; }
 .settings-entity-table--cars td:nth-child(2) {
   min-width: 18rem;
@@ -36,9 +36,9 @@
 .car-active-pill[data-state="active"] { background: var(--pill-ok-bg); color: var(--pill-ok-text); }
 .car-active-pill[data-state="inactive"] { background: var(--pill-muted-bg); color: var(--pill-muted-text); }
 .car-readiness-pill[data-state="ready"] {
-  background: var(--surface-2);
-  color: var(--text);
-  border: 1px solid var(--border);
+  background: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
 }
 .car-readiness-pill[data-state="incomplete"] {
   background: var(--pill-warn-bg);
@@ -67,7 +67,7 @@
 }
 .car-row__type,
 .car-row__variant {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.82rem;
   line-height: 1.4;
 }
@@ -96,17 +96,17 @@
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 .car-row__setup-value {
   font-size: 0.86rem;
   line-height: 1.45;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
   overflow-wrap: anywhere;
 }
 .car-selection-feedback--success {
   border-color: rgba(22, 163, 74, 0.35);
-  background: linear-gradient(180deg, rgba(22, 163, 74, 0.08), var(--surface-2));
+  background: linear-gradient(180deg, rgba(22, 163, 74, 0.08), var(--md-sys-color-surface-container-high));
 }
 .car-selection-feedback--success::before {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23166534' stroke-width='1.8'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M5 13l4 4L19 7'/%3E%3C/svg%3E");

--- a/apps/ui/src/styles/settings-common.css
+++ b/apps/ui/src/styles/settings-common.css
@@ -1,8 +1,8 @@
 .settings-layout { display: grid; gap: var(--space-4); }
 .settings-help-disclosure {
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
 }
 .settings-help-disclosure__summary {
   display: flex;
@@ -12,7 +12,7 @@
   cursor: pointer;
   list-style: none;
   font-weight: 600;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
 }
 .settings-help-disclosure__summary::-webkit-details-marker {
   display: none;
@@ -36,7 +36,7 @@
   content: "-";
 }
 .settings-help-disclosure__summary:focus-visible {
-  outline: 2px solid var(--focus);
+  outline: 2px solid var(--md-sys-color-focus);
   outline-offset: 2px;
 }
 .settings-help-disclosure__heading {
@@ -45,10 +45,10 @@
   min-width: 0;
 }
 .settings-help-disclosure__title {
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
 }
 .settings-help-disclosure__caption {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.82rem;
   line-height: 1.4;
   font-weight: 500;
@@ -89,7 +89,7 @@
   gap: var(--space-3);
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
-.settings-group { border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); padding: var(--space-3); }
+.settings-group { border: 1px solid var(--md-sys-color-outline-variant); border-radius: var(--radius-sm); background: var(--md-sys-color-surface-container-high); padding: var(--space-3); }
 .settings-group h3 { margin: 0 0 var(--space-2); font-size: 0.84rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--pill-muted-text); }
 .settings-subgrid {
   display: grid;
@@ -118,8 +118,8 @@
   bottom: 0;
   z-index: 1;
   padding-top: var(--space-3);
-  border-top: 1px solid var(--border);
-  background: linear-gradient(180deg, transparent, var(--surface) 35%);
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  background: linear-gradient(180deg, transparent, var(--md-sys-color-surface-container) 35%);
 }
 .manual-speed-row { display: flex; gap: var(--space-2); align-items: flex-end; margin: var(--space-2) 0; flex-wrap: wrap; }
 .manual-speed-row label { min-width: 140px; }
@@ -135,7 +135,7 @@
 }
 .clients-table th,
 .clients-table td {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
   padding: 0.6rem;
   text-align: left;
   vertical-align: middle;
@@ -147,8 +147,8 @@
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--muted);
-  background: var(--surface-2);
+  color: var(--md-sys-color-on-surface-variant);
+  background: var(--md-sys-color-surface-container-high);
 }
 .clients-table tbody tr:nth-child(even) td { background: var(--row-even); }
 .clients-table tbody tr:hover td { background: var(--row-hover); }
@@ -184,10 +184,10 @@
 .field { display: flex; flex-direction: column; gap: var(--space-1); }
 label { font-size: 0.86rem; color: var(--pill-muted-text); }
 input[aria-invalid="true"] {
-  border-color: var(--danger);
+  border-color: var(--md-sys-color-error);
   box-shadow: inset 0 0 0 1px rgba(197, 34, 31, 0.18);
 }
 select[aria-invalid="true"] {
-  border-color: var(--danger);
+  border-color: var(--md-sys-color-error);
   box-shadow: inset 0 0 0 1px rgba(197, 34, 31, 0.18);
 }

--- a/apps/ui/src/styles/settings-sensors.css
+++ b/apps/ui/src/styles/settings-sensors.css
@@ -17,7 +17,7 @@
   flex-wrap: wrap;
   gap: 0.4rem;
   align-items: center;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
 }
 .settings-sensor-row__meta code {
   font-size: 0.82rem;

--- a/apps/ui/src/styles/settings-shell.css
+++ b/apps/ui/src/styles/settings-shell.css
@@ -1,15 +1,15 @@
 .settings-tabs {
   display: flex; gap: var(--space-1); margin-bottom: var(--space-3);
-  border-bottom: 2px solid var(--border);
+  border-bottom: 2px solid var(--md-sys-color-outline-variant);
   padding-bottom: 0;
 }
 .settings-tab {
   padding: var(--space-2) var(--space-3); border: none; background: none;
-  cursor: pointer; font: inherit; color: var(--muted);
+  cursor: pointer; font: inherit; color: var(--md-sys-color-on-surface-variant);
   border-bottom: 2px solid transparent; margin-bottom: -2px;
   transition: color .15s, border-color .15s;
 }
-.settings-tab:hover { color: var(--text); }
-.settings-tab[aria-selected="true"] { color: var(--brand-500); border-bottom-color: var(--brand-500); font-weight: 600; }
-.settings-tab:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; border-radius: 2px; }
+.settings-tab:hover { color: var(--md-sys-color-on-surface); }
+.settings-tab[aria-selected="true"] { color: var(--md-sys-color-primary); border-bottom-color: var(--md-sys-color-primary); font-weight: 600; }
+.settings-tab:focus-visible { outline: 2px solid var(--md-sys-color-focus); outline-offset: 2px; border-radius: 2px; }
 .settings-tab-panel[hidden] { display: none !important; }

--- a/apps/ui/src/styles/settings-speed-source.css
+++ b/apps/ui/src/styles/settings-speed-source.css
@@ -31,13 +31,13 @@
   font-size: 0.76rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-weight: 700;
 }
 .speed-source-summary__value {
   font-size: 1.1rem;
   font-weight: 700;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
 }
 .speed-source-config {
   display: grid;
@@ -72,9 +72,9 @@
   display: grid;
   gap: var(--space-2);
   padding: var(--space-2);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
 }
 .speed-source-device__header {
   display: flex;
@@ -91,7 +91,7 @@
   font-weight: 700;
 }
 .speed-source-device__mac {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-family: var(--font-mono);
   font-size: 0.84rem;
 }

--- a/apps/ui/src/styles/settings-transport.css
+++ b/apps/ui/src/styles/settings-transport.css
@@ -9,9 +9,9 @@
   display: grid;
   gap: 0.35rem;
   padding: var(--space-3);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
   cursor: pointer;
   transition: border-color 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
 }
@@ -20,22 +20,22 @@
   background: var(--menu-hover);
 }
 .speed-source-choice[data-selected="true"] {
-  border-color: var(--brand-500);
+  border-color: var(--md-sys-color-primary);
   background: var(--menu-hover);
-  box-shadow: inset 0 0 0 1px var(--brand-500);
+  box-shadow: inset 0 0 0 1px var(--md-sys-color-primary);
 }
 .update-transport-choice:hover {
   border-color: var(--brand-300);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
 }
 .update-transport-choice:focus-within {
-  outline: 2px solid var(--focus);
+  outline: 2px solid var(--md-sys-color-focus);
   outline-offset: 2px;
 }
 .update-transport-choice[data-selected="true"] {
-  border-color: var(--brand-500);
-  background: color-mix(in srgb, var(--menu-hover) 65%, var(--surface-2));
-  box-shadow: inset 0 0 0 1px var(--brand-500);
+  border-color: var(--md-sys-color-primary);
+  background: color-mix(in srgb, var(--menu-hover) 65%, var(--md-sys-color-surface-container-high));
+  box-shadow: inset 0 0 0 1px var(--md-sys-color-primary);
 }
 .speed-source-choice[data-choice-state="active"]::after,
 .speed-source-choice[data-choice-state="draft"]::after {
@@ -51,11 +51,11 @@
 }
 .speed-source-choice[data-choice-state="active"]::after {
   background: var(--menu-hover);
-  color: var(--brand-500);
+  color: var(--md-sys-color-primary);
 }
 .speed-source-choice[data-choice-state="draft"] {
   border-color: var(--warning);
-  background: color-mix(in srgb, var(--warning) 8%, var(--surface-2));
+  background: color-mix(in srgb, var(--warning) 8%, var(--md-sys-color-surface-container-high));
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--warning) 60%, transparent);
 }
 .speed-source-choice[data-choice-state="draft"]::after {
@@ -63,7 +63,7 @@
   color: var(--warning);
 }
 .speed-source-choice[data-choice-state="error"] {
-  border-color: var(--danger);
+  border-color: var(--md-sys-color-error);
   box-shadow: inset 0 0 0 1px rgba(197, 34, 31, 0.18);
 }
 .speed-source-choice[data-disabled="true"] {
@@ -72,12 +72,12 @@
   border-style: dashed;
 }
 .speed-source-choice[data-disabled="true"]:hover {
-  border-color: var(--border);
-  background: var(--surface-2);
+  border-color: var(--md-sys-color-outline-variant);
+  background: var(--md-sys-color-surface-container-high);
   box-shadow: none;
 }
 .update-transport-choice[data-disabled="true"]:focus-within {
-  outline-color: var(--focus);
+  outline-color: var(--md-sys-color-focus);
 }
 .speed-source-choice__radio {
   position: absolute;
@@ -87,10 +87,10 @@
 .speed-source-choice__title {
   font-size: 0.96rem;
   font-weight: 700;
-  color: var(--text);
+  color: var(--md-sys-color-on-surface);
 }
 .speed-source-choice__caption {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.84rem;
   line-height: 1.45;
 }

--- a/apps/ui/src/styles/shell.css
+++ b/apps/ui/src/styles/shell.css
@@ -10,7 +10,7 @@
   z-index: 100;
   background: rgba(255, 255, 255, 0.95);
   border: none;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
   border-radius: 0;
   box-shadow: none;
   backdrop-filter: blur(6px);
@@ -42,9 +42,9 @@
   flex-wrap: wrap;
   margin-left: auto;
   padding: var(--space-1) var(--space-2);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-md);
-  background: var(--surface);
+  background: var(--md-sys-color-surface-container);
 }
 
 .header-select {
@@ -61,9 +61,9 @@
   display: grid;
   gap: 0.2rem;
   padding: var(--space-2);
-  border: 1px solid var(--border);
+  border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--md-sys-color-surface-container-high);
 }
 
 .settings-feedback[data-tone="error"] {
@@ -89,7 +89,7 @@
 }
 
 .settings-feedback__detail {
-  color: var(--muted);
+  color: var(--md-sys-color-on-surface-variant);
   font-size: 0.8rem;
   line-height: 1.4;
 }

--- a/apps/ui/src/styles/theme.css
+++ b/apps/ui/src/styles/theme.css
@@ -68,7 +68,7 @@
 
   .site-header {
     background: rgba(15, 17, 23, 0.92);
-    border-bottom-color: var(--border);
+    border-bottom-color: var(--md-sys-color-outline-variant);
   }
 
   .empty-state {
@@ -88,7 +88,7 @@
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
   }
 
-  .history-row[data-expanded="true"] td { background: var(--surface-2) !important; }
+  .history-row[data-expanded="true"] td { background: var(--md-sys-color-surface-container-high) !important; }
 
   .uplot .u-select { background: rgba(167, 139, 250, 0.15); }
 

--- a/apps/ui/src/styles/tokens.css
+++ b/apps/ui/src/styles/tokens.css
@@ -20,26 +20,15 @@
   --md-sys-color-on-error: #ffffff;
   --md-sys-color-focus: #a78bfa;
 
-  /* Alias tokens kept for existing selectors */
-  --bg: var(--md-sys-color-surface);
-  --surface: var(--md-sys-color-surface-container);
-  --surface-2: var(--md-sys-color-surface-container-high);
-  --border: var(--md-sys-color-outline-variant);
-  --border-strong: var(--md-sys-color-outline);
-  --text: var(--md-sys-color-on-surface);
-  --muted: var(--md-sys-color-on-surface-variant);
-  --brand-500: var(--md-sys-color-primary);
+  /* Accent/status palette and semantic tokens */
   --brand-600: #6d28d9;
   --brand-700: #5b21b6;
   --brand-400: #8b5cf6;
-  --success: var(--md-sys-color-tertiary);
   --success-400: #29b56c;
   --success-700: #0b7a44;
-  --danger: var(--md-sys-color-error);
   --danger-400: #d64e4b;
   --danger-700: #9f1b18;
   --warning: #b7791f;
-  --focus: var(--md-sys-color-focus);
   --on-fill: #ffffff;
   --menu-hover: #f0ebfe;
   --pill-muted-bg: #eef0f5;
@@ -93,8 +82,8 @@
 body {
   margin: 0;
   font-family: "Segoe UI", "Trebuchet MS", Arial, sans-serif;
-  background: var(--bg);
-  color: var(--text);
+  background: var(--md-sys-color-surface);
+  color: var(--md-sys-color-on-surface);
   font-size: 15px;
 }
 
@@ -109,7 +98,7 @@ body {
   --variant-surface: var(--pill-muted-bg);
   --variant-banner-surface: var(--pill-muted-bg);
   --variant-text: var(--pill-muted-text);
-  --variant-border: var(--border);
+  --variant-border: var(--md-sys-color-outline-variant);
 }
 
 [data-variant="ok"] {
@@ -134,9 +123,9 @@ body {
 }
 
 [data-readiness-state] {
-  --readiness-surface: var(--surface-2);
-  --readiness-text: var(--text);
-  --readiness-border: var(--border);
+  --readiness-surface: var(--md-sys-color-surface-container-high);
+  --readiness-text: var(--md-sys-color-on-surface);
+  --readiness-border: var(--md-sys-color-outline-variant);
   --readiness-marker-surface: var(--pill-muted-bg);
   --readiness-marker-text: var(--pill-muted-text);
 }
@@ -145,7 +134,7 @@ body {
   --readiness-surface: var(--pill-ok-bg);
   --readiness-text: var(--pill-ok-text);
   --readiness-border: rgba(11, 122, 68, 0.18);
-  --readiness-marker-surface: var(--success);
+  --readiness-marker-surface: var(--md-sys-color-tertiary);
   --readiness-marker-text: var(--on-fill);
 }
 
@@ -154,13 +143,13 @@ body {
   --readiness-text: var(--pill-warn-text);
   --readiness-border: rgba(170, 108, 26, 0.28);
   --readiness-marker-surface: var(--warning);
-  --readiness-marker-text: var(--text);
+  --readiness-marker-text: var(--md-sys-color-on-surface);
 }
 
 [data-readiness-state="blocked"] {
   --readiness-surface: var(--pill-bad-bg);
   --readiness-text: var(--pill-bad-text);
   --readiness-border: #f0c4c4;
-  --readiness-marker-surface: var(--danger);
+  --readiness-marker-surface: var(--md-sys-color-error);
   --readiness-marker-text: var(--on-fill);
 }


### PR DESCRIPTION
## What change
- migrate selectors off the direct alias tokens (`--bg`, `--surface`, `--surface-2`, `--border`, `--border-strong`, `--text`, `--muted`, `--brand-500`, `--success`, `--danger`, `--focus`) onto canonical `--md-sys-*` tokens
- remove those obsolete alias definitions from `apps/ui/src/styles/tokens.css`
- keep richer semantic palette tokens (`--brand-600`, `--warning-*`, `--pill-*`, `--on-fill`) where they still express real design intent

## Why
- the alias layer was frontend compatibility code only
- the canonical design-token layer already exists under `--md-sys-*`, so selectors should use it directly instead of preserving old renames forever

## Validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run test:visual`

## Risk / tradeoffs
- broad mechanical CSS touch across 21 style owners, so accidental visual drift is the main risk
- intent stays the same; visual specs passed after the migration
- kept non-1:1 semantic palette tokens in place instead of flattening them into unrelated canonical names

Closes #2934