### PR TITLE
perf(ui): pause hidden-tab polling

### DIFF
--- a/apps/ui/src/app/features/dashboard_speed_source_status_module.ts
+++ b/apps/ui/src/app/features/dashboard_speed_source_status_module.ts
@@ -4,10 +4,18 @@ import { getSpeedSourceStatus } from "../../api";
 import { GPS_POLL_FAST_MS, GPS_POLL_SLOW_MS } from "../../config";
 import type { SettingsState } from "../ui_app_state";
 import { computed, signal, type ReadonlySignal } from "../ui_signals";
-import { createObservedServerStateQuery } from "./server_state_query";
+import {
+  createHiddenTabPollingObserverOptions,
+  createObservedServerStateQuery,
+} from "./server_state_query";
 import { applySpeedSourceStatusToSettings } from "./speed_source_status_state";
 
 const DASHBOARD_SPEED_STATUS_QUERY_KEY = ["settings", "dashboard-gps-status"] as const;
+
+interface DashboardGpsStatusSnapshot {
+  obdStatus: null;
+  status: Awaited<ReturnType<typeof getSpeedSourceStatus>>;
+}
 
 interface DashboardSpeedSourceStatusModuleDeps {
   activeViewId: ReadonlySignal<string>;
@@ -34,17 +42,19 @@ export function createDashboardSpeedSourceStatusModule(
 
   const gpsStatusQuery = createObservedServerStateQuery({
     enabled: pollingEnabled,
-    observerOptions: {
-      refetchInterval: (query) => query.state.data?.status.connection_state === "connected"
+    observerOptions: createHiddenTabPollingObserverOptions<
+      DashboardGpsStatusSnapshot,
+      typeof DASHBOARD_SPEED_STATUS_QUERY_KEY
+    >(
+      (query) => query.state.data?.status.connection_state === "connected"
         ? GPS_POLL_FAST_MS
         : GPS_POLL_SLOW_MS,
-      refetchIntervalInBackground: true,
-    },
+    ),
     onData: ({ status }) => {
       applySpeedSourceStatusToSettings(deps.settings.speed, status);
     },
     queryClient: deps.queryClient,
-    queryFn: async () => ({
+    queryFn: async (): Promise<DashboardGpsStatusSnapshot> => ({
       obdStatus: null,
       status: await getSpeedSourceStatus(),
     }),

--- a/apps/ui/src/app/features/esp_flash_feature_workflow.ts
+++ b/apps/ui/src/app/features/esp_flash_feature_workflow.ts
@@ -26,7 +26,10 @@ import {
   signal,
   type ReadonlySignal,
 } from "../ui_signals";
-import { createObservedServerStateQuery } from "./server_state_query";
+import {
+  createHiddenTabPollingObserverOptions,
+  createObservedServerStateQuery,
+} from "./server_state_query";
 import { serverStateQueryKeys } from "./server_state_query_keys";
 
 export interface EspFlashFeatureWorkflowApi {
@@ -170,12 +173,11 @@ export function createEspFlashFeatureWorkflow(
 
   const statusSnapshotQuery = createObservedServerStateQuery<EspFlashStatusSnapshot>({
     enabled: deps.pollingEnabled,
-    observerOptions: {
-      refetchInterval: (query) => safeEspFlashState(query.state.data?.status.state) === "running"
+    observerOptions: createHiddenTabPollingObserverOptions<EspFlashStatusSnapshot>(
+      (query) => safeEspFlashState(query.state.data?.status.state) === "running"
         ? ESP_FLASH_POLL_ACTIVE_MS
         : ESP_FLASH_POLL_IDLE_MS,
-      refetchIntervalInBackground: true,
-    },
+    ),
     onData: applyStatusSnapshot,
     queryClient: deps.queryClient,
     queryFn: fetchStatusSnapshot,

--- a/apps/ui/src/app/features/realtime_feature_workflow.ts
+++ b/apps/ui/src/app/features/realtime_feature_workflow.ts
@@ -29,7 +29,10 @@ import {
   type Signal,
 } from "../ui_signals";
 import type { RealtimeLoggingPendingAction } from "../views/realtime_logging_view_models";
-import { createObservedServerStateQuery } from "./server_state_query";
+import {
+  createHiddenTabPollingObserverOptions,
+  createObservedServerStateQuery,
+} from "./server_state_query";
 import { serverStateQueryKeys } from "./server_state_query_keys";
 
 export interface RealtimeFeatureWorkflowApi {
@@ -219,15 +222,14 @@ export function createRealtimeFeatureWorkflow(
 
   const loggingStatusQuery = createObservedServerStateQuery<LoggingStatusPayload>({
     enabled: loggingStatusPollingEnabled,
-    observerOptions: {
-      refetchInterval: (query) => {
+    observerOptions: createHiddenTabPollingObserverOptions<LoggingStatusPayload>(
+      (query) => {
         const nextStatus = query.state.data;
         return nextStatus?.enabled || nextStatus?.analysis_in_progress
           ? LOGGING_STATUS_ACTIVE_POLL_MS
           : LOGGING_STATUS_IDLE_POLL_MS;
       },
-      refetchIntervalInBackground: true,
-    },
+    ),
     onData: handleLoggingStatusData,
     onError: () => {
       batch(() => {

--- a/apps/ui/src/app/features/server_state_query.ts
+++ b/apps/ui/src/app/features/server_state_query.ts
@@ -36,6 +36,24 @@ export interface ObservedServerStateQuery<TData> {
   setData(updater: Updater<TData | undefined, TData | undefined>): void;
 }
 
+export function createHiddenTabPollingObserverOptions<
+  TData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  refetchInterval: NonNullable<
+    QueryObserverOptions<TData, unknown, TData, TData, TQueryKey>["refetchInterval"]
+  >,
+): Pick<
+  QueryObserverOptions<TData, unknown, TData, TData, TQueryKey>,
+  "refetchInterval" | "refetchIntervalInBackground" | "refetchOnWindowFocus"
+> {
+  return {
+    refetchInterval,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+  };
+}
+
 export function createObservedServerStateQuery<
   TData,
   TQueryKey extends QueryKey = QueryKey,

--- a/apps/ui/src/app/features/settings_gps_status_module.ts
+++ b/apps/ui/src/app/features/settings_gps_status_module.ts
@@ -16,7 +16,10 @@ import {
   buildSpeedSourceDiagnosticsRenderModel,
   type SettingsSpeedSourcePresenterDeps,
 } from "../views/settings_speed_source_presenter";
-import { createObservedServerStateQuery } from "./server_state_query";
+import {
+  createHiddenTabPollingObserverOptions,
+  createObservedServerStateQuery,
+} from "./server_state_query";
 import { serverStateQueryKeys } from "./server_state_query_keys";
 import { applySpeedSourceStatusToSettings } from "./speed_source_status_state";
 
@@ -71,12 +74,11 @@ export function createSettingsGpsStatusModule(
 
   const gpsStatusQuery = createObservedServerStateQuery<GpsStatusSnapshot>({
     enabled: pollingEnabled,
-    observerOptions: {
-      refetchInterval: (query) => query.state.data?.status.connection_state === "connected"
+    observerOptions: createHiddenTabPollingObserverOptions<GpsStatusSnapshot>(
+      (query) => query.state.data?.status.connection_state === "connected"
         ? GPS_POLL_FAST_MS
         : GPS_POLL_SLOW_MS,
-      refetchIntervalInBackground: true,
-    },
+    ),
     onData: ({ status, obdStatus }) => {
       batch(() => {
         applySpeedSourceStatusToSettings(settings.speed, status);

--- a/apps/ui/src/app/features/settings_speed_source_workflow.ts
+++ b/apps/ui/src/app/features/settings_speed_source_workflow.ts
@@ -26,7 +26,10 @@ import {
   type SettingsSpeedSourceTransport,
 } from "./settings_speed_source_transport";
 import { applySpeedSourcePayloadToSettings } from "./dashboard_startup_state";
-import { createObservedServerStateQuery } from "./server_state_query";
+import {
+  createHiddenTabPollingObserverOptions,
+  createObservedServerStateQuery,
+} from "./server_state_query";
 import { serverStateQueryKeys } from "./server_state_query_keys";
 
 const OBD_BACKGROUND_RESCAN_DELAY_MS = 2_000;
@@ -503,10 +506,10 @@ export function createSettingsSpeedSourceWorkflow(
 
   const obdBackgroundRescan = createObservedServerStateQuery({
     enabled: obdBackgroundRescanEnabled,
-    observerOptions: {
-      refetchInterval: OBD_BACKGROUND_RESCAN_DELAY_MS,
-      refetchIntervalInBackground: true,
-    },
+    observerOptions: createHiddenTabPollingObserverOptions<
+      Awaited<ReturnType<SettingsSpeedSourceTransport["scanObdDevices"]>>,
+      ReturnType<typeof serverStateQueryKeys.settings.speedSourceObdScan>
+    >(OBD_BACKGROUND_RESCAN_DELAY_MS),
     onData: (payload) => {
       mergeScannedDevices(payload.devices);
     },

--- a/apps/ui/src/app/features/update_feature_workflow.ts
+++ b/apps/ui/src/app/features/update_feature_workflow.ts
@@ -27,7 +27,10 @@ import {
   signal,
   type ReadonlySignal,
 } from "../ui_signals";
-import { createObservedServerStateQuery } from "./server_state_query";
+import {
+  createHiddenTabPollingObserverOptions,
+  createObservedServerStateQuery,
+} from "./server_state_query";
 import { serverStateQueryKeys } from "./server_state_query_keys";
 
 export interface UpdateFeatureWorkflowApi {
@@ -145,12 +148,11 @@ export function createUpdateFeatureWorkflow(
     onError: (error) => {
       deps.showError(error instanceof Error ? error.message : deps.t("status.unavailable"));
     },
-    observerOptions: {
-      refetchInterval: (query) => query.state.data?.status.state === "running"
+    observerOptions: createHiddenTabPollingObserverOptions<UpdateStatusSnapshot>(
+      (query) => query.state.data?.status.state === "running"
         ? UPDATE_POLL_INTERVAL_RUNNING_MS
         : UPDATE_POLL_INTERVAL_IDLE_MS,
-      refetchIntervalInBackground: true,
-    },
+    ),
     onData: applyStatusSnapshot,
     queryClient: deps.queryClient,
     queryFn: fetchStatusSnapshot,

--- a/apps/ui/src/app/ui_app_boot_runtime.ts
+++ b/apps/ui/src/app/ui_app_boot_runtime.ts
@@ -80,6 +80,7 @@ export function createUiAppBootRuntime(deps: {
   state: AppState;
 }): UiAppBootRuntime {
   const queryClient = createUiQueryClient();
+  queryClient.mount();
   let featurePorts!: AppFeatureBundle;
   const shell = new UiShellController({
     bindFeatureHandlers: () => featurePorts.shell.bindHandlers(),
@@ -132,6 +133,7 @@ export function createUiAppBootRuntime(deps: {
       disposed = true;
       featurePorts.dispose();
       queryClient.clear();
+      queryClient.unmount();
       transport.dispose();
       spectrum.dispose();
       shell.dispose();

--- a/apps/ui/tests/server_state_query.spec.ts
+++ b/apps/ui/tests/server_state_query.spec.ts
@@ -1,11 +1,26 @@
-import { describe, expect, test } from "vitest";
+import { focusManager } from "@tanstack/query-core";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { createObservedServerStateQuery } from "../src/app/features/server_state_query";
+import {
+  createHiddenTabPollingObserverOptions,
+  createObservedServerStateQuery,
+} from "../src/app/features/server_state_query";
 import { signal } from "../src/app/ui_signals";
 import { createDeferred, flushAsyncWork } from "./async_test_helpers";
 import { createTestQueryClient } from "./query_client_test_support";
 
+async function flushMicrotasks(rounds = 6): Promise<void> {
+  for (let index = 0; index < rounds; index += 1) {
+    await Promise.resolve();
+  }
+}
+
 describe("createObservedServerStateQuery", () => {
+  afterEach(() => {
+    focusManager.setFocused(undefined);
+    vi.useRealTimers();
+  });
+
   test("fetch populates the current result data", async () => {
     const query = createObservedServerStateQuery({
       queryClient: createTestQueryClient(),
@@ -63,5 +78,36 @@ describe("createObservedServerStateQuery", () => {
     response.resolve(1);
     await flushAsyncWork();
     expect(query.result.value.data).toBeUndefined();
+  });
+
+  test("hidden-tab polling pauses until focus returns", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const queryClient = createTestQueryClient();
+    queryClient.mount();
+    const query = createObservedServerStateQuery({
+      observerOptions: createHiddenTabPollingObserverOptions<number>(500),
+      queryClient,
+      queryFn: async () => {
+        calls += 1;
+        return calls;
+      },
+      queryKey: ["test", "hidden-tab-polling"] as const,
+    });
+
+    await flushMicrotasks();
+    expect(calls).toBe(1);
+
+    focusManager.setFocused(false);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushMicrotasks();
+    expect(calls).toBe(1);
+
+    focusManager.setFocused(true);
+    await flushMicrotasks();
+    expect(calls).toBe(2);
+
+    query.dispose();
+    queryClient.unmount();
   });
 });


### PR DESCRIPTION
## What changed
- add a shared hidden-tab polling helper that sets `refetchIntervalInBackground: false` and `refetchOnWindowFocus: true`
- apply that helper to realtime logging status, dashboard GPS status, settings GPS status, OBD background rescans, updater status, and ESP flash status
- mount/unmount the TanStack `QueryClient` in `ui_app_boot_runtime.ts` so focus/reconnect listeners actually run at runtime
- add a focused query test that proves hidden polling pauses until focus returns

## Why
- these flows kept polling in hidden tabs even when the user was no longer looking at the screen
- current issue evidence showed hidden-tab floors of 1.0-1.5 req/s on common dashboard/settings/admin paths
- without mounting the query client, disabling background intervals would leave tabs stale because focus-driven refresh was inert
- after this change the non-critical pollers stop while hidden and refetch when the tab becomes active again

## Validation
- `cd apps/ui && npm run test:unit -- tests/server_state_query.spec.ts tests/realtime_feature_workflow.spec.ts tests/settings_speed_source_workflow.spec.ts tests/update_feature_workflow.spec.ts tests/esp_flash_feature_workflow.spec.ts`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx playwright test --config=playwright.smoke.config.ts --project=laptop-light tests/smoke.bootstrap.spec.ts tests/smoke.settings.spec.ts tests/smoke.update.spec.ts tests/smoke.esp-flash.spec.ts`
- `make ui-typecheck`

## Risks / tradeoffs
- hidden tabs no longer receive continuous status churn for these paths; freshness depends on the focus refresh when the user returns
- this intentionally does not touch every query in the app, only the non-critical polling owners in issue scope

Closes #3043