### PR TITLE
Make websocket ingress signal-native

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -110,6 +110,19 @@ Frontend server-state ownership is centralized on the runtime-owned
   narrow allowed exception is one-off browser-owned side effects such as binary
   file downloads that are not cacheable server state.
 
+## Live transport ownership
+
+Frontend live transport ingress is signal-native end to end.
+
+- `src/ws.ts` owns raw WebSocket lifecycle, reconnect/stale timers, and the
+  latest raw payload signal from the socket.
+- `src/app/runtime/ui_live_transport_controller.ts` owns the reactive bridge
+  from that socket signal into `AppState.transport`, client-selection sends, and
+  payload application into the runtime state slices.
+- Keep render throttling/RAF pacing only where it is explicitly needed for
+  spectrum or DOM performance. Do not reintroduce callback-style payload fan-out
+  from `ws.ts` into app/runtime consumers.
+
 ## Worker-owned spectrum frame preparation
 
 Live spectrum payload adaptation stays on the main thread, but heavy spectrum

--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -3,7 +3,7 @@ import { composeVehicleSettings, type AppState } from "./ui_app_state";
 import { batch } from "./ui_signals";
 
 type DemoDeps = {
-  queueTransportPayload(payload: unknown): void;
+  ingestTransportPayload(payload: unknown): void;
   state: Pick<AppState, "settings">;
 };
 
@@ -198,7 +198,7 @@ export function runDemoMode(deps: DemoDeps): void {
     ];
     state.settings.car.activeCarId.value = "demo-car-1";
   });
-  deps.queueTransportPayload(demoPayload);
+  deps.ingestTransportPayload(demoPayload);
 
   window.__vibesensorDemoCleanup = undefined;
 }

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -6,7 +6,7 @@ import {
   applyLivePayloadUpdate,
   type AppState,
 } from "../ui_app_state";
-import { batch, effect, effectOnChange, untracked } from "../ui_signals";
+import { batch, computed, effectOnChange, untracked } from "../ui_signals";
 
 type UiLiveTransportControllerDeps = {
   state: AppState;
@@ -26,6 +26,8 @@ export class UiLiveTransportController {
 
   private readonly disposeTransportStateSync: () => void;
 
+  private readonly disposeTransportIngressSync: () => void;
+
   private readonly disposePendingPayloadSync: () => void;
 
   private readonly disposeWsStateSync: () => void;
@@ -41,6 +43,7 @@ export class UiLiveTransportController {
     this.payloadErrorMessage = deps.payloadErrorMessage;
     const disposers = this.bindTransportSignalSync();
     this.disposeTransportStateSync = disposers.transportStateSync;
+    this.disposeTransportIngressSync = disposers.transportIngressSync;
     this.disposePendingPayloadSync = disposers.pendingPayloadSync;
     this.disposeWsStateSync = disposers.wsStateSync;
     this.disposeSelectionSync = disposers.selectionSync;
@@ -80,27 +83,34 @@ export class UiLiveTransportController {
     this.disposeSelectionSync();
     this.disposeWsStateSync();
     this.disposePendingPayloadSync();
+    this.disposeTransportIngressSync();
     this.disposeTransportStateSync();
   }
 
   private bindTransportSignalSync(): {
     pendingPayloadSync: () => void;
     selectionSync: () => void;
+    transportIngressSync: () => void;
     transportStateSync: () => void;
     wsStateSync: () => void;
   } {
-    const transportStateSync = effect(() => {
-      const ws = this.state.transport.ws.value;
-      if (!ws) {
+    const wsUiState = computed(() => this.state.transport.ws.value?.uiState.value ?? null);
+    const wsLatestPayload = computed(
+      () => this.state.transport.ws.value?.latestPayload.value ?? null,
+    );
+
+    const transportStateSync = effectOnChange(wsUiState, (nextWsState) => {
+      if (nextWsState === null || this.state.transport.wsState.value === nextWsState) {
         return;
       }
-      const nextWsState = ws.uiState.value;
-      if (this.state.transport.wsState.value === nextWsState) {
+      this.state.transport.wsState.value = nextWsState;
+    });
+
+    const transportIngressSync = effectOnChange(wsLatestPayload, (nextPayload) => {
+      if (nextPayload === null) {
         return;
       }
-      batch(() => {
-        this.state.transport.wsState.value = nextWsState;
-      });
+      this.ingestTransportPayload(nextPayload);
     });
 
     const pendingPayloadSync = effectOnChange(this.state.transport.pendingPayload, (nextPendingPayload) => {
@@ -125,6 +135,7 @@ export class UiLiveTransportController {
     return {
       pendingPayloadSync,
       selectionSync,
+      transportIngressSync,
       transportStateSync,
       wsStateSync,
     };
@@ -137,7 +148,7 @@ export class UiLiveTransportController {
     const isDemoMode = new URLSearchParams(window.location.search).has("demo");
     if (isDemoMode) {
       runDemoMode({
-        queueTransportPayload: (payload) => this.queueTransportPayload(payload),
+        ingestTransportPayload: (payload) => this.ingestTransportPayload(payload, "connected"),
         state: this.state,
       });
       return;
@@ -160,6 +171,8 @@ export class UiLiveTransportController {
         now - this.state.transport.lastRenderTsMs.value
         < this.state.transport.minRenderIntervalMs.value
       ) {
+        // Retain RAF pacing here for render/spectrum throughput, not because the
+        // transport ingress path still needs callback-style fan-out.
         this.queueRender();
         return;
       }
@@ -199,12 +212,17 @@ export class UiLiveTransportController {
     });
   }
 
-  private queueTransportPayload(payload: unknown): void {
+  private ingestTransportPayload(
+    payload: unknown,
+    wsState: "connected" | null = null,
+  ): void {
     if (this.disposed) {
       return;
     }
     batch(() => {
-      this.state.transport.wsState.value = "connected";
+      if (wsState !== null) {
+        this.state.transport.wsState.value = wsState;
+      }
       this.state.transport.hasReceivedPayload.value = true;
       this.state.transport.pendingPayload.value = payload;
     });
@@ -217,10 +235,6 @@ export class UiLiveTransportController {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     this.state.transport.ws.value = createWsClient({
       url: `${protocol}//${window.location.host}/ws`,
-      onMessage: (payload) => {
-        this.state.transport.hasReceivedPayload.value = true;
-        this.state.transport.pendingPayload.value = payload;
-      },
     });
     this.state.transport.ws.value.connect();
   }

--- a/apps/ui/src/ws.ts
+++ b/apps/ui/src/ws.ts
@@ -12,10 +12,10 @@ export interface WsClientOptions {
   staleAfterMs?: number;
   reconnectDelayMs?: number;
   hasData?: (payload: unknown) => boolean;
-  onMessage: (payload: unknown) => void;
 }
 
 export interface WsClient {
+  readonly latestPayload: ReadonlySignal<unknown | null>;
   readonly uiState: ReadonlySignal<WsUiState>;
   connect(): void;
   close(): void;
@@ -32,7 +32,7 @@ function hasSpectraClients(payload: unknown): boolean {
 }
 
 export function createWsClient(options: WsClientOptions): WsClient {
-  const resolvedOptions: Required<Omit<WsClientOptions, "onMessage">> & Pick<WsClientOptions, "onMessage"> = {
+  const resolvedOptions: Required<WsClientOptions> = {
     // 3s is too aggressive on weaker Pi + hotspot links and causes false stale flicker.
     staleAfterMs: 10000,
     reconnectDelayMs: 1200,
@@ -41,6 +41,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
   };
 
   let ws: WebSocket | null = null;
+  const latestPayload = signal<unknown | null>(null);
   const uiState = signal<WsUiState>("connecting");
   const lastMessageAtMs = signal(0);
   const hasReceivedData = signal(false);
@@ -55,6 +56,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
   let disposed = false;
 
   return {
+    latestPayload,
     uiState,
     connect,
     close,
@@ -108,6 +110,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
       commitState(initialState);
       hasReceivedData.value = false;
       lastMessageAtMs.value = 0;
+      latestPayload.value = null;
       socketOpen.value = false;
     });
     ws = new WebSocket(resolvedOptions.url);
@@ -132,7 +135,7 @@ export function createWsClient(options: WsClientOptions): WsClient {
         lastMessageAtMs.value = receivedAt;
         hasReceivedData.value = hasReceivedData.value || resolvedOptions.hasData(payload);
         commitState(hasReceivedData.value ? "connected" : "no_data");
-        resolvedOptions.onMessage(payload);
+        latestPayload.value = payload;
       });
     };
 

--- a/apps/ui/tests/demo_mode.spec.ts
+++ b/apps/ui/tests/demo_mode.spec.ts
@@ -16,7 +16,7 @@ describe("runDemoMode", () => {
     let queuedPayload: unknown = null;
 
     runDemoMode({
-      queueTransportPayload: (payload) => {
+      ingestTransportPayload: (payload) => {
         queuedPayload = payload;
       },
       state,

--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -84,9 +84,11 @@ describe("UiLiveTransportController", () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
     state.transport.ws.value = {
+      latestPayload: signal<LiveWsPayload | null>(null),
       uiState: signal("connecting"),
       close() {},
       connect() {},
+      dispose() {},
       send(selection: { client_id: string | null }) {
         sentSelections.push(selection);
       },
@@ -145,10 +147,13 @@ describe("UiLiveTransportController", () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
     const wsUiState = signal("connecting");
+    const latestPayload = signal<LiveWsPayload | null>(null);
     state.transport.ws.value = {
+      latestPayload,
       uiState: wsUiState,
       close() {},
       connect() {},
+      dispose() {},
       send(selection: { client_id: string | null }) {
         sentSelections.push(selection);
       },
@@ -176,10 +181,13 @@ describe("UiLiveTransportController", () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
     const wsUiState = signal("connecting");
+    const latestPayload = signal<LiveWsPayload | null>(null);
     state.transport.ws.value = {
+      latestPayload,
       uiState: wsUiState,
       close() {},
       connect() {},
+      dispose() {},
       send(selection: { client_id: string | null }) {
         sentSelections.push(selection);
       },
@@ -212,9 +220,11 @@ describe("UiLiveTransportController", () => {
     const state = createAppState();
     const sentSelections: Array<{ client_id: string | null }> = [];
     state.transport.ws.value = {
+      latestPayload: signal<LiveWsPayload | null>(null),
       uiState: signal("connected"),
       close() {},
       connect() {},
+      dispose() {},
       send(selection: { client_id: string | null }) {
         sentSelections.push(selection);
       },
@@ -234,9 +244,11 @@ describe("UiLiveTransportController", () => {
     const state = createAppState();
     const wsUiState = signal("connecting");
     state.transport.ws.value = {
+      latestPayload: signal<LiveWsPayload | null>(null),
       uiState: wsUiState,
       close() {},
       connect() {},
+      dispose() {},
       send() {},
     } as typeof state.transport.ws.value;
 
@@ -291,6 +303,45 @@ describe("UiLiveTransportController", () => {
       expect(state.spectrum.hasSpectrumData.value).toBe(true);
     } finally {
       restoreLocation();
+      raf.restore();
+    }
+  });
+
+  test("mirrors websocket ingress payloads through the shared transport slice", async () => {
+    const state = createAppState();
+    const latestPayload = signal<LiveWsPayload | null>(null);
+    state.transport.ws.value = {
+      latestPayload,
+      uiState: signal("connected"),
+      close() {},
+      connect() {},
+      dispose() {},
+      send() {},
+    } as typeof state.transport.ws.value;
+
+    const controller = new UiLiveTransportController({
+      state,
+      payloadErrorMessage: () => "payload error",
+    });
+    const raf = installRafHarness();
+    try {
+      latestPayload.value = makeLivePayload({
+        clients: [makeClient("client-1")],
+        speed_mps: 12,
+      });
+      await flushAsyncWork();
+
+      expect(state.transport.hasReceivedPayload.value).toBe(true);
+      expect(state.transport.pendingPayload.value).not.toBeNull();
+
+      raf.flushNext();
+      await flushAsyncWork();
+
+      expect(state.transport.pendingPayload.value).toBeNull();
+      expect(state.realtime.selectedClientId.value).toBe("client-1");
+      expect(state.realtime.speedMps.value).toBe(12);
+    } finally {
+      controller.dispose();
       raf.restore();
     }
   });

--- a/apps/ui/tests/ws.spec.ts
+++ b/apps/ui/tests/ws.spec.ts
@@ -1,6 +1,4 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import { createAppState } from "../src/app/ui_app_state";
-import { batch } from "../src/app/ui_signals";
 import { createWsClient } from "../src/ws";
 import { installWindowGlobal } from "./async_test_helpers";
 
@@ -104,19 +102,12 @@ describe("createWsClient", () => {
     FakeWebSocket.reset();
   });
 
-  test("exposes signal state and forwards queued payloads through onMessage", () => {
+  test("exposes signal state and stores the latest payload reactively", () => {
     const originalWebSocket = globalThis.WebSocket;
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
     try {
-      const state = createAppState();
       const client = createWsClient({
         url: "ws://example.test/ws",
-        onMessage: (payload) => {
-          batch(() => {
-            state.transport.hasReceivedPayload.value = true;
-            state.transport.pendingPayload.value = payload;
-          });
-        },
       });
 
       client.connect();
@@ -137,8 +128,7 @@ describe("createWsClient", () => {
       socket?.emitMessage(payload);
 
       expect(client.uiState.value).toBe("connected");
-      expect(state.transport.hasReceivedPayload.value).toBe(true);
-      expect(state.transport.pendingPayload.value).toEqual(payload);
+      expect(client.latestPayload.value).toEqual(payload);
 
       client.close();
     } finally {
@@ -157,7 +147,6 @@ describe("createWsClient", () => {
       const client = createWsClient({
         url: "ws://example.test/ws",
         staleAfterMs: 10,
-        onMessage: () => undefined,
       });
 
       client.connect();
@@ -208,7 +197,6 @@ describe("createWsClient", () => {
     try {
       const client = createWsClient({
         url: "ws://example.test/ws",
-        onMessage: () => undefined,
       });
 
       client.connect();
@@ -238,7 +226,6 @@ describe("createWsClient", () => {
     try {
       const client = createWsClient({
         url: "ws://example.test/ws",
-        onMessage: () => undefined,
       });
 
       client.connect();


### PR DESCRIPTION
## what changed
- replace websocket callback delivery with signal-owned raw payload state on `WsClient`
- make `UiLiveTransportController` reactively mirror websocket ui-state and ingress payloads into `AppState.transport`
- keep demo mode on the same ingress helper instead of a second callback-shaped path
- document the live transport ownership model in the UI README and update focused transport tests

## why
Live transport was still mixed: `ws.ts` delivered payloads through callbacks while runtime state elsewhere was signal-based. This closes the remaining callback seam without rewriting the spectrum pacing path.

## validation
- `cd apps/ui && npm run test:unit -- tests/ws.spec.ts tests/ui_live_transport_controller.spec.ts tests/demo_mode.spec.ts tests/ui_live_payload_application.spec.ts`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run build`

## risks / tradeoffs
- RAF payload pacing stays in `UiLiveTransportController`; kept on purpose for render/spectrum throughput, not because transport ingress still needs imperative fan-out
- raw websocket payloads are still adapted on the controller side before app-state writes; this PR changes the ingress ownership seam, not the server payload contract

Closes #3029