### PR TITLE
perf(ws): drop payload non-finite prescan

### DIFF
--- a/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
+++ b/apps/server/tests/adapters/websocket/test_payload_orchestrator.py
@@ -64,6 +64,28 @@ async def test_prepare_falls_back_to_error_payload_on_serialization_failure() ->
 
 
 @pytest.mark.asyncio
+async def test_prepare_serializes_plain_non_finite_payload_without_sanitizer() -> None:
+    payload_builder = MagicMock(
+        side_effect=lambda selected: {
+            "selected_client_id": selected,
+            "value": float("nan"),
+        }
+    )
+    orchestrator = PayloadBuildOrchestrator(payload_builder, capture_debug=False)
+
+    with patch(
+        "vibesensor.adapters.websocket.payload_orchestrator.sanitize_for_json",
+        side_effect=AssertionError("plain Python NaN should stay on the direct dump path"),
+    ):
+        await orchestrator.prepare(["sensor-a"])
+
+    assert json.loads(orchestrator.payload_cache["sensor-a"]) == {
+        "selected_client_id": "sensor-a",
+        "value": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_prepare_reuses_serialized_template_across_selected_clients() -> None:
     shared_clients = [{"id": "sensor-a", "connected": True}]
     shared_rotational_speeds = {

--- a/apps/server/tests/adapters/websocket/test_ws_hub.py
+++ b/apps/server/tests/adapters/websocket/test_ws_hub.py
@@ -526,13 +526,15 @@ async def test_broadcast_sanitizes_nan_to_null() -> None:
 
 
 @pytest.mark.asyncio
-async def test_broadcast_logs_warning_on_nan(caplog) -> None:
-    """A warning is logged when NaN/Inf values are found in the payload."""
+async def test_broadcast_logs_warning_when_sanitizer_replaces_non_finite_values(caplog) -> None:
+    """A warning is logged when the sanitize fallback replaces NaN/Inf values."""
     hub, [ws] = await build_hub("sensor_1")
+    payload = {"freq": np.array([1.0, float("nan"), 3.0], dtype=np.float32)}
 
     with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.websocket.hub"):
-        await hub.broadcast(lambda _: {"val": float("nan")})
+        await hub.broadcast(lambda _: payload)
 
+    assert _sent_json(ws) == {"freq": [1.0, None, 3.0]}
     assert any("NaN/Inf" in r.message for r in caplog.records)
 
 

--- a/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
+++ b/apps/server/vibesensor/adapters/websocket/payload_orchestrator.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import logging
-import math
 from collections.abc import Callable, Iterable, Mapping
-from typing import cast
 
 import anyio
 
@@ -24,32 +22,6 @@ _SELECTED_CLIENT_ID_NULL_JSON = '"selected_client_id":null'
 
 def _dump_json_text(value: object) -> str:
     return json_text_dumps(value)
-
-
-def _payload_contains_non_finite(obj: object, *, _max_depth: int = 128) -> bool:
-    _isfinite = math.isfinite
-
-    def _walk(value: object, depth: int = 0) -> bool:
-        if depth > _max_depth:
-            return True
-        t = type(value)
-        if t is int or t is str or t is bool or value is None:
-            return False
-        if hasattr(value, "tolist") and hasattr(value, "ndim"):
-            value = value.tolist()
-            t = type(value)
-        elif hasattr(value, "item"):
-            value = value.item()
-            t = type(value)
-        if t is float:
-            return not _isfinite(cast(float, value))
-        if isinstance(value, dict):
-            return any(_walk(item, depth + 1) for item in value.values())
-        if isinstance(value, (list, tuple)):
-            return any(_walk(item, depth + 1) for item in value)
-        return False
-
-    return _walk(obj)
 
 
 class PayloadBuildOrchestrator:
@@ -124,22 +96,9 @@ class PayloadBuildOrchestrator:
         _dumps = _dump_json_text
         try:
             try:
-                if _payload_contains_non_finite(raw_payload):
-                    payload_for_debug, had_non_finite = sanitize_for_json(raw_payload)
-                    LOGGER.warning(
-                        "WebSocket payload for client %r contained NaN/Inf values; "
-                        "replaced with null.",
-                        selected_client_id,
-                        extra=log_extra(
-                            event="ws_payload_non_finite_replaced",
-                            selected_client_id=selected_client_id,
-                        ),
-                    )
-                else:
-                    had_non_finite = False
                 text = self._serialize_selected_client_payload(
                     selected_client_id,
-                    payload_for_debug,
+                    raw_payload,
                     _dumps,
                 )
             except (TypeError, ValueError, OverflowError):


### PR DESCRIPTION
## size
small

## what changed
- remove the unconditional recursive `_payload_contains_non_finite()` walk from `PayloadBuildOrchestrator._serialize_payload()`
- let direct `orjson` serialization handle plain Python `NaN`/`Inf` values, which already emit `null`
- keep `sanitize_for_json()` as the retry path for unsupported payload shapes like NumPy arrays
- pin the common-path and fallback-path behavior in websocket tests

## why
- healthy payloads were walked twice per variant: once by `_payload_contains_non_finite()`, then again by JSON serialization
- the hot-path benchmark reproduced the issue: `prepare([None])` was 1.666 ms median and `prepare(4 ids)` was 6.689 ms median, with the recursive scan dominating `cProfile`
- this keeps payload bytes correct while moving the scan off the common path

## validation
- `cd apps/server && PYTHONPATH=. /workspace/VibeSensor/.venv/bin/pytest -q tests/adapters/websocket/`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make test-changed`
- representative hot-path benchmark after the fix:
  - `prepare([None])`: 1.666 ms median / 1.816 ms p95 -> 0.225 ms / 0.252 ms
  - `prepare(4 ids)`: 6.689 ms median / 22.462 ms p95 -> 0.843 ms / 0.943 ms
  - `cProfile`: recursive non-finite scan gone from the serializer hot path

## risks / tradeoffs
- plain Python non-finite values no longer emit a warning from the common path because we no longer pre-scan them; the payload bytes still stay correct through `orjson`
- warning coverage stays on the sanitize-retry path, which is the path that still does mutation work

Closes #3034
