### PR TITLE
perf(ui): split dashboard boot graph

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -4,25 +4,18 @@ import {
   createAppFeatureBundlePorts,
   createRealtimeFeatureRecordingPorts,
 } from "./app_feature_bundle_ports";
-import { createCarsFeature, type CarsFeature } from "./features/cars_feature";
-import { createEspFlashFeature } from "./features/esp_flash_feature";
-import { createHistoryFeature } from "./features/history_feature";
 import {
   createRealtimeFeature,
   type RealtimeFeatureChromePorts,
   type RealtimeFeatureSelectionPorts,
 } from "./features/realtime_feature";
-import {
-  createSettingsFeature,
-  type SettingsFeature,
-  type SettingsFeatureViewPorts,
-} from "./features/settings_feature";
-import { createUpdateFeature } from "./features/update_feature";
+import type { SettingsFeatureViewPorts } from "./features/settings_feature";
 import type { FeatureFormatting, FeatureServices } from "./feature_deps_base";
 import type { AppState } from "./ui_app_state";
 import type { UiMountedPanels } from "./ui_lazy_panels";
-import type { ReadonlySignal } from "./ui_signals";
+import { type ReadonlySignal } from "./ui_signals";
 import type { AppFeatureBundle } from "./app_feature_bundle_ports";
+import type { AppFeatureSecondaryBundle } from "./app_feature_secondary_bundle";
 export type { AppFeatureBundle } from "./app_feature_bundle_ports";
 
 export interface AppFeatureBundleSharedDeps {
@@ -50,6 +43,116 @@ export interface AppFeatureBundleDeps {
   runtime: AppFeatureBundleRuntimePorts;
 }
 
+interface LazySecondaryFeatureBundle {
+  dispose(): void;
+  ensureHistoryDataLoaded(): Promise<void>;
+  ensureSettingsDataLoaded(): Promise<void>;
+  openCarWizard(): Promise<void>;
+  refreshHistory(): Promise<void>;
+}
+
+function createLazySecondaryFeatureBundle(
+  deps: AppFeatureBundleDeps,
+): LazySecondaryFeatureBundle {
+  let bundle: AppFeatureSecondaryBundle | null = null;
+  let bundlePromise: Promise<AppFeatureSecondaryBundle> | null = null;
+  let historyLoadPromise: Promise<void> | null = null;
+  let settingsLoadPromise: Promise<void> | null = null;
+  let historyLoaded = false;
+  let settingsLoaded = false;
+  let disposed = false;
+
+  function ensureLoaded(): Promise<AppFeatureSecondaryBundle> {
+    if (bundle !== null) {
+      return Promise.resolve(bundle);
+    }
+    if (bundlePromise !== null) {
+      return bundlePromise;
+    }
+    bundlePromise = import("./app_feature_secondary_bundle")
+      .then(({ createAppFeatureSecondaryBundle }) => {
+        const nextBundle = createAppFeatureSecondaryBundle(deps);
+        if (disposed) {
+          nextBundle.dispose();
+          return nextBundle;
+        }
+        bundle = nextBundle;
+        return nextBundle;
+      })
+      .catch((error) => {
+        bundlePromise = null;
+        throw error;
+      });
+    return bundlePromise;
+  }
+
+  function ensureSettingsDataLoaded(): Promise<void> {
+    if (settingsLoaded || disposed) {
+      return Promise.resolve();
+    }
+    if (settingsLoadPromise !== null) {
+      return settingsLoadPromise;
+    }
+    settingsLoadPromise = (async () => {
+      const loadedBundle = await ensureLoaded();
+      if (disposed) {
+        return;
+      }
+      await Promise.all([
+        loadedBundle.settings.loadSpeedSourceFromServer(),
+        loadedBundle.settings.loadAnalysisSettingsFromServer(),
+        loadedBundle.settings.loadCarsFromServer(),
+      ]);
+      settingsLoaded = true;
+    })().catch((error) => {
+      settingsLoadPromise = null;
+      throw error;
+    });
+    return settingsLoadPromise;
+  }
+
+  function ensureHistoryDataLoaded(): Promise<void> {
+    if (historyLoaded || disposed) {
+      return Promise.resolve();
+    }
+    if (historyLoadPromise !== null) {
+      return historyLoadPromise;
+    }
+    historyLoadPromise = (async () => {
+      const loadedBundle = await ensureLoaded();
+      if (disposed) {
+        return;
+      }
+      await loadedBundle.history.refreshHistory();
+      historyLoaded = true;
+    })().catch((error) => {
+      historyLoadPromise = null;
+      throw error;
+    });
+    return historyLoadPromise;
+  }
+
+  return {
+    dispose(): void {
+      disposed = true;
+      bundle?.dispose();
+      bundle = null;
+    },
+    ensureHistoryDataLoaded,
+    ensureSettingsDataLoaded,
+    openCarWizard(): Promise<void> {
+      return ensureLoaded().then((loadedBundle) => {
+        if (!disposed) {
+          loadedBundle.openCarWizard();
+        }
+      });
+    },
+    refreshHistory(): Promise<void> {
+      return ensureLoaded().then((loadedBundle) => loadedBundle.history.refreshHistory());
+    },
+  };
+}
+
 export function createAppFeatureBundle(
   deps: AppFeatureBundleDeps,
 ): AppFeatureBundle {
@@ -59,18 +162,22 @@ export function createAppFeatureBundle(
     runtime,
   } = deps;
   const { panels } = runtime;
+  const secondary = createLazySecondaryFeatureBundle(deps);
+  const reportSecondaryLoadError = (error: unknown): void => {
+    services.showError(
+      error instanceof Error ? error.message : services.t("status.view_load_failed"),
+    );
+  };
+  const ensureSecondaryViewReady = (viewId: string): Promise<void> => {
+    if (viewId === "historyView") {
+      return secondary.ensureHistoryDataLoaded();
+    }
+    if (viewId === "settingsView") {
+      return secondary.ensureSettingsDataLoaded();
+    }
+    return Promise.resolve();
+  };
 
-  const history = createHistoryFeature({
-    history: state.history,
-    shell: state.shell,
-    panel: panels.history,
-    navigation: runtime.navigation,
-    services,
-    formatting,
-    queryClient: serverState.queryClient,
-  });
-
-  let carsFeature: CarsFeature | null = null;
   const realtime = createRealtimeFeature({
     state: {
       realtime: state.realtime,
@@ -91,11 +198,11 @@ export function createAppFeatureBundle(
         activatePrimaryView: runtime.navigation.activatePrimaryView,
         activateSettingsTab: (tabId) => panels.settingsShell.activateTab(tabId),
         openCarWizard: () => {
-          carsFeature?.openWizard();
+          void secondary.openCarWizard().catch(reportSecondaryLoadError);
         },
       },
       selection: runtime.transport,
-      recording: createRealtimeFeatureRecordingPorts(history),
+      recording: createRealtimeFeatureRecordingPorts(() => secondary.refreshHistory()),
     },
     services,
     formatting: {
@@ -104,73 +211,12 @@ export function createAppFeatureBundle(
     queryClient: serverState.queryClient,
   });
 
-  const settings: SettingsFeature = createSettingsFeature({
-    state: {
-      settings: state.settings,
-      shell: state.shell,
-    },
-    panels: {
-      settingsShell: panels.settingsShell,
-      analysisPanel: panels.settings.analysis,
-      carsPanel: panels.settings.cars.list,
-      speedSourcePanel: panels.settings.speedSource,
-    },
-    ports: {
-      openCarWizard: () => {
-        carsFeature?.openWizard();
-      },
-      activeViewId: runtime.navigation.activeViewId,
-      view: runtime.view,
-    },
-    services,
-    formatting: {
-      fmt: formatting.fmt,
-    },
-    queryClient: serverState.queryClient,
-  });
-
-  const cars: CarsFeature = createCarsFeature({
-    panel: panels.settings.cars.wizard,
-    services: {
-      t: services.t,
-    },
-    formatting: {
-      fmt: formatting.fmt,
-    },
-    queryClient: serverState.queryClient,
-    addCarFromWizard: (name, carType, aspects, variant) =>
-      settings.addCarFromWizard(name, carType, aspects, variant),
-  });
-  carsFeature = cars;
-
-  const update = createUpdateFeature({
-    panels: {
-      update: panels.settings.update,
-      internet: panels.settings.internet,
-    },
-    ports: {
-      activeViewId: runtime.navigation.activeViewId,
-      activeSettingsTabId: panels.settingsShell.activeTabId,
-    },
-    services,
-    queryClient: serverState.queryClient,
-  });
-  const espFlash = createEspFlashFeature({
-    panel: panels.settings.espFlash,
-    ports: {
-      activeViewId: runtime.navigation.activeViewId,
-      activeSettingsTabId: panels.settingsShell.activeTabId,
-    },
-    services,
-    queryClient: serverState.queryClient,
-  });
-
   return createAppFeatureBundlePorts({
-    history,
     realtime,
-    settings,
-    cars,
-    update,
-    espFlash,
+    secondary,
+    ensureViewReady: (viewId) => ensureSecondaryViewReady(viewId).catch((error) => {
+      reportSecondaryLoadError(error);
+      throw error;
+    }),
   });
 }

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -16,6 +16,8 @@ import type { UiMountedPanels } from "./ui_lazy_panels";
 import { type ReadonlySignal } from "./ui_signals";
 import type { AppFeatureBundle } from "./app_feature_bundle_ports";
 import type { AppFeatureSecondaryBundle } from "./app_feature_secondary_bundle";
+import { preloadHistoryLazyView } from "./views/history_lazy_view";
+import { preloadSettingsLazyView } from "./views/settings_lazy_view";
 export type { AppFeatureBundle } from "./app_feature_bundle_ports";
 
 export interface AppFeatureBundleSharedDeps {
@@ -45,6 +47,7 @@ export interface AppFeatureBundleDeps {
 
 interface LazySecondaryFeatureBundle {
   dispose(): void;
+  ensureDashboardDataLoaded(): Promise<void>;
   ensureHistoryDataLoaded(): Promise<void>;
   ensureSettingsDataLoaded(): Promise<void>;
   openCarWizard(): Promise<void>;
@@ -56,8 +59,10 @@ function createLazySecondaryFeatureBundle(
 ): LazySecondaryFeatureBundle {
   let bundle: AppFeatureSecondaryBundle | null = null;
   let bundlePromise: Promise<AppFeatureSecondaryBundle> | null = null;
+  let dashboardDataLoadPromise: Promise<void> | null = null;
   let historyLoadPromise: Promise<void> | null = null;
   let settingsLoadPromise: Promise<void> | null = null;
+  let dashboardDataLoaded = false;
   let historyLoaded = false;
   let settingsLoaded = false;
   let disposed = false;
@@ -101,7 +106,6 @@ function createLazySecondaryFeatureBundle(
       await Promise.all([
         loadedBundle.settings.loadSpeedSourceFromServer(),
         loadedBundle.settings.loadAnalysisSettingsFromServer(),
-        loadedBundle.settings.loadCarsFromServer(),
       ]);
       settingsLoaded = true;
     })().catch((error) => {
@@ -109,6 +113,30 @@ function createLazySecondaryFeatureBundle(
       throw error;
     });
     return settingsLoadPromise;
+  }
+
+  function ensureDashboardDataLoaded(): Promise<void> {
+    if (dashboardDataLoaded || disposed) {
+      return Promise.resolve();
+    }
+    if (dashboardDataLoadPromise !== null) {
+      return dashboardDataLoadPromise;
+    }
+    dashboardDataLoadPromise = (async () => {
+      const loadedBundle = await ensureLoaded();
+      if (disposed) {
+        return;
+      }
+      await Promise.all([
+        loadedBundle.settings.loadSpeedSourceFromServer(),
+        loadedBundle.settings.loadCarsFromServer(),
+      ]);
+      dashboardDataLoaded = true;
+    })().catch((error) => {
+      dashboardDataLoadPromise = null;
+      throw error;
+    });
+    return dashboardDataLoadPromise;
   }
 
   function ensureHistoryDataLoaded(): Promise<void> {
@@ -138,6 +166,7 @@ function createLazySecondaryFeatureBundle(
       bundle?.dispose();
       bundle = null;
     },
+    ensureDashboardDataLoaded,
     ensureHistoryDataLoaded,
     ensureSettingsDataLoaded,
     openCarWizard(): Promise<void> {
@@ -170,10 +199,16 @@ export function createAppFeatureBundle(
   };
   const ensureSecondaryViewReady = (viewId: string): Promise<void> => {
     if (viewId === "historyView") {
-      return secondary.ensureHistoryDataLoaded();
+      return Promise.all([
+        preloadHistoryLazyView(),
+        secondary.ensureHistoryDataLoaded(),
+      ]).then(() => undefined);
     }
     if (viewId === "settingsView") {
-      return secondary.ensureSettingsDataLoaded();
+      return Promise.all([
+        preloadSettingsLazyView(),
+        secondary.ensureSettingsDataLoaded(),
+      ]).then(() => undefined);
     }
     return Promise.resolve();
   };
@@ -213,10 +248,16 @@ export function createAppFeatureBundle(
 
   return createAppFeatureBundlePorts({
     realtime,
-    secondary,
     ensureViewReady: (viewId) => ensureSecondaryViewReady(viewId).catch((error) => {
       reportSecondaryLoadError(error);
       throw error;
     }),
+    secondary: {
+      dispose: () => secondary.dispose(),
+      primeDashboardState: () => secondary.ensureDashboardDataLoaded().catch((error) => {
+        reportSecondaryLoadError(error);
+        throw error;
+      }),
+    },
   });
 }

--- a/apps/ui/src/app/app_feature_bundle_ports.ts
+++ b/apps/ui/src/app/app_feature_bundle_ports.ts
@@ -23,6 +23,7 @@ interface AppFeatureBundlePortSources {
   >;
   secondary?: {
     dispose(): void;
+    primeDashboardState(): Promise<void>;
   };
   ensureViewReady?: (viewId: string) => Promise<void>;
 }
@@ -56,6 +57,9 @@ export function createAppFeatureBundlePorts(
       realtime: {
         refreshLocationOptions: () => features.realtime.refreshLocationOptions(),
         refreshLoggingStatus: () => features.realtime.refreshLoggingStatus(),
+      },
+      secondary: {
+        primeDashboardState: () => features.secondary?.primeDashboardState() ?? Promise.resolve(),
       },
     },
   };

--- a/apps/ui/src/app/app_feature_bundle_ports.ts
+++ b/apps/ui/src/app/app_feature_bundle_ports.ts
@@ -1,10 +1,6 @@
 import type { UiStartupFeaturePorts } from "./runtime/ui_startup_feature_ports";
-import type { CarsFeature } from "./features/cars_feature";
-import type { EspFlashFeature } from "./features/esp_flash_feature";
 import type { HistoryFeature } from "./features/history_feature";
 import type { RealtimeFeature, RealtimeFeatureRecordingPorts } from "./features/realtime_feature";
-import type { SettingsFeature } from "./features/settings_feature";
-import type { UpdateFeature } from "./features/update_feature";
 
 export interface AppShellFeatureBindings {
   bindHandlers(): void;
@@ -12,12 +8,12 @@ export interface AppShellFeatureBindings {
 
 export interface AppFeatureBundle {
   dispose(): void;
+  ensureViewReady(viewId: string): Promise<void>;
   shell: AppShellFeatureBindings;
   startup: UiStartupFeaturePorts;
 }
 
 interface AppFeatureBundlePortSources {
-  history: Pick<HistoryFeature, "bindHandlers" | "dispose" | "refreshHistory">;
   realtime: Pick<
     RealtimeFeature,
     | "bindHandlers"
@@ -25,25 +21,20 @@ interface AppFeatureBundlePortSources {
     | "refreshLocationOptions"
     | "refreshLoggingStatus"
   >;
-  settings: Pick<
-    SettingsFeature,
-    | "bindHandlers"
-    | "dispose"
-    | "syncSettingsInputs"
-    | "loadSpeedSourceFromServer"
-    | "loadAnalysisSettingsFromServer"
-    | "loadCarsFromServer"
-  >;
-  cars: Pick<CarsFeature, "bindWizardHandlers" | "dispose">;
-  update: Pick<UpdateFeature, "bindUpdateHandlers" | "dispose">;
-  espFlash: Pick<EspFlashFeature, "bindHandlers" | "dispose">;
+  secondary?: {
+    dispose(): void;
+  };
+  ensureViewReady?: (viewId: string) => Promise<void>;
 }
 
 export function createRealtimeFeatureRecordingPorts(
-  history: Pick<HistoryFeature, "refreshHistory">,
+  history: Pick<HistoryFeature, "refreshHistory"> | (() => Promise<void>),
 ): RealtimeFeatureRecordingPorts {
+  const refreshHistory = typeof history === "function"
+    ? history
+    : () => history.refreshHistory();
   return {
-    onRecordingStatusChanged: () => history.refreshHistory(),
+    onRecordingStatusChanged: () => refreshHistory(),
   };
 }
 
@@ -52,36 +43,19 @@ export function createAppFeatureBundlePorts(
 ): AppFeatureBundle {
   return {
     dispose: () => {
-      features.espFlash.dispose();
-      features.update.dispose();
-      features.history.dispose();
+      features.secondary?.dispose();
       features.realtime.dispose();
-      features.settings.dispose();
-      features.cars.dispose();
     },
+    ensureViewReady: (viewId) => features.ensureViewReady?.(viewId) ?? Promise.resolve(),
     shell: {
       bindHandlers: () => {
-        features.settings.bindHandlers();
-        features.cars.bindWizardHandlers();
         features.realtime.bindHandlers();
-        features.history.bindHandlers();
-        features.update.bindUpdateHandlers();
-        features.espFlash.bindHandlers();
       },
     },
     startup: {
-      history: {
-        refreshHistory: () => features.history.refreshHistory(),
-      },
       realtime: {
         refreshLocationOptions: () => features.realtime.refreshLocationOptions(),
         refreshLoggingStatus: () => features.realtime.refreshLoggingStatus(),
-      },
-      settings: {
-        loadSpeedSourceFromServer: () => features.settings.loadSpeedSourceFromServer(),
-        loadAnalysisSettingsFromServer: () =>
-          features.settings.loadAnalysisSettingsFromServer(),
-        loadCarsFromServer: () => features.settings.loadCarsFromServer(),
       },
     },
   };

--- a/apps/ui/src/app/app_feature_secondary_bundle.ts
+++ b/apps/ui/src/app/app_feature_secondary_bundle.ts
@@ -1,0 +1,129 @@
+import { createCarsFeature, type CarsFeature } from "./features/cars_feature";
+import { createEspFlashFeature } from "./features/esp_flash_feature";
+import { createHistoryFeature, type HistoryFeature } from "./features/history_feature";
+import { createSettingsFeature, type SettingsFeature } from "./features/settings_feature";
+import { createUpdateFeature } from "./features/update_feature";
+import type { AppFeatureBundleDeps } from "./app_feature_bundle";
+
+export interface AppFeatureSecondaryBundle {
+  dispose(): void;
+  history: Pick<HistoryFeature, "refreshHistory">;
+  openCarWizard(): void;
+  settings: Pick<
+    SettingsFeature,
+    | "loadAnalysisSettingsFromServer"
+    | "loadCarsFromServer"
+    | "loadSpeedSourceFromServer"
+  >;
+}
+
+export function createAppFeatureSecondaryBundle(
+  deps: AppFeatureBundleDeps,
+): AppFeatureSecondaryBundle {
+  const {
+    state,
+    shared: { services, formatting, serverState },
+    runtime,
+  } = deps;
+  const { panels } = runtime;
+
+  const history = createHistoryFeature({
+    history: state.history,
+    shell: state.shell,
+    panel: panels.history,
+    navigation: runtime.navigation,
+    services,
+    formatting,
+    queryClient: serverState.queryClient,
+  });
+
+  let carsFeature: CarsFeature | null = null;
+  const settings = createSettingsFeature({
+    state: {
+      settings: state.settings,
+      shell: state.shell,
+    },
+    panels: {
+      settingsShell: panels.settingsShell,
+      analysisPanel: panels.settings.analysis,
+      carsPanel: panels.settings.cars.list,
+      speedSourcePanel: panels.settings.speedSource,
+    },
+    ports: {
+      openCarWizard: () => {
+        carsFeature?.openWizard();
+      },
+      activeViewId: runtime.navigation.activeViewId,
+      view: runtime.view,
+    },
+    services,
+    formatting: {
+      fmt: formatting.fmt,
+    },
+    queryClient: serverState.queryClient,
+  });
+
+  const cars = createCarsFeature({
+    panel: panels.settings.cars.wizard,
+    services: {
+      t: services.t,
+    },
+    formatting: {
+      fmt: formatting.fmt,
+    },
+    queryClient: serverState.queryClient,
+    addCarFromWizard: (name, carType, aspects, variant) =>
+      settings.addCarFromWizard(name, carType, aspects, variant),
+  });
+  carsFeature = cars;
+
+  const update = createUpdateFeature({
+    panels: {
+      update: panels.settings.update,
+      internet: panels.settings.internet,
+    },
+    ports: {
+      activeViewId: runtime.navigation.activeViewId,
+      activeSettingsTabId: panels.settingsShell.activeTabId,
+    },
+    services,
+    queryClient: serverState.queryClient,
+  });
+
+  const espFlash = createEspFlashFeature({
+    panel: panels.settings.espFlash,
+    ports: {
+      activeViewId: runtime.navigation.activeViewId,
+      activeSettingsTabId: panels.settingsShell.activeTabId,
+    },
+    services,
+    queryClient: serverState.queryClient,
+  });
+
+  settings.bindHandlers();
+  cars.bindWizardHandlers();
+  history.bindHandlers();
+  update.bindUpdateHandlers();
+  espFlash.bindHandlers();
+
+  return {
+    dispose(): void {
+      espFlash.dispose();
+      update.dispose();
+      history.dispose();
+      settings.dispose();
+      cars.dispose();
+    },
+    history: {
+      refreshHistory: () => history.refreshHistory(),
+    },
+    openCarWizard(): void {
+      cars.openWizard();
+    },
+    settings: {
+      loadSpeedSourceFromServer: () => settings.loadSpeedSourceFromServer(),
+      loadAnalysisSettingsFromServer: () => settings.loadAnalysisSettingsFromServer(),
+      loadCarsFromServer: () => settings.loadCarsFromServer(),
+    },
+  };
+}

--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -2,13 +2,15 @@ import type { QueryClient } from "@tanstack/query-core";
 
 import {
   getClientLocations as getClientLocationsApi,
-  getLoggingStatus as getLoggingStatusApi,
   identifyClient as identifyClientApi,
   removeClient as removeClientApi,
   setClientLocation as setClientLocationApi,
+} from "../../api/clients";
+import {
+  getLoggingStatus as getLoggingStatusApi,
   startLoggingRun as startLoggingRunApi,
   stopLoggingRun as stopLoggingRunApi,
-} from "../../api";
+} from "../../api/logging";
 import { defaultLocationCodes } from "../../constants";
 import type {
   ClientLocationsResponse,

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -180,7 +180,7 @@ export function createSettingsFeature(
     try {
       await speedSourceModule.loadSpeedSourceFromServer();
     } finally {
-      gpsStatusModule.markStartupReady();
+      await gpsStatusModule.markStartupReady();
     }
   }
 

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -43,7 +43,7 @@ interface GpsStatusSnapshot {
 export interface SettingsGpsStatusModule {
   bindHandlers(): void;
   dispose(): void;
-  markStartupReady(): void;
+  markStartupReady(): Promise<void>;
 }
 
 export function createSettingsGpsStatusModule(
@@ -115,8 +115,9 @@ export function createSettingsGpsStatusModule(
     dispose(): void {
       gpsStatusQuery.dispose();
     },
-    markStartupReady(): void {
+    markStartupReady(): Promise<void> {
       startupReady.value = true;
+      return gpsStatusQuery.fetch().then(() => undefined).catch(() => undefined);
     },
   };
 }

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -293,13 +293,18 @@ export function createSettingsSpeedSourceWorkflow(
     scheduleContextVisibilitySync();
   }
 
-  function applyPayload(payload: SpeedSourcePayload): void {
+  function applyPayload(
+    payload: SpeedSourcePayload,
+    options: { preserveResolvedSource?: boolean } = {},
+  ): void {
     batch(() => {
       deps.settings.speed.source.value = payload.speed_source;
       deps.settings.speed.manualSpeedKph.value = payload.manual_speed_kph;
       deps.settings.speed.obdDeviceMac.value = payload.obd_device_mac ?? null;
       deps.settings.speed.obdDeviceName.value = payload.obd_device_name ?? null;
-      deps.settings.speed.resolvedSource.value = null;
+      if (!options.preserveResolvedSource) {
+        deps.settings.speed.resolvedSource.value = null;
+      }
       staleTimeoutInputValue.value = String(payload.stale_timeout_s);
       syncInputsFromSettings();
     });
@@ -311,7 +316,7 @@ export function createSettingsSpeedSourceWorkflow(
       queryKey: serverStateQueryKeys.settings.speedSource(),
       staleTime: 0,
     });
-    applyPayload(payload);
+    applyPayload(payload, { preserveResolvedSource: true });
   }
 
   function handleSpeedSourceChanged(mode: DisplayedSpeedSourceMode): void {

--- a/apps/ui/src/app/runtime/ui_live_transport_controller.ts
+++ b/apps/ui/src/app/runtime/ui_live_transport_controller.ts
@@ -1,12 +1,46 @@
-import { adaptServerPayload } from "../../server_payload";
 import type { AdaptedPayload } from "../../transport/live_models";
-import { runDemoMode } from "../demo_mode";
-import { createWsClient } from "../../ws";
 import {
   applyLivePayloadUpdate,
   type AppState,
 } from "../ui_app_state";
 import { batch, computed, effectOnChange, untracked } from "../ui_signals";
+
+type AdaptServerPayload = typeof import("../../server_payload").adaptServerPayload;
+type LiveTransportRuntime = {
+  createWsClient: typeof import("../../ws").createWsClient;
+  runDemoMode: typeof import("../demo_mode").runDemoMode;
+};
+
+let liveTransportRuntimePromise: Promise<LiveTransportRuntime> | null = null;
+let payloadAdapterPromise: Promise<AdaptServerPayload> | null = null;
+
+function loadLiveTransportRuntime(): Promise<LiveTransportRuntime> {
+  if (liveTransportRuntimePromise === null) {
+    liveTransportRuntimePromise = Promise.all([
+      import("../../ws"),
+      import("../demo_mode"),
+    ]).then(([wsModule, demoModeModule]) => ({
+      createWsClient: wsModule.createWsClient,
+      runDemoMode: demoModeModule.runDemoMode,
+    })).catch((error) => {
+      liveTransportRuntimePromise = null;
+      throw error;
+    });
+  }
+  return liveTransportRuntimePromise;
+}
+
+function loadPayloadAdapter(): Promise<AdaptServerPayload> {
+  if (payloadAdapterPromise === null) {
+    payloadAdapterPromise = import("../../server_payload")
+      .then(({ adaptServerPayload }) => adaptServerPayload)
+      .catch((error) => {
+        payloadAdapterPromise = null;
+        throw error;
+      });
+  }
+  return payloadAdapterPromise;
+}
 
 type UiLiveTransportControllerDeps = {
   state: AppState;
@@ -36,6 +70,8 @@ export class UiLiveTransportController {
 
   private disposed = false;
 
+  private adaptServerPayload: AdaptServerPayload | null = null;
+
   private queuedRenderFrameId: number | null = null;
 
   constructor(deps: UiLiveTransportControllerDeps) {
@@ -47,6 +83,12 @@ export class UiLiveTransportController {
     this.disposePendingPayloadSync = disposers.pendingPayloadSync;
     this.disposeWsStateSync = disposers.wsStateSync;
     this.disposeSelectionSync = disposers.selectionSync;
+    void loadLiveTransportRuntime().catch((error) => {
+      console.error("[VibeSensor] Failed to preload websocket transport runtime.", error);
+    });
+    void this.preloadPayloadAdapter().catch((error) => {
+      console.error("[VibeSensor] Failed to preload live payload adapter.", error);
+    });
   }
 
   sendSelection(): void {
@@ -146,14 +188,18 @@ export class UiLiveTransportController {
       return;
     }
     const isDemoMode = new URLSearchParams(window.location.search).has("demo");
+    void this.preloadPayloadAdapter().catch((error) => {
+      console.error("[VibeSensor] Failed to preload live payload adapter.", error);
+    });
     if (isDemoMode) {
-      runDemoMode({
-        ingestTransportPayload: (payload) => this.ingestTransportPayload(payload, "connected"),
-        state: this.state,
+      void this.startDemoMode().catch((error) => {
+        console.error("[VibeSensor] Failed to start demo transport mode.", error);
       });
       return;
     }
-    this.connectWs();
+    void this.connectWs().catch((error) => {
+      console.error("[VibeSensor] Failed to load websocket transport runtime.", error);
+    });
   }
 
   private queueRender(): void {
@@ -190,6 +236,37 @@ export class UiLiveTransportController {
     if (this.disposed) {
       return;
     }
+    const adaptServerPayload = this.adaptServerPayload;
+    if (adaptServerPayload === null) {
+      void this.applyPayloadAsync(payload);
+      return;
+    }
+    this.applyPayloadWithAdapter(payload, adaptServerPayload);
+  }
+
+  private async applyPayloadAsync(payload: unknown): Promise<void> {
+    try {
+      const adaptServerPayload = await this.preloadPayloadAdapter();
+      if (this.disposed) {
+        return;
+      }
+      this.applyPayloadWithAdapter(payload, adaptServerPayload);
+    } catch (error) {
+      if (this.disposed) {
+        return;
+      }
+      batch(() => {
+        this.state.transport.payloadError.value =
+          error instanceof Error ? error.message : this.payloadErrorMessage();
+        this.state.spectrum.hasSpectrumData.value = false;
+      });
+    }
+  }
+
+  private applyPayloadWithAdapter(
+    payload: unknown,
+    adaptServerPayload: AdaptServerPayload,
+  ): void {
     let adapted: AdaptedPayload;
     try {
       adapted = adaptServerPayload(payload);
@@ -228,7 +305,31 @@ export class UiLiveTransportController {
     });
   }
 
-  private connectWs(): void {
+  private async startDemoMode(): Promise<void> {
+    const { runDemoMode } = await loadLiveTransportRuntime();
+    if (this.disposed) {
+      return;
+    }
+    runDemoMode({
+      ingestTransportPayload: (payload) => this.ingestTransportPayload(payload, "connected"),
+      state: this.state,
+    });
+  }
+
+  private async preloadPayloadAdapter(): Promise<AdaptServerPayload> {
+    if (this.adaptServerPayload !== null) {
+      return this.adaptServerPayload;
+    }
+    const adaptServerPayload = await loadPayloadAdapter();
+    this.adaptServerPayload = adaptServerPayload;
+    return adaptServerPayload;
+  }
+
+  private async connectWs(): Promise<void> {
+    if (this.disposed) {
+      return;
+    }
+    const { createWsClient } = await loadLiveTransportRuntime();
     if (this.disposed) {
       return;
     }

--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -51,6 +51,7 @@ type UiShellControllerDeps = {
   chrome: UiShellChromeView;
   chromeActions: Signal<UiShellChromeActions>;
   liveOverview: RealtimeLiveOverviewBridge;
+  onViewActivated?: (viewId: string) => Promise<void>;
   queryClient: QueryClient;
   state: AppState;
 };
@@ -106,6 +107,12 @@ export class UiShellController {
       window,
     });
     this.navigation = createUiShellNavigationModule({
+      onViewActivated: deps.onViewActivated,
+      onViewActivationFailed: (_viewId, error) => {
+        this.showError(
+          error instanceof Error ? error.message : this.t("status.view_load_failed"),
+        );
+      },
       shell: this.state.shell,
       viewIds: SHELL_NAV_ITEMS.map((item) => item.viewId),
       onDashboardViewActivated: () => {
@@ -178,7 +185,7 @@ export class UiShellController {
 
   start(defaultViewId: string): void {
     this.bindFeatureHandlers();
-    this.setActiveView(defaultViewId);
+    this.setActiveView(this.activeViewId.value || defaultViewId);
   }
 
   dispose(): void {

--- a/apps/ui/src/app/runtime/ui_startup_coordinator.ts
+++ b/apps/ui/src/app/runtime/ui_startup_coordinator.ts
@@ -84,24 +84,8 @@ export class UiStartupCoordinator {
             run: () => this.features.realtime.refreshLocationOptions(),
           },
           {
-            name: "load speed source",
-            run: () => this.features.settings.loadSpeedSourceFromServer(),
-          },
-          {
-            name: "load analysis settings",
-            run: () => this.features.settings.loadAnalysisSettingsFromServer(),
-          },
-          {
-            name: "load cars",
-            run: () => this.features.settings.loadCarsFromServer(),
-          },
-          {
             name: "refresh logging status",
             run: () => this.features.realtime.refreshLoggingStatus(),
-          },
-          {
-            name: "refresh history",
-            run: () => this.features.history.refreshHistory(),
           },
         ];
 

--- a/apps/ui/src/app/runtime/ui_startup_coordinator.ts
+++ b/apps/ui/src/app/runtime/ui_startup_coordinator.ts
@@ -87,6 +87,10 @@ export class UiStartupCoordinator {
             name: "refresh logging status",
             run: () => this.features.realtime.refreshLoggingStatus(),
           },
+          {
+            name: "prime dashboard state",
+            run: () => this.features.secondary.primeDashboardState(),
+          },
         ];
 
     return {

--- a/apps/ui/src/app/runtime/ui_startup_feature_ports.ts
+++ b/apps/ui/src/app/runtime/ui_startup_feature_ports.ts
@@ -1,14 +1,5 @@
-import type { HistoryFeature } from "../features/history_feature";
 import type { RealtimeFeature } from "../features/realtime_feature";
-import type { SettingsFeature } from "../features/settings_feature";
 
 export interface UiStartupFeaturePorts {
-  history: Pick<HistoryFeature, "refreshHistory">;
   realtime: Pick<RealtimeFeature, "refreshLocationOptions" | "refreshLoggingStatus">;
-  settings: Pick<
-    SettingsFeature,
-    | "loadSpeedSourceFromServer"
-    | "loadAnalysisSettingsFromServer"
-    | "loadCarsFromServer"
-  >;
 }

--- a/apps/ui/src/app/runtime/ui_startup_feature_ports.ts
+++ b/apps/ui/src/app/runtime/ui_startup_feature_ports.ts
@@ -2,4 +2,7 @@ import type { RealtimeFeature } from "../features/realtime_feature";
 
 export interface UiStartupFeaturePorts {
   realtime: Pick<RealtimeFeature, "refreshLocationOptions" | "refreshLoggingStatus">;
+  secondary: {
+    primeDashboardState(): Promise<void>;
+  };
 }

--- a/apps/ui/src/app/start_ui_app.ts
+++ b/apps/ui/src/app/start_ui_app.ts
@@ -16,6 +16,7 @@ export function startUiApp(deps: Omit<StartUiAppDeps, "renderRoot"> = {}): Start
     renderApp: deps.renderApp ?? render,
     renderRoot: (runtime) => h(UiAppRoot, {
       attachSettingsPanels: runtime.attachSettingsPanels,
+      bootReady: runtime.bootReady,
       panels: runtime.panels,
       shellChrome: runtime.shellChrome,
       spectrumPanel: runtime.spectrumPanel,

--- a/apps/ui/src/app/ui_app_boot_runtime.ts
+++ b/apps/ui/src/app/ui_app_boot_runtime.ts
@@ -1,0 +1,147 @@
+import { fmt, fmtTs } from "../format";
+import {
+  createAppFeatureBundle,
+  type AppFeatureBundle,
+  type AppFeatureBundleRuntimePorts,
+  type AppFeatureBundleSharedDeps,
+} from "./app_feature_bundle";
+import type { AppState } from "./ui_app_state";
+import type {
+  UiLazyPanels,
+  UiMountedPanels,
+} from "./ui_lazy_panels";
+import { UiLiveTransportController } from "./runtime/ui_live_transport_controller";
+import { createUiQueryClient } from "./runtime/ui_query_client";
+import {
+  DEFAULT_SHELL_VIEW_ID,
+} from "./runtime/ui_shell_navigation_module";
+import { UiShellController } from "./runtime/ui_shell_controller";
+import { createWorkerSpectrumFramePreparer } from "./runtime/spectrum_frame_preparer_worker_client";
+import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
+import { UiStartupCoordinator } from "./runtime/ui_startup_coordinator";
+import { type Signal } from "./ui_signals";
+import type {
+  UiShellChromeActions,
+  UiShellChromeBindings,
+} from "./runtime/ui_shell_chrome";
+
+function createUiAppSharedDeps(
+  shell: UiShellController,
+): Pick<AppFeatureBundleSharedDeps, "formatting" | "services"> {
+  return {
+    services: {
+      t: (key, vars) => shell.t(key, vars),
+      requestConfirmation: (message) => shell.requestConfirmation(message),
+      showError: (message) => shell.showError(message),
+    },
+    formatting: {
+      fmt,
+      fmtTs,
+      formatInt: (value) => shell.localFormatInt(value),
+    },
+  };
+}
+
+function createUiAppFeatureRuntimePorts(deps: {
+  panels: UiMountedPanels;
+  shell: UiShellController;
+  spectrum: UiSpectrumController;
+  transport: UiLiveTransportController;
+}): AppFeatureBundleRuntimePorts {
+  const { panels, shell, spectrum, transport } = deps;
+  return {
+    panels,
+    navigation: {
+      activatePrimaryView: (viewId) => shell.setActiveView(viewId),
+      activeViewId: shell.activeViewId,
+    },
+    realtimeChrome: {
+      setShellLiveStatus: (variant, text) => shell.setLiveStatus(variant, text),
+    },
+    view: {
+      renderSpectrum: () => spectrum.renderSpectrum(),
+      refreshSpectrumDecorations: () => spectrum.refreshSpectrumDecorations(),
+    },
+    transport: {
+      sendSelection: () => transport.sendSelection(),
+    },
+  };
+}
+
+export interface UiAppBootRuntime {
+  dispose(): void;
+  start(): void;
+}
+
+export function createUiAppBootRuntime(deps: {
+  lazyPanels: UiLazyPanels;
+  shellChrome: UiShellChromeBindings;
+  shellChromeActions: Signal<UiShellChromeActions>;
+  state: AppState;
+}): UiAppBootRuntime {
+  const queryClient = createUiQueryClient();
+  let featurePorts!: AppFeatureBundle;
+  const shell = new UiShellController({
+    bindFeatureHandlers: () => featurePorts.shell.bindHandlers(),
+    state: deps.state,
+    chrome: deps.shellChrome.view,
+    chromeActions: deps.shellChromeActions,
+    liveOverview: deps.lazyPanels.panels.dashboard.liveOverview,
+    onViewActivated: (viewId) => featurePorts.ensureViewReady(viewId),
+    queryClient,
+  });
+  const spectrum = new UiSpectrumController({
+    state: deps.state,
+    panel: deps.lazyPanels.panels.dashboard.spectrum,
+    t: (key, vars) => shell.t(key, vars),
+    framePreparer: createWorkerSpectrumFramePreparer(),
+  });
+  const transport = new UiLiveTransportController({
+    state: deps.state,
+    payloadErrorMessage: () => shell.t("ws.payload_error"),
+  });
+  featurePorts = createAppFeatureBundle({
+    state: deps.state,
+    shared: {
+      ...createUiAppSharedDeps(shell),
+      serverState: {
+        queryClient,
+      },
+    },
+    runtime: createUiAppFeatureRuntimePorts({
+      panels: deps.lazyPanels.panels,
+      shell,
+      spectrum,
+      transport,
+    }),
+  });
+  const startup = new UiStartupCoordinator({
+    shell,
+    transport,
+    features: featurePorts.startup,
+    defaultViewId: DEFAULT_SHELL_VIEW_ID,
+  });
+  let started = false;
+  let disposed = false;
+
+  return {
+    dispose(): void {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      featurePorts.dispose();
+      queryClient.clear();
+      transport.dispose();
+      spectrum.dispose();
+      shell.dispose();
+    },
+    start(): void {
+      if (disposed || started) {
+        return;
+      }
+      started = true;
+      startup.start();
+    },
+  };
+}

--- a/apps/ui/src/app/ui_app_root.tsx
+++ b/apps/ui/src/app/ui_app_root.tsx
@@ -3,6 +3,7 @@ import type { ComponentChildren } from "preact";
 import { UiShellChrome, type UiShellChromeBindings } from "./runtime/ui_shell_chrome";
 import { DEFAULT_NAVIGATION_MODEL } from "./runtime/shell/ui_shell_chrome_shared";
 import type { UiMountedLazyPanelHandles, UiMountedPanels } from "./ui_lazy_panels";
+import type { ReadonlySignal } from "./ui_signals";
 import HistoryLazyView from "./views/history_lazy_view";
 import RealtimeLiveOverviewLazy from "./views/realtime_live_overview_lazy";
 import RealtimeLoggingPanelLazy from "./views/realtime_logging_panel_lazy";
@@ -34,10 +35,18 @@ function ShellViewSection(props: {
 
 export function UiAppRoot(props: {
   attachSettingsPanels(handles: UiMountedLazyPanelHandles): void;
+  bootReady: ReadonlySignal<boolean>;
   panels: UiMountedPanels;
   shellChrome: UiShellChromeBindings;
   spectrumPanel: CreatedSpectrumPanel;
 }) {
+  if (!props.bootReady.value) {
+    return (
+      <div id="appBootLoading" class="app-boot-loading" role="status" aria-live="polite">
+        Loading dashboard...
+      </div>
+    );
+  }
   const navigationModel = useDeferredModel(
     props.shellChrome.props.navigationModel,
     DEFAULT_NAVIGATION_MODEL,

--- a/apps/ui/src/app/ui_app_root.tsx
+++ b/apps/ui/src/app/ui_app_root.tsx
@@ -4,10 +4,11 @@ import { UiShellChrome, type UiShellChromeBindings } from "./runtime/ui_shell_ch
 import { DEFAULT_NAVIGATION_MODEL } from "./runtime/shell/ui_shell_chrome_shared";
 import type { UiMountedLazyPanelHandles, UiMountedPanels } from "./ui_lazy_panels";
 import HistoryLazyView from "./views/history_lazy_view";
-import { RealtimeLiveOverviewPanel } from "./views/realtime_live_overview";
-import { RealtimeLoggingPanelView } from "./views/realtime_logging_panel";
+import RealtimeLiveOverviewLazy from "./views/realtime_live_overview_lazy";
+import RealtimeLoggingPanelLazy from "./views/realtime_logging_panel_lazy";
 import SettingsLazyView from "./views/settings_lazy_view";
-import { SpectrumPanelHost, type CreatedSpectrumPanel } from "./views/spectrum_panel";
+import type { CreatedSpectrumPanel } from "./views/spectrum_panel";
+import SpectrumPanelHostLazy from "./views/spectrum_panel_host_lazy";
 import { useDeferredModel } from "./views/view_model_binding";
 
 function ShellViewSection(props: {
@@ -52,13 +53,22 @@ export function UiAppRoot(props: {
       >
         <div class="dashboard-grid">
           <div class="panel card dashboard-grid__overview">
-            <RealtimeLiveOverviewPanel view={props.panels.dashboard.liveOverview} />
+            <RealtimeLiveOverviewLazy
+              active={activeViewId === "dashboardView"}
+              view={props.panels.dashboard.liveOverview}
+            />
           </div>
           <div class="panel card dashboard-grid__main">
-            <SpectrumPanelHost panel={props.spectrumPanel} />
+            <SpectrumPanelHostLazy
+              active={activeViewId === "dashboardView"}
+              panel={props.spectrumPanel}
+            />
           </div>
           <div class="panel card dashboard-grid__controls">
-            <RealtimeLoggingPanelView view={props.panels.dashboard.logging} />
+            <RealtimeLoggingPanelLazy
+              active={activeViewId === "dashboardView"}
+              view={props.panels.dashboard.logging}
+            />
           </div>
         </div>
       </ShellViewSection>
@@ -69,7 +79,10 @@ export function UiAppRoot(props: {
         viewId="historyView"
       >
         <div class="panel card">
-          <HistoryLazyView view={props.panels.history} />
+          <HistoryLazyView
+            active={activeViewId === "historyView"}
+            view={props.panels.history}
+          />
         </div>
       </ShellViewSection>
 
@@ -79,6 +92,7 @@ export function UiAppRoot(props: {
         viewId="settingsView"
       >
         <SettingsLazyView
+          active={activeViewId === "settingsView"}
           onReady={props.attachSettingsPanels}
           settings={props.panels.settings}
         />

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -13,11 +13,15 @@ import {
   type UiShellChromeBindings,
   type UiShellChromeNavigationModel,
 } from "./runtime/ui_shell_chrome";
-import { computed, signal, type Signal } from "./ui_signals";
+import { computed, signal, type ReadonlySignal, type Signal } from "./ui_signals";
 import type { UiAppBootRuntime } from "./ui_app_boot_runtime";
+import { preloadRealtimeLiveOverviewPanel } from "./views/realtime_live_overview_lazy";
+import { preloadRealtimeLoggingPanel } from "./views/realtime_logging_panel_lazy";
+import { preloadSpectrumPanelHost } from "./views/spectrum_panel_host_lazy";
 
 export interface UiAppRuntime {
   attachSettingsPanels(handles: UiMountedLazyPanelHandles): void;
+  bootReady: ReadonlySignal<boolean>;
   dispose(): void;
   panels: UiMountedPanels;
   shellChrome: UiShellChromeBindings;
@@ -39,6 +43,7 @@ export function createUiAppRuntime(deps: UiAppRuntimeDeps = {}): UiAppRuntime {
       },
     });
   const shellChrome = createUiShellChromeBindings(shellChromeActions);
+  const bootReady = signal(false);
   const prebootNavigationModel = computed<UiShellChromeNavigationModel>(() => ({
     activeViewId: state.shell.activeViewId.value,
     navItems: SHELL_NAV_ITEMS.map((item) => ({
@@ -60,8 +65,12 @@ export function createUiAppRuntime(deps: UiAppRuntimeDeps = {}): UiAppRuntime {
     if (bootRuntimePromise !== null) {
       return bootRuntimePromise;
     }
-    bootRuntimePromise = import("./ui_app_boot_runtime")
-      .then(({ createUiAppBootRuntime }) => {
+    bootRuntimePromise = Promise.all([
+      import("./ui_app_boot_runtime"),
+      preloadRealtimeLiveOverviewPanel(),
+      preloadRealtimeLoggingPanel(),
+      preloadSpectrumPanelHost(),
+    ]).then(([{ createUiAppBootRuntime }]) => {
         if (disposed) {
           return null;
         }
@@ -76,6 +85,7 @@ export function createUiAppRuntime(deps: UiAppRuntimeDeps = {}): UiAppRuntime {
           return null;
         }
         bootRuntime = nextBootRuntime;
+        bootReady.value = true;
         return nextBootRuntime;
       })
       .catch((error) => {
@@ -87,11 +97,13 @@ export function createUiAppRuntime(deps: UiAppRuntimeDeps = {}): UiAppRuntime {
 
   return {
     attachSettingsPanels: lazyPanels.attachSettingsPanels,
+    bootReady,
     dispose() {
       if (disposed) {
         return;
       }
       disposed = true;
+      bootReady.value = false;
       bootRuntime?.dispose();
       lazyPanels.dispose();
     },

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -1,10 +1,3 @@
-import { fmt, fmtTs } from "../format";
-import {
-  createAppFeatureBundle,
-  type AppFeatureBundle,
-  type AppFeatureBundleRuntimePorts,
-  type AppFeatureBundleSharedDeps,
-} from "./app_feature_bundle";
 import { createAppState, type AppState } from "./ui_app_state";
 import {
   createLazyUiPanels,
@@ -12,70 +5,16 @@ import {
   type UiMountedLazyPanelHandles,
   type UiMountedPanels,
 } from "./ui_lazy_panels";
-import { UiLiveTransportController } from "./runtime/ui_live_transport_controller";
-import { createUiQueryClient } from "./runtime/ui_query_client";
 import {
   createUiShellChromeBindings,
   DEFAULT_UI_SHELL_CHROME_ACTIONS,
+  SHELL_NAV_ITEMS,
   type UiShellChromeActions,
   type UiShellChromeBindings,
+  type UiShellChromeNavigationModel,
 } from "./runtime/ui_shell_chrome";
-import { DEFAULT_SHELL_VIEW_ID } from "./runtime/ui_shell_navigation_module";
-import { UiShellController } from "./runtime/ui_shell_controller";
-import { createWorkerSpectrumFramePreparer } from "./runtime/spectrum_frame_preparer_worker_client";
-import { UiSpectrumController } from "./runtime/ui_spectrum_controller";
-import { UiStartupCoordinator } from "./runtime/ui_startup_coordinator";
-import { signal, type Signal } from "./ui_signals";
-
-function requireUiRuntimeDependency<T>(value: T | null, name: string): T {
-  if (value === null) {
-    throw new Error(`UiAppRuntime ${name} used before initialization`);
-  }
-  return value;
-}
-
-function createUiAppSharedDeps(
-  shell: UiShellController,
-): Pick<AppFeatureBundleSharedDeps, "formatting" | "services"> {
-  return {
-    services: {
-      t: (key, vars) => shell.t(key, vars),
-      requestConfirmation: (message) => shell.requestConfirmation(message),
-      showError: (message) => shell.showError(message),
-    },
-    formatting: {
-      fmt,
-      fmtTs,
-      formatInt: (value) => shell.localFormatInt(value),
-    },
-  };
-}
-
-function createUiAppFeatureRuntimePorts(deps: {
-  panels: UiMountedPanels;
-  shell: UiShellController;
-  spectrum: UiSpectrumController;
-  transport: UiLiveTransportController;
-}): AppFeatureBundleRuntimePorts {
-  const { panels, shell, spectrum, transport } = deps;
-  return {
-    panels,
-    navigation: {
-      activatePrimaryView: (viewId) => shell.setActiveView(viewId),
-      activeViewId: shell.activeViewId,
-    },
-    realtimeChrome: {
-      setShellLiveStatus: (variant, text) => shell.setLiveStatus(variant, text),
-    },
-    view: {
-      renderSpectrum: () => spectrum.renderSpectrum(),
-      refreshSpectrumDecorations: () => spectrum.refreshSpectrumDecorations(),
-    },
-    transport: {
-      sendSelection: () => transport.sendSelection(),
-    },
-  };
-}
+import { computed, signal, type Signal } from "./ui_signals";
+import type { UiAppBootRuntime } from "./ui_app_boot_runtime";
 
 export interface UiAppRuntime {
   attachSettingsPanels(handles: UiMountedLazyPanelHandles): void;
@@ -92,58 +31,59 @@ export interface UiAppRuntimeDeps {
 
 export function createUiAppRuntime(deps: UiAppRuntimeDeps = {}): UiAppRuntime {
   const state = deps.state ?? createAppState();
-  const queryClient = createUiQueryClient();
   const shellChromeActions: Signal<UiShellChromeActions> =
-    signal<UiShellChromeActions>({ ...DEFAULT_UI_SHELL_CHROME_ACTIONS });
-  const shellChrome = createUiShellChromeBindings(shellChromeActions);
-  const lazyPanels = createLazyUiPanels();
-  let spectrum: UiSpectrumController | null = null;
-  let shellBindings: AppFeatureBundle["shell"] | null = null;
-  const shell = new UiShellController({
-    bindFeatureHandlers: () =>
-      requireUiRuntimeDependency(
-        shellBindings,
-        "shell bindings",
-      ).bindHandlers(),
-    state,
-    chrome: shellChrome.view,
-    chromeActions: shellChromeActions,
-    liveOverview: lazyPanels.panels.dashboard.liveOverview,
-    queryClient,
-  });
-  spectrum = new UiSpectrumController({
-    state,
-    panel: lazyPanels.panels.dashboard.spectrum,
-    t: (key, vars) => shell.t(key, vars),
-    framePreparer: createWorkerSpectrumFramePreparer(),
-  });
-  const transport = new UiLiveTransportController({
-    state,
-    payloadErrorMessage: () => shell.t("ws.payload_error"),
-  });
-  const featurePorts = createAppFeatureBundle({
-    state,
-    shared: {
-      ...createUiAppSharedDeps(shell),
-      serverState: {
-        queryClient,
+    signal<UiShellChromeActions>({
+      ...DEFAULT_UI_SHELL_CHROME_ACTIONS,
+      activateView: (viewId) => {
+        state.shell.activeViewId.value = viewId;
       },
-    },
-    runtime: createUiAppFeatureRuntimePorts({
-      panels: lazyPanels.panels,
-      shell,
-      spectrum,
-      transport,
-    }),
-  });
-  shellBindings = featurePorts.shell;
-  const startup = new UiStartupCoordinator({
-    shell,
-    transport,
-    features: featurePorts.startup,
-    defaultViewId: DEFAULT_SHELL_VIEW_ID,
-  });
+    });
+  const shellChrome = createUiShellChromeBindings(shellChromeActions);
+  const prebootNavigationModel = computed<UiShellChromeNavigationModel>(() => ({
+    activeViewId: state.shell.activeViewId.value,
+    navItems: SHELL_NAV_ITEMS.map((item) => ({
+      labelText: item.fallbackLabel,
+      tabId: item.tabId,
+      viewId: item.viewId,
+    })),
+  }));
+  shellChrome.view.bindNavigationModel(prebootNavigationModel);
+  const lazyPanels = createLazyUiPanels();
+  let bootRuntime: UiAppBootRuntime | null = null;
+  let bootRuntimePromise: Promise<UiAppBootRuntime | null> | null = null;
   let disposed = false;
+
+  function ensureBootRuntime(): Promise<UiAppBootRuntime | null> {
+    if (bootRuntime !== null) {
+      return Promise.resolve(bootRuntime);
+    }
+    if (bootRuntimePromise !== null) {
+      return bootRuntimePromise;
+    }
+    bootRuntimePromise = import("./ui_app_boot_runtime")
+      .then(({ createUiAppBootRuntime }) => {
+        if (disposed) {
+          return null;
+        }
+        const nextBootRuntime = createUiAppBootRuntime({
+          state,
+          shellChrome,
+          shellChromeActions,
+          lazyPanels,
+        });
+        if (disposed) {
+          nextBootRuntime.dispose();
+          return null;
+        }
+        bootRuntime = nextBootRuntime;
+        return nextBootRuntime;
+      })
+      .catch((error) => {
+        bootRuntimePromise = null;
+        throw error;
+      });
+    return bootRuntimePromise;
+  }
 
   return {
     attachSettingsPanels: lazyPanels.attachSettingsPanels,
@@ -152,11 +92,7 @@ export function createUiAppRuntime(deps: UiAppRuntimeDeps = {}): UiAppRuntime {
         return;
       }
       disposed = true;
-      featurePorts.dispose();
-      queryClient.clear();
-      transport.dispose();
-      spectrum.dispose();
-      shell.dispose();
+      bootRuntime?.dispose();
       lazyPanels.dispose();
     },
     panels: lazyPanels.panels,
@@ -166,7 +102,13 @@ export function createUiAppRuntime(deps: UiAppRuntimeDeps = {}): UiAppRuntime {
       if (disposed) {
         return;
       }
-      startup.start();
+      void ensureBootRuntime()
+        .then((resolvedBootRuntime) => {
+          resolvedBootRuntime?.start();
+        })
+        .catch((error) => {
+          console.error("[VibeSensor] Failed to start UI boot runtime.", error);
+        });
     },
   };
 }

--- a/apps/ui/src/app/views/history_lazy_view.tsx
+++ b/apps/ui/src/app/views/history_lazy_view.tsx
@@ -1,21 +1,57 @@
-import { useEffect } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
+import type { FunctionComponent } from "preact";
 
-import "../../styles/history-table.css";
-import "../../styles/history-detail.css";
-import "../../styles/history-adaptive.css";
-
-import { HistoryPanel } from "./history_panel";
 import type { HistoryPanelView } from "./history_table_view";
 
 export interface HistoryLazyViewProps {
+  active: boolean;
   onReady?(): void;
   view: HistoryPanelView;
 }
 
-export default function HistoryLazyView(props: HistoryLazyViewProps) {
-  useEffect(() => {
-    props.onReady?.();
-  }, [props.onReady]);
+type HistoryLazyViewImpl = FunctionComponent<HistoryLazyViewProps>;
 
-  return <HistoryPanel actions={props.view.actions} model={props.view.model} />;
+let historyLazyViewPromise: Promise<HistoryLazyViewImpl> | null = null;
+
+function loadHistoryLazyView(): Promise<HistoryLazyViewImpl> {
+  if (historyLazyViewPromise === null) {
+    historyLazyViewPromise = import("./history_lazy_view_content")
+      .then((module) => module.default)
+      .catch((error) => {
+        historyLazyViewPromise = null;
+        throw error;
+      });
+  }
+  return historyLazyViewPromise;
+}
+
+export default function HistoryLazyView(props: HistoryLazyViewProps) {
+  const [LoadedView, setLoadedView] = useState<HistoryLazyViewImpl | null>(null);
+
+  useEffect(() => {
+    if (!props.active || LoadedView !== null) {
+      return;
+    }
+    let cancelled = false;
+    void loadHistoryLazyView()
+      .then((nextLoadedView) => {
+        if (!cancelled) {
+          setLoadedView(() => nextLoadedView);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error("[VibeSensor] Failed to load history view.", error);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [LoadedView, props.active]);
+
+  if (LoadedView === null) {
+    return null;
+  }
+
+  return <LoadedView {...props} />;
 }

--- a/apps/ui/src/app/views/history_lazy_view.tsx
+++ b/apps/ui/src/app/views/history_lazy_view.tsx
@@ -13,7 +13,7 @@ type HistoryLazyViewImpl = FunctionComponent<HistoryLazyViewProps>;
 
 let historyLazyViewPromise: Promise<HistoryLazyViewImpl> | null = null;
 
-function loadHistoryLazyView(): Promise<HistoryLazyViewImpl> {
+export function preloadHistoryLazyView(): Promise<HistoryLazyViewImpl> {
   if (historyLazyViewPromise === null) {
     historyLazyViewPromise = import("./history_lazy_view_content")
       .then((module) => module.default)
@@ -33,7 +33,7 @@ export default function HistoryLazyView(props: HistoryLazyViewProps) {
       return;
     }
     let cancelled = false;
-    void loadHistoryLazyView()
+    void preloadHistoryLazyView()
       .then((nextLoadedView) => {
         if (!cancelled) {
           setLoadedView(() => nextLoadedView);

--- a/apps/ui/src/app/views/history_lazy_view_content.tsx
+++ b/apps/ui/src/app/views/history_lazy_view_content.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "preact/hooks";
+
+import "../../styles/history-table.css";
+import "../../styles/history-detail.css";
+import "../../styles/history-adaptive.css";
+
+import { HistoryPanel } from "./history_panel";
+import type { HistoryLazyViewProps } from "./history_lazy_view";
+
+export default function HistoryLazyViewContent(props: HistoryLazyViewProps) {
+  useEffect(() => {
+    props.onReady?.();
+  }, [props.onReady]);
+
+  return <HistoryPanel actions={props.view.actions} model={props.view.model} />;
+}

--- a/apps/ui/src/app/views/realtime_live_overview_lazy.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview_lazy.tsx
@@ -12,7 +12,7 @@ type RealtimeLiveOverviewPanelImpl = FunctionComponent<RealtimeLiveOverviewLazyP
 
 let realtimeLiveOverviewPromise: Promise<RealtimeLiveOverviewPanelImpl> | null = null;
 
-function loadRealtimeLiveOverviewPanel(): Promise<RealtimeLiveOverviewPanelImpl> {
+export function preloadRealtimeLiveOverviewPanel(): Promise<RealtimeLiveOverviewPanelImpl> {
   if (realtimeLiveOverviewPromise === null) {
     realtimeLiveOverviewPromise = import("./realtime_live_overview")
       .then((module) => module.RealtimeLiveOverviewPanel as RealtimeLiveOverviewPanelImpl)
@@ -34,7 +34,7 @@ export default function RealtimeLiveOverviewLazy(
       return;
     }
     let cancelled = false;
-    void loadRealtimeLiveOverviewPanel()
+    void preloadRealtimeLiveOverviewPanel()
       .then((nextLoadedPanel) => {
         if (!cancelled) {
           setLoadedPanel(() => nextLoadedPanel);

--- a/apps/ui/src/app/views/realtime_live_overview_lazy.tsx
+++ b/apps/ui/src/app/views/realtime_live_overview_lazy.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "preact/hooks";
+import type { FunctionComponent } from "preact";
+
+import type { RealtimeLiveOverviewBridge } from "./realtime_live_overview";
+
+export interface RealtimeLiveOverviewLazyProps {
+  active: boolean;
+  view: RealtimeLiveOverviewBridge;
+}
+
+type RealtimeLiveOverviewPanelImpl = FunctionComponent<RealtimeLiveOverviewLazyProps>;
+
+let realtimeLiveOverviewPromise: Promise<RealtimeLiveOverviewPanelImpl> | null = null;
+
+function loadRealtimeLiveOverviewPanel(): Promise<RealtimeLiveOverviewPanelImpl> {
+  if (realtimeLiveOverviewPromise === null) {
+    realtimeLiveOverviewPromise = import("./realtime_live_overview")
+      .then((module) => module.RealtimeLiveOverviewPanel as RealtimeLiveOverviewPanelImpl)
+      .catch((error) => {
+        realtimeLiveOverviewPromise = null;
+        throw error;
+      });
+  }
+  return realtimeLiveOverviewPromise;
+}
+
+export default function RealtimeLiveOverviewLazy(
+  props: RealtimeLiveOverviewLazyProps,
+) {
+  const [LoadedPanel, setLoadedPanel] = useState<RealtimeLiveOverviewPanelImpl | null>(null);
+
+  useEffect(() => {
+    if (!props.active || LoadedPanel !== null) {
+      return;
+    }
+    let cancelled = false;
+    void loadRealtimeLiveOverviewPanel()
+      .then((nextLoadedPanel) => {
+        if (!cancelled) {
+          setLoadedPanel(() => nextLoadedPanel);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error("[VibeSensor] Failed to load live overview panel.", error);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [LoadedPanel, props.active]);
+
+  if (LoadedPanel === null) {
+    return null;
+  }
+
+  return <LoadedPanel {...props} />;
+}

--- a/apps/ui/src/app/views/realtime_logging_panel_lazy.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel_lazy.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "preact/hooks";
+import type { FunctionComponent } from "preact";
+
+import type { RealtimeLoggingPanelBridge } from "./realtime_logging_panel";
+
+export interface RealtimeLoggingPanelLazyProps {
+  active: boolean;
+  view: RealtimeLoggingPanelBridge;
+}
+
+type RealtimeLoggingPanelImpl = FunctionComponent<RealtimeLoggingPanelLazyProps>;
+
+let realtimeLoggingPanelPromise: Promise<RealtimeLoggingPanelImpl> | null = null;
+
+function loadRealtimeLoggingPanel(): Promise<RealtimeLoggingPanelImpl> {
+  if (realtimeLoggingPanelPromise === null) {
+    realtimeLoggingPanelPromise = import("./realtime_logging_panel")
+      .then((module) => module.RealtimeLoggingPanelView as RealtimeLoggingPanelImpl)
+      .catch((error) => {
+        realtimeLoggingPanelPromise = null;
+        throw error;
+      });
+  }
+  return realtimeLoggingPanelPromise;
+}
+
+export default function RealtimeLoggingPanelLazy(
+  props: RealtimeLoggingPanelLazyProps,
+) {
+  const [LoadedPanel, setLoadedPanel] = useState<RealtimeLoggingPanelImpl | null>(null);
+
+  useEffect(() => {
+    if (!props.active || LoadedPanel !== null) {
+      return;
+    }
+    let cancelled = false;
+    void loadRealtimeLoggingPanel()
+      .then((nextLoadedPanel) => {
+        if (!cancelled) {
+          setLoadedPanel(() => nextLoadedPanel);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error("[VibeSensor] Failed to load realtime logging panel.", error);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [LoadedPanel, props.active]);
+
+  if (LoadedPanel === null) {
+    return null;
+  }
+
+  return <LoadedPanel {...props} />;
+}

--- a/apps/ui/src/app/views/realtime_logging_panel_lazy.tsx
+++ b/apps/ui/src/app/views/realtime_logging_panel_lazy.tsx
@@ -12,7 +12,7 @@ type RealtimeLoggingPanelImpl = FunctionComponent<RealtimeLoggingPanelLazyProps>
 
 let realtimeLoggingPanelPromise: Promise<RealtimeLoggingPanelImpl> | null = null;
 
-function loadRealtimeLoggingPanel(): Promise<RealtimeLoggingPanelImpl> {
+export function preloadRealtimeLoggingPanel(): Promise<RealtimeLoggingPanelImpl> {
   if (realtimeLoggingPanelPromise === null) {
     realtimeLoggingPanelPromise = import("./realtime_logging_panel")
       .then((module) => module.RealtimeLoggingPanelView as RealtimeLoggingPanelImpl)
@@ -34,7 +34,7 @@ export default function RealtimeLoggingPanelLazy(
       return;
     }
     let cancelled = false;
-    void loadRealtimeLoggingPanel()
+    void preloadRealtimeLoggingPanel()
       .then((nextLoadedPanel) => {
         if (!cancelled) {
           setLoadedPanel(() => nextLoadedPanel);

--- a/apps/ui/src/app/views/settings_lazy_view.tsx
+++ b/apps/ui/src/app/views/settings_lazy_view.tsx
@@ -41,7 +41,7 @@ type SettingsLazyViewImpl = FunctionComponent<SettingsLazyViewProps>;
 
 let settingsLazyViewPromise: Promise<SettingsLazyViewImpl> | null = null;
 
-function loadSettingsLazyView(): Promise<SettingsLazyViewImpl> {
+export function preloadSettingsLazyView(): Promise<SettingsLazyViewImpl> {
   if (settingsLazyViewPromise === null) {
     settingsLazyViewPromise = import("./settings_lazy_view_content")
       .then((module) => module.default)
@@ -61,7 +61,7 @@ export default function SettingsLazyView(props: SettingsLazyViewProps) {
       return;
     }
     let cancelled = false;
-    void loadSettingsLazyView()
+    void preloadSettingsLazyView()
       .then((nextLoadedView) => {
         if (!cancelled) {
           setLoadedView(() => nextLoadedView);

--- a/apps/ui/src/app/views/settings_lazy_view.tsx
+++ b/apps/ui/src/app/views/settings_lazy_view.tsx
@@ -1,52 +1,14 @@
-import { render } from "preact";
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
+import type { FunctionComponent } from "preact";
 
-import "../../styles/maintenance-cards.css";
-import "../../styles/maintenance-readiness.css";
-import "../../styles/maintenance-journey.css";
-import "../../styles/maintenance-details.css";
-import "../../styles/maintenance-layout.css";
-import "../../styles/settings-common.css";
-import "../../styles/settings-shell.css";
-import "../../styles/settings-transport.css";
-import "../../styles/settings-speed-source.css";
-import "../../styles/settings-cars.css";
-import "../../styles/settings-sensors.css";
-import "../../styles/settings-cars-wizard.css";
-import "../../styles/settings-adaptive.css";
-
-import {
-  mountAnalysisPanel,
-  type AnalysisPanelView,
-} from "./analysis_panel";
-import {
-  mountCarsPanel,
-  type CarsPanelView,
-} from "./cars_panel";
-import {
-  mountEspFlashPanel,
-  type EspFlashPanelView,
-} from "./esp_flash_panel";
-import {
-  mountInternetPanel,
-  type InternetPanelView,
-} from "./internet_panel";
-import {
-  mountSensorsPanel,
-  type SensorsPanelView,
-} from "./sensors_panel";
-import {
-  mountSettingsShell,
-  type SettingsShellView,
-} from "./settings_shell";
-import {
-  mountSpeedSourcePanel,
-  type SpeedSourcePanelView,
-} from "./speed_source_panel";
-import {
-  mountUpdatePanel,
-  type UpdatePanelView,
-} from "./update_panel";
+import type { AnalysisPanelView } from "./analysis_panel";
+import type { CarsPanelView } from "./cars_panel";
+import type { EspFlashPanelView } from "./esp_flash_panel";
+import type { InternetPanelView } from "./internet_panel";
+import type { SensorsPanelView } from "./sensors_panel";
+import type { SettingsShellView } from "./settings_shell";
+import type { SpeedSourcePanelView } from "./speed_source_panel";
+import type { UpdatePanelView } from "./update_panel";
 
 interface SettingsLazyViewReadyHandles {
   settingsShell: SettingsShellView;
@@ -62,6 +24,7 @@ interface SettingsLazyViewReadyHandles {
 }
 
 export interface SettingsLazyViewProps {
+  active: boolean;
   onReady(handles: SettingsLazyViewReadyHandles): void;
   settings: {
     analysis: AnalysisPanelView;
@@ -74,42 +37,49 @@ export interface SettingsLazyViewProps {
   };
 }
 
+type SettingsLazyViewImpl = FunctionComponent<SettingsLazyViewProps>;
+
+let settingsLazyViewPromise: Promise<SettingsLazyViewImpl> | null = null;
+
+function loadSettingsLazyView(): Promise<SettingsLazyViewImpl> {
+  if (settingsLazyViewPromise === null) {
+    settingsLazyViewPromise = import("./settings_lazy_view_content")
+      .then((module) => module.default)
+      .catch((error) => {
+        settingsLazyViewPromise = null;
+        throw error;
+      });
+  }
+  return settingsLazyViewPromise;
+}
+
 export default function SettingsLazyView(props: SettingsLazyViewProps) {
-  const hostRef = useRef<HTMLDivElement | null>(null);
+  const [LoadedView, setLoadedView] = useState<SettingsLazyViewImpl | null>(null);
 
   useEffect(() => {
-    const host = hostRef.current;
-    if (!host) {
+    if (!props.active || LoadedView !== null) {
       return;
     }
-
-    const settingsShellMount = mountSettingsShell(host);
-    const settingsShell = settingsShellMount.view;
-    const settingsHosts = settingsShellMount.panelHosts;
-    const cars = mountCarsPanel(settingsHosts.cars, props.settings.cars);
-    const analysis = mountAnalysisPanel(settingsHosts.analysis, props.settings.analysis);
-    const internet = mountInternetPanel(settingsHosts.internet, props.settings.internet);
-    mountUpdatePanel(settingsHosts.update, props.settings.update);
-    mountSensorsPanel(settingsHosts.sensors, props.settings.sensors);
-    const speedSource = mountSpeedSourcePanel(
-      settingsHosts.speedSource,
-      props.settings.speedSource,
-    );
-    mountEspFlashPanel(settingsHosts.espFlash, props.settings.espFlash);
-    props.onReady({
-      settingsShell,
-      settings: {
-        analysis,
-        cars,
-        internet,
-        speedSource,
-      },
-    });
-
+    let cancelled = false;
+    void loadSettingsLazyView()
+      .then((nextLoadedView) => {
+        if (!cancelled) {
+          setLoadedView(() => nextLoadedView);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error("[VibeSensor] Failed to load settings view.", error);
+        }
+      });
     return () => {
-      render(null, host);
+      cancelled = true;
     };
-  }, [props.onReady, props.settings]);
+  }, [LoadedView, props.active]);
 
-  return <div ref={hostRef} />;
+  if (LoadedView === null) {
+    return null;
+  }
+
+  return <LoadedView {...props} />;
 }

--- a/apps/ui/src/app/views/settings_lazy_view_content.tsx
+++ b/apps/ui/src/app/views/settings_lazy_view_content.tsx
@@ -1,0 +1,66 @@
+import { render } from "preact";
+import { useEffect, useRef } from "preact/hooks";
+
+import "../../styles/maintenance-cards.css";
+import "../../styles/maintenance-readiness.css";
+import "../../styles/maintenance-journey.css";
+import "../../styles/maintenance-details.css";
+import "../../styles/maintenance-layout.css";
+import "../../styles/settings-common.css";
+import "../../styles/settings-shell.css";
+import "../../styles/settings-transport.css";
+import "../../styles/settings-speed-source.css";
+import "../../styles/settings-cars.css";
+import "../../styles/settings-sensors.css";
+import "../../styles/settings-cars-wizard.css";
+import "../../styles/settings-adaptive.css";
+
+import { mountAnalysisPanel } from "./analysis_panel";
+import { mountCarsPanel } from "./cars_panel";
+import { mountEspFlashPanel } from "./esp_flash_panel";
+import { mountInternetPanel } from "./internet_panel";
+import { mountSensorsPanel } from "./sensors_panel";
+import { mountSettingsShell } from "./settings_shell";
+import { mountSpeedSourcePanel } from "./speed_source_panel";
+import { mountUpdatePanel } from "./update_panel";
+import type { SettingsLazyViewProps } from "./settings_lazy_view";
+
+export default function SettingsLazyViewContent(props: SettingsLazyViewProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) {
+      return;
+    }
+
+    const settingsShellMount = mountSettingsShell(host);
+    const settingsShell = settingsShellMount.view;
+    const settingsHosts = settingsShellMount.panelHosts;
+    const cars = mountCarsPanel(settingsHosts.cars, props.settings.cars);
+    const analysis = mountAnalysisPanel(settingsHosts.analysis, props.settings.analysis);
+    const internet = mountInternetPanel(settingsHosts.internet, props.settings.internet);
+    mountUpdatePanel(settingsHosts.update, props.settings.update);
+    mountSensorsPanel(settingsHosts.sensors, props.settings.sensors);
+    const speedSource = mountSpeedSourcePanel(
+      settingsHosts.speedSource,
+      props.settings.speedSource,
+    );
+    mountEspFlashPanel(settingsHosts.espFlash, props.settings.espFlash);
+    props.onReady({
+      settingsShell,
+      settings: {
+        analysis,
+        cars,
+        internet,
+        speedSource,
+      },
+    });
+
+    return () => {
+      render(null, host);
+    };
+  }, [props.onReady, props.settings]);
+
+  return <div ref={hostRef} />;
+}

--- a/apps/ui/src/app/views/spectrum_panel.tsx
+++ b/apps/ui/src/app/views/spectrum_panel.tsx
@@ -1,12 +1,8 @@
-import type { JSX } from "preact";
-import { memo } from "preact/compat";
-import { getUiText } from "../ui_i18n";
 import {
   signal,
-  useSignalProperties,
   type ReadonlySignal,
 } from "../ui_signals";
-import { createDeferredModelSignal, useDeferredModel } from "./view_model_binding";
+import { createDeferredModelSignal } from "./view_model_binding";
 import type {
   SpectrumBandLegendModel,
   SpectrumInspectorRenderModel,
@@ -24,57 +20,10 @@ type MutableSpectrumPanelChartDom = {
   specChart: HTMLElement | null;
 };
 
-const DEFAULT_SPECTRUM_BAND_TOGGLE_MODEL: SpectrumPanelBandToggleModel = {
-  disabled: true,
-  hasBands: false,
-  bandsVisible: false,
-  hidden: true,
-  pressed: "false",
-  text: "Show reference bands",
-};
 const DEFAULT_SPECTRUM_OVERLAY_MODEL: SpectrumPanelOverlayModel = {
   hidden: true,
   text: "Waiting for sensor data...",
 };
-const DEFAULT_SPECTRUM_BAND_LEGEND_MODEL: SpectrumBandLegendModel = {
-  visible: false,
-  items: [],
-  emptyText: "No reference band",
-};
-const EMPTY_SPECTRUM_SENSOR_LEGEND_ITEMS: SpectrumSensorLegendModel["items"] = [];
-type SpectrumCssVariableStyle = JSX.CSSProperties & {
-  "--band-color"?: string;
-  "--swatch-color"?: string;
-};
-
-function bandColorStyle(color: string): SpectrumCssVariableStyle {
-  return { "--band-color": color };
-}
-
-function swatchColorStyle(color: string): SpectrumCssVariableStyle {
-  return { "--swatch-color": color };
-}
-
-const SPECTRUM_BAND_TOGGLE_KEYS = [
-  "bandsVisible",
-  "disabled",
-  "hasBands",
-  "hidden",
-  "pressed",
-  "text",
-] as const;
-const SPECTRUM_BAND_LEGEND_KEYS = ["emptyText", "items", "visible"] as const;
-const SCREEN_READER_ONLY_STYLE = {
-  border: "0",
-  clip: "rect(0 0 0 0)",
-  height: "1px",
-  margin: "-1px",
-  overflow: "hidden",
-  padding: "0",
-  position: "absolute",
-  whiteSpace: "nowrap",
-  width: "1px",
-} as const satisfies JSX.CSSProperties;
 
 function requireSpectrumElement<T extends HTMLElement>(
   element: T | null,
@@ -85,114 +34,6 @@ function requireSpectrumElement<T extends HTMLElement>(
   }
   throw new Error(`Spectrum UI requires ${target}`);
 }
-
-const SpectrumBandLegend = memo(function SpectrumBandLegend(props: {
-  bandLegend: ReadonlySignal<SpectrumBandLegendModel>;
-}) {
-  const {
-    emptyText,
-    items,
-    visible,
-  } = useSignalProperties(props.bandLegend, SPECTRUM_BAND_LEGEND_KEYS);
-  const hidden = !visible.value;
-
-  return (
-    <div id="bandLegend" class="legend band-legend" hidden={hidden}>
-      {visible.value
-        ? items.value.length
-          ? items.value.map((item) => (
-            <div
-              key={item.labelText}
-              class="legend-item legend-item--band"
-              data-band-state="active"
-              style={bandColorStyle(item.color)}
-            >
-              <span class="swatch" style={swatchColorStyle(item.color)} />
-              <span>{item.labelText}</span>
-            </div>
-          ))
-          : (
-            <div class="legend-item legend-item--band" data-band-state="empty">
-              {emptyText}
-            </div>
-          )
-        : null}
-    </div>
-  );
-});
-
-const SpectrumSensorLegend = memo(function SpectrumSensorLegend(props: {
-  sensorLegend: ReadonlySignal<SpectrumSensorLegendModel | null>;
-  sensorLegendHandlers: ReadonlySignal<SpectrumLegendHandlers | null>;
-}) {
-  const legend = props.sensorLegend.value;
-  const hasLegend = legend !== null
-    && legend.items.length > 0
-    && props.sensorLegendHandlers.value !== null;
-
-  return (
-    hasLegend
-      ? (
-        <SpectrumSensorLegendContent
-          sensorLegend={props.sensorLegend}
-          sensorLegendHandlers={props.sensorLegendHandlers}
-        />
-      )
-      : null
-  );
-});
-
-const SpectrumSensorLegendContent = memo(function SpectrumSensorLegendContent(
-  props: {
-    sensorLegend: ReadonlySignal<SpectrumSensorLegendModel | null>;
-    sensorLegendHandlers: ReadonlySignal<SpectrumLegendHandlers | null>;
-  },
-) {
-  const legend = props.sensorLegend.value;
-  const items = legend?.items ?? EMPTY_SPECTRUM_SENSOR_LEGEND_ITEMS;
-  const reset = legend?.reset ?? null;
-  const handlers = props.sensorLegendHandlers.value;
-
-  return (
-    reset !== null && handlers !== null
-      ? (
-        <>
-          <button
-            type="button"
-            class="legend-item legend-item--interactive legend-item--reset"
-            aria-pressed={reset.ariaPressed ? "true" : "false"}
-            title={reset.titleText}
-            aria-label={reset.ariaLabel}
-            data-legend-state={reset.active ? "active" : undefined}
-            onClick={() => props.sensorLegendHandlers.peek()?.onReset()}
-          >
-            <span class="legend-item__label">{reset.labelText}</span>
-          </button>
-          {items.map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              class="legend-item legend-item--interactive"
-              aria-pressed={item.ariaPressed ? "true" : "false"}
-              title={item.titleText}
-              aria-label={item.ariaLabel}
-              data-legend-state={item.active ? "active" : item.muted ? "muted" : undefined}
-              onClick={() => props.sensorLegendHandlers.peek()?.onSelect(item.id)}
-            >
-              <span class="swatch" style={swatchColorStyle(item.color)} />
-              <span class="legend-item__text-group">
-                <span class="legend-item__label">{item.labelText}</span>
-                {item.detailText
-                  ? <span class="legend-item__meta">{item.detailText}</span>
-                  : null}
-              </span>
-            </button>
-          ))}
-        </>
-      )
-      : null
-  );
-});
 
 type SpectrumPanelProps = {
   bandLegendModel: ReadonlySignal<ReadonlySignal<SpectrumBandLegendModel> | null>;
@@ -206,90 +47,6 @@ type SpectrumPanelProps = {
   sensorLegendHandlersModel: ReadonlySignal<ReadonlySignal<SpectrumLegendHandlers | null> | null>;
   sensorLegendModel: ReadonlySignal<ReadonlySignal<SpectrumSensorLegendModel | null> | null>;
 };
-
-function SpectrumPanel(props: SpectrumPanelProps) {
-  const { chartDom } = props;
-  const bandLegend = useDeferredModel(props.bandLegendModel, DEFAULT_SPECTRUM_BAND_LEGEND_MODEL);
-  const bandToggle = useDeferredModel(props.bandToggleModel, DEFAULT_SPECTRUM_BAND_TOGGLE_MODEL);
-  const overlayModel = props.overlayModel.value ?? DEFAULT_SPECTRUM_OVERLAY_MODEL;
-  const sensorLegend = useDeferredModel(props.sensorLegendModel, null);
-  const sensorLegendHandlers = useDeferredModel(props.sensorLegendHandlersModel, null);
-  const titleText = getUiText("chart.spectrum_title", props.header.value.titleText);
-  const hintText = getUiText("spectrum.controls_hint", props.header.value.hintText);
-  const {
-    disabled: bandToggleDisabled,
-    hidden: bandToggleHidden,
-    pressed: bandTogglePressed,
-    text: bandToggleText,
-  } = useSignalProperties(bandToggle, SPECTRUM_BAND_TOGGLE_KEYS);
-
-  return (
-    <>
-      <div class="card__header">
-        <div class="card__title">
-          {titleText}
-        </div>
-      </div>
-      <div
-        id="specChartWrap"
-        class="spectrum-wrap"
-        ref={(element) => {
-          chartDom.specChartWrap = element;
-        }}
-      >
-        <div
-          id="specChart"
-          ref={(element) => {
-            chartDom.specChart = element;
-          }}
-        />
-        <div id="spectrumOverlay" class="empty-state" hidden={overlayModel.hidden}>
-          {overlayModel.text}
-        </div>
-      </div>
-        <div class="spectrum-controls-panel">
-        <div class="spectrum-toolbar">
-            <div class="card__subtle spectrum-toolbar__hint">
-              {hintText}
-          </div>
-          <div class="spectrum-toolbar__bands">
-            <button
-              id="spectrumBandToggle"
-              class="btn spectrum-toolbar__toggle"
-              type="button"
-              aria-controls="bandLegend"
-              aria-pressed={bandTogglePressed}
-              aria-expanded={bandTogglePressed}
-              hidden={bandToggleHidden}
-              disabled={bandToggleDisabled}
-              onClick={() => props.onBandToggle.peek()?.()}
-            >
-              {bandToggleText}
-            </button>
-            <SpectrumBandLegend bandLegend={bandLegend} />
-          </div>
-        </div>
-        <div id="spectrumInspector" class="spectrum-inspector">
-          {props.inspectorText}
-        </div>
-        <div
-          class="spectrum-inspector-announcer"
-          aria-live="polite"
-          aria-atomic="true"
-          style={SCREEN_READER_ONLY_STYLE}
-        >
-          {props.inspectorAnnouncement}
-        </div>
-        <div id="legend" class="legend">
-          <SpectrumSensorLegend
-            sensorLegend={sensorLegend}
-            sensorLegendHandlers={sensorLegendHandlers}
-          />
-        </div>
-      </div>
-    </>
-  );
-}
 
 export interface CreatedSpectrumPanel {
   props: SpectrumPanelProps;
@@ -365,14 +122,4 @@ export function createSpectrumPanel(): CreatedSpectrumPanel {
       },
     },
   };
-}
-
-export function SpectrumPanelHost(props: {
-  panel: CreatedSpectrumPanel;
-}) {
-  return (
-    <div id="spectrumPanelRoot">
-      <SpectrumPanel {...props.panel.props} />
-    </div>
-  );
 }

--- a/apps/ui/src/app/views/spectrum_panel_host.tsx
+++ b/apps/ui/src/app/views/spectrum_panel_host.tsx
@@ -1,0 +1,271 @@
+import type { JSX } from "preact";
+import { memo } from "preact/compat";
+
+import { getUiText } from "../ui_i18n";
+import {
+  useSignalProperties,
+  type ReadonlySignal,
+} from "../ui_signals";
+import { useDeferredModel } from "./view_model_binding";
+import type {
+  SpectrumBandLegendModel,
+  SpectrumLegendHandlers,
+  SpectrumPanelBandToggleModel,
+  SpectrumPanelOverlayModel,
+  SpectrumSensorLegendModel,
+} from "../runtime/spectrum_panel_view";
+import type { CreatedSpectrumPanel } from "./spectrum_panel";
+
+const DEFAULT_SPECTRUM_BAND_TOGGLE_MODEL: SpectrumPanelBandToggleModel = {
+  disabled: true,
+  hasBands: false,
+  bandsVisible: false,
+  hidden: true,
+  pressed: "false",
+  text: "Show reference bands",
+};
+const DEFAULT_SPECTRUM_OVERLAY_MODEL: SpectrumPanelOverlayModel = {
+  hidden: true,
+  text: "Waiting for sensor data...",
+};
+const DEFAULT_SPECTRUM_BAND_LEGEND_MODEL: SpectrumBandLegendModel = {
+  visible: false,
+  items: [],
+  emptyText: "No reference band",
+};
+const EMPTY_SPECTRUM_SENSOR_LEGEND_ITEMS: SpectrumSensorLegendModel["items"] = [];
+const SPECTRUM_BAND_TOGGLE_KEYS = [
+  "bandsVisible",
+  "disabled",
+  "hasBands",
+  "hidden",
+  "pressed",
+  "text",
+] as const;
+const SPECTRUM_BAND_LEGEND_KEYS = ["emptyText", "items", "visible"] as const;
+const SCREEN_READER_ONLY_STYLE = {
+  border: "0",
+  clip: "rect(0 0 0 0)",
+  height: "1px",
+  margin: "-1px",
+  overflow: "hidden",
+  padding: "0",
+  position: "absolute",
+  whiteSpace: "nowrap",
+  width: "1px",
+} as const satisfies JSX.CSSProperties;
+type SpectrumCssVariableStyle = JSX.CSSProperties & {
+  "--band-color"?: string;
+  "--swatch-color"?: string;
+};
+type SpectrumPanelProps = CreatedSpectrumPanel["props"];
+
+function bandColorStyle(color: string): SpectrumCssVariableStyle {
+  return { "--band-color": color };
+}
+
+function swatchColorStyle(color: string): SpectrumCssVariableStyle {
+  return { "--swatch-color": color };
+}
+
+const SpectrumBandLegend = memo(function SpectrumBandLegend(props: {
+  bandLegend: ReadonlySignal<SpectrumBandLegendModel>;
+}) {
+  const {
+    emptyText,
+    items,
+    visible,
+  } = useSignalProperties(props.bandLegend, SPECTRUM_BAND_LEGEND_KEYS);
+  const hidden = !visible.value;
+
+  return (
+    <div id="bandLegend" class="legend band-legend" hidden={hidden}>
+      {visible.value
+        ? items.value.length
+          ? items.value.map((item) => (
+            <div
+              key={item.labelText}
+              class="legend-item legend-item--band"
+              data-band-state="active"
+              style={bandColorStyle(item.color)}
+            >
+              <span class="swatch" style={swatchColorStyle(item.color)} />
+              <span>{item.labelText}</span>
+            </div>
+          ))
+          : (
+            <div class="legend-item legend-item--band" data-band-state="empty">
+              {emptyText}
+            </div>
+          )
+        : null}
+    </div>
+  );
+});
+
+const SpectrumSensorLegend = memo(function SpectrumSensorLegend(props: {
+  sensorLegend: ReadonlySignal<SpectrumSensorLegendModel | null>;
+  sensorLegendHandlers: ReadonlySignal<SpectrumLegendHandlers | null>;
+}) {
+  const legend = props.sensorLegend.value;
+  const hasLegend = legend !== null
+    && legend.items.length > 0
+    && props.sensorLegendHandlers.value !== null;
+
+  return (
+    hasLegend
+      ? (
+        <SpectrumSensorLegendContent
+          sensorLegend={props.sensorLegend}
+          sensorLegendHandlers={props.sensorLegendHandlers}
+        />
+      )
+      : null
+  );
+});
+
+const SpectrumSensorLegendContent = memo(function SpectrumSensorLegendContent(
+  props: {
+    sensorLegend: ReadonlySignal<SpectrumSensorLegendModel | null>;
+    sensorLegendHandlers: ReadonlySignal<SpectrumLegendHandlers | null>;
+  },
+) {
+  const legend = props.sensorLegend.value;
+  const items = legend?.items ?? EMPTY_SPECTRUM_SENSOR_LEGEND_ITEMS;
+  const reset = legend?.reset ?? null;
+  const handlers = props.sensorLegendHandlers.value;
+
+  return (
+    reset !== null && handlers !== null
+      ? (
+        <>
+          <button
+            type="button"
+            class="legend-item legend-item--interactive legend-item--reset"
+            aria-pressed={reset.ariaPressed ? "true" : "false"}
+            title={reset.titleText}
+            aria-label={reset.ariaLabel}
+            data-legend-state={reset.active ? "active" : undefined}
+            onClick={() => props.sensorLegendHandlers.peek()?.onReset()}
+          >
+            <span class="legend-item__label">{reset.labelText}</span>
+          </button>
+          {items.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              class="legend-item legend-item--interactive"
+              aria-pressed={item.ariaPressed ? "true" : "false"}
+              title={item.titleText}
+              aria-label={item.ariaLabel}
+              data-legend-state={item.active ? "active" : item.muted ? "muted" : undefined}
+              onClick={() => props.sensorLegendHandlers.peek()?.onSelect(item.id)}
+            >
+              <span class="swatch" style={swatchColorStyle(item.color)} />
+              <span class="legend-item__text-group">
+                <span class="legend-item__label">{item.labelText}</span>
+                {item.detailText
+                  ? <span class="legend-item__meta">{item.detailText}</span>
+                  : null}
+              </span>
+            </button>
+          ))}
+        </>
+      )
+      : null
+  );
+});
+
+function SpectrumPanel(props: SpectrumPanelProps) {
+  const { chartDom } = props;
+  const bandLegend = useDeferredModel(props.bandLegendModel, DEFAULT_SPECTRUM_BAND_LEGEND_MODEL);
+  const bandToggle = useDeferredModel(props.bandToggleModel, DEFAULT_SPECTRUM_BAND_TOGGLE_MODEL);
+  const overlayModel = props.overlayModel.value ?? DEFAULT_SPECTRUM_OVERLAY_MODEL;
+  const sensorLegend = useDeferredModel(props.sensorLegendModel, null);
+  const sensorLegendHandlers = useDeferredModel(props.sensorLegendHandlersModel, null);
+  const titleText = getUiText("chart.spectrum_title", props.header.value.titleText);
+  const hintText = getUiText("spectrum.controls_hint", props.header.value.hintText);
+  const {
+    disabled: bandToggleDisabled,
+    hidden: bandToggleHidden,
+    pressed: bandTogglePressed,
+    text: bandToggleText,
+  } = useSignalProperties(bandToggle, SPECTRUM_BAND_TOGGLE_KEYS);
+
+  return (
+    <>
+      <div class="card__header">
+        <div class="card__title">
+          {titleText}
+        </div>
+      </div>
+      <div
+        id="specChartWrap"
+        class="spectrum-wrap"
+        ref={(element) => {
+          chartDom.specChartWrap = element;
+        }}
+      >
+        <div
+          id="specChart"
+          ref={(element) => {
+            chartDom.specChart = element;
+          }}
+        />
+        <div id="spectrumOverlay" class="empty-state" hidden={overlayModel.hidden}>
+          {overlayModel.text}
+        </div>
+      </div>
+      <div class="spectrum-controls-panel">
+        <div class="spectrum-toolbar">
+          <div class="card__subtle spectrum-toolbar__hint">
+            {hintText}
+          </div>
+          <div class="spectrum-toolbar__bands">
+            <button
+              id="spectrumBandToggle"
+              class="btn spectrum-toolbar__toggle"
+              type="button"
+              aria-controls="bandLegend"
+              aria-pressed={bandTogglePressed}
+              aria-expanded={bandTogglePressed}
+              hidden={bandToggleHidden}
+              disabled={bandToggleDisabled}
+              onClick={() => props.onBandToggle.peek()?.()}
+            >
+              {bandToggleText}
+            </button>
+            <SpectrumBandLegend bandLegend={bandLegend} />
+          </div>
+        </div>
+        <div id="spectrumInspector" class="spectrum-inspector">
+          {props.inspectorText}
+        </div>
+        <div
+          class="spectrum-inspector-announcer"
+          aria-live="polite"
+          aria-atomic="true"
+          style={SCREEN_READER_ONLY_STYLE}
+        >
+          {props.inspectorAnnouncement}
+        </div>
+        <div id="legend" class="legend">
+          <SpectrumSensorLegend
+            sensorLegend={sensorLegend}
+            sensorLegendHandlers={sensorLegendHandlers}
+          />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function SpectrumPanelHost(props: {
+  panel: CreatedSpectrumPanel;
+}) {
+  return (
+    <div id="spectrumPanelRoot">
+      <SpectrumPanel {...props.panel.props} />
+    </div>
+  );
+}

--- a/apps/ui/src/app/views/spectrum_panel_host_lazy.tsx
+++ b/apps/ui/src/app/views/spectrum_panel_host_lazy.tsx
@@ -12,7 +12,7 @@ type SpectrumPanelHostImpl = FunctionComponent<SpectrumPanelHostLazyProps>;
 
 let spectrumPanelHostPromise: Promise<SpectrumPanelHostImpl> | null = null;
 
-function loadSpectrumPanelHost(): Promise<SpectrumPanelHostImpl> {
+export function preloadSpectrumPanelHost(): Promise<SpectrumPanelHostImpl> {
   if (spectrumPanelHostPromise === null) {
     spectrumPanelHostPromise = import("./spectrum_panel_host")
       .then((module) => module.SpectrumPanelHost as SpectrumPanelHostImpl)
@@ -32,7 +32,7 @@ export default function SpectrumPanelHostLazy(props: SpectrumPanelHostLazyProps)
       return;
     }
     let cancelled = false;
-    void loadSpectrumPanelHost()
+    void preloadSpectrumPanelHost()
       .then((nextLoadedPanelHost) => {
         if (!cancelled) {
           setLoadedPanelHost(() => nextLoadedPanelHost);

--- a/apps/ui/src/app/views/spectrum_panel_host_lazy.tsx
+++ b/apps/ui/src/app/views/spectrum_panel_host_lazy.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "preact/hooks";
+import type { FunctionComponent } from "preact";
+
+import type { CreatedSpectrumPanel } from "./spectrum_panel";
+
+export interface SpectrumPanelHostLazyProps {
+  active: boolean;
+  panel: CreatedSpectrumPanel;
+}
+
+type SpectrumPanelHostImpl = FunctionComponent<SpectrumPanelHostLazyProps>;
+
+let spectrumPanelHostPromise: Promise<SpectrumPanelHostImpl> | null = null;
+
+function loadSpectrumPanelHost(): Promise<SpectrumPanelHostImpl> {
+  if (spectrumPanelHostPromise === null) {
+    spectrumPanelHostPromise = import("./spectrum_panel_host")
+      .then((module) => module.SpectrumPanelHost as SpectrumPanelHostImpl)
+      .catch((error) => {
+        spectrumPanelHostPromise = null;
+        throw error;
+      });
+  }
+  return spectrumPanelHostPromise;
+}
+
+export default function SpectrumPanelHostLazy(props: SpectrumPanelHostLazyProps) {
+  const [LoadedPanelHost, setLoadedPanelHost] = useState<SpectrumPanelHostImpl | null>(null);
+
+  useEffect(() => {
+    if (!props.active || LoadedPanelHost !== null) {
+      return;
+    }
+    let cancelled = false;
+    void loadSpectrumPanelHost()
+      .then((nextLoadedPanelHost) => {
+        if (!cancelled) {
+          setLoadedPanelHost(() => nextLoadedPanelHost);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error("[VibeSensor] Failed to load spectrum panel host.", error);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [LoadedPanelHost, props.active]);
+
+  if (LoadedPanelHost === null) {
+    return null;
+  }
+
+  return <LoadedPanelHost {...props} />;
+}

--- a/apps/ui/tests/app_feature_ports.spec.ts
+++ b/apps/ui/tests/app_feature_ports.spec.ts
@@ -30,6 +30,9 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
     dispose() {
       calls.push("secondary.dispose");
     },
+    async primeDashboardState() {
+      calls.push("secondary.primeDashboardState");
+    },
   };
 
   const recording = createRealtimeFeatureRecordingPorts(history);
@@ -47,6 +50,7 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
 
   await bundle.startup.realtime.refreshLocationOptions();
   await bundle.startup.realtime.refreshLoggingStatus();
+  await bundle.startup.secondary.primeDashboardState();
   bundle.dispose();
 
   expect(calls).toEqual([
@@ -54,6 +58,7 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
     "realtime.bindHandlers",
     "realtime.refreshLocationOptions",
     "realtime.refreshLoggingStatus",
+    "secondary.primeDashboardState",
     "secondary.dispose",
     "realtime.dispose",
   ]);

--- a/apps/ui/tests/app_feature_ports.spec.ts
+++ b/apps/ui/tests/app_feature_ports.spec.ts
@@ -8,12 +8,6 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
   const calls: string[] = [];
 
   const history = {
-    bindHandlers() {
-      calls.push("history.bindHandlers");
-    },
-    dispose() {
-      calls.push("history.dispose");
-    },
     async refreshHistory() {
       calls.push("history.refreshHistory");
     },
@@ -32,107 +26,36 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
       calls.push("realtime.refreshLoggingStatus");
     },
   };
-  const settings = {
-    bindHandlers() {
-      calls.push("settings.bindHandlers");
-    },
+  const secondary = {
     dispose() {
-      calls.push("settings.dispose");
-    },
-    syncSettingsInputs() {
-      calls.push("settings.syncSettingsInputs");
-    },
-    async loadSpeedSourceFromServer() {
-      calls.push("settings.loadSpeedSourceFromServer");
-    },
-    async loadAnalysisSettingsFromServer() {
-      calls.push("settings.loadAnalysisSettingsFromServer");
-    },
-    async loadCarsFromServer() {
-      calls.push("settings.loadCarsFromServer");
-    },
-    syncCarsPayload() {
-      calls.push("settings.syncCarsPayload");
-    },
-    syncActiveCarToInputs() {
-      calls.push("settings.syncActiveCarToInputs");
-    },
-    showCarCreationSuccess(carId: string, carName: string) {
-      calls.push(`settings.showCarCreationSuccess:${carId}:${carName}`);
-    },
-    renderCarList() {
-      calls.push("settings.renderCarList");
-    },
-  };
-  const cars = {
-    bindWizardHandlers() {
-      calls.push("cars.bindWizardHandlers");
-    },
-    dispose() {
-      calls.push("cars.dispose");
-    },
-  };
-  const update = {
-    bindUpdateHandlers() {
-      calls.push("update.bindUpdateHandlers");
-    },
-    dispose() {
-      calls.push("update.dispose");
-    },
-  };
-  const espFlash = {
-    bindHandlers() {
-      calls.push("espFlash.bindHandlers");
-    },
-    dispose() {
-      calls.push("espFlash.dispose");
+      calls.push("secondary.dispose");
     },
   };
 
   const recording = createRealtimeFeatureRecordingPorts(history);
   const bundle = createAppFeatureBundlePorts({
-    history,
     realtime,
-    settings,
-    cars,
-    update,
-    espFlash,
+    secondary,
   });
 
-  expect(Object.keys(bundle).sort()).toEqual(["dispose", "shell", "startup"]);
+  expect(Object.keys(bundle).sort()).toEqual(["dispose", "ensureViewReady", "shell", "startup"]);
 
   await recording.onRecordingStatusChanged();
 
   bundle.shell.bindHandlers();
+  await bundle.ensureViewReady("historyView");
 
-  await bundle.startup.history.refreshHistory();
   await bundle.startup.realtime.refreshLocationOptions();
   await bundle.startup.realtime.refreshLoggingStatus();
-  await bundle.startup.settings.loadSpeedSourceFromServer();
-  await bundle.startup.settings.loadAnalysisSettingsFromServer();
-  await bundle.startup.settings.loadCarsFromServer();
   bundle.dispose();
 
   expect(calls).toEqual([
     "history.refreshHistory",
-    "settings.bindHandlers",
-    "cars.bindWizardHandlers",
     "realtime.bindHandlers",
-    "history.bindHandlers",
-    "update.bindUpdateHandlers",
-    "espFlash.bindHandlers",
-    "history.refreshHistory",
     "realtime.refreshLocationOptions",
     "realtime.refreshLoggingStatus",
-    "settings.loadSpeedSourceFromServer",
-    "settings.loadAnalysisSettingsFromServer",
-    "settings.loadCarsFromServer",
-    "espFlash.dispose",
-    "update.dispose",
-    "history.dispose",
+    "secondary.dispose",
     "realtime.dispose",
-    "settings.dispose",
-    "cars.dispose",
   ]);
 });
 

--- a/apps/ui/tests/start_ui_app.spec.ts
+++ b/apps/ui/tests/start_ui_app.spec.ts
@@ -37,6 +37,7 @@ test("startUiApp returns a disposable mounted app handle", () => {
       runtimeCreations += 1;
       return {
         attachSettingsPanels() {},
+        bootReady: { value: true } as UiAppRuntime["bootReady"],
         dispose() {
           disposeCalls += 1;
         },

--- a/apps/ui/tests/ui_live_transport_controller.spec.ts
+++ b/apps/ui/tests/ui_live_transport_controller.spec.ts
@@ -76,8 +76,13 @@ function installLocation(search: string): () => void {
 }
 
 describe("UiLiveTransportController", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     installWindowGlobal();
+    await Promise.all([
+      import("../src/app/demo_mode"),
+      import("../src/server_payload"),
+      import("../src/ws"),
+    ]);
   });
 
   test("applies queued transport payloads through shared state without transport ports", async () => {
@@ -107,7 +112,7 @@ describe("UiLiveTransportController", () => {
       });
       await flushAsyncWork();
       raf.flushNext();
-      await flushAsyncWork();
+      await flushAsyncWork(30);
 
       expect(state.transport.pendingPayload.value).toBeNull();
       expect(state.realtime.clients.value.map((client) => client.id)).toEqual(["client-1"]);
@@ -266,7 +271,7 @@ describe("UiLiveTransportController", () => {
     expect(state.transport.wsState.value).toBe("connected");
   });
 
-  test("applies payloads without requiring feature-port attachment", () => {
+  test("applies payloads without requiring feature-port attachment", async () => {
     const state = createAppState();
     const controller = new UiLiveTransportController({
       state,
@@ -274,6 +279,7 @@ describe("UiLiveTransportController", () => {
     });
 
     expect(() => applyPayload(controller, makeLivePayload())).not.toThrow();
+    await flushAsyncWork(30);
     expect(state.realtime.speedMps.value).toBe(10);
   });
 
@@ -287,14 +293,14 @@ describe("UiLiveTransportController", () => {
     const raf = installRafHarness();
     try {
       controller.startTransportMode();
-      await flushAsyncWork();
+      await flushAsyncWork(30);
 
       expect(state.transport.wsState.value).toBe("connected");
       expect(state.transport.hasReceivedPayload.value).toBe(true);
       expect(state.transport.pendingPayload.value).not.toBeNull();
 
       raf.flushNext();
-      await flushAsyncWork();
+      await flushAsyncWork(30);
 
       expect(state.transport.pendingPayload.value).toBeNull();
       expect(state.realtime.clients.value).toHaveLength(5);

--- a/apps/ui/tests/ui_startup_coordinator.spec.ts
+++ b/apps/ui/tests/ui_startup_coordinator.spec.ts
@@ -24,6 +24,7 @@ function createCoordinatorHarness() {
   const hydrate = createDeferred<void>();
   const refreshLocationOptions = createDeferred<void>();
   const refreshLoggingStatus = createDeferred<void>();
+  const primeDashboardState = createDeferred<void>();
 
   const coordinator = new UiStartupCoordinator({
     shell: {
@@ -46,6 +47,12 @@ function createCoordinatorHarness() {
           return refreshLoggingStatus.promise;
         },
       },
+      secondary: {
+        primeDashboardState(): Promise<void> {
+          calls.push("secondary.primeDashboardState");
+          return primeDashboardState.promise;
+        },
+      },
     },
     transport: {
       startTransportMode(): void {
@@ -64,6 +71,7 @@ function createCoordinatorHarness() {
     hydrate,
     refreshLocationOptions,
     refreshLoggingStatus,
+    primeDashboardState,
     coordinator,
   };
 }
@@ -102,6 +110,7 @@ describe("UiStartupCoordinator", () => {
         "shell.hydratePersistedPreferences",
         "realtime.refreshLocationOptions",
         "realtime.refreshLoggingStatus",
+        "secondary.primeDashboardState",
         "transport.startTransportMode",
       ]);
     } finally {
@@ -119,6 +128,7 @@ describe("UiStartupCoordinator", () => {
       harness.hydrate.reject(hydrateError);
       harness.refreshLocationOptions.resolve();
       harness.refreshLoggingStatus.resolve();
+      harness.primeDashboardState.resolve();
 
       await flushAsyncWork();
 

--- a/apps/ui/tests/ui_startup_coordinator.spec.ts
+++ b/apps/ui/tests/ui_startup_coordinator.spec.ts
@@ -23,11 +23,7 @@ function createCoordinatorHarness() {
   const warnings: Array<{ message: string; error: unknown }> = [];
   const hydrate = createDeferred<void>();
   const refreshLocationOptions = createDeferred<void>();
-  const loadSpeedSource = createDeferred<void>();
-  const loadAnalysisSettings = createDeferred<void>();
-  const loadCars = createDeferred<void>();
   const refreshLoggingStatus = createDeferred<void>();
-  const refreshHistory = createDeferred<void>();
 
   const coordinator = new UiStartupCoordinator({
     shell: {
@@ -40,12 +36,6 @@ function createCoordinatorHarness() {
       },
     },
     features: {
-      history: {
-        refreshHistory(): Promise<void> {
-          calls.push("history.refreshHistory");
-          return refreshHistory.promise;
-        },
-      },
       realtime: {
         refreshLocationOptions(): Promise<void> {
           calls.push("realtime.refreshLocationOptions");
@@ -54,20 +44,6 @@ function createCoordinatorHarness() {
         refreshLoggingStatus(): Promise<void> {
           calls.push("realtime.refreshLoggingStatus");
           return refreshLoggingStatus.promise;
-        },
-      },
-      settings: {
-        loadSpeedSourceFromServer(): Promise<void> {
-          calls.push("settings.loadSpeedSourceFromServer");
-          return loadSpeedSource.promise;
-        },
-        loadAnalysisSettingsFromServer(): Promise<void> {
-          calls.push("settings.loadAnalysisSettingsFromServer");
-          return loadAnalysisSettings.promise;
-        },
-        loadCarsFromServer(): Promise<void> {
-          calls.push("settings.loadCarsFromServer");
-          return loadCars.promise;
         },
       },
     },
@@ -87,11 +63,7 @@ function createCoordinatorHarness() {
     warnings,
     hydrate,
     refreshLocationOptions,
-    loadSpeedSource,
-    loadAnalysisSettings,
-    loadCars,
     refreshLoggingStatus,
-    refreshHistory,
     coordinator,
   };
 }
@@ -129,11 +101,7 @@ describe("UiStartupCoordinator", () => {
         "shell.start:dashboardView",
         "shell.hydratePersistedPreferences",
         "realtime.refreshLocationOptions",
-        "settings.loadSpeedSourceFromServer",
-        "settings.loadAnalysisSettingsFromServer",
-        "settings.loadCarsFromServer",
         "realtime.refreshLoggingStatus",
-        "history.refreshHistory",
         "transport.startTransportMode",
       ]);
     } finally {
@@ -145,16 +113,11 @@ describe("UiStartupCoordinator", () => {
     const restoreLocation = installLocation("");
     const harness = createCoordinatorHarness();
     const hydrateError = new Error("hydrate failed");
-    const historyError = new Error("history failed");
 
     try {
       harness.coordinator.start();
       harness.hydrate.reject(hydrateError);
-      harness.refreshHistory.reject(historyError);
       harness.refreshLocationOptions.resolve();
-      harness.loadSpeedSource.resolve();
-      harness.loadAnalysisSettings.resolve();
-      harness.loadCars.resolve();
       harness.refreshLoggingStatus.resolve();
 
       await flushAsyncWork();
@@ -164,10 +127,6 @@ describe("UiStartupCoordinator", () => {
         {
           message: "UI startup task failed: hydrate persisted preferences",
           error: hydrateError,
-        },
-        {
-          message: "UI startup task failed: refresh history",
-          error: historyError,
         },
       ]);
     } finally {


### PR DESCRIPTION
## what changed
- split history and settings into real lazy chunks by moving heavy view bodies into activation-loaded `*_content.tsx` modules
- move history/settings/cars/update/ESP-flash wiring into `app_feature_secondary_bundle.ts` so dashboard boot only wires the live path
- defer websocket payload/runtime helpers and boot the heavy shell/runtime controller graph from `ui_app_boot_runtime.ts`
- gate the interactive shell until the lazy boot runtime and default dashboard islands are bound, preload the dashboard islands, and keep settings/history code loads parallel with their data loads
- restore dashboard-critical speed/car bootstrap and preserve resolved speed-source state across settings refreshes so the lazy boot path stays smoke-safe

## why
- `npm run analyze` on `main` had `index` at 121.53 KB gzip, about 2x over the repo boot budget for hotspot clients
- the first split fixed bundle size, then CI exposed a startup race where preboot defaults leaked into real smoke flows on slower runners
- this branch now keeps the startup graph small without regressing dashboard boot behavior

## validation
- `cd apps/ui && npm run typecheck`
- `cd apps/ui && npm run test:unit`
- `cd apps/ui && npm run test:smoke`
- `cd apps/ui && npm run test:smoke:mock`
- `cd apps/ui && npm run analyze`
  - before: `index` 121.53 KB gzip, `chart` 22.26 KB gzip
  - after: `index` 7.94 KB gzip, `chart` 22.26 KB gzip

## risks / tradeoffs
- the dashboard still preloads only the code and state it needs; non-dashboard settings/history view bodies remain lazy, but startup now eagerly restores the car/speed state the live view depends on
- `chart` stays above the stated budget because that chunk is effectively `uPlot`; this PR fixes the main boot-path regression and leaves the third-party chart cost explicit

## out of scope
- reducing the `uPlot`-owned chart chunk

Closes #3033