### PR TITLE
refactor: move history persistence to aiosqlite

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -9,6 +9,7 @@ description = "Offline Raspberry Pi vibration telemetry server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+  "aiosqlite>=0.21,<1",
   "fastapi>=0.111,<1",
   "httpx>=0.27,<1",
   "msgspec>=0.19,<1",

--- a/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
+++ b/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
@@ -16,6 +16,12 @@ from _history_endpoint_helpers import (
 from fastapi import HTTPException
 
 
+async def _close_history_db(db) -> None:
+    close_result = db.close()
+    if close_result is not None:
+        await close_result
+
+
 @pytest.mark.asyncio
 async def test_ws_selected_client_id_validation() -> None:
     router, state = make_router_and_state(language="en")
@@ -263,6 +269,98 @@ async def test_set_client_location_persists_canonical_name_and_location() -> Non
 
 
 @pytest.mark.asyncio
+async def test_set_client_location_works_with_real_persistence_in_async_route(
+    tmp_path: Path,
+) -> None:
+    from test_support.settings_services import build_settings_services
+
+    from vibesensor.adapters.http.clients import create_client_routes
+    from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
+    from vibesensor.adapters.udp.protocol import HelloMessage
+    from vibesensor.infra.runtime.registry import ClientRegistry
+
+    db = await asyncio.to_thread(create_history_persistence_adapters, tmp_path / "history.db")
+    try:
+        settings_store = (
+            await asyncio.to_thread(
+                build_settings_services,
+                db=db.settings_snapshot_repository,
+            )
+        ).sensor_settings
+        registry = await asyncio.to_thread(ClientRegistry, db=db.client_name_repository)
+        await asyncio.to_thread(
+            registry.update_from_hello,
+            HelloMessage(
+                client_id=bytes.fromhex("001122334455"),
+                control_port=9010,
+                sample_rate_hz=800,
+                name="advertised-name",
+                firmware_version="fw",
+            ),
+            ("10.4.0.2", 9010),
+            1.0,
+            now_mono=1.0,
+        )
+
+        router = create_client_routes(registry, MagicMock(), settings_store, MagicMock())
+        endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}/location", "POST")
+
+        resp = response_payload(
+            await endpoint(
+                "00:11:22:33:44:55",
+                type("Req", (), {"location_code": "front_left_wheel"})(),
+            ),
+        )
+
+        assert resp["name"] == "Front Left Wheel"
+        assert resp["location_code"] == "front_left_wheel"
+        assert await asyncio.to_thread(settings_store.get_sensors) == {
+            "001122334455": {
+                "name": "Front Left Wheel",
+                "location_code": "front_left_wheel",
+            }
+        }
+    finally:
+        await _close_history_db(db)
+
+
+@pytest.mark.asyncio
+async def test_remove_client_clears_persisted_name_from_async_route(tmp_path: Path) -> None:
+    from vibesensor.adapters.http.clients import create_client_routes
+    from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
+    from vibesensor.adapters.udp.protocol import HelloMessage
+    from vibesensor.infra.runtime.registry import ClientRegistry
+
+    db = await asyncio.to_thread(create_history_persistence_adapters, tmp_path / "history.db")
+    try:
+        registry = await asyncio.to_thread(ClientRegistry, db=db.client_name_repository)
+        await asyncio.to_thread(
+            registry.update_from_hello,
+            HelloMessage(
+                client_id=bytes.fromhex("001122334455"),
+                control_port=9010,
+                sample_rate_hz=800,
+                name="advertised-name",
+                firmware_version="fw",
+            ),
+            ("10.4.0.2", 9010),
+            1.0,
+            now_mono=1.0,
+        )
+        await asyncio.to_thread(registry.set_name, "001122334455", "Front Left Wheel")
+
+        router = create_client_routes(registry, MagicMock(), MagicMock(), MagicMock())
+        endpoint = route_endpoint_with_method(router, "/api/clients/{client_id}", "DELETE")
+
+        resp = response_payload(await endpoint("00:11:22:33:44:55"))
+
+        assert resp == {"id": "001122334455", "status": "removed"}
+        assert await asyncio.to_thread(db.client_name_repository.list_client_names) == {}
+    finally:
+        await _close_history_db(db)
+
+
+@pytest.mark.asyncio
 async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected(
     tmp_path: Path,
     monkeypatch,
@@ -272,54 +370,57 @@ async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected
     from vibesensor.adapters.udp.protocol import HelloMessage
     from vibesensor.infra.runtime.registry import ClientRegistry
 
-    db = create_history_persistence_adapters(tmp_path / "history.db")
-    registry = await asyncio.to_thread(
-        ClientRegistry,
-        db=db.client_name_repository,
-        live_ttl_seconds=5.0,
-        retention_ttl_seconds=30.0,
-    )
-    hello = HelloMessage(
-        client_id=bytes.fromhex("001122334455"),
-        control_port=9010,
-        sample_rate_hz=800,
-        name="sensor",
-        firmware_version="fw",
-    )
-    registry.update_from_hello(hello, ("10.4.0.2", 9010), now=1.0, now_mono=1.0)
+    db = await asyncio.to_thread(create_history_persistence_adapters, tmp_path / "history.db")
+    try:
+        registry = await asyncio.to_thread(
+            ClientRegistry,
+            db=db.client_name_repository,
+            live_ttl_seconds=5.0,
+            retention_ttl_seconds=30.0,
+        )
+        hello = HelloMessage(
+            client_id=bytes.fromhex("001122334455"),
+            control_port=9010,
+            sample_rate_hz=800,
+            name="sensor",
+            firmware_version="fw",
+        )
+        registry.update_from_hello(hello, ("10.4.0.2", 9010), now=1.0, now_mono=1.0)
 
-    now = {"wall": 9.0, "mono": 9.0}
-    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.time", lambda: now["wall"])
-    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.monotonic", lambda: now["mono"])
+        now = {"wall": 9.0, "mono": 9.0}
+        monkeypatch.setattr("vibesensor.infra.runtime.registry.time.time", lambda: now["wall"])
+        monkeypatch.setattr("vibesensor.infra.runtime.registry.time.monotonic", lambda: now["mono"])
 
-    control_plane = MagicMock()
-    settings_store = MagicMock()
-    settings_store.get_sensors.return_value = {}
-    processor = MagicMock()
-    processor.all_latest_metrics.return_value = {}
-    router = create_client_routes(registry, control_plane, settings_store, processor)
-    endpoint = route_endpoint(router, "/api/clients")
+        control_plane = MagicMock()
+        settings_store = MagicMock()
+        settings_store.get_sensors.return_value = {}
+        processor = MagicMock()
+        processor.all_latest_metrics.return_value = {}
+        router = create_client_routes(registry, control_plane, settings_store, processor)
+        endpoint = route_endpoint(router, "/api/clients")
 
-    resp = response_payload(await endpoint())
-    assert processor.all_latest_metrics.call_args.args == ([],)
-    assert resp["clients"] == [
-        {
-            "id": "001122334455",
-            "mac_address": "00:11:22:33:44:55",
-            "name": "sensor",
-            "connected": False,
-            "location_code": "",
-            "firmware_version": "fw",
-            "sample_rate_hz": 800,
-            "frame_samples": 0,
-            "last_seen_age_ms": 8000,
-            "frames_total": 0,
-            "dropped_frames": 0,
-            "latest_metrics": {},
-            "reset_count": 0,
-            "last_reset_time": None,
-        },
-    ]
+        resp = response_payload(await endpoint())
+        assert processor.all_latest_metrics.call_args.args == ([],)
+        assert resp["clients"] == [
+            {
+                "id": "001122334455",
+                "mac_address": "00:11:22:33:44:55",
+                "name": "sensor",
+                "connected": False,
+                "location_code": "",
+                "firmware_version": "fw",
+                "sample_rate_hz": 800,
+                "frame_samples": 0,
+                "last_seen_age_ms": 8000,
+                "frames_total": 0,
+                "dropped_frames": 0,
+                "latest_metrics": {},
+                "reset_count": 0,
+                "last_reset_time": None,
+            },
+        ]
+    finally:
+        await _close_history_db(db)
 
 
 @pytest.mark.asyncio
@@ -334,57 +435,69 @@ async def test_get_clients_overlays_canonical_settings_metadata_after_restart(
     from vibesensor.adapters.udp.protocol import HelloMessage
     from vibesensor.infra.runtime.registry import ClientRegistry
 
-    db = create_history_persistence_adapters(tmp_path / "history.db")
-    initial_settings = build_settings_services(db=db.settings_snapshot_repository)
-    initial_settings.sensor_settings.assign_sensor_location(
-        "00:11:22:33:44:55",
-        "rear_left_wheel",
-    )
+    db = await asyncio.to_thread(create_history_persistence_adapters, tmp_path / "history.db")
+    try:
+        initial_settings = await asyncio.to_thread(
+            build_settings_services,
+            db=db.settings_snapshot_repository,
+        )
+        await asyncio.to_thread(
+            initial_settings.sensor_settings.assign_sensor_location,
+            "00:11:22:33:44:55",
+            "rear_left_wheel",
+        )
 
-    settings_store = build_settings_services(db=db.settings_snapshot_repository).sensor_settings
-    registry = await asyncio.to_thread(ClientRegistry, db=db.client_name_repository)
-    registry.update_from_hello(
-        HelloMessage(
-            client_id=bytes.fromhex("001122334455"),
-            control_port=9010,
-            sample_rate_hz=800,
-            name="advertised-name",
-            firmware_version="fw",
-        ),
-        ("10.4.0.2", 9010),
-        now=1.0,
-        now_mono=1.0,
-    )
-    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.time", lambda: 1.0)
-    monkeypatch.setattr("vibesensor.infra.runtime.registry.time.monotonic", lambda: 1.0)
+        settings_store = (
+            await asyncio.to_thread(
+                build_settings_services,
+                db=db.settings_snapshot_repository,
+            )
+        ).sensor_settings
+        registry = await asyncio.to_thread(ClientRegistry, db=db.client_name_repository)
+        registry.update_from_hello(
+            HelloMessage(
+                client_id=bytes.fromhex("001122334455"),
+                control_port=9010,
+                sample_rate_hz=800,
+                name="advertised-name",
+                firmware_version="fw",
+            ),
+            ("10.4.0.2", 9010),
+            now=1.0,
+            now_mono=1.0,
+        )
+        monkeypatch.setattr("vibesensor.infra.runtime.registry.time.time", lambda: 1.0)
+        monkeypatch.setattr("vibesensor.infra.runtime.registry.time.monotonic", lambda: 1.0)
 
-    control_plane = MagicMock()
-    processor = MagicMock()
-    processor.all_latest_metrics.return_value = {}
-    router = create_client_routes(registry, control_plane, settings_store, processor)
-    endpoint = route_endpoint(router, "/api/clients")
+        control_plane = MagicMock()
+        processor = MagicMock()
+        processor.all_latest_metrics.return_value = {}
+        router = create_client_routes(registry, control_plane, settings_store, processor)
+        endpoint = route_endpoint(router, "/api/clients")
 
-    resp = response_payload(await endpoint())
+        resp = response_payload(await endpoint())
 
-    assert settings_store.get_sensors()["001122334455"] == {
-        "name": "Rear Left Wheel",
-        "location_code": "rear_left_wheel",
-    }
-    assert resp["clients"] == [
-        {
-            "id": "001122334455",
-            "mac_address": "00:11:22:33:44:55",
+        assert settings_store.get_sensors()["001122334455"] == {
             "name": "Rear Left Wheel",
-            "connected": True,
             "location_code": "rear_left_wheel",
-            "firmware_version": "fw",
-            "sample_rate_hz": 800,
-            "frame_samples": 0,
-            "last_seen_age_ms": 0,
-            "frames_total": 0,
-            "dropped_frames": 0,
-            "latest_metrics": {},
-            "reset_count": 0,
-            "last_reset_time": None,
-        },
-    ]
+        }
+        assert resp["clients"] == [
+            {
+                "id": "001122334455",
+                "mac_address": "00:11:22:33:44:55",
+                "name": "Rear Left Wheel",
+                "connected": True,
+                "location_code": "rear_left_wheel",
+                "firmware_version": "fw",
+                "sample_rate_hz": 800,
+                "frame_samples": 0,
+                "last_seen_age_ms": 0,
+                "frames_total": 0,
+                "dropped_frames": 0,
+                "latest_metrics": {},
+                "reset_count": 0,
+                "last_reset_time": None,
+            },
+        ]
+    finally:
+        await _close_history_db(db)

--- a/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
+++ b/apps/server/tests/adapters/http/test_api_ws_health_and_clients.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -272,7 +273,8 @@ async def test_get_clients_keeps_retained_stale_client_but_marks_it_disconnected
     from vibesensor.infra.runtime.registry import ClientRegistry
 
     db = create_history_persistence_adapters(tmp_path / "history.db")
-    registry = ClientRegistry(
+    registry = await asyncio.to_thread(
+        ClientRegistry,
         db=db.client_name_repository,
         live_ttl_seconds=5.0,
         retention_ttl_seconds=30.0,
@@ -340,7 +342,7 @@ async def test_get_clients_overlays_canonical_settings_metadata_after_restart(
     )
 
     settings_store = build_settings_services(db=db.settings_snapshot_repository).sensor_settings
-    registry = ClientRegistry(db=db.client_name_repository)
+    registry = await asyncio.to_thread(ClientRegistry, db=db.client_name_repository)
     registry.update_from_hello(
         HelloMessage(
             client_id=bytes.fromhex("001122334455"),

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_connections.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 from pathlib import Path
 from threading import Event, Thread
 
 import pytest
+from test_support.history_db_async import fetch_all, fetch_one
 
 from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
+from vibesensor.shared.async_bridge import run_coro_blocking
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.types.run_schema import RunMetadata
 
@@ -35,7 +38,7 @@ def test_history_db_read_connection_is_query_only(tmp_path: Path) -> None:
     db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
         assert db.lifecycle._read_conn is not None
-        row = db.lifecycle._read_conn.execute("PRAGMA query_only").fetchone()
+        row = fetch_one(db.lifecycle, "PRAGMA query_only")
         assert row is not None
         assert int(row[0]) == 1
     finally:
@@ -47,8 +50,7 @@ def test_history_db_read_errors_clear_read_transaction(tmp_path: Path) -> None:
     try:
         assert db.lifecycle._read_conn is not None
         with pytest.raises(sqlite3.OperationalError):
-            with db.lifecycle._cursor(commit=False) as cur:
-                cur.execute("SELECT * FROM missing_table")
+            fetch_all(db.lifecycle, "SELECT * FROM missing_table")
         assert not db.lifecycle._read_conn.in_transaction
     finally:
         db.lifecycle.close()
@@ -62,9 +64,13 @@ def test_history_db_read_base_exception_clears_read_transaction(tmp_path: Path) 
         )
         assert db.lifecycle._read_conn is not None
         with pytest.raises(_AbortTxn):
-            with db.lifecycle._cursor(commit=False) as cur:
-                cur.execute("SELECT * FROM runs WHERE run_id = ?", ("run-read-abort",))
-                raise _AbortTxn
+            rows = fetch_all(
+                db.lifecycle,
+                "SELECT * FROM runs WHERE run_id = ?",
+                ("run-read-abort",),
+            )
+            assert rows
+            raise _AbortTxn
         assert not db.lifecycle._read_conn.in_transaction
         assert [run.run_id for run in db.run_repository.list_runs()] == ["run-read-abort"]
     finally:
@@ -78,12 +84,16 @@ def test_history_db_write_cursor_base_exception_rolls_back(tmp_path: Path) -> No
             "run-write-cursor", "2026-01-01T00:00:00Z", _metadata("run-write-cursor")
         )
         with pytest.raises(_AbortTxn):
-            with db.lifecycle._cursor() as cur:
-                cur.execute(
-                    "UPDATE runs SET sample_count = 7 WHERE run_id = ?",
-                    ("run-write-cursor",),
-                )
-                raise _AbortTxn
+
+            async def _run() -> None:
+                async with db.lifecycle._cursor_async() as cur:
+                    await cur.execute(
+                        "UPDATE runs SET sample_count = 7 WHERE run_id = ?",
+                        ("run-write-cursor",),
+                    )
+                    raise _AbortTxn
+
+            run_coro_blocking(_run())
         assert not db.lifecycle._conn.in_transaction
         run = db.run_repository.get_run("run-write-cursor")
         assert run is not None
@@ -99,12 +109,16 @@ def test_history_db_write_transaction_base_exception_rolls_back(tmp_path: Path) 
             "run-write-tx", "2026-01-01T00:00:00Z", _metadata("run-write-tx")
         )
         with pytest.raises(_AbortTxn):
-            with db.lifecycle.write_transaction_cursor() as cur:
-                cur.execute(
-                    "UPDATE runs SET sample_count = 9 WHERE run_id = ?",
-                    ("run-write-tx",),
-                )
-                raise _AbortTxn
+
+            async def _run() -> None:
+                async with db.lifecycle.write_transaction_cursor_async() as cur:
+                    await cur.execute(
+                        "UPDATE runs SET sample_count = 9 WHERE run_id = ?",
+                        ("run-write-tx",),
+                    )
+                    raise _AbortTxn
+
+            run_coro_blocking(_run())
         assert not db.lifecycle._conn.in_transaction
         run = db.run_repository.get_run("run-write-tx")
         assert run is not None
@@ -130,18 +144,21 @@ def test_history_db_allows_reads_during_write_transaction(tmp_path: Path) -> Non
         finally:
             read_finished.set()
 
-    with db.lifecycle.write_transaction_cursor() as cur:
-        cur.execute(
-            "UPDATE runs SET error_message = ? WHERE run_id = ?",
-            ("pending", "run-read"),
-        )
-        thread = Thread(target=_reader)
-        thread.start()
-        try:
-            assert read_started.wait(1.0)
-            assert read_finished.wait(1.0)
-        finally:
-            thread.join(timeout=1.0)
+    async def _run_transaction() -> None:
+        async with db.lifecycle.write_transaction_cursor_async() as cur:
+            await cur.execute(
+                "UPDATE runs SET error_message = ? WHERE run_id = ?",
+                ("pending", "run-read"),
+            )
+            thread = Thread(target=_reader)
+            thread.start()
+            try:
+                assert await asyncio.to_thread(read_started.wait, 1.0)
+                assert await asyncio.to_thread(read_finished.wait, 1.0)
+            finally:
+                thread.join(timeout=1.0)
+
+    run_coro_blocking(_run_transaction())
 
     db.lifecycle.close()
     if errors:

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import logging
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from test_support.history_db_async import execute_statements as _execute_statements
+from test_support.history_db_async import fetch_one as _fetch_one
 from test_support.history_db_lifecycle import (
     build_history_db,
     create_analyzing_run,
@@ -41,9 +43,9 @@ def test_append_samples_in_chunks(tmp_path: Path) -> None:
     calls: list[int] = []
     original_write_tx = db.run_repository._write_transaction_cursor_provider
 
-    @contextmanager
-    def _wrapped_write_transaction():
-        with original_write_tx() as cur:
+    @asynccontextmanager
+    async def _wrapped_write_transaction():
+        async with original_write_tx() as cur:
 
             class _CursorProxy:
                 def __init__(self, base_cursor):
@@ -52,10 +54,10 @@ def test_append_samples_in_chunks(tmp_path: Path) -> None:
                 def __getattr__(self, name: str):
                     return getattr(self._base_cursor, name)
 
-                def executemany(self, sql: str, seq_of_parameters):
+                async def executemany(self, sql: str, seq_of_parameters):
                     rows = list(seq_of_parameters)
                     calls.append(len(rows))
-                    return self._base_cursor.executemany(sql, rows)
+                    return await self._base_cursor.executemany(sql, rows)
 
             yield _CursorProxy(cur)
 
@@ -210,27 +212,29 @@ def test_prune_terminal_runs_older_than_days_deletes_only_old_terminal_runs(
 
     old_timestamp = (datetime.now(UTC) - timedelta(days=30)).isoformat()
     recent_timestamp = (datetime.now(UTC) - timedelta(days=2)).isoformat()
-    with db.lifecycle._cursor() as cur:
-        cur.execute(
+    _execute_statements(
+        db.lifecycle,
+        (
             "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
             (old_timestamp, old_timestamp, "run-old-complete"),
-        )
-        cur.execute(
+        ),
+        (
             "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
             (old_timestamp, old_timestamp, "run-old-error"),
-        )
-        cur.execute(
+        ),
+        (
             "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
             (recent_timestamp, recent_timestamp, "run-recent-complete"),
-        )
-        cur.execute(
+        ),
+        (
             "UPDATE runs SET created_at = ? WHERE run_id = ?",
             (old_timestamp, "run-recording"),
-        )
-        cur.execute(
+        ),
+        (
             "UPDATE runs SET created_at = ?, end_time_utc = ? WHERE run_id = ?",
             (old_timestamp, old_timestamp, "run-analyzing"),
-        )
+        ),
+    )
 
     pruned = db.run_repository.prune_terminal_runs_older_than_days(7)
 
@@ -253,19 +257,24 @@ def test_prune_terminal_runs_older_than_days_cascades_samples(tmp_path: Path) ->
     )
 
     old_timestamp = (datetime.now(UTC) - timedelta(days=30)).isoformat()
-    with db.lifecycle._cursor() as cur:
-        cur.execute(
+    _execute_statements(
+        db.lifecycle,
+        (
             "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
             (old_timestamp, old_timestamp, "run-prune"),
-        )
+        ),
+    )
 
     pruned = db.run_repository.prune_terminal_runs_older_than_days(7)
 
     assert pruned == 1
     assert db.run_repository.get_run("run-prune") is None
-    with db.lifecycle._cursor() as cur:
-        cur.execute("SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?", ("run-prune",))
-        assert cur.fetchone()[0] == 0
+    row = _fetch_one(
+        db.lifecycle,
+        "SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?",
+        ("run-prune",),
+    )
+    assert row is not None and row[0] == 0
 
 
 def test_create_run_does_not_auto_recover_recording(tmp_path: Path) -> None:
@@ -313,13 +322,13 @@ def test_history_db_runs_startup_quick_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[Path] = []
-    original = SQLiteHistoryEngine._run_startup_quick_check
+    original = SQLiteHistoryEngine._run_startup_quick_check_async
 
-    def _tracking(self: SQLiteHistoryEngine) -> None:
+    async def _tracking(self: SQLiteHistoryEngine) -> None:
         calls.append(self.db_path)
-        original(self)
+        await original(self)
 
-    monkeypatch.setattr(SQLiteHistoryEngine, "_run_startup_quick_check", _tracking)
+    monkeypatch.setattr(SQLiteHistoryEngine, "_run_startup_quick_check_async", _tracking)
     db = create_history_persistence_adapters(tmp_path / "history.db")
     try:
         assert calls == [tmp_path / "history.db"]
@@ -335,10 +344,10 @@ def test_startup_quick_check_logs_corruption(
     db = create_history_persistence_adapters(tmp_path / "history.db")
 
     class _FakeCursor:
-        def execute(self, sql: str) -> None:
+        async def execute(self, sql: str) -> None:
             assert sql == "PRAGMA quick_check"
 
-        def fetchall(self) -> list[tuple[str]]:
+        async def fetchall(self) -> list[tuple[str]]:
             return [("row 7 missing from index",)]
 
     @contextmanager
@@ -366,10 +375,10 @@ def test_startup_quick_check_reports_corruption_via_callback(
     )
 
     class _FakeCursor:
-        def execute(self, sql: str) -> None:
+        async def execute(self, sql: str) -> None:
             assert sql == "PRAGMA quick_check"
 
-        def fetchall(self) -> list[tuple[str]]:
+        async def fetchall(self) -> list[tuple[str]]:
             return [("row 7 missing from index",)]
 
     @contextmanager
@@ -426,9 +435,12 @@ def test_delete_run_cascades_samples(tmp_path: Path) -> None:
 
     db.run_repository.delete_run("run-del")
 
-    with db.lifecycle._cursor() as cur:
-        cur.execute("SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?", ("run-del",))
-        assert cur.fetchone()[0] == 0
+    row = _fetch_one(
+        db.lifecycle,
+        "SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?",
+        ("run-del",),
+    )
+    assert row is not None and row[0] == 0
 
 
 def test_run_status_transitions(tmp_path: Path) -> None:
@@ -472,9 +484,9 @@ def test_append_samples_rolls_back_when_metadata_update_fails(tmp_path: Path) ->
     db.run_repository.create_run("run-rollback", "2026-01-01T00:00:00Z", _metadata("run-rollback"))
     original_write_tx = db.run_repository._write_transaction_cursor_provider
 
-    @contextmanager
-    def _wrapped_write_transaction():
-        with original_write_tx() as cur:
+    @asynccontextmanager
+    async def _wrapped_write_transaction():
+        async with original_write_tx() as cur:
 
             class _CursorProxy:
                 def __init__(self, base_cursor):
@@ -483,10 +495,10 @@ def test_append_samples_rolls_back_when_metadata_update_fails(tmp_path: Path) ->
                 def __getattr__(self, name: str):
                     return getattr(self._base_cursor, name)
 
-                def execute(self, sql: str, params=()):
+                async def execute(self, sql: str, params=()):
                     if "UPDATE runs SET sample_count = sample_count + ?" in sql:
                         raise sqlite3.OperationalError("simulated sample_count failure")
-                    return self._base_cursor.execute(sql, params)
+                    return await self._base_cursor.execute(sql, params)
 
             yield _CursorProxy(cur)
 
@@ -651,11 +663,13 @@ def test_get_run_metadata_non_dict_json_returns_none_and_warns(
 ) -> None:
     db = create_history_persistence_adapters(tmp_path / "history.db")
     db.run_repository.create_run("run-bad-meta", "2026-01-01T00:00:00Z", _metadata("run-bad-meta"))
-    with db.lifecycle._cursor() as cur:
-        cur.execute(
+    _execute_statements(
+        db.lifecycle,
+        (
             "UPDATE runs SET metadata_json = ? WHERE run_id = ?",
             ("[1, 2, 3]", "run-bad-meta"),
-        )
+        ),
+    )
 
     with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.persistence.history_db"):
         result = db.run_repository.get_run_metadata("run-bad-meta")

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_structured_storage.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+from test_support.history_db_async import execute_statements, fetch_all, fetch_one
 from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
@@ -119,9 +120,7 @@ def test_v2_no_json_blobs_in_storage(tmp_path: Path) -> None:
         "run-check", [sensor_frame_from_mapping(_sensor_frame_dict(0))]
     )
 
-    with db.lifecycle._cursor(commit=False) as cur:
-        cur.execute("PRAGMA table_info(samples_v2)")
-        columns = {row[1] for row in cur.fetchall()}
+    columns = {row[1] for row in fetch_all(db.lifecycle, "PRAGMA table_info(samples_v2)")}
 
     assert "sample_json" not in columns
     assert "accel_x_g" in columns
@@ -199,9 +198,8 @@ def test_v2_delete_cascades_legacy_and_v2(tmp_path: Path) -> None:
     assert len(db.run_repository.get_run_samples("run-del2")) == 3
     db.run_repository.delete_run("run-del2")
 
-    with db.lifecycle._cursor(commit=False) as cur:
-        cur.execute("SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?", ("run-del2",))
-        assert cur.fetchone()[0] == 0
+    row = fetch_one(db.lifecycle, "SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?", ("run-del2",))
+    assert row is not None and row[0] == 0
 
 
 def test_v2_record_then_export_roundtrip(tmp_path: Path) -> None:
@@ -269,11 +267,10 @@ def test_iter_run_samples_skips_corrupt_rows_and_continues(tmp_path: Path) -> No
         "run-corrupt",
         [sensor_frame_from_mapping({"t_s": 1.0}), sensor_frame_from_mapping({"t_s": 2.0})],
     )
-    with db.lifecycle._cursor() as cur:
-        cur.execute(
-            "INSERT INTO samples_v2 (run_id, top_peaks) VALUES (?, ?)",
-            ("run-corrupt", "{bad"),
-        )
+    execute_statements(
+        db.lifecycle,
+        ("INSERT INTO samples_v2 (run_id, top_peaks) VALUES (?, ?)", ("run-corrupt", "{bad")),
+    )
     db.run_repository.append_samples("run-corrupt", [sensor_frame_from_mapping({"t_s": 3.0})])
 
     rows = [
@@ -296,11 +293,13 @@ def test_v2_row_to_dict_non_list_peak_column_warns_and_skips_row(
         "run-peak-warn", "2026-01-01T00:00:00Z", _metadata("run-peak-warn")
     )
 
-    with db.lifecycle._cursor() as cur:
-        cur.execute(
+    execute_statements(
+        db.lifecycle,
+        (
             "INSERT INTO samples_v2 (run_id, top_peaks) VALUES (?, ?)",
             ("run-peak-warn", '{"unexpected": "dict"}'),
-        )
+        ),
+    )
 
     import logging
 

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_validation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+from test_support.history_db_async import execute_statements
 from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
@@ -172,8 +173,10 @@ def test_verify_run_integrity_sample_count_mismatch(tmp_path: Path) -> None:
     db.run_repository.finalize_run("run-m", "2026-01-01T00:10:00Z")
     db.run_repository.store_analysis("run-m", make_persisted_analysis(_analysis("run-m")))
     # Manually corrupt sample_count
-    with db.lifecycle._cursor() as cur:
-        cur.execute("UPDATE runs SET sample_count = 99 WHERE run_id = 'run-m'")
+    execute_statements(
+        db.lifecycle,
+        ("UPDATE runs SET sample_count = 99 WHERE run_id = 'run-m'", ()),
+    )
     problems = db.run_repository.verify_run_integrity("run-m")
     assert any("sample_count mismatch" in p for p in problems)
 
@@ -187,8 +190,10 @@ def test_verify_run_integrity_complete_without_analysis(tmp_path: Path) -> None:
     )
     db.run_repository.finalize_run("run-na", "2026-01-01T00:10:00Z")
     # Force status to complete without analysis
-    with db.lifecycle._cursor() as cur:
-        cur.execute("UPDATE runs SET status = 'complete' WHERE run_id = 'run-na'")
+    execute_statements(
+        db.lifecycle,
+        ("UPDATE runs SET status = 'complete' WHERE run_id = 'run-na'", ()),
+    )
     problems = db.run_repository.verify_run_integrity("run-na")
     assert any("missing analysis_json" in p for p in problems)
 

--- a/apps/server/tests/app/test_app_lifecycle.py
+++ b/apps/server/tests/app/test_app_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -48,7 +49,7 @@ async def test_lifespan_shutdown_closes_history_db(tmp_path: Path, monkeypatch) 
     monkeypatch.setattr(UDPControlPlane, "start", _fake_start)
     monkeypatch.setattr(SQLiteHistoryEngine, "close", _fake_close)
 
-    app = app_module.create_app(config_path=cfg_path)
+    app = await asyncio.to_thread(app_module.create_app, config_path=cfg_path)
     async with app.router.lifespan_context(app):
         pass
 
@@ -73,7 +74,7 @@ async def test_lifespan_startup_runtime_error_cleans_up(tmp_path: Path, monkeypa
     monkeypatch.setattr(bootstrap_mod.LifecycleManager, "start", _failing_start)
     monkeypatch.setattr(bootstrap_mod.LifecycleManager, "stop", _fake_stop)
 
-    app = app_module.create_app(config_path=cfg_path)
+    app = await asyncio.to_thread(app_module.create_app, config_path=cfg_path)
 
     with pytest.raises(RuntimeError, match="start failed"):
         async with app.router.lifespan_context(app):
@@ -103,7 +104,7 @@ async def test_lifespan_startup_programmer_error_does_not_clean_up(
     monkeypatch.setattr(bootstrap_mod.LifecycleManager, "start", _failing_start)
     monkeypatch.setattr(bootstrap_mod.LifecycleManager, "stop", _fake_stop)
 
-    app = app_module.create_app(config_path=cfg_path)
+    app = await asyncio.to_thread(app_module.create_app, config_path=cfg_path)
 
     with pytest.raises(TypeError, match="bad bootstrap wiring"):
         async with app.router.lifespan_context(app):

--- a/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
+++ b/apps/server/tests/integration/test_runtime_queue_and_export_regressions.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from test_support.history_db_async import fetch_one
+
 from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
 from vibesensor.infra.processing import SignalProcessor
 
@@ -18,7 +20,7 @@ class TestSQLiteBusyTimeout:
         """HistoryDB must set PRAGMA busy_timeout to avoid immediate SQLITE_BUSY."""
         db = create_history_persistence_adapters(tmp_path / "test.db")
         try:
-            result = db.lifecycle._conn.execute("PRAGMA busy_timeout").fetchone()
+            result = fetch_one(db.lifecycle, "PRAGMA busy_timeout")
             assert result is not None
             assert result[0] == 5000
         finally:

--- a/apps/server/tests/test_support/history_db_async.py
+++ b/apps/server/tests/test_support/history_db_async.py
@@ -1,0 +1,47 @@
+"""Async history-db test helpers for direct table inspection and mutation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vibesensor.shared.async_bridge import run_coro_blocking
+
+
+def execute_statements(
+    db: Any,
+    *statements: tuple[str, tuple[object, ...]],
+) -> None:
+    async def _run() -> None:
+        async with db._cursor_async() as cur:
+            for sql, params in statements:
+                await cur.execute(sql, params)
+
+    run_coro_blocking(_run())
+
+
+def fetch_one(
+    db: Any,
+    sql: str,
+    params: tuple[object, ...] = (),
+) -> tuple[object, ...] | None:
+    async def _run() -> tuple[object, ...] | None:
+        async with db._cursor_async(commit=False) as cur:
+            await cur.execute(sql, params)
+            row = await cur.fetchone()
+        return tuple(row) if row is not None else None
+
+    return run_coro_blocking(_run())
+
+
+def fetch_all(
+    db: Any,
+    sql: str,
+    params: tuple[object, ...] = (),
+) -> list[tuple[object, ...]]:
+    async def _run() -> list[tuple[object, ...]]:
+        async with db._cursor_async(commit=False) as cur:
+            await cur.execute(sql, params)
+            rows = await cur.fetchall()
+        return [tuple(row) for row in rows]
+
+    return run_coro_blocking(_run())

--- a/apps/server/tests/test_support/settings_services.py
+++ b/apps/server/tests/test_support/settings_services.py
@@ -13,6 +13,7 @@ from vibesensor.infra.config.settings_derivation import SettingsDerivationServic
 from vibesensor.infra.config.settings_persistence import SettingsPersistenceCoordinator
 from vibesensor.infra.config.speed_source_settings import PersistedSpeedSourceSettingsService
 from vibesensor.infra.config.ui_preferences import UiPreferencesService
+from vibesensor.shared.async_bridge import run_coro_blocking
 from vibesensor.shared.ports import SettingsSnapshotPersistence
 from vibesensor.shared.time_utils import utc_now_iso
 
@@ -53,10 +54,13 @@ def build_settings_services(
 def write_raw_settings_snapshot(db: Any, value_json: str) -> None:
     """Write raw JSON into the settings snapshot table for load-path tests."""
 
-    with db._cursor() as cur:
-        cur.execute(
-            "INSERT INTO settings_snapshot (id, value_json, updated_at) VALUES (1, ?, ?) "
-            "ON CONFLICT(id) DO UPDATE SET value_json = excluded.value_json, "
-            "updated_at = excluded.updated_at",
-            (value_json, utc_now_iso()),
-        )
+    async def _run() -> None:
+        async with db._cursor_async() as cur:
+            await cur.execute(
+                "INSERT INTO settings_snapshot (id, value_json, updated_at) VALUES (1, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET value_json = excluded.value_json, "
+                "updated_at = excluded.updated_at",
+                (value_json, utc_now_iso()),
+            )
+
+    run_coro_blocking(_run())

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_persistence.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 from test_support import response_payload
+from test_support.history_db_async import fetch_all
 from test_support.persisted_analysis import make_persisted_analysis
 
 from tests.conftest import FakeState
@@ -70,8 +71,7 @@ def _stored_run(
 def test_fresh_db_has_analysis_columns(tmp_path: Path) -> None:
     """Fresh DB should have analysis_started_at, analysis_completed_at."""
     db = create_history_persistence_adapters(tmp_path / "history.db")
-    cursor = db.lifecycle._conn.execute("PRAGMA table_info(runs)")
-    columns = {row[1] for row in cursor.fetchall()}
+    columns = {row[1] for row in fetch_all(db.lifecycle, "PRAGMA table_info(runs)")}
     assert "analysis_started_at" in columns
     assert "analysis_completed_at" in columns
     db.lifecycle.close()

--- a/apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py
+++ b/apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from pathlib import Path
 
@@ -156,9 +157,11 @@ async def test_shutdown_waits_for_analysis_before_db_close(tmp_path: Path, monke
 
     original_close = SQLiteHistoryEngine.close
 
-    def _tracking_close(self):
+    async def _tracking_close(self):
         events.append("db_close")
-        original_close(self)
+        close_result = original_close(self)
+        if close_result is not None:
+            await close_result
 
     original_wait = RunRecorder.wait_for_post_analysis
 
@@ -172,7 +175,7 @@ async def test_shutdown_waits_for_analysis_before_db_close(tmp_path: Path, monke
     monkeypatch.setattr(SQLiteHistoryEngine, "close", _tracking_close)
     monkeypatch.setattr(RunRecorder, "wait_for_post_analysis", _tracking_wait)
 
-    app = app_module.create_app(config_path=cfg_path)
+    app = await asyncio.to_thread(app_module.create_app, config_path=cfg_path)
     async with app.router.lifespan_context(app):
         pass
 

--- a/apps/server/vibesensor/adapters/http/clients.py
+++ b/apps/server/vibesensor/adapters/http/clients.py
@@ -125,14 +125,15 @@ def create_client_routes(
             raise http_exception_for_value_error(exc, status_code=status_code) from exc
         stored_sensor = stored.get(normalized_client_id)
         code = str(stored_sensor["location_code"] if stored_sensor is not None else "").strip()
-        registry.set_location(normalized_client_id, code)
+        await asyncio.to_thread(registry.set_location, normalized_client_id, code)
         if code:
-            registry.set_name(
+            await asyncio.to_thread(
+                registry.set_name,
                 normalized_client_id,
                 str(stored_sensor["name"] if stored_sensor is not None else "").strip(),
             )
         else:
-            registry.clear_name(normalized_client_id)
+            await asyncio.to_thread(registry.clear_name, normalized_client_id)
         mac = client_id_mac(normalized_client_id)
         fallback_sensor: SensorConfigPayload = {
             "name": normalized_client_id,
@@ -161,7 +162,7 @@ def create_client_routes(
     async def remove_client(client_id: str) -> RemoveClientResponse:
         """Remove a disconnected sensor from the runtime registry."""
         normalized_client_id = normalize_client_id_or_400(client_id)
-        removed = registry.remove_client(normalized_client_id)
+        removed = await asyncio.to_thread(registry.remove_client, normalized_client_id)
         if not removed:
             raise HTTPException(status_code=404, detail="Sensor not found")
         return RemoveClientResponse(id=normalized_client_id, status="removed")

--- a/apps/server/vibesensor/adapters/http/health.py
+++ b/apps/server/vibesensor/adapters/http/health.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
@@ -31,7 +32,8 @@ def create_health_routes(
     async def health() -> HealthResponse:
         """Return the current runtime health snapshot for the server and sensor pipeline."""
         return HealthResponse.model_validate(
-            build_system_health_snapshot(
+            await asyncio.to_thread(
+                build_system_health_snapshot,
                 loop_state,
                 health_state,
                 processor,

--- a/apps/server/vibesensor/adapters/http/recording.py
+++ b/apps/server/vibesensor/adapters/http/recording.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
@@ -63,16 +64,16 @@ def create_recording_routes(
     @router.get("/api/recording/status", response_model=RecordingStatusResponse)
     async def get_logging_status() -> RecordingStatusResponse:
         """Return the current recording state, counters, and last completed run details."""
-        return _recording_status_response(run_recorder.status())
+        return _recording_status_response(await asyncio.to_thread(run_recorder.status))
 
     @router.post("/api/recording/start", response_model=RecordingStatusResponse)
     async def start_logging() -> RecordingStatusResponse:
         """Start recording a new run and return the updated recorder status snapshot."""
-        return _recording_status_response(run_recorder.start_recording())
+        return _recording_status_response(await asyncio.to_thread(run_recorder.start_recording))
 
     @router.post("/api/recording/stop", response_model=RecordingStatusResponse)
     async def stop_logging() -> RecordingStatusResponse:
         """Stop the active recording and return the updated recorder status snapshot."""
-        return _recording_status_response(run_recorder.stop_recording())
+        return _recording_status_response(await asyncio.to_thread(run_recorder.stop_recording))
 
     return router

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -15,7 +15,6 @@ from vibesensor.adapters.persistence.history_db._run_repository import RunHistor
 from vibesensor.adapters.persistence.history_db._settings_repository import (
     SettingsSnapshotRepository,
 )
-from vibesensor.shared.async_bridge import run_coro_blocking
 
 __all__ = [
     "ClientNameRepository",
@@ -39,10 +38,16 @@ class HistoryPersistenceAdapters:
     settings_snapshot_repository: SettingsSnapshotRepository
     client_name_repository: ClientNameRepository
 
-    async def open(self) -> None:
+    def open(self) -> None:
+        self.lifecycle.open()
+
+    async def aopen(self) -> None:
         await self.lifecycle.aopen()
 
-    async def close(self) -> None:
+    def close(self) -> object:
+        return self.lifecycle.close()
+
+    async def aclose(self) -> None:
         await self.lifecycle.aclose()
 
 
@@ -81,7 +86,7 @@ def create_history_persistence_adapters(
         db_path,
         corruption_reporter=corruption_reporter,
     )
-    run_coro_blocking(history.open())
+    history.open()
     return history
 
 
@@ -94,5 +99,5 @@ async def create_history_persistence_adapters_async(
         db_path,
         corruption_reporter=corruption_reporter,
     )
-    await history.open()
+    await history.aopen()
     return history

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -15,6 +15,7 @@ from vibesensor.adapters.persistence.history_db._run_repository import RunHistor
 from vibesensor.adapters.persistence.history_db._settings_repository import (
     SettingsSnapshotRepository,
 )
+from vibesensor.shared.async_bridge import run_coro_blocking
 
 __all__ = [
     "ClientNameRepository",
@@ -23,6 +24,7 @@ __all__ = [
     "SQLiteHistoryEngine",
     "SettingsSnapshotRepository",
     "create_history_persistence_adapters",
+    "create_history_persistence_adapters_async",
 ]
 
 LOGGER = logging.getLogger(__name__)
@@ -37,13 +39,18 @@ class HistoryPersistenceAdapters:
     settings_snapshot_repository: SettingsSnapshotRepository
     client_name_repository: ClientNameRepository
 
+    async def open(self) -> None:
+        await self.lifecycle.aopen()
 
-def create_history_persistence_adapters(
+    async def close(self) -> None:
+        await self.lifecycle.aclose()
+
+
+def _build_history_persistence_adapters(
     db_path: Path,
     *,
     corruption_reporter: Callable[[str], None] | None = None,
 ) -> HistoryPersistenceAdapters:
-    """Build the shared history engine plus narrow repositories on top of it."""
     lifecycle = SQLiteHistoryEngine(
         db_path,
         corruption_reporter=corruption_reporter,
@@ -62,3 +69,30 @@ def create_history_persistence_adapters(
             cursor_provider=cursor_provider,
         ),
     )
+
+
+def create_history_persistence_adapters(
+    db_path: Path,
+    *,
+    corruption_reporter: Callable[[str], None] | None = None,
+) -> HistoryPersistenceAdapters:
+    """Build and open the shared history engine plus narrow repositories on top of it."""
+    history = _build_history_persistence_adapters(
+        db_path,
+        corruption_reporter=corruption_reporter,
+    )
+    run_coro_blocking(history.open())
+    return history
+
+
+async def create_history_persistence_adapters_async(
+    db_path: Path,
+    *,
+    corruption_reporter: Callable[[str], None] | None = None,
+) -> HistoryPersistenceAdapters:
+    history = _build_history_persistence_adapters(
+        db_path,
+        corruption_reporter=corruption_reporter,
+    )
+    await history.open()
+    return history

--- a/apps/server/vibesensor/adapters/persistence/history_db/_client_names_repository.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_client_names_repository.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-import sqlite3
 from collections.abc import Callable
-from contextlib import AbstractContextManager
+from contextlib import AbstractAsyncContextManager
 
+import aiosqlite
+
+from vibesensor.shared.async_bridge import run_coro_blocking
 from vibesensor.shared.time_utils import utc_now_iso
 
 __all__ = ["ClientNameRepository"]
@@ -19,23 +21,29 @@ class ClientNameRepository:
     def __init__(
         self,
         *,
-        cursor_provider: Callable[..., AbstractContextManager[sqlite3.Cursor]],
+        cursor_provider: Callable[..., AbstractAsyncContextManager[aiosqlite.Cursor]],
     ) -> None:
         self._cursor_provider = cursor_provider
 
-    def _cursor(self, *, commit: bool = True) -> AbstractContextManager[sqlite3.Cursor]:
+    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         return self._cursor_provider(commit=commit)
 
     def list_client_names(self) -> dict[str, str]:
-        with self._cursor(commit=False) as cur:
-            cur.execute("SELECT client_id, name FROM client_names")
-            rows = cur.fetchall()
+        return run_coro_blocking(self.alist_client_names())
+
+    async def alist_client_names(self) -> dict[str, str]:
+        async with self._cursor(commit=False) as cur:
+            await cur.execute("SELECT client_id, name FROM client_names")
+            rows = await cur.fetchall()
         return {row[0]: row[1] for row in rows}
 
     def upsert_client_name(self, client_id: str, name: str) -> None:
+        run_coro_blocking(self.aupsert_client_name(client_id, name))
+
+    async def aupsert_client_name(self, client_id: str, name: str) -> None:
         now = utc_now_iso()
-        with self._cursor() as cur:
-            cur.execute(
+        async with self._cursor() as cur:
+            await cur.execute(
                 "INSERT INTO client_names (client_id, name, updated_at) VALUES (?, ?, ?) "
                 "ON CONFLICT(client_id) DO UPDATE SET name = excluded.name, "
                 "updated_at = excluded.updated_at",
@@ -43,6 +51,9 @@ class ClientNameRepository:
             )
 
     def delete_client_name(self, client_id: str) -> bool:
-        with self._cursor() as cur:
-            cur.execute("DELETE FROM client_names WHERE client_id = ?", (client_id,))
+        return run_coro_blocking(self.adelete_client_name(client_id))
+
+    async def adelete_client_name(self, client_id: str) -> bool:
+        async with self._cursor() as cur:
+            await cur.execute("DELETE FROM client_names WHERE client_id = ?", (client_id,))
             return bool(int(cur.rowcount) > 0)

--- a/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
@@ -247,8 +247,13 @@ class SQLiteHistoryEngine:
                 await conn.close()
                 raise
 
-    def close(self) -> None:
-        run_coro_blocking(self.aclose())
+    def close(self) -> object:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            run_coro_blocking(self.aclose())
+            return None
+        return self.aclose()
 
     async def aclose(self) -> None:
         async with _async_lock_context(self._lock):

--- a/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
@@ -2,34 +2,168 @@
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import logging
-import sqlite3
-from collections.abc import Callable, Iterator
-from contextlib import AbstractContextManager, contextmanager
+import threading
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from pathlib import Path
-from threading import RLock
+from types import TracebackType
+from typing import Any, cast
+
+import aiosqlite
 
 from vibesensor.adapters.persistence.history_db._schema import (
     SCHEMA_SQL,
     SCHEMA_VERSION,
 )
+from vibesensor.shared.async_bridge import run_coro_blocking
 
 LOGGER = logging.getLogger(__name__)
 
 __all__ = ["SQLiteHistoryEngine"]
 
 
-def run_startup_quick_check(
+class _DualContextManager[CursorT]:
+    """Context manager that supports both ``with`` and ``async with``."""
+
+    __slots__ = ("_manager",)
+
+    def __init__(self, manager: object) -> None:
+        self._manager = manager
+
+    def __enter__(self) -> CursorT:
+        manager = cast(Any, self._manager)
+        if hasattr(manager, "__aenter__"):
+            result = run_coro_blocking(cast(Awaitable[CursorT], manager.__aenter__()))
+        else:
+            result = cast(CursorT, manager.__enter__())
+        return _syncify_result(result)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        manager = cast(Any, self._manager)
+        if hasattr(manager, "__aexit__"):
+            return run_coro_blocking(
+                cast(Awaitable[bool | None], manager.__aexit__(exc_type, exc, tb))
+            )
+        return cast(bool | None, manager.__exit__(exc_type, exc, tb))
+
+    async def __aenter__(self) -> CursorT:
+        manager = cast(Any, self._manager)
+        if hasattr(manager, "__aenter__"):
+            return cast(CursorT, await manager.__aenter__())
+        return _asyncify_result(cast(CursorT, manager.__enter__()))
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        manager = cast(Any, self._manager)
+        if hasattr(manager, "__aexit__"):
+            return cast(bool | None, await manager.__aexit__(exc_type, exc, tb))
+        return cast(bool | None, manager.__exit__(exc_type, exc, tb))
+
+
+class _SyncCursorProxy:
+    """Expose awaitable cursor methods through a synchronous API."""
+
+    __slots__ = ("_cursor",)
+
+    def __init__(self, cursor: object) -> None:
+        self._cursor = cursor
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._cursor, name)
+        if not callable(attr):
+            return attr
+
+        def _wrapped(*args: object, **kwargs: object) -> Any:
+            result = attr(*args, **kwargs)
+            if inspect.isawaitable(result):
+                return run_coro_blocking(result)
+            return result
+
+        return _wrapped
+
+
+class _AsyncCursorProxy:
+    """Expose synchronous cursor methods through an awaitable API."""
+
+    __slots__ = ("_cursor",)
+
+    def __init__(self, cursor: object) -> None:
+        self._cursor = cursor
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._cursor, name)
+        if not callable(attr):
+            return attr
+
+        async def _wrapped(*args: object, **kwargs: object) -> Any:
+            result = attr(*args, **kwargs)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+
+        return _wrapped
+
+
+def _syncify_result[ResultT](value: ResultT) -> ResultT:
+    if value is None:
+        return value
+    if hasattr(value, "execute") and (hasattr(value, "fetchone") or hasattr(value, "fetchall")):
+        return cast(ResultT, _SyncCursorProxy(value))
+    return value
+
+
+def _asyncify_result[ResultT](value: ResultT) -> ResultT:
+    if value is None:
+        return value
+    if hasattr(value, "execute") and (hasattr(value, "fetchone") or hasattr(value, "fetchall")):
+        return cast(ResultT, _AsyncCursorProxy(value))
+    return value
+
+
+@asynccontextmanager
+async def _async_lock_context(lock: object) -> AsyncIterator[None]:
+    manager = cast(Any, lock)
+    if hasattr(manager, "__aenter__"):
+        async with manager:
+            yield
+        return
+    if hasattr(manager, "acquire") and hasattr(manager, "release"):
+        await asyncio.to_thread(manager.acquire)
+        try:
+            yield
+        finally:
+            manager.release()
+        return
+    if hasattr(manager, "__enter__") and hasattr(manager, "__exit__"):
+        with manager:
+            yield
+        return
+    raise TypeError(f"Unsupported lock object: {type(lock)!r}")
+
+
+async def run_startup_quick_check(
     *,
-    cursor_provider: Callable[..., AbstractContextManager[sqlite3.Cursor]],
+    cursor_provider: Callable[..., AbstractAsyncContextManager[aiosqlite.Cursor]],
     db_path: Path,
     mark_corrupted: Callable[[str], None],
 ) -> None:
     try:
-        with cursor_provider(commit=False) as cur:
-            cur.execute("PRAGMA quick_check")
-            problems = [str(row[0]) for row in cur.fetchall() if str(row[0]) != "ok"]
-    except sqlite3.Error:
+        async with _DualContextManager[aiosqlite.Cursor](cursor_provider(commit=False)) as cur:
+            await cur.execute("PRAGMA quick_check")
+            problems = [str(row[0]) for row in await cur.fetchall() if str(row[0]) != "ok"]
+    except aiosqlite.Error:
         LOGGER.critical(
             "History DB quick_check failed during startup for %s",
             db_path,
@@ -55,6 +189,7 @@ class SQLiteHistoryEngine:
         "_corruption_details",
         "_corruption_reporter",
         "_lock",
+        "_open_lock",
         "_read_conn",
         "_read_lock",
         "_use_separate_read_conn",
@@ -69,92 +204,115 @@ class SQLiteHistoryEngine:
         self.db_path = db_path
         self._corruption_reporter = corruption_reporter
         self._corruption_details: str | None = None
-        self._lock = RLock()
-        self._read_lock = RLock()
-        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._open_lock = threading.Lock()
+        self._read_lock = threading.Lock()
         self._use_separate_read_conn = str(db_path) != ":memory:"
-        self._conn: sqlite3.Connection | None = sqlite3.connect(db_path, check_same_thread=False)
-        self._read_conn: sqlite3.Connection | None = None
-        try:
-            self._configure_connection(self._conn, read_only=False)
-            self._ensure_schema()
-            self._run_startup_quick_check()
-            if self._use_separate_read_conn:
-                self._read_conn = sqlite3.connect(db_path, check_same_thread=False)
-                self._configure_connection(self._read_conn, read_only=True)
-        except sqlite3.Error:
-            if self._read_conn is not None:
-                self._read_conn.close()
-            self._conn.close()
-            raise
+        self._conn: aiosqlite.Connection | None = None
+        self._read_conn: aiosqlite.Connection | None = None
 
     @staticmethod
-    def _configure_connection(conn: sqlite3.Connection, *, read_only: bool) -> None:
-        conn.execute("PRAGMA journal_mode=WAL")
+    async def _configure_connection(conn: aiosqlite.Connection, *, read_only: bool) -> None:
+        await conn.execute("PRAGMA journal_mode=WAL")
         if not read_only:
-            conn.execute("PRAGMA wal_autocheckpoint=500")
-        conn.execute("PRAGMA foreign_keys=ON")
-        conn.execute("PRAGMA busy_timeout=5000")
+            await conn.execute("PRAGMA wal_autocheckpoint=500")
+        await conn.execute("PRAGMA foreign_keys=ON")
+        await conn.execute("PRAGMA busy_timeout=5000")
         if read_only:
-            conn.execute("PRAGMA query_only=ON")
+            await conn.execute("PRAGMA query_only=ON")
+
+    def open(self) -> None:
+        run_coro_blocking(self.aopen())
+
+    async def aopen(self) -> None:
+        async with _async_lock_context(self._open_lock):
+            if self._conn is not None:
+                return
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            conn = await aiosqlite.connect(self.db_path, check_same_thread=False)
+            read_conn: aiosqlite.Connection | None = None
+            try:
+                await self._configure_connection(conn, read_only=False)
+                self._conn = conn
+                await self._ensure_schema()
+                await self._run_startup_quick_check_async()
+                if self._use_separate_read_conn:
+                    read_conn = await aiosqlite.connect(self.db_path, check_same_thread=False)
+                    await self._configure_connection(read_conn, read_only=True)
+                self._read_conn = read_conn
+            except aiosqlite.Error:
+                self._conn = None
+                if read_conn is not None:
+                    await read_conn.close()
+                await conn.close()
+                raise
 
     def close(self) -> None:
-        with self._lock:
+        run_coro_blocking(self.aclose())
+
+    async def aclose(self) -> None:
+        async with _async_lock_context(self._lock):
             if self._conn is not None:
-                self._conn.close()
+                await self._conn.close()
                 self._conn = None
-        with self._read_lock:
+        async with _async_lock_context(self._read_lock):
             if self._read_conn is not None:
-                self._read_conn.close()
+                await self._read_conn.close()
                 self._read_conn = None
 
     def _cursor_connection(
         self,
         *,
         commit: bool,
-    ) -> tuple[sqlite3.Connection | None, RLock]:
+    ) -> tuple[aiosqlite.Connection | None, object]:
         if not commit and self._read_conn is not None:
             return self._read_conn, self._read_lock
         return self._conn, self._lock
 
-    @contextmanager
-    def _cursor(self, *, commit: bool = True) -> Iterator[sqlite3.Cursor]:
+    @asynccontextmanager
+    async def _cursor_async(self, *, commit: bool = True) -> AsyncIterator[aiosqlite.Cursor]:
         conn, lock = self._cursor_connection(commit=commit)
-        with lock:
+        async with _async_lock_context(lock):
             if conn is None:
                 raise RuntimeError("HistoryDB is closed")
             if commit:
                 self._assert_write_allowed()
-            cur = conn.cursor()
+            cur = await conn.cursor()
             completed = False
             try:
                 yield cur
                 if commit:
-                    conn.commit()
+                    await conn.commit()
                 completed = True
             finally:
                 if not completed:
-                    self._rollback_transaction(conn, context="_cursor")
-                cur.close()
+                    await self._rollback_transaction(conn, context="_cursor")
+                await cur.close()
 
-    @contextmanager
-    def write_transaction_cursor(self) -> Iterator[sqlite3.Cursor]:
+    def _cursor(self, *, commit: bool = True) -> _DualContextManager[aiosqlite.Cursor]:
+        return _DualContextManager(self._cursor_async(commit=commit))
+
+    @asynccontextmanager
+    async def write_transaction_cursor_async(self) -> AsyncIterator[aiosqlite.Cursor]:
         """Run a multi-step write sequence as one explicit transaction."""
-        with self._lock:
+        async with _async_lock_context(self._lock):
             if self._conn is None:
                 raise RuntimeError("HistoryDB is closed")
             self._assert_write_allowed()
-            cur = self._conn.cursor()
+            cur = await self._conn.cursor()
             completed = False
             try:
-                cur.execute("BEGIN IMMEDIATE")
+                await cur.execute("BEGIN IMMEDIATE")
                 yield cur
-                self._conn.commit()
+                await self._conn.commit()
                 completed = True
             finally:
                 if not completed:
-                    self._rollback_transaction(self._conn, context="write_transaction_cursor")
-                cur.close()
+                    await self._rollback_transaction(self._conn, context="write_transaction_cursor")
+                await cur.close()
+
+    def write_transaction_cursor(self) -> _DualContextManager[aiosqlite.Cursor]:
+        return _DualContextManager(self.write_transaction_cursor_async())
 
     @property
     def corruption_detected(self) -> bool:
@@ -167,7 +325,7 @@ class SQLiteHistoryEngine:
     def _assert_write_allowed(self) -> None:
         if self._corruption_details is None:
             return
-        raise sqlite3.DatabaseError(
+        raise aiosqlite.DatabaseError(
             "History DB quick_check reported corruption for "
             f"{self.db_path}: {self._corruption_details}. Writes are disabled until "
             "the database is repaired or replaced."
@@ -178,33 +336,33 @@ class SQLiteHistoryEngine:
         if self._corruption_reporter is not None:
             self._corruption_reporter(details)
 
-    def _rollback_transaction(self, conn: sqlite3.Connection, *, context: str) -> None:
+    async def _rollback_transaction(self, conn: aiosqlite.Connection, *, context: str) -> None:
         if not conn.in_transaction:
             return
         try:
-            conn.rollback()
-        except sqlite3.Error:
+            await conn.rollback()
+        except aiosqlite.Error:
             LOGGER.critical("History DB rollback failed during %s", context, exc_info=True)
 
-    def _ensure_schema(self) -> None:
-        with self._cursor() as cur:
-            cur.executescript(SCHEMA_SQL)
+    async def _ensure_schema(self) -> None:
+        async with self._cursor() as cur:
+            await cur.executescript(SCHEMA_SQL)
 
-        version = self._schema_version()
+        version = await self._schema_version()
 
         if version == 0:
-            with self._cursor(commit=False) as cur:
-                cur.execute(
+            async with self._cursor(commit=False) as cur:
+                await cur.execute(
                     "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_meta'"
                 )
-                if cur.fetchone() is not None:
+                if await cur.fetchone() is not None:
                     raise RuntimeError(
                         f"Database at {self.db_path} uses a legacy "
                         "schema_meta table incompatible with the current "
                         f"v{SCHEMA_VERSION} format. Delete it to recreate."
                     )
-            with self._cursor() as cur:
-                cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+            async with self._cursor() as cur:
+                await cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
             return
 
         if version == SCHEMA_VERSION:
@@ -219,14 +377,17 @@ class SQLiteHistoryEngine:
             f"Delete the database file at {self.db_path} to recreate it."
         )
 
-    def _schema_version(self) -> int:
-        with self._cursor(commit=False) as cur:
-            cur.execute("PRAGMA user_version")
-            row = cur.fetchone()
+    async def _schema_version(self) -> int:
+        async with self._cursor(commit=False) as cur:
+            await cur.execute("PRAGMA user_version")
+            row = await cur.fetchone()
         return int(row[0]) if row is not None else 0
 
     def _run_startup_quick_check(self) -> None:
-        run_startup_quick_check(
+        run_coro_blocking(self._run_startup_quick_check_async())
+
+    async def _run_startup_quick_check_async(self) -> None:
+        await run_startup_quick_check(
             cursor_provider=self._cursor,
             db_path=self.db_path,
             mark_corrupted=self._mark_corrupted,

--- a/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
-from contextlib import AbstractContextManager
+from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime
 
+import aiosqlite
+
 from vibesensor.domain.run_status import RunStatus
+from vibesensor.shared.async_bridge import run_coro_blocking
 from vibesensor.shared.boundaries.analysis_payloads import (
     persisted_analysis_from_storage_json_object,
 )
@@ -26,7 +28,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class _HistoryDBQueryMixin:
-    def _cursor(self, *, commit: bool = True) -> AbstractContextManager[sqlite3.Cursor]:
+    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         raise NotImplementedError
 
     @staticmethod
@@ -79,22 +81,25 @@ class _HistoryDBQueryMixin:
         return run_metadata_from_mapping(parsed)
 
     def list_runs(self, limit: int = 500) -> list[HistoryRunListEntry]:
-        with self._cursor(commit=False) as cur:
+        return run_coro_blocking(self.alist_runs(limit))
+
+    async def alist_runs(self, limit: int = 500) -> list[HistoryRunListEntry]:
+        async with self._cursor(commit=False) as cur:
             limit = max(limit, 0)
             if limit > 0:
-                cur.execute(
+                await cur.execute(
                     "SELECT r.run_id, r.status, r.start_time_utc, r.end_time_utc, "
                     "r.created_at, r.error_message, r.sample_count, r.metadata_json "
                     "FROM runs r ORDER BY r.created_at DESC LIMIT ?",
                     (limit,),
                 )
             else:
-                cur.execute(
+                await cur.execute(
                     "SELECT r.run_id, r.status, r.start_time_utc, r.end_time_utc, "
                     "r.created_at, r.error_message, r.sample_count, r.metadata_json "
                     "FROM runs r ORDER BY r.created_at DESC",
                 )
-            rows = cur.fetchall()
+            rows = await cur.fetchall()
         result: list[HistoryRunListEntry] = []
         for row in rows:
             run_id, status_raw, start, end, created, error, sample_count, metadata_json = row
@@ -125,15 +130,18 @@ class _HistoryDBQueryMixin:
         return result
 
     def get_run(self, run_id: str) -> StoredHistoryRun | None:
-        with self._cursor(commit=False) as cur:
-            cur.execute(
+        return run_coro_blocking(self.aget_run(run_id))
+
+    async def aget_run(self, run_id: str) -> StoredHistoryRun | None:
+        async with self._cursor(commit=False) as cur:
+            await cur.execute(
                 "SELECT run_id, case_id, status, start_time_utc, end_time_utc, "
                 "metadata_json, analysis_json, error_message, created_at, "
                 "sample_count, analysis_started_at, analysis_completed_at "
                 "FROM runs WHERE run_id = ?",
                 (run_id,),
             )
-            row = cur.fetchone()
+            row = await cur.fetchone()
         if row is None:
             return None
         (
@@ -193,12 +201,15 @@ class _HistoryDBQueryMixin:
         )
 
     def get_run_metadata(self, run_id: str) -> RunMetadata | None:
-        with self._cursor(commit=False) as cur:
-            cur.execute(
+        return run_coro_blocking(self.aget_run_metadata(run_id))
+
+    async def aget_run_metadata(self, run_id: str) -> RunMetadata | None:
+        async with self._cursor(commit=False) as cur:
+            await cur.execute(
                 "SELECT start_time_utc, end_time_utc, metadata_json FROM runs WHERE run_id = ?",
                 (run_id,),
             )
-            row = cur.fetchone()
+            row = await cur.fetchone()
         if row is None:
             return None
         start_time_utc, end_time_utc, metadata_json = row
@@ -212,28 +223,37 @@ class _HistoryDBQueryMixin:
         )
 
     def get_active_run_id(self) -> str | None:
-        with self._cursor(commit=False) as cur:
-            cur.execute(
+        return run_coro_blocking(self.aget_active_run_id())
+
+    async def aget_active_run_id(self) -> str | None:
+        async with self._cursor(commit=False) as cur:
+            await cur.execute(
                 "SELECT run_id FROM runs WHERE status = 'recording' "
                 "ORDER BY created_at DESC LIMIT 1",
             )
-            row = cur.fetchone()
+            row = await cur.fetchone()
         return str(row[0]) if row else None
 
     def stale_analyzing_run_ids(self) -> list[str]:
-        with self._cursor(commit=False) as cur:
-            cur.execute(
+        return run_coro_blocking(self.astale_analyzing_run_ids())
+
+    async def astale_analyzing_run_ids(self) -> list[str]:
+        async with self._cursor(commit=False) as cur:
+            await cur.execute(
                 "SELECT run_id FROM runs WHERE status = 'analyzing' "
                 "ORDER BY created_at ASC LIMIT 1000",
             )
-            return [str(row[0]) for row in cur.fetchall()]
+            return [str(row[0]) for row in await cur.fetchall()]
 
     def analyzing_run_health(self) -> AnalyzingRunHealth:
-        with self._cursor(commit=False) as cur:
-            cur.execute(
+        return run_coro_blocking(self.aanalyzing_run_health())
+
+    async def aanalyzing_run_health(self) -> AnalyzingRunHealth:
+        async with self._cursor(commit=False) as cur:
+            await cur.execute(
                 "SELECT COUNT(*), MIN(analysis_started_at) FROM runs WHERE status = 'analyzing'",
             )
-            row = cur.fetchone()
+            row = await cur.fetchone()
         count = int(row[0]) if row and row[0] is not None else 0
         oldest_started_at = str(row[1]) if row and row[1] else None
         oldest_age_s: float | None = None
@@ -256,25 +276,29 @@ class _HistoryDBQueryMixin:
         )
 
     def verify_run_integrity(self, run_id: str) -> list[str]:
+        return run_coro_blocking(self.averify_run_integrity(run_id))
+
+    async def averify_run_integrity(self, run_id: str) -> list[str]:
         """Check a completed run for consistency issues. Returns problem descriptions."""
         problems: list[str] = []
-        with self._cursor(commit=False) as cur:
-            cur.execute(
+        async with self._cursor(commit=False) as cur:
+            await cur.execute(
                 "SELECT status, sample_count, analysis_json FROM runs WHERE run_id = ?",
                 (run_id,),
             )
-            row = cur.fetchone()
+            row = await cur.fetchone()
             if row is None:
                 return ["run not found"]
             status, stored_count, analysis_raw = row[0], row[1], row[2]
             if status == "complete" and not analysis_raw:
                 problems.append("complete run missing analysis_json")
             if stored_count is not None:
-                cur.execute(
+                await cur.execute(
                     "SELECT COUNT(*) FROM samples_v2 WHERE run_id = ?",
                     (run_id,),
                 )
-                actual_count = int(cur.fetchone()[0])
+                count_row = await cur.fetchone()
+                actual_count = int(count_row[0]) if count_row is not None else 0
                 stored_int = int(stored_count)
                 if actual_count != stored_int:
                     problems.append(

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
-from contextlib import AbstractContextManager
+from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime, timedelta
+
+import aiosqlite
 
 from vibesensor.adapters.persistence.history_db._samples import V2_INSERT_SQL, sample_to_v2_row
 from vibesensor.domain.run_status import RunStatus, is_run_deletable, transition_run
+from vibesensor.shared.async_bridge import run_coro_blocking
 from vibesensor.shared.boundaries.analysis_payloads import (
     persisted_analysis_to_storage_json_object,
 )
@@ -26,21 +28,30 @@ _EXPECTED_ANALYSIS_KEYS: frozenset[str] = frozenset({"findings", "top_causes", "
 
 
 class _HistoryDBRunLifecycleMixin:
-    def _cursor(self, *, commit: bool = True) -> AbstractContextManager[sqlite3.Cursor]:
+    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         raise NotImplementedError
 
-    def write_transaction_cursor(self) -> AbstractContextManager[sqlite3.Cursor]:
+    def write_transaction_cursor(self) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         raise NotImplementedError
 
     @staticmethod
-    def _run_status(cur: sqlite3.Cursor, run_id: str) -> str | None:
-        cur.execute("SELECT status FROM runs WHERE run_id = ?", (run_id,))
-        row = cur.fetchone()
+    async def _run_status(cur: aiosqlite.Cursor, run_id: str) -> str | None:
+        await cur.execute("SELECT status FROM runs WHERE run_id = ?", (run_id,))
+        row = await cur.fetchone()
         if row is None:
             return None
         return str(row[0])
 
     def create_run(
+        self,
+        run_id: str,
+        start_time_utc: str,
+        metadata: RunMetadata,
+        case_id: str | None = None,
+    ) -> None:
+        run_coro_blocking(self.acreate_run(run_id, start_time_utc, metadata, case_id))
+
+    async def acreate_run(
         self,
         run_id: str,
         start_time_utc: str,
@@ -60,8 +71,8 @@ class _HistoryDBRunLifecycleMixin:
                 ", ".join(sorted(missing)),
             )
         now = utc_now_iso()
-        with self._cursor() as cur:
-            cur.execute(
+        async with self._cursor() as cur:
+            await cur.execute(
                 "INSERT INTO runs (run_id, case_id, status, start_time_utc, metadata_json, "
                 "created_at) VALUES (?, ?, 'recording', ?, ?, ?)",
                 (run_id, case_id, start_time_utc, safe_json_dumps(metadata_payload), now),
@@ -72,14 +83,21 @@ class _HistoryDBRunLifecycleMixin:
         run_id: str,
         samples: list[SensorFrame],
     ) -> int:
+        return run_coro_blocking(self.aappend_samples(run_id, samples))
+
+    async def aappend_samples(
+        self,
+        run_id: str,
+        samples: list[SensorFrame],
+    ) -> int:
         if not samples:
             return 0
         if not run_id or not run_id.strip():
             raise ValueError("append_samples: run_id must be a non-empty string")
 
         chunk_size = 256
-        with self.write_transaction_cursor() as cur:
-            current_status = self._run_status(cur, run_id)
+        async with self.write_transaction_cursor() as cur:
+            current_status = await self._run_status(cur, run_id)
             if current_status != RunStatus.RECORDING.value:
                 LOGGER.warning(
                     "append_samples for run %s: rejected %d sample(s) because status is %s",
@@ -90,17 +108,17 @@ class _HistoryDBRunLifecycleMixin:
                 return 0
             for start in range(0, len(samples), chunk_size):
                 batch = samples[start : start + chunk_size]
-                cur.executemany(
+                await cur.executemany(
                     V2_INSERT_SQL,
-                    (sample_to_v2_row(run_id, sample) for sample in batch),
+                    [sample_to_v2_row(run_id, sample) for sample in batch],
                 )
-            cur.execute(
+            await cur.execute(
                 "UPDATE runs SET sample_count = sample_count + ? "
                 "WHERE run_id = ? AND status = 'recording'",
                 (len(samples), run_id),
             )
             if int(cur.rowcount) <= 0:
-                raise sqlite3.IntegrityError(
+                raise aiosqlite.IntegrityError(
                     f"append_samples: run {run_id} left recording during append",
                 )
             return len(samples)
@@ -112,9 +130,18 @@ class _HistoryDBRunLifecycleMixin:
         metadata: RunMetadata | None = None,
         case_id: str | None = None,
     ) -> bool:
+        return run_coro_blocking(self.afinalize_run(run_id, end_time_utc, metadata, case_id))
+
+    async def afinalize_run(
+        self,
+        run_id: str,
+        end_time_utc: str,
+        metadata: RunMetadata | None = None,
+        case_id: str | None = None,
+    ) -> bool:
         now = utc_now_iso()
-        with self._cursor() as cur:
-            current_status = self._run_status(cur, run_id)
+        async with self._cursor() as cur:
+            current_status = await self._run_status(cur, run_id)
             try:
                 transition_run(current_status, RunStatus.ANALYZING)
             except ValueError:
@@ -133,7 +160,7 @@ class _HistoryDBRunLifecycleMixin:
                 assignments.insert(0, "case_id = ?")
                 params.insert(0, case_id)
             params.append(run_id)
-            cur.execute(
+            await cur.execute(
                 f"UPDATE runs SET {', '.join(assignments)} WHERE run_id = ?",
                 params,
             )
@@ -144,8 +171,15 @@ class _HistoryDBRunLifecycleMixin:
         run_id: str,
         metadata: RunMetadata,
     ) -> bool:
-        with self._cursor() as cur:
-            cur.execute(
+        return run_coro_blocking(self.aupdate_run_metadata(run_id, metadata))
+
+    async def aupdate_run_metadata(
+        self,
+        run_id: str,
+        metadata: RunMetadata,
+    ) -> bool:
+        async with self._cursor() as cur:
+            await cur.execute(
                 "UPDATE runs SET metadata_json = ? WHERE run_id = ?",
                 (safe_json_dumps(run_metadata_to_json_object(metadata)), run_id),
             )
@@ -155,18 +189,31 @@ class _HistoryDBRunLifecycleMixin:
         self,
         run_id: str,
     ) -> tuple[bool, str | None]:
-        with self._cursor() as cur:
-            cur.execute("SELECT status FROM runs WHERE run_id = ?", (run_id,))
-            row = cur.fetchone()
+        return run_coro_blocking(self.adelete_run_if_safe(run_id))
+
+    async def adelete_run_if_safe(
+        self,
+        run_id: str,
+    ) -> tuple[bool, str | None]:
+        async with self._cursor() as cur:
+            await cur.execute("SELECT status FROM runs WHERE run_id = ?", (run_id,))
+            row = await cur.fetchone()
             if row is None:
                 return False, "not_found"
             status = RunStatus(row[0])
             if not is_run_deletable(status):
                 return False, "active" if status == RunStatus.RECORDING else status.value
-            cur.execute("DELETE FROM runs WHERE run_id = ?", (run_id,))
+            await cur.execute("DELETE FROM runs WHERE run_id = ?", (run_id,))
             return bool(int(cur.rowcount) > 0), None
 
     def store_analysis(
+        self,
+        run_id: str,
+        analysis: PersistedAnalysis,
+    ) -> bool:
+        return run_coro_blocking(self.astore_analysis(run_id, analysis))
+
+    async def astore_analysis(
         self,
         run_id: str,
         analysis: PersistedAnalysis,
@@ -180,8 +227,8 @@ class _HistoryDBRunLifecycleMixin:
                 ", ".join(sorted(missing)),
             )
         now = utc_now_iso()
-        with self._cursor() as cur:
-            current_status = self._run_status(cur, run_id)
+        async with self._cursor() as cur:
+            current_status = await self._run_status(cur, run_id)
             if current_status == RunStatus.COMPLETE:
                 LOGGER.warning(
                     "store_analysis for run %s: skipped — already complete",
@@ -197,7 +244,7 @@ class _HistoryDBRunLifecycleMixin:
                     current_status,
                 )
                 return False
-            cur.execute(
+            await cur.execute(
                 "UPDATE runs SET status = 'complete', analysis_json = ?, "
                 "analysis_completed_at = ?, end_time_utc = COALESCE(end_time_utc, ?) "
                 "WHERE run_id = ?",
@@ -211,9 +258,12 @@ class _HistoryDBRunLifecycleMixin:
             return int(cur.rowcount) > 0
 
     def store_analysis_error(self, run_id: str, error: str) -> bool:
+        return run_coro_blocking(self.astore_analysis_error(run_id, error))
+
+    async def astore_analysis_error(self, run_id: str, error: str) -> bool:
         now = utc_now_iso()
-        with self._cursor() as cur:
-            current_status = self._run_status(cur, run_id)
+        async with self._cursor() as cur:
+            current_status = await self._run_status(cur, run_id)
             if current_status == RunStatus.COMPLETE:
                 LOGGER.warning(
                     "store_analysis_error for run %s: skipped — already complete",
@@ -229,7 +279,7 @@ class _HistoryDBRunLifecycleMixin:
                     current_status,
                 )
                 return False
-            cur.execute(
+            await cur.execute(
                 "UPDATE runs SET status = 'error', error_message = ?, "
                 "analysis_completed_at = ?, end_time_utc = COALESCE(end_time_utc, ?) "
                 "WHERE run_id = ?",
@@ -238,25 +288,34 @@ class _HistoryDBRunLifecycleMixin:
             return int(cur.rowcount) > 0
 
     def delete_run(self, run_id: str) -> bool:
-        with self._cursor() as cur:
-            cur.execute("DELETE FROM runs WHERE run_id = ?", (run_id,))
+        return run_coro_blocking(self.adelete_run(run_id))
+
+    async def adelete_run(self, run_id: str) -> bool:
+        async with self._cursor() as cur:
+            await cur.execute("DELETE FROM runs WHERE run_id = ?", (run_id,))
             return bool(int(cur.rowcount) > 0)
 
     def recover_stale_recording_runs(self) -> int:
+        return run_coro_blocking(self.arecover_stale_recording_runs())
+
+    async def arecover_stale_recording_runs(self) -> int:
         now = utc_now_iso()
-        with self._cursor() as cur:
-            cur.execute(
+        async with self._cursor() as cur:
+            await cur.execute(
                 "UPDATE runs SET status = 'error', error_message = ? WHERE status = 'recording'",
                 (f"Recovered stale recording during startup at {now}",),
             )
             return int(cur.rowcount)
 
     def prune_terminal_runs_older_than_days(self, retention_days: int) -> int:
+        return run_coro_blocking(self.aprune_terminal_runs_older_than_days(retention_days))
+
+    async def aprune_terminal_runs_older_than_days(self, retention_days: int) -> int:
         if retention_days < 1:
             raise ValueError("retention_days must be at least 1")
         cutoff_utc = (datetime.now(UTC) - timedelta(days=retention_days)).isoformat()
-        with self._cursor() as cur:
-            cur.execute(
+        async with self._cursor() as cur:
+            await cur.execute(
                 """
                 DELETE FROM runs
                 WHERE status IN ('complete', 'error')

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_repository.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_repository.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
-import sqlite3
 from collections.abc import Callable
-from contextlib import AbstractContextManager
+from contextlib import AbstractAsyncContextManager
 
+import aiosqlite
+
+from vibesensor.adapters.persistence.history_db._engine import _DualContextManager
 from vibesensor.adapters.persistence.history_db._queries import _HistoryDBQueryMixin
 from vibesensor.adapters.persistence.history_db._run_lifecycle import _HistoryDBRunLifecycleMixin
 from vibesensor.adapters.persistence.history_db._sample_io import _HistoryDBSampleIOMixin
 
 __all__ = ["RunHistoryRepository"]
+
+CursorProvider = Callable[..., AbstractAsyncContextManager[aiosqlite.Cursor]]
+WriteTransactionCursorProvider = Callable[[], AbstractAsyncContextManager[aiosqlite.Cursor]]
 
 
 class RunHistoryRepository(
@@ -25,14 +30,14 @@ class RunHistoryRepository(
     def __init__(
         self,
         *,
-        cursor_provider: Callable[..., AbstractContextManager[sqlite3.Cursor]],
-        write_transaction_cursor_provider: Callable[[], AbstractContextManager[sqlite3.Cursor]],
+        cursor_provider: CursorProvider,
+        write_transaction_cursor_provider: WriteTransactionCursorProvider,
     ) -> None:
         self._cursor_provider = cursor_provider
         self._write_transaction_cursor_provider = write_transaction_cursor_provider
 
-    def _cursor(self, *, commit: bool = True) -> AbstractContextManager[sqlite3.Cursor]:
-        return self._cursor_provider(commit=commit)
+    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
+        return _DualContextManager(self._cursor_provider(commit=commit))
 
-    def write_transaction_cursor(self) -> AbstractContextManager[sqlite3.Cursor]:
-        return self._write_transaction_cursor_provider()
+    def write_transaction_cursor(self) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
+        return _DualContextManager(self._write_transaction_cursor_provider())

--- a/apps/server/vibesensor/adapters/persistence/history_db/_sample_io.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_sample_io.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
-from collections.abc import Iterator
-from contextlib import AbstractContextManager
+from collections.abc import AsyncIterator, Iterator
+from contextlib import AbstractAsyncContextManager
+
+import aiosqlite
 
 from vibesensor.adapters.persistence.history_db._samples import (
     ALLOWED_SAMPLE_TABLES,
     V2_SELECT_SQL_COLS,
     v2_row_to_sensor_frame,
 )
+from vibesensor.shared.async_bridge import run_coro_blocking
 from vibesensor.shared.boundaries.codecs.sensor_frame_values import SensorFrameDecodeError
 from vibesensor.shared.types.sensor_frame import SensorFrame
 
@@ -19,12 +21,15 @@ LOGGER = logging.getLogger(__name__)
 
 
 class _HistoryDBSampleIOMixin:
-    def _cursor(self, *, commit: bool = True) -> AbstractContextManager[sqlite3.Cursor]:
+    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         raise NotImplementedError
 
     def get_run_samples(self, run_id: str) -> list[SensorFrame]:
+        return run_coro_blocking(self.aget_run_samples(run_id))
+
+    async def aget_run_samples(self, run_id: str) -> list[SensorFrame]:
         rows: list[SensorFrame] = []
-        for batch in self.iter_run_samples(run_id):
+        async for batch in self.aiter_run_samples(run_id):
             rows.extend(batch)
         return rows
 
@@ -36,13 +41,59 @@ class _HistoryDBSampleIOMixin:
         *,
         stride: int = 1,
     ) -> Iterator[list[SensorFrame]]:
+        return iter(
+            run_coro_blocking(
+                self._collect_sample_batches(
+                    run_id,
+                    batch_size=batch_size,
+                    offset=offset,
+                    stride=stride,
+                )
+            )
+        )
+
+    async def _collect_sample_batches(
+        self,
+        run_id: str,
+        batch_size: int = 1000,
+        offset: int = 0,
+        *,
+        stride: int = 1,
+    ) -> list[list[SensorFrame]]:
+        return [
+            batch
+            async for batch in self.aiter_run_samples(
+                run_id,
+                batch_size=batch_size,
+                offset=offset,
+                stride=stride,
+            )
+        ]
+
+    async def aiter_run_samples(
+        self,
+        run_id: str,
+        batch_size: int = 1000,
+        offset: int = 0,
+        *,
+        stride: int = 1,
+    ) -> AsyncIterator[list[SensorFrame]]:
         if offset < 0:
             raise ValueError(f"iter_run_samples: offset must be >= 0, got {offset}")
         if stride < 1:
             raise ValueError(f"iter_run_samples: stride must be >= 1, got {stride}")
-        yield from self._iter_v2_samples(run_id, batch_size, offset, stride)
+        async for batch in self._iter_v2_samples(run_id, batch_size, offset, stride):
+            yield batch
 
     def _resolve_keyset_offset(
+        self,
+        table: str,
+        run_id: str,
+        offset: int,
+    ) -> int | None:
+        return run_coro_blocking(self._aresolve_keyset_offset(table, run_id, offset))
+
+    async def _aresolve_keyset_offset(
         self,
         table: str,
         run_id: str,
@@ -53,44 +104,44 @@ class _HistoryDBSampleIOMixin:
                 f"_resolve_keyset_offset: invalid table name {table!r}; "
                 f"must be one of {sorted(ALLOWED_SAMPLE_TABLES)}",
             )
-        with self._cursor(commit=False) as cur:
-            cur.execute(
+        async with self._cursor(commit=False) as cur:
+            await cur.execute(
                 f"SELECT id FROM {table} WHERE run_id = ? ORDER BY id LIMIT 1 OFFSET ?",
                 (run_id, offset - 1),
             )
-            row = cur.fetchone()
+            row = await cur.fetchone()
         return int(row[0]) if row else None
 
-    def _iter_v2_samples(
+    async def _iter_v2_samples(
         self,
         run_id: str,
         batch_size: int = 1000,
         offset: int = 0,
         stride: int = 1,
-    ) -> Iterator[list[SensorFrame]]:
+    ) -> AsyncIterator[list[SensorFrame]]:
         size = max(1, batch_size)
         last_id: int | None = None
         if offset > 0:
-            last_id = self._resolve_keyset_offset("samples_v2", run_id, offset)
+            last_id = await self._aresolve_keyset_offset("samples_v2", run_id, offset)
             if last_id is None:
                 return
         total_skipped = 0
         sample_index = offset
         while True:
-            with self._cursor(commit=False) as cur:
+            async with self._cursor(commit=False) as cur:
                 if last_id is None:
-                    cur.execute(
+                    await cur.execute(
                         f"SELECT {V2_SELECT_SQL_COLS} FROM samples_v2"
                         " WHERE run_id = ? ORDER BY id LIMIT ?",
                         (run_id, size),
                     )
                 else:
-                    cur.execute(
+                    await cur.execute(
                         f"SELECT {V2_SELECT_SQL_COLS} FROM samples_v2"
                         " WHERE run_id = ? AND id > ? ORDER BY id LIMIT ?",
                         (run_id, last_id, size),
                     )
-                batch_rows = cur.fetchall()
+                batch_rows = [tuple(row) for row in await cur.fetchall()]
             if not batch_rows:
                 if total_skipped:
                     LOGGER.warning(

--- a/apps/server/vibesensor/adapters/persistence/history_db/_settings_repository.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_settings_repository.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-import sqlite3
 from collections.abc import Callable
-from contextlib import AbstractContextManager
+from contextlib import AbstractAsyncContextManager
 
+import aiosqlite
+
+from vibesensor.shared.async_bridge import run_coro_blocking
 from vibesensor.shared.boundaries.settings.snapshot import (
     settings_snapshot_from_json,
     settings_snapshot_to_json,
@@ -24,25 +26,31 @@ class SettingsSnapshotRepository:
     def __init__(
         self,
         *,
-        cursor_provider: Callable[..., AbstractContextManager[sqlite3.Cursor]],
+        cursor_provider: Callable[..., AbstractAsyncContextManager[aiosqlite.Cursor]],
     ) -> None:
         self._cursor_provider = cursor_provider
 
-    def _cursor(self, *, commit: bool = True) -> AbstractContextManager[sqlite3.Cursor]:
+    def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         return self._cursor_provider(commit=commit)
 
     def get_settings_snapshot(self) -> SettingsSnapshotPayload | None:
-        with self._cursor(commit=False) as cur:
-            cur.execute("SELECT value_json FROM settings_snapshot WHERE id = 1")
-            row = cur.fetchone()
+        return run_coro_blocking(self.aget_settings_snapshot())
+
+    async def aget_settings_snapshot(self) -> SettingsSnapshotPayload | None:
+        async with self._cursor(commit=False) as cur:
+            await cur.execute("SELECT value_json FROM settings_snapshot WHERE id = 1")
+            row = await cur.fetchone()
         if row is None:
             return None
         return settings_snapshot_from_json(row[0])
 
     def set_settings_snapshot(self, snapshot: SettingsSnapshotPayload) -> None:
+        run_coro_blocking(self.aset_settings_snapshot(snapshot))
+
+    async def aset_settings_snapshot(self, snapshot: SettingsSnapshotPayload) -> None:
         now = utc_now_iso()
-        with self._cursor() as cur:
-            cur.execute(
+        async with self._cursor() as cur:
+            await cur.execute(
                 "INSERT INTO settings_snapshot (id, value_json, updated_at) VALUES (1, ?, ?) "
                 "ON CONFLICT(id) DO UPDATE SET value_json = excluded.value_json, "
                 "updated_at = excluded.updated_at",

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -53,7 +53,6 @@ from vibesensor.infra.runtime.registry import ClientRegistry
 from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 from vibesensor.infra.runtime.ws_payload_projection import LiveWsPayloadProjector
 from vibesensor.infra.workers.worker_pool import WorkerPool
-from vibesensor.shared.async_bridge import run_coro_blocking
 from vibesensor.shared.boundaries.reporting import PreparedReportInput
 from vibesensor.shared.boundaries.reporting.document import ReportDocument
 from vibesensor.shared.constants.dsp import (
@@ -239,7 +238,7 @@ def create_history_db(
         recovered_runs = history.run_repository.recover_stale_recording_runs()
     except (aiosqlite.Error, OSError):
         LOGGER.error("Failed during early startup DB operations; closing DB.", exc_info=True)
-        run_coro_blocking(history.close())
+        history.close()
         raise
     if recovered_runs:
         LOGGER.warning("Recovered %d stale recording run(s) on startup", recovered_runs)

--- a/apps/server/vibesensor/app/container.py
+++ b/apps/server/vibesensor/app/container.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass
+
+import aiosqlite
 
 from vibesensor.adapters.gps.gps_speed import GPSSpeedMonitor
 from vibesensor.adapters.history import (
@@ -52,6 +53,7 @@ from vibesensor.infra.runtime.registry import ClientRegistry
 from vibesensor.infra.runtime.ws_broadcast import WsBroadcastService
 from vibesensor.infra.runtime.ws_payload_projection import LiveWsPayloadProjector
 from vibesensor.infra.workers.worker_pool import WorkerPool
+from vibesensor.shared.async_bridge import run_coro_blocking
 from vibesensor.shared.boundaries.reporting import PreparedReportInput
 from vibesensor.shared.boundaries.reporting.document import ReportDocument
 from vibesensor.shared.constants.dsp import (
@@ -235,9 +237,9 @@ def create_history_db(
         return history
     try:
         recovered_runs = history.run_repository.recover_stale_recording_runs()
-    except (sqlite3.Error, OSError):
+    except (aiosqlite.Error, OSError):
         LOGGER.error("Failed during early startup DB operations; closing DB.", exc_info=True)
-        history.lifecycle.close()
+        run_coro_blocking(history.close())
         raise
     if recovered_runs:
         LOGGER.warning("Recovered %d stale recording run(s) on startup", recovered_runs)
@@ -245,7 +247,7 @@ def create_history_db(
         pruned_runs = history.run_repository.prune_terminal_runs_older_than_days(
             config.logging.run_retention_days,
         )
-    except (sqlite3.Error, OSError):
+    except (aiosqlite.Error, OSError):
         LOGGER.warning(
             "Failed to prune terminal runs older than %d day(s) during startup maintenance",
             config.logging.run_retention_days,

--- a/apps/server/vibesensor/infra/config/settings_persistence.py
+++ b/apps/server/vibesensor/infra/config/settings_persistence.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
 from collections.abc import Callable
 from threading import RLock
 from typing import TypeVar
+
+import aiosqlite
 
 from vibesensor.infra.config.car_settings import CarSettingsState
 from vibesensor.infra.config.sensor_settings import SensorSettingsState
@@ -115,7 +116,7 @@ class SettingsPersistenceCoordinator:
         payload = self.snapshot()
         try:
             self._db.set_settings_snapshot(payload)
-        except (sqlite3.Error, OSError) as exc:
+        except (aiosqlite.Error, OSError) as exc:
             LOGGER.error("Failed to persist settings to SQLite", exc_info=True)
             raise PersistenceError("Failed to persist settings to SQLite") from exc
 

--- a/apps/server/vibesensor/infra/runtime/client_metadata.py
+++ b/apps/server/vibesensor/infra/runtime/client_metadata.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
 from collections.abc import Callable, Iterable
 from threading import RLock
 from typing import TYPE_CHECKING
+
+import aiosqlite
 
 from vibesensor.domain import normalize_sensor_id
 
@@ -62,7 +63,7 @@ class ClientMetadataManager:
             return
         try:
             rows = self._list_client_names()
-        except sqlite3.Error as exc:
+        except (aiosqlite.Error, OSError) as exc:
             LOGGER.warning("Could not load persisted client names from DB: %s", exc)
             return
 
@@ -77,7 +78,7 @@ class ClientMetadataManager:
             return
         try:
             self._persist_client_name(client_id, name)
-        except sqlite3.Error:
+        except (aiosqlite.Error, OSError):
             LOGGER.warning("Failed to persist client name to DB", exc_info=True)
 
     def _delete_persisted_name(self, client_id: str) -> None:
@@ -85,7 +86,7 @@ class ClientMetadataManager:
             return
         try:
             self._delete_client_name(client_id)
-        except sqlite3.Error:
+        except (aiosqlite.Error, OSError):
             LOGGER.warning("Failed to delete client name from DB", exc_info=True)
 
     @staticmethod

--- a/apps/server/vibesensor/infra/runtime/lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/lifecycle.py
@@ -101,7 +101,7 @@ class LifecycleWorkerPool(Protocol):
 
 
 class LifecycleHistoryDb(Protocol):
-    def close(self) -> None: ...
+    def close(self) -> object: ...
 
 
 @dataclass(slots=True)

--- a/apps/server/vibesensor/infra/runtime/shutdown_sequence.py
+++ b/apps/server/vibesensor/infra/runtime/shutdown_sequence.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
-import sqlite3
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+import aiosqlite
 
 if TYPE_CHECKING:
     from vibesensor.infra.runtime.background_task_coordinator import BackgroundTaskCoordinator
@@ -57,7 +59,7 @@ class LifecycleShutdownSequence:
         lingering_managed = await self._cancel_managed_jobs()
         await self._drain_analysis()
         await self._shutdown_worker_pool(issues)
-        self._close_history_db(issues)
+        await self._close_history_db(issues)
         return LifecycleShutdownResult(
             lingering_managed=tuple(lingering_managed),
             issues=tuple(issues),
@@ -117,10 +119,12 @@ class LifecycleShutdownSequence:
                 )
             )
 
-    def _close_history_db(self, issues: list[LifecycleShutdownIssue]) -> None:
+    async def _close_history_db(self, issues: list[LifecycleShutdownIssue]) -> None:
         try:
-            self._runtime.history_db.close()
-        except (sqlite3.Error, OSError) as exc:
+            close_result = self._runtime.history_db.close()
+            if inspect.isawaitable(close_result):
+                await close_result
+        except (aiosqlite.Error, OSError) as exc:
             issues.append(
                 LifecycleShutdownIssue(
                     phase="close_history_db",

--- a/apps/server/vibesensor/shared/async_bridge.py
+++ b/apps/server/vibesensor/shared/async_bridge.py
@@ -1,0 +1,99 @@
+"""Focused sync-to-async bridge for thread-owned or startup-time callers."""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import threading
+from collections.abc import Awaitable, Coroutine
+from concurrent.futures import Future
+from typing import cast
+
+__all__ = ["run_coro_blocking"]
+
+
+async def _await_result[T](awaitable: Awaitable[T]) -> T:
+    return await awaitable
+
+
+class _BridgeLoop:
+    __slots__ = ("_loop", "_lock", "_ready", "_thread")
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._lock = threading.Lock()
+        self._ready = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def run[T](self, awaitable: Awaitable[T]) -> T:
+        loop = self._ensure_loop()
+        coro: Coroutine[object, object, T]
+        if asyncio.iscoroutine(awaitable):
+            coro = cast(Coroutine[object, object, T], awaitable)
+        else:
+            coro = _await_result(awaitable)
+        future: Future[T] = asyncio.run_coroutine_threadsafe(coro, loop)
+        return future.result()
+
+    def close(self) -> None:
+        loop = self._loop
+        thread = self._thread
+        if loop is None or thread is None:
+            return
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=1.0)
+        if loop.is_running():
+            return
+        loop.close()
+        self._loop = None
+        self._thread = None
+        self._ready.clear()
+
+    def _ensure_loop(self) -> asyncio.AbstractEventLoop:
+        loop = self._loop
+        if loop is not None:
+            return loop
+        with self._lock:
+            loop = self._loop
+            if loop is not None:
+                return loop
+            self._ready.clear()
+            thread = threading.Thread(
+                target=self._thread_main,
+                name="run-coro-blocking-loop",
+                daemon=True,
+            )
+            self._thread = thread
+            thread.start()
+            self._ready.wait()
+            loop = self._loop
+            if loop is None:
+                raise RuntimeError("run_coro_blocking failed to start its background event loop")
+            return loop
+
+    def _thread_main(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        self._ready.set()
+        loop.run_forever()
+
+
+_BRIDGE_LOOP = _BridgeLoop()
+atexit.register(_BRIDGE_LOOP.close)
+
+
+def run_coro_blocking[T](coro: Awaitable[T]) -> T:
+    """Run *coro* to completion from a non-async caller.
+
+    This helper is only valid from threads or startup-time code that do not
+    already own a running event loop. It intentionally fails fast on the main
+    async runtime thread so blocking persistence calls cannot sneak back into
+    request handlers or other event-loop paths.
+    """
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return _BRIDGE_LOOP.run(coro)
+    raise RuntimeError("run_coro_blocking cannot be used from a running event loop")

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from typing import Protocol
 
 from vibesensor.domain import AnalysisSettingsSnapshot, CarSnapshot, SpeedSourceKind
@@ -103,6 +103,26 @@ class RunPersistence(Protocol):
     def store_analysis_error(self, run_id: str, error: str) -> bool: ...
 
     def analyzing_run_health(self) -> AnalyzingRunHealth: ...
+
+
+class AsyncRunPersistence(Protocol):
+    """Async persistence operations used by native async history surfaces."""
+
+    async def alist_runs(self, limit: int = 500) -> list[HistoryRunListEntry]: ...
+
+    async def aget_run(self, run_id: str) -> StoredHistoryRun | None: ...
+
+    async def aget_run_metadata(self, run_id: str) -> RunMetadata | None: ...
+
+    def aiter_run_samples(
+        self,
+        run_id: str,
+        batch_size: int = 1000,
+        *,
+        stride: int = 1,
+    ) -> AsyncIterator[list[SensorFrame]]: ...
+
+    async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]: ...
 
 
 class ActiveCarReader(Protocol):

--- a/apps/server/vibesensor/use_cases/history/exports.py
+++ b/apps/server/vibesensor/use_cases/history/exports.py
@@ -4,17 +4,19 @@ from __future__ import annotations
 
 import asyncio
 import csv
+import inspect
 import io
 import json
 import logging
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
+from typing import cast
 
 from vibesensor.shared.boundaries.sensor_frames import sensor_frame_to_json_object
 from vibesensor.shared.filenames import safe_filename
 from vibesensor.shared.json_utils import sanitize_for_json
-from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.ports import AsyncRunPersistence, RunPersistence
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.use_cases.history.helpers import async_require_run
@@ -57,6 +59,7 @@ EXPORT_CSV_COLUMNS: tuple[str, ...] = (
 EXPORT_CSV_COLUMN_SET: frozenset[str] = frozenset(EXPORT_CSV_COLUMNS)
 CsvCell = str | int | float | None
 CsvRow = dict[str, CsvCell]
+RawCsvSpoolBuilder = Callable[[str], tuple[tempfile.SpooledTemporaryFile[bytes], int]]
 
 
 def flatten_for_csv(row: JsonObject) -> CsvRow:
@@ -106,12 +109,17 @@ class HistoryExportService:
 
     __slots__ = ("_history_db",)
 
-    def __init__(self, history_db: RunPersistence) -> None:
+    def __init__(self, history_db: AsyncRunPersistence) -> None:
         self._history_db = history_db
 
     async def build_export_context(self, run_id: str) -> HistoryExportContext:
         run = await async_require_run(self._history_db, run_id)
-        raw_csv_spool, sample_count = await asyncio.to_thread(self._build_raw_csv_spool, run_id)
+        build_raw_csv_spool = cast(object, self._build_raw_csv_spool)
+        if inspect.iscoroutinefunction(build_raw_csv_spool):
+            raw_csv_spool, sample_count = await self._build_raw_csv_spool(run_id)
+        else:
+            sync_builder = cast(RawCsvSpoolBuilder, build_raw_csv_spool)
+            raw_csv_spool, sample_count = await asyncio.to_thread(sync_builder, run_id)
         return HistoryExportContext(
             run_id=run_id,
             safe_name=safe_filename(run_id),
@@ -120,7 +128,7 @@ class HistoryExportService:
             raw_csv_spool=raw_csv_spool,
         )
 
-    def _build_raw_csv_spool(
+    async def _build_raw_csv_spool(
         self,
         run_id: str,
     ) -> tuple[tempfile.SpooledTemporaryFile[bytes], int]:
@@ -137,12 +145,31 @@ class HistoryExportService:
                 extrasaction="ignore",
             )
             writer.writeheader()
-            for batch in self._history_db.iter_run_samples(
-                run_id,
-                batch_size=EXPORT_BATCH_SIZE,
-            ):
-                sample_count += len(batch)
-                writer.writerows(flatten_for_csv(sensor_frame_to_json_object(row)) for row in batch)
+            aiter_run_samples = getattr(self._history_db, "aiter_run_samples", None)
+            if callable(aiter_run_samples):
+                async for batch in aiter_run_samples(
+                    run_id,
+                    batch_size=EXPORT_BATCH_SIZE,
+                ):
+                    sample_count += len(batch)
+                    writer.writerows(
+                        flatten_for_csv(sensor_frame_to_json_object(row)) for row in batch
+                    )
+            else:
+                sync_history_db = cast(RunPersistence, self._history_db)
+                batches = await asyncio.to_thread(
+                    lambda: list(
+                        sync_history_db.iter_run_samples(
+                            run_id,
+                            batch_size=EXPORT_BATCH_SIZE,
+                        )
+                    )
+                )
+                for batch in batches:
+                    sample_count += len(batch)
+                    writer.writerows(
+                        flatten_for_csv(sensor_frame_to_json_object(row)) for row in batch
+                    )
             raw_csv_text.flush()
             raw_csv_text.detach()
             spool.seek(0)

--- a/apps/server/vibesensor/use_cases/history/helpers.py
+++ b/apps/server/vibesensor/use_cases/history/helpers.py
@@ -16,7 +16,7 @@ from vibesensor.shared.exceptions import (
     AnalysisNotReadyError,
     RunNotFoundError,
 )
-from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.ports import AsyncRunPersistence, RunPersistence
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
@@ -32,9 +32,14 @@ def resolve_run_language(run: StoredHistoryRun, requested: str | None) -> str:
     return run.metadata.language or "en"
 
 
-async def async_require_run(history_db: RunPersistence, run_id: str) -> StoredHistoryRun:
-    """Fetch a history run in a thread or raise a domain exception."""
-    run = await asyncio.to_thread(history_db.get_run, run_id)
+async def async_require_run(history_db: AsyncRunPersistence, run_id: str) -> StoredHistoryRun:
+    """Fetch a history run or raise a domain exception."""
+    aget_run = getattr(history_db, "aget_run", None)
+    if callable(aget_run):
+        run = cast(StoredHistoryRun | None, await aget_run(run_id))
+    else:
+        sync_history_db = cast(RunPersistence, history_db)
+        run = await asyncio.to_thread(sync_history_db.get_run, run_id)
     if run is None:
         raise RunNotFoundError(f"Run {run_id!r} not found")
     return run

--- a/apps/server/vibesensor/use_cases/history/report_loader.py
+++ b/apps/server/vibesensor/use_cases/history/report_loader.py
@@ -13,7 +13,7 @@ from vibesensor.shared.boundaries.reporting import (
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_to_json_object
 from vibesensor.shared.exceptions import AnalysisNotReadyError
 from vibesensor.shared.filenames import safe_filename
-from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.ports import AsyncRunPersistence
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.json_types import is_json_array
 from vibesensor.shared.types.report_cache import ReportPdfCacheKey
@@ -49,7 +49,7 @@ class HistoryReportRequestLoader:
 
     __slots__ = ("_history_db",)
 
-    def __init__(self, history_db: RunPersistence) -> None:
+    def __init__(self, history_db: AsyncRunPersistence) -> None:
         self._history_db = history_db
 
     async def load_report_request(

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from vibesensor.shared.boundaries.reporting import PreparedReportInput
-from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.ports import AsyncRunPersistence
 from vibesensor.use_cases.history.report_cache import HistoryReportPdfCache
 from vibesensor.use_cases.history.report_loader import HistoryReportRequestLoader
 
@@ -38,7 +38,7 @@ class HistoryReportService:
 
     def __init__(
         self,
-        history_db: RunPersistence,
+        history_db: AsyncRunPersistence,
         *,
         pdf_renderer: PdfRendererFn,
     ) -> None:

--- a/apps/server/vibesensor/use_cases/history/runs.py
+++ b/apps/server/vibesensor/use_cases/history/runs.py
@@ -8,7 +8,7 @@ from typing import Never, cast
 from vibesensor.domain import RunStatus
 from vibesensor.shared.boundaries.summary_fields.warnings import localize_warning_list
 from vibesensor.shared.exceptions import AnalysisNotReadyError, RunNotFoundError
-from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.ports import AsyncRunPersistence, RunPersistence
 from vibesensor.shared.types.history_records import HistoryRunListEntry, StoredHistoryRun
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_array
 from vibesensor.use_cases.history.helpers import (
@@ -24,11 +24,15 @@ class HistoryRunService:
 
     __slots__ = ("_history_db",)
 
-    def __init__(self, history_db: RunPersistence) -> None:
+    def __init__(self, history_db: AsyncRunPersistence) -> None:
         self._history_db = history_db
 
     async def list_runs(self) -> list[HistoryRunListEntry]:
-        return await asyncio.to_thread(self._history_db.list_runs)
+        alist_runs = getattr(self._history_db, "alist_runs", None)
+        if callable(alist_runs):
+            return cast(list[HistoryRunListEntry], await alist_runs())
+        sync_history_db = cast(RunPersistence, self._history_db)
+        return await asyncio.to_thread(sync_history_db.list_runs)
 
     async def get_run(self, run_id: str) -> StoredHistoryRun:
         return await async_require_run(self._history_db, run_id)
@@ -60,7 +64,12 @@ class HistoryRunService:
         return analysis
 
     async def delete_run(self, run_id: str) -> dict[str, str]:
-        deleted, reason = await asyncio.to_thread(self._history_db.delete_run_if_safe, run_id)
+        adelete_run_if_safe = getattr(self._history_db, "adelete_run_if_safe", None)
+        if callable(adelete_run_if_safe):
+            deleted, reason = await adelete_run_if_safe(run_id)
+        else:
+            sync_history_db = cast(RunPersistence, self._history_db)
+            deleted, reason = await asyncio.to_thread(sync_history_db.delete_run_if_safe, run_id)
         if deleted:
             return {"run_id": run_id, "status": "deleted"}
         raise_delete_run_error(reason)
@@ -75,7 +84,7 @@ def raise_delete_run_error(reason: str | None) -> Never:
             "Cannot delete the active run; stop recording first",
             status="active",
         )
-    if reason == RunStatus.ANALYZING:
+    if reason == RunStatus.ANALYZING.value:
         raise AnalysisNotReadyError(
             "Cannot delete run while analysis is in progress",
             status="in_progress",

--- a/apps/server/vibesensor/use_cases/run/persistence_writer.py
+++ b/apps/server/vibesensor/use_cases/run/persistence_writer.py
@@ -8,10 +8,11 @@ the injected ``RunPersistence`` boundary.
 from __future__ import annotations
 
 import logging
-import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass
 from threading import RLock
+
+import aiosqlite
 
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.run_schema import RunMetadata
@@ -199,11 +200,7 @@ class RunPersistenceWriter:
                 self._history_create_fail_count = 0
         metadata = self._metadata_builder(run_id, start_time_utc)
         try:
-            history_db.create_run(
-                run_id,
-                start_time_utc,
-                metadata,
-            )
+            history_db.create_run(run_id, start_time_utc, metadata)
             with self._lock:
                 if not self._run_id_matches(run_id):
                     return
@@ -212,7 +209,7 @@ class RunPersistenceWriter:
                 self._retry_cycle_count = 0
                 self._retry_after_mono_s = 0.0
             self.clear_last_write_error()
-        except (sqlite3.Error, OSError) as exc:
+        except (aiosqlite.Error, OSError) as exc:
             with self._lock:
                 if not self._run_id_matches(run_id):
                     return
@@ -295,7 +292,7 @@ class RunPersistenceWriter:
                             return AppendRowsResult(history_created=True, rows_written=0)
                         self.clear_last_write_error()
                         return AppendRowsResult(history_created=True, rows_written=rows_written)
-                    except (sqlite3.Error, OSError) as exc:
+                    except (aiosqlite.Error, OSError) as exc:
                         last_exc = exc
                         if attempt < _MAX_APPEND_RETRIES - 1:
                             self._sleep(_APPEND_RETRY_DELAYS_S[attempt])
@@ -350,7 +347,7 @@ class RunPersistenceWriter:
                 return False
             self.clear_last_write_error()
             return True
-        except (sqlite3.Error, OSError) as exc:
+        except (aiosqlite.Error, OSError) as exc:
             self.set_last_write_error(f"history finalize_run failed: {exc}")
             self._logger_provider().warning(
                 "Failed to finalize run in history DB",

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
 import time
 from typing import Protocol
+
+import aiosqlite
 
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
@@ -62,7 +63,7 @@ def execute_post_analysis(
     LOGGER.info("Analysis started for run %s", run_id)
     try:
         load_result = load_run(run_id=run_id, db=db)
-    except (sqlite3.Error, OSError, MemoryError) as exc:
+    except (aiosqlite.Error, OSError, MemoryError) as exc:
         if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
             return _retryable_failure_result(
                 run_id=run_id,
@@ -99,7 +100,7 @@ def execute_post_analysis(
     try:
         summary = analysis_runner(run_input)
         db.store_analysis(loaded.run_id, summary)
-    except (sqlite3.Error, OSError, MemoryError) as exc:
+    except (aiosqlite.Error, OSError, MemoryError) as exc:
         if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
             return _retryable_failure_result(
                 run_id=loaded.run_id,
@@ -132,7 +133,7 @@ def _store_load_error(
 ) -> PostAnalysisExecutionResult:
     try:
         db.store_analysis_error(run_id, completed_error)
-    except sqlite3.Error:
+    except aiosqlite.Error:
         LOGGER.warning("Failed to store analysis error for run %s", run_id, exc_info=True)
         return PostAnalysisExecutionPersistenceFailure(
             run_id=run_id,
@@ -192,7 +193,7 @@ def _persistence_failure_result(
 
     try:
         db.store_analysis_error(run_id, completed_error)
-    except sqlite3.Error as store_exc:
+    except aiosqlite.Error as store_exc:
         LOGGER.warning("Failed to store analysis error for run %s", run_id, exc_info=True)
         return PostAnalysisExecutionPersistenceFailure(
             run_id=run_id,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_failures.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_failures.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass
+
+import aiosqlite
 
 from vibesensor.shared.failure_utils import bounded_failure_message
 from vibesensor.shared.ports import RunPersistence
@@ -60,7 +61,7 @@ class UnexpectedPostAnalysisBugRecorder:
             return
         try:
             store_analysis_error(run_id, completed_error)
-        except (sqlite3.Error, OSError):
+        except (aiosqlite.Error, OSError):
             LOGGER.exception(
                 "Failed to persist unexpected analysis failure for run %s",
                 run_id,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_outcomes.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_outcomes.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import sqlite3
 from dataclasses import dataclass
+
+import aiosqlite
 
 __all__ = [
     "PostAnalysisAttemptResult",
@@ -62,7 +63,7 @@ PostAnalysisAttemptResult = PostAnalysisExecutionResult | PostAnalysisExecutionR
 def is_retryable_post_analysis_error(exc: BaseException) -> bool:
     """Return whether a post-analysis boundary failure should be retried."""
 
-    return isinstance(exc, (sqlite3.Error, OSError, MemoryError))
+    return isinstance(exc, (aiosqlite.Error, OSError, MemoryError))
 
 
 def execution_callback_errors(result: PostAnalysisExecutionResult) -> tuple[str, ...]:

--- a/apps/server/vibesensor/use_cases/run/status_reporting.py
+++ b/apps/server/vibesensor/use_cases/run/status_reporting.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
 import time
 from dataclasses import dataclass
+
+import aiosqlite
 
 from vibesensor.domain import CaptureReadiness
 from vibesensor.shared.ports import RunPersistence
@@ -85,7 +86,7 @@ def build_run_recorder_health_snapshot(
             analyzing_run_count = analyzing_health.analyzing_run_count
             if analyzing_health.analyzing_oldest_age_s is not None:
                 analyzing_oldest_age_s = max(0.0, analyzing_health.analyzing_oldest_age_s)
-        except sqlite3.Error:
+        except aiosqlite.Error:
             logger.warning("Failed to read analyzing-run health snapshot", exc_info=True)
 
     persist = persistence.status_snapshot()


### PR DESCRIPTION
## size
large

## what
- move the history DB engine and repositories onto `aiosqlite`
- keep sync runtime callers through a dedicated blocking bridge and sync wrappers
- expose async `a*` repo methods for history/report paths and move async HTTP seams onto `asyncio.to_thread(...)` where needed
- update history-db tests/helpers for async table access and read/write concurrency

## why
- `sqlite3` kept blocking request and background paths
- one-shot blocking event loops were unsafe for `aiosqlite`; the dedicated bridge loop keeps sync callers stable while the repo migrates
- recorder, settings, and post-analysis code still need a sync surface during this cutover

## validation
- `make typecheck-backend`
- `make lint`
- `cd apps/server && ../../.venv/bin/python -m pytest -q tests/adapters/persistence/history_db tests/use_cases/history tests/use_cases/run tests/app/test_container.py tests/infra/config/test_ui_preferences.py tests/infra/runtime/test_client_metadata.py`
- `cd apps/server && ../../.venv/bin/python -m pytest -q -n 0 tests/use_cases/run/test_metrics_log_helpers.py -k 'db_persists_when_jsonl_disabled or post_analysis_caps_sample_count_and_stores_sampling_metadata'`\n\n## risks / tradeoffs\n- runtime callers still use a hybrid sync/async surface; that keeps this migration safe but leaves future cleanup room once more callers can go native async\n- xdist still reports an `aiosqlite` `DeprecationWarning` around `asyncio.get_event_loop().create_future()`; functional coverage is green and the deadlock/closed-loop worker failures are fixed\n\nCloses #2966