### PR TITLE
Improve low-load processing loop cadence

### DIFF
--- a/apps/server/tests/infra/runtime/test_processing_loop.py
+++ b/apps/server/tests/infra/runtime/test_processing_loop.py
@@ -89,6 +89,7 @@ def _make_loop(
     registry: Any = None,
     sample_rate_hz: int = 800,
     fft_n: int = 2048,
+    fft_update_hz: int = 10,
     control_plane: Any = None,
 ) -> tuple[ProcessingLoop, ProcessingLoopState]:
     state = ProcessingLoopState()
@@ -96,7 +97,7 @@ def _make_loop(
     reg = registry if registry is not None else _StubRegistry()
     loop = ProcessingLoop(
         state=state,
-        fft_update_hz=10,
+        fft_update_hz=fft_update_hz,
         sample_rate_hz=sample_rate_hz,
         fft_n=fft_n,
         registry=reg,
@@ -246,6 +247,49 @@ class TestProcessingLoopMismatchDetection:
         await loop._run_tick(sync_clock=True)
 
         assert control_plane.broadcast_calls == 1
+
+
+class TestProcessingLoopCadence:
+    def test_success_delay_uses_low_load_fast_path_with_duty_cap(self) -> None:
+        clients = {f"sensor-{index}": _StubRecord() for index in range(5)}
+        loop, _state = _make_loop(
+            registry=_StubRegistry(clients),
+            fft_update_hz=4,
+        )
+
+        delay_s = loop._success_delay_s(
+            interval_s=0.25,
+            tick_duration_s=0.04,
+            active_client_count=5,
+        )
+
+        assert delay_s == pytest.approx(0.06)
+
+    def test_success_delay_keeps_base_interval_for_larger_active_set(self) -> None:
+        clients = {f"sensor-{index}": _StubRecord() for index in range(12)}
+        loop, _state = _make_loop(
+            registry=_StubRegistry(clients),
+            fft_update_hz=4,
+        )
+
+        delay_s = loop._success_delay_s(
+            interval_s=0.25,
+            tick_duration_s=0.04,
+            active_client_count=12,
+        )
+
+        assert delay_s == pytest.approx(0.25)
+
+    def test_success_delay_keeps_base_interval_when_idle(self) -> None:
+        loop, _state = _make_loop(fft_update_hz=4)
+
+        delay_s = loop._success_delay_s(
+            interval_s=0.25,
+            tick_duration_s=0.01,
+            active_client_count=0,
+        )
+
+        assert delay_s == pytest.approx(0.25)
 
     @pytest.mark.asyncio
     async def test_sync_clock_offloads_broadcast_to_thread(

--- a/apps/server/vibesensor/infra/runtime/processing_loop.py
+++ b/apps/server/vibesensor/infra/runtime/processing_loop.py
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
     from vibesensor.infra.runtime.registry import ClientRegistry
 
 LOGGER = logging.getLogger(__name__)
+_LOW_LOAD_FAST_PATH_CLIENT_LIMIT = 8
+_LOW_LOAD_FAST_PATH_UPDATE_HZ = 10
+_LOW_LOAD_MAX_DUTY_CYCLE = 0.5
 
 
 class ProcessingLoop:
@@ -60,11 +63,28 @@ class ProcessingLoop:
             control_plane=control_plane,
         )
 
-    async def _run_tick(self, *, sync_clock: bool) -> None:
-        await self._tick_runner.run(sync_clock=sync_clock)
+    async def _run_tick(self, *, sync_clock: bool) -> int:
+        return await self._tick_runner.run(sync_clock=sync_clock)
+
+    def _success_delay_s(
+        self,
+        *,
+        interval_s: float,
+        tick_duration_s: float,
+        active_client_count: int,
+    ) -> float:
+        if active_client_count <= 0:
+            return interval_s
+        if active_client_count > _LOW_LOAD_FAST_PATH_CLIENT_LIMIT:
+            return interval_s
+
+        fast_path_period_s = 1.0 / _LOW_LOAD_FAST_PATH_UPDATE_HZ
+        duty_cycle_period_s = tick_duration_s / _LOW_LOAD_MAX_DUTY_CYCLE
+        target_period_s = max(fast_path_period_s, duty_cycle_period_s)
+        return max(0.0, target_period_s - tick_duration_s)
 
     async def run(self) -> None:
-        """~100 ms tick loop: evict stale clients, compute metrics, handle failures."""
+        """Tick loop: low-load fast path with bounded CPU, default cadence otherwise."""
         interval = 1.0 / max(1, self._fft_update_hz)
         _sync_clock_tick = 0
         _SYNC_CLOCK_EVERY_N_TICKS = max(1, int(5.0 / interval))  # ~every 5 s
@@ -77,8 +97,13 @@ class ProcessingLoop:
                     _sync_clock_tick = 0
                     sync_clock = True
                 tick_start = time.monotonic()
-                await self._run_tick(sync_clock=sync_clock)
+                active_client_count = await self._run_tick(sync_clock=sync_clock)
                 tick_dur = time.monotonic() - tick_start
+                delay = self._success_delay_s(
+                    interval_s=interval,
+                    tick_duration_s=tick_dur,
+                    active_client_count=active_client_count,
+                )
                 self._apply_success(
                     self._failure_policy.plan_success(tick_duration_s=tick_dur),
                 )

--- a/apps/server/vibesensor/infra/runtime/processing_tick.py
+++ b/apps/server/vibesensor/infra/runtime/processing_tick.py
@@ -59,7 +59,7 @@ class ProcessingTickRunner:
         self._processor = processor
         self._control_plane = control_plane
 
-    async def run(self, *, sync_clock: bool) -> None:
+    async def run(self, *, sync_clock: bool) -> int:
         if sync_clock:
             await self._sync_clock()
         compute_client_ids, sample_rates = self._collect_compute_clients()
@@ -67,6 +67,7 @@ class ProcessingTickRunner:
             compute_client_ids=compute_client_ids,
             sample_rates=sample_rates,
         )
+        return len(compute_client_ids)
 
     async def _sync_clock(self) -> None:
         if self._control_plane is None:


### PR DESCRIPTION
## Summary
- return the active client count from the processing tick so the loop can adapt its post-success delay
- add a bounded low-load fast path that targets 10 Hz for up to 8 active clients while capping processing duty cycle at 50%
- keep idle and larger active sets on the existing base interval and add focused cadence coverage in runtime tests

## Validation
- `cd apps/server && /home/psewu/repos/VibeSensor/.venv/bin/python -m pytest -q tests/infra/runtime`
- `make typecheck-backend`

## Pi 5-sensor measurement
Baseline:
- mean CPU: 25.21% of one core
- avg `last_compute_all_duration_s`: 0.036086 s
- avg `tick_duration_s`: 0.038341 s
- approx ticks/sec: 3.67

After change:
- mean CPU: 41.45% of one core
- max CPU: 43.69%
- avg `last_compute_all_duration_s`: 0.017232 s
- avg `tick_duration_s`: 0.020045 s
- approx ticks/sec: 9.33

This trades some spare CPU headroom for materially lower low-load latency while staying below half a core at the typical 5-sensor load.