### PR TITLE
[codex] Reduce GPS reconnect log load

### DIFF
--- a/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
+++ b/apps/server/tests/adapters/gps/test_gps_speed_run_loop.py
@@ -174,6 +174,11 @@ async def test_run_reconnects_on_connection_failure(
     await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=5.0)
 
     assert "GPS connection lost, retrying" in caplog.text
+    reconnect_records = [
+        record for record in caplog.records if "GPS connection lost, retrying" in record.message
+    ]
+    assert reconnect_records
+    assert all(record.exc_info is None for record in reconnect_records)
 
 
 @pytest.mark.asyncio

--- a/apps/server/vibesensor/adapters/gps/gps_transport_runner.py
+++ b/apps/server/vibesensor/adapters/gps/gps_transport_runner.py
@@ -112,7 +112,10 @@ class GPSTransportRunner:
                 LOGGER.warning(
                     "GPS connection lost, retrying in %gs: %s",
                     transition.sleep_before_retry,
-                    exc,
+                    str(exc) or type(exc).__name__,
+                )
+                LOGGER.debug(
+                    "GPS reconnect exception detail",
                     exc_info=True,
                 )
                 await asyncio.sleep(transition.sleep_before_retry)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Reduce routine GPS reconnect warnings from full exception tracebacks to one-line warnings.
- Keep traceback detail available at debug level for actual diagnosis.
- Add a regression assertion that reconnect warnings do not carry `exc_info`.

## Root cause
On the Pi, `gpsd` accepts the WATCH request but then repeatedly times out without TPV data. The reconnect loop logged each expected timeout with `exc_info=True`; the production formatter expanded that into a large traceback with locals. During investigation this produced roughly 1,200 journal lines in 2 minutes and lined up with periodic CPU/event-loop stalls.

## Pi verification
Before this patch:
- `/api/health` intermittently missed a 2s timeout while GPS timeout tracebacks were being emitted.
- GPS reconnects produced full tracebacks and `TimeoutError` stack dumps.
- Worker CPU had periodic near-core spikes during the traceback bursts.

After deploying this patch to `10.4.0.1`:
- `GET /` and `/api/health` return `200 OK`.
- 8 consecutive `/api/health` probes with `--max-time 2` succeeded.
- `max_tick_duration_s` stayed at ~0.064s in the sample.
- Journal sample: 4-6 GPS reconnect warnings, 0 `Traceback` lines.
- Worker sampled around 17-23% of one core, with total CPU mostly ~4-7% across the Pi.

## Validation
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/gps/test_gps_speed_run_loop.py::test_run_reconnects_on_connection_failure apps/server/tests/adapters/gps/test_gps_reconnect_backoff.py`
- `.venv/bin/ruff check apps/server/vibesensor/adapters/gps/gps_transport_runner.py apps/server/tests/adapters/gps/test_gps_speed_run_loop.py`
- `.venv/bin/ruff format --check apps/server/vibesensor/adapters/gps/gps_transport_runner.py apps/server/tests/adapters/gps/test_gps_speed_run_loop.py`
