### PR TITLE
perf(history): denormalize run car names

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py
@@ -70,15 +70,6 @@ def test_append_samples_in_chunks(tmp_path: Path) -> None:
     assert len(calls) >= 3
 
 
-def test_list_runs_includes_recorded_car_name(tmp_path: Path) -> None:
-    db = build_history_db(tmp_path)
-    create_recording_run(db, "run-car", active_car_snapshot={"name": "Track Car"})
-
-    run = db.run_repository.list_runs()[0]
-
-    assert run.car_name == "Track Car"
-
-
 def test_history_db_thread_safe_appends(tmp_path: Path) -> None:
     db = build_history_db(tmp_path)
     create_recording_run(db, "run-2")

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_list_runs.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_list_runs.py
@@ -1,0 +1,130 @@
+"""Focused list-run projection and migration coverage for HistoryDB."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from test_support.history_db_async import execute_statements as _execute_statements
+from test_support.history_db_async import fetch_one as _fetch_one
+from test_support.history_db_lifecycle import build_history_db
+from test_support.history_db_lifecycle import (
+    make_run_metadata as _metadata,
+)
+
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
+from vibesensor.adapters.persistence.history_db._schema import SCHEMA_VERSION
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_to_json_object
+
+_V11_RUNS_SCHEMA = """\
+CREATE TABLE runs (
+    run_id                  TEXT PRIMARY KEY,
+    case_id                 TEXT,
+    status                  TEXT NOT NULL DEFAULT 'recording'
+                            CHECK (status IN ('recording', 'analyzing', 'complete', 'error')),
+    start_time_utc          TEXT NOT NULL,
+    end_time_utc            TEXT,
+    metadata_json           TEXT NOT NULL,
+    analysis_json           TEXT,
+    error_message           TEXT,
+    sample_count            INTEGER NOT NULL DEFAULT 0,
+    created_at              TEXT NOT NULL,
+    analysis_started_at     TEXT,
+    analysis_completed_at   TEXT
+);
+"""
+
+
+def test_list_runs_includes_recorded_car_name(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    db.run_repository.create_run(
+        "run-car",
+        "2026-01-01T00:00:00Z",
+        _metadata("run-car", active_car_snapshot={"name": "Track Car"}),
+    )
+
+    run = db.run_repository.list_runs()[0]
+
+    assert run.car_name == "Track Car"
+
+
+def test_list_runs_uses_denormalized_car_name_when_metadata_json_is_invalid(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    db.run_repository.create_run(
+        "run-car",
+        "2026-01-01T00:00:00Z",
+        _metadata("run-car", active_car_snapshot={"name": "Track Car"}),
+    )
+    _execute_statements(
+        db.lifecycle,
+        (
+            "UPDATE runs SET metadata_json = ? WHERE run_id = ?",
+            ("[1, 2, 3]", "run-car"),
+        ),
+    )
+
+    run = db.run_repository.list_runs()[0]
+
+    assert run.car_name == "Track Car"
+
+
+def test_schema_version_11_migrates_run_car_name_backfill(tmp_path: Path) -> None:
+    db_path = tmp_path / "history.db"
+    metadata_json = json.dumps(
+        run_metadata_to_json_object(
+            _metadata("run-legacy", active_car_snapshot={"name": "Legacy Car"})
+        )
+    )
+    insert_sql = (
+        "INSERT INTO runs (run_id, status, start_time_utc, metadata_json, "
+        "sample_count, created_at) VALUES (?, 'recording', ?, ?, ?, ?)"
+    )
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_V11_RUNS_SCHEMA)
+    conn.execute(
+        insert_sql,
+        (
+            "run-legacy",
+            "2026-01-01T00:00:00Z",
+            metadata_json,
+            0,
+            "2026-01-01T00:00:01Z",
+        ),
+    )
+    conn.execute("PRAGMA user_version = 11")
+    conn.commit()
+    conn.close()
+
+    db = create_history_persistence_adapters(db_path)
+
+    run = db.run_repository.list_runs()[0]
+    version_row = _fetch_one(db.lifecycle, "PRAGMA user_version")
+    car_name_row = _fetch_one(
+        db.lifecycle,
+        "SELECT car_name FROM runs WHERE run_id = ?",
+        ("run-legacy",),
+    )
+
+    assert run.car_name == "Legacy Car"
+    assert version_row == (SCHEMA_VERSION,)
+    assert car_name_row == ("Legacy Car",)
+
+
+def test_update_run_metadata_refreshes_list_run_car_name(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    db.run_repository.create_run(
+        "run-meta",
+        "2026-01-01T00:00:00Z",
+        _metadata("run-meta", active_car_snapshot={"name": "Track Car"}),
+    )
+
+    updated = db.run_repository.update_run_metadata(
+        "run-meta",
+        _metadata("run-meta", active_car_snapshot={"name": "Updated Car"}),
+    )
+
+    listed_run = db.run_repository.list_runs()[0]
+
+    assert updated is True
+    assert listed_run.car_name == "Updated Car"

--- a/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
@@ -16,12 +16,30 @@ from vibesensor.adapters.persistence.history_db._schema import (
     SCHEMA_SQL,
     SCHEMA_VERSION,
 )
+from vibesensor.shared.boundaries.codecs.scalars import text_or_none
+from vibesensor.shared.json_utils import safe_json_loads
+from vibesensor.shared.types.json_types import is_json_object
 
 LOGGER = logging.getLogger(__name__)
 
 __all__ = ["SQLiteHistoryEngine", "run_startup_quick_check"]
 
 _T = TypeVar("_T")
+
+
+def _extract_run_car_name(metadata_json: object) -> str | None:
+    parsed = safe_json_loads(
+        str(metadata_json) if metadata_json is not None else None,
+        context="history_db v11->v12 car_name migration",
+    )
+    if not is_json_object(parsed):
+        return None
+    active_car_snapshot = parsed.get("active_car_snapshot")
+    if is_json_object(active_car_snapshot):
+        nested_name = text_or_none(active_car_snapshot.get("name"))
+        if nested_name:
+            return nested_name
+    return text_or_none(parsed.get("car_name"))
 
 
 class _EngineLoopThread:
@@ -331,6 +349,9 @@ class SQLiteHistoryEngine:
 
         if version == SCHEMA_VERSION:
             return
+        if version == 11:
+            await self._migrate_v11_to_v12()
+            return
         if version > SCHEMA_VERSION:
             raise RuntimeError(
                 f"History DB schema version {version} is newer than "
@@ -346,6 +367,27 @@ class SQLiteHistoryEngine:
             await cur.execute("PRAGMA user_version")
             row = await cur.fetchone()
         return int(row[0]) if row is not None else 0
+
+    async def _migrate_v11_to_v12(self) -> None:
+        LOGGER.info("Migrating history DB schema v11 -> v12")
+        async with self._cursor(commit=False) as cur:
+            await cur.execute("PRAGMA table_info(runs)")
+            columns = {str(row[1]) for row in await cur.fetchall()}
+        if "car_name" not in columns:
+            async with self._cursor() as cur:
+                await cur.execute("ALTER TABLE runs ADD COLUMN car_name TEXT")
+        async with self.write_transaction_cursor() as cur:
+            await cur.execute("SELECT run_id, metadata_json FROM runs WHERE car_name IS NULL")
+            rows = await cur.fetchall()
+            if rows:
+                await cur.executemany(
+                    "UPDATE runs SET car_name = ? WHERE run_id = ?",
+                    [
+                        (_extract_run_car_name(metadata_json), str(run_id))
+                        for run_id, metadata_json in rows
+                    ],
+                )
+            await cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
     async def _run_startup_quick_check(self) -> None:
         await run_startup_quick_check(

--- a/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
@@ -95,32 +95,23 @@ class _HistoryDBQueryMixin:
             if limit > 0:
                 await cur.execute(
                     "SELECT r.run_id, r.status, r.start_time_utc, r.end_time_utc, "
-                    "r.created_at, r.error_message, r.sample_count, r.metadata_json "
+                    "r.created_at, r.error_message, r.sample_count, r.car_name "
                     "FROM runs r ORDER BY r.created_at DESC LIMIT ?",
                     (limit,),
                 )
             else:
                 await cur.execute(
                     "SELECT r.run_id, r.status, r.start_time_utc, r.end_time_utc, "
-                    "r.created_at, r.error_message, r.sample_count, r.metadata_json "
+                    "r.created_at, r.error_message, r.sample_count, r.car_name "
                     "FROM runs r ORDER BY r.created_at DESC",
                 )
             rows = await cur.fetchall()
         result: list[HistoryRunListEntry] = []
         for row in rows:
-            run_id, status_raw, start, end, created, error, sample_count, metadata_json = row
+            run_id, status_raw, start, end, created, error, sample_count, car_name = row
             normalized_run_id = str(run_id)
             normalized_start = str(start)
             normalized_end = str(end) if end is not None else None
-            normalized_metadata_json = str(metadata_json) if metadata_json is not None else None
-            metadata = self._coerce_run_metadata(
-                run_id=normalized_run_id,
-                start_time_utc=normalized_start,
-                end_time_utc=normalized_end,
-                metadata_json=normalized_metadata_json,
-                source="list_runs",
-                allow_fallback=True,
-            )
             result.append(
                 HistoryRunListEntry(
                     run_id=normalized_run_id,
@@ -129,7 +120,7 @@ class _HistoryDBQueryMixin:
                     end_time_utc=normalized_end,
                     created_at=str(created),
                     sample_count=int(sample_count or 0),
-                    car_name=metadata.car_name if metadata is not None else None,
+                    car_name=str(car_name) if car_name else None,
                     error_message=str(error) if error else None,
                 )
             )

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
@@ -48,6 +48,10 @@ class _HistoryDBRunLifecycleMixin:
             return None
         return str(row[0])
 
+    @staticmethod
+    def _car_name_from_metadata(metadata: RunMetadata) -> str | None:
+        return metadata.car_name
+
     def create_run(
         self,
         run_id: str,
@@ -80,8 +84,15 @@ class _HistoryDBRunLifecycleMixin:
         async with self._cursor() as cur:
             await cur.execute(
                 "INSERT INTO runs (run_id, case_id, status, start_time_utc, metadata_json, "
-                "created_at) VALUES (?, ?, 'recording', ?, ?, ?)",
-                (run_id, case_id, start_time_utc, safe_json_dumps(metadata_payload), now),
+                "car_name, created_at) VALUES (?, ?, 'recording', ?, ?, ?, ?)",
+                (
+                    run_id,
+                    case_id,
+                    start_time_utc,
+                    safe_json_dumps(metadata_payload),
+                    self._car_name_from_metadata(metadata),
+                    now,
+                ),
             )
 
     def append_samples(self, run_id: str, samples: list[SensorFrame]) -> int:
@@ -156,8 +167,11 @@ class _HistoryDBRunLifecycleMixin:
             assignments = ["status = 'analyzing'", "end_time_utc = ?", "analysis_started_at = ?"]
             params: list[object] = [end_time_utc, now]
             if metadata is not None:
-                assignments.insert(0, "metadata_json = ?")
-                params.insert(0, safe_json_dumps(run_metadata_to_json_object(metadata)))
+                assignments[0:0] = ["metadata_json = ?", "car_name = ?"]
+                params[0:0] = [
+                    safe_json_dumps(run_metadata_to_json_object(metadata)),
+                    self._car_name_from_metadata(metadata),
+                ]
             if case_id is not None:
                 assignments.insert(0, "case_id = ?")
                 params.insert(0, case_id)
@@ -178,8 +192,12 @@ class _HistoryDBRunLifecycleMixin:
     ) -> bool:
         async with self._cursor() as cur:
             await cur.execute(
-                "UPDATE runs SET metadata_json = ? WHERE run_id = ?",
-                (safe_json_dumps(run_metadata_to_json_object(metadata)), run_id),
+                "UPDATE runs SET metadata_json = ?, car_name = ? WHERE run_id = ?",
+                (
+                    safe_json_dumps(run_metadata_to_json_object(metadata)),
+                    self._car_name_from_metadata(metadata),
+                    run_id,
+                ),
             )
             return bool(int(cur.rowcount) > 0)
 

--- a/apps/server/vibesensor/adapters/persistence/history_db/_schema.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_schema.py
@@ -7,7 +7,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS runs (
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS runs (
     start_time_utc          TEXT NOT NULL,
     end_time_utc            TEXT,
     metadata_json           TEXT NOT NULL,
+    car_name                TEXT,
     analysis_json           TEXT,
     error_message           TEXT,
     sample_count            INTEGER NOT NULL DEFAULT 0,

--- a/docs/history_db_schema.md
+++ b/docs/history_db_schema.md
@@ -1,4 +1,4 @@
-# History DB Schema (v11)
+# History DB Schema (v12)
 
 The VibeSensor server stores run history, samples, analysis results,
 application settings and client names in a single SQLite file located at
@@ -47,6 +47,7 @@ One row per recording session.
 | `start_time_utc` | TEXT | ISO-8601 start time |
 | `end_time_utc` | TEXT | ISO-8601 end time (set on finalize) |
 | `metadata_json` | TEXT | Run-level metadata (car config, language, sensor model, etc.) |
+| `car_name` | TEXT | Denormalized active car name used by the history list path |
 | `analysis_json` | TEXT | Post-run analysis summary |
 | `error_message` | TEXT | Error description when status = `error` |
 | `sample_count` | INTEGER | Running count of appended samples |
@@ -127,14 +128,12 @@ integer version:
 
 | Stored version | Action |
 |----------------|--------|
-| `0` on a fresh DB | Create all tables, stamp `user_version = 11` |
+| `0` on a fresh DB | Create all tables, stamp `user_version = 12` |
 | `0` with a legacy `schema_meta` table present | Raise `RuntimeError` directing the user to delete the incompatible DB |
-| `11` | No action needed |
-| `10` | Migrate stored persisted-analysis payloads to stamp the current schema version (v10→v11) |
-| `9` | Migrate `settings_kv` → `settings_snapshot` single-row table, then stamp persisted-analysis payload version (v9→v10→v11) |
-| `8` | Chain migrate: add `case_id` column (v8→v9), then `settings_kv` → `settings_snapshot` (v9→v10), then stamp persisted-analysis payload version (v10→v11) |
-| Older unsupported values (for example `1` or `4`) | Raise `RuntimeError` directing the user to delete the database file |
-| Newer than `11` | Raise `RuntimeError` (downgrade not supported) |
+| `12` | No action needed |
+| `11` | Add the denormalized `runs.car_name` column, backfill it from `metadata_json`, then stamp `user_version = 12` |
+| Older unsupported values (for example `1`, `4`, `8`, `9`, or `10`) | Raise `RuntimeError` directing the user to delete the database file |
+| Newer than `12` | Raise `RuntimeError` (downgrade not supported) |
 
 ### Schema versioning policy
 


### PR DESCRIPTION
## What changed
- add a denormalized `runs.car_name` column and bump the history DB schema to v12
- migrate v11 databases by backfilling `car_name` from stored run metadata once on open
- keep `car_name` synchronized on run create/finalize/update metadata writes
- change `alist_runs()` to project `car_name` directly instead of decoding `metadata_json` into `RunMetadata` for every list row
- add focused history-db list/migration tests and update the history DB schema doc

## Why
- the history list path only needs a small summary field set, but it was paying full JSON decode and metadata coercion cost for every row
- issue baseline on the synthetic 500-row setup: raw fetch `0.999 ms`, typed `list_runs(500)` `8.730 ms`
- current result on the same 500-row shape: raw fetch `0.745 ms`, typed `list_runs(500)` `1.828 ms`
- this keeps detail/report paths on full metadata while removing repeated list-path CPU churn

## Validation
- `source .venv/bin/activate && pytest -q apps/server/tests/adapters/persistence/history_db/test_history_db_lifecycle.py apps/server/tests/adapters/persistence/history_db/test_history_db_list_runs.py apps/server/tests/adapters/http/test_api_history_route_state.py`
- `source .venv/bin/activate && make lint`
- `source .venv/bin/activate && make typecheck-backend`
- synthetic 500-row benchmark using `create_history_persistence_adapters(...)`, raw SQLite fetch timing, and `db.run_repository.list_runs(500)` timing

## Risks / tradeoffs
- schema change requires the explicit v11 -> v12 migration path to stay correct for existing DBs
- list rows now trust the denormalized column; if future metadata write paths skip `car_name` sync, list/detail views could drift
- this intentionally optimizes the list path only; full run/detail reads still decode canonical metadata

Closes #3044