### PR TITLE
refactor(runtime): standardize AnyIO concurrency

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -9,6 +9,7 @@ description = "Offline Raspberry Pi vibration telemetry server"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+  "anyio>=4.11,<5",
   "aiosqlite>=0.21,<1",
   "fastapi>=0.111,<1",
   "httpx>=0.27,<1",

--- a/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
+++ b/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
@@ -34,7 +34,7 @@ async def test_get_or_build_payload_text_reuses_pending_task() -> None:
         return func(*args, **kwargs)
 
     with patch(
-        "vibesensor.adapters.websocket.payload_orchestrator.asyncio.to_thread",
+        "vibesensor.adapters.websocket.payload_orchestrator.anyio.to_thread.run_sync",
         side_effect=fake_to_thread,
     ):
         first, second = await asyncio.gather(

--- a/apps/server/tests/adapters/websocket/test_tick_controller.py
+++ b/apps/server/tests/adapters/websocket/test_tick_controller.py
@@ -79,7 +79,7 @@ async def test_controller_escalates_after_consecutive_failures(caplog) -> None:
 
     with (
         patch(
-            "vibesensor.adapters.websocket.tick_controller.asyncio.sleep",
+            "vibesensor.adapters.websocket.tick_controller.anyio.sleep",
             side_effect=fake_sleep,
         ),
         caplog.at_level(logging.WARNING, logger="vibesensor.adapters.websocket.hub"),
@@ -107,7 +107,7 @@ async def test_controller_clamps_hz_to_minimum_one(caplog) -> None:
 
     with (
         patch(
-            "vibesensor.adapters.websocket.tick_controller.asyncio.sleep",
+            "vibesensor.adapters.websocket.tick_controller.anyio.sleep",
             side_effect=fake_sleep,
         ),
         caplog.at_level(logging.WARNING, logger="vibesensor.adapters.websocket.hub"),

--- a/apps/server/tests/adapters/websocket/test_ws_hub.py
+++ b/apps/server/tests/adapters/websocket/test_ws_hub.py
@@ -179,7 +179,7 @@ async def test_broadcast_uses_latest_selection_when_selection_changes_during_ser
         return func(*args, **kwargs)
 
     monkeypatch.setattr(
-        "vibesensor.adapters.websocket.payload_orchestrator.asyncio.to_thread",
+        "vibesensor.adapters.websocket.payload_orchestrator.anyio.to_thread.run_sync",
         fake_to_thread,
     )
 
@@ -213,7 +213,7 @@ async def test_broadcast_reuses_lazy_payload_for_connections_converging_on_same_
         return func(*args, **kwargs)
 
     monkeypatch.setattr(
-        "vibesensor.adapters.websocket.payload_orchestrator.asyncio.to_thread",
+        "vibesensor.adapters.websocket.payload_orchestrator.anyio.to_thread.run_sync",
         fake_to_thread,
     )
 
@@ -246,7 +246,7 @@ async def test_payload_error_affected_count_uses_updated_selection(
         return func(*args, **kwargs)
 
     monkeypatch.setattr(
-        "vibesensor.adapters.websocket.payload_orchestrator.asyncio.to_thread",
+        "vibesensor.adapters.websocket.payload_orchestrator.anyio.to_thread.run_sync",
         fake_to_thread,
     )
 
@@ -385,7 +385,7 @@ async def test_broadcast_offloads_serialization_to_thread(monkeypatch: pytest.Mo
         return func(*args, **kwargs)
 
     monkeypatch.setattr(
-        "vibesensor.adapters.websocket.payload_orchestrator.asyncio.to_thread",
+        "vibesensor.adapters.websocket.payload_orchestrator.anyio.to_thread.run_sync",
         fake_to_thread,
     )
 
@@ -556,12 +556,10 @@ async def test_send_error_logging_is_rate_limited(caplog) -> None:
     await hub.add(ws1, "c1")
     await hub.add(ws2, "c2")
 
-    fake_loop = MagicMock()
-    fake_loop.time.side_effect = [1000.0, 1001.0]
     with (
         patch(
-            "vibesensor.adapters.websocket.broadcast_runner.asyncio.get_running_loop",
-            return_value=fake_loop,
+            "vibesensor.adapters.websocket.broadcast_runner.anyio.current_time",
+            side_effect=[1000.0, 1001.0],
         ),
         caplog.at_level(logging.WARNING, logger="vibesensor.adapters.websocket.hub"),
     ):

--- a/apps/server/tests/app/test_app_lifecycle.py
+++ b/apps/server/tests/app/test_app_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from pathlib import Path
 
 import pytest
@@ -40,12 +41,19 @@ async def test_lifespan_shutdown_closes_history_db(tmp_path: Path, monkeypatch) 
     async def _fake_start(self):
         return None
 
+    async def _fake_stop(self):
+        close_result = self._runtime.history_db.close()
+        if inspect.isawaitable(close_result):
+            await close_result
+
     closed = {"value": False}
 
     def _fake_close(self):
         closed["value"] = True
 
     monkeypatch.setattr(bootstrap_mod, "start_udp_data_receiver", _fake_udp_receiver)
+    monkeypatch.setattr(bootstrap_mod.LifecycleManager, "start", _fake_start)
+    monkeypatch.setattr(bootstrap_mod.LifecycleManager, "stop", _fake_stop)
     monkeypatch.setattr(UDPControlPlane, "start", _fake_start)
     monkeypatch.setattr(SQLiteHistoryEngine, "close", _fake_close)
 

--- a/apps/server/tests/infra/runtime/test_background_task_coordinator.py
+++ b/apps/server/tests/infra/runtime/test_background_task_coordinator.py
@@ -1,11 +1,11 @@
-"""Exercise background task supervision and cancellation timeout behavior."""
+"""Exercise AnyIO-backed background task tracking and cancellation behavior."""
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 
+import anyio
 import pytest
 
 from vibesensor.infra.runtime.background_task_coordinator import BackgroundTaskCoordinator
@@ -13,83 +13,86 @@ from vibesensor.infra.runtime.health_state import RuntimeHealthState
 from vibesensor.infra.runtime.task_supervisor import TaskSupervisor
 
 
-async def _stubborn_task() -> None:
-    first_wait = asyncio.Event()
-    second_wait = asyncio.Event()
-    try:
-        await first_wait.wait()
-    except asyncio.CancelledError:
-        await second_wait.wait()
-
-
 @pytest.mark.asyncio
-async def test_start_monitors_failure_via_task_supervisor() -> None:
+async def test_start_records_failure_via_task_supervisor() -> None:
     health_state = RuntimeHealthState()
     supervisor = TaskSupervisor(
         health_state=health_state,
         logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
     )
     coordinator = BackgroundTaskCoordinator(
-        monitor_task=supervisor.monitor_task,
         logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
     )
+    await coordinator.open()
 
     async def _fail() -> None:
         raise RuntimeError("boom")
 
-    task = coordinator.start(_fail(), name="update-startup-recover")
-    await asyncio.gather(task, return_exceptions=True)
-    await asyncio.sleep(0)
+    coordinator.start(
+        lambda: supervisor.run(_fail, name="update-startup-recover"),
+        name="update-startup-recover",
+    )
+
+    for _ in range(10):
+        if "update-startup-recover" in health_state.background_task_failures:
+            break
+        await asyncio.sleep(0)
 
     assert health_state.background_task_failures["update-startup-recover"] == "boom"
-    assert coordinator.tasks == [task]
+    assert coordinator.tasks == []
+    await coordinator.cancel_all(timeout_s=1.0)
+    await coordinator.close()
 
 
 @pytest.mark.asyncio
-async def test_cancel_all_retains_pending_tasks_after_timeout(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_cancel_all_reports_lingering_task_names_after_timeout(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    import vibesensor.infra.runtime.background_task_coordinator as coordinator_module
-
     coordinator = BackgroundTaskCoordinator(
-        monitor_task=lambda task: None,
         logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
     )
-    stubborn = asyncio.create_task(_stubborn_task(), name="stubborn-background")
-    coordinator.tasks = [stubborn]
+    await coordinator.open()
+    release = anyio.Event()
+
+    async def _shielded_linger() -> None:
+        cancelled_exc_class = anyio.get_cancelled_exc_class()
+        try:
+            await anyio.sleep_forever()
+        except cancelled_exc_class:
+            with anyio.CancelScope(shield=True):
+                await release.wait()
+
+    coordinator.start(_shielded_linger, name="stubborn-background")
     await asyncio.sleep(0)
 
-    async def _wait_pending(tasks, timeout):
-        del timeout
-        await asyncio.sleep(0)
-        return set(), set(tasks)
-
-    monkeypatch.setattr(coordinator_module.asyncio, "wait", _wait_pending)
-
     with caplog.at_level(logging.WARNING):
-        lingering = await coordinator.cancel_all(timeout_s=1.0)
+        lingering = await coordinator.cancel_all(timeout_s=0.01)
 
-    assert lingering == [stubborn]
-    assert coordinator.tasks == [stubborn]
+    assert lingering == ["stubborn-background"]
+    assert coordinator.tasks == ["stubborn-background"]
     assert "stubborn-background" in caplog.text
     assert "remain pending" in caplog.text
 
-    stubborn.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await stubborn
+    release.set()
+    await coordinator.close()
+    assert coordinator.tasks == []
 
 
 @pytest.mark.asyncio
-async def test_retain_pending_drops_completed_tasks() -> None:
+async def test_close_clears_finished_tasks() -> None:
     coordinator = BackgroundTaskCoordinator(
-        monitor_task=lambda task: None,
         logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
     )
-    done_task = asyncio.create_task(asyncio.sleep(0), name="completed-background")
-    coordinator.tasks = [done_task]
+    await coordinator.open()
+    finished = anyio.Event()
 
-    await done_task
+    async def _done() -> None:
+        finished.set()
 
-    assert coordinator.retain_pending() == []
+    coordinator.start(_done, name="completed-background")
+    await finished.wait()
+    await asyncio.sleep(0)
+
     assert coordinator.tasks == []
+    await coordinator.cancel_all(timeout_s=1.0)
+    await coordinator.close()

--- a/apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py
+++ b/apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py
@@ -1,4 +1,4 @@
-"""Verify lifecycle shutdown logs lingering background and managed tasks consistently."""
+"""Verify lifecycle shutdown logs lingering managed tasks consistently."""
 
 from __future__ import annotations
 
@@ -61,38 +61,6 @@ async def _stubborn_task() -> None:
         await first_wait.wait()
     except asyncio.CancelledError:
         await second_wait.wait()
-
-
-@pytest.mark.asyncio
-async def test_stop_retains_background_tasks_that_outlive_cancel_timeout(
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    import vibesensor.infra.runtime.background_task_coordinator as coordinator_module
-
-    lifecycle = _make_lifecycle()
-    stubborn = asyncio.create_task(_stubborn_task(), name="stubborn-background")
-    lifecycle.tasks = [stubborn]
-    await asyncio.sleep(0)
-
-    async def _wait_pending(tasks, timeout):
-        del timeout
-        await asyncio.sleep(0)
-        return set(), set(tasks)
-
-    monkeypatch.setattr(coordinator_module.asyncio, "wait", _wait_pending)
-
-    with caplog.at_level(logging.WARNING):
-        await lifecycle.stop()
-
-    assert lifecycle.tasks == [stubborn]
-    assert "stubborn-background" in caplog.text
-    assert "remain pending" in caplog.text
-    assert "lingering tasks" in caplog.text
-
-    stubborn.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await stubborn
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/infra/runtime/test_processing_loop.py
+++ b/apps/server/tests/infra/runtime/test_processing_loop.py
@@ -123,7 +123,7 @@ async def _run_loop(loop: ProcessingLoop, *, max_ticks: int) -> None:
             raise asyncio.CancelledError
         await original_sleep(0)
 
-    with patch("asyncio.sleep", _counting_sleep):
+    with patch("anyio.sleep", _counting_sleep):
         with pytest.raises(asyncio.CancelledError):
             await loop.run()
 
@@ -189,7 +189,7 @@ class TestProcessingLoopFailureTracking:
         async def _fast_sleep(delay: float) -> None:
             await original_sleep(0)
 
-        with patch("asyncio.sleep", _fast_sleep):
+        with patch("anyio.sleep", _fast_sleep):
             with pytest.raises(ProcessingLoopFailure, match="Processing loop remained unhealthy"):
                 await loop.run()
 
@@ -267,7 +267,7 @@ class TestProcessingLoopMismatchDetection:
             return func(*args, **kwargs)
 
         monkeypatch.setattr(
-            "vibesensor.infra.runtime.processing_loop.asyncio.to_thread",
+            "vibesensor.infra.runtime.processing_tick.anyio.to_thread.run_sync",
             fake_to_thread,
         )
 

--- a/apps/server/tests/infra/runtime/test_runtime.py
+++ b/apps/server/tests/infra/runtime/test_runtime.py
@@ -36,7 +36,7 @@ from vibesensor.shared.runtime_failures import BroadcastTickLoopFailure
 async def _run_processing_loop(rt, *, max_ticks: int = 1) -> None:
     """Run *rt*.processing_loop.run() for *max_ticks* iterations, then cancel.
 
-    Temporarily replaces ``asyncio.sleep`` with a counting stub so the loop
+    Temporarily replaces ``anyio.sleep`` with a counting stub so the loop
     completes deterministically without real delays.
     """
     tick_count = 0
@@ -49,7 +49,7 @@ async def _run_processing_loop(rt, *, max_ticks: int = 1) -> None:
             raise asyncio.CancelledError
         await original_sleep(0)
 
-    with patch("asyncio.sleep", _counting_sleep):
+    with patch("anyio.sleep", _counting_sleep):
         with pytest.raises(asyncio.CancelledError):
             await rt.processing_loop.run()
 
@@ -133,7 +133,11 @@ async def test_start_creates_tasks(monkeypatch) -> None:
     lifecycle._udp_transport_lifecycle._start_udp_receiver = _fake_udp
 
     await lifecycle.start()
-    assert len(lifecycle.tasks) == 6
+    for _ in range(20):
+        if "processing-loop" in lifecycle.tasks:
+            break
+        await asyncio.sleep(0)
+    assert "processing-loop" in lifecycle.tasks
     control_plane.start.assert_called_once()
     assert rt.health_state.startup_state == "ready"
     assert rt.health_state.startup_phase == "ready"
@@ -170,6 +174,12 @@ async def test_start_follows_declared_startup_phase_order(monkeypatch) -> None:
         update_manager=update_manager,
     )
     lifecycle._udp_transport_lifecycle._start_udp_receiver = _fake_udp
+
+    def _skip_background_start(self, _task_factory, *, name: str) -> None:
+        del self
+        del name
+
+    monkeypatch.setattr(type(lifecycle._background_tasks), "start", _skip_background_start)
 
     original_set_phase = runtime_module.RuntimeHealthState.set_phase
 
@@ -231,8 +241,10 @@ async def test_start_records_background_task_failure(monkeypatch) -> None:
     lifecycle._task_supervisor._max_attempts = 0
 
     await lifecycle.start()
-    failed_task = next(task for task in lifecycle.tasks if task.get_name() == "ws-broadcast")
-    await asyncio.gather(failed_task, return_exceptions=True)
+    for _ in range(20):
+        if "ws-broadcast" in rt.health_state.background_task_failures:
+            break
+        await asyncio.sleep(0)
 
     assert rt.health_state.background_task_failures["ws-broadcast"] == "ws boom"
 
@@ -286,7 +298,7 @@ async def test_start_restarts_supervised_task_after_failure(monkeypatch) -> None
 
     lifecycle._task_supervisor._base_delay_s = 0.0
     lifecycle._task_supervisor._max_delay_s = 0.0
-    monkeypatch.setattr(task_supervisor_module.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(task_supervisor_module.anyio, "sleep", _fast_sleep)
 
     await lifecycle.start()
     await asyncio.wait_for(restart_started.wait(), timeout=1.0)
@@ -305,8 +317,12 @@ async def test_start_monitors_udp_consumer_failure(monkeypatch) -> None:
         consumer_started.set()
         raise RuntimeError("udp boom")
 
+    class _FakeConsumer:
+        async def process_queue(self) -> None:
+            await _consumer()
+
     async def _fake_udp(*args, **kwargs):
-        return MagicMock(), asyncio.create_task(_consumer(), name="udp-data-consumer")
+        return MagicMock(), _FakeConsumer()
 
     control_plane = MagicMock()
     control_plane.start = AsyncMock()
@@ -331,11 +347,10 @@ async def test_start_monitors_udp_consumer_failure(monkeypatch) -> None:
 
     await lifecycle.start()
     await asyncio.wait_for(consumer_started.wait(), timeout=1.0)
-    consumer_task = lifecycle._udp_transport_lifecycle.consumer_task
-    if consumer_task is not None:
-        await asyncio.gather(consumer_task, return_exceptions=True)
-    # Yield so the done-callback that records the failure can fire.
-    await asyncio.sleep(0)
+    for _ in range(20):
+        if "udp-data-consumer" in rt.health_state.background_task_failures:
+            break
+        await asyncio.sleep(0)
 
     assert rt.health_state.background_task_failures["udp-data-consumer"] == "udp boom"
 
@@ -391,6 +406,10 @@ async def test_stop_cancels_tasks_and_closes_resources(monkeypatch) -> None:
     lifecycle._udp_transport_lifecycle._start_udp_receiver = _fake_udp
 
     await lifecycle.start()
+    for _ in range(20):
+        if lifecycle.tasks:
+            break
+        await asyncio.sleep(0)
     assert len(lifecycle.tasks) > 0
 
     await lifecycle.stop()

--- a/apps/server/tests/infra/runtime/test_startup_runner.py
+++ b/apps/server/tests/infra/runtime/test_startup_runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -33,15 +32,13 @@ def _make_runner() -> tuple[StartupRunner, RuntimeHealthState, MagicMock]:
     runtime.update_manager.startup_recover = AsyncMock()
 
     task_supervisor = MagicMock()
-    task_supervisor.start = MagicMock(return_value=MagicMock(spec=asyncio.Task))
+    task_supervisor.run = AsyncMock()
 
-    def _start_background_task(coro, *, name: str) -> MagicMock:
+    def _start_background_task(task_factory, *, name: str) -> None:
         del name
-        coro.close()
-        return MagicMock(spec=asyncio.Task)
+        task_factory().close()
 
     background_tasks = MagicMock()
-    background_tasks.add = MagicMock()
     background_tasks.start = MagicMock(side_effect=_start_background_task)
 
     udp_transport = MagicMock()
@@ -114,9 +111,7 @@ class TestStartupRunnerPhases:
 
         await runner.run()
 
-        restartable = runner._task_supervisor.start.call_args_list[1].kwargs[
-            "restartable_exceptions"
-        ]
+        restartable = runner._task_supervisor.run.call_args_list[1].kwargs["restartable_exceptions"]
         assert restartable == (BroadcastTickLoopFailure,)
 
     @pytest.mark.asyncio
@@ -142,16 +137,16 @@ class TestStartupRunnerPhases:
 
         runner._udp_transport_lifecycle.startup = recording_startup
 
-        orig_add = runner._background_tasks.add
+        orig_start = runner._background_tasks.start
 
-        def recording_add(*a, **kw):
-            call_order.append("background_add")
-            return orig_add(*a, **kw)
+        def recording_start(*a, **kw):
+            call_order.append("background_start")
+            return orig_start(*a, **kw)
 
-        runner._background_tasks.add = recording_add
+        runner._background_tasks.start = recording_start
 
         await runner.run()
 
         udp_idx = call_order.index("udp_startup")
-        bg_idx = call_order.index("background_add")
+        bg_idx = call_order.index("background_start")
         assert udp_idx < bg_idx

--- a/apps/server/tests/infra/runtime/test_task_supervisor.py
+++ b/apps/server/tests/infra/runtime/test_task_supervisor.py
@@ -1,4 +1,4 @@
-"""Exercise supervised task restart, terminal failure recording, and backoff caps."""
+"""Exercise supervised service restart, terminal failure recording, and backoff caps."""
 
 from __future__ import annotations
 
@@ -14,9 +14,7 @@ from vibesensor.infra.runtime.task_supervisor import TaskSupervisor
 
 
 @pytest.mark.asyncio
-async def test_supervisor_restarts_failed_task_and_clears_health(monkeypatch) -> None:
-    import vibesensor.infra.runtime.task_supervisor as task_supervisor_module
-
+async def test_supervisor_restarts_failed_task_and_clears_health() -> None:
     health_state = RuntimeHealthState()
     supervisor = TaskSupervisor(
         health_state=health_state,
@@ -40,21 +38,20 @@ async def test_supervisor_restarts_failed_task_and_clears_health(monkeypatch) ->
         restart_started.set()
         await asyncio.Future()
 
-    monkeypatch.setattr(task_supervisor_module.asyncio, "sleep", _fast_sleep)
-
-    task = supervisor.start(
-        task_factory,
-        name="ws-broadcast",
-        restartable_exceptions=(RuntimeError,),
-    )
-    await asyncio.wait_for(restart_started.wait(), timeout=1.0)
-
-    assert call_count == 2
-    assert health_state.background_task_failures == {}
-
-    task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await task
+    with patch("vibesensor.infra.runtime.task_supervisor.anyio.sleep", side_effect=_fast_sleep):
+        task = asyncio.create_task(
+            supervisor.run(
+                task_factory,
+                name="ws-broadcast",
+                restartable_exceptions=(RuntimeError,),
+            )
+        )
+        await asyncio.wait_for(restart_started.wait(), timeout=1.0)
+        assert call_count == 2
+        assert health_state.background_task_failures == {}
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
 
 @pytest.mark.asyncio
@@ -72,14 +69,11 @@ async def test_supervisor_treats_unexpected_exit_as_terminal_failure() -> None:
         nonlocal call_count
         call_count += 1
 
-    task = supervisor.start(
+    await supervisor.run(
         task_factory,
         name="metrics-log",
         restartable_exceptions=(RuntimeError,),
     )
-    with pytest.raises(RuntimeError, match="managed task metrics-log exited unexpectedly"):
-        await task
-    await asyncio.sleep(0)
 
     assert call_count == 1
     assert (
@@ -100,9 +94,7 @@ async def test_supervisor_records_terminal_failure_after_max_attempts() -> None:
     async def task_factory() -> None:
         raise RuntimeError("boom")
 
-    task = supervisor.start(task_factory, name="processing-loop")
-    await asyncio.gather(task, return_exceptions=True)
-    await asyncio.sleep(0)
+    await supervisor.run(task_factory, name="processing-loop")
 
     assert health_state.background_task_failures["processing-loop"] == "boom"
 
@@ -128,15 +120,14 @@ async def test_supervisor_caps_restart_delay() -> None:
         raise RuntimeError("boom")
 
     with (
-        patch("vibesensor.infra.runtime.task_supervisor.asyncio.sleep", side_effect=_fake_sleep),
+        patch("vibesensor.infra.runtime.task_supervisor.anyio.sleep", side_effect=_fake_sleep),
         pytest.raises(asyncio.CancelledError),
     ):
-        task = supervisor.start(
+        await supervisor.run(
             task_factory,
             name="gps-speed",
             restartable_exceptions=(RuntimeError,),
         )
-        await task
 
     assert sleep_calls == [1.0, 2.0, 2.0]
 
@@ -157,13 +148,11 @@ async def test_supervisor_does_not_restart_unclassified_exception() -> None:
         call_count += 1
         raise TypeError("bug")
 
-    task = supervisor.start(
+    await supervisor.run(
         task_factory,
         name="obd-speed",
         restartable_exceptions=(RuntimeError,),
     )
-    await asyncio.gather(task, return_exceptions=True)
-    await asyncio.sleep(0)
 
     assert call_count == 1
     assert health_state.background_task_failures["obd-speed"] == "bug"

--- a/apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py
+++ b/apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
@@ -12,18 +10,20 @@ import pytest
 from vibesensor.infra.runtime.udp_transport_lifecycle import UdpTransportLifecycle
 
 
-@pytest.mark.asyncio
-async def test_startup_tracks_transport_and_monitors_consumer_task() -> None:
-    async def _consumer() -> None:
-        await asyncio.Future()
+class _FakeConsumer:
+    async def process_queue(self) -> None:
+        return None
 
-    consumer = asyncio.create_task(_consumer(), name="udp-data-consumer")
+
+@pytest.mark.asyncio
+async def test_startup_tracks_transport_and_starts_consumer_task() -> None:
+    consumer = _FakeConsumer()
     transport = MagicMock()
-    monitor_task = MagicMock()
+    start_background_task = MagicMock()
     start_udp_receiver = AsyncMock(return_value=(transport, consumer))
     lifecycle = UdpTransportLifecycle(
         start_udp_receiver=start_udp_receiver,
-        monitor_task=monitor_task,
+        start_background_task=start_background_task,
         logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
     )
 
@@ -36,32 +36,18 @@ async def test_startup_tracks_transport_and_monitors_consumer_task() -> None:
     )
 
     assert lifecycle.transport is transport
-    assert lifecycle.consumer_task is consumer
-    monitor_task.assert_called_once_with(consumer)
-
-    await lifecycle.shutdown()
-    with contextlib.suppress(asyncio.CancelledError):
-        await consumer
+    start_background_task.assert_called_once()
+    task_factory = start_background_task.call_args.args[0]
+    assert getattr(task_factory, "__self__", None) is consumer
+    assert getattr(task_factory, "__name__", "") == "process_queue"
 
 
 @pytest.mark.asyncio
-async def test_shutdown_closes_transport_and_cancels_consumer_task() -> None:
-    cancelled = asyncio.Event()
-    started = asyncio.Event()
-
-    async def _consumer() -> None:
-        started.set()
-        try:
-            await asyncio.Future()
-        except asyncio.CancelledError:
-            cancelled.set()
-            raise
-
-    consumer = asyncio.create_task(_consumer(), name="udp-data-consumer")
+async def test_shutdown_closes_transport() -> None:
     transport = MagicMock()
     lifecycle = UdpTransportLifecycle(
-        start_udp_receiver=AsyncMock(return_value=(transport, consumer)),
-        monitor_task=MagicMock(),
+        start_udp_receiver=AsyncMock(return_value=(transport, None)),
+        start_background_task=MagicMock(),
         logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
     )
 
@@ -72,13 +58,10 @@ async def test_shutdown_closes_transport_and_cancels_consumer_task() -> None:
         processor=MagicMock(),
         queue_maxsize=64,
     )
-    await asyncio.wait_for(started.wait(), timeout=1.0)
     await lifecycle.shutdown()
-    await asyncio.wait_for(cancelled.wait(), timeout=1.0)
 
     transport.close.assert_called_once_with()
     assert lifecycle.transport is None
-    assert lifecycle.consumer_task is None
 
 
 @pytest.mark.asyncio
@@ -87,7 +70,7 @@ async def test_shutdown_logs_transport_close_error(caplog: pytest.LogCaptureFixt
     transport.close.side_effect = OSError("close boom")
     lifecycle = UdpTransportLifecycle(
         start_udp_receiver=AsyncMock(),
-        monitor_task=MagicMock(),
+        start_background_task=MagicMock(),
         logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
     )
     lifecycle._data_transport = transport
@@ -102,11 +85,10 @@ async def test_shutdown_logs_transport_close_error(caplog: pytest.LogCaptureFixt
 async def test_shutdown_without_started_transport_is_noop() -> None:
     lifecycle = UdpTransportLifecycle(
         start_udp_receiver=AsyncMock(),
-        monitor_task=MagicMock(),
+        start_background_task=MagicMock(),
         logger=logging.getLogger("vibesensor.infra.runtime.lifecycle"),
     )
 
     await lifecycle.shutdown()
 
     assert lifecycle.transport is None
-    assert lifecycle.consumer_task is None

--- a/apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py
+++ b/apps/server/tests/use_cases/diagnostics/test_shutdown_analysis.py
@@ -10,7 +10,6 @@ import pytest
 import yaml
 
 from vibesensor.adapters.persistence.history_db import SQLiteHistoryEngine
-from vibesensor.adapters.udp.udp_control_tx import UDPControlPlane
 from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
 
 # ---------------------------------------------------------------------------
@@ -147,9 +146,6 @@ async def test_shutdown_waits_for_analysis_before_db_close(tmp_path: Path, monke
     from vibesensor import app as app_module
     from vibesensor.app import bootstrap as bootstrap_mod
 
-    async def _fake_udp_receiver(*args, **kwargs):
-        return None, None
-
     async def _fake_start(self):
         return None
 
@@ -170,8 +166,7 @@ async def test_shutdown_waits_for_analysis_before_db_close(tmp_path: Path, monke
         events.append("analysis_wait_done")
         return result
 
-    monkeypatch.setattr(bootstrap_mod, "start_udp_data_receiver", _fake_udp_receiver)
-    monkeypatch.setattr(UDPControlPlane, "start", _fake_start)
+    monkeypatch.setattr(bootstrap_mod.LifecycleManager, "start", _fake_start)
     monkeypatch.setattr(SQLiteHistoryEngine, "close", _tracking_close)
     monkeypatch.setattr(RunRecorder, "wait_for_post_analysis", _tracking_wait)
 

--- a/apps/server/vibesensor/adapters/udp/udp_data_rx.py
+++ b/apps/server/vibesensor/adapters/udp/udp_data_rx.py
@@ -214,7 +214,7 @@ async def start_udp_data_receiver(
     registry: ClientRegistry,
     processor: SignalProcessor,
     queue_maxsize: int = 1024,
-) -> tuple[asyncio.DatagramTransport, asyncio.Task[None]]:
+) -> tuple[asyncio.DatagramTransport, DataDatagramProtocol]:
     """Bind the UDP data socket and start the background consumer task."""
     loop = asyncio.get_running_loop()
     protocol = DataDatagramProtocol(
@@ -226,5 +226,4 @@ async def start_udp_data_receiver(
         lambda: protocol,
         local_addr=(host, port),
     )
-    consumer = asyncio.create_task(protocol.process_queue(), name="udp-data-consumer")
-    return transport, consumer
+    return transport, protocol

--- a/apps/server/vibesensor/adapters/websocket/broadcast_runner.py
+++ b/apps/server/vibesensor/adapters/websocket/broadcast_runner.py
@@ -7,11 +7,11 @@ connection lifecycle and tick cadence.
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import logging
 from collections.abc import Callable
 
+import anyio
 from opentelemetry.trace import SpanKind
 
 from vibesensor.adapters.websocket.connection_tracker import (
@@ -72,12 +72,17 @@ class BroadcastRunner:
                 await payloads.prepare(conn.selected_client_id for conn in conns)
                 sent_selected_client_ids: dict[int, str | None] = {}
 
-                dead_ws = await asyncio.gather(
-                    *(
-                        self._send_current_conn(conn, payloads, sent_selected_client_ids)
-                        for conn in conns
-                    ),
-                )
+                dead_ws: list[WSConnectionSnapshot | None] = [None] * len(conns)
+                async with anyio.create_task_group() as task_group:
+                    for index, conn in enumerate(conns):
+                        task_group.start_soon(
+                            self._send_current_conn_into_slot,
+                            index,
+                            conn,
+                            payloads,
+                            sent_selected_client_ids,
+                            dead_ws,
+                        )
                 await self._cleanup_dead(dead_ws)
             except Exception as exc:
                 mark_span_error(span, exc)
@@ -101,13 +106,11 @@ class BroadcastRunner:
         if not await self._tracker.is_snapshot_current(conn):
             return None
         try:
-            await asyncio.wait_for(
-                conn.websocket.send_text(payload_text),
-                timeout=self._send_timeout_s,
-            )
+            with anyio.fail_after(self._send_timeout_s):
+                await conn.websocket.send_text(payload_text)
             return None
-        except _SEND_FAILURE_EXCEPTIONS:
-            now = asyncio.get_running_loop().time()
+        except (*_SEND_FAILURE_EXCEPTIONS, TimeoutError):
+            now = anyio.current_time()
             if (now - self._last_send_error_log_ts) >= self._send_error_log_interval_s:
                 self._last_send_error_log_ts = now
                 LOGGER.warning(
@@ -149,6 +152,16 @@ class BroadcastRunner:
             payload_text,
             selected_client_id=selected_client_id,
         )
+
+    async def _send_current_conn_into_slot(
+        self,
+        index: int,
+        conn: WSConnectionSnapshot,
+        payloads: PayloadBuildOrchestrator,
+        sent_selected_client_ids: dict[int, str | None],
+        dead_ws: list[WSConnectionSnapshot | None],
+    ) -> None:
+        dead_ws[index] = await self._send_current_conn(conn, payloads, sent_selected_client_ids)
 
     async def _cleanup_dead(
         self,

--- a/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
+++ b/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import math
 from collections.abc import Callable, Iterable, Mapping
 from typing import cast
 
+import anyio
 import orjson
 
 from vibesensor.shared.json_utils import sanitize_for_json
@@ -65,7 +65,7 @@ class PayloadBuildOrchestrator:
         self._payload_builder = payload_builder
         self._payload_cache: dict[str | None, str] = {}
         self._payload_template_cache: dict[tuple[tuple[str, object], ...], str] = {}
-        self._pending_payload_tasks: dict[str | None, asyncio.Task[str]] = {}
+        self._pending_payload_events: dict[str | None, anyio.Event] = {}
         self._failed_client_ids: set[str | None] = set()
         self._debug_info: dict[str | None, bool] | None = {} if capture_debug else None
 
@@ -237,17 +237,24 @@ class PayloadBuildOrchestrator:
         if not raw_payloads:
             return
 
-        serialized_payloads = await asyncio.gather(
-            *(
-                asyncio.to_thread(self._serialize_payload, selected_client_id, raw_payload)
-                for selected_client_id, raw_payload in raw_payloads.items()
-            ),
-        )
-        for selected_client_id, (text, failed, has_freq) in zip(
-            raw_payloads,
-            serialized_payloads,
-            strict=True,
-        ):
+        serialized_payloads: dict[str | None, tuple[str, bool, bool | None]] = {}
+
+        async def _serialize_one(
+            selected_client_id: str | None,
+            raw_payload: LiveWsPayload,
+        ) -> None:
+            serialized_payloads[selected_client_id] = await anyio.to_thread.run_sync(
+                self._serialize_payload,
+                selected_client_id,
+                raw_payload,
+            )
+
+        async with anyio.create_task_group() as task_group:
+            for selected_client_id, raw_payload in raw_payloads.items():
+                task_group.start_soon(_serialize_one, selected_client_id, raw_payload)
+
+        for selected_client_id in raw_payloads:
+            text, failed, has_freq = serialized_payloads[selected_client_id]
             self._payload_cache[selected_client_id] = text
             if failed:
                 self._failed_client_ids.add(selected_client_id)
@@ -261,7 +268,7 @@ class PayloadBuildOrchestrator:
         if raw_payload is None:
             self._payload_cache[selected_client_id] = _ERROR_PAYLOAD
             return _ERROR_PAYLOAD
-        text, failed, has_freq = await asyncio.to_thread(
+        text, failed, has_freq = await anyio.to_thread.run_sync(
             self._serialize_payload,
             selected_client_id,
             raw_payload,
@@ -279,12 +286,15 @@ class PayloadBuildOrchestrator:
         cached = self._payload_cache.get(selected_client_id)
         if cached is not None:
             return cached
-        task = self._pending_payload_tasks.get(selected_client_id)
-        if task is None:
-            task = asyncio.create_task(self._build_payload_text(selected_client_id))
-            self._pending_payload_tasks[selected_client_id] = task
-        try:
-            return await task
-        finally:
-            if self._pending_payload_tasks.get(selected_client_id) is task and task.done():
-                self._pending_payload_tasks.pop(selected_client_id, None)
+        pending = self._pending_payload_events.get(selected_client_id)
+        if pending is None:
+            pending = anyio.Event()
+            self._pending_payload_events[selected_client_id] = pending
+            try:
+                return await self._build_payload_text(selected_client_id)
+            finally:
+                pending.set()
+                if self._pending_payload_events.get(selected_client_id) is pending:
+                    self._pending_payload_events.pop(selected_client_id, None)
+        await pending.wait()
+        return self._payload_cache.get(selected_client_id, _ERROR_PAYLOAD)

--- a/apps/server/vibesensor/adapters/websocket/tick_controller.py
+++ b/apps/server/vibesensor/adapters/websocket/tick_controller.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+
+import anyio
 
 from vibesensor.shared.runtime_failures import BroadcastTickLoopFailure
 
@@ -48,9 +49,8 @@ class BroadcastTickController:
         """
 
         consecutive_failures = 0
-        loop = asyncio.get_running_loop()
         while True:
-            tick_start = loop.time()
+            tick_start = anyio.current_time()
             if on_tick is not None:
                 on_tick()
             try:
@@ -73,5 +73,5 @@ class BroadcastTickController:
                     consecutive_failures,
                     exc_info=True,
                 )
-            elapsed = loop.time() - tick_start
-            await asyncio.sleep(max(0, self._interval - elapsed))
+            elapsed = anyio.current_time() - tick_start
+            await anyio.sleep(max(0, self._interval - elapsed))

--- a/apps/server/vibesensor/app/bootstrap.py
+++ b/apps/server/vibesensor/app/bootstrap.py
@@ -8,7 +8,6 @@ and serves static assets.
 from __future__ import annotations
 
 import argparse
-import asyncio
 import errno
 import logging
 import sys
@@ -16,6 +15,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+import anyio
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from granian import Granian
@@ -92,9 +92,10 @@ def create_app(config_path: Path | None = None) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        cancelled_exc_class = anyio.get_cancelled_exc_class()
         try:
             await lifecycle.start()
-        except asyncio.CancelledError:
+        except cancelled_exc_class:
             LOGGER.info("Runtime lifecycle start cancelled; cleaning up before re-raise")
             await lifecycle.stop()
             raise

--- a/apps/server/vibesensor/infra/runtime/background_task_coordinator.py
+++ b/apps/server/vibesensor/infra/runtime/background_task_coordinator.py
@@ -2,65 +2,103 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
 
-MonitorTask = Callable[[asyncio.Task[object]], None]
+import anyio
+from anyio.abc import TaskGroup
+
+TaskFactory = Callable[[], Awaitable[object]]
 
 
 class BackgroundTaskCoordinator:
-    """Track lifecycle-owned background tasks and cancel them coherently."""
+    """Own the lifecycle-scoped AnyIO task group for background services."""
 
-    __slots__ = ("_logger", "_monitor_task", "_tasks")
+    __slots__ = (
+        "_active_names",
+        "_all_done",
+        "_logger",
+        "_task_group",
+        "_task_group_cm",
+        "_task_scopes",
+    )
 
     def __init__(
         self,
         *,
-        monitor_task: MonitorTask,
         logger: logging.Logger,
     ) -> None:
-        self._monitor_task = monitor_task
         self._logger = logger
-        self._tasks: list[asyncio.Task[object]] = []
+        self._active_names: set[str] = set()
+        self._all_done = anyio.Event()
+        self._all_done.set()
+        self._task_group: TaskGroup | None = None
+        self._task_group_cm: AbstractAsyncContextManager[TaskGroup] | None = None
+        self._task_scopes: dict[str, anyio.CancelScope] = {}
 
     @property
-    def tasks(self) -> list[asyncio.Task[object]]:
-        return self._tasks
+    def tasks(self) -> list[str]:
+        return sorted(self._active_names)
 
-    @tasks.setter
-    def tasks(self, tasks: list[asyncio.Task[object]]) -> None:
-        self._tasks = tasks
+    async def open(self) -> None:
+        if self._task_group is not None:
+            return
+        self._task_group_cm = anyio.create_task_group()
+        self._task_group = await self._task_group_cm.__aenter__()
 
-    def add(self, task: asyncio.Task[object]) -> asyncio.Task[object]:
-        self._tasks.append(task)
-        return task
+    async def close(self) -> None:
+        if self._task_group_cm is None:
+            return
+        await self._task_group_cm.__aexit__(None, None, None)
+        self._task_group = None
+        self._task_group_cm = None
+
+    async def _run_tracked(
+        self,
+        task_factory: TaskFactory,
+        name: str,
+    ) -> None:
+        cancelled_exc_class = anyio.get_cancelled_exc_class()
+        if not self._active_names:
+            self._all_done = anyio.Event()
+        with anyio.CancelScope() as cancel_scope:
+            self._active_names.add(name)
+            self._task_scopes[name] = cancel_scope
+            try:
+                try:
+                    await task_factory()
+                except cancelled_exc_class:
+                    return
+            finally:
+                self._task_scopes.pop(name, None)
+                self._active_names.discard(name)
+                if not self._active_names:
+                    self._all_done.set()
 
     def start(
         self,
-        coroutine: Coroutine[object, object, object],
+        task_factory: TaskFactory,
         *,
         name: str,
-    ) -> asyncio.Task[object]:
-        task = asyncio.create_task(coroutine, name=name)
-        self._monitor_task(task)
-        return self.add(task)
+    ) -> None:
+        if self._task_group is None:
+            raise RuntimeError("BackgroundTaskCoordinator.start() called before open()")
+        self._task_group.start_soon(self._run_tracked, task_factory, name, name=name)
 
-    def retain_pending(self) -> list[asyncio.Task[object]]:
-        self._tasks = [task for task in self._tasks if not task.done()]
-        return list(self._tasks)
-
-    async def cancel_all(self, *, timeout_s: float) -> list[asyncio.Task[object]]:
-        for task in self._tasks:
-            task.cancel()
-        if not self._tasks:
+    async def cancel_all(self, *, timeout_s: float) -> list[str]:
+        if self._task_group is None:
             return []
-        _done, pending = await asyncio.wait(self._tasks, timeout=timeout_s)
-        if pending:
+        for cancel_scope in list(self._task_scopes.values()):
+            cancel_scope.cancel()
+        with anyio.move_on_after(timeout_s) as scope:
+            await self._all_done.wait()
+        lingering = self.tasks if scope.cancel_called else []
+        if lingering:
             self._logger.warning(
                 "%d background task(s) did not finish within the cancellation "
                 "deadline and remain pending: %s",
-                len(pending),
-                [task.get_name() for task in pending],
+                len(lingering),
+                lingering,
             )
-        return self.retain_pending()
+        return lingering

--- a/apps/server/vibesensor/infra/runtime/lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/lifecycle.py
@@ -159,12 +159,17 @@ class LifecycleManager:
             logger=LOGGER,
         )
         self._background_tasks = BackgroundTaskCoordinator(
-            monitor_task=self._task_supervisor.monitor_task,
             logger=LOGGER,
         )
         self._udp_transport_lifecycle = UdpTransportLifecycle(
             start_udp_receiver=start_udp_receiver,
-            monitor_task=self._task_supervisor.monitor_task,
+            start_background_task=lambda task_factory: self._background_tasks.start(
+                lambda: self._task_supervisor.run(
+                    task_factory,
+                    name="udp-data-consumer",
+                ),
+                name="udp-data-consumer",
+            ),
             logger=LOGGER,
         )
         self._shutdown_sequence = LifecycleShutdownSequence(
@@ -175,12 +180,8 @@ class LifecycleManager:
         )
 
     @property
-    def tasks(self) -> list[asyncio.Task[object]]:
+    def tasks(self) -> list[str]:
         return self._background_tasks.tasks
-
-    @tasks.setter
-    def tasks(self, tasks: list[asyncio.Task[object]]) -> None:
-        self._background_tasks.tasks = tasks
 
     _LOW_DISK_THRESHOLD_MB = 100
 
@@ -207,7 +208,7 @@ class LifecycleManager:
         from vibesensor.infra.runtime.startup_runner import StartupRunner
 
         self._validate_startup()
-        self.tasks = []
+        await self._background_tasks.open()
         runner = StartupRunner(
             runtime=self._runtime,
             health_state=self._health_state,
@@ -221,7 +222,10 @@ class LifecycleManager:
         """Graceful shutdown with explicit ingress-stop and metrics-drain phases."""
         shutdown = await self._shutdown_sequence.run()
         self._report_shutdown_issues(shutdown.issues)
-        self._report_lingering_tasks(list(shutdown.lingering_managed))
+        self._report_lingering_tasks(
+            list(shutdown.lingering_background),
+            list(shutdown.lingering_managed),
+        )
 
     def _report_shutdown_issues(self, issues: tuple[LifecycleShutdownIssue, ...]) -> None:
         for issue in issues:
@@ -236,11 +240,11 @@ class LifecycleManager:
 
     def _report_lingering_tasks(
         self,
+        lingering_background: list[str],
         lingering_managed: list[asyncio.Task[None]],
     ) -> None:
-        lingering_background = self._background_tasks.retain_pending()
         lingering_task_names = [
-            *(task.get_name() for task in lingering_background if not task.done()),
+            *lingering_background,
             *(task.get_name() for task in lingering_managed if not task.done()),
         ]
         if lingering_task_names:

--- a/apps/server/vibesensor/infra/runtime/processing_failure_policy.py
+++ b/apps/server/vibesensor/infra/runtime/processing_failure_policy.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass
+
+import anyio
 
 from vibesensor.shared.failure_utils import bounded_failure_message
 from vibesensor.shared.runtime_failures import ProcessingLoopFailure
@@ -182,7 +183,7 @@ class ProcessingFailurePolicy:
         cycle: int,
         total_failure_count: int,
     ) -> None:
-        await asyncio.sleep(self._failure_backoff_s)
+        await anyio.sleep(self._failure_backoff_s)
         self._logger.info(
             "Processing loop resuming after fatal-backoff cycle %d/%d; "
             "total failure count so far: %d",

--- a/apps/server/vibesensor/infra/runtime/processing_loop.py
+++ b/apps/server/vibesensor/infra/runtime/processing_loop.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING
+
+import anyio
 
 from vibesensor.shared.ports import ClockSyncBroadcaster
 
@@ -87,7 +88,7 @@ class ProcessingLoop:
                     interval_s=interval,
                 )
                 delay = await self._apply_failure(decision)
-            await asyncio.sleep(delay)
+            await anyio.sleep(delay)
 
     def _apply_success(self, decision: ProcessingSuccessDecision) -> None:
         self.state.last_tick_duration_s = decision.tick_duration_s

--- a/apps/server/vibesensor/infra/runtime/processing_tick.py
+++ b/apps/server/vibesensor/infra/runtime/processing_tick.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
+from functools import partial
 from typing import TYPE_CHECKING, Protocol
+
+import anyio
 
 from vibesensor.shared.exceptions import ProcessingError
 from vibesensor.shared.ports import ClockSyncBroadcaster
@@ -70,7 +72,7 @@ class ProcessingTickRunner:
         if self._control_plane is None:
             return
         try:
-            await asyncio.to_thread(self._control_plane.broadcast_sync_clock)
+            await anyio.to_thread.run_sync(self._control_plane.broadcast_sync_clock)
         except OSError as exc:
             raise ProcessingTickFailure(ProcessingFailureCategory.SYNC_CLOCK, exc) from exc
 
@@ -132,10 +134,12 @@ class ProcessingTickRunner:
     ) -> None:
         compute_failure: ProcessingTickFailure | None = None
         try:
-            await asyncio.to_thread(
-                self._processor.compute_all,
-                compute_client_ids,
-                sample_rates_hz=sample_rates,
+            await anyio.to_thread.run_sync(
+                partial(
+                    self._processor.compute_all,
+                    compute_client_ids,
+                    sample_rates_hz=sample_rates,
+                )
             )
         except _OPERATIONAL_PROCESSING_EXCEPTIONS as exc:
             compute_failure = ProcessingTickFailure(

--- a/apps/server/vibesensor/infra/runtime/shutdown_sequence.py
+++ b/apps/server/vibesensor/infra/runtime/shutdown_sequence.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import aiosqlite
+import anyio
 
 if TYPE_CHECKING:
     from vibesensor.infra.runtime.background_task_coordinator import BackgroundTaskCoordinator
@@ -29,6 +30,7 @@ class LifecycleShutdownIssue:
 class LifecycleShutdownResult:
     """Collected shutdown issues plus managed jobs that outlived cancellation."""
 
+    lingering_background: tuple[str, ...]
     lingering_managed: tuple[asyncio.Task[None], ...]
     issues: tuple[LifecycleShutdownIssue, ...]
 
@@ -55,12 +57,15 @@ class LifecycleShutdownSequence:
         issues: list[LifecycleShutdownIssue] = []
         self._stop_ingress(issues)
         await self._udp_transport_lifecycle.shutdown()
-        await self._background_tasks.cancel_all(timeout_s=15.0)
+        lingering_background = await self._background_tasks.cancel_all(timeout_s=15.0)
         lingering_managed = await self._cancel_managed_jobs()
         await self._drain_analysis()
         await self._shutdown_worker_pool(issues)
         await self._close_history_db(issues)
+        if not lingering_background:
+            await self._background_tasks.close()
         return LifecycleShutdownResult(
+            lingering_background=tuple(lingering_background),
             lingering_managed=tuple(lingering_managed),
             issues=tuple(issues),
         )
@@ -90,7 +95,7 @@ class LifecycleShutdownSequence:
 
     async def _drain_analysis(self) -> None:
         analysis_timeout_s = self._runtime.shutdown_analysis_timeout_s
-        shutdown_report = await asyncio.to_thread(
+        shutdown_report = await anyio.to_thread.run_sync(
             self._runtime.run_recorder.shutdown_report,
             analysis_timeout_s,
         )
@@ -109,7 +114,7 @@ class LifecycleShutdownSequence:
 
     async def _shutdown_worker_pool(self, issues: list[LifecycleShutdownIssue]) -> None:
         try:
-            await asyncio.to_thread(self._runtime.worker_pool.shutdown, True)
+            await anyio.to_thread.run_sync(self._runtime.worker_pool.shutdown, True)
         except (OSError, RuntimeError) as exc:
             issues.append(
                 LifecycleShutdownIssue(

--- a/apps/server/vibesensor/infra/runtime/startup_runner.py
+++ b/apps/server/vibesensor/infra/runtime/startup_runner.py
@@ -6,11 +6,11 @@ previously inlined in ``LifecycleManager.start()``.
 
 from __future__ import annotations
 
-import asyncio
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import anyio
 from opentelemetry.trace import SpanKind
 
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
@@ -65,6 +65,7 @@ class StartupRunner:
         """Execute all startup phases in order."""
         phase_name = "starting"
         self._health_state.set_phase(phase_name)
+        cancelled_exc_class = anyio.get_cancelled_exc_class()
         try:
             for phase in self._phases():
                 phase_name = phase.name
@@ -77,7 +78,7 @@ class StartupRunner:
                 ) as span:
                     try:
                         await phase.run()
-                    except asyncio.CancelledError:
+                    except cancelled_exc_class:
                         span.set_attribute("vibesensor.cancelled", True)
                         raise
                     except (OSError, RuntimeError) as exc:
@@ -146,21 +147,22 @@ class StartupRunner:
 
     async def _start_background(
         self,
-        coro_factory: Callable[[], Coroutine[object, object, object]],
+        coro_factory: Callable[[], Awaitable[object]],
         name: str,
         *,
         restartable_exceptions: RestartableExceptions = (),
     ) -> None:
-        self._background_tasks.add(
-            self._task_supervisor.start(
+        self._background_tasks.start(
+            lambda: self._task_supervisor.run(
                 coro_factory,
                 name=name,
                 restartable_exceptions=restartable_exceptions,
             ),
+            name=name,
         )
 
     async def _start_update_recovery(self) -> None:
         self._background_tasks.start(
-            self._runtime.update_manager.startup_recover(),
+            self._runtime.update_manager.startup_recover,
             name="update-startup-recover",
         )

--- a/apps/server/vibesensor/infra/runtime/task_supervisor.py
+++ b/apps/server/vibesensor/infra/runtime/task_supervisor.py
@@ -1,12 +1,12 @@
-"""Managed task supervision with restart/backoff policy for runtime services."""
+"""Managed-task supervision with restart/backoff policy for runtime services."""
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable
 
+import anyio
 from opentelemetry.trace import SpanKind, Status, StatusCode
 
 from vibesensor.infra.runtime.health_state import RuntimeHealthState
@@ -15,7 +15,7 @@ from vibesensor.shared.tracing import mark_span_error, start_span
 
 __all__ = ["TaskSupervisor", "task_failure_message"]
 
-TaskFactory = Callable[[], Coroutine[object, object, object]]
+TaskFactory = Callable[[], Awaitable[object]]
 RestartableExceptions = tuple[type[Exception], ...]
 
 _TASK_RESTART_MAX_ATTEMPTS = 3
@@ -31,7 +31,7 @@ def task_failure_message(exc: BaseException) -> str:
 
 
 class TaskSupervisor:
-    """Create managed tasks that restart with exponential backoff on failure."""
+    """Run managed services with restart/backoff and terminal-failure recording."""
 
     __slots__ = (
         "_base_delay_s",
@@ -59,95 +59,86 @@ class TaskSupervisor:
         self._max_delay_s = max_delay_s
         self._reset_after_s = reset_after_s
 
-    def monitor_task(self, task: asyncio.Task[object]) -> None:
-        task_name = task.get_name()
-        recorded = False
-
-        def _record_failure(done_task: asyncio.Task[object]) -> None:
-            nonlocal recorded
-            if recorded:
-                return
-            recorded = True
-            if done_task.cancelled():
-                return
-            try:
-                exc = done_task.exception()
-            except asyncio.CancelledError:
-                return
-            if exc is None:
-                return
-            message = task_failure_message(exc)
-            self._health_state.record_task_failure(task_name, message)
-            self._logger.error("Managed task %s failed: %s", task_name, message, exc_info=exc)
-
-        task.add_done_callback(_record_failure)
-        if task.done():
-            _record_failure(task)
-
     def _restart_delay_s(self, restart_count: int) -> float:
         exponent = max(0, restart_count - 1)
         return float(min(self._max_delay_s, self._base_delay_s * (2**exponent)))
 
-    def start(
+    def _record_terminal_failure(
+        self,
+        *,
+        name: str,
+        exc: BaseException,
+    ) -> None:
+        message = task_failure_message(exc)
+        self._health_state.record_task_failure(name, message)
+        self._logger.error("Managed task %s failed: %s", name, message, exc_info=exc)
+
+    async def run(
         self,
         task_factory: TaskFactory,
         *,
         name: str,
         restartable_exceptions: RestartableExceptions = (),
-    ) -> asyncio.Task[object]:
-        """Create a supervised task that restarts only on declared failures."""
+    ) -> None:
+        """Run a supervised task inline inside the owning task group."""
 
-        async def _run_supervised() -> None:
-            restart_count = 0
-            while True:
-                with start_span(
-                    __name__,
-                    "runtime.managed_task",
-                    kind=SpanKind.INTERNAL,
-                    attributes={
-                        "vibesensor.task.name": name,
-                        "vibesensor.task.attempt": restart_count + 1,
-                    },
-                ) as span:
-                    started_at = time.monotonic()
-                    try:
-                        await task_factory()
-                    except asyncio.CancelledError:
-                        span.set_attribute("vibesensor.cancelled", True)
-                        raise
-                    except restartable_exceptions as exc:
-                        runtime_s = time.monotonic() - started_at
-                        span.set_attribute("vibesensor.runtime_s", round(runtime_s, 3))
-                        mark_span_error(span, exc)
-                        if runtime_s >= self._reset_after_s:
-                            restart_count = 0
-                        if restart_count >= self._max_attempts:
-                            span.set_attribute("vibesensor.restart_exhausted", True)
-                            raise
-                        restart_count += 1
-                        delay_s = self._restart_delay_s(restart_count)
-                        span.set_attribute("vibesensor.restart_delay_s", delay_s)
-                        self._health_state.record_task_failure(name, task_failure_message(exc))
-                        self._logger.error(
-                            (
-                                "Managed task %s failed with restartable error; "
-                                "restarting in %.1fs (%d/%d)."
-                            ),
-                            name,
-                            delay_s,
-                            restart_count,
-                            self._max_attempts,
-                            exc_info=exc,
-                        )
-                        await asyncio.sleep(delay_s)
-                        self._health_state.clear_task_failure(name)
-                        continue
+        cancelled_exc_class = anyio.get_cancelled_exc_class()
+        restart_count = 0
+        while True:
+            with start_span(
+                __name__,
+                "runtime.managed_task",
+                kind=SpanKind.INTERNAL,
+                attributes={
+                    "vibesensor.task.name": name,
+                    "vibesensor.task.attempt": restart_count + 1,
+                },
+            ) as span:
+                started_at = time.monotonic()
+                try:
+                    await task_factory()
+                except cancelled_exc_class:
+                    span.set_attribute("vibesensor.cancelled", True)
+                    raise
+                except restartable_exceptions as exc:
                     runtime_s = time.monotonic() - started_at
                     span.set_attribute("vibesensor.runtime_s", round(runtime_s, 3))
-                    span.set_attribute("vibesensor.unexpected_exit", True)
-                    span.set_status(Status(StatusCode.ERROR, "managed task exited unexpectedly"))
-                raise RuntimeError(f"managed task {name} exited unexpectedly")
+                    mark_span_error(span, exc)
+                    if runtime_s >= self._reset_after_s:
+                        restart_count = 0
+                    if restart_count >= self._max_attempts:
+                        span.set_attribute("vibesensor.restart_exhausted", True)
+                        self._record_terminal_failure(name=name, exc=exc)
+                        return
+                    restart_count += 1
+                    delay_s = self._restart_delay_s(restart_count)
+                    span.set_attribute("vibesensor.restart_delay_s", delay_s)
+                    self._health_state.record_task_failure(name, task_failure_message(exc))
+                    self._logger.error(
+                        (
+                            "Managed task %s failed with restartable error; "
+                            "restarting in %.1fs (%d/%d)."
+                        ),
+                        name,
+                        delay_s,
+                        restart_count,
+                        self._max_attempts,
+                        exc_info=exc,
+                    )
+                    await anyio.sleep(delay_s)
+                    self._health_state.clear_task_failure(name)
+                    continue
+                except Exception as exc:
+                    runtime_s = time.monotonic() - started_at
+                    span.set_attribute("vibesensor.runtime_s", round(runtime_s, 3))
+                    mark_span_error(span, exc)
+                    self._record_terminal_failure(name=name, exc=exc)
+                    return
 
-        task = asyncio.create_task(_run_supervised(), name=name)
-        self.monitor_task(task)
-        return task
+                runtime_s = time.monotonic() - started_at
+                span.set_attribute("vibesensor.runtime_s", round(runtime_s, 3))
+                span.set_attribute("vibesensor.unexpected_exit", True)
+                terminal = RuntimeError(f"managed task {name} exited unexpectedly")
+                span.set_status(Status(StatusCode.ERROR, str(terminal)))
+                self._record_terminal_failure(name=name, exc=terminal)
+                return

--- a/apps/server/vibesensor/infra/runtime/udp_transport_lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/udp_transport_lifecycle.py
@@ -4,29 +4,30 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable
+from typing import Protocol
 
 __all__ = ["StartUdpReceiver", "UdpTransportLifecycle"]
 
+
+class UdpQueueConsumer(Protocol):
+    async def process_queue(self) -> None: ...
+
+
 StartUdpReceiver = Callable[
     ...,
-    Coroutine[
-        object,
-        object,
-        tuple[asyncio.DatagramTransport | None, asyncio.Task[object] | None],
-    ],
+    Awaitable[tuple[asyncio.DatagramTransport | None, UdpQueueConsumer | None]],
 ]
-MonitorTask = Callable[[asyncio.Task[object]], None]
+StartBackgroundTask = Callable[[Callable[[], Awaitable[object]]], None]
 
 
 class UdpTransportLifecycle:
     """Own the UDP receiver transport and consumer-task lifecycle."""
 
     __slots__ = (
-        "_data_consumer_task",
         "_data_transport",
         "_logger",
-        "_monitor_task",
+        "_start_background_task",
         "_start_udp_receiver",
     )
 
@@ -34,18 +35,13 @@ class UdpTransportLifecycle:
         self,
         *,
         start_udp_receiver: StartUdpReceiver,
-        monitor_task: MonitorTask,
+        start_background_task: StartBackgroundTask,
         logger: logging.Logger,
     ) -> None:
         self._start_udp_receiver = start_udp_receiver
-        self._monitor_task = monitor_task
+        self._start_background_task = start_background_task
         self._logger = logger
         self._data_transport: asyncio.DatagramTransport | None = None
-        self._data_consumer_task: asyncio.Task[object] | None = None
-
-    @property
-    def consumer_task(self) -> asyncio.Task[object] | None:
-        return self._data_consumer_task
 
     @property
     def transport(self) -> asyncio.DatagramTransport | None:
@@ -60,15 +56,15 @@ class UdpTransportLifecycle:
         processor: object,
         queue_maxsize: int,
     ) -> None:
-        self._data_transport, self._data_consumer_task = await self._start_udp_receiver(
+        self._data_transport, consumer = await self._start_udp_receiver(
             host=host,
             port=port,
             registry=registry,
             processor=processor,
             queue_maxsize=queue_maxsize,
         )
-        if self._data_consumer_task is not None:
-            self._monitor_task(self._data_consumer_task)
+        if consumer is not None:
+            self._start_background_task(consumer.process_queue)
 
     async def shutdown(self) -> None:
         try:
@@ -77,7 +73,3 @@ class UdpTransportLifecycle:
                 self._data_transport = None
         except OSError:
             self._logger.warning("Error closing data transport", exc_info=True)
-        if self._data_consumer_task is not None:
-            self._data_consumer_task.cancel()
-            await asyncio.gather(self._data_consumer_task, return_exceptions=True)
-            self._data_consumer_task = None

--- a/docs/run_lifecycle.md
+++ b/docs/run_lifecycle.md
@@ -131,6 +131,26 @@ Shutdown does not start new work:
 - an in-flight analysis attempt is allowed to finish its current call path; the
   worker checks the shutdown flag before starting the next queued item or retry
 
+## Runtime concurrency ownership
+
+The run lifecycle is coordinated inside the backend runtime, but concurrency
+ownership now stays in one AnyIO-based path instead of split `asyncio`
+task/timeout helpers:
+
+- `LifecycleManager` opens one runtime-scoped AnyIO task group before startup
+  phases begin
+- `BackgroundTaskCoordinator` starts named runtime services inside that task
+  group and owns per-service cancel scopes for shutdown
+- `TaskSupervisor` owns restart/backoff for long-lived runtime services such as
+  `processing-loop`, `ws-broadcast`, `gps-speed`, `obd-speed`, and the UDP data
+  consumer while still recording terminal failures into health state
+- runtime shutdown closes ingress first, cancels those service scopes with a
+  bounded wait, then drains `RunRecorder.shutdown_report()` and closes the
+  worker pool / history DB
+- WebSocket tick timing, send timeouts, and thread offloads in the runtime path
+  use AnyIO scheduling/timeouts (`sleep`, `fail_after`, `to_thread.run_sync`)
+  so startup/shutdown behavior stays on the same cancellation model
+
 ## Key invariants
 
 - At most one live recording run is active at a time.


### PR DESCRIPTION
## what changed
- runtime background ownership now goes through one lifecycle-owned AnyIO task group
- `BackgroundTaskCoordinator` tracks active service names plus per-service cancel scopes instead of raw `asyncio.Task` handles
- `TaskSupervisor` runs inline under that AnyIO owner and still handles restart/backoff plus terminal health-state reporting
- UDP receiver startup stops creating its own consumer task; lifecycle starts the consumer through the same background-service path
- runtime/websocket canonical paths moved to AnyIO primitives for sleep, timeout, task-group fanout, and thread offload
- shutdown closes services through AnyIO cancellation, then drains analysis, worker pool, and history DB in order
- tests/docs updated to the new observable behavior; one shutdown-order test was narrowed so it checks app shutdown ordering without booting unrelated GPS/runtime background loops

## why
- old runtime ownership was split across raw `asyncio` task creation plus partial AnyIO-aware startup/shutdown paths
- this makes cancellation and shutdown reasoning harder, especially around who owns background service lifetime
- new shape gives one clear owner for task groups, cancel scopes, and timeout boundaries in the migrated runtime surfaces

## validation
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- focused runtime/websocket pytest slice: `91 passed`
- broader `tests/infra tests/adapters/websocket tests/app`: `774 passed`
- `make test-changed`
- `make test-all`

## risks / edges
- runtime shutdown semantics changed from raw-task tracking to active service names plus cancel scopes; tests cover cancellation, lingering-task reporting, UDP consumer wiring, and shutdown ordering
- local `docker compose build --pull && docker compose up -d` is still host-blocked here because this machine does not have the `docker compose` v2 plugin (`docker compose` rejects the command before compose subcommands run)

Closes #2969
