### PR TITLE
Speed up vibration-strength floor selection

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py
+++ b/apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py
@@ -118,6 +118,13 @@ class TestNoiseFloorAmpP20G:
         result = noise_floor_amp_p20_g(combined_spectrum_amp_g=[100.0, 0.01, 0.02, 0.03])
         assert result < 1.0  # Should use P20 of [0.01, 0.02, 0.03]
 
+    def test_skips_dc_bin_with_exact_linear_interpolation(self) -> None:
+        result = noise_floor_amp_p20_g(
+            combined_spectrum_amp_g=[100.0, 0.01, 0.02, 0.04, 0.08, 0.10],
+        )
+        expected = float(np.quantile(np.array([0.01, 0.02, 0.04, 0.08, 0.10]), 0.20))
+        assert result == pytest.approx(expected)
+
     def test_negative_values_filtered(self) -> None:
         result = noise_floor_amp_p20_g(combined_spectrum_amp_g=[-1.0, -2.0, 0.01, 0.02])
         # Only non-negative finite values are used

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -114,7 +114,41 @@ def _aligned_float_arrays(
 def _quantile_or_zero(values: npt.NDArray[np.float64], q: float) -> float:
     if values.size == 0:
         return 0.0
-    return float(np.quantile(values, q))
+    q_value = float(q)
+    if not 0.0 <= q_value <= 1.0:
+        return float(np.quantile(values, q_value))
+    if values.size == 1:
+        return float(values[0])
+    if q_value == 0.0:
+        return float(np.min(values))
+    if q_value == 1.0:
+        return float(np.max(values))
+
+    # The linear-interpolation quantile only needs the two bracketing order
+    # statistics, so use partition instead of the heavier generic quantile path.
+    position = q_value * float(values.size - 1)
+    lower_idx = int(position)
+    upper_idx = int(np.ceil(position))
+    if lower_idx == upper_idx:
+        partitioned = np.partition(values, lower_idx)
+        return float(partitioned[lower_idx])
+
+    partitioned = np.partition(values, (lower_idx, upper_idx))
+    lower_value = float(partitioned[lower_idx])
+    upper_value = float(partitioned[upper_idx])
+    return lower_value + (upper_value - lower_value) * (position - lower_idx)
+
+
+def _median_or_zero(values: npt.NDArray[np.float64]) -> float:
+    if values.size == 0:
+        return 0.0
+    mid = values.size // 2
+    if values.size % 2:
+        partitioned = np.partition(values, mid)
+        return float(partitioned[mid])
+
+    partitioned = np.partition(values, (mid - 1, mid))
+    return float((partitioned[mid - 1] + partitioned[mid]) * 0.5)
 
 
 def _combined_spectrum_amp_g_array(
@@ -266,7 +300,7 @@ def _strength_floor_amp_g_aligned(
         # (assuming DC content at 0 Hz) — an assumption that breaks when
         # the caller has already stripped the DC bin from the spectrum.
         return _quantile_or_zero(amps[base_mask], 0.20)
-    return float(np.median(selected))
+    return _median_or_zero(selected)
 
 
 def _exclude_peak_regions_aligned(


### PR DESCRIPTION
## Summary
Speed up the vibration-strength floor calculations by replacing the hot quantile and median paths with exact partition-based selection helpers.

## What changed
- optimize the P20 noise-floor selection path in `vibration_strength.py`
- optimize the non-peak floor median selection path in the same hot slice
- add a regression test that locks the skipped-DC interpolation result to NumPy-equivalent behavior

## Validation
- `cd apps/server && /home/psewu/repos/VibeSensor/.venv/bin/python -m pytest -q tests/use_cases/diagnostics/test_vibration_strength_core.py tests/use_cases/diagnostics/test_strength_scoring.py tests/use_cases/diagnostics/test_noise_floor_consistency.py`
- `cd apps/server && /home/psewu/repos/VibeSensor/.venv/bin/python -m pytest -q tests/infra/processing/test_strength_and_spectrum_runtime_regressions.py tests/infra/processing/test_spectrum_and_peak_selection_regressions.py tests/use_cases/diagnostics/test_vibration_math_coverage.py tests/use_cases/diagnostics/test_vibration_strength_boundaries.py`
- live Pi check on `10.4.0.1` under a 16-sensor simulator run after wheel install showed `status=ok`, `processing_state=ok`, `frames_dropped=0`, and `last_compute_duration_s` at about `0.0199s`
