### PR TITLE
fix(pi-image): match granian startup log in smoke validator

### DIFF
--- a/infra/pi-image/pi-gen/lib/image_validation.sh
+++ b/infra/pi-image/pi-gen/lib/image_validation.sh
@@ -462,7 +462,7 @@ if [ "$code" -ne 0 ] && [ "$code" -ne 124 ]; then
   tail -n 80 /tmp/vibesensor-smoke.log || true
   exit 1
 fi
-if ! grep -q "Application startup complete" /tmp/vibesensor-smoke.log; then
+if ! grep -q "Listening at:" /tmp/vibesensor-smoke.log; then
   echo "Server startup smoke did not reach successful startup"
   tail -n 80 /tmp/vibesensor-smoke.log || true
   exit 1


### PR DESCRIPTION
follow-up to #3013.

## what
- image_validation.sh smoke test now greps `Listening at:` instead of `Application startup complete`.

## why
- 968b792a switched the app from uvicorn to granian. granian's bind-ready log is `Listening at: <proto>://<host>:<port>`, not uvicorn's `Application startup complete`. the smoke test never saw a match, timed out, and reported failure even though the server was actually up.
- run [24687079062](https://github.com/Skamba/VibeSensor/actions/runs/24687079062) shows `IMPORT_VALIDATION_OK` + `WHEEL_INSTALL_PATH_OK`, server starts, then `timeout 10s` kills it before the stale grep ever matches.

## risks
- none — it's literally the granian startup log line; short and stable.

## size
tiny.