### PR TITLE
fix(pi-image): drop stale apps/server/data references

### DIFF
--- a/infra/pi-image/pi-gen/lib/stage_assembly.sh
+++ b/infra/pi-image/pi-gen/lib/stage_assembly.sh
@@ -23,7 +23,6 @@ sync_stage_repo_snapshot() {
     --exclude "firmware/" \
     --exclude "hardware/" \
     --exclude "tools/tests/" \
-    --exclude "apps/server/data/" \
     --exclude "infra/pi-image/pi-gen/.cache/" \
     --exclude "infra/pi-image/pi-gen/.pip-cache-stage/" \
     --exclude "infra/pi-image/pi-gen/out/" \

--- a/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template
+++ b/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-run.sh.template
@@ -139,14 +139,9 @@ if [ "${#INSTALLED_TRIM_PACKAGES[@]}" -gt 0 ]; then
   echo "Purging trim-only packages: ${INSTALLED_TRIM_PACKAGES[*]}"
   apt-get purge -y --auto-remove "${INSTALLED_TRIM_PACKAGES[@]}"
 fi
-SITE_PACKAGES="$(/opt/VibeSensor/apps/server/.venv/bin/python - <<'PY'
-import site
-print(site.getsitepackages()[0])
-PY
-)"
-rm -rf "${SITE_PACKAGES}/data" "${SITE_PACKAGES}/public" "${SITE_PACKAGES}/static"
-cp -a /opt/VibeSensor/apps/server/data "${SITE_PACKAGES}/data"
 # Keep runtime assets/scripts/config while ensuring Python code comes from wheels.
+# Static data lives inside the installed `vibesensor` package (site-packages/vibesensor/data);
+# no sibling copy needed after the data-tree collapse (#2951).
 rm -rf \
   /opt/VibeSensor/apps/server/vibesensor \
   /opt/VibeSensor/apps/server/tests \


### PR DESCRIPTION
closes #3002 (also fixes pi-image regression from #2951/#2987).

## what
- remove `cp -a /opt/VibeSensor/apps/server/data ${SITE_PACKAGES}/data` + the preceding stale `rm -rf` sibling-cleanup from the stage-vibesensor template.
- remove stale `--exclude apps/server/data/` in `stage_assembly.sh`.

## why
- #2951 collapsed the static data tree into `apps/server/vibesensor/data/`. the pi-image stage script still referenced the removed `apps/server/data/` path, causing weekly ARM image builds to fail:
  - `cp: cannot stat '/opt/VibeSensor/apps/server/data': No such file or directory`
  - evidence: run [24683800179](https://github.com/Skamba/VibeSensor/actions/runs/24683800179) (dispatched for #3002 validation).
- static data now ships inside the installed `vibesensor` package (`site-packages/vibesensor/data/`) via the wheel. source tree also places the files under `apps/server/vibesensor/data/` which `image_validation.sh` already asserts. no sibling copy is needed.

## validation
- `make lint` not affected (shell templates).
- image rebuild via re-dispatched weekly-pi-image workflow will confirm. followup comment will post the green run URL once available.

## risks
- if anything still reads from `${SITE_PACKAGES}/data` at runtime, it would break. grep shows only the removed lines reference that path. canonical reader `vibesensor.shared._data_files` resolves package-relative (`_PACKAGE_ROOT / 'data'`).

## size
tiny.