### PR TITLE
[codex] Improve updater HTTP failure diagnostics

### DIFF
--- a/apps/server/tests/use_cases/updates/test_http_client.py
+++ b/apps/server/tests/use_cases/updates/test_http_client.py
@@ -71,6 +71,40 @@ def test_github_api_client_get_json_maps_non_200_to_oserror(httpx_mock: HTTPXMoc
         client.get_json(url)
 
 
+def test_github_api_client_get_json_includes_status_diagnostics(
+    httpx_mock: HTTPXMock,
+) -> None:
+    url = "https://api.github.com/repos/owner/repo/releases"
+    add_json_response(
+        httpx_mock,
+        url=url,
+        payload={
+            "message": "API rate limit exceeded",
+            "documentation_url": "https://docs.github.com/rest",
+        },
+        status_code=403,
+        headers={
+            "x-github-request-id": "ABC:123",
+            "x-ratelimit-limit": "60",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-used": "60",
+            "x-ratelimit-reset": "1776841530",
+        },
+    )
+    client = GitHubApiClient()
+
+    with pytest.raises(OSError) as exc_info:
+        client.get_json(url)
+
+    message = str(exc_info.value)
+    assert "HTTP 403" in message
+    assert "API rate limit exceeded" in message
+    assert "x-github-request-id" in message
+    assert "ABC:123" in message
+    assert "x-ratelimit-remaining" in message
+    assert "'0'" in message
+
+
 def test_github_api_client_get_json_rejects_invalid_json(httpx_mock: HTTPXMock) -> None:
     url = "https://api.github.com/repos/owner/repo/releases"
     add_text_response(httpx_mock, url=url, text="{not-json")

--- a/apps/server/vibesensor/use_cases/updates/http_client.py
+++ b/apps/server/vibesensor/use_cases/updates/http_client.py
@@ -63,8 +63,48 @@ def build_get_request(
 
 def _http_error_as_oserror(exc: httpx.HTTPError, *, context: str, url: str) -> OSError:
     if isinstance(exc, httpx.HTTPStatusError):
-        return OSError(f"{context} request failed with HTTP {exc.response.status_code}: {url}")
+        diagnostic = _status_error_diagnostic(exc.response)
+        return OSError(
+            f"{context} request failed with HTTP {exc.response.status_code}: {url}"
+            f"{diagnostic}"
+        )
     return OSError(f"{context} request failed for {url}: {exc}")
+
+
+def _status_error_diagnostic(response: httpx.Response) -> str:
+    parts = []
+    body = _response_body_excerpt(response)
+    if body:
+        parts.append(f"body={body!r}")
+    headers = _diagnostic_headers(response.headers)
+    if headers:
+        parts.append(f"headers={headers}")
+    if not parts:
+        return ""
+    return f" ({'; '.join(parts)})"
+
+
+def _response_body_excerpt(response: httpx.Response, *, limit: int = 500) -> str:
+    try:
+        text = response.text
+    except httpx.ResponseNotRead:
+        return ""
+    text = " ".join(text.split())
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3]}..."
+
+
+def _diagnostic_headers(headers: httpx.Headers) -> dict[str, str]:
+    names = (
+        "x-github-request-id",
+        "x-ratelimit-limit",
+        "x-ratelimit-remaining",
+        "x-ratelimit-used",
+        "x-ratelimit-reset",
+        "retry-after",
+    )
+    return {name: value for name in names if (value := headers.get(name))}
 
 
 def _client(


### PR DESCRIPTION
## What changed

- Include HTTP response body excerpts in updater-owned outbound HTTP status failures.
- Include useful GitHub diagnostic headers such as request id, rate-limit counters, reset time, and retry-after.
- Cover the GitHub 403/rate-limit style response path in the updater HTTP client tests.

## Why

The updater previously collapsed GitHub status failures to only `HTTP <status>: <url>`. In the field, that hid the reason GitHub returned 403, making it hard to distinguish rate limits, auth problems, transient CDN rejection, or another API error.

## Validation

- `.venv/bin/ruff check apps/server/vibesensor/use_cases/updates/http_client.py apps/server/tests/use_cases/updates/test_http_client.py`
- `.venv/bin/pytest -q apps/server/tests/use_cases/updates/test_http_client.py`
