### PR TITLE
fix(pi-image): validate packaged data at wheel-install path

### DIFF
--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -244,13 +244,31 @@ validate_image_artifact() {
     exit 1
   fi
 
-  if [ ! -f "${ROOT_MNT}/opt/VibeSensor/apps/server/vibesensor/data/report_i18n.json" ]; then
-    echo "Validation failed: missing ${ROOT_MNT}/opt/VibeSensor/apps/server/vibesensor/data/report_i18n.json"
+  # Static data ships inside the installed `vibesensor` package wheel
+  # (site-packages/vibesensor/data/*). The source tree under
+  # /opt/VibeSensor/apps/server/vibesensor is intentionally removed after install,
+  # so check the wheel-install path instead. `shopt -s nullglob` avoids literal
+  # glob strings when the path is missing; the explicit -f check then fails.
+  local venv_site_packages_glob="${ROOT_MNT}/opt/VibeSensor/apps/server/.venv/lib/python*/site-packages/vibesensor/data"
+  local venv_data_dir=""
+  for candidate in ${venv_site_packages_glob}; do
+    if [ -d "${candidate}" ]; then
+      venv_data_dir="${candidate}"
+      break
+    fi
+  done
+  if [ -z "${venv_data_dir}" ]; then
+    echo "Validation failed: missing site-packages/vibesensor/data directory under ${ROOT_MNT}/opt/VibeSensor/apps/server/.venv"
     exit 1
   fi
 
-  if [ ! -f "${ROOT_MNT}/opt/VibeSensor/apps/server/vibesensor/data/car_library.json" ]; then
-    echo "Validation failed: missing ${ROOT_MNT}/opt/VibeSensor/apps/server/vibesensor/data/car_library.json"
+  if [ ! -f "${venv_data_dir}/report_i18n.json" ]; then
+    echo "Validation failed: missing ${venv_data_dir}/report_i18n.json"
+    exit 1
+  fi
+
+  if [ ! -f "${venv_data_dir}/car_library.json" ]; then
+    echo "Validation failed: missing ${venv_data_dir}/car_library.json"
     exit 1
   fi
 


### PR DESCRIPTION
follow-up to #3008 / closes #3002 remainder.

## what
- `image_validation.sh`: check `report_i18n.json` + `car_library.json` under `apps/server/.venv/lib/python*/site-packages/vibesensor/data/` instead of the removed source tree.

## why
- weekly pi-image build [24684588080](https://github.com/Skamba/VibeSensor/actions/runs/24684588080) built fine but failed validation: `missing .../apps/server/vibesensor/data/report_i18n.json`.
- root cause: #2951 mechanically rewrote the data-file paths in the validator to `apps/server/vibesensor/data/…` while the same validator (line 263) asserts the whole `apps/server/vibesensor/` source tree was removed. those two asserts are mutually exclusive.
- stage trim already removes the source tree (correct — wheel owns the code and data). validator needs to look where the data actually lives post-install.

## validation
- shell syntax: `bash -n infra/pi-image/pi-gen/lib/image_validation.sh`.
- image rebuild via redispatched weekly-pi-image workflow will prove end-to-end. run URL will be posted after.

## risks
- glob pattern covers `python*`; if venv directory layout changes in the future (e.g. `python3.13t`), the glob still matches. if site-packages resolves elsewhere (pep-668 system vs venv), the loop explicit -d check fails loudly.

## size
tiny.