### PR TITLE
Replace ad-hoc backend logging with structlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ vibesensor-sim --count 5 --server-host 127.0.0.1
 
 Open http://localhost:8000.
 
+Backend logs now flow through a shared `structlog` pipeline: `docker compose logs`
+shows human-readable structured lines, and optional `logging.app_log_path` files
+capture the same events as JSON for request/run correlation.
+
 If you want source-mounted hot-reload instead of a production-style container
 build, use the Docker dev mode below.
 
@@ -324,6 +328,9 @@ run log format. Synthetic analysis scenarios live in
   server bound on 0.0.0.0:80 (or 8000 in dev)
 - **High dropped frames** — reduce Wi-Fi contention, keep ESP close to Pi,
   check AP channel
+- **Need backend log correlation** — use `docker compose logs` for live
+  structured console output, or match the `X-Request-ID` response header
+  against the JSON file log configured by `logging.app_log_path`
 - **Hotspot has no DHCP leases** — rerun `apps/server/scripts/hotspot_nmcli.sh`
 - **Need config details** — check [apps/server/README.md](apps/server/README.md)
   and [firmware/esp/README.md](firmware/esp/README.md) for AP/firmware settings

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "uvloop>=0.22,<1; sys_platform == 'linux'",
   "numpy>=2.4.4,<3",
   "scipy>=1.16.3,<2",
+  "structlog>=25.4,<26",
   "orjson>=3.11.4,<4",
   "pyfftw>=0.15.1,<0.16",
   "packaging>=24,<27",

--- a/apps/server/tests/adapters/websocket/test_ws_hub.py
+++ b/apps/server/tests/adapters/websocket/test_ws_hub.py
@@ -278,6 +278,12 @@ async def test_payload_error_logged_at_error_level(caplog) -> None:
     assert any("sensor_42" in r.message for r in error_records)
     # Summary log should mention connection count
     assert any("1 connection(s)" in r.message for r in error_records)
+    client_error = next(
+        record
+        for record in error_records
+        if getattr(record, "selected_client_id", None) == "sensor_42"
+    )
+    assert client_error.event == "ws_payload_build_failed"
 
 
 @pytest.mark.asyncio
@@ -310,10 +316,14 @@ async def test_payload_error_affected_count_logged(caplog) -> None:
 
     # Summary log mentions 2 affected connections
     assert any("2 connection(s)" in r.message for r in caplog.records)
-    assert any(
-        "WebSocket payload build failed for 1 client id(s) ('bad')" in r.message
-        for r in caplog.records
+    summary_record = next(
+        record
+        for record in caplog.records
+        if "WebSocket payload build failed for 1 client id(s) ('bad')" in record.message
     )
+    assert summary_record.event == "ws_broadcast_payload_build_failed"
+    assert summary_record.failed_client_ids == ["bad"]
+    assert summary_record.affected_connection_count == 2
 
 
 @pytest.mark.asyncio
@@ -634,6 +644,8 @@ async def test_send_failure_log_includes_client_id(caplog) -> None:
     warn_logs = [r for r in caplog.records if "broadcast send failed" in r.message]
     assert len(warn_logs) == 1
     assert "sensor_42" in warn_logs[0].message
+    assert warn_logs[0].event == "ws_broadcast_send_failed"
+    assert warn_logs[0].selected_client_id == "sensor_42"
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/app/test_app_main.py
+++ b/apps/server/tests/app/test_app_main.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import errno
+import logging
 import os
 from argparse import Namespace
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -21,6 +23,30 @@ def _runtime_app(port: int):
     )
 
 
+def _loaded_config(*, host: str, port: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        server=SimpleNamespace(host=host, port=port),
+        logging=SimpleNamespace(app_log_path=None),
+    )
+
+
+def _run_with_restored_root_logging(callable_obj: Callable[[], None]) -> None:
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_level = root_logger.level
+    try:
+        callable_obj()
+    finally:
+        for handler in list(root_logger.handlers):
+            root_logger.removeHandler(handler)
+            if handler not in original_handlers:
+                handler.close()
+        for handler in original_handlers:
+            if handler not in root_logger.handlers:
+                root_logger.addHandler(handler)
+        root_logger.setLevel(original_level)
+
+
 def _run_main(monkeypatch, *, port: int, fail_port: int | None = None) -> list[int]:
     """Shared harness: patch app_module, call ``main()``, return recorded port calls."""
     from vibesensor.app import bootstrap as app_module
@@ -33,9 +59,7 @@ def _run_main(monkeypatch, *, port: int, fail_port: int | None = None) -> list[i
     monkeypatch.setattr(
         app_module,
         "load_config",
-        lambda config_path=None: SimpleNamespace(
-            server=SimpleNamespace(host="0.0.0.0", port=port),
-        ),
+        lambda config_path=None: _loaded_config(host="0.0.0.0", port=port),
     )
     monkeypatch.setattr(app_module, "export_config_path_env", lambda config_path: None)
     calls: list[int] = []
@@ -51,7 +75,7 @@ def _run_main(monkeypatch, *, port: int, fail_port: int | None = None) -> list[i
 
     monkeypatch.setattr(app_module, "Granian", FakeGranian)
     monkeypatch.setattr(app_module, "_granian_loop", lambda: "uvloop")
-    app_module.main()
+    _run_with_restored_root_logging(app_module.main)
     return calls
 
 
@@ -94,9 +118,7 @@ def test_main_reload_uses_factory_target(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         app_module,
         "load_config",
-        lambda config_path=None: SimpleNamespace(
-            server=SimpleNamespace(host="127.0.0.1", port=8000),
-        ),
+        lambda config_path=None: _loaded_config(host="127.0.0.1", port=8000),
     )
     calls: list[tuple[object, dict[str, object]]] = []
 
@@ -110,7 +132,7 @@ def test_main_reload_uses_factory_target(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(app_module, "Granian", FakeGranian)
     monkeypatch.setattr(app_module, "_granian_loop", lambda: "uvloop")
 
-    app_module.main()
+    _run_with_restored_root_logging(app_module.main)
 
     assert calls == [
         (

--- a/apps/server/tests/shared/test_structured_logging.py
+++ b/apps/server/tests/shared/test_structured_logging.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 
 from vibesensor.shared.structured_logging import (
     StructuredLogFormatter,
     bind_request_id,
+    configure_logging,
     log_extra,
     normalize_request_id,
     reset_request_id,
@@ -53,3 +55,64 @@ def test_log_extra_includes_bound_request_id() -> None:
 def test_normalize_request_id_falls_back_when_header_is_invalid() -> None:
     request_id = normalize_request_id(" \n\t ")
     assert request_id
+
+
+def test_configure_logging_preserves_non_managed_root_handlers(tmp_path: Path) -> None:
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_level = root_logger.level
+    probe_handler = logging.NullHandler()
+    root_logger.addHandler(probe_handler)
+    try:
+        configure_logging(tmp_path / "app.log")
+        assert probe_handler in root_logger.handlers
+
+        configure_logging(None)
+        assert probe_handler in root_logger.handlers
+    finally:
+        for handler in list(root_logger.handlers):
+            root_logger.removeHandler(handler)
+            if handler is not probe_handler:
+                handler.close()
+        for handler in original_handlers:
+            root_logger.addHandler(handler)
+        root_logger.setLevel(original_level)
+
+
+def test_configure_logging_writes_structured_json_file(tmp_path: Path) -> None:
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_level = root_logger.level
+    log_path = tmp_path / "app.log"
+    try:
+        configure_logging(log_path)
+        request_id, token = bind_request_id("req-structured")
+        try:
+            logging.getLogger("vibesensor.test").info(
+                "settings_change",
+                extra=log_extra(
+                    event="settings_change",
+                    before={"language": "en"},
+                    after={"language": "nl"},
+                ),
+            )
+        finally:
+            reset_request_id(token)
+
+        for handler in root_logger.handlers:
+            handler.flush()
+
+        payload = json.loads(log_path.read_text(encoding="utf-8").strip().splitlines()[-1])
+        assert payload["message"] == "settings_change"
+        assert payload["event"] == "settings_change"
+        assert payload["request_id"] == request_id
+        assert payload["logger"] == "vibesensor.test"
+        assert payload["before"] == {"language": "en"}
+        assert payload["after"] == {"language": "nl"}
+    finally:
+        for handler in list(root_logger.handlers):
+            root_logger.removeHandler(handler)
+            handler.close()
+        for handler in original_handlers:
+            root_logger.addHandler(handler)
+        root_logger.setLevel(original_level)

--- a/apps/server/tests/use_cases/updates/test_update_manager_async.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_async.py
@@ -513,7 +513,12 @@ class TestUpdateManagerAsync:
             and issue.detail == ""
             for issue in manager.status.issues
         )
-        assert any(rec.message == "update: runtime details refresh error" for rec in caplog.records)
+        refresh_log = next(
+            rec for rec in caplog.records if rec.message == "update: runtime details refresh error"
+        )
+        assert refresh_log.event == "update_runtime_refresh_error"
+        assert refresh_log.update_phase == "cleanup"
+        assert refresh_log.repo_path == str(tmp_path / "repo")
 
     async def test_run_update_surfaces_programmer_bug_from_cancellation_cleanup(
         self,

--- a/apps/server/vibesensor/adapters/websocket/broadcast_runner.py
+++ b/apps/server/vibesensor/adapters/websocket/broadcast_runner.py
@@ -17,6 +17,7 @@ from vibesensor.adapters.websocket.connection_tracker import (
     WSConnectionSnapshot,
 )
 from vibesensor.adapters.websocket.payload_orchestrator import PayloadBuildOrchestrator
+from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.types.payload_types import LiveWsPayload
 
 LOGGER = logging.getLogger(__name__)
@@ -90,6 +91,10 @@ class BroadcastRunner:
                     "connection will be removed.",
                     selected_client_id,
                     exc_info=True,
+                    extra=log_extra(
+                        event="ws_broadcast_send_failed",
+                        selected_client_id=selected_client_id,
+                    ),
                 )
             if await self._tracker.mark_snapshot_closing(conn):
                 return conn
@@ -147,6 +152,13 @@ class BroadcastRunner:
             len(payloads.failed_client_ids),
             ", ".join(repr(cid) for cid in payloads.failed_client_ids),
             affected,
+            extra=log_extra(
+                event="ws_broadcast_payload_build_failed",
+                failed_client_ids=sorted(
+                    "None" if cid is None else cid for cid in payloads.failed_client_ids
+                ),
+                affected_connection_count=affected,
+            ),
         )
 
     def _log_debug(

--- a/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
+++ b/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
@@ -11,6 +11,7 @@ from typing import cast
 import orjson
 
 from vibesensor.shared.json_utils import sanitize_for_json
+from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.types.payload_types import LiveWsPayload, WsErrorPayload
 
 LOGGER = logging.getLogger("vibesensor.adapters.websocket.hub")
@@ -91,6 +92,10 @@ class PayloadBuildOrchestrator:
                 "sending error payload to affected connections.",
                 selected_client_id,
                 exc_info=True,
+                extra=log_extra(
+                    event="ws_payload_build_failed",
+                    selected_client_id=selected_client_id,
+                ),
             )
             self._failed_client_ids.add(selected_client_id)
             return None
@@ -126,6 +131,10 @@ class PayloadBuildOrchestrator:
                         "WebSocket payload for client %r contained NaN/Inf values; "
                         "replaced with null.",
                         selected_client_id,
+                        extra=log_extra(
+                            event="ws_payload_non_finite_replaced",
+                            selected_client_id=selected_client_id,
+                        ),
                     )
                 else:
                     had_non_finite = False
@@ -141,6 +150,10 @@ class PayloadBuildOrchestrator:
                         "WebSocket payload for client %r contained NaN/Inf values; "
                         "replaced with null.",
                         selected_client_id,
+                        extra=log_extra(
+                            event="ws_payload_non_finite_replaced",
+                            selected_client_id=selected_client_id,
+                        ),
                     )
                 text = self._serialize_selected_client_payload(
                     selected_client_id,
@@ -159,6 +172,10 @@ class PayloadBuildOrchestrator:
                 "sending error payload to affected connections.",
                 selected_client_id,
                 exc_info=True,
+                extra=log_extra(
+                    event="ws_payload_serialize_failed",
+                    selected_client_id=selected_client_id,
+                ),
             )
             return _ERROR_PAYLOAD, True, None
 

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -14,7 +14,6 @@ import logging
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -35,7 +34,7 @@ from vibesensor.shared.process_settings import (
     export_config_path_env,
     load_bootstrap_env_settings,
 )
-from vibesensor.shared.structured_logging import StructuredLogFormatter
+from vibesensor.shared.structured_logging import configure_logging
 
 __all__ = ["create_app", "create_app_from_env", "main"]
 
@@ -52,36 +51,15 @@ on port 80).  Chosen to be a common unprivileged alternative."""
 _BIND_ERROR_NUMBERS: frozenset[int] = frozenset({errno.EACCES, errno.EADDRINUSE, 10013, 10048})
 """OS errno values indicating a port-bind failure (includes Windows equivalents)."""
 
-_LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB per file
-_LOG_BACKUP_COUNT = 3
 _CONFIG_PATH_ENV = CONFIG_PATH_ENV
-
-
-def _setup_file_logging(log_path: Path | None) -> None:
-    """Attach a RotatingFileHandler to the root logger when *log_path* is set."""
-    if log_path is None:
-        return
-    try:
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        handler = RotatingFileHandler(
-            log_path,
-            maxBytes=_LOG_MAX_BYTES,
-            backupCount=_LOG_BACKUP_COUNT,
-            encoding="utf-8",
-        )
-        handler.setLevel(logging.INFO)
-        handler.setFormatter(StructuredLogFormatter())
-        logging.getLogger().addHandler(handler)
-        LOGGER.info("File logging enabled: %s", log_path)
-    except OSError:
-        LOGGER.warning("Failed to set up file logging at %s", log_path, exc_info=True)
 
 
 def create_app(config_path: Path | None = None) -> FastAPI:
     """Create and configure the VibeSensor FastAPI application."""
+    configure_logging(None)
     config = load_config(config_path)
     bootstrap_settings = load_bootstrap_env_settings()
-    _setup_file_logging(config.logging.app_log_path)
+    configure_logging(config.logging.app_log_path)
     runtime = build_runtime(config)
     lifecycle = LifecycleManager(
         runtime=LifecycleRuntime(
@@ -248,7 +226,9 @@ def main() -> None:
         help="Enable Granian auto-reload for local development.",
     )
     args = parser.parse_args()
+    configure_logging(None)
     config = load_config(args.config)
+    configure_logging(config.logging.app_log_path)
     export_config_path_env(args.config)
     _run_server_with_port_fallback(
         "vibesensor.app.bootstrap:create_app_from_env",

--- a/apps/server/vibesensor/shared/structured_logging.py
+++ b/apps/server/vibesensor/shared/structured_logging.py
@@ -1,4 +1,4 @@
-"""Structured logging helpers for request-scoped JSON log output."""
+"""Structured logging helpers for request context and structlog-backed rendering."""
 
 from __future__ import annotations
 
@@ -6,15 +6,173 @@ import json
 import logging
 import string
 from contextvars import ContextVar, Token
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 from uuid import uuid4
+
+import structlog
 
 REQUEST_ID_HEADER = "X-Request-ID"
 
-JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
-
 _REQUEST_ID: ContextVar[str | None] = ContextVar("vibesensor_request_id", default=None)
 _ALLOWED_REQUEST_ID_CHARS = frozenset(string.ascii_letters + string.digits + "-._:/")
-_STANDARD_LOG_RECORD_FIELDS = frozenset(logging.makeLogRecord({}).__dict__) | {"message", "asctime"}
+_LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB per file
+_LOG_BACKUP_COUNT = 3
+_HANDLER_MARKER = "_vibesensor_structlog_handler"
+
+
+def _add_request_id(
+    _logger: logging.Logger | None,
+    _method_name: str,
+    event_dict: structlog.typing.EventDict,
+) -> structlog.typing.EventDict:
+    if "request_id" not in event_dict:
+        request_id = current_request_id()
+        if request_id is not None:
+            event_dict["request_id"] = request_id
+    return event_dict
+
+
+def _json_dumps(payload: object, **_: object) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True)
+
+
+def _foreign_pre_chain() -> list[structlog.typing.Processor]:
+    return [
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.ExtraAdder(),
+        _add_request_id,
+        structlog.processors.TimeStamper(fmt="iso", utc=True, key="timestamp"),
+    ]
+
+
+def _add_message_field(
+    _logger: logging.Logger | None,
+    _method_name: str,
+    event_dict: structlog.typing.EventDict,
+) -> structlog.typing.EventDict:
+    event_dict.setdefault("message", str(event_dict.get("event", "")))
+    return event_dict
+
+
+def _shared_formatter_processors(
+    renderer: structlog.typing.Processor,
+    *,
+    format_exceptions: bool = True,
+) -> list[structlog.typing.Processor]:
+    processors: list[structlog.typing.Processor] = [
+        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+        _add_message_field,
+        structlog.processors.StackInfoRenderer(),
+    ]
+    if format_exceptions:
+        processors.append(structlog.processors.format_exc_info)
+    processors.append(renderer)
+    return processors
+
+
+def _configure_structlog() -> None:
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            _add_request_id,
+            structlog.processors.TimeStamper(fmt="iso", utc=True, key="timestamp"),
+            structlog.stdlib.render_to_log_kwargs,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+
+def _mark_handler(handler: logging.Handler) -> logging.Handler:
+    setattr(handler, _HANDLER_MARKER, True)
+    return handler
+
+
+def _managed_handlers(root_logger: logging.Logger) -> list[logging.Handler]:
+    return [handler for handler in root_logger.handlers if getattr(handler, _HANDLER_MARKER, False)]
+
+
+def _replace_managed_handlers(root_logger: logging.Logger, handlers: list[logging.Handler]) -> None:
+    for handler in _managed_handlers(root_logger):
+        root_logger.removeHandler(handler)
+        handler.close()
+    for handler in handlers:
+        root_logger.addHandler(_mark_handler(handler))
+
+
+def _build_console_handler() -> logging.Handler:
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(
+        structlog.stdlib.ProcessorFormatter(
+            foreign_pre_chain=_foreign_pre_chain(),
+            processors=_shared_formatter_processors(
+                structlog.dev.ConsoleRenderer(colors=False),
+                format_exceptions=False,
+            ),
+        )
+    )
+    return handler
+
+
+class StructuredLogFormatter(structlog.stdlib.ProcessorFormatter):
+    def __init__(self) -> None:
+        super().__init__(
+            foreign_pre_chain=_foreign_pre_chain(),
+            processors=_shared_formatter_processors(
+                structlog.processors.JSONRenderer(serializer=_json_dumps),
+            ),
+        )
+
+
+def configure_logging(log_path: Path | None) -> None:
+    """Install the canonical structlog-backed backend logging handlers."""
+    _configure_structlog()
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    handlers: list[logging.Handler] = [_build_console_handler()]
+    if log_path is not None:
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            file_handler = RotatingFileHandler(
+                log_path,
+                maxBytes=_LOG_MAX_BYTES,
+                backupCount=_LOG_BACKUP_COUNT,
+                encoding="utf-8",
+            )
+            file_handler.setLevel(logging.INFO)
+            file_handler.setFormatter(StructuredLogFormatter())
+            handlers.append(file_handler)
+        except OSError:
+            _replace_managed_handlers(root_logger, handlers)
+            logging.getLogger(__name__).warning(
+                "Failed to set up file logging at %s",
+                log_path,
+                exc_info=True,
+                extra=log_extra(
+                    event="file_logging_setup_failed",
+                    log_path=str(log_path),
+                ),
+            )
+            return
+
+    _replace_managed_handlers(root_logger, handlers)
+    if log_path is not None:
+        logging.getLogger(__name__).info(
+            "File logging enabled: %s",
+            log_path,
+            extra=log_extra(
+                event="file_logging_enabled",
+                log_path=str(log_path),
+            ),
+        )
 
 
 def current_request_id() -> str | None:
@@ -48,31 +206,3 @@ def log_extra(**fields: object) -> dict[str, object]:
     if request_id is not None:
         extra["request_id"] = request_id
     return extra
-
-
-def _json_compatible(value: object) -> JsonValue:
-    if value is None or isinstance(value, bool | int | float | str):
-        return value
-    if isinstance(value, dict):
-        return {str(key): _json_compatible(inner) for key, inner in value.items()}
-    if isinstance(value, list | tuple | set | frozenset):
-        return [_json_compatible(item) for item in value]
-    return str(value)
-
-
-class StructuredLogFormatter(logging.Formatter):
-    def format(self, record: logging.LogRecord) -> str:
-        """Serialize *record* as a stable JSON object with extra fields preserved."""
-        payload: dict[str, JsonValue] = {
-            "timestamp": self.formatTime(record, self.datefmt),
-            "level": record.levelname,
-            "logger": record.name,
-            "message": record.getMessage(),
-        }
-        for key, value in record.__dict__.items():
-            if key in _STANDARD_LOG_RECORD_FIELDS:
-                continue
-            payload[key] = _json_compatible(value)
-        if record.exc_info:
-            payload["exception"] = self.formatException(record.exc_info)
-        return json.dumps(payload, ensure_ascii=True, sort_keys=True)

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -9,6 +9,7 @@ from typing import Protocol
 import aiosqlite
 
 from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.run.post_analysis_input import (
     PostAnalysisRunInput,
@@ -60,7 +61,11 @@ def execute_post_analysis(
     defer_retryable_error_storage: bool = False,
 ) -> PostAnalysisAttemptResult:
     analysis_start = time.monotonic()
-    LOGGER.info("Analysis started for run %s", run_id)
+    LOGGER.info(
+        "Analysis started for run %s",
+        run_id,
+        extra=log_extra(event="post_analysis_started", run_id=run_id),
+    )
     try:
         load_result = load_run(run_id=run_id, db=db)
     except (aiosqlite.Error, OSError, MemoryError) as exc:
@@ -78,7 +83,15 @@ def execute_post_analysis(
         )
 
     if isinstance(load_result, MissingPostAnalysisMetadata):
-        LOGGER.warning("Cannot analyse run %s: metadata not found", run_id)
+        LOGGER.warning(
+            "Cannot analyse run %s: metadata not found",
+            run_id,
+            extra=log_extra(
+                event="post_analysis_skipped",
+                run_id=run_id,
+                failure_kind="missing_metadata",
+            ),
+        )
         return _store_load_error(
             db=db,
             run_id=run_id,
@@ -87,7 +100,15 @@ def execute_post_analysis(
         )
 
     if isinstance(load_result, EmptyPostAnalysisSamples):
-        LOGGER.warning("Skipping post-analysis for run %s: no samples collected", run_id)
+        LOGGER.warning(
+            "Skipping post-analysis for run %s: no samples collected",
+            run_id,
+            extra=log_extra(
+                event="post_analysis_skipped",
+                run_id=run_id,
+                failure_kind="no_samples",
+            ),
+        )
         return _store_load_error(
             db=db,
             run_id=run_id,
@@ -120,6 +141,12 @@ def execute_post_analysis(
         loaded.run_id,
         len(run_input.samples),
         duration_s,
+        extra=log_extra(
+            event="post_analysis_completed",
+            run_id=loaded.run_id,
+            sample_count=len(run_input.samples),
+            duration_s=round(duration_s, 3),
+        ),
     )
     return PostAnalysisExecutionSuccess(run_id=loaded.run_id)
 
@@ -134,7 +161,15 @@ def _store_load_error(
     try:
         db.store_analysis_error(run_id, completed_error)
     except aiosqlite.Error:
-        LOGGER.warning("Failed to store analysis error for run %s", run_id, exc_info=True)
+        LOGGER.warning(
+            "Failed to store analysis error for run %s",
+            run_id,
+            exc_info=True,
+            extra=log_extra(
+                event="post_analysis_error_persist_failed",
+                run_id=run_id,
+            ),
+        )
         return PostAnalysisExecutionPersistenceFailure(
             run_id=run_id,
             completed_error=completed_error,
@@ -164,6 +199,12 @@ def _retryable_failure_result(
         duration_s,
         exc,
         exc_info=True,
+        extra=log_extra(
+            event="post_analysis_retryable_failure",
+            run_id=run_id,
+            duration_s=round(duration_s, 3),
+            error_message=str(exc),
+        ),
     )
     return PostAnalysisExecutionRetryableFailure(
         run_id=run_id,
@@ -187,6 +228,12 @@ def _persistence_failure_result(
         duration_s,
         exc,
         exc_info=True,
+        extra=log_extra(
+            event="post_analysis_failed",
+            run_id=run_id,
+            duration_s=round(duration_s, 3),
+            error_message=str(exc),
+        ),
     )
     completed_error = str(exc)
     callback_errors = (callback_error,)
@@ -194,7 +241,16 @@ def _persistence_failure_result(
     try:
         db.store_analysis_error(run_id, completed_error)
     except aiosqlite.Error as store_exc:
-        LOGGER.warning("Failed to store analysis error for run %s", run_id, exc_info=True)
+        LOGGER.warning(
+            "Failed to store analysis error for run %s",
+            run_id,
+            exc_info=True,
+            extra=log_extra(
+                event="post_analysis_error_persist_failed",
+                run_id=run_id,
+                error_message=str(store_exc),
+            ),
+        )
         return PostAnalysisExecutionPersistenceFailure(
             run_id=run_id,
             completed_error=completed_error,

--- a/apps/server/vibesensor/use_cases/updates/runtime_refresh.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime_refresh.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 
 from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
+from vibesensor.shared.structured_logging import log_extra
 from vibesensor.use_cases.updates.status import (
     UpdateStatusTracker,
     collect_runtime_details,
@@ -35,7 +36,14 @@ class UpdateRuntimeDetailsRefresher:
         try:
             runtime_details = await asyncio.to_thread(collect_runtime_details, self._repo)
         except (OSError, UpdateError) as exc:
-            self._logger.exception("update: runtime details refresh error")
+            self._logger.exception(
+                "update: runtime details refresh error",
+                extra=log_extra(
+                    event="update_runtime_refresh_error",
+                    update_phase="cleanup",
+                    repo_path=str(self._repo),
+                ),
+            )
             raise UpdateCleanupError(
                 "Runtime details refresh failed",
                 phase="cleanup",

--- a/docs/operational-runbooks.md
+++ b/docs/operational-runbooks.md
@@ -45,10 +45,11 @@ or shorter local-history window.
 docker compose logs --tail 100
 ```
 
-5. If file logging is enabled, use the `X-Request-ID` response header from the
-   failing HTTP call to find the matching structured JSON app-log entry; the
-   same `request_id` also appears on request-scoped `settings_change` audit
-   events.
+5. Use `docker compose logs --tail 100` for the human-readable `structlog`
+   console stream. If file logging is enabled, use the `X-Request-ID` response
+   header from the failing HTTP call to find the matching structured JSON
+   app-log entry; the same `request_id` also appears on request-scoped
+   `settings_change` audit events.
 6. If the issue is on a Pi, also review systemd or journal output for the service and hotspot helpers.
 
 ## Diagnose stale or missing live updates
@@ -153,8 +154,9 @@ df -h /var/lib/vibesensor /var/log/vibesensor
 sudo journalctl -u vibesensor.service -n 200 --no-pager
 ```
 
-4. If file logging is enabled, inspect the structured app log configured by
-   `logging.app_log_path`.
+4. Review the live `structlog` console output first with `journalctl` above. If
+   file logging is enabled, inspect the matching structured JSON app log
+   configured by `logging.app_log_path`.
 5. Before any manual DB recovery, copy `/var/lib/vibesensor/history.db` off the
    device (or snapshot the card) so the original evidence is preserved.
 6. If the device lost power and now reports repeated write failures, treat that


### PR DESCRIPTION
## what changed
- make `apps/server/vibesensor/shared/structured_logging.py` the one backend logging owner
- switch bootstrap and `main()` to one structlog-backed console + file pipeline
- keep stdlib `LogRecord` fields like `message`, `event`, and `request_id` so existing `caplog` assertions still work
- add explicit structured fields on updater runtime-refresh, post-analysis, and websocket failure logs
- extend logging tests/docs and make bootstrap CLI tests restore global logging state after exercising `main()`

## why
- issue wants one canonical logging path, not bespoke file formatting beside ad hoc stdlib logging
- operators need the same useful fields in console, file, and packaged smoke flows
- backend tests already rely on stdlib record attributes, so the migration must keep that contract

## validation
- focused logging pytest slice (`97 passed`)
- `make typecheck-backend`
- `make lint`
- `cd apps/server && ../../.venv/bin/python -m pytest -q tests/app tests/use_cases/run tests/use_cases/updates` (`587 passed`)
- `make test-changed` (`6612 passed, 8 skipped`)
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH .venv/bin/python tools/tests/run_ci_parallel.py`
- live `vibesensor-server` startup + `/api/health` check confirmed readable console logs and structured file JSON
- `.venv/bin/python tools/tests/run_release_smoke.py --skip-ui-build`

## risks / tradeoffs
- first-party backend logs still enter through stdlib loggers; this keeps `caplog` compatibility, but some low-value call sites still only emit raw message text until we add more explicit fields later
- local `docker compose build --pull && docker compose up -d` is host-blocked here because this machine has no running Docker daemon and no compose v2 plugin, so runtime validation used the direct server path plus packaged release smoke instead

Refs #2967
