### PR TITLE
refactor: adopt SciPy signal primitives

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "granian[reload]>=2.7,<3",
   "uvloop>=0.22,<1; sys_platform == 'linux'",
   "numpy>=2.4.4,<3",
+  "scipy>=1.16.3,<2",
   "orjson>=3.11.4,<4",
   "pyfftw>=0.15.1,<0.16",
   "packaging>=24,<27",
@@ -197,6 +198,8 @@ per_rule_ignores = { DEP002 = ["esptool"] }
 
 [[tool.mypy.overrides]]
 module = [
+  "scipy",
+  "scipy.*",
   "pyfftw",
   "pyfftw.*",
   "reportlab.*",

--- a/apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py
+++ b/apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py
@@ -112,6 +112,15 @@ class TestComputeVibrationStrengthBoundaries:
         assert result["vibration_strength_db"] > 0.0
         assert len(result["top_peaks"]) >= 1
 
+    def test_last_bin_peak_is_still_reported(self) -> None:
+        result = compute_vibration_strength_db(
+            freq_hz=[0.0, 1.0, 2.0, 3.0, 4.0],
+            combined_spectrum_amp_g_values=[0.001, 0.001, 0.001, 0.004, 0.08],
+        )
+        assert result["top_peaks"]
+        assert result["top_peaks"][0]["hz"] == pytest.approx(4.0)
+        assert result["vibration_strength_db"] > 0.0
+
 
 # -- vibration_strength_db_scalar direct tests --------------------------------
 

--- a/apps/server/vibesensor/infra/processing/compute.py
+++ b/apps/server/vibesensor/infra/processing/compute.py
@@ -7,6 +7,8 @@ from collections import OrderedDict
 from threading import RLock
 
 import numpy as np
+from scipy import fft as scipy_fft
+from scipy.signal import windows as signal_windows
 
 from vibesensor.infra.processing.fft import (
     AXES,
@@ -42,7 +44,10 @@ class SignalMetricsComputer:
 
     def __init__(self, config: ProcessorConfig) -> None:
         self._config = config
-        self.fft_window: FloatArray = np.hanning(config.fft_n).astype(np.float32)
+        self.fft_window: FloatArray = np.asarray(
+            signal_windows.hann(config.fft_n, sym=True),
+            dtype=np.float32,
+        )
         self.fft_scale = float(2.0 / max(1.0, float(np.sum(self.fft_window))))
         self.fft_cache: OrderedDict[int, tuple[FloatArray, IntIndexArray, BoolArray]] = (
             OrderedDict()
@@ -62,7 +67,7 @@ class SignalMetricsComputer:
                     sample_rate_hz,
                 )
                 return _EMPTY_F32, np.empty(0, dtype=np.intp), _EMPTY_BOOL
-            freqs = np.fft.rfftfreq(self._config.fft_n, d=1.0 / sample_rate_hz)
+            freqs = scipy_fft.rfftfreq(self._config.fft_n, d=1.0 / sample_rate_hz)
             valid = (freqs >= self._config.spectrum_min_hz) & (
                 freqs <= self._config.spectrum_max_hz
             )

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -27,6 +27,7 @@ from typing import Final, TypedDict, cast
 
 import numpy as np
 import numpy.typing as npt
+from scipy.signal import find_peaks
 
 from vibesensor.strength_bands import _buckets_for_strength_db_aligned, bucket_for_strength
 
@@ -384,18 +385,20 @@ def _peak_band_rms_amp_g_from_bounds(
     return float(np.sqrt(np.mean(np.square(band, dtype=np.float64))))
 
 
-def _local_maxima_indexes(values: npt.NDArray[np.float64], threshold: float) -> list[int]:
-    maxima: list[int] = []
-    if values.size > 2:
-        interior = values[1:-1]
-        mask = (interior >= threshold) & (interior > values[:-2]) & (interior >= values[2:])
-        maxima.extend((np.flatnonzero(mask) + 1).tolist())
+def _candidate_peak_indexes(values: npt.NDArray[np.float64], threshold: float) -> list[int]:
+    peak_indexes_raw, _properties = find_peaks(values, height=threshold)
+    peak_indexes = np.asarray(peak_indexes_raw, dtype=np.intp)
     if values.size > 1:
-        last_val = float(values[-1])
-        if last_val >= threshold and last_val > float(values[-2]):
-            maxima.append(values.size - 1)
-    maxima.sort(key=lambda idx: float(values[idx]), reverse=True)
-    return maxima
+        last_idx = values.size - 1
+        last_val = float(values[last_idx])
+        if last_val >= threshold and last_val > float(values[last_idx - 1]):
+            peak_indexes = np.append(peak_indexes, last_idx)
+    if peak_indexes.size == 0:
+        return []
+    heights = np.asarray(values[peak_indexes], dtype=np.float64)
+    order = np.argsort(heights)[::-1]
+    ordered_indexes = np.asarray(peak_indexes[order], dtype=np.intp)
+    return [int(idx) for idx in ordered_indexes.tolist()]
 
 
 def vibration_strength_db_scalar(
@@ -475,7 +478,7 @@ def compute_vibration_strength_db(
         floor_p20 + STRENGTH_EPSILON_MIN_G,
     )
 
-    local_maxima = _local_maxima_indexes(combined, threshold)
+    local_maxima = _candidate_peak_indexes(combined, threshold)
     invalid_idx = next((idx for idx in local_maxima if not (0 <= idx < freq.size)), None)
     if invalid_idx is not None:
         raise ValueError(

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -36,8 +36,10 @@ Scope: architecture and data flow for the post-stop diagnostics pipeline in
 | **Stateless?** | Yes — each tick processes the current rolling window | Yes — processes all stored samples in one pass |
 
 Mathematical primitives (e.g. `compute_vibration_strength_db`,
-`noise_floor_amp_p20_g`) live in the `vibesensor` top-level package
-and are shared by both layers.
+`noise_floor_amp_p20_g`) live in the `vibesensor` top-level package and the
+live-processing owners under `infra/processing/`; the canonical windowing,
+frequency-bin, and peak-detection steps are SciPy-backed and the same persisted
+peak/floor outputs are then reused by diagnostics/reporting.
 
 ## Related deep dives
 

--- a/docs/intake_buffering.md
+++ b/docs/intake_buffering.md
@@ -77,7 +77,7 @@ then analyzes that one block.
 `infra/processing/compute.py` owns the cached FFT setup:
 
 - `SignalMetricsComputer` precomputes a Hann window with
-  `np.hanning(config.fft_n)`.
+  `scipy.signal.windows.hann(config.fft_n)`.
 - `fft_scale = 2.0 / max(1.0, sum(window))` keeps amplitudes normalized after
   windowing.
 - `fft_params(sample_rate_hz)` caches the frequency slice and valid FFT indices
@@ -90,13 +90,13 @@ then analyzes that one block.
    content.
 2. `SignalMetricsComputer.compute()` detrends the captured windows by removing
    the per-axis mean before RMS/P2P and FFT computation.
-3. `compute_fft_spectrum()` applies the Hann window, runs `np.fft.rfft()`,
-   scales the magnitudes, slices the configured frequency range, and produces
-   both per-axis spectra and a combined amplitude curve.
-4. `top_peaks()` smooths the spectrum with a 5-bin sliding average, estimates a
-   P20 noise floor, thresholds peaks above that floor, and returns the strongest
-   bins with SNR metadata.
-5. `compute_vibration_strength_db()` converts the dominant peak band into the
+3. `compute_fft_spectrum()` applies the SciPy-backed Hann window, runs the
+   planned pyFFTW RFFT backend, slices the configured frequency range via
+   SciPy FFT frequency bins, and produces both per-axis spectra and a combined
+   amplitude curve.
+4. `compute_vibration_strength_db()` uses SciPy peak finding to select dominant
+   candidate bins, estimates a P20/median noise floor, and converts the
+   dominant peak band into the
    shared dB metric used by both live telemetry and post-stop analysis:
 
    ```text

--- a/docs/order_tracking.md
+++ b/docs/order_tracking.md
@@ -124,6 +124,11 @@ The same reference math serves both runtime and diagnostics:
 - post-stop diagnostics uses the same order references, then asks whether peaks
   keep recurring in the predicted bands across the saved run
 
+The saved per-sample peak/floor inputs consumed by order matching come from the
+same canonical live-processing FFT/strength pipeline (`infra/processing/` plus
+`vibration_strength.py`), so order analysis does not maintain a second
+independent DSP stack.
+
 That shared ownership is why `shared/order_bands.py` exists outside
 `use_cases/diagnostics/`.
 


### PR DESCRIPTION
## What changed
- add SciPy to backend runtime deps and wire the canonical Hann-window, FFT-bin, and peak-candidate helpers onto SciPy
- keep the live FFT execution on the existing pyFFTW backend and preserve the current dB / endpoint-peak semantics
- add an endpoint-peak regression and update the DSP docs to match the live owners

## Why
- this moves the shared backend DSP primitives onto one vetted scientific math source without splitting live processing and diagnostics onto parallel helper paths
- the issue asked for before/after measurement on representative hot paths, so this PR includes the benchmark-backed final slice instead of landing the first SciPy-shaped diff blindly

## Validation
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- `cd apps/server && ../../.venv/bin/python -m pytest -q tests/infra tests/use_cases/diagnostics`
- `cd apps/server && ../../.venv/bin/python -m pytest -q -o addopts='' tests/infra/workers/benchmark_compute_all.py --benchmark-only --benchmark-warmup=off`
- `./.venv/bin/python tools/tests/benchmark_pipeline.py --sensors 4 --rounds 10`

## Risk / tradeoffs
- kept `medfilt3()` on the existing vectorized path after measuring SciPy median-filter variants; they regressed the hot path enough to miss the issue's performance bar
- final benchmark deltas vs baseline stayed tight: pipeline compute median `2.206 -> 2.182 ms` sequential and `2.715 -> 2.790 ms` parallel; compute-round mean `3.1211 -> 3.2548 ms` sequential and `4.2793 -> 4.3430 ms` parallel

Closes #2963
