### PR TITLE
test(ui): guard ClientApiRow.frame_samples required at compile time

### DIFF
--- a/apps/ui/tests/ws_contract.spec.ts
+++ b/apps/ui/tests/ws_contract.spec.ts
@@ -13,7 +13,29 @@ import { adaptServerPayload } from "../src/server_payload";
 import {
   EXPECTED_SCHEMA_VERSION,
   type StrengthMetricsPayload,
+  type WsClientInfo,
 } from "../src/contracts/ws_payload_types";
+import type { components as HttpComponents } from "../src/generated/http_api_contracts";
+
+// Compile-time guard: if `frame_samples` ever regresses to optional in either
+// generated contract, this file fails `tsc` before runtime tests run. Keeps
+// #3000 closed for good — matches schema `required` list.
+type RequiredKeys<T> = {
+  [K in keyof T]-?: object extends Pick<T, K> ? never : K;
+}[keyof T];
+
+type _WsFrameSamplesRequired = "frame_samples" extends RequiredKeys<WsClientInfo>
+  ? true
+  : never;
+type _HttpFrameSamplesRequired = "frame_samples" extends RequiredKeys<
+  HttpComponents["schemas"]["ClientApiRow"]
+>
+  ? true
+  : never;
+const _wsFrameSamplesRequired: _WsFrameSamplesRequired = true;
+const _httpFrameSamplesRequired: _HttpFrameSamplesRequired = true;
+void _wsFrameSamplesRequired;
+void _httpFrameSamplesRequired;
 
 function makeStrengthMetrics(
   overrides: Partial<StrengthMetricsPayload> = {},


### PR DESCRIPTION
closes #3000

## what
- add TS type-level guard in `apps/ui/tests/ws_contract.spec.ts` asserting `frame_samples` stays required on both `WsClientInfo` and HTTP `ClientApiRow`.

## why
- audit of #2929/#2980 claimed generated types still had `frame_samples?`. current generated files already expose `frame_samples: number` (required). gap was: no compile-time guard to catch future regression when generator or schema drift.
- now any drop back to optional fails `tsc` before runtime tests.

## validation
- `make sync-contracts` clean (no regen diff).
- `apps/ui: npm run lint && npm run typecheck && npm run build && npm run test:unit -- tests/ws_contract.spec.ts` all green.

## risks
- guard relies on `RequiredKeys<T>` via `object extends Pick<T,K>`; if typed-fetch generator emits union with undefined, guard still rejects. intentional.

## size
small.