### PR TITLE
Keep secondary bundle off dashboard startup path

### DIFF
--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -9,6 +9,7 @@ import {
   type RealtimeFeatureChromePorts,
   type RealtimeFeatureSelectionPorts,
 } from "./features/realtime_feature";
+import { createDashboardSpeedSourceStatusModule } from "./features/dashboard_speed_source_status_module";
 import { loadDashboardStartupState } from "./features/dashboard_startup_state";
 import type { SettingsFeatureViewPorts } from "./features/settings_feature";
 import type { FeatureFormatting, FeatureServices } from "./feature_deps_base";
@@ -165,6 +166,11 @@ export function createAppFeatureBundle(
   } = deps;
   const { panels } = runtime;
   const secondary = createLazySecondaryFeatureBundle(deps);
+  const dashboardSpeedSourceStatus = createDashboardSpeedSourceStatusModule({
+    activeViewId: runtime.navigation.activeViewId,
+    queryClient: serverState.queryClient,
+    settings: state.settings,
+  });
   const reportFeatureLoadError = (error: unknown): void => {
     services.showError(
       error instanceof Error ? error.message : services.t("status.view_load_failed"),
@@ -219,13 +225,12 @@ export function createAppFeatureBundle(
     queryClient: serverState.queryClient,
   });
 
-  return createAppFeatureBundlePorts({
+  const bundle = createAppFeatureBundlePorts({
     dashboard: {
-      hydrateStartupState: () => loadDashboardStartupState(serverState.queryClient, state.settings)
-        .catch((error) => {
-          reportFeatureLoadError(error);
-          throw error;
-        }),
+      hydrateStartupState: () => Promise.all([
+        loadDashboardStartupState(serverState.queryClient, state.settings),
+        dashboardSpeedSourceStatus.markStartupReady(),
+      ]).then(() => undefined),
     },
     realtime,
     ensureViewReady: (viewId) => ensureSecondaryViewReady(viewId).catch((error) => {
@@ -236,4 +241,27 @@ export function createAppFeatureBundle(
       dispose: () => secondary.dispose(),
     },
   });
+
+  return {
+    ...bundle,
+    dispose(): void {
+      dashboardSpeedSourceStatus.dispose();
+      bundle.dispose();
+    },
+    shell: {
+      bindHandlers(): void {
+        dashboardSpeedSourceStatus.bindHandlers();
+        bundle.shell.bindHandlers();
+      },
+    },
+    startup: {
+      ...bundle.startup,
+      dashboard: {
+        hydrateStartupState: () => bundle.startup.dashboard.hydrateStartupState().catch((error) => {
+          reportFeatureLoadError(error);
+          throw error;
+        }),
+      },
+    },
+  };
 }

--- a/apps/ui/src/app/app_feature_bundle.ts
+++ b/apps/ui/src/app/app_feature_bundle.ts
@@ -9,11 +9,12 @@ import {
   type RealtimeFeatureChromePorts,
   type RealtimeFeatureSelectionPorts,
 } from "./features/realtime_feature";
+import { loadDashboardStartupState } from "./features/dashboard_startup_state";
 import type { SettingsFeatureViewPorts } from "./features/settings_feature";
 import type { FeatureFormatting, FeatureServices } from "./feature_deps_base";
 import type { AppState } from "./ui_app_state";
 import type { UiMountedPanels } from "./ui_lazy_panels";
-import { type ReadonlySignal } from "./ui_signals";
+import type { ReadonlySignal } from "./ui_signals";
 import type { AppFeatureBundle } from "./app_feature_bundle_ports";
 import type { AppFeatureSecondaryBundle } from "./app_feature_secondary_bundle";
 import { preloadHistoryLazyView } from "./views/history_lazy_view";
@@ -47,7 +48,6 @@ export interface AppFeatureBundleDeps {
 
 interface LazySecondaryFeatureBundle {
   dispose(): void;
-  ensureDashboardDataLoaded(): Promise<void>;
   ensureHistoryDataLoaded(): Promise<void>;
   ensureSettingsDataLoaded(): Promise<void>;
   openCarWizard(): Promise<void>;
@@ -59,10 +59,8 @@ function createLazySecondaryFeatureBundle(
 ): LazySecondaryFeatureBundle {
   let bundle: AppFeatureSecondaryBundle | null = null;
   let bundlePromise: Promise<AppFeatureSecondaryBundle> | null = null;
-  let dashboardDataLoadPromise: Promise<void> | null = null;
   let historyLoadPromise: Promise<void> | null = null;
   let settingsLoadPromise: Promise<void> | null = null;
-  let dashboardDataLoaded = false;
   let historyLoaded = false;
   let settingsLoaded = false;
   let disposed = false;
@@ -115,30 +113,6 @@ function createLazySecondaryFeatureBundle(
     return settingsLoadPromise;
   }
 
-  function ensureDashboardDataLoaded(): Promise<void> {
-    if (dashboardDataLoaded || disposed) {
-      return Promise.resolve();
-    }
-    if (dashboardDataLoadPromise !== null) {
-      return dashboardDataLoadPromise;
-    }
-    dashboardDataLoadPromise = (async () => {
-      const loadedBundle = await ensureLoaded();
-      if (disposed) {
-        return;
-      }
-      await Promise.all([
-        loadedBundle.settings.loadSpeedSourceFromServer(),
-        loadedBundle.settings.loadCarsFromServer(),
-      ]);
-      dashboardDataLoaded = true;
-    })().catch((error) => {
-      dashboardDataLoadPromise = null;
-      throw error;
-    });
-    return dashboardDataLoadPromise;
-  }
-
   function ensureHistoryDataLoaded(): Promise<void> {
     if (historyLoaded || disposed) {
       return Promise.resolve();
@@ -166,7 +140,6 @@ function createLazySecondaryFeatureBundle(
       bundle?.dispose();
       bundle = null;
     },
-    ensureDashboardDataLoaded,
     ensureHistoryDataLoaded,
     ensureSettingsDataLoaded,
     openCarWizard(): Promise<void> {
@@ -192,7 +165,7 @@ export function createAppFeatureBundle(
   } = deps;
   const { panels } = runtime;
   const secondary = createLazySecondaryFeatureBundle(deps);
-  const reportSecondaryLoadError = (error: unknown): void => {
+  const reportFeatureLoadError = (error: unknown): void => {
     services.showError(
       error instanceof Error ? error.message : services.t("status.view_load_failed"),
     );
@@ -233,7 +206,7 @@ export function createAppFeatureBundle(
         activatePrimaryView: runtime.navigation.activatePrimaryView,
         activateSettingsTab: (tabId) => panels.settingsShell.activateTab(tabId),
         openCarWizard: () => {
-          void secondary.openCarWizard().catch(reportSecondaryLoadError);
+          void secondary.openCarWizard().catch(reportFeatureLoadError);
         },
       },
       selection: runtime.transport,
@@ -247,17 +220,20 @@ export function createAppFeatureBundle(
   });
 
   return createAppFeatureBundlePorts({
+    dashboard: {
+      hydrateStartupState: () => loadDashboardStartupState(serverState.queryClient, state.settings)
+        .catch((error) => {
+          reportFeatureLoadError(error);
+          throw error;
+        }),
+    },
     realtime,
     ensureViewReady: (viewId) => ensureSecondaryViewReady(viewId).catch((error) => {
-      reportSecondaryLoadError(error);
+      reportFeatureLoadError(error);
       throw error;
     }),
     secondary: {
       dispose: () => secondary.dispose(),
-      primeDashboardState: () => secondary.ensureDashboardDataLoaded().catch((error) => {
-        reportSecondaryLoadError(error);
-        throw error;
-      }),
     },
   });
 }

--- a/apps/ui/src/app/app_feature_bundle_ports.ts
+++ b/apps/ui/src/app/app_feature_bundle_ports.ts
@@ -14,6 +14,9 @@ export interface AppFeatureBundle {
 }
 
 interface AppFeatureBundlePortSources {
+  dashboard?: {
+    hydrateStartupState(): Promise<void>;
+  };
   realtime: Pick<
     RealtimeFeature,
     | "bindHandlers"
@@ -23,7 +26,6 @@ interface AppFeatureBundlePortSources {
   >;
   secondary?: {
     dispose(): void;
-    primeDashboardState(): Promise<void>;
   };
   ensureViewReady?: (viewId: string) => Promise<void>;
 }
@@ -54,12 +56,12 @@ export function createAppFeatureBundlePorts(
       },
     },
     startup: {
+      dashboard: {
+        hydrateStartupState: () => features.dashboard?.hydrateStartupState() ?? Promise.resolve(),
+      },
       realtime: {
         refreshLocationOptions: () => features.realtime.refreshLocationOptions(),
         refreshLoggingStatus: () => features.realtime.refreshLoggingStatus(),
-      },
-      secondary: {
-        primeDashboardState: () => features.secondary?.primeDashboardState() ?? Promise.resolve(),
       },
     },
   };

--- a/apps/ui/src/app/features/dashboard_speed_source_status_module.ts
+++ b/apps/ui/src/app/features/dashboard_speed_source_status_module.ts
@@ -1,0 +1,66 @@
+import type { QueryClient } from "@tanstack/query-core";
+
+import { getSpeedSourceStatus } from "../../api";
+import { GPS_POLL_FAST_MS, GPS_POLL_SLOW_MS } from "../../config";
+import type { SettingsState } from "../ui_app_state";
+import { computed, signal, type ReadonlySignal } from "../ui_signals";
+import { createObservedServerStateQuery } from "./server_state_query";
+import { applySpeedSourceStatusToSettings } from "./speed_source_status_state";
+
+const DASHBOARD_SPEED_STATUS_QUERY_KEY = ["settings", "dashboard-gps-status"] as const;
+
+interface DashboardSpeedSourceStatusModuleDeps {
+  activeViewId: ReadonlySignal<string>;
+  queryClient: QueryClient;
+  settings: SettingsState;
+}
+
+export interface DashboardSpeedSourceStatusModule {
+  bindHandlers(): void;
+  dispose(): void;
+  markStartupReady(): Promise<void>;
+}
+
+export function createDashboardSpeedSourceStatusModule(
+  deps: DashboardSpeedSourceStatusModuleDeps,
+): DashboardSpeedSourceStatusModule {
+  const handlersBound = signal(false);
+  const startupReady = signal(false);
+  const pollingEnabled = computed(() =>
+    handlersBound.value
+    && startupReady.value
+    && deps.activeViewId.value === "dashboardView"
+  );
+
+  const gpsStatusQuery = createObservedServerStateQuery({
+    enabled: pollingEnabled,
+    observerOptions: {
+      refetchInterval: (query) => query.state.data?.status.connection_state === "connected"
+        ? GPS_POLL_FAST_MS
+        : GPS_POLL_SLOW_MS,
+      refetchIntervalInBackground: true,
+    },
+    onData: ({ status }) => {
+      applySpeedSourceStatusToSettings(deps.settings.speed, status);
+    },
+    queryClient: deps.queryClient,
+    queryFn: async () => ({
+      obdStatus: null,
+      status: await getSpeedSourceStatus(),
+    }),
+    queryKey: DASHBOARD_SPEED_STATUS_QUERY_KEY,
+  });
+
+  return {
+    bindHandlers(): void {
+      handlersBound.value = true;
+    },
+    dispose(): void {
+      gpsStatusQuery.dispose();
+    },
+    markStartupReady(): Promise<void> {
+      startupReady.value = true;
+      return gpsStatusQuery.fetch().then(() => undefined).catch(() => undefined);
+    },
+  };
+}

--- a/apps/ui/src/app/features/dashboard_startup_state.ts
+++ b/apps/ui/src/app/features/dashboard_startup_state.ts
@@ -1,0 +1,65 @@
+import type { QueryClient } from "@tanstack/query-core";
+
+import type { CarsPayload, SpeedSourcePayload } from "../../api/types";
+import type { SettingsState } from "../ui_app_state";
+import { batch } from "../ui_signals";
+import { serverStateQueryKeys } from "./server_state_query_keys";
+import { createSettingsCarsTransport } from "./settings_cars_transport";
+import { createSettingsSpeedSourceTransport } from "./settings_speed_source_transport";
+
+export function applyCarsPayloadToSettings(
+  settings: SettingsState["car"],
+  payload: CarsPayload,
+): void {
+  batch(() => {
+    settings.cars.value = payload.cars;
+    settings.carsLoaded.value = true;
+    const requestedActiveCarId = payload.active_car_id;
+    const hasRequestedActive = requestedActiveCarId
+      ? settings.cars.value.some((car) => car.id === requestedActiveCarId)
+      : false;
+    settings.activeCarId.value = hasRequestedActive
+      ? requestedActiveCarId
+      : null;
+  });
+}
+
+export function applySpeedSourcePayloadToSettings(
+  settings: SettingsState["speed"],
+  payload: SpeedSourcePayload,
+  options: { preserveResolvedSource?: boolean } = {},
+): void {
+  batch(() => {
+    settings.source.value = payload.speed_source;
+    settings.manualSpeedKph.value = payload.manual_speed_kph;
+    settings.obdDeviceMac.value = payload.obd_device_mac ?? null;
+    settings.obdDeviceName.value = payload.obd_device_name ?? null;
+    if (!options.preserveResolvedSource) {
+      settings.resolvedSource.value = null;
+    }
+  });
+}
+
+export async function loadDashboardStartupState(
+  queryClient: QueryClient,
+  settings: SettingsState,
+): Promise<void> {
+  const carsTransport = createSettingsCarsTransport(undefined);
+  const speedSourceTransport = createSettingsSpeedSourceTransport();
+  const [carsPayload, speedSourcePayload] = await Promise.all([
+    queryClient.fetchQuery({
+      queryFn: () => carsTransport.loadCars(),
+      queryKey: serverStateQueryKeys.settings.cars(),
+      staleTime: 0,
+    }),
+    queryClient.fetchQuery({
+      queryFn: () => speedSourceTransport.loadSpeedSource(),
+      queryKey: serverStateQueryKeys.settings.speedSource(),
+      staleTime: 0,
+    }),
+  ]);
+  applyCarsPayloadToSettings(settings.car, carsPayload);
+  applySpeedSourcePayloadToSettings(settings.speed, speedSourcePayload, {
+    preserveResolvedSource: true,
+  });
+}

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -33,6 +33,7 @@ import {
   createSettingsCarsTransport,
   type SettingsCarsTransport,
 } from "./settings_cars_transport";
+import { applyCarsPayloadToSettings } from "./dashboard_startup_state";
 import { serverStateQueryKeys } from "./server_state_query_keys";
 
 interface SettingsCarsModulePanels {
@@ -157,15 +158,7 @@ export function createSettingsCarsModule(
   }
 
   function syncCarsPayload(payload: CarsPayload): void {
-    settings.car.cars.value = payload.cars;
-    settings.car.carsLoaded.value = true;
-    const requestedActiveCarId = payload.active_car_id;
-    const hasRequestedActive = requestedActiveCarId
-      ? settings.car.cars.value.some((car) => car.id === requestedActiveCarId)
-      : false;
-    settings.car.activeCarId.value = hasRequestedActive
-      ? requestedActiveCarId
-      : null;
+    applyCarsPayloadToSettings(settings.car, payload);
     if (
       highlightedCar.value &&
       !settings.car.cars.value.some(

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -18,6 +18,7 @@ import {
 } from "../views/settings_speed_source_presenter";
 import { createObservedServerStateQuery } from "./server_state_query";
 import { serverStateQueryKeys } from "./server_state_query_keys";
+import { applySpeedSourceStatusToSettings } from "./speed_source_status_state";
 
 interface SettingsGpsStatusModulePorts {
   activeViewId: ReadonlySignal<string>;
@@ -63,11 +64,8 @@ export function createSettingsGpsStatusModule(
     handlersBound.value
     && startupReady.value
     && (
-      ctx.ports.activeViewId.value === "dashboardView"
-      || (
-        ctx.ports.activeViewId.value === "settingsView"
-        && ctx.ports.activeSettingsTabId.value === "speedSourceTab"
-      )
+      ctx.ports.activeViewId.value === "settingsView"
+      && ctx.ports.activeSettingsTabId.value === "speedSourceTab"
     )
   );
 
@@ -81,9 +79,7 @@ export function createSettingsGpsStatusModule(
     },
     onData: ({ status, obdStatus }) => {
       batch(() => {
-        settings.speed.gpsFallbackActive.value = status.fallback_active;
-        settings.speed.gpsEffectiveSpeedKph.value = status.effective_speed_kmh;
-        settings.speed.resolvedSource.value = status.speed_source;
+        applySpeedSourceStatusToSettings(settings.speed, status);
         diagnosticsModel.value = buildSpeedSourceDiagnosticsRenderModel(
           status,
           obdStatus,

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -25,6 +25,7 @@ import {
   createSettingsSpeedSourceTransport,
   type SettingsSpeedSourceTransport,
 } from "./settings_speed_source_transport";
+import { applySpeedSourcePayloadToSettings } from "./dashboard_startup_state";
 import { createObservedServerStateQuery } from "./server_state_query";
 import { serverStateQueryKeys } from "./server_state_query_keys";
 
@@ -298,13 +299,11 @@ export function createSettingsSpeedSourceWorkflow(
     options: { preserveResolvedSource?: boolean } = {},
   ): void {
     batch(() => {
-      deps.settings.speed.source.value = payload.speed_source;
-      deps.settings.speed.manualSpeedKph.value = payload.manual_speed_kph;
-      deps.settings.speed.obdDeviceMac.value = payload.obd_device_mac ?? null;
-      deps.settings.speed.obdDeviceName.value = payload.obd_device_name ?? null;
-      if (!options.preserveResolvedSource) {
-        deps.settings.speed.resolvedSource.value = null;
-      }
+      applySpeedSourcePayloadToSettings(
+        deps.settings.speed,
+        payload,
+        options,
+      );
       staleTimeoutInputValue.value = String(payload.stale_timeout_s);
       syncInputsFromSettings();
     });

--- a/apps/ui/src/app/features/speed_source_status_state.ts
+++ b/apps/ui/src/app/features/speed_source_status_state.ts
@@ -1,0 +1,14 @@
+import type { SpeedSourceStatusPayload } from "../../api/types";
+import type { SettingsState } from "../ui_app_state";
+import { batch } from "../ui_signals";
+
+export function applySpeedSourceStatusToSettings(
+  settings: SettingsState["speed"],
+  status: SpeedSourceStatusPayload,
+): void {
+  batch(() => {
+    settings.gpsFallbackActive.value = status.fallback_active;
+    settings.gpsEffectiveSpeedKph.value = status.effective_speed_kmh;
+    settings.resolvedSource.value = status.speed_source;
+  });
+}

--- a/apps/ui/src/app/runtime/ui_startup_coordinator.ts
+++ b/apps/ui/src/app/runtime/ui_startup_coordinator.ts
@@ -88,8 +88,8 @@ export class UiStartupCoordinator {
             run: () => this.features.realtime.refreshLoggingStatus(),
           },
           {
-            name: "prime dashboard state",
-            run: () => this.features.secondary.primeDashboardState(),
+            name: "hydrate dashboard state",
+            run: () => this.features.dashboard.hydrateStartupState(),
           },
         ];
 

--- a/apps/ui/src/app/runtime/ui_startup_feature_ports.ts
+++ b/apps/ui/src/app/runtime/ui_startup_feature_ports.ts
@@ -1,8 +1,8 @@
 import type { RealtimeFeature } from "../features/realtime_feature";
 
 export interface UiStartupFeaturePorts {
-  realtime: Pick<RealtimeFeature, "refreshLocationOptions" | "refreshLoggingStatus">;
-  secondary: {
-    primeDashboardState(): Promise<void>;
+  dashboard: {
+    hydrateStartupState(): Promise<void>;
   };
+  realtime: Pick<RealtimeFeature, "refreshLocationOptions" | "refreshLoggingStatus">;
 }

--- a/apps/ui/tests/app_feature_ports.spec.ts
+++ b/apps/ui/tests/app_feature_ports.spec.ts
@@ -7,6 +7,11 @@ import {
 test("feature port helpers expose the narrowed shell and startup contracts", async () => {
   const calls: string[] = [];
 
+  const dashboard = {
+    async hydrateStartupState() {
+      calls.push("dashboard.hydrateStartupState");
+    },
+  };
   const history = {
     async refreshHistory() {
       calls.push("history.refreshHistory");
@@ -30,13 +35,11 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
     dispose() {
       calls.push("secondary.dispose");
     },
-    async primeDashboardState() {
-      calls.push("secondary.primeDashboardState");
-    },
   };
 
   const recording = createRealtimeFeatureRecordingPorts(history);
   const bundle = createAppFeatureBundlePorts({
+    dashboard,
     realtime,
     secondary,
   });
@@ -48,17 +51,17 @@ test("feature port helpers expose the narrowed shell and startup contracts", asy
   bundle.shell.bindHandlers();
   await bundle.ensureViewReady("historyView");
 
+  await bundle.startup.dashboard.hydrateStartupState();
   await bundle.startup.realtime.refreshLocationOptions();
   await bundle.startup.realtime.refreshLoggingStatus();
-  await bundle.startup.secondary.primeDashboardState();
   bundle.dispose();
 
   expect(calls).toEqual([
     "history.refreshHistory",
     "realtime.bindHandlers",
+    "dashboard.hydrateStartupState",
     "realtime.refreshLocationOptions",
     "realtime.refreshLoggingStatus",
-    "secondary.primeDashboardState",
     "secondary.dispose",
     "realtime.dispose",
   ]);

--- a/apps/ui/tests/smoke.bootstrap.spec.ts
+++ b/apps/ui/tests/smoke.bootstrap.spec.ts
@@ -398,6 +398,45 @@ test("ui bootstrap smoke: tabs, ws state, recording, history", async ({ page }) 
   await expect.poll(() => stopCalls).toBe(1);
 });
 
+test("dashboard bootstrap defers secondary bundle until a dependent view opens", async ({ page }) => {
+  const secondaryBundleRequests: string[] = [];
+  page.on("request", (request) => {
+    if (request.url().includes("app_feature_secondary_bundle")) {
+      secondaryBundleRequests.push(request.url());
+    }
+  });
+
+  await installCommonRoutes(page, {
+    settingsHandler: async (route) => {
+      const path = requestPath(route);
+      if (path === "/api/settings/cars") {
+        await fulfillJson(route, {
+          cars: [{ id: "car-1", name: "Test Hatch", type: "Simulated setup", aspects: {} }],
+          active_car_id: "car-1",
+        });
+        return;
+      }
+      if (path === "/api/settings/speed-source") {
+        await fulfillJson(route, {
+          speed_source: "gps",
+          manual_speed_kph: null,
+          stale_timeout_s: 5,
+        });
+        return;
+      }
+      await fulfillJson(route, {});
+    },
+  });
+  await installFakeWebSocket(page);
+
+  await page.goto("/");
+  await expect(page.locator("#liveActiveCar [data-value]")).toHaveText("Test Hatch");
+  expect(secondaryBundleRequests).toEqual([]);
+
+  await page.locator("#tab-settings").click();
+  await expect.poll(() => secondaryBundleRequests.length).toBeGreaterThan(0);
+});
+
 test("saved run state points directly to History", async ({ page }) => {
   const recordingStatus = {
     enabled: false,

--- a/apps/ui/tests/ui_startup_coordinator.spec.ts
+++ b/apps/ui/tests/ui_startup_coordinator.spec.ts
@@ -22,9 +22,9 @@ function createCoordinatorHarness() {
   const calls: string[] = [];
   const warnings: Array<{ message: string; error: unknown }> = [];
   const hydrate = createDeferred<void>();
+  const hydrateDashboardState = createDeferred<void>();
   const refreshLocationOptions = createDeferred<void>();
   const refreshLoggingStatus = createDeferred<void>();
-  const primeDashboardState = createDeferred<void>();
 
   const coordinator = new UiStartupCoordinator({
     shell: {
@@ -37,6 +37,12 @@ function createCoordinatorHarness() {
       },
     },
     features: {
+      dashboard: {
+        hydrateStartupState(): Promise<void> {
+          calls.push("dashboard.hydrateStartupState");
+          return hydrateDashboardState.promise;
+        },
+      },
       realtime: {
         refreshLocationOptions(): Promise<void> {
           calls.push("realtime.refreshLocationOptions");
@@ -45,12 +51,6 @@ function createCoordinatorHarness() {
         refreshLoggingStatus(): Promise<void> {
           calls.push("realtime.refreshLoggingStatus");
           return refreshLoggingStatus.promise;
-        },
-      },
-      secondary: {
-        primeDashboardState(): Promise<void> {
-          calls.push("secondary.primeDashboardState");
-          return primeDashboardState.promise;
         },
       },
     },
@@ -69,9 +69,9 @@ function createCoordinatorHarness() {
     calls,
     warnings,
     hydrate,
+    hydrateDashboardState,
     refreshLocationOptions,
     refreshLoggingStatus,
-    primeDashboardState,
     coordinator,
   };
 }
@@ -110,7 +110,7 @@ describe("UiStartupCoordinator", () => {
         "shell.hydratePersistedPreferences",
         "realtime.refreshLocationOptions",
         "realtime.refreshLoggingStatus",
-        "secondary.primeDashboardState",
+        "dashboard.hydrateStartupState",
         "transport.startTransportMode",
       ]);
     } finally {
@@ -126,9 +126,9 @@ describe("UiStartupCoordinator", () => {
     try {
       harness.coordinator.start();
       harness.hydrate.reject(hydrateError);
+      harness.hydrateDashboardState.resolve();
       harness.refreshLocationOptions.resolve();
       harness.refreshLoggingStatus.resolve();
-      harness.primeDashboardState.resolve();
 
       await flushAsyncWork();
 


### PR DESCRIPTION
## what changed
- replace the startup-only `primeDashboardState()` path with a lightweight dashboard startup loader that hydrates cars and speed-source state directly into app settings
- keep dashboard-side GPS/manual fallback status updates on the main bundle with a lightweight speed-status monitor instead of reviving the secondary feature bundle
- extract shared speed-source payload/status applicators so startup, dashboard status polling, and settings flows keep the same state-sync rules
- add startup unit coverage plus bootstrap/settings smoke coverage proving cold dashboard boot still defers `app_feature_secondary_bundle` until a dependent view opens

## why
- dashboard boot still paid the secondary feature bundle load just to populate active-car and speed-source state
- dashboard still needs active-car plus resolved GPS/manual fallback state on first paint
- keep those updates alive without instantiating settings/history/update features on cold boot

## validation
- `cd apps/ui && npm run test:unit -- tests/ui_startup_coordinator.spec.ts tests/app_feature_ports.spec.ts`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts --project=laptop-light tests/smoke.settings.spec.ts tests/smoke.bootstrap.spec.ts`
- `cd apps/ui && npm run build`
- `make ui-typecheck`

## risks / tradeoffs
- startup still fetches the minimum dashboard data and dashboard speed status because live overview + speed source status depend on them
- richer settings diagnostics still come from the secondary settings bundle on first relevant navigation

Closes #3041
