### PR TITLE
fix(pi-image): install libfftw3 runtime libraries

### DIFF
--- a/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-packages
+++ b/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-packages
@@ -9,3 +9,6 @@ gpsd
 python3-venv
 libopenblas0-pthread
 libopenjp2-7
+libfftw3-double3
+libfftw3-single3
+libfftw3-long3


### PR DESCRIPTION
follow-up to #3010 / closes #3002 remainder.

## what
- add `libfftw3-double3`, `libfftw3-single3`, `libfftw3-long3` to the stage-vibesensor runtime package list.

## why
- weekly ARM build [24685564290](https://github.com/Skamba/VibeSensor/actions/runs/24685564290) passed the (now-fixed) data-path validation and then failed the python import smoke test: `libfftw3_omp.so.3: cannot open shared object file: No such file or directory`.
- pyfftw landed in e50d8591 on 2026-04-20 after the previous green weekly run. pyfftw loads the Debian libfftw3 shared libs at import time. they were not in the stage package list.

## validation
- reloaded image will be re-dispatched; URL posted in follow-up.

## risks
- small image size delta (~1–2 MB each). acceptable for runtime correctness.

## size
tiny.