### PR TITLE
perf(ui): offload spectrum prep

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -9,6 +9,7 @@ server over HTTP (REST) and WebSocket (live data).
 - **TypeScript** — application logic
 - **Preact + @preact/signals** — UI rendering plus shared reactive state
 - **@tanstack/query-core** — canonical server-state fetch, cache, polling, and invalidation ownership
+- **comlink** — typed Web Worker bridge for off-main-thread spectrum frame preparation
 - **Vite** — build tool and dev server
 - **uPlot** — high-performance spectrum charts
 - **Vitest + happy-dom** — canonical fast unit/integration test runner
@@ -105,6 +106,26 @@ Frontend server-state ownership is centralized on the runtime-owned
   and invalidation instead of reintroducing ad hoc loaders or poll loops.
 - Mutations should either write authoritative results into the cache with
   `setQueryData(...)` or explicitly invalidate/refetch the affected keys.
+
+## Worker-owned spectrum frame preparation
+
+Live spectrum payload adaptation stays on the main thread, but heavy spectrum
+frame preparation does not.
+
+- `src/app/runtime/ui_spectrum_controller.ts` owns worker startup, stale-result
+  suppression, surfaced worker failure state, and teardown.
+- `src/app/runtime/spectrum_frame_preparer_worker.ts` exposes the canonical
+  Comlink worker API. Do not add a second production owner for spectrum frame
+  preparation.
+- `src/app/runtime/spectrum_frame_preparer.ts` owns the shared typed frame-prep
+  contract plus the pure preparation core reused by the worker and focused
+  tests.
+- `src/app/runtime/spectrum_canvas_renderer.ts` no longer prepares frames from
+  raw AppState. It only composes chart-band metadata, owns uPlot/canvas
+  lifecycle, and renders already prepared frames.
+- Worker responses may return transferable typed arrays (`Float64Array`) for the
+  prepared frequency/series payloads. Treat those series as read-only numeric
+  buffers.
 
 ## HTTP boundary tests with MSW
 
@@ -205,10 +226,13 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `app/runtime/ui_shell_chrome.tsx` | Preact owner for the primary nav, header preferences, pills, app-level error banner, and the top-level dashboard/history/settings view containers plus the typed shell bridge |
 | `app/runtime/ui_shell_controller.ts` | Menu/view shell, language and preference hydration, and the reactive shell-chrome model that feeds header pills, feedback, and app-level banners |
 | `app/runtime/ui_live_transport_controller.ts` | Demo/WebSocket transport coordinator that queues payloads through AppState, throttles live-session adaptation, and lets realtime, shell, and spectrum surfaces react from signal-backed state |
-| `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that splits heavy data refreshes from lighter settings-driven decoration refreshes while wiring overlay, canvas, interaction, and panel modules |
+| `app/runtime/ui_spectrum_controller.ts` | Thin spectrum coordinator that owns Comlink worker lifecycle for heavy spectrum frame preparation, splits data refreshes from lighter settings-driven decoration refreshes, and wires overlay, canvas, interaction, and panel modules |
 | `app/runtime/ui_startup_coordinator.ts` | Declarative startup-task runner that lets the shell own its initial bind/language/view boot while startup loads and transport start from a named sync/async plan |
 | `app/runtime/ui_startup_feature_ports.ts` | Narrow startup-only feature contract for initial refresh/load work |
-| `app/runtime/spectrum_canvas_renderer.ts` | Spectrum frame preparation, cached per-client display-series reuse, plot lifecycle, cadence-aware tween scheduling, stable uPlot buffer reuse for same-shape frames, and canvas draw plugin orchestration |
+| `app/runtime/spectrum_canvas_renderer.ts` | Prepared-frame chart-band composition, plot lifecycle, cadence-aware tween scheduling, stable uPlot buffer reuse for same-shape frames, and canvas draw plugin orchestration |
+| `app/runtime/spectrum_frame_preparer.ts` | Typed spectrum frame-prep contract plus pure interpolation/dB conversion core shared by worker and focused tests |
+| `app/runtime/spectrum_frame_preparer_worker.ts` | Canonical Comlink worker entrypoint for off-main-thread spectrum frame preparation plus transferable response packing |
+| `app/runtime/spectrum_frame_preparer_worker_client.ts` | Runtime-owned worker client wrapper that creates, proxies, and disposes the spectrum frame-prep worker |
 | `app/runtime/spectrum_interaction_controller.ts` | Spectrum focus, band-toggle, cursor, and legend/isolation interaction state with explicit ports plus throttled hover-inspector updates and announcement routing |
 | `app/runtime/spectrum_panel_view.ts` | Typed spectrum panel contract for the signal-backed legend, band legend, split visual inspector vs live announcer, band-toggle, and chart-host refs |
 | `app/app_feature_bundle.ts` | Creates concrete feature instances, then exposes explicit shell, transport, and startup port bundles back to the runtime |

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@preact/signals": "^2.9.0",
         "@tanstack/query-core": "^5.99.2",
+        "comlink": "^4.4.2",
         "preact": "^10.29.1",
         "uplot": "^1.6.31",
         "valibot": "^1.3.1"
@@ -3235,6 +3236,12 @@
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
     },
     "node_modules/commander": {
       "version": "14.0.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@preact/signals": "^2.9.0",
     "@tanstack/query-core": "^5.99.2",
+    "comlink": "^4.4.2",
     "preact": "^10.29.1",
     "uplot": "^1.6.31",
     "valibot": "^1.3.1"

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -1,10 +1,9 @@
 import type uPlot from "uplot";
 
 import { SPECTRUM_TWEEN_DURATION_MS } from "../../config";
-import { convertSpectrumAmplitudesToDbInPlace } from "../../spectrum";
 import type { SpectrumSeriesMeta, SpectrumText } from "../../spectrum_chart";
 import { getSpectrumCssVars } from "../../spectrum_css_vars";
-import { chartSeriesPalette, orderBandFills } from "../../theme";
+import { orderBandFills } from "../../theme";
 import {
   createRafAnimation,
   type RafAnimation,
@@ -17,8 +16,14 @@ import {
 } from "../spectrum_animation";
 import type { AppState, ChartBand } from "../ui_app_state";
 import { computed, effect, signal, untracked, type ReadonlySignal } from "../ui_signals";
+import type { SpectrumPreparedFrameData } from "./spectrum_frame_preparer";
 import type { SpectrumPanelChartDom } from "./spectrum_panel_view";
-import { closestFrequencyIndex, freqGridsMatch, type SpectrumFocusMarker, type SpectrumSeriesEntry } from "./spectrum_shared";
+import {
+  closestFrequencyIndex,
+  type SpectrumFocusMarker,
+  type SpectrumNumericSeries,
+  type SpectrumSeriesEntry,
+} from "./spectrum_shared";
 
 type SpectrumChartModule = Pick<typeof import("../../spectrum_chart"), "createSpectrumChart">;
 const EMPTY_FREQ_AXIS: number[] = [];
@@ -39,7 +44,7 @@ const bandKeyPresentation: Record<string, { color: string; labelKey: string }> =
 
 export interface SpectrumPreparedRenderData {
   entries: SpectrumSeriesEntry[];
-  freqAxis: number[];
+  freqAxis: SpectrumNumericSeries;
   chartBands: ChartBand[];
   frame: SpectrumHeavyFrame | null;
   hasData: boolean;
@@ -61,19 +66,11 @@ export interface SpectrumCanvasRendererDeps {
 
 export interface SpectrumCanvasRenderer {
   dispose(): void;
-  prepareFrame(): SpectrumPreparedRenderData;
+  composePreparedFrame(frameData: SpectrumPreparedFrameData): SpectrumPreparedRenderData;
   refreshPreparedFrameMetadata(): SpectrumPreparedRenderData;
   renderPreparedFrame(prepared: SpectrumPreparedRenderData): void;
   refreshDecorations(): void;
   setSeriesIsolation(seriesIndex: number | null): void;
-}
-
-interface PreparedSpectrumCacheEntry {
-  sourceCombined: readonly number[];
-  sourceFreq: readonly number[];
-  sourceLength: number;
-  targetFreq: readonly number[];
-  values: number[];
 }
 
 export function createSpectrumCanvasRenderer(
@@ -88,7 +85,6 @@ export function createSpectrumCanvasRenderer(
   let disposed = false;
   let lastAcceptedFrameAtMs: number | null = null;
   let lastPreparedFrame: SpectrumPreparedRenderData | null = null;
-  const preparedSpectrumCache = new Map<string, PreparedSpectrumCacheEntry>();
 
   const spectrumLastFrame = signal<SpectrumHeavyFrame | null>(null);
   const pendingPreparedFrame = signal<SpectrumPreparedRenderData | null>(null);
@@ -106,7 +102,7 @@ export function createSpectrumCanvasRenderer(
 
   const tweenTarget = signal<SpectrumHeavyFrame | null>(null);
   const currentEntries = signal<readonly SpectrumSeriesEntry[]>([]);
-  const currentFreqAxis = signal<readonly number[]>([]);
+  const currentFreqAxis = signal<SpectrumNumericSeries>(EMPTY_FREQ_AXIS);
   const chartSeriesMeta = signal<readonly SpectrumSeriesMeta[]>([]);
   const chartData = signal<uPlot.AlignedData>(EMPTY_CHART_DATA);
   const chartHeight = signal(360);
@@ -144,96 +140,13 @@ export function createSpectrumCanvasRenderer(
     });
   }
 
-  function prepareFrame(): SpectrumPreparedRenderData {
-    const entries: SpectrumSeriesEntry[] = [];
-    let targetFreq: number[] = [];
-
-    for (const [index, client] of deps.state.realtime.clients.value.entries()) {
-      if (!client?.connected) {
-        continue;
-      }
-      const spectrum = deps.state.spectrum.spectra.value.clients?.[client.id];
-      if (!spectrum || !Array.isArray(spectrum.combined)) {
-        continue;
-      }
-      const clientFreq = Array.isArray(spectrum.freq) && spectrum.freq.length
-        ? spectrum.freq
-        : EMPTY_FREQ_AXIS;
-      const length = Math.min(clientFreq.length, spectrum.combined.length);
-      if (!length) {
-        continue;
-      }
-
-      if (!targetFreq.length) {
-        targetFreq = clientFreq.length === length ? clientFreq : clientFreq.slice(0, length);
-      }
-
-      const preparedValues = getPreparedSpectrumValues(
-        client.id,
-        spectrum.combined,
-        clientFreq,
-        length,
-        targetFreq,
-      );
-      if (!preparedValues.length) {
-        continue;
-      }
-
-      entries.push({
-        id: client.id,
-        label: client.name || client.id,
-        color: colorForClient(index),
-        values: preparedValues,
-      });
-    }
-
-    const chartBands = calculateBands();
-    if (!targetFreq.length || !entries.length) {
-      return {
-        entries: [],
-        freqAxis: [],
-        chartBands,
-        frame: null,
-        hasData: false,
-      };
-    }
-
-    let minLen = targetFreq.length;
-    const seriesIds = new Array<string>(entries.length);
-    const frameValues = new Array<number[]>(entries.length);
-    for (let index = 0; index < entries.length; index += 1) {
-      const entry = entries[index];
-      seriesIds[index] = entry.id;
-      frameValues[index] = entry.values;
-      if (entry.values.length < minLen) {
-        minLen = entry.values.length;
-      }
-    }
-    if (minLen < targetFreq.length) {
-      targetFreq = targetFreq.slice(0, minLen);
-      for (let index = 0; index < frameValues.length; index += 1) {
-        const frameValuesEntry = frameValues[index];
-        const entry = entries[index];
-        if (!frameValuesEntry || !entry || frameValuesEntry.length === minLen) {
-          continue;
-        }
-        const trimmedValues = frameValuesEntry.slice(0, minLen);
-        frameValues[index] = trimmedValues;
-        entry.values = trimmedValues;
-      }
-    }
-    const frame: SpectrumHeavyFrame = {
-      seriesIds,
-      freq: targetFreq,
-      values: frameValues,
-    };
-
+  function composePreparedFrame(frameData: SpectrumPreparedFrameData): SpectrumPreparedRenderData {
     return {
-      entries,
-      freqAxis: frame.freq,
-      chartBands,
-      frame,
-      hasData: true,
+      entries: frameData.entries,
+      freqAxis: frameData.freqAxis,
+      chartBands: calculateBands(),
+      frame: frameData.frame,
+      hasData: frameData.hasData,
     };
   }
 
@@ -324,54 +237,6 @@ export function createSpectrumCanvasRenderer(
     deps.state.spectrum.spectrumPlot.value?.setSeriesIsolation(seriesIndex);
   }
 
-  function colorForClient(index: number): string {
-    return chartSeriesPalette[index % chartSeriesPalette.length];
-  }
-
-  function getPreparedSpectrumValues(
-    clientId: string,
-    combined: readonly number[],
-    clientFreq: readonly number[],
-    sourceLength: number,
-    targetFreq: readonly number[],
-  ): number[] {
-    const cached = preparedSpectrumCache.get(clientId);
-    if (
-      cached
-      && cached.sourceCombined === combined
-      && cached.sourceFreq === clientFreq
-      && cached.sourceLength === sourceLength
-      && cached.targetFreq.length === targetFreq.length
-      && (
-        cached.targetFreq === targetFreq
-        || freqGridsMatch(cached.targetFreq, targetFreq, targetFreq.length)
-      )
-    ) {
-      return cached.values;
-    }
-
-    const needsInterpolation = clientFreq.length !== targetFreq.length
-      || !freqGridsMatch(clientFreq, targetFreq, sourceLength);
-    const preparedValues = needsInterpolation
-      ? interpolateToTarget(clientFreq, combined, targetFreq, sourceLength)
-      : combined.slice(0, sourceLength);
-
-    if (!preparedValues.length) {
-      preparedSpectrumCache.delete(clientId);
-      return preparedValues;
-    }
-
-    convertSpectrumAmplitudesToDbInPlace(preparedValues);
-    preparedSpectrumCache.set(clientId, {
-      sourceCombined: combined,
-      sourceFreq: clientFreq,
-      sourceLength,
-      targetFreq,
-      values: preparedValues,
-    });
-    return preparedValues;
-  }
-
   function setSpectrumDataFromFrame(frame: SpectrumHeavyFrame): void {
     const plot = deps.state.spectrum.spectrumPlot.value;
     if (!plot) {
@@ -414,7 +279,10 @@ export function createSpectrumCanvasRenderer(
     chartSeriesMeta.value = nextMeta;
   }
 
-  function syncChartDataBuffer(freqAxis: readonly number[], seriesValues: readonly number[][]): void {
+  function syncChartDataBuffer(
+    freqAxis: SpectrumNumericSeries,
+    seriesValues: readonly SpectrumNumericSeries[],
+  ): void {
     if (freqAxis.length === 0 || seriesValues.length === 0) {
       chartData.value = EMPTY_CHART_DATA;
       return;
@@ -441,7 +309,7 @@ export function createSpectrumCanvasRenderer(
     }
   }
 
-  function copyNumbersInto(target: number[], source: readonly number[]): void {
+  function copyNumbersInto(target: number[], source: SpectrumNumericSeries): void {
     for (let index = 0; index < source.length; index += 1) {
       const value = source[index];
       if (value === undefined) {
@@ -639,6 +507,7 @@ export function createSpectrumCanvasRenderer(
   }
 
   return {
+    composePreparedFrame,
     dispose() {
       if (disposed) {
         return;
@@ -647,14 +516,12 @@ export function createSpectrumCanvasRenderer(
       disposeTweenEffect();
       tweenTarget.value = null;
       pendingPreparedFrame.value = null;
-      preparedSpectrumCache.clear();
       if (deps.state.spectrum.spectrumPlot.value) {
         deps.state.spectrum.spectrumPlot.value.destroy();
         deps.state.spectrum.spectrumPlot.value = null;
       }
       deps.state.spectrum.chartLoading.value = false;
     },
-    prepareFrame,
     refreshPreparedFrameMetadata,
     renderPreparedFrame,
     refreshDecorations,
@@ -679,33 +546,4 @@ function getChartLoadErrorDetail(error: unknown): string {
     return error;
   }
   return "Unknown error";
-}
-
-function interpolateToTarget(
-  sourceFreq: readonly number[],
-  sourceVals: readonly number[],
-  desiredFreq: readonly number[],
-  sourceLen: number,
-): number[] {
-  if (sourceLen < 2 || !desiredFreq.length) {
-    return [];
-  }
-  const output = new Array<number>(desiredFreq.length);
-  let index = 0;
-  for (let desiredIndex = 0; desiredIndex < desiredFreq.length; desiredIndex += 1) {
-    const freq = desiredFreq[desiredIndex];
-    while (index + 1 < sourceLen && sourceFreq[index + 1] < freq) {
-      index += 1;
-    }
-    if (index + 1 >= sourceLen) {
-      output[desiredIndex] = sourceVals[sourceLen - 1];
-      continue;
-    }
-    const f0 = sourceFreq[index];
-    const f1 = sourceFreq[index + 1];
-    const v0 = sourceVals[index];
-    const v1 = sourceVals[index + 1];
-    output[desiredIndex] = f1 <= f0 ? v0 : v0 + ((v1 - v0) * ((freq - f0) / (f1 - f0)));
-  }
-  return output;
 }

--- a/apps/ui/src/app/runtime/spectrum_frame_preparer.ts
+++ b/apps/ui/src/app/runtime/spectrum_frame_preparer.ts
@@ -1,0 +1,256 @@
+import { convertSpectrumAmplitudesToDbInPlace } from "../../spectrum";
+import { chartSeriesPalette } from "../../theme";
+import type { SpectrumClientData } from "../../transport/live_models";
+import type { SpectrumHeavyFrame } from "../spectrum_animation";
+import {
+  freqGridsMatch,
+  type SpectrumNumericSeries,
+  type SpectrumSeriesEntry,
+} from "./spectrum_shared";
+
+const EMPTY_FREQ_AXIS: number[] = [];
+
+export interface SpectrumFramePreparationClient {
+  id: string;
+  name: string;
+  connected: boolean;
+}
+
+export interface SpectrumFramePreparationInput {
+  clients: readonly SpectrumFramePreparationClient[];
+  spectraByClient: Record<string, SpectrumClientData | undefined>;
+}
+
+export interface SpectrumPreparedFrameData {
+  entries: SpectrumSeriesEntry[];
+  freqAxis: SpectrumNumericSeries;
+  frame: SpectrumHeavyFrame | null;
+  hasData: boolean;
+}
+
+export interface SpectrumFramePreparer {
+  dispose(): void;
+  prepare(input: SpectrumFramePreparationInput): Promise<SpectrumPreparedFrameData>;
+}
+
+interface PreparedSpectrumCacheEntry {
+  sourceCombined: readonly number[];
+  sourceFreq: readonly number[];
+  sourceLength: number;
+  targetFreq: readonly number[];
+  values: number[];
+}
+
+interface SpectrumFramePreparerCore {
+  dispose(): void;
+  prepare(input: SpectrumFramePreparationInput): SpectrumPreparedFrameData;
+}
+
+export function createInlineSpectrumFramePreparer(): SpectrumFramePreparer {
+  const core = createSpectrumFramePreparerCore();
+  return {
+    dispose(): void {
+      core.dispose();
+    },
+    async prepare(input): Promise<SpectrumPreparedFrameData> {
+      return core.prepare(input);
+    },
+  };
+}
+
+export function createSpectrumFramePreparerCore(): SpectrumFramePreparerCore {
+  const preparedSpectrumCache = new Map<string, PreparedSpectrumCacheEntry>();
+
+  function dispose(): void {
+    preparedSpectrumCache.clear();
+  }
+
+  function prepare(input: SpectrumFramePreparationInput): SpectrumPreparedFrameData {
+    const entries: SpectrumSeriesEntry[] = [];
+    let targetFreq: number[] = [];
+
+    for (const [index, client] of input.clients.entries()) {
+      if (!client?.connected) {
+        continue;
+      }
+      const spectrum = input.spectraByClient[client.id];
+      if (!spectrum || !Array.isArray(spectrum.combined)) {
+        continue;
+      }
+      const clientFreq = Array.isArray(spectrum.freq) && spectrum.freq.length
+        ? spectrum.freq
+        : EMPTY_FREQ_AXIS;
+      const length = Math.min(clientFreq.length, spectrum.combined.length);
+      if (!length) {
+        continue;
+      }
+
+      if (!targetFreq.length) {
+        targetFreq = clientFreq.length === length ? clientFreq : clientFreq.slice(0, length);
+      }
+
+      const preparedValues = getPreparedSpectrumValues(
+        client.id,
+        spectrum.combined,
+        clientFreq,
+        length,
+        targetFreq,
+      );
+      if (!preparedValues.length) {
+        continue;
+      }
+
+      entries.push({
+        id: client.id,
+        label: client.name || client.id,
+        color: colorForClient(index),
+        values: preparedValues,
+      });
+    }
+
+    if (!targetFreq.length || !entries.length) {
+      return {
+        entries: [],
+        freqAxis: [],
+        frame: null,
+        hasData: false,
+      };
+    }
+
+    let minLen = targetFreq.length;
+    const seriesIds = new Array<string>(entries.length);
+    const frameValues = new Array<SpectrumNumericSeries>(entries.length);
+    for (let index = 0; index < entries.length; index += 1) {
+      const entry = entries[index];
+      seriesIds[index] = entry.id;
+      frameValues[index] = entry.values;
+      if (entry.values.length < minLen) {
+        minLen = entry.values.length;
+      }
+    }
+    if (minLen < targetFreq.length) {
+      targetFreq = targetFreq.slice(0, minLen);
+      for (let index = 0; index < frameValues.length; index += 1) {
+        const frameValuesEntry = frameValues[index];
+        const entry = entries[index];
+        if (!frameValuesEntry || !entry || frameValuesEntry.length === minLen) {
+          continue;
+        }
+        const trimmedValues = sliceSeries(frameValuesEntry, minLen);
+        frameValues[index] = trimmedValues;
+        entry.values = trimmedValues;
+      }
+    }
+    const frame: SpectrumHeavyFrame = {
+      seriesIds,
+      freq: targetFreq,
+      values: frameValues,
+    };
+
+    return {
+      entries,
+      freqAxis: frame.freq,
+      frame,
+      hasData: true,
+    };
+  }
+
+  function getPreparedSpectrumValues(
+    clientId: string,
+    combined: readonly number[],
+    clientFreq: readonly number[],
+    sourceLength: number,
+    targetFreq: readonly number[],
+  ): number[] {
+    const cached = preparedSpectrumCache.get(clientId);
+    if (
+      cached
+      && cached.sourceCombined === combined
+      && cached.sourceFreq === clientFreq
+      && cached.sourceLength === sourceLength
+      && cached.targetFreq.length === targetFreq.length
+      && (
+        cached.targetFreq === targetFreq
+        || freqGridsMatch(cached.targetFreq, targetFreq, targetFreq.length)
+      )
+    ) {
+      return cached.values;
+    }
+
+    const needsInterpolation = clientFreq.length !== targetFreq.length
+      || !freqGridsMatch(clientFreq, targetFreq, sourceLength);
+    const preparedValues = needsInterpolation
+      ? interpolateToTarget(clientFreq, combined, targetFreq, sourceLength)
+      : combined.slice(0, sourceLength);
+
+    if (!preparedValues.length) {
+      preparedSpectrumCache.delete(clientId);
+      return preparedValues;
+    }
+
+    convertSpectrumAmplitudesToDbInPlace(preparedValues);
+    preparedSpectrumCache.set(clientId, {
+      sourceCombined: combined,
+      sourceFreq: clientFreq,
+      sourceLength,
+      targetFreq,
+      values: preparedValues,
+    });
+    return preparedValues;
+  }
+
+  return {
+    dispose,
+    prepare,
+  };
+}
+
+function colorForClient(index: number): string {
+  return chartSeriesPalette[index % chartSeriesPalette.length];
+}
+
+function sliceSeries(values: SpectrumNumericSeries, endExclusive: number): number[] {
+  return Array.from(values.slice(0, endExclusive));
+}
+
+function interpolateToTarget(
+  clientFreq: readonly number[],
+  combined: readonly number[],
+  targetFreq: readonly number[],
+  sourceLength: number,
+): number[] {
+  const output = new Array<number>(targetFreq.length);
+  let sourceIndex = 0;
+  for (let targetIndex = 0; targetIndex < targetFreq.length; targetIndex += 1) {
+    const targetHz = targetFreq[targetIndex];
+    while (
+      sourceIndex + 1 < sourceLength
+      && clientFreq[sourceIndex + 1] !== undefined
+      && clientFreq[sourceIndex + 1] < targetHz
+    ) {
+      sourceIndex += 1;
+    }
+
+    const lowerFreq = clientFreq[sourceIndex];
+    const lowerValue = combined[sourceIndex];
+    const upperIndex = Math.min(sourceIndex + 1, sourceLength - 1);
+    const upperFreq = clientFreq[upperIndex];
+    const upperValue = combined[upperIndex];
+    if (
+      lowerFreq === undefined
+      || lowerValue === undefined
+      || upperFreq === undefined
+      || upperValue === undefined
+    ) {
+      output[targetIndex] = Number.NaN;
+      continue;
+    }
+    if (upperFreq <= lowerFreq || upperIndex === sourceIndex) {
+      output[targetIndex] = lowerValue;
+      continue;
+    }
+    const alpha = Math.min(1, Math.max(0, (targetHz - lowerFreq) / (upperFreq - lowerFreq)));
+    output[targetIndex] = lowerValue + ((upperValue - lowerValue) * alpha);
+  }
+  return output;
+}

--- a/apps/ui/src/app/runtime/spectrum_frame_preparer_worker.ts
+++ b/apps/ui/src/app/runtime/spectrum_frame_preparer_worker.ts
@@ -1,0 +1,72 @@
+import { expose, transfer } from "comlink";
+
+import {
+  createSpectrumFramePreparerCore,
+  type SpectrumPreparedFrameData,
+  type SpectrumFramePreparationInput,
+} from "./spectrum_frame_preparer";
+
+interface SpectrumFramePreparerWorkerApi {
+  prepare(input: SpectrumFramePreparationInput): Promise<SpectrumPreparedFrameData>;
+}
+
+const core = createSpectrumFramePreparerCore();
+
+function collectTransferables(prepared: SpectrumPreparedFrameData): Transferable[] {
+  const seen = new Set<ArrayBufferLike>();
+  const transferables: Transferable[] = [];
+
+  function addSeriesBuffer(series: Float64Array | readonly number[]): void {
+    if (!(series instanceof Float64Array)) {
+      return;
+    }
+    if (seen.has(series.buffer)) {
+      return;
+    }
+    seen.add(series.buffer);
+    transferables.push(series.buffer);
+  }
+
+  addSeriesBuffer(prepared.freqAxis);
+  for (const entry of prepared.entries) {
+    addSeriesBuffer(entry.values);
+  }
+  if (prepared.frame) {
+    addSeriesBuffer(prepared.frame.freq);
+    for (const values of prepared.frame.values) {
+      addSeriesBuffer(values);
+    }
+  }
+  return transferables;
+}
+
+function toTransferablePreparedFrame(prepared: SpectrumPreparedFrameData): SpectrumPreparedFrameData {
+  if (!prepared.frame) {
+    return prepared;
+  }
+
+  const freqAxis = Float64Array.from(prepared.frame.freq);
+  const frameValues = prepared.frame.values.map((values) => Float64Array.from(values));
+  return {
+    entries: prepared.entries.map((entry, index) => ({
+      ...entry,
+      values: frameValues[index] ?? Float64Array.from(entry.values),
+    })),
+    freqAxis,
+    frame: {
+      ...prepared.frame,
+      freq: freqAxis,
+      values: frameValues,
+    },
+    hasData: prepared.hasData,
+  };
+}
+
+const api: SpectrumFramePreparerWorkerApi = {
+  async prepare(input): Promise<SpectrumPreparedFrameData> {
+    const prepared = toTransferablePreparedFrame(core.prepare(input));
+    return transfer(prepared, collectTransferables(prepared));
+  },
+};
+
+expose(api);

--- a/apps/ui/src/app/runtime/spectrum_frame_preparer_worker_client.ts
+++ b/apps/ui/src/app/runtime/spectrum_frame_preparer_worker_client.ts
@@ -1,0 +1,30 @@
+import { releaseProxy, wrap } from "comlink";
+
+import type {
+  SpectrumFramePreparer,
+  SpectrumPreparedFrameData,
+  SpectrumFramePreparationInput,
+} from "./spectrum_frame_preparer";
+
+interface SpectrumFramePreparerWorkerApi {
+  prepare(input: SpectrumFramePreparationInput): Promise<SpectrumPreparedFrameData>;
+  [releaseProxy]?: () => void;
+}
+
+export function createWorkerSpectrumFramePreparer(): SpectrumFramePreparer {
+  const worker = new Worker(
+    new URL("./spectrum_frame_preparer_worker.ts", import.meta.url),
+    { type: "module" },
+  );
+  const proxy = wrap<SpectrumFramePreparerWorkerApi>(worker);
+
+  return {
+    dispose(): void {
+      proxy[releaseProxy]?.();
+      worker.terminate();
+    },
+    prepare(input): Promise<SpectrumPreparedFrameData> {
+      return proxy.prepare(input);
+    },
+  };
+}

--- a/apps/ui/src/app/runtime/spectrum_interaction_controller.ts
+++ b/apps/ui/src/app/runtime/spectrum_interaction_controller.ts
@@ -1,6 +1,10 @@
 import { batch, computed, effect, signal, type ReadonlySignal } from "../ui_signals";
 import type { ChartBand } from "../ui_app_state";
-import type { SpectrumFocusMarker, SpectrumSeriesEntry } from "./spectrum_shared";
+import type {
+  SpectrumFocusMarker,
+  SpectrumNumericSeries,
+  SpectrumSeriesEntry,
+} from "./spectrum_shared";
 import { closestFrequencyIndex } from "./spectrum_shared";
 import type {
   SpectrumBandLegendModel,
@@ -17,7 +21,7 @@ const HOVER_INSPECTOR_THROTTLE_MS = 33;
 
 export interface SpectrumInteractionSyncParams {
   entries: readonly SpectrumSeriesEntry[];
-  freqAxis: readonly number[];
+  freqAxis: SpectrumNumericSeries;
   chartBands: readonly ChartBand[];
 }
 
@@ -40,7 +44,7 @@ export interface SpectrumInteractionSyncOptions {
 export class SpectrumInteractionController {
   private readonly currentEntries = signal<readonly SpectrumSeriesEntry[]>([]);
 
-  private readonly currentFreqAxis = signal<readonly number[]>([]);
+  private readonly currentFreqAxis = signal<SpectrumNumericSeries>([]);
 
   private readonly currentBands = signal<readonly ChartBand[]>([]);
 

--- a/apps/ui/src/app/runtime/spectrum_shared.ts
+++ b/apps/ui/src/app/runtime/spectrum_shared.ts
@@ -1,8 +1,10 @@
+export type SpectrumNumericSeries = readonly number[] | Float64Array;
+
 export interface SpectrumSeriesEntry {
   id: string;
   label: string;
   color: string;
-  values: number[];
+  values: SpectrumNumericSeries;
 }
 
 export interface SpectrumFocusMarker {
@@ -14,7 +16,7 @@ export interface SpectrumFocusMarker {
 const FREQ_MATCH_EPSILON = 1e-6;
 
 export function closestFrequencyIndex(
-  freqAxis: readonly number[],
+  freqAxis: SpectrumNumericSeries,
   targetHz: number,
 ): number | null {
   if (!freqAxis.length || !Number.isFinite(targetHz)) {
@@ -33,8 +35,8 @@ export function closestFrequencyIndex(
 }
 
 export function freqGridsMatch(
-  left: readonly number[],
-  right: readonly number[],
+  left: SpectrumNumericSeries,
+  right: SpectrumNumericSeries,
   len: number,
 ): boolean {
   for (let index = 0; index < len; index += 1) {

--- a/apps/ui/src/app/runtime/ui_spectrum_controller.ts
+++ b/apps/ui/src/app/runtime/ui_spectrum_controller.ts
@@ -3,7 +3,13 @@ import { computed, effectOnChange, untracked } from "../ui_signals";
 import {
   createSpectrumCanvasRenderer,
   type SpectrumCanvasRenderer,
+  type SpectrumPreparedRenderData,
 } from "./spectrum_canvas_renderer";
+import {
+  createInlineSpectrumFramePreparer,
+  type SpectrumFramePreparer,
+  type SpectrumFramePreparationInput,
+} from "./spectrum_frame_preparer";
 import { SpectrumInteractionController } from "./spectrum_interaction_controller";
 import type { SpectrumPanelView } from "./spectrum_panel_view";
 
@@ -11,6 +17,7 @@ type UiSpectrumControllerDeps = {
   state: AppState;
   panel: SpectrumPanelView;
   t: (key: string, vars?: Record<string, unknown>) => string;
+  framePreparer?: SpectrumFramePreparer;
 };
 
 export class UiSpectrumController {
@@ -20,16 +27,27 @@ export class UiSpectrumController {
 
   private readonly canvas: SpectrumCanvasRenderer;
 
+  private readonly framePreparer: SpectrumFramePreparer;
+
   private readonly disposeLanguageSync: () => void;
 
   private readonly disposeSpectraSync: () => void;
 
   private readonly disposeTransportOverlaySync: () => void;
 
+  private disposed = false;
+
+  private framePreparationRunning = false;
+
+  private requestedSpectrumVersion = 0;
+
+  private processedSpectrumVersion = 0;
+
   constructor(
     private readonly deps: UiSpectrumControllerDeps,
   ) {
     this.panel = this.deps.panel;
+    this.framePreparer = this.deps.framePreparer ?? createInlineSpectrumFramePreparer();
     this.canvas = createSpectrumCanvasRenderer({
       state: this.state,
       dom: this.panel.chartDom,
@@ -83,7 +101,7 @@ export class UiSpectrumController {
   }
 
   private applyPreparedSpectrum(
-    prepared: ReturnType<SpectrumCanvasRenderer["prepareFrame"]>,
+    prepared: SpectrumPreparedRenderData,
     mode: "data" | "decorations",
   ): void {
     this.state.spectrum.chartBands.value = prepared.chartBands;
@@ -104,8 +122,12 @@ export class UiSpectrumController {
 
   renderSpectrum(): void {
     this.renderSpectrumHeader();
-    const prepared = this.canvas.prepareFrame();
-    this.applyPreparedSpectrum(prepared, "data");
+    this.requestedSpectrumVersion += 1;
+    if (this.framePreparationRunning) {
+      return;
+    }
+    this.framePreparationRunning = true;
+    void this.preparePendingSpectrumFrames();
   }
 
   refreshSpectrumDecorations(): void {
@@ -115,9 +137,11 @@ export class UiSpectrumController {
   }
 
   dispose(): void {
+    this.disposed = true;
     this.disposeTransportOverlaySync();
     this.disposeSpectraSync();
     this.disposeLanguageSync();
+    this.framePreparer.dispose();
     this.interaction.dispose();
     this.canvas.dispose();
   }
@@ -127,6 +151,10 @@ export class UiSpectrumController {
     if (this.state.spectrum.chartLoadErrorDetail.value) {
       message = this.t("spectrum.chart_load_error", {
         message: this.state.spectrum.chartLoadErrorDetail.value,
+      });
+    } else if (this.state.spectrum.framePrepareErrorDetail.value) {
+      message = this.t("spectrum.frame_prepare_error", {
+        message: this.state.spectrum.framePrepareErrorDetail.value,
       });
     } else if (this.state.transport.payloadError.value) {
       message = this.state.transport.payloadError.value;
@@ -184,6 +212,7 @@ export class UiSpectrumController {
   private bindReactiveOverlaySync(): () => void {
     const transportOverlayState = computed(() => ({
       hasReceivedPayload: this.state.transport.hasReceivedPayload.value,
+      framePrepareErrorDetail: this.state.spectrum.framePrepareErrorDetail.value,
       payloadError: this.state.transport.payloadError.value,
       wsState: this.state.transport.wsState.value,
     }));
@@ -191,4 +220,62 @@ export class UiSpectrumController {
       untracked(() => this.updateSpectrumOverlay());
     });
   }
+
+  private buildFramePreparationInput(): SpectrumFramePreparationInput {
+    return {
+      clients: this.state.realtime.clients.value.map((client) => ({
+        id: client.id,
+        name: client.name,
+        connected: client.connected,
+      })),
+      spectraByClient: this.state.spectrum.spectra.value.clients,
+    };
+  }
+
+  private async preparePendingSpectrumFrames(): Promise<void> {
+    try {
+      while (!this.disposed && this.processedSpectrumVersion < this.requestedSpectrumVersion) {
+        const version = this.requestedSpectrumVersion;
+        this.state.spectrum.framePrepareErrorDetail.value = null;
+        try {
+          const frameData = await this.framePreparer.prepare(this.buildFramePreparationInput());
+          if (this.disposed) {
+            return;
+          }
+          if (version !== this.requestedSpectrumVersion) {
+            continue;
+          }
+          this.processedSpectrumVersion = version;
+          const prepared = this.canvas.composePreparedFrame(frameData);
+          this.applyPreparedSpectrum(prepared, "data");
+        } catch (error: unknown) {
+          if (this.disposed) {
+            return;
+          }
+          if (version !== this.requestedSpectrumVersion) {
+            continue;
+          }
+          this.processedSpectrumVersion = version;
+          this.state.spectrum.framePrepareErrorDetail.value = getFramePrepareErrorDetail(error);
+          this.updateSpectrumOverlay();
+        }
+      }
+    } finally {
+      this.framePreparationRunning = false;
+      if (!this.disposed && this.processedSpectrumVersion < this.requestedSpectrumVersion) {
+        this.framePreparationRunning = true;
+        void this.preparePendingSpectrumFrames();
+      }
+    }
+  }
+}
+
+function getFramePrepareErrorDetail(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+  return "Unknown error";
 }

--- a/apps/ui/src/app/spectrum_animation.ts
+++ b/apps/ui/src/app/spectrum_animation.ts
@@ -1,9 +1,10 @@
 import { computed, type ReadonlySignal } from "./ui_signals";
+import type { SpectrumNumericSeries } from "./runtime/spectrum_shared";
 
 export interface SpectrumHeavyFrame {
   seriesIds: string[];
-  freq: number[];
-  values: number[][];
+  freq: SpectrumNumericSeries;
+  values: SpectrumNumericSeries[];
   /** Cached fingerprint for fast frequency-grid equality checks. */
   _freqFingerprint?: string;
 }
@@ -15,7 +16,7 @@ const MIN_TWEEN_DURATION_MS = 60;
 const FAST_FRAME_TWEEN_FRACTION = 0.75;
 
 /** Compute a lightweight fingerprint (length + sampled values) for a freq array. */
-function freqFingerprint(freq: number[]): string {
+function freqFingerprint(freq: SpectrumNumericSeries): string {
   const n = freq.length;
   if (n === 0) return "0";
   // Sample first, last, and up to 4 evenly-spaced interior points.

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -22,6 +22,7 @@ import {
 } from "./runtime/ui_shell_chrome";
 import { DEFAULT_SHELL_VIEW_ID } from "./runtime/ui_shell_navigation_module";
 import { UiShellController } from "./runtime/ui_shell_controller";
+import { createWorkerSpectrumFramePreparer } from "./runtime/spectrum_frame_preparer_worker_client";
 import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
 import { UiStartupCoordinator } from "./runtime/ui_startup_coordinator";
 import { signal, type Signal } from "./ui_signals";
@@ -112,6 +113,7 @@ export function createUiAppRuntime(
     state,
     panel: lazyPanels.panels.dashboard.spectrum,
     t: (key, vars) => shell.t(key, vars),
+    framePreparer: createWorkerSpectrumFramePreparer(),
   });
   const transport = new UiLiveTransportController({
     state,

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -375,6 +375,7 @@ export interface SpectrumStateValue {
   hasSpectrumData: boolean;
   chartLoading: boolean;
   chartLoadErrorDetail: string | null;
+  framePrepareErrorDetail: string | null;
 }
 
 export type ShellState = SignalState<ShellStateValue>;
@@ -469,6 +470,7 @@ export function createAppState(): AppState {
       hasSpectrumData: signal(false),
       chartLoading: signal(false),
       chartLoadErrorDetail: signal<string | null>(null),
+      framePrepareErrorDetail: signal<string | null>(null),
     },
   };
 }

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -489,6 +489,7 @@
   "spectrum.stale": "Data is stale. Waiting for fresh frames.",
   "spectrum.empty": "Connected, but no spectrum frames yet.",
   "spectrum.chart_load_error": "Failed to load the spectrum chart: {message}",
+  "spectrum.frame_prepare_error": "Failed to prepare the spectrum frame: {message}",
   "spectrum.inspector_idle": "Hover the chart or select a trace to inspect the peak.",
   "spectrum.inspector_hover": "{sensor} · {freq} Hz · {value} dB · {bands}",
   "spectrum.inspector_focus_selected": "Focused: {sensor} · {freq} Hz · {value} dB · {bands}",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -489,6 +489,7 @@
   "spectrum.stale": "Data is verouderd — wachten op nieuwe frames.",
   "spectrum.empty": "Verbonden, maar nog geen spectrumdata.",
   "spectrum.chart_load_error": "Spectrumgrafiek laden mislukt: {message}",
+  "spectrum.frame_prepare_error": "Spectrumframe voorbereiden mislukt: {message}",
   "spectrum.inspector_idle": "Beweeg over de grafiek of kies een spoor om de piek te bekijken.",
   "spectrum.inspector_hover": "{sensor} · {freq} Hz · {value} dB · {bands}",
   "spectrum.inspector_focus_selected": "Focus: {sensor} · {freq} Hz · {value} dB · {bands}",

--- a/apps/ui/tests/spectrum_cache.spec.ts
+++ b/apps/ui/tests/spectrum_cache.spec.ts
@@ -50,8 +50,8 @@ describe("createSpectrumCanvasRenderer cache reuse", () => {
           ]);
         },
       },
-      async ({ renderer, state }) => {
-        const firstPrepared = renderer.prepareFrame();
+      async ({ prepareFrame, renderer, state }) => {
+        const firstPrepared = prepareFrame();
         renderer.renderPreparedFrame(firstPrepared);
         await flushSignalUpdates();
 
@@ -64,7 +64,7 @@ describe("createSpectrumCanvasRenderer cache reuse", () => {
           },
         };
 
-        const nextPrepared = renderer.prepareFrame();
+        const nextPrepared = prepareFrame();
         renderer.renderPreparedFrame(nextPrepared);
         await flushSignalUpdates();
 
@@ -100,8 +100,8 @@ describe("createSpectrumCanvasRenderer cache reuse", () => {
           ]);
         },
       },
-      async ({ renderer, state }) => {
-        const prepared = renderer.prepareFrame();
+      async ({ prepareFrame, renderer, state }) => {
+        const prepared = prepareFrame();
         renderer.renderPreparedFrame(prepared);
         await flushSignalUpdates();
 
@@ -155,9 +155,9 @@ describe("createSpectrumCanvasRenderer cache reuse", () => {
           ]);
         },
       },
-      ({ renderer }) => {
-        const firstPrepared = renderer.prepareFrame();
-        const secondPrepared = renderer.prepareFrame();
+      ({ prepareFrame }) => {
+        const firstPrepared = prepareFrame();
+        const secondPrepared = prepareFrame();
 
         expect(secondPrepared.entries[0]?.values).toBe(firstPrepared.entries[0]?.values);
         expect(secondPrepared.entries[1]?.values).toBe(firstPrepared.entries[1]?.values);
@@ -186,8 +186,8 @@ describe("createSpectrumCanvasRenderer cache reuse", () => {
           ]);
         },
       },
-      ({ renderer, state }) => {
-        const firstPrepared = renderer.prepareFrame();
+      ({ prepareFrame, state }) => {
+        const firstPrepared = prepareFrame();
 
         state.spectrum.spectra.value = {
           clients: {
@@ -199,7 +199,7 @@ describe("createSpectrumCanvasRenderer cache reuse", () => {
           },
         };
 
-        const secondPrepared = renderer.prepareFrame();
+        const secondPrepared = prepareFrame();
 
         expect(secondPrepared.entries[0]?.values).toBe(firstPrepared.entries[0]?.values);
         expect(secondPrepared.entries[1]?.values).not.toBe(firstPrepared.entries[1]?.values);
@@ -237,8 +237,8 @@ describe("createSpectrumCanvasRenderer cache reuse", () => {
           ]);
         },
       },
-      async ({ renderer, state }) => {
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+      async ({ prepareFrame, renderer, state }) => {
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
 
         state.spectrum.spectra.value = {
@@ -251,7 +251,7 @@ describe("createSpectrumCanvasRenderer cache reuse", () => {
           },
         };
 
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
 
         expect(setDataSnapshots).toHaveLength(2);

--- a/apps/ui/tests/spectrum_canvas_renderer_test_support.ts
+++ b/apps/ui/tests/spectrum_canvas_renderer_test_support.ts
@@ -2,7 +2,9 @@ import type { SpectrumPanelChartDom } from "../src/app/runtime/spectrum_panel_vi
 import type {
   SpectrumCanvasRenderer,
   SpectrumCanvasRendererDeps,
+  SpectrumPreparedRenderData,
 } from "../src/app/runtime/spectrum_canvas_renderer";
+import { createSpectrumFramePreparerCore } from "../src/app/runtime/spectrum_frame_preparer";
 import { createAppState } from "../src/app/ui_app_state";
 import type { AdaptedClient } from "../src/transport/live_models";
 import { createElementStub, installDocumentStub } from "./spectrum_test_support";
@@ -31,6 +33,7 @@ export interface SpectrumRendererHarnessOptions {
 
 export interface SpectrumRendererHarness {
   dom: SpectrumPanelChartDom;
+  prepareFrame: () => SpectrumPreparedRenderData;
   renderer: SpectrumCanvasRenderer;
   state: AppState;
 }
@@ -103,6 +106,7 @@ export async function withSpectrumRendererHarness(
   run: (harness: SpectrumRendererHarness) => Promise<void> | void,
 ): Promise<void> {
   const restoreDocument = installDocumentStub();
+  const framePreparer = createSpectrumFramePreparerCore();
   try {
     const { createSpectrumCanvasRenderer } = await import(
       "../src/app/runtime/spectrum_canvas_renderer"
@@ -123,9 +127,18 @@ export async function withSpectrumRendererHarness(
       onCursorDataIndexChange: () => undefined,
       ...options.deps,
     });
+    const prepareFrame = () => renderer.composePreparedFrame(framePreparer.prepare({
+      clients: state.realtime.clients.value.map((client) => ({
+        id: client.id,
+        name: client.name,
+        connected: client.connected,
+      })),
+      spectraByClient: state.spectrum.spectra.value.clients,
+    }));
 
-    await run({ dom, renderer, state });
+    await run({ dom, prepareFrame, renderer, state });
   } finally {
+    framePreparer.dispose();
     restoreDocument();
   }
 }

--- a/apps/ui/tests/spectrum_chart_lifecycle.spec.ts
+++ b/apps/ui/tests/spectrum_chart_lifecycle.spec.ts
@@ -62,8 +62,8 @@ describe("createSpectrumCanvasRenderer chart lifecycle", () => {
           ]);
         },
       },
-      async ({ renderer, state }) => {
-        const prepared = renderer.prepareFrame();
+      async ({ prepareFrame, renderer, state }) => {
+        const prepared = prepareFrame();
         renderer.renderPreparedFrame(prepared);
 
         expect(state.spectrum.chartLoading.value).toBe(true);
@@ -122,8 +122,8 @@ describe("createSpectrumCanvasRenderer chart lifecycle", () => {
           ]);
         },
       },
-      async ({ renderer, state }) => {
-        const prepared = renderer.prepareFrame();
+      async ({ prepareFrame, renderer, state }) => {
+        const prepared = prepareFrame();
         renderer.renderPreparedFrame(prepared);
         await flushSignalUpdates();
 
@@ -179,8 +179,8 @@ describe("createSpectrumCanvasRenderer chart lifecycle", () => {
           ]);
         },
       },
-      async ({ renderer }) => {
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+      async ({ prepareFrame, renderer }) => {
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
         setDataCalls = 0;
         redrawCalls = 0;

--- a/apps/ui/tests/spectrum_prepare_frame.spec.ts
+++ b/apps/ui/tests/spectrum_prepare_frame.spec.ts
@@ -33,11 +33,11 @@ describe("createSpectrumCanvasRenderer frame preparation", () => {
           ]);
         },
       },
-      ({ renderer }) => {
-        const prepared = renderer.prepareFrame();
+      ({ prepareFrame }) => {
+        const prepared = prepareFrame();
 
         expect(prepared.hasData).toBe(true);
-        expect(prepared.freqAxis).toEqual([10, 15, 20]);
+        expect(Array.from(prepared.freqAxis)).toEqual([10, 15, 20]);
         expect(prepared.entries.map((entry) => entry.id)).toEqual(["sensor-a", "sensor-b"]);
         expect(prepared.frame?.values[1]).toHaveLength(3);
         expect(prepared.entries[1]?.values.every((value) => Number.isFinite(value))).toBe(true);

--- a/apps/ui/tests/spectrum_tweening.spec.ts
+++ b/apps/ui/tests/spectrum_tweening.spec.ts
@@ -50,8 +50,8 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
           ]);
         },
       },
-      async ({ renderer, state }) => {
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+      async ({ prepareFrame, renderer, state }) => {
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
 
         state.spectrum.spectra.value = {
@@ -63,7 +63,7 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
           },
         };
 
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
 
         expect(animationStarts).toEqual([75]);
@@ -115,8 +115,8 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
           ]);
         },
       },
-      async ({ renderer, state }) => {
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+      async ({ prepareFrame, renderer, state }) => {
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
         setDataCalls = 0;
         redrawCalls = 0;
@@ -130,7 +130,7 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
           },
         };
 
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
 
         expect(setDataCalls).toBe(1);
@@ -175,8 +175,8 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
           ]);
         },
       },
-      async ({ renderer, state }) => {
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+      async ({ prepareFrame, renderer, state }) => {
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
 
         state.spectrum.spectra.value = {
@@ -188,7 +188,7 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
           },
         };
 
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
 
         expect(animationStarts).toEqual([]);
@@ -232,8 +232,8 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
           ]);
         },
       },
-      async ({ renderer, state }) => {
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+      async ({ prepareFrame, renderer, state }) => {
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
 
         state.spectrum.spectra.value = {
@@ -245,7 +245,7 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
           },
         };
 
-        renderer.renderPreparedFrame(renderer.prepareFrame());
+        renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
 
         expect(animationStarts).toEqual([180]);

--- a/apps/ui/tests/ui_spectrum_controller.spec.ts
+++ b/apps/ui/tests/ui_spectrum_controller.spec.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, test } from "vitest";
+import type { SpectrumFramePreparer } from "../src/app/runtime/spectrum_frame_preparer";
 import type { SpectrumPanelView } from "../src/app/runtime/spectrum_panel_view";
 import { applyLivePayloadUpdate, createAppState } from "../src/app/ui_app_state";
 import { batch } from "../src/app/ui_signals";
 import type { AdaptedPayload } from "../src/transport/live_models";
-import { installWindowGlobal } from "./async_test_helpers";
+import {
+  createDeferred,
+  flushSignalUpdates,
+  installWindowGlobal,
+} from "./async_test_helpers";
 import { createElementStub, installDocumentStub } from "./spectrum_test_support";
 
 async function importUiSpectrumController() {
@@ -77,6 +82,15 @@ function createPanelStub(): {
     get lastOverlayModel() {
       return lastOverlayModel;
     },
+  };
+}
+
+function createFramePreparerStub(
+  prepare: SpectrumFramePreparer["prepare"],
+): SpectrumFramePreparer {
+  return {
+    dispose() {},
+    prepare,
   };
 }
 
@@ -222,7 +236,6 @@ describe("UiSpectrumController", () => {
       });
       const canvas = (controller as unknown as {
         canvas: {
-          prepareFrame: () => unknown;
           refreshPreparedFrameMetadata: () => {
             entries: [];
             freqAxis: [];
@@ -233,13 +246,8 @@ describe("UiSpectrumController", () => {
           refreshDecorations: () => void;
         };
       }).canvas;
-      let prepareCalls = 0;
       let refreshCalls = 0;
 
-      canvas.prepareFrame = () => {
-        prepareCalls += 1;
-        return null;
-      };
       canvas.refreshPreparedFrameMetadata = () => ({
         entries: [],
         freqAxis: [],
@@ -253,8 +261,113 @@ describe("UiSpectrumController", () => {
 
       controller.refreshSpectrumDecorations();
 
-      expect(prepareCalls).toBe(0);
       expect(refreshCalls).toBe(1);
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("shows worker frame-preparation failures through the overlay", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const UiSpectrumController = await importUiSpectrumController();
+      const state = createAppState();
+      state.transport.wsState.value = "connected";
+      state.transport.hasReceivedPayload.value = true;
+      const panel = createPanelStub();
+      const controller = new UiSpectrumController({
+        state,
+        panel: panel.panel,
+        t: (key, vars) =>
+          key === "spectrum.frame_prepare_error"
+            ? `frame prep failed: ${String(vars?.message)}`
+            : key,
+        framePreparer: createFramePreparerStub(async () => {
+          throw new Error("worker crashed");
+        }),
+      });
+
+      controller.renderSpectrum();
+      await flushSignalUpdates();
+
+      expect(panel.lastOverlayModel).toEqual({
+        hidden: false,
+        text: "frame prep failed: worker crashed",
+      });
+      expect(state.spectrum.framePrepareErrorDetail.value).toBe("worker crashed");
+    } finally {
+      restoreDocument();
+    }
+  });
+
+  test("drops stale worker results and applies only newest spectrum frame", async () => {
+    const restoreDocument = installDocumentStub();
+    try {
+      const UiSpectrumController = await importUiSpectrumController();
+      const state = createAppState();
+      const panel = createPanelStub();
+      const first = createDeferred<{
+        entries: [];
+        freqAxis: [];
+        frame: null;
+        hasData: false;
+      }>();
+      const second = createDeferred<{
+        entries: [];
+        freqAxis: [];
+        frame: null;
+        hasData: false;
+      }>();
+      const calls: string[] = [];
+      const controller = new UiSpectrumController({
+        state,
+        panel: panel.panel,
+        t: (key) => key,
+        framePreparer: createFramePreparerStub(async (input) => {
+          calls.push(String(input.spectraByClient["sensor-a"]?.combined[2] ?? "empty"));
+          if (calls.length === 1) {
+            return first.promise;
+          }
+          return second.promise;
+        }),
+      });
+      const applyCalls: string[] = [];
+      const controllerForTest = controller as UiSpectrumController & {
+        applyPreparedSpectrum: (prepared: { hasData: boolean }) => void;
+      };
+      controllerForTest.applyPreparedSpectrum = ((prepared) => {
+        applyCalls.push(String(prepared.hasData));
+      }) as typeof controllerForTest.applyPreparedSpectrum;
+
+      applyLivePayloadUpdate({
+        realtime: state.realtime,
+        spectrum: state.spectrum,
+        adaptedPayload: makeSpectrumPayload([0.1, 0.2, 0.3]),
+      });
+      applyLivePayloadUpdate({
+        realtime: state.realtime,
+        spectrum: state.spectrum,
+        adaptedPayload: makeSpectrumPayload([0.1, 0.2, 0.4]),
+      });
+      first.resolve({
+        entries: [],
+        freqAxis: [],
+        frame: null,
+        hasData: false,
+      });
+      await flushSignalUpdates();
+      expect(applyCalls).toEqual([]);
+
+      second.resolve({
+        entries: [],
+        freqAxis: [],
+        frame: null,
+        hasData: false,
+      });
+      await flushSignalUpdates();
+
+      expect(calls).toEqual(["0.3", "0.4"]);
+      expect(applyCalls).toEqual(["false"]);
     } finally {
       restoreDocument();
     }


### PR DESCRIPTION
## What changed
- profiled live dashboard path, confirmed spectrum frame prep was real hot path, left WS payload validation/adaptation on main thread
- added typed Comlink worker path for spectrum frame preparation with shared prep core, worker entry, and runtime client wrapper
- moved production ownership into `UiSpectrumController`, including worker startup, stale-result coalescing, teardown, and surfaced worker failure state
- kept `SpectrumCanvasRenderer` on prepared-frame composition/rendering only, updated docs/i18n, and rewired focused tests onto extracted prep core

## Why
- `SpectrumCanvasRenderer.prepareFrame()` was hottest measured step under representative live load
- offloading interpolation + dB conversion keeps live dashboard responsive without duplicating ownership paths
- controller/runtime is right place to own worker lifecycle and error handling

## Validation
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run test:unit`
- `cd apps/ui && npm run test:visual`

## Risks / tradeoffs
- inbound spectra still cross worker boundary by structured clone; outbound prepared frequency/series buffers use transferable `Float64Array` payloads
- renderer-focused tests now call shared prep core directly; production runtime no longer uses renderer-owned prep path
- stale worker results are dropped so newest spectrum frame wins under load

Closes #2974
