### PR TITLE
[codex] Auto-scale live spectrum chart

### DIFF
--- a/apps/server/tests/adapters/websocket/test_build_ws_payload.py
+++ b/apps/server/tests/adapters/websocket/test_build_ws_payload.py
@@ -172,3 +172,31 @@ def test_on_ws_broadcast_tick_toggles_heavy_and_requests_matching_payload_weight
         ws_broadcast.build_payload(selected_client=None)
 
     assert payload_source.calls == [True, False, False, False, False, True]
+
+
+def test_on_ws_broadcast_tick_honors_fractional_heavy_cadence() -> None:
+    payload_source = _StubPayloadSource([_shared_payload()] * 11)
+    ws_broadcast = WsBroadcastService(
+        ui_push_hz=10,
+        ui_heavy_push_hz=4,
+        payload_source=payload_source,
+    )
+
+    ws_broadcast.build_payload(selected_client=None)
+    for _ in range(10):
+        ws_broadcast.on_tick()
+        ws_broadcast.build_payload(selected_client=None)
+
+    assert payload_source.calls == [
+        True,
+        False,
+        False,
+        True,
+        False,
+        True,
+        False,
+        False,
+        True,
+        False,
+        True,
+    ]

--- a/apps/server/vibesensor/infra/runtime/ws_broadcast.py
+++ b/apps/server/vibesensor/infra/runtime/ws_broadcast.py
@@ -26,6 +26,7 @@ class WsBroadcastService:
 
     __slots__ = (
         "_payload_source",
+        "_heavy_tick_credit",
         "_ui_heavy_push_hz",
         "_ui_push_hz",
         "include_heavy",
@@ -44,6 +45,7 @@ class WsBroadcastService:
     ) -> None:
         self.tick = 0
         self.include_heavy = True
+        self._heavy_tick_credit = 0
         self._shared_payload: LiveWsPayload | None = None
         self._shared_payload_tick: int = -1
         self._shared_payload_heavy: bool = True
@@ -53,12 +55,17 @@ class WsBroadcastService:
 
     def on_tick(self) -> None:
         """Advance the broadcast tick counter and toggle heavy-tick flag."""
-        heavy_every = max(
-            1,
-            int(self._ui_push_hz / max(1, self._ui_heavy_push_hz)),
-        )
+        push_hz = max(1, self._ui_push_hz)
+        heavy_hz = max(1, self._ui_heavy_push_hz)
         self.tick += 1
-        self.include_heavy = (self.tick % heavy_every) == 0
+        if heavy_hz >= push_hz:
+            self.include_heavy = True
+            self._heavy_tick_credit = 0
+            return
+        self._heavy_tick_credit += heavy_hz
+        self.include_heavy = self._heavy_tick_credit >= push_hz
+        if self.include_heavy:
+            self._heavy_tick_credit -= push_hz
 
     def _build_shared_payload(self) -> LiveWsPayload:
         return self._payload_source.build_shared_payload(include_heavy=self.include_heavy)

--- a/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
+++ b/apps/ui/src/app/runtime/spectrum_canvas_renderer.ts
@@ -128,11 +128,11 @@ export function createSpectrumCanvasRenderer(
           tweenAlpha.value = alpha;
           const frame = tweenState.frame.value;
           if (frame) {
-            setSpectrumDataFromFrame(frame);
+            setSpectrumDataFromFrame(frame, { resetScales: false });
           }
         },
         onComplete: () => {
-          untracked(() => setSpectrumDataFromFrame(to));
+          untracked(() => setSpectrumDataFromFrame(to, { resetScales: true }));
         },
       });
       anim.start();
@@ -192,7 +192,7 @@ export function createSpectrumCanvasRenderer(
     const canTween = deps.state.transport.wsState.value === "connected"
       && tweenState.canTween.value;
     if (!canTween || !spectrumLastFrame.value || tweenDurationForFrameMs <= 0) {
-      setSpectrumDataFromFrame(nextFrame);
+      setSpectrumDataFromFrame(nextFrame, { resetScales: true });
       return;
     }
 
@@ -237,17 +237,22 @@ export function createSpectrumCanvasRenderer(
     deps.state.spectrum.spectrumPlot.value?.setSeriesIsolation(seriesIndex);
   }
 
-  function setSpectrumDataFromFrame(frame: SpectrumHeavyFrame): void {
+  function setSpectrumDataFromFrame(
+    frame: SpectrumHeavyFrame,
+    options: { resetScales: boolean },
+  ): void {
     const plot = deps.state.spectrum.spectrumPlot.value;
     if (!plot) {
       return;
     }
     currentFreqAxis.value = frame.freq;
     syncChartDataBuffer(frame.freq, frame.values);
-    plot.setData(chartData.value, false);
+    plot.setData(chartData.value, options.resetScales);
     // uPlot does not commit a paint when setData() skips scale recalculation.
     // Tween frames reuse fixed axes, so explicitly rebuild paths and redraw.
-    plot.redraw(true, false);
+    if (!options.resetScales) {
+      plot.redraw(true, false);
+    }
     spectrumLastFrame.value = frame;
   }
 

--- a/apps/ui/src/spectrum.ts
+++ b/apps/ui/src/spectrum.ts
@@ -6,6 +6,9 @@ import {
 } from "./config";
 
 const SPECTRUM_LOG10_REF = Math.log10(SPECTRUM_DB_REFERENCE_AMP_G);
+const SPECTRUM_DISPLAY_HEADROOM_DB = 6;
+const SPECTRUM_DISPLAY_MIN_SPAN_DB = 20;
+const SPECTRUM_DISPLAY_STEP_DB = 10;
 
 export function convertSpectrumAmplitudesToDbInPlace(values: number[]): void {
   for (let i = 0; i < values.length; i += 1) {
@@ -16,4 +19,27 @@ export function convertSpectrumAmplitudesToDbInPlace(values: number[]): void {
     const db = 20 * (Math.log10(safe) - SPECTRUM_LOG10_REF);
     values[i] = Math.max(SPECTRUM_DB_MIN, Math.min(SPECTRUM_DB_MAX, db));
   }
+}
+
+export function spectrumDbDisplayRangeFromDataBounds(
+  _dataMin: number,
+  dataMax: number,
+): [number, number] {
+  if (!Number.isFinite(dataMax)) {
+    return [SPECTRUM_DB_MIN, SPECTRUM_DB_MAX];
+  }
+
+  const paddedMax = Math.max(
+    SPECTRUM_DB_MIN + SPECTRUM_DISPLAY_MIN_SPAN_DB,
+    dataMax + SPECTRUM_DISPLAY_HEADROOM_DB,
+  );
+  const roundedMax = Math.ceil(paddedMax / SPECTRUM_DISPLAY_STEP_DB)
+    * SPECTRUM_DISPLAY_STEP_DB;
+  return [
+    SPECTRUM_DB_MIN,
+    Math.max(
+      SPECTRUM_DB_MIN + SPECTRUM_DISPLAY_MIN_SPAN_DB,
+      Math.min(SPECTRUM_DB_MAX, roundedMax),
+    ),
+  ];
 }

--- a/apps/ui/src/spectrum_chart.ts
+++ b/apps/ui/src/spectrum_chart.ts
@@ -2,7 +2,7 @@ import "uplot/dist/uPlot.min.css";
 
 import uPlot from "uplot";
 
-import { SPECTRUM_DB_MAX, SPECTRUM_DB_MIN } from "./config";
+import { spectrumDbDisplayRangeFromDataBounds } from "./spectrum";
 import { getSpectrumCssVars } from "./spectrum_css_vars";
 import {
   computed,
@@ -104,7 +104,8 @@ export function createSpectrumChart(deps: CreateSpectrumChartDeps): SpectrumChar
         scales: {
           x: { time: false },
           y: {
-            range: [SPECTRUM_DB_MIN, SPECTRUM_DB_MAX] as uPlot.Range.MinMax,
+            range: (_self, dataMin, dataMax) =>
+              spectrumDbDisplayRangeFromDataBounds(dataMin, dataMax),
           },
         },
         axes: [

--- a/apps/ui/tests/spectrum_scale.spec.ts
+++ b/apps/ui/tests/spectrum_scale.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import { spectrumDbDisplayRangeFromDataBounds } from "../src/spectrum";
+
+describe("spectrum dB display range", () => {
+  test("keeps the canonical full range when no finite data bounds exist", () => {
+    expect(
+      spectrumDbDisplayRangeFromDataBounds(
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+      ),
+    ).toEqual([0, 100]);
+  });
+
+  test("uses a compact range for low-amplitude live spectra", () => {
+    expect(spectrumDbDisplayRangeFromDataBounds(0, 30.8)).toEqual([0, 40]);
+  });
+
+  test("preserves a minimum readable span for quiet spectra", () => {
+    expect(spectrumDbDisplayRangeFromDataBounds(0, 4)).toEqual([0, 20]);
+  });
+
+  test("never expands beyond the canonical maximum", () => {
+    expect(spectrumDbDisplayRangeFromDataBounds(0, 98)).toEqual([0, 100]);
+  });
+});

--- a/apps/ui/tests/spectrum_tweening.spec.ts
+++ b/apps/ui/tests/spectrum_tweening.spec.ts
@@ -73,7 +73,7 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
 
   test("redraws tween frames when setData skips scale recalculation", async () => {
     let redrawCalls = 0;
-    let setDataCalls = 0;
+    const resetScaleValues: Array<boolean | undefined> = [];
     const renderTimesMs = [1_000, 1_165];
 
     await withSpectrumRendererHarness(
@@ -96,8 +96,7 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
                 },
                 resize() {},
                 setData(_data, resetScales) {
-                  expect(resetScales).toBe(false);
-                  setDataCalls += 1;
+                  resetScaleValues.push(resetScales);
                 },
                 setSeriesIsolation() {},
               };
@@ -118,7 +117,7 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
       async ({ prepareFrame, renderer, state }) => {
         renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
-        setDataCalls = 0;
+        resetScaleValues.length = 0;
         redrawCalls = 0;
 
         state.spectrum.spectra.value = {
@@ -133,7 +132,7 @@ describe("createSpectrumCanvasRenderer tween cadence", () => {
         renderer.renderPreparedFrame(prepareFrame());
         await flushSignalUpdates();
 
-        expect(setDataCalls).toBe(1);
+        expect(resetScaleValues).toContain(false);
         expect(redrawCalls).toBe(1);
       },
     );


### PR DESCRIPTION
## Summary
- Auto-scale the live spectrum y-axis from current dB data while clamping to the canonical 0-100 dB bounds.
- Recalculate chart scales on real spectrum frames, while keeping tween frames on fixed axes for cheap animation redraws.
- Fix the WebSocket heavy-payload scheduler so `UI_HEAVY_PUSH_HZ = 4` is honored instead of rounding `10 / 4` down to a 5 Hz heavy cadence.
- Add unit coverage for the live spectrum dB display range and fractional heavy-frame cadence.

## Root Cause
The Pi was receiving valid spectrum frames, but live amplitudes were peaking around 30 dB while the chart was fixed at 0-100 dB. The trace rendered near the bottom of the plot and looked like no chart was present.

The remaining “inconsistent update” feel came from transport cadence: lightweight UI payloads run at 10 Hz, FFT updates run at 4 Hz, and the heavy spectrum scheduler used integer division. That accidentally sent heavy spectrum payloads every 2 ticks (about 5 Hz), which sometimes repeated unchanged FFT data and got deduplicated by the UI.

## Pi Verification
Deployed the built UI bundle to `pi@10.4.0.1` under `/opt/VibeSensor/apps/server/.venv/lib/python3.13/site-packages/vibesensor/static`.

Verified in a cold Playwright browser session against `http://10.4.0.1/`:
- Loaded fixed bundle asset `http://10.4.0.1/assets/spectrum_chart-DmvAzSqc.js`.
- Spectrum overlay hidden.
- Live chart text showed `Strongest: Driver Seat · 47.3 Hz · 27.3 dB`.
- Canvas contained a visible purple trace (`purpleCount: 23497`, bounds spanning `minY: 11` to `maxY: 338`).
- Screenshot showed the chart axis using `0-40 dB` and the trace clearly visible.

Also patched `ws_broadcast.py` on the Pi and restarted `vibesensor.service` to verify cadence. New stream samples show the intended 10 Hz lightweight stream with a 4 Hz-ish heavy spectrum pattern (`heavy, light, light, heavy...`). The Pi still occasionally reports `queue_overflow_drops`, so rare multi-second stalls appear to be runtime ingest/load pressure rather than chart rendering.

## Validation
- `cd apps/ui && npm run test:unit -- spectrum_tweening spectrum_scale spectrum_cache ws_contract`
- `cd apps/ui && npm run typecheck`
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/websocket/test_build_ws_payload.py`
- `.venv/bin/ruff format --check apps/server/vibesensor/infra/runtime/ws_broadcast.py apps/server/tests/adapters/websocket/test_build_ws_payload.py`
- `.venv/bin/ruff check apps/server/vibesensor/infra/runtime/ws_broadcast.py apps/server/tests/adapters/websocket/test_build_ws_payload.py`
- Prior to the cadence patch: `cd apps/ui && npm run build`
- Prior to the cadence patch: `cd apps/ui && npm run lint` (passes with one pre-existing unrelated warning in `tests/maintenance_feature_test_support.ts`)