### PR TITLE
perf(ui): lazy-load Dutch i18n catalog

### DIFF
--- a/apps/ui/src/app/runtime/ui_shell_controller.ts
+++ b/apps/ui/src/app/runtime/ui_shell_controller.ts
@@ -2,7 +2,7 @@ import type { QueryClient } from "@tanstack/query-core";
 
 import * as I18N from "../../i18n";
 import { formatIntLocale } from "../../format";
-import { setUiLanguage } from "../ui_i18n";
+import { setUiLanguage, translateUiText } from "../ui_i18n";
 import type { AppState } from "../ui_app_state";
 import {
   computed,
@@ -134,6 +134,7 @@ export class UiShellController {
       shell: this.state.shell,
       t: (key, vars) => this.t(key, vars),
       normalizeLanguage: (lang) => I18N.normalizeLang(lang ?? ""),
+      prepareLanguage: (lang) => setUiLanguage(lang),
     });
     deps.chromeActions.value = {
       activateView: (viewId) => this.setActiveView(viewId),
@@ -153,7 +154,7 @@ export class UiShellController {
   }
 
   t(key: string, vars?: Record<string, unknown>): string {
-    return I18N.get(this.state.shell.lang.value, key, vars);
+    return translateUiText(key, vars);
   }
 
   localFormatInt(value: number): string {
@@ -201,7 +202,7 @@ export class UiShellController {
   private bindReactiveLanguageSync(): () => void {
     return effectOnChange(this.state.shell.lang, (currentLanguage) => {
       untracked(() => {
-        setUiLanguage(currentLanguage);
+        void setUiLanguage(currentLanguage);
       });
     });
   }

--- a/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
+++ b/apps/ui/src/app/runtime/ui_shell_preferences_module.ts
@@ -24,6 +24,7 @@ export interface UiShellPreferencesModule {
 
 type UiShellPreferencesDeps = {
   normalizeLanguage: (value: string | null | undefined) => string;
+  prepareLanguage: (value: string) => Promise<void>;
   queryClient: QueryClient;
   shell: ShellState;
   t: (key: string, vars?: Record<string, unknown>) => string;
@@ -51,9 +52,11 @@ export function createUiShellPreferencesModule(
     return value === "nl" ? "Nederlands" : "English";
   }
 
-  function applyLanguageValue(rawLanguage: string): void {
-    deps.shell.lang.value = deps.normalizeLanguage(rawLanguage);
-    selectedLanguage.value = deps.shell.lang.value;
+  async function applyLanguageValue(rawLanguage: string): Promise<void> {
+    const nextLanguage = deps.normalizeLanguage(rawLanguage);
+    await deps.prepareLanguage(nextLanguage);
+    deps.shell.lang.value = nextLanguage;
+    selectedLanguage.value = nextLanguage;
   }
 
   function applySpeedUnitValue(rawUnit: string): void {
@@ -104,7 +107,7 @@ export function createUiShellPreferencesModule(
         languageResult.status === "fulfilled" &&
         languageResult.value?.language
       ) {
-        applyLanguageValue(languageResult.value.language);
+        await applyLanguageValue(languageResult.value.language);
       } else if (languageResult.status === "rejected") {
         console.warn(
           "Failed to load persisted language",
@@ -135,7 +138,7 @@ export function createUiShellPreferencesModule(
           serverStateQueryKeys.settings.language(),
           { language: resolvedLanguage },
         );
-        applyLanguageValue(resolvedLanguage);
+        await applyLanguageValue(resolvedLanguage);
       } catch (error) {
         selectedLanguage.value = previousLanguage;
         languageFeedback.value = buildSaveFailureFeedback(

--- a/apps/ui/src/app/ui_app_runtime.ts
+++ b/apps/ui/src/app/ui_app_runtime.ts
@@ -18,6 +18,7 @@ import type { UiAppBootRuntime } from "./ui_app_boot_runtime";
 import { preloadRealtimeLiveOverviewPanel } from "./views/realtime_live_overview_lazy";
 import { preloadRealtimeLoggingPanel } from "./views/realtime_logging_panel_lazy";
 import { preloadSpectrumPanelHost } from "./views/spectrum_panel_host_lazy";
+import { setUiLanguage } from "./ui_i18n";
 
 export interface UiAppRuntime {
   attachSettingsPanels(handles: UiMountedLazyPanelHandles): void;
@@ -66,11 +67,12 @@ export function createUiAppRuntime(deps: UiAppRuntimeDeps = {}): UiAppRuntime {
       return bootRuntimePromise;
     }
     bootRuntimePromise = Promise.all([
+      setUiLanguage(state.shell.lang.value),
       import("./ui_app_boot_runtime"),
       preloadRealtimeLiveOverviewPanel(),
       preloadRealtimeLoggingPanel(),
       preloadSpectrumPanelHost(),
-    ]).then(([{ createUiAppBootRuntime }]) => {
+    ]).then(([, { createUiAppBootRuntime }]) => {
         if (disposed) {
           return null;
         }

--- a/apps/ui/src/app/ui_i18n.ts
+++ b/apps/ui/src/app/ui_i18n.ts
@@ -1,22 +1,23 @@
-import { get as translate, normalizeLang } from "../i18n";
+import { ensureCatalogLoaded, get as translate, normalizeLang } from "../i18n";
 import { signal, useComputed, type ReadonlySignal } from "./ui_signals";
 
 const currentLanguage = signal("en");
 
-export function getUiText(
-  key: string,
-  fallback: string,
-  vars?: Record<string, unknown>,
-): string {
-  return translate(currentLanguage.value, key, vars) || fallback;
-}
-
-export function setUiLanguage(lang: string): void {
+export async function setUiLanguage(lang: string): Promise<void> {
   const normalizedLanguage = normalizeLang(lang);
+  await ensureCatalogLoaded(normalizedLanguage);
   if (normalizedLanguage === currentLanguage.value) {
     return;
   }
   currentLanguage.value = normalizedLanguage;
+}
+
+export function translateUiText(key: string, vars?: Record<string, unknown>): string {
+  return translate(currentLanguage.value, key, vars);
+}
+
+export function getUiText(key: string, fallback: string, vars?: Record<string, unknown>): string {
+  return translateUiText(key, vars) || fallback;
 }
 
 export function useUiText(
@@ -24,5 +25,5 @@ export function useUiText(
   fallback: string,
   vars?: Record<string, unknown>,
 ): ReadonlySignal<string> {
-  return useComputed(() => translate(currentLanguage.value, key, vars) || fallback);
+  return useComputed(() => translateUiText(key, vars) || fallback);
 }

--- a/apps/ui/src/app/views/spectrum_panel_host.tsx
+++ b/apps/ui/src/app/views/spectrum_panel_host.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from "preact";
 import { memo } from "preact/compat";
 
-import { getUiText } from "../ui_i18n";
+import { useUiText } from "../ui_i18n";
 import {
   useSignalProperties,
   type ReadonlySignal,
@@ -183,8 +183,8 @@ function SpectrumPanel(props: SpectrumPanelProps) {
   const overlayModel = props.overlayModel.value ?? DEFAULT_SPECTRUM_OVERLAY_MODEL;
   const sensorLegend = useDeferredModel(props.sensorLegendModel, null);
   const sensorLegendHandlers = useDeferredModel(props.sensorLegendHandlersModel, null);
-  const titleText = getUiText("chart.spectrum_title", props.header.value.titleText);
-  const hintText = getUiText("spectrum.controls_hint", props.header.value.hintText);
+  const titleText = useUiText("chart.spectrum_title", props.header.value.titleText);
+  const hintText = useUiText("spectrum.controls_hint", props.header.value.hintText);
   const {
     disabled: bandToggleDisabled,
     hidden: bandToggleHidden,

--- a/apps/ui/src/i18n.ts
+++ b/apps/ui/src/i18n.ts
@@ -19,7 +19,7 @@ const _catalogs: Partial<Record<SupportedLanguage, Catalog>> = {
 };
 const _catalogLoads = new Map<SupportedLanguage, Promise<void>>();
 const _catalogLoaders: Record<SupportedLanguage, () => Promise<CatalogModule>> = {
-  nl: () => import("./i18n/catalogs/nl.json", { with: { type: "json" } }),
+  nl: () => import("./i18n/catalogs/nl"),
   en: async () => ({ default: enCatalog }),
 };
 

--- a/apps/ui/src/i18n.ts
+++ b/apps/ui/src/i18n.ts
@@ -1,7 +1,7 @@
 import enCatalog from "./i18n/catalogs/en.json" with { type: "json" };
-import nlCatalog from "./i18n/catalogs/nl.json" with { type: "json" };
 
 type Catalog = Record<string, string>;
+type CatalogModule = { default: Catalog };
 
 export type NumberVar = {
   number: number;
@@ -9,10 +9,19 @@ export type NumberVar = {
 };
 
 export const supported = ["en", "nl"] as const;
+type SupportedLanguage = (typeof supported)[number];
 
 const _PLACEHOLDER_RE = /\{([a-zA-Z0-9_]+)\}/g;
 const _numberFormatCache = new Map<string, Intl.NumberFormat>();
 const _HAS_OWN = Object.prototype.hasOwnProperty;
+const _catalogs: Partial<Record<SupportedLanguage, Catalog>> = {
+  en: enCatalog,
+};
+const _catalogLoads = new Map<SupportedLanguage, Promise<void>>();
+const _catalogLoaders: Record<SupportedLanguage, () => Promise<CatalogModule>> = {
+  nl: () => import("./i18n/catalogs/nl.json", { with: { type: "json" } }),
+  en: async () => ({ default: enCatalog }),
+};
 
 function _getDefaultNumberFormat(lang: string): Intl.NumberFormat {
   let fmt = _numberFormatCache.get(lang);
@@ -23,15 +32,39 @@ function _getDefaultNumberFormat(lang: string): Intl.NumberFormat {
   return fmt;
 }
 
-const dict: Record<string, Catalog> = {
-  en: enCatalog,
-  nl: nlCatalog,
-};
-
 export function normalizeLang(value: string): string {
   const raw = String(value || "").trim().toLowerCase();
   if (raw.startsWith("nl")) return "nl";
   return "en";
+}
+
+function normalizeSupportedLanguage(value: string): SupportedLanguage {
+  return normalizeLang(value) as SupportedLanguage;
+}
+
+export async function ensureCatalogLoaded(lang: string): Promise<void> {
+  const normalized = normalizeSupportedLanguage(lang);
+  if (_catalogs[normalized]) {
+    return;
+  }
+  const existingLoad = _catalogLoads.get(normalized);
+  if (existingLoad) {
+    await existingLoad;
+    return;
+  }
+  const load = _catalogLoaders[normalized]().then((module) => {
+    _catalogs[normalized] = module.default;
+  });
+  _catalogLoads.set(normalized, load);
+  try {
+    await load;
+  } finally {
+    _catalogLoads.delete(normalized);
+  }
+}
+
+function getLoadedCatalog(lang: string): Catalog | undefined {
+  return _catalogs[normalizeSupportedLanguage(lang)];
 }
 
 function isNumberVar(value: unknown): value is NumberVar {
@@ -52,8 +85,8 @@ function formatVar(lang: string, value: unknown): string {
 
 export function get(lang: string, key: string, vars?: Record<string, unknown>): string {
   const normalized = normalizeLang(lang);
-  const fallback = dict.en?.[key] || key;
-  const template = dict[normalized]?.[key] || fallback;
+  const fallback = getLoadedCatalog("en")?.[key] || key;
+  const template = getLoadedCatalog(normalized)?.[key] || fallback;
   if (!vars || typeof vars !== "object") return template;
   return String(template).replace(_PLACEHOLDER_RE, (_m, placeholder) => {
     if (_HAS_OWN.call(vars, placeholder)) {
@@ -64,5 +97,5 @@ export function get(lang: string, key: string, vars?: Record<string, unknown>): 
 }
 
 export function getForAllLangs(key: string): string[] {
-  return supported.map((lang) => get(lang, key));
+  return supported.map((lang) => getLoadedCatalog(lang)?.[key] || key);
 }

--- a/apps/ui/src/i18n/catalogs/nl.ts
+++ b/apps/ui/src/i18n/catalogs/nl.ts
@@ -1,0 +1,3 @@
+import catalog from "./nl.json" with { type: "json" };
+
+export default catalog;

--- a/apps/ui/tests/ui_i18n.spec.ts
+++ b/apps/ui/tests/ui_i18n.spec.ts
@@ -1,0 +1,18 @@
+import { beforeEach, expect, test } from "vitest";
+
+import { getUiText, setUiLanguage } from "../src/app/ui_i18n";
+
+beforeEach(async () => {
+  await setUiLanguage("en");
+});
+
+test("loads the active catalog before switching UI language", async () => {
+  expect(getUiText("settings.language", "Language")).toBe("Language");
+
+  await setUiLanguage("nl");
+
+  expect(getUiText("settings.language", "Language")).toBe("Taal");
+  expect(getUiText("dashboard.sensor_unassigned", "Location unassigned")).toBe(
+    "Locatie niet toegewezen",
+  );
+});

--- a/apps/ui/tests/ui_shell_runtime_modules.spec.ts
+++ b/apps/ui/tests/ui_shell_runtime_modules.spec.ts
@@ -348,12 +348,16 @@ describe("createUiShellPreferencesModule", () => {
   test("hydrates persisted language and speed unit from the server", async () => {
     const state = createAppState();
     const requests: string[] = [];
+    const preparedLanguages: string[] = [];
 
     const module = createUiShellPreferencesModule({
       queryClient: createTestQueryClient(),
       shell: state.shell,
       t: (key) => key,
       normalizeLanguage: (lang) => String(lang),
+      prepareLanguage: async (lang) => {
+        preparedLanguages.push(lang);
+      },
     });
 
     mswServer.use(
@@ -373,6 +377,7 @@ describe("createUiShellPreferencesModule", () => {
       "/api/settings/language",
       "/api/settings/speed-unit",
     ]);
+    expect(preparedLanguages).toEqual(["nl"]);
     expect(state.shell.lang.value).toBe("nl");
     expect(state.shell.speedUnit.value).toBe("mps");
     expect(module.selectedLanguage.value).toBe("nl");
@@ -382,12 +387,16 @@ describe("createUiShellPreferencesModule", () => {
   test("keeps the pending language selection visible until the save resolves", async () => {
     const state = createAppState();
     let resolveResponse: ((response: Response) => void) | null = null;
+    const preparedLanguages: string[] = [];
 
     const module = createUiShellPreferencesModule({
       queryClient: createTestQueryClient(),
       shell: state.shell,
       t: (key) => key,
       normalizeLanguage: (lang) => String(lang),
+      prepareLanguage: async (lang) => {
+        preparedLanguages.push(lang);
+      },
     });
 
     mswServer.use(
@@ -405,6 +414,7 @@ describe("createUiShellPreferencesModule", () => {
     resolveResponse?.(HttpResponse.json({ language: "nl" }));
     await savePromise;
 
+    expect(preparedLanguages).toEqual(["nl"]);
     expect(state.shell.lang.value).toBe("nl");
     expect(module.selectedLanguage.value).toBe("nl");
   });
@@ -417,6 +427,7 @@ describe("createUiShellPreferencesModule", () => {
       shell: state.shell,
       t: testTranslation,
       normalizeLanguage: (lang) => String(lang),
+      prepareLanguage: async () => undefined,
     });
 
     mswServer.use(


### PR DESCRIPTION
## Summary
- keep English resident and move Dutch behind an async catalog load
- preload the current UI language before boot runtime starts and before preference-driven language flips land
- add focused UI i18n tests and assert the preference module waits for catalog readiness

## Why
- `ui_i18n` shipped both catalogs on the common boot path
- analyzer baseline was 30.75 kB gzip for the eager i18n chunk
- after the split, eager `ui_i18n` is 16.07 kB gzip and Dutch moved to a 15.94 kB gzip lazy chunk

## Validation
- `make ui-typecheck`
- `cd apps/ui && npm run test:unit -- tests/ui_i18n.spec.ts tests/ui_shell_runtime_modules.spec.ts`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm run analyze`

## Risks / tradeoffs
- English stays resident so first render stays deterministic; Dutch is the lazy path for now
- `make ui-typecheck` still emits the existing Biome schema/useImportType/unused-import warnings outside this diff

Closes #3040
