### PR TITLE
[AI] Adopt uvloop as the canonical Linux event loop for the backend runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ commands like `vibesensor-server` and `vibesensor-sim` stay tied to your working
 tree. A local virtualenv created from the matrix-supported native-dev Python is
 the recommended path before you run the install above, and `make setup` will
 create or refresh that `.venv` for you automatically.
+On Linux, Docker, and Raspberry Pi runtimes, `vibesensor-server` installs the
+canonical `uvloop` event-loop policy automatically before the backend runtime
+starts; unsupported non-Linux local development falls back to the default
+asyncio loop.
 
 In another terminal:
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -101,7 +101,8 @@ apps/server/
 └── vibesensor/
 ```
 
-- `data/`: runtime state, history database, and report i18n JSON.
+- `data/`: runtime state, history database, and local logs for native/dev flows.
+- `vibesensor/data/`: packaged static data such as report i18n JSON, the car library, and scripted scenarios.
 - `vibesensor/static/`: built UI assets served by FastAPI.
 - `scripts/` and `systemd/`: Pi deployment and hotspot support.
 - `tests/`: pytest suite, organized by backend ownership boundary.
@@ -117,6 +118,9 @@ The local development configs default the HTTP listener to port `8000`.
 For native backend iteration, run `vibesensor-server --reload --config
 apps/server/config.dev.yaml` from the repo root so Python changes hot-reload
 while the Vite dev server proxies browser traffic to `http://127.0.0.1:8000`.
+Linux, Docker, and Raspberry Pi backend runs install the canonical `uvloop`
+event-loop policy automatically at startup; unsupported non-Linux local
+development falls back to the default asyncio loop.
 
 ## Dependency management
 

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "starlette>=0.37.2,<1",
   "tenacity>=9.1,<10",
   "uvicorn[standard]>=0.30,<1",
+  "uvloop>=0.22,<1; sys_platform == 'linux'",
   "numpy>=2.4.4,<3",
   "orjson>=3.11.4,<4",
   "pyfftw>=0.15.1,<0.16",

--- a/apps/server/tests/app/test_app_main.py
+++ b/apps/server/tests/app/test_app_main.py
@@ -107,6 +107,7 @@ def test_main_reload_uses_factory_target(monkeypatch, tmp_path) -> None:
                 "host": "127.0.0.1",
                 "port": 8000,
                 "log_level": "info",
+                "loop": "asyncio",
                 "reload": True,
                 "factory": True,
             },

--- a/apps/server/tests/app/test_event_loop_policy.py
+++ b/apps/server/tests/app/test_event_loop_policy.py
@@ -1,0 +1,95 @@
+"""Event-loop policy coverage for backend startup."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _write_config(tmp_path: Path) -> Path:
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump(
+            {
+                "logging": {
+                    "history_db_path": str(tmp_path / "history.db"),
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    return cfg_path
+
+
+def test_install_runtime_event_loop_policy_uses_uvloop_on_linux(monkeypatch) -> None:
+    from vibesensor.app import bootstrap as app_module
+
+    class FakeUvloopPolicy(asyncio.DefaultEventLoopPolicy):
+        pass
+
+    FakeUvloopPolicy.__module__ = "uvloop"
+
+    recorded: list[asyncio.AbstractEventLoopPolicy] = []
+    monkeypatch.setattr(app_module.sys, "platform", "linux")
+    monkeypatch.setattr(
+        app_module.asyncio,
+        "get_event_loop_policy",
+        lambda: asyncio.DefaultEventLoopPolicy(),
+    )
+    monkeypatch.setattr(
+        app_module.asyncio,
+        "set_event_loop_policy",
+        lambda policy: recorded.append(policy),
+    )
+    fake_uvloop = type(
+        "FakeUvloopModule",
+        (),
+        {"EventLoopPolicy": FakeUvloopPolicy},
+    )
+    monkeypatch.setitem(sys.modules, "uvloop", fake_uvloop)
+
+    app_module._install_runtime_event_loop_policy()
+
+    assert len(recorded) == 1
+    assert isinstance(recorded[0], FakeUvloopPolicy)
+
+
+def test_install_runtime_event_loop_policy_skips_non_linux(monkeypatch) -> None:
+    from vibesensor.app import bootstrap as app_module
+
+    called = {"set": False}
+    monkeypatch.setattr(app_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        app_module.asyncio,
+        "set_event_loop_policy",
+        lambda policy: called.__setitem__("set", True),
+    )
+
+    app_module._install_runtime_event_loop_policy()
+
+    assert called["set"] is False
+
+
+def test_create_app_installs_runtime_event_loop_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg_path = _write_config(tmp_path)
+    monkeypatch.setenv("VIBESENSOR_SERVE_STATIC", "0")
+    from vibesensor import app as app_module
+    from vibesensor.app import bootstrap as bootstrap_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        bootstrap_mod,
+        "_install_runtime_event_loop_policy",
+        lambda: calls.append("install"),
+    )
+
+    app_module.create_app(config_path=cfg_path)
+
+    assert calls == ["install"]

--- a/apps/server/tests/shared/test_subprocess_server.py
+++ b/apps/server/tests/shared/test_subprocess_server.py
@@ -74,4 +74,5 @@ def test_build_server_subprocess_cmd_uses_embedded_bootstrap(tmp_path: Path) -> 
 
     assert cmd[:2] == [sys.executable, "-c"]
     assert "from vibesensor.app import create_app" in cmd[2]
+    assert "loop='asyncio'" in cmd[2]
     assert cmd[3] == str(config_path)

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -11,6 +11,7 @@ import argparse
 import asyncio
 import errno
 import logging
+import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from logging.handlers import RotatingFileHandler
@@ -55,6 +56,21 @@ _LOG_BACKUP_COUNT = 3
 _CONFIG_PATH_ENV = CONFIG_PATH_ENV
 
 
+def _install_runtime_event_loop_policy() -> None:
+    """Install the canonical runtime event-loop policy for this platform."""
+    if not sys.platform.startswith("linux"):
+        return
+    if type(asyncio.get_event_loop_policy()).__module__.startswith("uvloop"):
+        return
+    try:
+        import uvloop
+    except ImportError as exc:
+        raise RuntimeError(
+            "uvloop is required on Linux runtimes; reinstall the backend dependencies.",
+        ) from exc
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+
 def _setup_file_logging(log_path: Path | None) -> None:
     """Attach a RotatingFileHandler to the root logger when *log_path* is set."""
     if log_path is None:
@@ -77,6 +93,7 @@ def _setup_file_logging(log_path: Path | None) -> None:
 
 def create_app(config_path: Path | None = None) -> FastAPI:
     """Create and configure the VibeSensor FastAPI application."""
+    _install_runtime_event_loop_policy()
     config = load_config(config_path)
     bootstrap_settings = load_bootstrap_env_settings()
     _setup_file_logging(config.logging.app_log_path)
@@ -170,6 +187,7 @@ def _run_server(
         host=host,
         port=port,
         log_level="info",
+        loop="asyncio",
         reload=reload,
         factory=factory,
     )

--- a/apps/server/vibesensor/shared/subprocess_server.py
+++ b/apps/server/vibesensor/shared/subprocess_server.py
@@ -46,6 +46,7 @@ _SERVER_SUBPROCESS_BOOTSTRAP = "\n".join(
         "    host=runtime.config.server.host,",
         "    port=runtime.config.server.port,",
         "    log_level='info',",
+        "    loop='asyncio',",
         ")",
     ],
 )

--- a/docs/ai/repo-map.md
+++ b/docs/ai/repo-map.md
@@ -6,7 +6,7 @@ Paths below are repo-relative unless a line explicitly calls out a Python import
 
 ## Primary entry points
 
-- Backend app: `apps/server/vibesensor/app/bootstrap.py`
+- Backend app: `apps/server/vibesensor/app/bootstrap.py` (installs the canonical Linux `uvloop` policy before building the backend runtime)
 - Backend service wiring: `apps/server/vibesensor/app/container.py`
 - Backend route assembly: `apps/server/vibesensor/adapters/http/router.py` with domain bundles in `apps/server/vibesensor/adapters/http/route_bundles.py`
 - UI app entry: `apps/ui/src/main.ts`

--- a/docs/operational-runbooks.md
+++ b/docs/operational-runbooks.md
@@ -83,6 +83,14 @@ sudo systemctl status vibesensor-hotspot-self-heal.timer --no-pager
 sudo journalctl -u vibesensor.service -u vibesensor-hotspot.service -n 200 --no-pager
 ```
 
+Linux, Docker, and Raspberry Pi backends install `uvloop` automatically during
+startup. If the service exits before `/api/health` responds, confirm the active
+environment still imports it cleanly:
+
+```bash
+python -c "import uvloop"
+```
+
 3. Validate the on-device config before restarting anything:
 
 ```bash
@@ -181,6 +189,9 @@ vibesensor-sim --count 5 --duration 10 --no-interactive
 ```
 
 If the stack does not serve on port `80`, use `http://127.0.0.1:8000` as the dev fallback.
+On Linux/Docker/Pi, this stack should be running on the canonical `uvloop`
+policy by default; unsupported non-Linux local development is the only place
+the default asyncio loop remains expected.
 
 ## CI failure triage
 


### PR DESCRIPTION
## what changed
- add explicit Linux-only `uvloop` runtime dependency in `apps/server/pyproject.toml`
- install the canonical Linux event-loop policy at backend startup in `apps/server/vibesensor/app/bootstrap.py` before runtime construction
- make the shared uvicorn path and subprocess server run on `loop="asyncio"` so they use the already-selected policy instead of a second auto-selection path
- add focused app/subprocess coverage and update runtime docs to describe `uvloop` as the default Linux/Docker/Pi path

## why
- issue `#2961` wants one canonical production loop-selection path, not implicit uvicorn extras or split caller behavior
- installing the policy in `create_app()` covers normal startup, reload child startup, and the isolated subprocess server before long-lived runtime objects are built
- explicit Linux-only dependency keeps supported production targets strict while leaving unsupported non-Linux local dev on the default asyncio loop

## validation
- `./.venv/bin/python -m pip install -e "./apps/server[dev]"`
- `cd apps/server && ../../.venv/bin/python -m ruff check pyproject.toml vibesensor/app/bootstrap.py vibesensor/shared/subprocess_server.py tests/app/test_app_main.py tests/app/test_app_lifecycle.py tests/app/test_event_loop_policy.py tests/shared/test_subprocess_server.py`
- `cd apps/server && ../../.venv/bin/python -m pytest -q --noconftest tests/app/test_app_main.py tests/app/test_app_lifecycle.py tests/app/test_event_loop_policy.py tests/shared/test_subprocess_server.py`
- `make typecheck-backend`
- `make docs-lint`
- `make lint`
- `cd apps/server && ../../.venv/bin/python -m pytest -q tests/app tests/adapters tests/infra`

## risks / tradeoffs / edge cases
- Linux startup now fails fast if `uvloop` is missing instead of silently falling back to the default asyncio policy
- unsupported non-Linux local dev keeps the default asyncio loop; that is the only remaining fallback path
- local Docker bring-up could not be exercised on this host because `docker compose` v2 is missing here (`docker compose build --pull` exits with `unknown flag: --pull`)

Closes #2961