### PR TITLE
perf: skip small compute_all worker-pool rounds

### DIFF
--- a/apps/server/tests/infra/processing/test_compute_all_parallel_cutoff.py
+++ b/apps/server/tests/infra/processing/test_compute_all_parallel_cutoff.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from math import pi
+
+import numpy as np
+
+from vibesensor.infra.processing import SignalProcessor
+from vibesensor.infra.workers.worker_pool import WorkerPool
+
+
+def _make_processor(*, fft_n: int, pool: WorkerPool) -> SignalProcessor:
+    return SignalProcessor(
+        sample_rate_hz=800,
+        waveform_seconds=4,
+        waveform_display_hz=100,
+        fft_n=fft_n,
+        spectrum_max_hz=200,
+        accel_scale_g_per_lsb=1.0 / 256.0,
+        worker_pool=pool,
+    )
+
+
+def _inject_signal(
+    proc: SignalProcessor,
+    client_id: str,
+    *,
+    fft_n: int,
+    freq_hz: float,
+) -> None:
+    t = np.arange(fft_n, dtype=np.float64) / 800
+    x_lsb = (0.05 * np.sin(2.0 * pi * freq_hz * t) * 256.0).astype(np.int16)
+    y_lsb = (0.03 * np.sin(2.0 * pi * (freq_hz + 10.0) * t) * 256.0).astype(np.int16)
+    z_lsb = np.zeros(fft_n, dtype=np.int16)
+    samples = np.stack([x_lsb, y_lsb, z_lsb], axis=1)
+    proc.ingest(client_id, samples, sample_rate_hz=800)
+
+
+def test_compute_all_small_workload_skips_worker_pool() -> None:
+    client_ids = [f"sensor-{idx:02d}" for idx in range(4)]
+    with WorkerPool(max_workers=4, thread_name_prefix="test-cutoff-small") as pool:
+        proc = _make_processor(fft_n=512, pool=pool)
+        for client_id, freq_hz in zip(client_ids, [20.0, 27.5, 35.0, 42.5], strict=True):
+            _inject_signal(proc, client_id, fft_n=512, freq_hz=freq_hz)
+
+        result = proc.compute_all(client_ids)
+
+        assert sorted(result) == client_ids
+        assert result["sensor-00"]["x"]["rms"] > 0
+        assert proc.intake_stats()["worker_pool"]["total_tasks"] == 0
+
+
+def test_compute_all_threshold_workload_uses_worker_pool() -> None:
+    client_ids = ["sensor-00", "sensor-01"]
+    with WorkerPool(max_workers=4, thread_name_prefix="test-cutoff-threshold") as pool:
+        proc = _make_processor(fft_n=2048, pool=pool)
+        for client_id, freq_hz in zip(client_ids, [20.0, 27.5], strict=True):
+            _inject_signal(proc, client_id, fft_n=2048, freq_hz=freq_hz)
+
+        result = proc.compute_all(client_ids)
+
+        assert sorted(result) == client_ids
+        assert result["sensor-00"]["x"]["rms"] > 0
+        assert proc.intake_stats()["worker_pool"]["total_tasks"] == 2

--- a/apps/server/tests/infra/workers/benchmark_compute_all.py
+++ b/apps/server/tests/infra/workers/benchmark_compute_all.py
@@ -11,7 +11,6 @@ from vibesensor.infra.processing import SignalProcessor
 from vibesensor.infra.workers.worker_pool import WorkerPool
 
 SAMPLE_RATE_HZ = 800
-FFT_N = 512
 WAVEFORM_SECONDS = 4
 SPECTRUM_MAX_HZ = 200
 INGEST_BATCHES = 5
@@ -19,45 +18,68 @@ CLIENT_IDS = [f"sensor-{idx:02d}" for idx in range(4)]
 FREQS_HZ = [20.0 + idx * 7.5 for idx in range(len(CLIENT_IDS))]
 
 
-def _make_processor(pool: WorkerPool | None = None) -> SignalProcessor:
+def _make_processor(
+    *,
+    fft_n: int,
+    pool: WorkerPool | None = None,
+) -> SignalProcessor:
     return SignalProcessor(
         sample_rate_hz=SAMPLE_RATE_HZ,
         waveform_seconds=WAVEFORM_SECONDS,
         waveform_display_hz=100,
-        fft_n=FFT_N,
+        fft_n=fft_n,
         spectrum_max_hz=SPECTRUM_MAX_HZ,
         accel_scale_g_per_lsb=1.0 / 256.0,
         worker_pool=pool,
     )
 
 
-def _inject_signal(proc: SignalProcessor, client_id: str, freq_hz: float) -> None:
-    t = np.arange(FFT_N, dtype=np.float64) / SAMPLE_RATE_HZ
+def _inject_signal(proc: SignalProcessor, client_id: str, freq_hz: float, *, fft_n: int) -> None:
+    t = np.arange(fft_n, dtype=np.float64) / SAMPLE_RATE_HZ
     x_lsb = (0.05 * np.sin(2.0 * pi * freq_hz * t) * 256.0).astype(np.int16)
     y_lsb = (0.03 * np.sin(2.0 * pi * (freq_hz + 10.0) * t) * 256.0).astype(np.int16)
-    z_lsb = np.zeros(FFT_N, dtype=np.int16)
+    z_lsb = np.zeros(fft_n, dtype=np.int16)
     samples = np.stack([x_lsb, y_lsb, z_lsb], axis=1)
     proc.ingest(client_id, samples, sample_rate_hz=SAMPLE_RATE_HZ)
 
 
-def _run_compute_round(use_worker_pool: bool) -> dict[str, object]:
+def _run_compute_round(
+    use_worker_pool: bool,
+    *,
+    fft_n: int,
+) -> tuple[dict[str, object], int | None]:
     pool = WorkerPool(max_workers=4, thread_name_prefix="bench-fft") if use_worker_pool else None
     try:
-        proc = _make_processor(pool=pool)
+        proc = _make_processor(fft_n=fft_n, pool=pool)
         for client_id, freq_hz in zip(CLIENT_IDS, FREQS_HZ, strict=True):
             for _ in range(INGEST_BATCHES):
-                _inject_signal(proc, client_id, freq_hz)
-        return proc.compute_all(CLIENT_IDS)
+                _inject_signal(proc, client_id, freq_hz, fft_n=fft_n)
+        result = proc.compute_all(CLIENT_IDS)
+        worker_pool_tasks = None
+        if pool is not None:
+            worker_pool_tasks = proc.intake_stats()["worker_pool"]["total_tasks"]
+        return result, worker_pool_tasks
     finally:
         if pool is not None:
             pool.shutdown()
 
 
 @pytest.mark.benchmark(group="signal-processor-compute-round")
+@pytest.mark.parametrize("fft_n", [512, 2048], ids=["fft-512", "fft-2048"])
 @pytest.mark.parametrize("use_worker_pool", [False, True], ids=["sequential", "parallel"])
-def test_signal_processor_compute_round_benchmark(benchmark, use_worker_pool: bool) -> None:
-    result = benchmark(lambda: _run_compute_round(use_worker_pool))
+def test_signal_processor_compute_round_benchmark(
+    benchmark,
+    use_worker_pool: bool,
+    fft_n: int,
+) -> None:
+    result, worker_pool_tasks = benchmark(lambda: _run_compute_round(use_worker_pool, fft_n=fft_n))
 
     assert sorted(result) == CLIENT_IDS
     assert result["sensor-00"]["x"]["rms"] > 0
     assert result["sensor-01"]["y"]["rms"] > 0
+    if not use_worker_pool:
+        assert worker_pool_tasks is None
+    elif fft_n == 512:
+        assert worker_pool_tasks == 0
+    else:
+        assert worker_pool_tasks == len(CLIENT_IDS)

--- a/apps/server/tests/infra/workers/test_worker_pool.py
+++ b/apps/server/tests/infra/workers/test_worker_pool.py
@@ -205,12 +205,16 @@ class TestWorkerPool:
 # ---------------------------------------------------------------------------
 
 
-def _make_processor(pool: WorkerPool | None = None) -> SignalProcessor:
+def _make_processor(
+    pool: WorkerPool | None = None,
+    *,
+    fft_n: int = 512,
+) -> SignalProcessor:
     return SignalProcessor(
         sample_rate_hz=800,
         waveform_seconds=4,
         waveform_display_hz=100,
-        fft_n=512,
+        fft_n=fft_n,
         spectrum_max_hz=200,
         accel_scale_g_per_lsb=1.0 / 256.0,
         worker_pool=pool,
@@ -247,11 +251,11 @@ class TestParallelComputeAll:
     def test_multi_client_parallel(self, make_pool) -> None:
         """Multiple clients computed in parallel should produce valid results."""
         pool = make_pool(max_workers=4)
-        proc = _make_processor(pool=pool)
+        proc = _make_processor(pool=pool, fft_n=2048)
         client_ids = [f"c{i}" for i in range(4)]
         freqs = [20.0, 30.0, 40.0, 50.0]
         for cid, freq in zip(client_ids, freqs, strict=True):
-            _inject_test_signal(proc, cid, freq_hz=freq)
+            _inject_test_signal(proc, cid, freq_hz=freq, n_samples=2048)
 
         results = proc.compute_all(client_ids)
         assert len(results) == 4
@@ -262,13 +266,13 @@ class TestParallelComputeAll:
     def test_parallel_matches_sequential(self, make_pool) -> None:
         """Parallel and sequential compute_all must produce identical results."""
         pool = make_pool(max_workers=4)
-        proc_seq = _make_processor(pool=None)
-        proc_par = _make_processor(pool=pool)
+        proc_seq = _make_processor(pool=None, fft_n=2048)
+        proc_par = _make_processor(pool=pool, fft_n=2048)
         client_ids = [f"c{i}" for i in range(4)]
         rng = np.random.default_rng(42)
         for cid in client_ids:
             freq = 15.0 + rng.uniform(0, 50)
-            n = 512
+            n = 2048
             t = np.arange(n, dtype=np.float64) / 800
             x_lsb = (0.05 * np.sin(2.0 * pi * freq * t) * 256.0).astype(np.int16)
             y_lsb = (0.02 * np.sin(2.0 * pi * (freq + 5) * t) * 256.0).astype(np.int16)
@@ -292,12 +296,12 @@ class TestParallelComputeAll:
     def test_concurrent_ingest_and_compute(self, make_pool) -> None:
         """Ingest and compute can run concurrently without data races."""
         pool = make_pool(max_workers=4)
-        proc = _make_processor(pool=pool)
+        proc = _make_processor(pool=pool, fft_n=2048)
         client_ids = [f"c{i}" for i in range(4)]
 
         # Pre-fill buffers
         for cid in client_ids:
-            _inject_test_signal(proc, cid)
+            _inject_test_signal(proc, cid, n_samples=2048)
 
         errors: list[Exception] = []
 
@@ -331,9 +335,9 @@ class TestParallelComputeAll:
     def test_compute_all_timing_counter(self, make_pool) -> None:
         """compute_all should update the timing counter."""
         pool = make_pool(max_workers=2)
-        proc = _make_processor(pool=pool)
-        _inject_test_signal(proc, "c1")
-        _inject_test_signal(proc, "c2")
+        proc = _make_processor(pool=pool, fft_n=2048)
+        _inject_test_signal(proc, "c1", n_samples=2048)
+        _inject_test_signal(proc, "c2", n_samples=2048)
         proc.compute_all(["c1", "c2"])
         stats = proc.intake_stats()
         assert stats["last_compute_all_duration_s"] > 0

--- a/apps/server/vibesensor/infra/processing/processor.py
+++ b/apps/server/vibesensor/infra/processing/processor.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 MAX_CLIENT_SAMPLE_RATE_HZ = _MAX_CLIENT_SAMPLE_RATE_HZ
+_MIN_PARALLEL_COMPUTE_WORK_UNITS = 4096
 
 
 class SignalProcessor:
@@ -130,13 +131,15 @@ class SignalProcessor:
         rates = sample_rates_hz or {}
         t0 = time.monotonic()
 
-        if len(client_ids) <= 1 or self._worker_pool is None:
+        if not self._should_parallelize_compute_all(client_ids):
             result = self._compute_all_serial(client_ids, rates)
             self._store.record_compute_all_duration(time.monotonic() - t0)
             return result
 
+        pool = self._worker_pool
+        assert pool is not None
         try:
-            result = self._worker_pool.map_unordered(
+            result = pool.map_unordered(
                 lambda client_id: self.compute_metrics(
                     client_id,
                     sample_rate_hz=rates.get(client_id),
@@ -151,6 +154,11 @@ class SignalProcessor:
             result = self._compute_all_serial(client_ids, rates, serial_fallback=True)
         self._store.record_compute_all_duration(time.monotonic() - t0)
         return result
+
+    def _should_parallelize_compute_all(self, client_ids: list[str]) -> bool:
+        if len(client_ids) <= 1 or self._worker_pool is None:
+            return False
+        return (len(client_ids) * self._config.fft_n) >= _MIN_PARALLEL_COMPUTE_WORK_UNITS
 
     def spectrum_payload(self, client_id: str) -> SpectrumSeriesPayload:
         with self._store.locked_client_buffer(client_id) as buf:

--- a/docs/multithreading_performance.md
+++ b/docs/multithreading_performance.md
@@ -2,26 +2,26 @@
 
 ## Summary
 
-Implemented parallel multi-sensor FFT processing using a fixed-size thread pool
-(4 workers, one per Raspberry Pi core) to reduce lag spikes and improve
-throughput when multiple sensors are connected.
+Implemented adaptive multi-sensor FFT processing using a fixed-size thread pool
+(4 workers, one per Raspberry Pi core) to reduce lag spikes on larger workloads
+without paying thread-pool overhead on trivially small compute rounds.
 
 ## Threading Opportunities Identified (ranked by impact)
 
-### 1. Parallel per-client FFT in `compute_all()` — **HIGH IMPACT, IMPLEMENTED**
+### 1. Adaptive per-client FFT in `compute_all()` — **HIGH IMPACT, IMPLEMENTED**
 
-- **Problem**: `compute_all()` ran `compute_metrics()` sequentially for each
-  connected sensor. With 4 sensors, the event loop blocked for 4× the
-  single-sensor FFT time on every processing tick.
+- **Problem**: `compute_all()` originally ran `compute_metrics()` sequentially for
+  each connected sensor. The first multithreaded version improved larger
+  workloads but still paid queue/scheduling overhead for small FFT rounds.
 - **Why it works**: `compute_metrics()` already uses a three-phase
   snapshot→compute→store design with brief locks. The heavy FFT math runs
   under NumPy, which releases the GIL, enabling true thread parallelism.
 - **Fix**: Added a `WorkerPool` wrapper with bounded outstanding work
   (`max_workers=4`, plus a small bounded waiting queue) and changed
-  `compute_all()` to dispatch per-client FFT tasks in parallel.
-  Single-client case stays sequential to avoid thread dispatch overhead.
-- **Impact**: P95 (tail) compute latency reduced by 25–30%, directly
-  reducing live-view lag spikes under multi-sensor load.
+  `compute_all()` to dispatch per-client FFT tasks adaptively. Small workloads
+  stay serial; larger multi-sensor rounds still fan out across the pool.
+- **Impact**: Larger workloads keep the tail-latency win from multithreading,
+  while small/default benchmark rounds stop paying unnecessary dispatch cost.
 
 ### 2. `asyncio.to_thread()` for `compute_all()` in the processing loop — already done
 
@@ -45,7 +45,7 @@ with explicit drop logging.
 | Component | Change |
 |-----------|--------|
 | `worker_pool.py` | Bounded worker pool wrapper: caps running + queued tasks, applies caller backpressure, isolates task failures, exposes metrics, supports clean shutdown |
-| `processing/` | `compute_all()` dispatches per-client FFT in parallel; ingest/compute timing counters added |
+| `processing/` | `compute_all()` dispatches per-client FFT adaptively; ingest/compute timing counters added |
 | `runtime/builders.py` | Creates shared `WorkerPool(max_workers=4)`, injects into `SignalProcessor`, runtime shuts it down on stop |
 | Tests | 14 new tests: pool correctness, parallel/sequential equivalence, concurrent ingest+compute safety |
 | Benchmark | `apps/server/tests/infra/workers/benchmark_compute_all.py` — canonical pytest-benchmark regression path; `tools/tests/benchmark_pipeline.py` stays as the standalone throughput table harness |
@@ -62,10 +62,10 @@ On a real 4-core Raspberry Pi, the parallel speedup is expected to be larger.
 | Ingest P95 (ms) | 0.95 | 0.78 | **−18% ingest jitter** |
 | Output equivalence | — | ✅ YES | Identical results |
 
-Key insight: the thread pool reduces **tail latency** (P95) significantly,
-which is the metric that causes visible lag spikes in the live view.
-Median overhead is from thread dispatch on very fast tasks; on a Pi with
-slower per-core performance, the median also improves.
+Key insight: the thread pool reduces **tail latency** (P95) when each
+per-client FFT round is large enough to amortize dispatch overhead. Small FFT
+workloads should stay serial; on a Pi with slower per-core performance or with
+larger FFT sizes, the adaptive parallel path still carries the benefit.
 
 ## How to run the benchmark
 

--- a/tools/tests/benchmark_pipeline.py
+++ b/tools/tests/benchmark_pipeline.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 """Multi-sensor throughput benchmark for VibeSensor pipeline.
 
-Measures ingest and compute latency with and without the parallel worker pool
-to quantify the improvement from multithreaded FFT.
+Measures ingest and compute latency with and without the adaptive worker-pool
+path to quantify when multithreaded FFT helps.
 
 Usage::
 
     python tools/tests/benchmark_pipeline.py
     python tools/tests/benchmark_pipeline.py --sensors 8 --rounds 20
 
-Output is a plain-text table comparing sequential vs parallel execution.
+Output is a plain-text table comparing sequential vs adaptive execution.
 
 For repeatable regression comparisons, use
 ``apps/server/tests/infra/workers/benchmark_compute_all.py`` through
@@ -37,28 +37,29 @@ def _p95(values: list[float]) -> float:
 
 
 SAMPLE_RATE_HZ = 800
-FFT_N = 512
 WAVEFORM_SECONDS = 4
 SPECTRUM_MAX_HZ = 200
 
 
-def _make_processor(pool: WorkerPool | None = None) -> SignalProcessor:
+def _make_processor(*, fft_n: int, pool: WorkerPool | None = None) -> SignalProcessor:
     return SignalProcessor(
         sample_rate_hz=SAMPLE_RATE_HZ,
         waveform_seconds=WAVEFORM_SECONDS,
         waveform_display_hz=100,
-        fft_n=FFT_N,
+        fft_n=fft_n,
         spectrum_max_hz=SPECTRUM_MAX_HZ,
         accel_scale_g_per_lsb=1.0 / 256.0,
         worker_pool=pool,
     )
 
 
-def _inject_signal(proc: SignalProcessor, client_id: str, freq_hz: float) -> None:
-    t = np.arange(FFT_N, dtype=np.float64) / SAMPLE_RATE_HZ
+def _inject_signal(
+    proc: SignalProcessor, client_id: str, freq_hz: float, *, fft_n: int
+) -> None:
+    t = np.arange(fft_n, dtype=np.float64) / SAMPLE_RATE_HZ
     x = (0.05 * np.sin(2.0 * pi * freq_hz * t) * 256.0).astype(np.int16)
     y = (0.03 * np.sin(2.0 * pi * (freq_hz + 10) * t) * 256.0).astype(np.int16)
-    z = np.zeros(FFT_N, dtype=np.int16)
+    z = np.zeros(fft_n, dtype=np.int16)
     samples = np.stack([x, y, z], axis=1)
     proc.ingest(client_id, samples, sample_rate_hz=SAMPLE_RATE_HZ)
 
@@ -67,15 +68,16 @@ def run_benchmark(
     n_sensors: int = 4,
     n_rounds: int = 10,
     n_ingest_per_round: int = 5,
+    fft_n: int = 512,
 ) -> dict[str, object]:
     """Run the benchmark and return a results dict."""
     client_ids = [f"sensor-{i:02d}" for i in range(n_sensors)]
     freqs = [20.0 + i * 7.5 for i in range(n_sensors)]
 
     # --- Sequential baseline ---
-    proc_seq = _make_processor(pool=None)
+    proc_seq = _make_processor(fft_n=fft_n, pool=None)
     for cid, freq in zip(client_ids, freqs, strict=True):
-        _inject_signal(proc_seq, cid, freq)
+        _inject_signal(proc_seq, cid, freq, fft_n=fft_n)
 
     seq_ingest_ms: list[float] = []
     seq_compute_ms: list[float] = []
@@ -83,19 +85,19 @@ def run_benchmark(
         t0 = time.monotonic()
         for cid, freq in zip(client_ids, freqs, strict=True):
             for _ in range(n_ingest_per_round):
-                _inject_signal(proc_seq, cid, freq)
+                _inject_signal(proc_seq, cid, freq, fft_n=fft_n)
         seq_ingest_ms.append((time.monotonic() - t0) * 1000)
 
         t0 = time.monotonic()
         proc_seq.compute_all(client_ids)
         seq_compute_ms.append((time.monotonic() - t0) * 1000)
 
-    # --- Parallel ---
+    # --- Adaptive worker-pool path ---
     pool = WorkerPool(max_workers=4, thread_name_prefix="bench-fft")
     try:
-        proc_par = _make_processor(pool=pool)
+        proc_par = _make_processor(fft_n=fft_n, pool=pool)
         for cid, freq in zip(client_ids, freqs, strict=True):
-            _inject_signal(proc_par, cid, freq)
+            _inject_signal(proc_par, cid, freq, fft_n=fft_n)
 
         par_ingest_ms: list[float] = []
         par_compute_ms: list[float] = []
@@ -103,7 +105,7 @@ def run_benchmark(
             t0 = time.monotonic()
             for cid, freq in zip(client_ids, freqs, strict=True):
                 for _ in range(n_ingest_per_round):
-                    _inject_signal(proc_par, cid, freq)
+                    _inject_signal(proc_par, cid, freq, fft_n=fft_n)
             par_ingest_ms.append((time.monotonic() - t0) * 1000)
 
             t0 = time.monotonic()
@@ -114,13 +116,13 @@ def run_benchmark(
 
     # --- Verify output equivalence ---
     # Re-run from fresh processors with identical input
-    proc_a = _make_processor(pool=None)
+    proc_a = _make_processor(fft_n=fft_n, pool=None)
     pool_b = WorkerPool(max_workers=4)
     try:
-        proc_b = _make_processor(pool=pool_b)
+        proc_b = _make_processor(fft_n=fft_n, pool=pool_b)
         for cid, freq in zip(client_ids, freqs, strict=True):
-            _inject_signal(proc_a, cid, freq)
-            _inject_signal(proc_b, cid, freq)
+            _inject_signal(proc_a, cid, freq, fft_n=fft_n)
+            _inject_signal(proc_b, cid, freq, fft_n=fft_n)
         res_a = proc_a.compute_all(client_ids)
         res_b = proc_b.compute_all(client_ids)
     finally:
@@ -136,13 +138,14 @@ def run_benchmark(
         "n_sensors": n_sensors,
         "n_rounds": n_rounds,
         "n_ingest_per_round": n_ingest_per_round,
+        "fft_n": fft_n,
         "sequential": {
             "ingest_median_ms": round(statistics.median(seq_ingest_ms), 3),
             "ingest_p95_ms": round(_p95(seq_ingest_ms), 3),
             "compute_median_ms": round(statistics.median(seq_compute_ms), 3),
             "compute_p95_ms": round(_p95(seq_compute_ms), 3),
         },
-        "parallel": {
+        "adaptive": {
             "ingest_median_ms": round(statistics.median(par_ingest_ms), 3),
             "ingest_p95_ms": round(_p95(par_ingest_ms), 3),
             "compute_median_ms": round(statistics.median(par_compute_ms), 3),
@@ -154,6 +157,7 @@ def run_benchmark(
             2,
         ),
         "output_equivalent": output_match,
+        "adaptive_worker_tasks": proc_par.intake_stats()["worker_pool"]["total_tasks"],
     }
 
 
@@ -165,15 +169,24 @@ def main() -> None:
     parser.add_argument(
         "--rounds", type=int, default=10, help="Number of benchmark rounds"
     )
+    parser.add_argument(
+        "--fft-n", type=int, default=512, help="FFT size for each compute round"
+    )
     args = parser.parse_args()
 
-    print(f"Benchmarking with {args.sensors} sensors, {args.rounds} rounds ...\n")
-    results = run_benchmark(n_sensors=args.sensors, n_rounds=args.rounds)
+    print(
+        f"Benchmarking with {args.sensors} sensors, fft_n={args.fft_n}, {args.rounds} rounds ...\n"
+    )
+    results = run_benchmark(
+        n_sensors=args.sensors,
+        n_rounds=args.rounds,
+        fft_n=args.fft_n,
+    )
 
     seq = results["sequential"]
-    par = results["parallel"]
+    par = results["adaptive"]
     print("=" * 60)
-    print(f"  {'Metric':<30} {'Sequential':>12} {'Parallel':>12}")
+    print(f"  {'Metric':<30} {'Sequential':>12} {'Adaptive':>12}")
     print("-" * 60)
     print(
         f"  {'Ingest median (ms)':<30} {seq['ingest_median_ms']:>12.3f} {par['ingest_median_ms']:>12.3f}"
@@ -192,6 +205,7 @@ def main() -> None:
     print(
         f"  {'Output equivalent':<30} {'YES' if results['output_equivalent'] else 'NO':>12}"
     )
+    print(f"  {'Adaptive worker tasks':<30} {results['adaptive_worker_tasks']:>12}")
     print("=" * 60)
 
 


### PR DESCRIPTION
## Summary
- add an adaptive `client_count * fft_n` cutoff before `compute_all()` uses the worker pool
- keep larger FFT rounds on the existing parallel path
- add focused cutoff tests, expand benchmark coverage, and refresh the standalone harness/docs

## Why
- 4x512 rounds spent more time on pool dispatch than on useful FFT work
- current code parallelized every multi-client round even when the pool bought nothing

## Validation
- `make format`
- `make lint`
- `make typecheck-backend`
- `cd apps/server && /workspace/VibeSensor/.venv/bin/python -m pytest -q -o addopts='' tests/infra/workers/test_worker_pool.py tests/infra/processing/test_processing_extended.py tests/infra/processing/test_compute_all_parallel_cutoff.py`
- `cd apps/server && /workspace/VibeSensor/.venv/bin/python -m pytest --benchmark-only -q -o addopts='' tests/infra/workers/benchmark_compute_all.py`
- `/workspace/VibeSensor/.venv/bin/python tools/tests/benchmark_pipeline.py --sensors 4 --rounds 20 --fft-n 512`
- `/workspace/VibeSensor/.venv/bin/python tools/tests/benchmark_pipeline.py --sensors 4 --rounds 20 --fft-n 2048`

## Risks / tradeoffs
- cutoff is calibrated from local benchmarks, not Pi-target hardware
- 2048-point rounds still stay parallel; Pi confirmation still matters before calling the threshold final

Closes #3039
