### PR TITLE
fix(pi-image): drop libfftw3-long3 (unavailable on armhf)

### DIFF
--- a/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-packages
+++ b/infra/pi-image/pi-gen/templates/stage-vibesensor/00-vibesensor/00-packages
@@ -11,4 +11,3 @@ libopenblas0-pthread
 libopenjp2-7
 libfftw3-double3
 libfftw3-single3
-libfftw3-long3


### PR DESCRIPTION
follow-up to #3012.

## what
- remove `libfftw3-long3` from stage-vibesensor apt package list.

## why
- run [24686543406](https://github.com/Skamba/VibeSensor/actions/runs/24686543406) failed: `E: Unable to locate package libfftw3-long3`. Debian trixie armhf does not ship the long-double variant (`long double == double` on armhf). pyfftw only needs `libfftw3-double3` (provides `libfftw3_omp.so.3`) and `libfftw3-single3`.

## validation
- weekly pi-image redispatch after merge.

## size
tiny.