### PR TITLE
refactor(udp): reject unknown CMD ids

### DIFF
--- a/apps/server/tests/adapters/udp/test_protocol.py
+++ b/apps/server/tests/adapters/udp/test_protocol.py
@@ -364,18 +364,14 @@ def test_pack_data_rejects_empty_samples() -> None:
         pack_data(client_id, seq=1, t0_us=0, samples=np.zeros((0, 3), dtype="<i2"))
 
 
-def test_parse_cmd_warns_on_unknown_cmd_id(caplog: pytest.LogCaptureFixture) -> None:
-    """parse_cmd must log a warning for an unrecognized cmd_id (Fix 5)."""
-    import logging
+def test_parse_cmd_rejects_unknown_cmd_id() -> None:
+    """parse_cmd must reject an unrecognized cmd_id."""
     import struct as _struct
 
     client_id = bytes.fromhex("aabbccddeeff")
-    # Build a CMD header with cmd_id=99 (unknown)
     raw = _struct.pack("<BB6sBI", 3, 1, client_id, 99, 42)
-    with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.udp.protocol"):
-        cmd = parse_cmd(raw)
-    assert cmd.cmd_id == 99
-    assert any("unrecognized cmd_id" in r.message for r in caplog.records)
+    with pytest.raises(ProtocolError, match="unsupported cmd_id=99"):
+        parse_cmd(raw)
 
 
 def test_pack_cmd_identify_rejects_negative_cmd_seq() -> None:

--- a/apps/server/vibesensor/adapters/udp/protocol.py
+++ b/apps/server/vibesensor/adapters/udp/protocol.py
@@ -354,10 +354,7 @@ def parse_cmd(data: bytes) -> CmdMessage:
     )
     _msg_type, _version, client_id, cmd_id, cmd_seq = header
     if cmd_id not in (CMD_IDENTIFY, CMD_SYNC_CLOCK):
-        LOGGER.warning(
-            "parse_cmd: unrecognized cmd_id=%d; continuing for forward compatibility",
-            cmd_id,
-        )
+        raise _ProtocolError(f"CMD has unsupported cmd_id={cmd_id}")
     params = data[CMD_HEADER_BYTES:]
     return CmdMessage(client_id=client_id, cmd_id=cmd_id, cmd_seq=cmd_seq, params=params)
 


### PR DESCRIPTION
## What changed
- make `parse_cmd()` raise `ProtocolError` for unsupported `cmd_id` values instead of warning and continuing
- tighten the focused UDP protocol regression to expect strict rejection for unknown command ids

## Why
- firmware, simulator, and server ship from the same repo, so the parser does not need a forward-compatibility path for unknown future command ids
- the simulator command receiver already treats `ProtocolError` as an invalid command and ignores it cleanly

## Validation
- `cd apps/server && ../../.venv/bin/python -m ruff check vibesensor/adapters/udp/protocol.py tests/adapters/udp/test_protocol.py`
- `cd apps/server && ../../.venv/bin/python -m pytest -q --noconftest tests/adapters/udp/test_protocol.py`
- `cd apps/server && ../../.venv/bin/python -m pytest -q tests/adapters/udp/test_udp_control_tx.py::test_send_identify_accepts_hex_and_mac_client_ids tests/infra/processing/test_time_alignment.py::TestCmdSyncClockProtocol`

## Risks / tradeoffs
- unknown future `cmd_id` values now fail fast until all repo producers and consumers land together
- known `CMD_IDENTIFY` and `CMD_SYNC_CLOCK` behavior stays unchanged

Closes #2937