### PR TITLE
docs(workflow): clarify Ruff format path

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,7 +5,7 @@ guard_script="tools/privacy/privacy_guard.py"
 
 if [[ ! -f "${guard_script}" ]]; then
 	echo "[vibesensor hooks] Skipping privacy guard: ${guard_script} is not present in this checkout." >&2
-	echo "[vibesensor hooks] See CONTRIBUTING.md for supported local validation commands." >&2
+	echo "[vibesensor hooks] Use 'make format' for canonical Python formatting and see CONTRIBUTING.md for the supported local validation commands." >&2
 	exit 0
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,7 +5,7 @@ guard_script="tools/privacy/privacy_guard.py"
 
 if [[ ! -f "${guard_script}" ]]; then
   echo "[vibesensor hooks] Skipping privacy guard: ${guard_script} is not present in this checkout." >&2
-  echo "[vibesensor hooks] See CONTRIBUTING.md for supported local validation commands." >&2
+  echo "[vibesensor hooks] Use 'make format' for canonical Python formatting and see CONTRIBUTING.md for the supported local validation commands." >&2
   exit 0
 fi
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,7 @@ Domain model (scope: behavioral rules only; see `docs/domain-model.md` for the f
 Commands
 - Other AI guidance and docs should reference this list instead of repeating it.
 - `make setup`
+- `make format`
 - `python -m pip install -e "./apps/server[dev]"`
 - `make lint`
 - `make typecheck-backend`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,9 @@ Current hook behavior:
 
 ## Validation workflow
 
+Use `make format` as the only supported Python formatter for backend and tooling
+files. Do not run competing Python formatters in this repo.
+
 Use `make test-changed` as a heuristic shortcut for the files changed on your
 current branch when you want a fast first pass. It is not a replacement for the
 broader tiers below before merge.
@@ -90,6 +93,7 @@ Additional local-only convenience commands:
 | Goal | Command |
 |---|---|
 | Docker dev stack | `make dev` |
+| Python formatting | `make format` |
 | Fast backend tests | `make test` |
 | UI lint | `make ui-lint` |
 | Changed-file heuristic | `make test-changed` |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ No internet connection required. No cloud. Everything runs locally on the Pi.
 - Hardware simulator for full-stack testing without physical sensors
 - Extensive pytest suite with CI integration
 - Playwright visual regression tests across 4 viewports
-- Ruff backend linting plus UI linting and TypeScript type checking enforced in CI
+- Ruff lint + Ruff format for backend/tooling Python, plus UI linting and TypeScript type checking enforced in CI
 - Custom binary UDP protocol with sequence-based loss detection
 
 ## Units
@@ -102,7 +102,8 @@ For supported Python and Node policy by environment, use
 
 Run `make doctor` after cloning to validate the pinned toolchain and see which
 workflow paths are available on your machine. Run bare `make` to list the
-supported repo commands.
+supported repo commands. Use `make format` as the only supported Python
+formatter for backend and tooling files.
 
 ## Quick Start
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,6 +6,7 @@
 - UI validation lives under `apps/ui/` (Vite build/typecheck plus Playwright browser checks).
 - Firmware build/flash guidance lives in `firmware/esp/README.md`.
 - Pi-image build/validation guidance lives in `infra/pi-image/pi-gen/README.md`.
+- `make format` is the canonical Python formatting command for backend and tooling files; no other Python formatter is supported in the repo workflow.
 - Use `make test-ci-lite` (`python3 tools/tests/run_ci_parallel.py --ci-lite`) for the non-Docker blocking-CI subset.
 - Use `make test-all` (`python3 tools/tests/run_ci_parallel.py`) for the broader local runner.
 - Use `make benchmark-backend` for the explicit pytest-benchmark backend suite; pass `BENCHMARK_OPTS="--benchmark-save=<name>"` to save runs and `BACKEND_BENCHMARK_TARGETS=...` to focus one benchmark file.


### PR DESCRIPTION
## what changed
- made the existing Ruff formatter path explicit in the shared command list, README, CONTRIBUTING guide, testing doc, and hook fallback messages
- documented `make format` as the only supported Python formatter for backend/tooling files
- left the actual formatter/config/CI path on the already-canonical Ruff setup instead of inventing another migration layer

## why
- current `main` already runs `ruff format` in Make and CI, and `make format` is already mechanically clean
- the remaining gap was human workflow ambiguity: some docs/hook messages pointed only at generic validation commands instead of the canonical formatter path
- this closes that ambiguity without adding fake churn or touching unrelated Python files

## validation
- `make format` (`1106 files already formatted`)
- `make lint`
- `make typecheck-backend`
- `make test-changed`
- `make test-all`

## risks / edges
- no Python source reformat diff was needed; this PR standardizes guidance around the formatter path that is already active on `main`
- local `make test-all` hit one unrelated existing `ui-smoke` failure on current `main`: `apps/ui/tests/smoke.history.spec.ts` expected inline diagnosis summary text that was not present in the rendered row. This docs/hooks-only change cannot affect that browser path, so treat it as baseline noise rather than formatter fallout

Closes #2970
