### PR TITLE
Add OpenTelemetry tracing across backend runtime flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Open http://localhost:8000.
 Backend logs now flow through a shared `structlog` pipeline: `docker compose logs`
 shows human-readable structured lines, and optional `logging.app_log_path` files
 capture the same events as JSON for request/run correlation.
+Optional backend tracing uses the offline JSONL exporter configured by
+`tracing.enabled` and `tracing.output_path`, with canonical spans for HTTP,
+WebSocket broadcast, UDP ingest, run lifecycle, history/report work, updates,
+and startup/background tasks.
 
 If you want source-mounted hot-reload instead of a production-style container
 build, use the Docker dev mode below.
@@ -330,7 +334,8 @@ run log format. Synthetic analysis scenarios live in
   check AP channel
 - **Need backend log correlation** — use `docker compose logs` for live
   structured console output, or match the `X-Request-ID` response header
-  against the JSON file log configured by `logging.app_log_path`
+  against the JSON file log configured by `logging.app_log_path`; if tracing is
+  enabled, inspect the matching JSONL spans written to `tracing.output_path`
 - **Hotspot has no DHCP leases** — rerun `apps/server/scripts/hotspot_nmcli.sh`
 - **Need config details** — check [apps/server/README.md](apps/server/README.md)
   and [firmware/esp/README.md](firmware/esp/README.md) for AP/firmware settings

--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
   "granian[reload]>=2.7,<3",
   "uvloop>=0.22,<1; sys_platform == 'linux'",
   "numpy>=2.4.4,<3",
+  "opentelemetry-api>=1.38,<2",
+  "opentelemetry-sdk>=1.38,<2",
   "scipy>=1.16.3,<2",
   "structlog>=25.4,<26",
   "orjson>=3.11.4,<4",
@@ -192,7 +194,7 @@ forbidden_modules = ["vibesensor.app", "vibesensor.cli"]
 [tool.deptry]
 known_first_party = ["test_support"]
 optional_dependencies_dev_groups = ["dev"]
-package_module_name_map = { PyYAML = ["yaml"], pyserial = ["serial"] }
+package_module_name_map = { PyYAML = ["yaml"], pyserial = ["serial"], "opentelemetry-api" = ["opentelemetry"], "opentelemetry-sdk" = ["opentelemetry"] }
 # ESP flashing intentionally resolves esptool via PATH / `python -m esptool`
 # rather than importing it directly, so DEP002 would otherwise be a false
 # positive for the optional firmware-flash extra.

--- a/apps/server/tests/adapters/http/test_request_observability.py
+++ b/apps/server/tests/adapters/http/test_request_observability.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -8,6 +9,7 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
+from test_support.tracing import configured_trace_output, read_trace_output
 
 from vibesensor.adapters.http.error_boundary import install_http_exception_handlers
 from vibesensor.adapters.http.middleware import install_request_logging_middleware
@@ -195,3 +197,24 @@ def test_request_validation_error_keeps_status_code_and_request_id(
     assert request_log.request_id == "validation-request"
     assert request_log.status_code == 422
     assert all(rec.message != "http_request_failed" for rec in caplog.records)
+
+
+def test_request_logging_middleware_exports_http_trace_span(tmp_path: Path) -> None:
+    app = FastAPI()
+    install_request_logging_middleware(app)
+
+    @app.get("/ping")
+    async def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    with configured_trace_output(tmp_path) as trace_path:
+        with TestClient(app) as client:
+            response = client.get("/ping", headers={REQUEST_ID_HEADER: "trace-request"})
+
+    assert response.status_code == 200
+    span = next(item for item in read_trace_output(trace_path) if item["name"] == "http.request")
+    assert span["kind"] == "server"
+    assert span["attributes"]["http.method"] == "GET"
+    assert span["attributes"]["url.path"] == "/ping"
+    assert span["attributes"]["http.status_code"] == 200
+    assert span["attributes"]["vibesensor.request_id"] == "trace-request"

--- a/apps/server/tests/adapters/udp/test_udp_data_rx.py
+++ b/apps/server/tests/adapters/udp/test_udp_data_rx.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
+from test_support.tracing import configured_trace_output, read_trace_output
 
 from vibesensor.adapters.udp.protocol import pack_data
 from vibesensor.adapters.udp.udp_data_rx import DataDatagramProtocol
@@ -226,3 +228,30 @@ def test_process_datagram_reset_detected_flushes_buffer_before_ingest(fake_trans
     processor.flush_client_buffer.assert_called_once_with("010203040506")
     processor.ingest.assert_called_once()
     assert len(fake_transport.sent) == 1
+
+
+def test_process_datagram_exports_trace_span(fake_transport, tmp_path: Path) -> None:
+    registry = Mock()
+    registry.update_from_data.return_value = DataUpdateResult(reset_detected=True)
+    registry.get.return_value = SimpleNamespace(sample_rate_hz=1600)
+    processor = Mock()
+    proto = DataDatagramProtocol(registry=registry, processor=processor, queue_maxsize=8)
+    proto.connection_made(fake_transport)
+
+    pkt = pack_data(
+        bytes.fromhex("010203040506"),
+        seq=10,
+        t0_us=321,
+        samples=np.zeros((2, 3), dtype=np.int16),
+    )
+
+    with configured_trace_output(tmp_path) as trace_path:
+        proto._process_datagram(pkt, ("127.0.0.1", 12345))
+
+    span = next(
+        item for item in read_trace_output(trace_path) if item["name"] == "udp.data.dispatch"
+    )
+    assert span["kind"] == "consumer"
+    assert span["attributes"]["vibesensor.client_id"] == "010203040506"
+    assert span["attributes"]["vibesensor.sample_count"] == 2
+    assert span["attributes"]["vibesensor.reset_detected"] is True

--- a/apps/server/tests/app/test_app_main.py
+++ b/apps/server/tests/app/test_app_main.py
@@ -27,6 +27,7 @@ def _loaded_config(*, host: str, port: int) -> SimpleNamespace:
     return SimpleNamespace(
         server=SimpleNamespace(host=host, port=port),
         logging=SimpleNamespace(app_log_path=None),
+        tracing=SimpleNamespace(enabled=False, output_path=Path("/tmp/traces.jsonl")),
     )
 
 

--- a/apps/server/tests/app/test_config.py
+++ b/apps/server/tests/app/test_config.py
@@ -45,6 +45,8 @@ def test_logging_flags_allow_db_only_mode(cfg_path: Path) -> None:
     assert cfg.logging.app_log_path == cfg_path.parent / "logs/app.log"
     assert cfg.logging.no_data_timeout_s == 15.0
     assert cfg.logging.run_retention_days == 7
+    assert cfg.tracing.enabled is False
+    assert cfg.tracing.output_path == cfg_path.parent / "data/traces.jsonl"
 
 
 @pytest.mark.parametrize(
@@ -74,6 +76,21 @@ def test_logging_defaults_and_overrides(
 ) -> None:
     cfg = _write_and_load(cfg_path, override)
     assert getattr(cfg.logging, field) == expected
+
+
+def test_tracing_defaults_and_overrides(cfg_path: Path) -> None:
+    cfg = _write_and_load(
+        cfg_path,
+        {
+            "tracing": {
+                "enabled": True,
+                "output_path": "logs/traces.jsonl",
+            }
+        },
+    )
+
+    assert cfg.tracing.enabled is True
+    assert cfg.tracing.output_path == cfg_path.parent / "logs/traces.jsonl"
 
 
 def test_base_dev_and_docker_configs_capture_intended_runtime_invariants(tmp_path: Path) -> None:

--- a/apps/server/tests/app/test_config_validation.py
+++ b/apps/server/tests/app/test_config_validation.py
@@ -17,6 +17,7 @@ from vibesensor.app.config_schema import (
     LoggingConfig,
     ProcessingConfig,
     ServerConfig,
+    TracingConfig,
     UDPConfig,
 )
 
@@ -210,6 +211,15 @@ class TestLoggingConfigValidation:
     def test_non_positive_run_retention_days_clamped(self) -> None:
         cfg = self._make(run_retention_days=0)
         assert cfg.run_retention_days >= 1
+
+
+class TestTracingConfigValidation:
+    """TracingConfig stores the enabled flag and resolved output path."""
+
+    def test_tracing_config_round_trip(self) -> None:
+        cfg = TracingConfig(enabled=True, output_path=Path("/tmp/traces.jsonl"))
+        assert cfg.enabled is True
+        assert cfg.output_path == Path("/tmp/traces.jsonl")
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/shared/test_tracing.py
+++ b/apps/server/tests/shared/test_tracing.py
@@ -1,0 +1,51 @@
+"""Focused tests for the shared OpenTelemetry tracing helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from opentelemetry.trace import SpanKind
+from test_support.tracing import configured_trace_output, read_trace_output
+
+from vibesensor.shared.tracing import start_span
+
+
+def test_configured_tracing_writes_jsonl_spans(tmp_path: Path) -> None:
+    with configured_trace_output(tmp_path, "app-traces.jsonl") as trace_path:
+        with start_span(
+            __name__,
+            "unit.test.span",
+            kind=SpanKind.INTERNAL,
+            attributes={"test.value": "ok"},
+        ):
+            pass
+    spans = read_trace_output(trace_path)
+
+    assert len(spans) == 1
+    span = spans[0]
+    assert span["name"] == "unit.test.span"
+    assert span["kind"] == "internal"
+    assert span["attributes"]["test.value"] == "ok"
+    assert span["resource"]["service.name"] == "vibesensor-server"
+
+
+def test_async_tasks_keep_parent_trace_context(tmp_path: Path) -> None:
+    with configured_trace_output(tmp_path, "app-traces.jsonl") as trace_path:
+
+        async def _run() -> None:
+            with start_span(__name__, "trace.parent"):
+
+                async def _child() -> None:
+                    with start_span(__name__, "trace.child"):
+                        return None
+
+                await asyncio.create_task(_child())
+
+        asyncio.run(_run())
+    spans = {span["name"]: span for span in read_trace_output(trace_path)}
+
+    parent = spans["trace.parent"]
+    child = spans["trace.child"]
+    assert child["trace_id"] == parent["trace_id"]
+    assert child["parent_span_id"] == parent["span_id"]

--- a/apps/server/tests/test_support/tracing.py
+++ b/apps/server/tests/test_support/tracing.py
@@ -1,0 +1,36 @@
+"""Helpers for tracing-focused tests that inspect exported JSONL spans."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from vibesensor.app.config_schema import TracingConfig
+from vibesensor.shared.tracing import (
+    configure_tracing,
+    force_flush_tracing,
+    shutdown_tracing,
+)
+
+
+@contextmanager
+def configured_trace_output(tmp_path: Path, filename: str = "traces.jsonl") -> Iterator[Path]:
+    """Enable tracing to a temp JSONL file for the duration of a test block."""
+
+    trace_path = tmp_path / filename
+    configure_tracing(TracingConfig(enabled=True, output_path=trace_path))
+    try:
+        yield trace_path
+    finally:
+        try:
+            force_flush_tracing()
+        finally:
+            shutdown_tracing()
+
+
+def read_trace_output(path: Path) -> list[dict[str, object]]:
+    """Parse exported JSONL spans from *path* into Python dicts."""
+
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]

--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -5,12 +5,14 @@ import io
 import json
 import zipfile
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
 from test_support.analysis import run_analysis
 from test_support.persisted_analysis import make_persisted_analysis
 from test_support.report_helpers import report_sample
+from test_support.tracing import configured_trace_output, read_trace_output
 
 from vibesensor.adapters.history import (
     ProjectedHistoryExportService,
@@ -32,6 +34,7 @@ from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.use_cases.history.exports import HistoryExportService
 from vibesensor.use_cases.history.report_cache import HistoryReportPdfCache
 from vibesensor.use_cases.history.report_loader import HistoryReportRequestLoader
+from vibesensor.use_cases.history.reports import HistoryReportService
 from vibesensor.use_cases.history.runs import HistoryRunService, raise_delete_run_error
 
 
@@ -225,6 +228,29 @@ async def test_report_service_load_report_request_keeps_persisted_summary_immuta
         WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE,
     ]
     assert prepared.domain_test_run is not None
+
+
+@pytest.mark.asyncio
+async def test_report_service_exports_tracing_spans(tmp_path: Path) -> None:
+    service = HistoryReportService(
+        _HistoryDbStub(
+            run={
+                "run_id": "run-1",
+                "status": "complete",
+                "metadata": {"language": "en"},
+                "analysis": {"lang": "nl", "findings": [], "title": "Trace"},
+            }
+        ),
+        pdf_renderer=lambda _prepared: b"%PDF-1.7",
+    )
+
+    with configured_trace_output(tmp_path) as trace_path:
+        pdf = await service.build_pdf("run-1", "en")
+
+    assert pdf.filename == "run-1_report.pdf"
+    spans = {item["name"]: item for item in read_trace_output(trace_path)}
+    assert spans["history.report.build_pdf"]["attributes"]["vibesensor.cache_hit"] is False
+    assert spans["history.report.load_request"]["attributes"]["vibesensor.report_lang"] == "nl"
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
 
 import pytest
 from test_support.persisted_analysis import make_persisted_analysis
+from test_support.tracing import configured_trace_output, read_trace_output
 
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
@@ -81,6 +83,39 @@ def test_execute_post_analysis_success_stores_summary() -> None:
     assert isinstance(result, PostAnalysisExecutionSuccess)
     assert stored["run_id"] == "run-ok"
     assert stored["analysis"]["lang"] == "nl"
+
+
+def test_execute_post_analysis_exports_trace_span(tmp_path: Path) -> None:
+    class FakeDB:
+        def store_analysis(self, run_id, analysis):
+            return None
+
+        def store_analysis_error(self, run_id, error):
+            raise AssertionError(f"unexpected store_analysis_error({run_id}, {error})")
+
+    with configured_trace_output(tmp_path) as trace_path:
+        result = execute_post_analysis(
+            run_id="run-trace",
+            db=FakeDB(),
+            load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+                run_id=run_id,
+                metadata=_run_metadata(run_id),
+                language="en",
+                samples=_samples(),
+                total_sample_count=1,
+                stride=1,
+            ),
+            analysis_runner=lambda _run: make_persisted_analysis({"run_suitability": []}),
+        )
+
+    assert isinstance(result, PostAnalysisExecutionSuccess)
+    span = next(
+        item
+        for item in read_trace_output(trace_path)
+        if item["name"] == "run.post_analysis.execute"
+    )
+    assert span["attributes"]["vibesensor.run_id"] == "run-trace"
+    assert span["attributes"]["vibesensor.sample_count"] == 1
 
 
 def test_execute_post_analysis_handles_missing_metadata() -> None:

--- a/apps/server/tests/use_cases/updates/test_update_manager_lifecycle.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_lifecycle.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from test_support.tracing import configured_trace_output, read_trace_output
 
 from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
 from vibesensor.use_cases.updates.manager import UpdateManager
@@ -120,3 +122,22 @@ async def test_cleanup_error_propagates_explicitly() -> None:
     reporter.fail.assert_called_once_with(error, default_phase="cleanup")
     tracker.clear_secrets.assert_called_once_with()
     tracker.finish_cleanup.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_start_exports_update_workflow_trace_span(tmp_path: Path) -> None:
+    manager, tracker, reporter, workflow_run = _build_manager()
+    request = _wifi_request()
+
+    with configured_trace_output(tmp_path) as trace_path:
+        manager.start(request.ssid, request.password, transport=request.transport)
+        task = manager.job_task
+        assert task is not None
+        await task
+
+    workflow_run.assert_awaited_once_with(request=request)
+    tracker.clear_secrets.assert_called_once_with()
+    tracker.finish_cleanup.assert_called_once_with()
+    assert reporter.fail.call_count == 0
+    span = next(item for item in read_trace_output(trace_path) if item["name"] == "update.workflow")
+    assert span["attributes"]["vibesensor.transport"] == "wifi"

--- a/apps/server/tests/use_cases/updates/test_update_manager_workflow.py
+++ b/apps/server/tests/use_cases/updates/test_update_manager_workflow.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from test_support.tracing import configured_trace_output, read_trace_output
 
 from vibesensor.shared.exceptions import (
     UpdatePreparationError,
@@ -146,3 +148,17 @@ async def test_startup_recover_uses_persisted_transport() -> None:
     await manager.startup_recover()
 
     recover.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_startup_recover_exports_trace_span(tmp_path: Path) -> None:
+    manager, recover = _build_manager()
+
+    with configured_trace_output(tmp_path) as trace_path:
+        await manager.startup_recover()
+
+    recover.assert_awaited_once()
+    span = next(
+        item for item in read_trace_output(trace_path) if item["name"] == "update.startup_recover"
+    )
+    assert span["attributes"] == {}

--- a/apps/server/vibesensor/adapters/http/middleware.py
+++ b/apps/server/vibesensor/adapters/http/middleware.py
@@ -6,6 +6,7 @@ import sys
 from time import perf_counter
 
 from fastapi import FastAPI
+from opentelemetry.trace import SpanKind
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -18,6 +19,7 @@ from vibesensor.shared.structured_logging import (
     log_extra,
     reset_request_id,
 )
+from vibesensor.shared.tracing import mark_span_error, start_span
 
 LOGGER = logging.getLogger(__name__)
 
@@ -88,34 +90,49 @@ class RequestLoggingMiddleware:
                     MutableHeaders(scope=message)[REQUEST_ID_HEADER] = resolved_request_id
             await send(message)
 
-        try:
-            await self.app(scope, receive, _send_with_request_id)
-            request_completed = True
-        except asyncio.CancelledError:
-            raise
-        finally:
-            duration_ms = round((perf_counter() - started_at) * 1000.0, 3)
-            active_error = sys.exc_info()[1]
-            if active_error is None and request_completed:
-                LOGGER.info(
-                    "http_request",
-                    extra=log_extra(
-                        event="http_request",
+        with start_span(
+            __name__,
+            "http.request",
+            kind=SpanKind.SERVER,
+            attributes={
+                "http.method": method,
+                "url.path": path,
+                "vibesensor.request_id": request_id or "",
+            },
+        ) as span:
+            try:
+                await self.app(scope, receive, _send_with_request_id)
+                request_completed = True
+            except asyncio.CancelledError:
+                span.set_attribute("vibesensor.cancelled", True)
+                raise
+            finally:
+                duration_ms = round((perf_counter() - started_at) * 1000.0, 3)
+                active_error = sys.exc_info()[1]
+                span.set_attribute("http.status_code", status_code)
+                span.set_attribute("vibesensor.duration_ms", duration_ms)
+                span.set_attribute("vibesensor.response_started", response_started)
+                if active_error is None and request_completed:
+                    LOGGER.info(
+                        "http_request",
+                        extra=log_extra(
+                            event="http_request",
+                            method=method,
+                            path=path,
+                            status_code=status_code,
+                            duration_ms=duration_ms,
+                        ),
+                    )
+                elif active_error is not None:
+                    mark_span_error(span, active_error)
+                    _log_request_failure(
+                        exc=active_error,
                         method=method,
                         path=path,
                         status_code=status_code,
                         duration_ms=duration_ms,
-                    ),
-                )
-            elif active_error is not None:
-                _log_request_failure(
-                    exc=active_error,
-                    method=method,
-                    path=path,
-                    status_code=status_code,
-                    duration_ms=duration_ms,
-                )
-            reset_request_id(token)
+                    )
+                reset_request_id(token)
 
 
 def install_request_logging_middleware(app: FastAPI) -> None:

--- a/apps/server/vibesensor/adapters/udp/udp_data_rx.py
+++ b/apps/server/vibesensor/adapters/udp/udp_data_rx.py
@@ -12,6 +12,8 @@ import logging
 import time
 from typing import cast
 
+from opentelemetry.trace import SpanKind
+
 from vibesensor.adapters.udp.protocol import (
     MSG_DATA,
     DataMessage,
@@ -21,8 +23,9 @@ from vibesensor.adapters.udp.protocol import (
 )
 from vibesensor.adapters.udp.protocol_validator import ProtocolVersionMismatch
 from vibesensor.infra.processing import SignalProcessor
-from vibesensor.infra.runtime.registry import ClientRegistry
+from vibesensor.infra.runtime.registry import ClientRegistry, DataUpdateResult
 from vibesensor.shared.exceptions import ProtocolError
+from vibesensor.shared.tracing import mark_span_error, start_span
 
 LOGGER = logging.getLogger(__name__)
 
@@ -122,10 +125,29 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
                 self._queue.task_done()
 
     def _process_datagram(self, data: bytes, addr: tuple[str, int]) -> None:
-        msg = self._parse_data_message(data, addr)
-        if msg is None:
-            return
-        self._dispatch_data_message(msg, addr)
+        with start_span(
+            __name__,
+            "udp.data.dispatch",
+            kind=SpanKind.CONSUMER,
+            attributes={
+                "net.peer.ip": addr[0],
+                "net.peer.port": addr[1],
+            },
+        ) as span:
+            msg = self._parse_data_message(data, addr)
+            if msg is None:
+                span.set_attribute("vibesensor.datagram.accepted", False)
+                return
+            span.set_attribute("vibesensor.datagram.accepted", True)
+            span.set_attribute("vibesensor.client_id", msg.client_id.hex())
+            span.set_attribute("vibesensor.sample_count", len(msg.samples))
+            try:
+                result = self._dispatch_data_message(msg, addr)
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
+            span.set_attribute("vibesensor.is_duplicate", result.is_duplicate)
+            span.set_attribute("vibesensor.reset_detected", result.reset_detected)
 
     def _parse_data_message(self, data: bytes, addr: tuple[str, int]) -> DataMessage | None:
         try:
@@ -141,7 +163,7 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
             self.registry.note_parse_error(client_id)
             return None
 
-    def _dispatch_data_message(self, msg: DataMessage, addr: tuple[str, int]) -> None:
+    def _dispatch_data_message(self, msg: DataMessage, addr: tuple[str, int]) -> DataUpdateResult:
         client_id = msg.client_id.hex()
         registry = self.registry
         processor = self.processor
@@ -163,6 +185,7 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
                 t0_us=msg.t0_us,
             )
         self._send_data_ack(msg, addr, client_id=client_id)
+        return result
 
     def _send_data_ack(
         self,

--- a/apps/server/vibesensor/adapters/websocket/broadcast_runner.py
+++ b/apps/server/vibesensor/adapters/websocket/broadcast_runner.py
@@ -12,12 +12,15 @@ import contextlib
 import logging
 from collections.abc import Callable
 
+from opentelemetry.trace import SpanKind
+
 from vibesensor.adapters.websocket.connection_tracker import (
     ConnectionTracker,
     WSConnectionSnapshot,
 )
 from vibesensor.adapters.websocket.payload_orchestrator import PayloadBuildOrchestrator
 from vibesensor.shared.structured_logging import log_extra
+from vibesensor.shared.tracing import mark_span_error, start_span
 from vibesensor.shared.types.payload_types import LiveWsPayload
 
 LOGGER = logging.getLogger(__name__)
@@ -52,19 +55,40 @@ class BroadcastRunner:
         conns = await self._tracker.snapshot()
         if not conns:
             return
-        payloads = PayloadBuildOrchestrator(
-            payload_builder,
-            capture_debug=capture_debug,
-        )
-        await payloads.prepare(conn.selected_client_id for conn in conns)
-        sent_selected_client_ids: dict[int, str | None] = {}
+        with start_span(
+            __name__,
+            "ws.broadcast.tick",
+            kind=SpanKind.INTERNAL,
+            attributes={
+                "vibesensor.connection_count": len(conns),
+                "vibesensor.capture_debug": capture_debug,
+            },
+        ) as span:
+            payloads = PayloadBuildOrchestrator(
+                payload_builder,
+                capture_debug=capture_debug,
+            )
+            try:
+                await payloads.prepare(conn.selected_client_id for conn in conns)
+                sent_selected_client_ids: dict[int, str | None] = {}
 
-        dead_ws = await asyncio.gather(
-            *(self._send_current_conn(conn, payloads, sent_selected_client_ids) for conn in conns),
-        )
-        await self._cleanup_dead(dead_ws)
-        self._log_build_failures(payloads, sent_selected_client_ids)
-        self._log_debug(payloads, conns, dead_ws)
+                dead_ws = await asyncio.gather(
+                    *(
+                        self._send_current_conn(conn, payloads, sent_selected_client_ids)
+                        for conn in conns
+                    ),
+                )
+                await self._cleanup_dead(dead_ws)
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
+            span.set_attribute("vibesensor.payload_variant_count", len(payloads.payload_cache))
+            span.set_attribute("vibesensor.failed_client_count", len(payloads.failed_client_ids))
+            span.set_attribute(
+                "vibesensor.removed_connection_count", sum(1 for ws in dead_ws if ws)
+            )
+            self._log_build_failures(payloads, sent_selected_client_ids)
+            self._log_debug(payloads, conns, dead_ws)
 
     async def _send_conn(
         self,

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -35,6 +35,7 @@ from vibesensor.shared.process_settings import (
     load_bootstrap_env_settings,
 )
 from vibesensor.shared.structured_logging import configure_logging
+from vibesensor.shared.tracing import configure_tracing, shutdown_tracing
 
 __all__ = ["create_app", "create_app_from_env", "main"]
 
@@ -60,6 +61,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     config = load_config(config_path)
     bootstrap_settings = load_bootstrap_env_settings()
     configure_logging(config.logging.app_log_path)
+    configure_tracing(config.tracing)
     runtime = build_runtime(config)
     lifecycle = LifecycleManager(
         runtime=LifecycleRuntime(
@@ -107,6 +109,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             yield
         finally:
             await lifecycle.stop()
+            shutdown_tracing()
 
     app = FastAPI(title="VibeSensor", lifespan=lifespan)
     app.state.runtime = runtime
@@ -229,6 +232,7 @@ def main() -> None:
     configure_logging(None)
     config = load_config(args.config)
     configure_logging(config.logging.app_log_path)
+    configure_tracing(config.tracing)
     export_config_path_env(args.config)
     _run_server_with_port_fallback(
         "vibesensor.app.bootstrap:create_app_from_env",

--- a/apps/server/vibesensor/app/config_defaults.py
+++ b/apps/server/vibesensor/app/config_defaults.py
@@ -49,6 +49,10 @@ DEFAULT_CONFIG: JsonObject = {
     "update": {
         "rollback_dir": "/var/lib/vibesensor/rollback",
     },
+    "tracing": {
+        "enabled": False,
+        "output_path": "data/traces.jsonl",
+    },
 }
 
 

--- a/apps/server/vibesensor/app/config_loader.py
+++ b/apps/server/vibesensor/app/config_loader.py
@@ -23,6 +23,7 @@ from .config_schema import (
     LoggingConfig,
     ProcessingConfig,
     ServerConfig,
+    TracingConfig,
     UDPConfig,
     UpdateConfig,
 )
@@ -99,6 +100,7 @@ def load_config(config_path: Path | None = None) -> AppConfig:
     logging_cfg = _require_config_section(merged.get("logging", {}), "logging")
     gps_cfg = _require_config_section(merged.get("gps", {}), "gps")
     update_cfg = _require_config_section(merged.get("update", {}), "update")
+    tracing_cfg = _require_config_section(merged.get("tracing", {}), "tracing")
 
     data_host = str(udp_cfg["data_host"])
     data_port = _coerce_port(udp_cfg["data_port"], "udp.data_port")
@@ -218,6 +220,13 @@ def load_config(config_path: Path | None = None) -> AppConfig:
         ),
         update=UpdateConfig(
             rollback_dir=Path(str(update_cfg["rollback_dir"])),
+        ),
+        tracing=TracingConfig(
+            enabled=bool(tracing_cfg["enabled"]),
+            output_path=_resolve_config_path(
+                str(tracing_cfg["output_path"]),
+                path,
+            ),
         ),
         config_path=path,
     )

--- a/apps/server/vibesensor/app/config_schema.py
+++ b/apps/server/vibesensor/app/config_schema.py
@@ -19,6 +19,7 @@ __all__ = [
     "LoggingConfig",
     "ProcessingConfig",
     "ServerConfig",
+    "TracingConfig",
     "UDPConfig",
     "UpdateConfig",
 ]
@@ -222,6 +223,14 @@ class UpdateConfig:
 
 
 @dataclass(slots=True)
+class TracingConfig:
+    """Backend tracing configuration (optional JSONL export)."""
+
+    enabled: bool
+    output_path: Path
+
+
+@dataclass(slots=True)
 class AppConfig:
     """Full application configuration assembled from the YAML config file."""
 
@@ -232,5 +241,6 @@ class AppConfig:
     logging: LoggingConfig
     gps: GPSConfig
     update: UpdateConfig
+    tracing: TracingConfig
     config_path: Path
     repo_dir: Path = REPO_DIR

--- a/apps/server/vibesensor/infra/runtime/startup_runner.py
+++ b/apps/server/vibesensor/infra/runtime/startup_runner.py
@@ -6,13 +6,17 @@ previously inlined in ``LifecycleManager.start()``.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from opentelemetry.trace import SpanKind
+
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.task_supervisor import task_failure_message
 from vibesensor.shared.runtime_failures import BroadcastTickLoopFailure
+from vibesensor.shared.tracing import mark_span_error, start_span
 
 if TYPE_CHECKING:
     from vibesensor.infra.runtime.background_task_coordinator import BackgroundTaskCoordinator
@@ -65,7 +69,20 @@ class StartupRunner:
             for phase in self._phases():
                 phase_name = phase.name
                 self._health_state.set_phase(phase_name)
-                await phase.run()
+                with start_span(
+                    __name__,
+                    "runtime.startup.phase",
+                    kind=SpanKind.INTERNAL,
+                    attributes={"vibesensor.phase": phase_name},
+                ) as span:
+                    try:
+                        await phase.run()
+                    except asyncio.CancelledError:
+                        span.set_attribute("vibesensor.cancelled", True)
+                        raise
+                    except (OSError, RuntimeError) as exc:
+                        mark_span_error(span, exc)
+                        raise
             self._health_state.mark_ready()
         except (OSError, RuntimeError) as exc:
             self._health_state.mark_failed(phase_name, task_failure_message(exc))

--- a/apps/server/vibesensor/infra/runtime/task_supervisor.py
+++ b/apps/server/vibesensor/infra/runtime/task_supervisor.py
@@ -7,8 +7,11 @@ import logging
 import time
 from collections.abc import Callable, Coroutine
 
+from opentelemetry.trace import SpanKind, Status, StatusCode
+
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.shared.failure_utils import bounded_failure_message
+from vibesensor.shared.tracing import mark_span_error, start_span
 
 __all__ = ["TaskSupervisor", "task_failure_message"]
 
@@ -97,34 +100,52 @@ class TaskSupervisor:
         async def _run_supervised() -> None:
             restart_count = 0
             while True:
-                started_at = time.monotonic()
-                try:
-                    await task_factory()
-                except asyncio.CancelledError:
-                    raise
-                except restartable_exceptions as exc:
-                    runtime_s = time.monotonic() - started_at
-                    if runtime_s >= self._reset_after_s:
-                        restart_count = 0
-                    if restart_count >= self._max_attempts:
+                with start_span(
+                    __name__,
+                    "runtime.managed_task",
+                    kind=SpanKind.INTERNAL,
+                    attributes={
+                        "vibesensor.task.name": name,
+                        "vibesensor.task.attempt": restart_count + 1,
+                    },
+                ) as span:
+                    started_at = time.monotonic()
+                    try:
+                        await task_factory()
+                    except asyncio.CancelledError:
+                        span.set_attribute("vibesensor.cancelled", True)
                         raise
-                    restart_count += 1
-                    delay_s = self._restart_delay_s(restart_count)
-                    self._health_state.record_task_failure(name, task_failure_message(exc))
-                    self._logger.error(
-                        (
-                            "Managed task %s failed with restartable error; "
-                            "restarting in %.1fs (%d/%d)."
-                        ),
-                        name,
-                        delay_s,
-                        restart_count,
-                        self._max_attempts,
-                        exc_info=exc,
-                    )
-                    await asyncio.sleep(delay_s)
-                    self._health_state.clear_task_failure(name)
-                    continue
+                    except restartable_exceptions as exc:
+                        runtime_s = time.monotonic() - started_at
+                        span.set_attribute("vibesensor.runtime_s", round(runtime_s, 3))
+                        mark_span_error(span, exc)
+                        if runtime_s >= self._reset_after_s:
+                            restart_count = 0
+                        if restart_count >= self._max_attempts:
+                            span.set_attribute("vibesensor.restart_exhausted", True)
+                            raise
+                        restart_count += 1
+                        delay_s = self._restart_delay_s(restart_count)
+                        span.set_attribute("vibesensor.restart_delay_s", delay_s)
+                        self._health_state.record_task_failure(name, task_failure_message(exc))
+                        self._logger.error(
+                            (
+                                "Managed task %s failed with restartable error; "
+                                "restarting in %.1fs (%d/%d)."
+                            ),
+                            name,
+                            delay_s,
+                            restart_count,
+                            self._max_attempts,
+                            exc_info=exc,
+                        )
+                        await asyncio.sleep(delay_s)
+                        self._health_state.clear_task_failure(name)
+                        continue
+                    runtime_s = time.monotonic() - started_at
+                    span.set_attribute("vibesensor.runtime_s", round(runtime_s, 3))
+                    span.set_attribute("vibesensor.unexpected_exit", True)
+                    span.set_status(Status(StatusCode.ERROR, "managed task exited unexpectedly"))
                 raise RuntimeError(f"managed task {name} exited unexpectedly")
 
         task = asyncio.create_task(_run_supervised(), name=name)

--- a/apps/server/vibesensor/shared/tracing.py
+++ b/apps/server/vibesensor/shared/tracing.py
@@ -1,0 +1,221 @@
+"""Optional OpenTelemetry tracing helpers for backend runtime flows."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter, SpanExportResult
+from opentelemetry.sdk.trace.sampling import ALWAYS_OFF, ALWAYS_ON
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+LOGGER = logging.getLogger(__name__)
+
+_SERVICE_NAME = "vibesensor-server"
+_EXPORT_BATCH_SIZE = 256
+_EXPORT_DELAY_MS = 200
+_SHUTDOWN_TIMEOUT_MS = 3_000
+
+type TracingAttributeValue = (
+    str | bool | int | float | Sequence[str] | Sequence[bool] | Sequence[int] | Sequence[float]
+)
+
+
+class TracingSettings(Protocol):
+    enabled: bool
+    output_path: Path
+
+
+def _json_value(value: object) -> object:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_json_value(item) for item in value]
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    return str(value)
+
+
+def _span_hex(span_id: int) -> str:
+    return f"{span_id:016x}"
+
+
+def _trace_hex(trace_id: int) -> str:
+    return f"{trace_id:032x}"
+
+
+def _span_payload(span: ReadableSpan) -> dict[str, object]:
+    parent = span.parent
+    duration_ms: float | None = None
+    if span.start_time is not None and span.end_time is not None:
+        duration_ms = round((span.end_time - span.start_time) / 1_000_000, 3)
+    return {
+        "name": span.name,
+        "trace_id": _trace_hex(span.context.trace_id),
+        "span_id": _span_hex(span.context.span_id),
+        "parent_span_id": _span_hex(parent.span_id) if parent is not None else None,
+        "kind": span.kind.name.lower(),
+        "start_time_unix_nano": span.start_time,
+        "end_time_unix_nano": span.end_time,
+        "duration_ms": duration_ms,
+        "status": span.status.status_code.name.lower(),
+        "status_description": span.status.description or None,
+        "attributes": {key: _json_value(value) for key, value in (span.attributes or {}).items()},
+        "events": [
+            {
+                "name": event.name,
+                "timestamp_unix_nano": event.timestamp,
+                "attributes": {
+                    key: _json_value(value) for key, value in (event.attributes or {}).items()
+                },
+            }
+            for event in span.events
+        ],
+        "resource": {
+            str(key): _json_value(value) for key, value in span.resource.attributes.items()
+        },
+    }
+
+
+class JsonlSpanExporter(SpanExporter):
+    """Append completed spans to a JSONL file for offline inspection."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._lock, self._path.open("a", encoding="utf-8") as handle:
+                for span in spans:
+                    handle.write(json.dumps(_span_payload(span), ensure_ascii=True, sort_keys=True))
+                    handle.write("\n")
+        except OSError:
+            LOGGER.warning(
+                "Failed to export spans to %s",
+                self._path,
+                exc_info=True,
+            )
+            return SpanExportResult.FAILURE
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        return None
+
+
+@dataclass(slots=True)
+class _TracingRuntime:
+    provider: TracerProvider
+    processor: BatchSpanProcessor | None
+    exporter: JsonlSpanExporter | None
+    enabled: bool
+
+
+def _build_runtime(*, enabled: bool, output_path: Path | None) -> _TracingRuntime:
+    provider = TracerProvider(
+        sampler=ALWAYS_ON if enabled else ALWAYS_OFF,
+        resource=Resource.create({"service.name": _SERVICE_NAME}),
+    )
+    processor: BatchSpanProcessor | None = None
+    exporter: JsonlSpanExporter | None = None
+    if enabled and output_path is not None:
+        exporter = JsonlSpanExporter(output_path)
+        processor = BatchSpanProcessor(
+            exporter,
+            max_export_batch_size=_EXPORT_BATCH_SIZE,
+            schedule_delay_millis=_EXPORT_DELAY_MS,
+        )
+        provider.add_span_processor(processor)
+    return _TracingRuntime(
+        provider=provider,
+        processor=processor,
+        exporter=exporter,
+        enabled=enabled,
+    )
+
+
+_RUNTIME = _build_runtime(enabled=False, output_path=None)
+
+
+def configure_tracing(settings: TracingSettings | None) -> None:
+    """Install the canonical tracing runtime from *settings*."""
+
+    global _RUNTIME
+    previous = _RUNTIME
+    enabled = bool(settings.enabled) if settings is not None else False
+    output_path = settings.output_path if settings is not None else None
+    _RUNTIME = _build_runtime(enabled=enabled, output_path=output_path)
+    previous.provider.shutdown()
+
+
+def force_flush_tracing() -> None:
+    """Flush completed spans to disk when tracing is enabled."""
+
+    if _RUNTIME.processor is None:
+        return
+    _RUNTIME.processor.force_flush(timeout_millis=_SHUTDOWN_TIMEOUT_MS)
+
+
+def shutdown_tracing() -> None:
+    """Flush and stop the current tracing runtime."""
+
+    global _RUNTIME
+    current = _RUNTIME
+    _RUNTIME = _build_runtime(enabled=False, output_path=None)
+    current.provider.shutdown()
+
+
+def tracing_enabled() -> bool:
+    """Return whether span export is currently enabled."""
+
+    return _RUNTIME.enabled
+
+
+def _coerce_span_attribute(value: object) -> TracingAttributeValue:
+    if isinstance(value, str | bool | int | float):
+        return value
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        if all(isinstance(item, str) for item in value):
+            return [item for item in value]
+        if all(isinstance(item, bool) for item in value):
+            return [item for item in value]
+        if all(isinstance(item, int) and not isinstance(item, bool) for item in value):
+            return [item for item in value]
+        if all(isinstance(item, float) for item in value):
+            return [item for item in value]
+    return str(value)
+
+
+@contextmanager
+def start_span(
+    tracer_name: str,
+    span_name: str,
+    *,
+    kind: SpanKind = SpanKind.INTERNAL,
+    attributes: Mapping[str, object] | None = None,
+) -> Iterator[Span]:
+    tracer = _RUNTIME.provider.get_tracer(tracer_name)
+    with tracer.start_as_current_span(span_name, kind=kind) as span:
+        for key, value in (attributes or {}).items():
+            span.set_attribute(key, _coerce_span_attribute(value))
+        yield span
+
+
+def mark_span_error(span: Span, exc: BaseException) -> None:
+    """Record *exc* on *span* and mark it failed when the span is recording."""
+
+    if not span.is_recording():
+        return
+    span.record_exception(exc)
+    span.set_status(Status(StatusCode.ERROR, str(exc)))

--- a/apps/server/vibesensor/use_cases/history/report_loader.py
+++ b/apps/server/vibesensor/use_cases/history/report_loader.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 
+from opentelemetry.trace import SpanKind
+
 from vibesensor.domain import RunStatus
 from vibesensor.shared.boundaries.reporting import (
     PreparedReportInput,
@@ -14,6 +16,7 @@ from vibesensor.shared.boundaries.runs.metadata import run_metadata_to_json_obje
 from vibesensor.shared.exceptions import AnalysisNotReadyError
 from vibesensor.shared.filenames import safe_filename
 from vibesensor.shared.ports import AsyncRunPersistence
+from vibesensor.shared.tracing import mark_span_error, start_span
 from vibesensor.shared.types.history_records import StoredHistoryRun
 from vibesensor.shared.types.json_types import is_json_array
 from vibesensor.shared.types.report_cache import ReportPdfCacheKey
@@ -57,38 +60,58 @@ class HistoryReportRequestLoader:
         run_id: str,
         requested_lang: str | None,
     ) -> HistoryReportRequest:
-        run = await async_require_run(self._history_db, run_id)
-        if run.status == RunStatus.ANALYZING:
-            raise AnalysisNotReadyError("Analysis is still in progress", status="in_progress")
-        if run.status == RunStatus.ERROR:
-            raise AnalysisNotReadyError(str(run.error_message or "Analysis failed"), status="error")
-        if run.analysis_corrupt:
-            raise AnalysisNotReadyError(
-                "Report data unavailable for this run. Re-analyze to regenerate the PDF."
-            )
-        analysis = run.analysis
-        if analysis is None:
-            raise AnalysisNotReadyError("No analysis available for this run")
+        with start_span(
+            __name__,
+            "history.report.load_request",
+            kind=SpanKind.INTERNAL,
+            attributes={
+                "vibesensor.run_id": run_id,
+                "vibesensor.requested_lang": requested_lang or "",
+            },
+        ) as span:
+            try:
+                run = await async_require_run(self._history_db, run_id)
+                if run.status == RunStatus.ANALYZING:
+                    raise AnalysisNotReadyError(
+                        "Analysis is still in progress", status="in_progress"
+                    )
+                if run.status == RunStatus.ERROR:
+                    raise AnalysisNotReadyError(
+                        str(run.error_message or "Analysis failed"),
+                        status="error",
+                    )
+                if run.analysis_corrupt:
+                    raise AnalysisNotReadyError(
+                        "Report data unavailable for this run. Re-analyze to regenerate the PDF."
+                    )
+                analysis = run.analysis
+                if analysis is None:
+                    raise AnalysisNotReadyError("No analysis available for this run")
 
-        requested_lang = self._analysis_language(run, requested_lang)
-        report_language = self._report_pdf_cache_lang(run, requested_lang)
-        raw_warnings = analysis.get("warnings")
-        warnings = raw_warnings if is_json_array(raw_warnings) else None
-        cache_key = self._report_pdf_cache_key(
-            run,
-            run_id,
-            report_language,
-        )
-        filename = f"{safe_filename(run_id)}_report.pdf"
-        return HistoryReportRequest(
-            prepared=prepare_persisted_report_input(
-                analysis,
-                warnings=warnings,
-                filename=filename,
-                language=report_language,
-                cache_key=cache_key,
-            ),
-        )
+                requested_lang = self._analysis_language(run, requested_lang)
+                report_language = self._report_pdf_cache_lang(run, requested_lang)
+                raw_warnings = analysis.get("warnings")
+                warnings = raw_warnings if is_json_array(raw_warnings) else None
+                cache_key = self._report_pdf_cache_key(
+                    run,
+                    run_id,
+                    report_language,
+                )
+                filename = f"{safe_filename(run_id)}_report.pdf"
+                request = HistoryReportRequest(
+                    prepared=prepare_persisted_report_input(
+                        analysis,
+                        warnings=warnings,
+                        filename=filename,
+                        language=report_language,
+                        cache_key=cache_key,
+                    ),
+                )
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
+            span.set_attribute("vibesensor.report_lang", report_language)
+            return request
 
     @staticmethod
     def _metadata_cache_token(metadata: RunMetadata) -> str:

--- a/apps/server/vibesensor/use_cases/history/reports.py
+++ b/apps/server/vibesensor/use_cases/history/reports.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from opentelemetry.trace import SpanKind
+
 from vibesensor.shared.boundaries.reporting import PreparedReportInput
 from vibesensor.shared.ports import AsyncRunPersistence
+from vibesensor.shared.tracing import mark_span_error, start_span
 from vibesensor.use_cases.history.report_cache import HistoryReportPdfCache
 from vibesensor.use_cases.history.report_loader import HistoryReportRequestLoader
 
@@ -47,13 +50,28 @@ class HistoryReportService:
         self._pdf_renderer = pdf_renderer
 
     async def build_pdf(self, run_id: str, requested_lang: str | None) -> HistoryReportPdf:
-        request = await self._loader.load_report_request(run_id, requested_lang)
-        cached_pdf = self._pdf_cache.get(request.cache_key)
-        if cached_pdf is not None:
-            return HistoryReportPdf(content=cached_pdf, filename=request.filename)
+        with start_span(
+            __name__,
+            "history.report.build_pdf",
+            kind=SpanKind.INTERNAL,
+            attributes={
+                "vibesensor.run_id": run_id,
+                "vibesensor.requested_lang": requested_lang or "",
+            },
+        ) as span:
+            try:
+                request = await self._loader.load_report_request(run_id, requested_lang)
+                cached_pdf = self._pdf_cache.get(request.cache_key)
+                if cached_pdf is not None:
+                    span.set_attribute("vibesensor.cache_hit", True)
+                    return HistoryReportPdf(content=cached_pdf, filename=request.filename)
 
-        pdf = await self._pdf_cache.get_or_build(
-            request.cache_key,
-            lambda: self._pdf_renderer(request.prepared),
-        )
-        return HistoryReportPdf(content=pdf, filename=request.filename)
+                pdf = await self._pdf_cache.get_or_build(
+                    request.cache_key,
+                    lambda: self._pdf_renderer(request.prepared),
+                )
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
+            span.set_attribute("vibesensor.cache_hit", False)
+            return HistoryReportPdf(content=pdf, filename=request.filename)

--- a/apps/server/vibesensor/use_cases/history/runs.py
+++ b/apps/server/vibesensor/use_cases/history/runs.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import asyncio
 from typing import Never, cast
 
+from opentelemetry.trace import SpanKind
+
 from vibesensor.domain import RunStatus
 from vibesensor.shared.boundaries.summary_fields.warnings import localize_warning_list
 from vibesensor.shared.exceptions import AnalysisNotReadyError, RunNotFoundError
 from vibesensor.shared.ports import AsyncRunPersistence, RunPersistence
+from vibesensor.shared.tracing import mark_span_error, start_span
 from vibesensor.shared.types.history_records import HistoryRunListEntry, StoredHistoryRun
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_array
 from vibesensor.use_cases.history.helpers import (
@@ -28,14 +31,34 @@ class HistoryRunService:
         self._history_db = history_db
 
     async def list_runs(self) -> list[HistoryRunListEntry]:
-        alist_runs = getattr(self._history_db, "alist_runs", None)
-        if callable(alist_runs):
-            return cast(list[HistoryRunListEntry], await alist_runs())
-        sync_history_db = cast(RunPersistence, self._history_db)
-        return await asyncio.to_thread(sync_history_db.list_runs)
+        with start_span(__name__, "history.runs.list", kind=SpanKind.INTERNAL) as span:
+            try:
+                alist_runs = getattr(self._history_db, "alist_runs", None)
+                if callable(alist_runs):
+                    runs = cast(list[HistoryRunListEntry], await alist_runs())
+                else:
+                    sync_history_db = cast(RunPersistence, self._history_db)
+                    runs = await asyncio.to_thread(sync_history_db.list_runs)
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
+            span.set_attribute("vibesensor.run_count", len(runs))
+            return runs
 
     async def get_run(self, run_id: str) -> StoredHistoryRun:
-        return await async_require_run(self._history_db, run_id)
+        with start_span(
+            __name__,
+            "history.run.get",
+            kind=SpanKind.INTERNAL,
+            attributes={"vibesensor.run_id": run_id},
+        ) as span:
+            try:
+                run = await async_require_run(self._history_db, run_id)
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
+            span.set_attribute("vibesensor.run_status", run.status.value)
+            return run
 
     async def get_insights(
         self,
@@ -43,36 +66,67 @@ class HistoryRunService:
         requested_lang: str | None = None,
     ) -> JsonObject | None:
         """Return analysis insights for a run, or ``None`` if still analyzing."""
-        run = await async_require_run(self._history_db, run_id)
-        if run.status == RunStatus.ANALYZING:
-            return None
+        with start_span(
+            __name__,
+            "history.run.insights",
+            kind=SpanKind.INTERNAL,
+            attributes={
+                "vibesensor.run_id": run_id,
+                "vibesensor.requested_lang": requested_lang or "",
+            },
+        ) as span:
+            try:
+                run = await async_require_run(self._history_db, run_id)
+                if run.status == RunStatus.ANALYZING:
+                    span.set_attribute("vibesensor.analysis_ready", False)
+                    return None
 
-        raw_analysis = require_analysis_ready(run)
-        analysis = strip_internal_fields(raw_analysis.payload)
-        response_lang = resolve_run_language(run, requested_lang)
-        raw_warnings = analysis.get("warnings")
-        analysis["warnings"] = cast(
-            JsonValue,
-            localize_warning_list(
-                raw_warnings if is_json_array(raw_warnings) else None,
-                lang=response_lang,
-            ),
-        )
-        analysis["run_id"] = run.run_id or run_id
-        analysis["status"] = RunStatus.COMPLETE.value
-
-        return analysis
+                raw_analysis = require_analysis_ready(run)
+                analysis = strip_internal_fields(raw_analysis.payload)
+                response_lang = resolve_run_language(run, requested_lang)
+                raw_warnings = analysis.get("warnings")
+                analysis["warnings"] = cast(
+                    JsonValue,
+                    localize_warning_list(
+                        raw_warnings if is_json_array(raw_warnings) else None,
+                        lang=response_lang,
+                    ),
+                )
+                analysis["run_id"] = run.run_id or run_id
+                analysis["status"] = RunStatus.COMPLETE.value
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
+            span.set_attribute("vibesensor.analysis_ready", True)
+            span.set_attribute("vibesensor.response_lang", response_lang)
+            return analysis
 
     async def delete_run(self, run_id: str) -> dict[str, str]:
-        adelete_run_if_safe = getattr(self._history_db, "adelete_run_if_safe", None)
-        if callable(adelete_run_if_safe):
-            deleted, reason = await adelete_run_if_safe(run_id)
-        else:
-            sync_history_db = cast(RunPersistence, self._history_db)
-            deleted, reason = await asyncio.to_thread(sync_history_db.delete_run_if_safe, run_id)
-        if deleted:
-            return {"run_id": run_id, "status": "deleted"}
-        raise_delete_run_error(reason)
+        with start_span(
+            __name__,
+            "history.run.delete",
+            kind=SpanKind.INTERNAL,
+            attributes={"vibesensor.run_id": run_id},
+        ) as span:
+            try:
+                adelete_run_if_safe = getattr(self._history_db, "adelete_run_if_safe", None)
+                if callable(adelete_run_if_safe):
+                    deleted, reason = await adelete_run_if_safe(run_id)
+                else:
+                    sync_history_db = cast(RunPersistence, self._history_db)
+                    deleted, reason = await asyncio.to_thread(
+                        sync_history_db.delete_run_if_safe,
+                        run_id,
+                    )
+                if deleted:
+                    span.set_attribute("vibesensor.deleted", True)
+                    return {"run_id": run_id, "status": "deleted"}
+                span.set_attribute("vibesensor.deleted", False)
+                span.set_attribute("vibesensor.delete_reason", reason or "")
+                raise_delete_run_error(reason)
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
 
 
 def raise_delete_run_error(reason: str | None) -> Never:

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -8,6 +8,8 @@ from threading import RLock
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+from opentelemetry.trace import SpanKind
+
 from vibesensor.shared.ports import (
     ClientTracker,
     LanguageReader,
@@ -19,6 +21,7 @@ from vibesensor.shared.ports import (
 )
 from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.tracing import mark_span_error, start_span
 from vibesensor.use_cases.run.capture_readiness import CaptureReadinessTracker
 from vibesensor.use_cases.run.capture_readiness_observation import observe_capture_readiness
 from vibesensor.use_cases.run.lifecycle_state import RunLifecycleState
@@ -270,67 +273,73 @@ class RunRecorder:
         LOGGER.info("run_lifecycle", extra=log_extra(**extra))
 
     def start_recording(self) -> RunRecorderStatusSnapshot:
-        completed_run_id: str | None = None
-        lifecycle_events: list[
-            tuple[str, str, str, str | None, str | None, int | None, int | None]
-        ] = []
-        with self._lock:
-            if self._lifecycle.shutdown_requested:
-                LOGGER.info(
-                    "Ignoring start_recording() while metrics logger shutdown is in progress.",
-                )
-                return self.status()
-            if self.enabled and self._run_id:
-                flush_snapshot = self._sample_flush.pending_flush_snapshot()
-                if flush_snapshot is not None:
-                    self._sample_flush.append_records(
-                        flush_snapshot.run_id,
-                        flush_snapshot.start_time_utc,
-                        flush_snapshot.start_mono_s,
-                        refresh_metrics=True,
+        with start_span(__name__, "run.recording.start", kind=SpanKind.INTERNAL) as span:
+            completed_run_id: str | None = None
+            lifecycle_events: list[
+                tuple[str, str, str, str | None, str | None, int | None, int | None]
+            ] = []
+            try:
+                with self._lock:
+                    if self._lifecycle.shutdown_requested:
+                        LOGGER.info(
+                            "Ignoring start_recording() while metrics logger "
+                            "shutdown is in progress.",
+                        )
+                        span.set_attribute("vibesensor.ignored_shutdown", True)
+                        return self.status()
+                    if self.enabled and self._run_id:
+                        flush_snapshot = self._sample_flush.pending_flush_snapshot()
+                        if flush_snapshot is not None:
+                            self._sample_flush.append_records(
+                                flush_snapshot.run_id,
+                                flush_snapshot.start_time_utc,
+                                flush_snapshot.start_mono_s,
+                                refresh_metrics=True,
+                            )
+                    if self.enabled and self._run_id:
+                        run_id = self._run_id
+                        completed_run_id = self._persistence.ready_for_analysis(run_id)
+                        start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
+                        end_time_utc = utc_now_iso()
+                        persistence_snapshot = self._persistence.status_snapshot()
+                        if run_id and not self._persistence.finalize_run(
+                            run_id,
+                            start_time_utc,
+                            end_time_utc,
+                        ):
+                            LOGGER.warning(
+                                "finalize_run failed for %s; scheduling analysis anyway",
+                                run_id,
+                            )
+                        lifecycle_events.append(
+                            (
+                                "stopped",
+                                run_id,
+                                start_time_utc,
+                                end_time_utc,
+                                "restart",
+                                persistence_snapshot.written_sample_count,
+                                persistence_snapshot.dropped_sample_count,
+                            )
+                        )
+                    started_run = self._start_new_run_locked()
+                    lifecycle_events.append(
+                        (
+                            "started",
+                            started_run.run_id,
+                            started_run.start_time_utc,
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
                     )
-            if self.enabled and self._run_id:
-                run_id = self._run_id
-                completed_run_id = self._persistence.ready_for_analysis(run_id)
-                start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
-                end_time_utc = utc_now_iso()
-                persistence_snapshot = self._persistence.status_snapshot()
-                if run_id and not self._persistence.finalize_run(
-                    run_id,
-                    start_time_utc,
-                    end_time_utc,
-                ):
-                    # finalize_run may fail (e.g. DB unavailable), but
-                    # store_analysis handles the RECORDING→COMPLETE bypass
-                    # path, so schedule analysis anyway.
-                    LOGGER.warning(
-                        "finalize_run failed for %s; scheduling analysis anyway",
-                        run_id,
-                    )
-                lifecycle_events.append(
-                    (
-                        "stopped",
-                        run_id,
-                        start_time_utc,
-                        end_time_utc,
-                        "restart",
-                        persistence_snapshot.written_sample_count,
-                        persistence_snapshot.dropped_sample_count,
-                    )
-                )
-            started_run = self._start_new_run_locked()
-            lifecycle_events.append(
-                (
-                    "started",
-                    started_run.run_id,
-                    started_run.start_time_utc,
-                    None,
-                    None,
-                    None,
-                    None,
-                )
-            )
-            result = self.status()
+                    result = self.status()
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
+            span.set_attribute("vibesensor.run_id", result.run_id or "")
+            span.set_attribute("vibesensor.restarted_previous_run", completed_run_id is not None)
         for (
             event_action,
             event_run_id,
@@ -359,53 +368,64 @@ class RunRecorder:
         _only_if_run_id: str | None = None,
         reason: str = "manual",
     ) -> RunRecorderStatusSnapshot:
-        lifecycle_event: (
-            tuple[str, str, str, str | None, str | None, int | None, int | None] | None
-        ) = None
-        with self._lock:
-            if _only_if_run_id is not None and self._run_id != _only_if_run_id:
-                return self.status()
-            flush_snapshot = self._sample_flush.pending_flush_snapshot()
-            if flush_snapshot is not None:
-                self._sample_flush.append_records(
-                    flush_snapshot.run_id,
-                    flush_snapshot.start_time_utc,
-                    flush_snapshot.start_mono_s,
-                    refresh_metrics=True,
-                )
-            if _only_if_run_id is not None and self._run_id != _only_if_run_id:
-                return self.status()
-            run_id = self._run_id
-            run_id_to_analyze = self._persistence.ready_for_analysis(run_id)
-            start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
-            end_time_utc = utc_now_iso()
-            persistence_snapshot = self._persistence.status_snapshot()
-            if run_id and not self._persistence.finalize_run(
-                run_id,
-                start_time_utc,
-                end_time_utc,
-            ):
-                # finalize_run may fail (e.g. DB unavailable), but
-                # store_analysis handles the RECORDING→COMPLETE bypass
-                # path, so schedule analysis anyway.
-                LOGGER.warning(
-                    "finalize_run failed for %s; scheduling analysis anyway",
-                    run_id,
-                )
-            if run_id is not None:
-                lifecycle_event = (
-                    "stopped",
-                    run_id,
-                    start_time_utc,
-                    end_time_utc,
-                    reason,
-                    persistence_snapshot.written_sample_count,
-                    persistence_snapshot.dropped_sample_count,
-                )
-            self._lifecycle.stop()
-            self._active_run_context = None
-            self._persistence.reset()
-            result = self.status()
+        with start_span(
+            __name__,
+            "run.recording.stop",
+            kind=SpanKind.INTERNAL,
+            attributes={"vibesensor.stop_reason": reason},
+        ) as span:
+            lifecycle_event: (
+                tuple[str, str, str, str | None, str | None, int | None, int | None] | None
+            ) = None
+            try:
+                with self._lock:
+                    if _only_if_run_id is not None and self._run_id != _only_if_run_id:
+                        span.set_attribute("vibesensor.skipped_run_id_guard", True)
+                        return self.status()
+                    flush_snapshot = self._sample_flush.pending_flush_snapshot()
+                    if flush_snapshot is not None:
+                        self._sample_flush.append_records(
+                            flush_snapshot.run_id,
+                            flush_snapshot.start_time_utc,
+                            flush_snapshot.start_mono_s,
+                            refresh_metrics=True,
+                        )
+                    if _only_if_run_id is not None and self._run_id != _only_if_run_id:
+                        span.set_attribute("vibesensor.skipped_run_id_guard", True)
+                        return self.status()
+                    run_id = self._run_id
+                    run_id_to_analyze = self._persistence.ready_for_analysis(run_id)
+                    start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
+                    end_time_utc = utc_now_iso()
+                    persistence_snapshot = self._persistence.status_snapshot()
+                    if run_id and not self._persistence.finalize_run(
+                        run_id,
+                        start_time_utc,
+                        end_time_utc,
+                    ):
+                        LOGGER.warning(
+                            "finalize_run failed for %s; scheduling analysis anyway",
+                            run_id,
+                        )
+                    if run_id is not None:
+                        lifecycle_event = (
+                            "stopped",
+                            run_id,
+                            start_time_utc,
+                            end_time_utc,
+                            reason,
+                            persistence_snapshot.written_sample_count,
+                            persistence_snapshot.dropped_sample_count,
+                        )
+                    self._lifecycle.stop()
+                    self._active_run_context = None
+                    self._persistence.reset()
+                    result = self.status()
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
+            span.set_attribute("vibesensor.run_id", lifecycle_event[1] if lifecycle_event else "")
+            span.set_attribute("vibesensor.post_analysis_scheduled", bool(run_id_to_analyze))
         if lifecycle_event is not None:
             (
                 event_action,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -7,9 +7,11 @@ import time
 from typing import Protocol
 
 import aiosqlite
+from opentelemetry.trace import SpanKind
 
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.structured_logging import log_extra
+from vibesensor.shared.tracing import mark_span_error, start_span
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.run.post_analysis_input import (
     PostAnalysisRunInput,
@@ -61,94 +63,106 @@ def execute_post_analysis(
     defer_retryable_error_storage: bool = False,
 ) -> PostAnalysisAttemptResult:
     analysis_start = time.monotonic()
-    LOGGER.info(
-        "Analysis started for run %s",
-        run_id,
-        extra=log_extra(event="post_analysis_started", run_id=run_id),
-    )
-    try:
-        load_result = load_run(run_id=run_id, db=db)
-    except (aiosqlite.Error, OSError, MemoryError) as exc:
-        if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
-            return _retryable_failure_result(
+    with start_span(
+        __name__,
+        "run.post_analysis.execute",
+        kind=SpanKind.INTERNAL,
+        attributes={"vibesensor.run_id": run_id},
+    ) as span:
+        LOGGER.info(
+            "Analysis started for run %s",
+            run_id,
+            extra=log_extra(event="post_analysis_started", run_id=run_id),
+        )
+        try:
+            load_result = load_run(run_id=run_id, db=db)
+        except (aiosqlite.Error, OSError, MemoryError) as exc:
+            mark_span_error(span, exc)
+            if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
+                return _retryable_failure_result(
+                    run_id=run_id,
+                    analysis_start=analysis_start,
+                    exc=exc,
+                )
+            return _persistence_failure_result(
                 run_id=run_id,
                 analysis_start=analysis_start,
                 exc=exc,
+                db=db,
             )
-        return _persistence_failure_result(
-            run_id=run_id,
-            analysis_start=analysis_start,
-            exc=exc,
-            db=db,
-        )
 
-    if isinstance(load_result, MissingPostAnalysisMetadata):
-        LOGGER.warning(
-            "Cannot analyse run %s: metadata not found",
-            run_id,
-            extra=log_extra(
-                event="post_analysis_skipped",
+        if isinstance(load_result, MissingPostAnalysisMetadata):
+            span.set_attribute("vibesensor.failure_kind", "missing_metadata")
+            LOGGER.warning(
+                "Cannot analyse run %s: metadata not found",
+                run_id,
+                extra=log_extra(
+                    event="post_analysis_skipped",
+                    run_id=run_id,
+                    failure_kind="missing_metadata",
+                ),
+            )
+            return _store_load_error(
+                db=db,
                 run_id=run_id,
-                failure_kind="missing_metadata",
-            ),
-        )
-        return _store_load_error(
-            db=db,
-            run_id=run_id,
-            completed_error=load_result.error_message,
-            kind="missing_metadata",
-        )
+                completed_error=load_result.error_message,
+                kind="missing_metadata",
+            )
 
-    if isinstance(load_result, EmptyPostAnalysisSamples):
-        LOGGER.warning(
-            "Skipping post-analysis for run %s: no samples collected",
-            run_id,
-            extra=log_extra(
-                event="post_analysis_skipped",
+        if isinstance(load_result, EmptyPostAnalysisSamples):
+            span.set_attribute("vibesensor.failure_kind", "no_samples")
+            LOGGER.warning(
+                "Skipping post-analysis for run %s: no samples collected",
+                run_id,
+                extra=log_extra(
+                    event="post_analysis_skipped",
+                    run_id=run_id,
+                    failure_kind="no_samples",
+                ),
+            )
+            return _store_load_error(
+                db=db,
                 run_id=run_id,
-                failure_kind="no_samples",
-            ),
-        )
-        return _store_load_error(
-            db=db,
-            run_id=run_id,
-            completed_error=load_result.error_message,
-            kind="no_samples",
-        )
+                completed_error=load_result.error_message,
+                kind="no_samples",
+            )
 
-    loaded = load_result
-    run_input = build_post_analysis_input(loaded)
-    try:
-        summary = analysis_runner(run_input)
-        db.store_analysis(loaded.run_id, summary)
-    except (aiosqlite.Error, OSError, MemoryError) as exc:
-        if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
-            return _retryable_failure_result(
+        loaded = load_result
+        run_input = build_post_analysis_input(loaded)
+        span.set_attribute("vibesensor.sample_count", len(run_input.samples))
+        try:
+            summary = analysis_runner(run_input)
+            db.store_analysis(loaded.run_id, summary)
+        except (aiosqlite.Error, OSError, MemoryError) as exc:
+            mark_span_error(span, exc)
+            if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
+                return _retryable_failure_result(
+                    run_id=loaded.run_id,
+                    analysis_start=analysis_start,
+                    exc=exc,
+                )
+            return _persistence_failure_result(
                 run_id=loaded.run_id,
                 analysis_start=analysis_start,
                 exc=exc,
+                db=db,
             )
-        return _persistence_failure_result(
-            run_id=loaded.run_id,
-            analysis_start=analysis_start,
-            exc=exc,
-            db=db,
-        )
 
-    duration_s = time.monotonic() - analysis_start
-    LOGGER.info(
-        "Analysis completed for run %s: %d samples in %.2fs",
-        loaded.run_id,
-        len(run_input.samples),
-        duration_s,
-        extra=log_extra(
-            event="post_analysis_completed",
-            run_id=loaded.run_id,
-            sample_count=len(run_input.samples),
-            duration_s=round(duration_s, 3),
-        ),
-    )
-    return PostAnalysisExecutionSuccess(run_id=loaded.run_id)
+        duration_s = time.monotonic() - analysis_start
+        span.set_attribute("vibesensor.duration_s", round(duration_s, 3))
+        LOGGER.info(
+            "Analysis completed for run %s: %d samples in %.2fs",
+            loaded.run_id,
+            len(run_input.samples),
+            duration_s,
+            extra=log_extra(
+                event="post_analysis_completed",
+                run_id=loaded.run_id,
+                sample_count=len(run_input.samples),
+                duration_s=round(duration_s, 3),
+            ),
+        )
+        return PostAnalysisExecutionSuccess(run_id=loaded.run_id)
 
 
 def _store_load_error(

--- a/apps/server/vibesensor/use_cases/updates/manager.py
+++ b/apps/server/vibesensor/use_cases/updates/manager.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import asyncio
 
+from opentelemetry.trace import SpanKind
+
 from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
+from vibesensor.shared.tracing import mark_span_error, start_span
 from vibesensor.use_cases.updates.models import (
     UpdateJobStatus,
     UpdateRequest,
@@ -79,25 +82,44 @@ class UpdateManager:
         return True
 
     async def startup_recover(self) -> None:
-        await self._startup_recovery.recover()
+        with start_span(__name__, "update.startup_recover", kind=SpanKind.INTERNAL) as span:
+            try:
+                await self._startup_recovery.recover()
+            except asyncio.CancelledError:
+                span.set_attribute("vibesensor.cancelled", True)
+                raise
+            except Exception as exc:
+                mark_span_error(span, exc)
+                raise
 
     async def _run_managed_workflow(self, request: UpdateRequest) -> None:
-        try:
-            await asyncio.wait_for(
-                self._workflow.run(request=request),
-                timeout=self._timeout_s,
-            )
-        except UpdateCleanupError as exc:
-            self._reporter.fail(exc, default_phase="cleanup")
-            raise
-        except UpdateError as exc:
-            self._reporter.fail(exc, default_phase="workflow")
-            return
-        except TimeoutError:
-            self._reporter.fail_timeout(timeout_s=self._timeout_s)
-        except asyncio.CancelledError:
-            self._reporter.fail_cancelled()
-            raise
-        finally:
-            self._status.clear_secrets()
-            self._status.finish_cleanup()
+        with start_span(
+            __name__,
+            "update.workflow",
+            kind=SpanKind.INTERNAL,
+            attributes={"vibesensor.transport": request.transport.value},
+        ) as span:
+            try:
+                await asyncio.wait_for(
+                    self._workflow.run(request=request),
+                    timeout=self._timeout_s,
+                )
+            except UpdateCleanupError as exc:
+                mark_span_error(span, exc)
+                self._reporter.fail(exc, default_phase="cleanup")
+                raise
+            except UpdateError as exc:
+                mark_span_error(span, exc)
+                self._reporter.fail(exc, default_phase="workflow")
+                return
+            except TimeoutError as exc:
+                mark_span_error(span, exc)
+                self._reporter.fail_timeout(timeout_s=self._timeout_s)
+            except asyncio.CancelledError:
+                span.set_attribute("vibesensor.cancelled", True)
+                self._reporter.fail_cancelled()
+                raise
+            finally:
+                span.set_attribute("vibesensor.final_state", self._status.status.state.value)
+                self._status.clear_secrets()
+                self._status.finish_cleanup()

--- a/apps/server/vibesensor/use_cases/updates/runtime_refresh.py
+++ b/apps/server/vibesensor/use_cases/updates/runtime_refresh.py
@@ -6,8 +6,11 @@ import asyncio
 import logging
 from pathlib import Path
 
+from opentelemetry.trace import SpanKind
+
 from vibesensor.shared.exceptions import UpdateCleanupError, UpdateError
 from vibesensor.shared.structured_logging import log_extra
+from vibesensor.shared.tracing import mark_span_error, start_span
 from vibesensor.use_cases.updates.status import (
     UpdateStatusTracker,
     collect_runtime_details,
@@ -33,20 +36,27 @@ class UpdateRuntimeDetailsRefresher:
         self._logger = logger
 
     async def refresh(self) -> None:
-        try:
-            runtime_details = await asyncio.to_thread(collect_runtime_details, self._repo)
-        except (OSError, UpdateError) as exc:
-            self._logger.exception(
-                "update: runtime details refresh error",
-                extra=log_extra(
-                    event="update_runtime_refresh_error",
-                    update_phase="cleanup",
-                    repo_path=str(self._repo),
-                ),
-            )
-            raise UpdateCleanupError(
-                "Runtime details refresh failed",
-                phase="cleanup",
-                detail=str(exc),
-            ) from exc
-        self._status.set_runtime(runtime_details)
+        with start_span(
+            __name__,
+            "update.runtime_refresh",
+            kind=SpanKind.INTERNAL,
+            attributes={"vibesensor.repo_path": str(self._repo)},
+        ) as span:
+            try:
+                runtime_details = await asyncio.to_thread(collect_runtime_details, self._repo)
+            except (OSError, UpdateError) as exc:
+                mark_span_error(span, exc)
+                self._logger.exception(
+                    "update: runtime details refresh error",
+                    extra=log_extra(
+                        event="update_runtime_refresh_error",
+                        update_phase="cleanup",
+                        repo_path=str(self._repo),
+                    ),
+                )
+                raise UpdateCleanupError(
+                    "Runtime details refresh failed",
+                    phase="cleanup",
+                    detail=str(exc),
+                ) from exc
+            self._status.set_runtime(runtime_details)

--- a/docs/operational-runbooks.md
+++ b/docs/operational-runbooks.md
@@ -34,6 +34,44 @@ prunes `complete` and `error` runs older than `logging.run_retention_days: 7`.
 Raise or lower that value in the server config when the device needs a longer
 or shorter local-history window.
 
+## Enable and inspect backend traces
+
+Tracing is disabled by default. When you need end-to-end backend traces, enable
+the offline JSONL exporter in the active server config:
+
+```yaml
+tracing:
+  enabled: true
+  output_path: data/traces.jsonl
+```
+
+`tracing.output_path` is resolved relative to the active config file unless you
+set an absolute path. The exporter never depends on internet access or an
+external SaaS collector.
+
+After restarting the backend, inspect the exported spans directly:
+
+```bash
+tail -f /path/to/traces.jsonl
+```
+
+The canonical high-value spans are:
+
+- `http.request`
+- `ws.broadcast.tick`
+- `udp.data.dispatch`
+- `runtime.startup.phase`
+- `runtime.managed_task`
+- `run.recording.start` / `run.recording.stop`
+- `run.post_analysis.execute`
+- `history.runs.list`, `history.run.get`, `history.run.insights`, `history.run.delete`
+- `history.report.load_request` / `history.report.build_pdf`
+- `update.startup_recover`, `update.workflow`, `update.runtime_refresh`
+
+Use `trace_id` / `span_id` plus the span attributes to correlate one request or
+background workflow across HTTP, background tasks, history/report work, and
+updater flows.
+
 ## Diagnose high dropped frames
 
 1. Confirm the health endpoint responds and inspect connected clients.
@@ -49,7 +87,9 @@ docker compose logs --tail 100
    console stream. If file logging is enabled, use the `X-Request-ID` response
    header from the failing HTTP call to find the matching structured JSON
    app-log entry; the same `request_id` also appears on request-scoped
-   `settings_change` audit events.
+   `settings_change` audit events. If tracing is enabled, inspect the matching
+   `http.request`, `udp.data.dispatch`, or `ws.broadcast.tick` spans in the
+   JSONL trace output.
 6. If the issue is on a Pi, also review systemd or journal output for the service and hotspot helpers.
 
 ## Diagnose stale or missing live updates
@@ -156,7 +196,9 @@ sudo journalctl -u vibesensor.service -n 200 --no-pager
 
 4. Review the live `structlog` console output first with `journalctl` above. If
    file logging is enabled, inspect the matching structured JSON app log
-   configured by `logging.app_log_path`.
+   configured by `logging.app_log_path`. If tracing is enabled, also inspect the
+   JSONL spans written to `tracing.output_path` for `run.post_analysis.execute`
+   or `history.*` failures around the same time.
 5. Before any manual DB recovery, copy `/var/lib/vibesensor/history.db` off the
    device (or snapshot the card) so the original evidence is preserved.
 6. If the device lost power and now reports repeated write failures, treat that


### PR DESCRIPTION
## size
large

## what
- add one shared backend tracing owner with an offline JSONL exporter
- add optional `tracing.enabled` / `tracing.output_path` config and bootstrap wiring
- instrument HTTP requests, startup/background tasks, WS broadcast ticks, UDP dispatch, run lifecycle/post-analysis, history/report, and update flows
- add focused trace-export tests plus tracing docs in the README and runbook

## why
- one canonical tracing path instead of parallel timing wrappers
- works in offline Pi deployments without SaaS or internet collectors
- keeps async/background context together so traces stay coherent

## validate
- `make typecheck-backend`
- `make lint`
- `cd apps/server && ../../.venv/bin/python -m pytest -q tests/shared/test_tracing.py tests/app/test_config.py tests/app/test_config_validation.py tests/app/test_app_main.py tests/adapters/http/test_request_observability.py tests/adapters/udp/test_udp_data_rx.py tests/use_cases/run/test_post_analysis_executor.py tests/use_cases/history/test_history_http_services.py tests/use_cases/updates/test_update_manager_workflow.py tests/use_cases/updates/test_update_manager_lifecycle.py`
- `cd apps/server && ../../.venv/bin/python -m pytest -q tests/app tests/adapters/http tests/adapters/udp tests/use_cases/history tests/use_cases/run tests/use_cases/updates`
- `make test-changed`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH .venv/bin/python tools/tests/run_ci_parallel.py`
- live runtime smoke: `vibesensor-server --config .ai-temp/runtime-tracing.yaml` + `curl http://127.0.0.1:18080/api/health` + inspect exported `http.request` span in `.ai-temp/runtime-traces.jsonl`

## risk / tradeoffs
- tracing stays disabled by default; enabling it adds JSONL export overhead on Pi-class devices
- existing health/request timing metrics stay in place where they still serve operator UX; tracing owns the cross-flow trace story
- `docker compose build --pull && docker compose up -d` is still host-blocked here because this machine lacks the `docker compose` v2 plugin, so runtime proof used the direct-server path instead

Closes #2968
