### PR TITLE
[codex] Optimize live spectrum hot path

### DIFF
--- a/apps/server/tests/infra/processing/test_processing_extended.py
+++ b/apps/server/tests/infra/processing/test_processing_extended.py
@@ -226,6 +226,27 @@ def test_multi_spectrum_payload_compares_freq_axes_without_np_asarray(
     assert result["freq"]
 
 
+def test_multi_spectrum_payload_skips_allclose_for_shared_freq_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proc = _make_processor(sample_rate_hz=200, fft_n=128, spectrum_max_hz=100)
+    samples = _random_samples(300)
+
+    proc.ingest("c1", samples, sample_rate_hz=200)
+    proc.ingest("c2", samples, sample_rate_hz=200)
+    proc.compute_metrics("c1", sample_rate_hz=200)
+    proc.compute_metrics("c2", sample_rate_hz=200)
+
+    def _fail_allclose(*args: object, **kwargs: object) -> None:
+        raise AssertionError("np.allclose should not be used for shared frequency arrays")
+
+    monkeypatch.setattr("vibesensor.infra.processing.payload.np.allclose", _fail_allclose)
+
+    result = proc.multi_spectrum_payload(["c1", "c2"])
+    assert sorted(result["clients"]) == ["c1", "c2"]
+    assert result["freq"]
+
+
 def test_multi_spectrum_payload_reuses_shared_freq_conversion_for_matching_clients(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
+++ b/apps/server/tests/use_cases/diagnostics/test_strength_scoring.py
@@ -393,29 +393,28 @@ def test_compute_vibration_strength_db_does_not_mutate_cached_strength_range_mas
 def test_compute_vibration_strength_db_limits_scored_candidates_before_band_rms(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    scored_candidate_calls = 0
-    original = vibration_strength_module._peak_band_rms_amp_g_from_bounds
+    scored_candidate_counts: list[int] = []
+    original = vibration_strength_module._peak_band_rms_amp_g_from_ranges
 
-    def counting_peak_band_rms_amp_g_from_bounds(
+    def counting_peak_band_rms_amp_g_from_ranges(
         *,
         combined_spectrum_amp_g: vibration_strength_module.npt.NDArray[
             vibration_strength_module.np.float64
         ],
-        start_idx: int,
-        stop_idx: int,
-    ) -> float:
-        nonlocal scored_candidate_calls
-        scored_candidate_calls += 1
+        left_bounds: vibration_strength_module.npt.NDArray[vibration_strength_module.np.intp],
+        right_bounds: vibration_strength_module.npt.NDArray[vibration_strength_module.np.intp],
+    ) -> vibration_strength_module.npt.NDArray[vibration_strength_module.np.float64]:
+        scored_candidate_counts.append(int(left_bounds.size))
         return original(
             combined_spectrum_amp_g=combined_spectrum_amp_g,
-            start_idx=start_idx,
-            stop_idx=stop_idx,
+            left_bounds=left_bounds,
+            right_bounds=right_bounds,
         )
 
     monkeypatch.setattr(
         vibration_strength_module,
-        "_peak_band_rms_amp_g_from_bounds",
-        counting_peak_band_rms_amp_g_from_bounds,
+        "_peak_band_rms_amp_g_from_ranges",
+        counting_peak_band_rms_amp_g_from_ranges,
     )
 
     combined = [
@@ -431,7 +430,7 @@ def test_compute_vibration_strength_db_limits_scored_candidates_before_band_rms(
         top_n=4,
     )
 
-    assert scored_candidate_calls == 8
+    assert scored_candidate_counts == [8]
     assert [peak["hz"] for peak in result["top_peaks"]] == [23.0, 21.0, 19.0, 17.0]
     assert result["vibration_strength_db"] == result["top_peaks"][0]["vibration_strength_db"]
 

--- a/apps/server/vibesensor/infra/processing/payload.py
+++ b/apps/server/vibesensor/infra/processing/payload.py
@@ -192,11 +192,14 @@ def build_multi_spectrum_payload(
             client_freq = np.array(client_freq, dtype=np.float32)
         if shared_freq is None:
             shared_freq = client_freq
-        elif len(client_freq) != len(shared_freq) or not np.allclose(
-            client_freq,
-            shared_freq,
-            rtol=0.0,
-            atol=1e-6,
+        elif client_freq is not shared_freq and (
+            len(client_freq) != len(shared_freq)
+            or not np.allclose(
+                client_freq,
+                shared_freq,
+                rtol=0.0,
+                atol=1e-6,
+            )
         ):
             mismatch_ids.append(client_id)
         per_client_freq[client_id] = client_freq

--- a/apps/server/vibesensor/infra/processing/processor.py
+++ b/apps/server/vibesensor/infra/processing/processor.py
@@ -12,6 +12,7 @@ metrics logging while delegating to focused collaborators:
 from __future__ import annotations
 
 import logging
+import math
 import time
 from typing import TYPE_CHECKING
 
@@ -139,13 +140,7 @@ class SignalProcessor:
         pool = self._worker_pool
         assert pool is not None
         try:
-            result = pool.map_unordered(
-                lambda client_id: self.compute_metrics(
-                    client_id,
-                    sample_rate_hz=rates.get(client_id),
-                ),
-                client_ids,
-            )
+            result = self._compute_all_parallel_chunked(client_ids, rates, pool)
         except (RuntimeError, OSError):
             LOGGER.warning(
                 "compute_all: worker pool raised; falling back to serial execution.",
@@ -263,4 +258,26 @@ class SignalProcessor:
                         client_id,
                         exc_info=True,
                     )
+        return result
+
+    def _compute_all_parallel_chunked(
+        self,
+        client_ids: list[str],
+        rates: dict[str, int],
+        pool: WorkerPool,
+    ) -> dict[str, ClientMetrics]:
+        chunk_count = min(pool.max_workers, len(client_ids))
+        chunk_size = max(1, math.ceil(len(client_ids) / chunk_count))
+        chunks = [
+            tuple(client_ids[start : start + chunk_size])
+            for start in range(0, len(client_ids), chunk_size)
+        ]
+
+        chunk_results = pool.map_unordered(
+            lambda chunk: self._compute_all_serial(list(chunk), rates, serial_fallback=True),
+            chunks,
+        )
+        result: dict[str, ClientMetrics] = {}
+        for chunk in chunks:
+            result.update(chunk_results.get(chunk, {}))
         return result

--- a/apps/server/vibesensor/use_cases/updates/http_client.py
+++ b/apps/server/vibesensor/use_cases/updates/http_client.py
@@ -65,8 +65,7 @@ def _http_error_as_oserror(exc: httpx.HTTPError, *, context: str, url: str) -> O
     if isinstance(exc, httpx.HTTPStatusError):
         diagnostic = _status_error_diagnostic(exc.response)
         return OSError(
-            f"{context} request failed with HTTP {exc.response.status_code}: {url}"
-            f"{diagnostic}"
+            f"{context} request failed with HTTP {exc.response.status_code}: {url}{diagnostic}"
         )
     return OSError(f"{context} request failed for {url}: {exc}")
 

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -385,6 +385,28 @@ def _peak_band_rms_amp_g_from_bounds(
     return float(np.sqrt(np.mean(np.square(band, dtype=np.float64))))
 
 
+def _peak_band_rms_amp_g_from_ranges(
+    *,
+    combined_spectrum_amp_g: npt.NDArray[np.float64],
+    left_bounds: npt.NDArray[np.intp],
+    right_bounds: npt.NDArray[np.intp],
+) -> npt.NDArray[np.float64]:
+    if left_bounds.size == 0:
+        return np.empty(0, dtype=np.float64)
+    squared = np.square(combined_spectrum_amp_g, dtype=np.float64)
+    prefix_sum = np.empty(squared.size + 1, dtype=np.float64)
+    prefix_sum[0] = 0.0
+    np.cumsum(squared, out=prefix_sum[1:])
+
+    counts = right_bounds - left_bounds
+    result = np.zeros(left_bounds.shape, dtype=np.float64)
+    valid = counts > 0
+    if np.any(valid):
+        sums = prefix_sum[right_bounds[valid]] - prefix_sum[left_bounds[valid]]
+        result[valid] = np.sqrt(sums / counts[valid])
+    return result
+
+
 def _candidate_peak_indexes(values: npt.NDArray[np.float64], threshold: float) -> list[int]:
     peak_indexes_raw, _properties = find_peaks(values, height=threshold)
     peak_indexes = np.asarray(peak_indexes_raw, dtype=np.intp)
@@ -516,14 +538,14 @@ def compute_vibration_strength_db(
             candidate_band_rms.append(float(band_rms))
     else:
         left_bounds, right_bounds = peak_band_ranges
+        band_rms_values = _peak_band_rms_amp_g_from_ranges(
+            combined_spectrum_amp_g=combined,
+            left_bounds=left_bounds,
+            right_bounds=right_bounds,
+        )
         for candidate_idx, idx in enumerate(scored_candidate_indexes):
-            band_rms = _peak_band_rms_amp_g_from_bounds(
-                combined_spectrum_amp_g=combined,
-                start_idx=int(left_bounds[candidate_idx]),
-                stop_idx=int(right_bounds[candidate_idx]),
-            )
             candidate_hz.append(float(freq[idx]))
-            candidate_band_rms.append(float(band_rms))
+            candidate_band_rms.append(float(band_rms_values[candidate_idx]))
     candidate_db = _batch_vibration_strength_db_aligned(
         peak_band_rms_amp_g_values=np.asarray(candidate_band_rms, dtype=np.float64),
         floor_amp_g=floor_strength,


### PR DESCRIPTION
## Summary

- skip redundant frequency-grid comparisons when live spectra share the same cached frequency axis
- batch peak-band RMS scoring with a prefix-sum helper instead of rescanning the same spectrum windows per candidate
- reduce worker-pool bookkeeping on multi-client compute by submitting per-worker chunks instead of one future per sensor

## Why

Profiling the 16-sensor Pi hot path showed the heavy live tick was dominated by repeated spectrum-strength reductions, followed by payload assembly work that repeatedly compared identical frequency arrays. These changes keep behavior and payload shape the same while removing redundant work.

On the Pi isolated hot-path benchmark, the heavy tick p95 improved from about 261 ms to about 147 ms. `multi_spectrum_payload` p95 dropped from about 16.6 ms to about 4.2 ms.

## Validation

- `.venv/bin/pytest -q apps/server/tests/infra/processing/test_processing_extended.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py apps/server/tests/use_cases/diagnostics/test_vibration_math_coverage.py`
- `.venv/bin/pytest -q apps/server/tests/infra/processing/test_processing_extended.py apps/server/tests/infra/workers/test_worker_pool.py apps/server/tests/infra/processing/test_compute_all_parallel_cutoff.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py`
- `.venv/bin/ruff check apps/server/vibesensor/infra/processing/payload.py apps/server/vibesensor/infra/processing/processor.py apps/server/vibesensor/vibration_strength.py apps/server/tests/infra/processing/test_processing_extended.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py`
- Applied directly on the Pi and verified `/api/health` returns `ok` after restart.
