### PR TITLE
Persist raw run capture for offline analysis

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+from test_support.history_db_async import execute_statements as _execute_statements
+from test_support.history_db_lifecycle import (
+    build_history_db,
+    create_completed_run,
+    create_recording_run,
+)
+
+from vibesensor.shared.types.raw_capture import RawCaptureChunk
+
+
+def _append_chunk(
+    db,
+    *,
+    run_id: str,
+    client_id: str,
+    t0_us: int,
+    samples: np.ndarray,
+    sample_rate_hz: int = 800,
+) -> None:
+    chunk = RawCaptureChunk(
+        client_id=client_id,
+        sample_rate_hz=sample_rate_hz,
+        t0_us=t0_us,
+        sample_count=int(samples.shape[0]),
+        samples_i16le=np.ascontiguousarray(samples, dtype=np.int16).tobytes(order="C"),
+    )
+    db.run_repository._run_sync(db.run_repository.aappend_raw_capture_chunk(run_id, chunk))
+
+
+def _finalize_raw_capture(db, run_id: str):
+    return db.run_repository._run_sync(db.run_repository.afinalize_raw_capture(run_id))
+
+
+def _load_raw_capture(db, run_id: str):
+    return db.run_repository._run_sync(db.run_repository.aload_raw_capture(run_id))
+
+
+def test_raw_capture_round_trip_persists_manifest_and_samples(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    create_recording_run(db, "run-raw")
+    first = np.asarray([[1, 2, 3], [4, 5, 6]], dtype=np.int16)
+    second = np.asarray([[7, 8, 9]], dtype=np.int16)
+
+    _append_chunk(db, run_id="run-raw", client_id="sensor-a", t0_us=1000, samples=first)
+    _append_chunk(db, run_id="run-raw", client_id="sensor-a", t0_us=2000, samples=second)
+
+    manifest = _finalize_raw_capture(db, "run-raw")
+
+    assert manifest is not None
+    assert manifest.total_samples == 3
+    assert manifest.sensor_manifest("sensor-a") is not None
+
+    stored = db.run_repository.get_run("run-raw")
+    assert stored is not None
+    assert stored.raw_capture_manifest == manifest
+
+    loaded = _load_raw_capture(db, "run-raw")
+    assert loaded is not None
+    sensor = loaded.sensor_data("sensor-a")
+    assert sensor is not None
+    assert sensor.manifest.chunk_count == 2
+    assert sensor.manifest.sample_count == 3
+    assert len(sensor.chunks) == 2
+    assert np.array_equal(sensor.samples_i16, np.vstack([first, second]))
+
+
+def test_delete_run_removes_raw_capture_artifacts(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    create_recording_run(db, "run-delete")
+    samples = np.asarray([[11, 12, 13]], dtype=np.int16)
+
+    _append_chunk(db, run_id="run-delete", client_id="sensor-a", t0_us=1000, samples=samples)
+    manifest = _finalize_raw_capture(db, "run-delete")
+
+    assert manifest is not None
+    raw_dir = tmp_path / "raw-runs" / "run-delete"
+    assert raw_dir.exists()
+
+    db.run_repository.delete_run("run-delete")
+
+    assert not raw_dir.exists()
+
+
+def test_prune_terminal_runs_removes_raw_capture_artifacts(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    create_completed_run(db, "run-prune")
+    samples = np.asarray([[21, 22, 23]], dtype=np.int16)
+
+    _append_chunk(db, run_id="run-prune", client_id="sensor-a", t0_us=1000, samples=samples)
+    manifest = _finalize_raw_capture(db, "run-prune")
+
+    assert manifest is not None
+    raw_dir = tmp_path / "raw-runs" / "run-prune"
+    assert raw_dir.exists()
+
+    old_timestamp = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+    _execute_statements(
+        db.lifecycle,
+        (
+            "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
+            (old_timestamp, old_timestamp, "run-prune"),
+        ),
+    )
+
+    db.run_repository.prune_terminal_runs_older_than_days(1)
+
+    assert not raw_dir.exists()

--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -22,6 +22,7 @@ from vibesensor.shared.types.persisted_analysis import (
     PERSISTED_ANALYSIS_SCHEMA_VERSION,
     PersistedAnalysis,
 )
+from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
 from vibesensor.use_cases.history.runs import HistoryRunService
 
 pytestmark = pytest.mark.smoke
@@ -35,6 +36,12 @@ class _RunPersistenceStub:
         if run_id != self.run.run_id:
             return None
         return self.run
+
+    async def aget_raw_capture_manifest(self, _run_id: str) -> RawCaptureManifest | None:
+        return None
+
+    async def aload_raw_capture(self, _run_id: str) -> RawRunCapture | None:
+        return None
 
 
 def _representative_summary() -> AnalysisSummary:

--- a/apps/server/tests/use_cases/run/test_post_analysis_loader.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_loader.py
@@ -54,6 +54,9 @@ def test_load_post_analysis_run_returns_loaded_run() -> None:
                 ]
             )
 
+        async def aload_raw_capture(self, _run_id):
+            return None
+
     result = load_post_analysis_run(run_id="run-ok", db=FakeDB())
 
     assert isinstance(result, LoadedPostAnalysisRun)
@@ -72,6 +75,9 @@ def test_load_post_analysis_run_handles_missing_metadata() -> None:
         async def aget_run_metadata(self, _run_id):
             return None
 
+        async def aload_raw_capture(self, _run_id):
+            return None
+
     result = load_post_analysis_run(run_id="run-missing", db=FakeDB())
 
     assert isinstance(result, MissingPostAnalysisMetadata)
@@ -88,6 +94,9 @@ def test_load_post_analysis_run_handles_no_samples() -> None:
             assert stride == 1
             return
             yield  # pragma: no cover
+
+        async def aload_raw_capture(self, _run_id):
+            return None
 
     result = load_post_analysis_run(run_id="run-empty", db=FakeDB())
 
@@ -118,6 +127,9 @@ def test_load_post_analysis_run_applies_upfront_stride(
                 ]
             )
 
+        async def aload_raw_capture(self, _run_id):
+            return None
+
     result = load_post_analysis_run(run_id="run-capped", db=FakeDB())
 
     assert isinstance(result, LoadedPostAnalysisRun)
@@ -139,7 +151,11 @@ def test_load_post_analysis_run_defaults_language_to_en() -> None:
             assert stride == 1
             yield sensor_frames_from_mappings([{"t_s": 1.0, "vibration_strength_db": 10.0}])
 
+        async def aload_raw_capture(self, _run_id):
+            return None
+
     result = load_post_analysis_run(run_id="run-lang", db=FakeDB())
 
     assert isinstance(result, LoadedPostAnalysisRun)
     assert result.language == "en"
+    assert result.raw_capture is None

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -52,6 +52,7 @@ def _run_input(
             ),
             language=language,
             samples=sensor_frames_from_mappings([{"t_s": 1.0, "vibration_strength_db": 10.0}]),
+            raw_capture=None,
             total_sample_count=total_sample_count,
             stride=stride,
         ),
@@ -97,6 +98,9 @@ def test_build_post_analysis_summary_adds_analysis_metadata(
         "analyzed_sample_count": 1,
         "total_sample_count": 3,
         "sampling_method": "full",
+        "raw_capture_available": False,
+        "raw_backed_sample_count": 0,
+        "raw_capture_mode": "summary_only",
     }
 
 
@@ -216,6 +220,7 @@ def test_build_post_analysis_summary_enriches_missing_strength_db_from_peak_and_
                     }
                 ]
             ),
+            raw_capture=None,
             total_sample_count=1,
             stride=1,
         )

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureManifest,
+    RawCaptureSensorData,
+    RawCaptureSensorManifest,
+    RawRunCapture,
+)
+from vibesensor.use_cases.run.post_analysis_input import build_post_analysis_input
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+
+
+def _metadata(run_id: str):
+    return run_metadata_from_mapping(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": 800,
+            "sample_rate_hz": 800,
+            "feature_interval_s": 1.0,
+            "fft_window_size_samples": 64,
+            "accel_scale_g_per_lsb": 0.001,
+            "language": "en",
+        }
+    )
+
+
+def _raw_capture(run_id: str) -> RawRunCapture:
+    sample_rate_hz = 800
+    fft_n = 64
+    time_axis = np.arange(fft_n, dtype=np.float64) / sample_rate_hz
+    wave = np.round(1000.0 * np.sin(2.0 * math.pi * 50.0 * time_axis)).astype(np.int16)
+    samples_i16 = np.column_stack(
+        [
+            wave,
+            np.zeros(fft_n, dtype=np.int16),
+            np.zeros(fft_n, dtype=np.int16),
+        ]
+    )
+    sensor_manifest = RawCaptureSensorManifest(
+        client_id="sensor-a",
+        sample_rate_hz=sample_rate_hz,
+        data_file="sensor-a.raw.i16le",
+        index_file="sensor-a.index.jsonl",
+        sample_count=fft_n,
+        chunk_count=1,
+        bytes_written=int(samples_i16.nbytes),
+        first_t0_us=1,
+        last_t0_us=1,
+    )
+    manifest = RawCaptureManifest(
+        run_id=run_id,
+        relative_dir=f"raw-runs/{run_id}",
+        sensors=(sensor_manifest,),
+        total_samples=fft_n,
+        total_bytes=int(samples_i16.nbytes),
+        created_at="2025-01-01T00:00:01Z",
+    )
+    return RawRunCapture(
+        manifest=manifest,
+        sensors=(
+            RawCaptureSensorData(
+                manifest=sensor_manifest,
+                samples_i16=samples_i16,
+                chunks=(),
+            ),
+        ),
+    )
+
+
+def test_build_post_analysis_input_replays_raw_backed_strength_metrics() -> None:
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-raw",
+        metadata=_metadata("run-raw"),
+        language="en",
+        samples=sensor_frames_from_mappings(
+            [
+                {
+                    "client_id": "sensor-a",
+                    "t_s": 64 / 800,
+                    "sample_rate_hz": 800,
+                    "vibration_strength_db": 0.0,
+                    "dominant_freq_hz": 0.0,
+                }
+            ]
+        ),
+        raw_capture=_raw_capture("run-raw"),
+        total_sample_count=1,
+        stride=1,
+    )
+
+    result = build_post_analysis_input(loaded)
+
+    rebuilt = result.diagnostics_run.samples[0]
+    assert result.raw_capture_available is True
+    assert result.raw_backed_sample_count == 1
+    assert rebuilt.vibration_strength_db is not None
+    assert rebuilt.vibration_strength_db > 0.0
+    assert rebuilt.dominant_freq_hz is not None
+    assert 30.0 <= rebuilt.dominant_freq_hz <= 70.0
+    assert rebuilt.top_peaks
+
+
+def test_build_post_analysis_input_falls_back_when_raw_capture_missing() -> None:
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-summary",
+        metadata=_metadata("run-summary"),
+        language="en",
+        samples=sensor_frames_from_mappings(
+            [
+                {
+                    "client_id": "sensor-a",
+                    "t_s": 64 / 800,
+                    "sample_rate_hz": 800,
+                    "vibration_strength_db": 12.0,
+                    "dominant_freq_hz": 14.0,
+                }
+            ]
+        ),
+        raw_capture=None,
+        total_sample_count=1,
+        stride=1,
+    )
+
+    result = build_post_analysis_input(loaded)
+
+    assert result.raw_capture_available is False
+    assert result.raw_backed_sample_count == 0
+    assert result.diagnostics_run.samples[0].vibration_strength_db == 12.0

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -11,6 +11,9 @@ from vibesensor.adapters.persistence.history_db._client_names_repository import 
     ClientNameRepository,
 )
 from vibesensor.adapters.persistence.history_db._engine import SQLiteHistoryEngine
+from vibesensor.adapters.persistence.history_db._raw_capture_store import (
+    HistoryRawCaptureStore,
+)
 from vibesensor.adapters.persistence.history_db._run_repository import RunHistoryRepository
 from vibesensor.adapters.persistence.history_db._settings_repository import (
     SettingsSnapshotRepository,
@@ -55,12 +58,14 @@ def _build_history_persistence_adapters(
         corruption_reporter=corruption_reporter,
     )
     cursor_provider = lifecycle._cursor
+    raw_capture_store = HistoryRawCaptureStore(data_dir=db_path.parent)
     return HistoryPersistenceAdapters(
         lifecycle=lifecycle,
         run_repository=RunHistoryRepository(
             engine=lifecycle,
             cursor_provider=cursor_provider,
             write_transaction_cursor_provider=lifecycle.write_transaction_cursor,
+            raw_capture_store=raw_capture_store,
         ),
         settings_snapshot_repository=SettingsSnapshotRepository(
             engine=lifecycle,

--- a/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
@@ -351,6 +351,10 @@ class SQLiteHistoryEngine:
             return
         if version == 11:
             await self._migrate_v11_to_v12()
+            await self._migrate_v12_to_v13()
+            return
+        if version == 12:
+            await self._migrate_v12_to_v13()
             return
         if version > SCHEMA_VERSION:
             raise RuntimeError(
@@ -387,6 +391,17 @@ class SQLiteHistoryEngine:
                         for run_id, metadata_json in rows
                     ],
                 )
+            await cur.execute("PRAGMA user_version = 12")
+
+    async def _migrate_v12_to_v13(self) -> None:
+        LOGGER.info("Migrating history DB schema v12 -> v13")
+        async with self._cursor(commit=False) as cur:
+            await cur.execute("PRAGMA table_info(runs)")
+            columns = {str(row[1]) for row in await cur.fetchall()}
+        if "raw_capture_manifest_json" not in columns:
+            async with self._cursor() as cur:
+                await cur.execute("ALTER TABLE runs ADD COLUMN raw_capture_manifest_json TEXT")
+        async with self._cursor() as cur:
             await cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
     async def _run_startup_quick_check(self) -> None:

--- a/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable
 from contextlib import AbstractAsyncContextManager
@@ -10,6 +11,9 @@ from typing import TypeVar
 
 import aiosqlite
 
+from vibesensor.adapters.persistence.history_db._raw_capture_store import (
+    HistoryRawCaptureStore,
+)
 from vibesensor.domain.run_status import RunStatus
 from vibesensor.shared.boundaries.analysis_payloads import (
     persisted_analysis_from_storage_json_object,
@@ -23,6 +27,7 @@ from vibesensor.shared.types.history_records import (
 )
 from vibesensor.shared.types.json_types import is_json_object
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
 from vibesensor.shared.types.run_schema import RunMetadata
 
 LOGGER = logging.getLogger(__name__)
@@ -31,6 +36,8 @@ _T = TypeVar("_T")
 
 
 class _HistoryDBQueryMixin:
+    _raw_capture_store: HistoryRawCaptureStore
+
     def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         raise NotImplementedError
 
@@ -86,6 +93,25 @@ class _HistoryDBQueryMixin:
             parsed["end_time_utc"] = end_time_utc
         return run_metadata_from_mapping(parsed)
 
+    def _coerce_raw_capture_manifest(
+        self,
+        *,
+        run_id: str,
+        manifest_json: str | None,
+        source: str,
+    ) -> RawCaptureManifest | None:
+        parsed = safe_json_loads(manifest_json, context=f"run {run_id} raw_capture_manifest")
+        if not is_json_object(parsed):
+            if parsed is not None:
+                LOGGER.warning(
+                    "%s: run %s raw_capture_manifest_json parsed to %s, expected dict",
+                    source,
+                    run_id,
+                    type(parsed).__name__,
+                )
+            return None
+        return RawCaptureManifest.from_mapping(parsed)
+
     def list_runs(self, limit: int = 500) -> list[HistoryRunListEntry]:
         return self._run_sync(self.alist_runs(limit))
 
@@ -133,7 +159,8 @@ class _HistoryDBQueryMixin:
         async with self._cursor(commit=False) as cur:
             await cur.execute(
                 "SELECT run_id, case_id, status, start_time_utc, end_time_utc, "
-                "metadata_json, analysis_json, error_message, created_at, "
+                "metadata_json, raw_capture_manifest_json, analysis_json, "
+                "error_message, created_at, "
                 "sample_count, analysis_started_at, analysis_completed_at "
                 "FROM runs WHERE run_id = ?",
                 (run_id,),
@@ -148,6 +175,7 @@ class _HistoryDBQueryMixin:
             start,
             end,
             meta_json,
+            raw_capture_manifest_json,
             analysis_json,
             error,
             created,
@@ -165,6 +193,13 @@ class _HistoryDBQueryMixin:
             allow_fallback=True,
         )
         assert metadata is not None
+        raw_capture_manifest = self._coerce_raw_capture_manifest(
+            run_id=str(rid),
+            manifest_json=str(raw_capture_manifest_json)
+            if raw_capture_manifest_json is not None
+            else None,
+            source="get_run",
+        )
         analysis: PersistedAnalysis | None = None
         analysis_corrupt = False
         if analysis_json:
@@ -189,6 +224,7 @@ class _HistoryDBQueryMixin:
             end_time_utc=str(end) if end is not None else None,
             metadata=metadata,
             analysis=analysis,
+            raw_capture_manifest=raw_capture_manifest,
             analysis_corrupt=analysis_corrupt,
             error_message=str(error) if error else None,
             created_at=str(created),
@@ -196,6 +232,27 @@ class _HistoryDBQueryMixin:
             analysis_started_at=str(analysis_started) if analysis_started else None,
             analysis_completed_at=str(analysis_completed) if analysis_completed else None,
         )
+
+    async def aget_raw_capture_manifest(self, run_id: str) -> RawCaptureManifest | None:
+        async with self._cursor(commit=False) as cur:
+            await cur.execute(
+                "SELECT raw_capture_manifest_json FROM runs WHERE run_id = ?",
+                (run_id,),
+            )
+            row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        return self._coerce_raw_capture_manifest(
+            run_id=run_id,
+            manifest_json=str(row[0]),
+            source="get_raw_capture_manifest",
+        )
+
+    async def aload_raw_capture(self, run_id: str) -> RawRunCapture | None:
+        manifest = await self.aget_raw_capture_manifest(run_id)
+        if manifest is None:
+            return None
+        return await asyncio.to_thread(self._raw_capture_store.load_capture, manifest)
 
     def get_run_metadata(self, run_id: str) -> RunMetadata | None:
         return self._run_sync(self.aget_run_metadata(run_id))

--- a/apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py
@@ -1,0 +1,188 @@
+"""File-backed raw waveform artifact store for history runs."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from threading import RLock
+from typing import BinaryIO, TextIO
+
+import numpy as np
+
+from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
+from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.types.json_types import is_json_object
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunk,
+    RawCaptureChunkIndex,
+    RawCaptureManifest,
+    RawCaptureSensorData,
+    RawCaptureSensorManifest,
+    RawRunCapture,
+)
+
+_MANIFEST_FILE_NAME = "manifest.json"
+_RAW_CAPTURE_DIR_NAME = "raw-runs"
+
+
+@dataclass(slots=True)
+class _OpenSensorStream:
+    client_id: str
+    sample_rate_hz: int
+    data_path: Path
+    index_path: Path
+    data_handle: BinaryIO
+    index_handle: TextIO
+    sample_count: int = 0
+    chunk_count: int = 0
+    bytes_written: int = 0
+    first_t0_us: int | None = None
+    last_t0_us: int | None = None
+
+
+class HistoryRawCaptureStore:
+    """Store raw waveform artifacts in deterministic per-run directories."""
+
+    __slots__ = ("_base_dir", "_data_dir", "_lock", "_open_runs")
+
+    def __init__(self, *, data_dir: Path) -> None:
+        self._data_dir = data_dir
+        self._base_dir = data_dir / _RAW_CAPTURE_DIR_NAME
+        self._lock = RLock()
+        self._open_runs: dict[str, dict[str, _OpenSensorStream]] = {}
+
+    def append_chunk(self, run_id: str, chunk: RawCaptureChunk) -> None:
+        with self._lock:
+            stream = self._ensure_stream(run_id, chunk.client_id, chunk.sample_rate_hz)
+            if stream.sample_rate_hz != chunk.sample_rate_hz:
+                raise ValueError(
+                    f"raw capture sample-rate mismatch for {chunk.client_id}: "
+                    f"{stream.sample_rate_hz} != {chunk.sample_rate_hz}"
+                )
+            byte_offset = stream.bytes_written
+            stream.data_handle.write(chunk.samples_i16le)
+            stream.index_handle.write(
+                safe_json_dumps(
+                    RawCaptureChunkIndex(
+                        sample_start=stream.sample_count,
+                        sample_count=chunk.sample_count,
+                        t0_us=chunk.t0_us,
+                        byte_offset=byte_offset,
+                    ).to_json_object()
+                )
+                + "\n"
+            )
+            stream.sample_count += chunk.sample_count
+            stream.chunk_count += 1
+            stream.bytes_written += len(chunk.samples_i16le)
+            stream.first_t0_us = chunk.t0_us if stream.first_t0_us is None else stream.first_t0_us
+            stream.last_t0_us = chunk.t0_us
+
+    def finalize_run(self, run_id: str) -> RawCaptureManifest | None:
+        with self._lock:
+            streams = self._open_runs.pop(run_id, None)
+        if not streams:
+            self.delete_run_artifacts(run_id)
+            return None
+        sensor_manifests: list[RawCaptureSensorManifest] = []
+        total_samples = 0
+        total_bytes = 0
+        for client_id in sorted(streams):
+            stream = streams[client_id]
+            stream.data_handle.close()
+            stream.index_handle.close()
+            sensor_manifest = RawCaptureSensorManifest(
+                client_id=stream.client_id,
+                sample_rate_hz=stream.sample_rate_hz,
+                data_file=stream.data_path.name,
+                index_file=stream.index_path.name,
+                sample_count=stream.sample_count,
+                chunk_count=stream.chunk_count,
+                bytes_written=stream.bytes_written,
+                first_t0_us=stream.first_t0_us,
+                last_t0_us=stream.last_t0_us,
+            )
+            sensor_manifests.append(sensor_manifest)
+            total_samples += sensor_manifest.sample_count
+            total_bytes += sensor_manifest.bytes_written
+        manifest = RawCaptureManifest(
+            run_id=run_id,
+            relative_dir=str(Path(_RAW_CAPTURE_DIR_NAME) / run_id),
+            sensors=tuple(sensor_manifests),
+            total_samples=total_samples,
+            total_bytes=total_bytes,
+            created_at=utc_now_iso(),
+        )
+        run_dir = self.run_dir(run_id)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / _MANIFEST_FILE_NAME).write_text(
+            safe_json_dumps(manifest.to_json_object()),
+            encoding="utf-8",
+        )
+        return manifest
+
+    def load_capture(self, manifest: RawCaptureManifest) -> RawRunCapture:
+        run_dir = self._data_dir / manifest.relative_dir
+        sensors: list[RawCaptureSensorData] = []
+        for sensor_manifest in manifest.sensors:
+            data_path = run_dir / sensor_manifest.data_file
+            raw_bytes = data_path.read_bytes()
+            samples_i16 = np.frombuffer(raw_bytes, dtype=np.dtype("<i2")).copy()
+            if samples_i16.size % 3 != 0:
+                raise ValueError(
+                    f"raw capture {data_path} length {samples_i16.size} is not divisible by 3 axes"
+                )
+            reshaped = samples_i16.reshape(-1, 3)
+            index_path = run_dir / sensor_manifest.index_file
+            chunk_indexes: list[RawCaptureChunkIndex] = []
+            if index_path.exists():
+                for line in index_path.read_text(encoding="utf-8").splitlines():
+                    parsed = safe_json_loads(line, context=f"raw capture index {index_path}")
+                    if is_json_object(parsed):
+                        chunk_indexes.append(RawCaptureChunkIndex.from_mapping(parsed))
+            sensors.append(
+                RawCaptureSensorData(
+                    manifest=sensor_manifest,
+                    samples_i16=reshaped,
+                    chunks=tuple(chunk_indexes),
+                )
+            )
+        return RawRunCapture(manifest=manifest, sensors=tuple(sensors))
+
+    def delete_run_artifacts(self, run_id: str) -> None:
+        with self._lock:
+            streams = self._open_runs.pop(run_id, None)
+        if streams:
+            for stream in streams.values():
+                stream.data_handle.close()
+                stream.index_handle.close()
+        shutil.rmtree(self.run_dir(run_id), ignore_errors=True)
+
+    def run_dir(self, run_id: str) -> Path:
+        return self._base_dir / run_id
+
+    def _ensure_stream(
+        self,
+        run_id: str,
+        client_id: str,
+        sample_rate_hz: int,
+    ) -> _OpenSensorStream:
+        run_streams = self._open_runs.setdefault(run_id, {})
+        existing = run_streams.get(client_id)
+        if existing is not None:
+            return existing
+        run_dir = self.run_dir(run_id)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        data_path = run_dir / f"{client_id}.raw.i16le"
+        index_path = run_dir / f"{client_id}.index.jsonl"
+        stream = _OpenSensorStream(
+            client_id=client_id,
+            sample_rate_hz=sample_rate_hz,
+            data_path=data_path,
+            index_path=index_path,
+            data_handle=data_path.open("ab"),
+            index_handle=index_path.open("a", encoding="utf-8"),
+        )
+        run_streams[client_id] = stream
+        return stream

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable
 from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime, timedelta
-from typing import TypeVar
+from typing import TypeVar, cast
 
 import aiosqlite
 
+from vibesensor.adapters.persistence.history_db._raw_capture_store import (
+    HistoryRawCaptureStore,
+)
 from vibesensor.adapters.persistence.history_db._samples import V2_INSERT_SQL, sample_to_v2_row
 from vibesensor.domain.run_status import RunStatus, is_run_deletable, transition_run
 from vibesensor.shared.boundaries.analysis_payloads import (
@@ -19,6 +23,7 @@ from vibesensor.shared.boundaries.runs.metadata import run_metadata_to_json_obje
 from vibesensor.shared.json_utils import safe_json_dumps
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.shared.types.raw_capture import RawCaptureChunk, RawCaptureManifest
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 
@@ -31,6 +36,8 @@ _T = TypeVar("_T")
 
 
 class _HistoryDBRunLifecycleMixin:
+    _raw_capture_store: HistoryRawCaptureStore
+
     def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         raise NotImplementedError
 
@@ -136,6 +143,26 @@ class _HistoryDBRunLifecycleMixin:
                 )
             return len(samples)
 
+    async def aappend_raw_capture_chunk(self, run_id: str, chunk: RawCaptureChunk) -> None:
+        await asyncio.to_thread(self._raw_capture_store.append_chunk, run_id, chunk)
+
+    async def afinalize_raw_capture(self, run_id: str) -> RawCaptureManifest | None:
+        manifest = cast(
+            RawCaptureManifest | None,
+            await asyncio.to_thread(self._raw_capture_store.finalize_run, run_id),
+        )
+        if manifest is None:
+            return None
+        async with self._cursor() as cur:
+            await cur.execute(
+                "UPDATE runs SET raw_capture_manifest_json = ? WHERE run_id = ?",
+                (safe_json_dumps(manifest.to_json_object()), run_id),
+            )
+            if int(cur.rowcount) <= 0:
+                await asyncio.to_thread(self._raw_capture_store.delete_run_artifacts, run_id)
+                return None
+        return manifest
+
     def finalize_run(
         self,
         run_id: str,
@@ -217,7 +244,10 @@ class _HistoryDBRunLifecycleMixin:
             if not is_run_deletable(status):
                 return False, "active" if status == RunStatus.RECORDING else status.value
             await cur.execute("DELETE FROM runs WHERE run_id = ?", (run_id,))
-            return bool(int(cur.rowcount) > 0), None
+            deleted = bool(int(cur.rowcount) > 0)
+        if deleted:
+            await asyncio.to_thread(self._raw_capture_store.delete_run_artifacts, run_id)
+        return deleted, None
 
     def store_analysis(self, run_id: str, analysis: PersistedAnalysis) -> bool:
         return self._run_sync(self.astore_analysis(run_id, analysis))
@@ -302,7 +332,10 @@ class _HistoryDBRunLifecycleMixin:
     async def adelete_run(self, run_id: str) -> bool:
         async with self._cursor() as cur:
             await cur.execute("DELETE FROM runs WHERE run_id = ?", (run_id,))
-            return bool(int(cur.rowcount) > 0)
+            deleted = bool(int(cur.rowcount) > 0)
+        if deleted:
+            await asyncio.to_thread(self._raw_capture_store.delete_run_artifacts, run_id)
+        return deleted
 
     def recover_stale_recording_runs(self) -> int:
         return self._run_sync(self.arecover_stale_recording_runs())
@@ -323,16 +356,25 @@ class _HistoryDBRunLifecycleMixin:
         if retention_days < 1:
             raise ValueError("retention_days must be at least 1")
         cutoff_utc = (datetime.now(UTC) - timedelta(days=retention_days)).isoformat()
-        async with self._cursor() as cur:
+        async with self.write_transaction_cursor() as cur:
             await cur.execute(
                 """
-                DELETE FROM runs
+                SELECT run_id FROM runs
                 WHERE status IN ('complete', 'error')
                   AND COALESCE(analysis_completed_at, end_time_utc, created_at) < ?
                 """,
                 (cutoff_utc,),
             )
-            return int(cur.rowcount)
+            run_ids = [str(row[0]) for row in await cur.fetchall()]
+            if not run_ids:
+                return 0
+            await cur.executemany(
+                "DELETE FROM runs WHERE run_id = ?",
+                [(run_id,) for run_id in run_ids],
+            )
+        for run_id in run_ids:
+            await asyncio.to_thread(self._raw_capture_store.delete_run_artifacts, run_id)
+        return len(run_ids)
 
 
 def _has_recommended_metadata_value(key: str, value: object) -> bool:

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_repository.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_repository.py
@@ -10,6 +10,9 @@ import aiosqlite
 
 from vibesensor.adapters.persistence.history_db._engine import SQLiteHistoryEngine
 from vibesensor.adapters.persistence.history_db._queries import _HistoryDBQueryMixin
+from vibesensor.adapters.persistence.history_db._raw_capture_store import (
+    HistoryRawCaptureStore,
+)
 from vibesensor.adapters.persistence.history_db._run_lifecycle import _HistoryDBRunLifecycleMixin
 from vibesensor.adapters.persistence.history_db._sample_io import _HistoryDBSampleIOMixin
 
@@ -27,7 +30,12 @@ class RunHistoryRepository(
 ):
     """Run/sample/query persistence bound to one shared SQLite history engine."""
 
-    __slots__ = ("_cursor_provider", "_engine", "_write_transaction_cursor_provider")
+    __slots__ = (
+        "_cursor_provider",
+        "_engine",
+        "_raw_capture_store",
+        "_write_transaction_cursor_provider",
+    )
 
     def __init__(
         self,
@@ -35,10 +43,12 @@ class RunHistoryRepository(
         engine: SQLiteHistoryEngine,
         cursor_provider: CursorProvider,
         write_transaction_cursor_provider: WriteTransactionCursorProvider,
+        raw_capture_store: HistoryRawCaptureStore,
     ) -> None:
         self._engine = engine
         self._cursor_provider = cursor_provider
         self._write_transaction_cursor_provider = write_transaction_cursor_provider
+        self._raw_capture_store = raw_capture_store
 
     def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         return self._cursor_provider(commit=commit)

--- a/apps/server/vibesensor/adapters/persistence/history_db/_schema.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_schema.py
@@ -7,7 +7,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 
 SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS runs (
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS runs (
     end_time_utc            TEXT,
     metadata_json           TEXT NOT NULL,
     car_name                TEXT,
+    raw_capture_manifest_json TEXT,
     analysis_json           TEXT,
     error_message           TEXT,
     sample_count            INTEGER NOT NULL DEFAULT 0,

--- a/apps/server/vibesensor/adapters/udp/udp_data_rx.py
+++ b/apps/server/vibesensor/adapters/udp/udp_data_rx.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import cast
+from typing import Protocol, cast
 
+import numpy as np
 from opentelemetry.trace import SpanKind
 
 from vibesensor.adapters.udp.protocol import (
@@ -30,6 +31,17 @@ from vibesensor.shared.tracing import mark_span_error, start_span
 LOGGER = logging.getLogger(__name__)
 
 _QUEUE_DROP_LOG_INTERVAL_S: float = 2.0
+
+
+class RawCaptureSink(Protocol):
+    def capture_raw_samples(
+        self,
+        *,
+        client_id: str,
+        sample_rate_hz: int | None,
+        t0_us: int,
+        samples: np.ndarray,
+    ) -> None: ...
 
 
 class DatagramDispatchError(RuntimeError):
@@ -56,11 +68,13 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
         self,
         registry: ClientRegistry,
         processor: SignalProcessor,
+        raw_capture_sink: RawCaptureSink | None = None,
         queue_maxsize: int = 1024,
         queue_drop_log_interval_s: float = _QUEUE_DROP_LOG_INTERVAL_S,
     ):
         self.registry = registry
         self.processor = processor
+        self._raw_capture_sink = raw_capture_sink
         self.transport: asyncio.DatagramTransport | None = None
         self._queue: asyncio.Queue[tuple[bytes, tuple[str, int]]] = asyncio.Queue(
             maxsize=max(1, queue_maxsize),
@@ -184,6 +198,13 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
                 sample_rate_hz=sample_rate_hz,
                 t0_us=msg.t0_us,
             )
+            if self._raw_capture_sink is not None:
+                self._raw_capture_sink.capture_raw_samples(
+                    client_id=client_id,
+                    sample_rate_hz=sample_rate_hz,
+                    t0_us=msg.t0_us,
+                    samples=msg.samples,
+                )
         self._send_data_ack(msg, addr, client_id=client_id)
         return result
 
@@ -213,6 +234,7 @@ async def start_udp_data_receiver(
     port: int,
     registry: ClientRegistry,
     processor: SignalProcessor,
+    raw_capture_sink: RawCaptureSink | None = None,
     queue_maxsize: int = 1024,
 ) -> tuple[asyncio.DatagramTransport, DataDatagramProtocol]:
     """Bind the UDP data socket and start the background consumer task."""
@@ -220,6 +242,7 @@ async def start_udp_data_receiver(
     protocol = DataDatagramProtocol(
         registry=registry,
         processor=processor,
+        raw_capture_sink=raw_capture_sink,
         queue_maxsize=queue_maxsize,
     )
     transport, _ = await loop.create_datagram_endpoint(

--- a/apps/server/vibesensor/infra/runtime/startup_runner.py
+++ b/apps/server/vibesensor/infra/runtime/startup_runner.py
@@ -142,6 +142,7 @@ class StartupRunner:
             port=self._runtime.udp_data_port,
             registry=self._runtime.registry,
             processor=self._runtime.processor,
+            raw_capture_sink=self._runtime.run_recorder,
             queue_maxsize=self._runtime.udp_data_queue_maxsize,
         )
 

--- a/apps/server/vibesensor/infra/runtime/udp_transport_lifecycle.py
+++ b/apps/server/vibesensor/infra/runtime/udp_transport_lifecycle.py
@@ -54,6 +54,7 @@ class UdpTransportLifecycle:
         port: int,
         registry: object,
         processor: object,
+        raw_capture_sink: object | None = None,
         queue_maxsize: int,
     ) -> None:
         self._data_transport, consumer = await self._start_udp_receiver(
@@ -61,6 +62,7 @@ class UdpTransportLifecycle:
             port=port,
             registry=registry,
             processor=processor,
+            raw_capture_sink=raw_capture_sink,
             queue_maxsize=queue_maxsize,
         )
         if consumer is not None:

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -14,6 +14,11 @@ from vibesensor.shared.types.history_records import (
 )
 from vibesensor.shared.types.payload_types import ClientMetrics
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunk,
+    RawCaptureManifest,
+    RawRunCapture,
+)
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_config import SensorsByMacPayload
 from vibesensor.shared.types.sensor_frame import SensorFrame
@@ -90,6 +95,8 @@ class RunPersistence(Protocol):
 
     async def aappend_samples(self, run_id: str, samples: list[SensorFrame]) -> int: ...
 
+    async def aappend_raw_capture_chunk(self, run_id: str, chunk: RawCaptureChunk) -> None: ...
+
     async def afinalize_run(
         self,
         run_id: str,
@@ -103,6 +110,12 @@ class RunPersistence(Protocol):
     async def astore_analysis(self, run_id: str, analysis: PersistedAnalysis) -> bool: ...
 
     async def astore_analysis_error(self, run_id: str, error: str) -> bool: ...
+
+    async def afinalize_raw_capture(self, run_id: str) -> RawCaptureManifest | None: ...
+
+    async def aget_raw_capture_manifest(self, run_id: str) -> RawCaptureManifest | None: ...
+
+    async def aload_raw_capture(self, run_id: str) -> RawRunCapture | None: ...
 
     async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]: ...
 

--- a/apps/server/vibesensor/shared/types/history_records.py
+++ b/apps/server/vibesensor/shared/types/history_records.py
@@ -8,6 +8,7 @@ from vibesensor.domain.run_status import RunStatus
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_to_json_object
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.shared.types.raw_capture import RawCaptureManifest
 from vibesensor.shared.types.run_schema import RunMetadata
 
 __all__ = [
@@ -60,6 +61,7 @@ class StoredHistoryRun:
     sample_count: int
     case_id: str | None = None
     analysis: PersistedAnalysis | None = None
+    raw_capture_manifest: RawCaptureManifest | None = None
     analysis_corrupt: bool = False
     error_message: str | None = None
     analysis_started_at: str | None = None
@@ -80,6 +82,8 @@ class StoredHistoryRun:
             payload["case_id"] = self.case_id
         if self.analysis is not None:
             payload["analysis"] = self.analysis.to_json_object()
+        if self.raw_capture_manifest is not None:
+            payload["raw_capture_manifest"] = self.raw_capture_manifest.to_json_object()
         if self.analysis_corrupt:
             payload["analysis_corrupt"] = True
         if self.error_message is not None:

--- a/apps/server/vibesensor/shared/types/raw_capture.py
+++ b/apps/server/vibesensor/shared/types/raw_capture.py
@@ -1,0 +1,205 @@
+"""Typed raw-capture artifact contracts shared by recording and history flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
+
+__all__ = [
+    "RawCaptureChunk",
+    "RawCaptureChunkIndex",
+    "RawCaptureManifest",
+    "RawCaptureSensorData",
+    "RawCaptureSensorManifest",
+    "RawRunCapture",
+]
+
+type Int16Array = npt.NDArray[np.int16]
+
+_RAW_CAPTURE_SCHEMA_VERSION = 1
+_RAW_CAPTURE_STORAGE_TYPE = "run-directory-v1"
+_RAW_CAPTURE_MODE = "full_run"
+
+
+@dataclass(frozen=True, slots=True)
+class RawCaptureChunk:
+    """One raw waveform chunk queued from UDP ingest into the raw-capture store."""
+
+    client_id: str
+    sample_rate_hz: int
+    t0_us: int
+    sample_count: int
+    samples_i16le: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class RawCaptureChunkIndex:
+    """Persistent index row locating one raw chunk inside a sensor stream file."""
+
+    sample_start: int
+    sample_count: int
+    t0_us: int
+    byte_offset: int
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "sample_start": self.sample_start,
+            "sample_count": self.sample_count,
+            "t0_us": self.t0_us,
+            "byte_offset": self.byte_offset,
+        }
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> RawCaptureChunkIndex:
+        return cls(
+            sample_start=_int_from_json(data.get("sample_start")),
+            sample_count=_int_from_json(data.get("sample_count")),
+            t0_us=_int_from_json(data.get("t0_us")),
+            byte_offset=_int_from_json(data.get("byte_offset")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RawCaptureSensorManifest:
+    """One sensor stream persisted inside a raw run-artifact bundle."""
+
+    client_id: str
+    sample_rate_hz: int
+    data_file: str
+    index_file: str
+    sample_count: int
+    chunk_count: int
+    bytes_written: int
+    first_t0_us: int | None = None
+    last_t0_us: int | None = None
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "client_id": self.client_id,
+            "sample_rate_hz": self.sample_rate_hz,
+            "data_file": self.data_file,
+            "index_file": self.index_file,
+            "sample_count": self.sample_count,
+            "chunk_count": self.chunk_count,
+            "bytes_written": self.bytes_written,
+        }
+        if self.first_t0_us is not None:
+            payload["first_t0_us"] = self.first_t0_us
+        if self.last_t0_us is not None:
+            payload["last_t0_us"] = self.last_t0_us
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> RawCaptureSensorManifest:
+        return cls(
+            client_id=_str_from_json(data.get("client_id")),
+            sample_rate_hz=_int_from_json(data.get("sample_rate_hz")),
+            data_file=_str_from_json(data.get("data_file")),
+            index_file=_str_from_json(data.get("index_file")),
+            sample_count=_int_from_json(data.get("sample_count")),
+            chunk_count=_int_from_json(data.get("chunk_count")),
+            bytes_written=_int_from_json(data.get("bytes_written")),
+            first_t0_us=_int_or_none(data.get("first_t0_us")),
+            last_t0_us=_int_or_none(data.get("last_t0_us")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RawCaptureManifest:
+    """Compact manifest persisted on a run record for one raw artifact bundle."""
+
+    run_id: str
+    relative_dir: str
+    sensors: tuple[RawCaptureSensorManifest, ...]
+    total_samples: int
+    total_bytes: int
+    created_at: str
+    schema_version: int = _RAW_CAPTURE_SCHEMA_VERSION
+    storage_type: str = _RAW_CAPTURE_STORAGE_TYPE
+    capture_mode: str = _RAW_CAPTURE_MODE
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "schema_version": self.schema_version,
+            "storage_type": self.storage_type,
+            "capture_mode": self.capture_mode,
+            "run_id": self.run_id,
+            "relative_dir": self.relative_dir,
+            "total_samples": self.total_samples,
+            "total_bytes": self.total_bytes,
+            "created_at": self.created_at,
+            "sensors": [sensor.to_json_object() for sensor in self.sensors],
+        }
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> RawCaptureManifest:
+        sensors_raw = data.get("sensors")
+        sensors: list[RawCaptureSensorManifest] = []
+        if isinstance(sensors_raw, list):
+            for item in sensors_raw:
+                if is_json_object(item):
+                    sensors.append(RawCaptureSensorManifest.from_mapping(item))
+        return cls(
+            schema_version=_int_from_json(data.get("schema_version"), _RAW_CAPTURE_SCHEMA_VERSION),
+            storage_type=_str_from_json(data.get("storage_type"), _RAW_CAPTURE_STORAGE_TYPE),
+            capture_mode=_str_from_json(data.get("capture_mode"), _RAW_CAPTURE_MODE),
+            run_id=_str_from_json(data.get("run_id")),
+            relative_dir=_str_from_json(data.get("relative_dir")),
+            sensors=tuple(sensors),
+            total_samples=_int_from_json(data.get("total_samples")),
+            total_bytes=_int_from_json(data.get("total_bytes")),
+            created_at=_str_from_json(data.get("created_at")),
+        )
+
+    def sensor_manifest(self, client_id: str) -> RawCaptureSensorManifest | None:
+        for sensor in self.sensors:
+            if sensor.client_id == client_id:
+                return sensor
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class RawCaptureSensorData:
+    """Decoded raw waveform stream plus its persisted chunk index."""
+
+    manifest: RawCaptureSensorManifest
+    samples_i16: Int16Array
+    chunks: tuple[RawCaptureChunkIndex, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RawRunCapture:
+    """Fully loaded raw capture bundle for one run."""
+
+    manifest: RawCaptureManifest
+    sensors: tuple[RawCaptureSensorData, ...]
+
+    def sensor_data(self, client_id: str) -> RawCaptureSensorData | None:
+        for sensor in self.sensors:
+            if sensor.manifest.client_id == client_id:
+                return sensor
+        return None
+
+
+def _int_or_none(value: JsonValue | object) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float, str)):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _int_from_json(value: JsonValue | object, default: int = 0) -> int:
+    parsed = _int_or_none(value)
+    return parsed if parsed is not None else default
+
+
+def _str_from_json(value: JsonValue | object, default: str = "") -> str:
+    return value if isinstance(value, str) else default

--- a/apps/server/vibesensor/use_cases/run/_recorder_types.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_types.py
@@ -79,6 +79,7 @@ def _shutdown_report(recorder: RunRecorder, timeout_s: float) -> RecorderShutdow
         health = recorder.health_snapshot()
         if not analysis_completed:
             recorder.shutdown_post_analysis(timeout_s=1.0)
+        recorder.shutdown_raw_capture(timeout_s=1.0)
         return RecorderShutdownReport(
             completed=analysis_completed,
             active_run_id_before_stop=active_run_id_before_stop,

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -8,6 +8,7 @@ from threading import RLock
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
+import numpy as np
 from opentelemetry.trace import SpanKind
 
 from vibesensor.shared.ports import (
@@ -34,6 +35,7 @@ from vibesensor.use_cases.run.persistence_writer import (
 )
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
 from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
+from vibesensor.use_cases.run.raw_capture_writer import RunRawCaptureWriter
 from vibesensor.use_cases.run.run_context import build_run_context_snapshot
 from vibesensor.use_cases.run.sample_flush import SampleFlushOrchestrator
 from vibesensor.use_cases.run.status_reporting import (
@@ -120,6 +122,10 @@ class RunRecorder:
             error_callback=self._persistence.set_last_write_error,
             clear_error_callback=self._persistence.clear_last_write_error,
             analysis_runner=build_post_analysis_summary,
+        )
+        self._raw_capture = RunRawCaptureWriter(
+            history_db=history_db if config.persist_history_db else None,
+            logger=LOGGER,
         )
 
         self._sample_flush = SampleFlushOrchestrator(
@@ -210,7 +216,25 @@ class RunRecorder:
         self._active_run_context = run_context
         self._persistence.reset()
         self._live_start_mono_s = snapshot.start_mono_s
+        self._raw_capture.start_run(snapshot.run_id)
         return snapshot
+
+    def capture_raw_samples(
+        self,
+        *,
+        client_id: str,
+        sample_rate_hz: int | None,
+        t0_us: int,
+        samples: object,
+    ) -> None:
+        if not isinstance(samples, np.ndarray):
+            return
+        self._raw_capture.capture_raw_samples(
+            client_id=client_id,
+            sample_rate_hz=sample_rate_hz,
+            t0_us=t0_us,
+            samples=samples,
+        )
 
     def status(self) -> RunRecorderStatusSnapshot:
         with self._lock:
@@ -302,6 +326,8 @@ class RunRecorder:
                         start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
                         end_time_utc = utc_now_iso()
                         persistence_snapshot = self._persistence.status_snapshot()
+                        if run_id:
+                            self._raw_capture.finalize_run(run_id)
                         if run_id and not self._persistence.finalize_run(
                             run_id,
                             start_time_utc,
@@ -398,6 +424,8 @@ class RunRecorder:
                     start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
                     end_time_utc = utc_now_iso()
                     persistence_snapshot = self._persistence.status_snapshot()
+                    if run_id:
+                        self._raw_capture.finalize_run(run_id)
                     if run_id and not self._persistence.finalize_run(
                         run_id,
                         start_time_utc,
@@ -463,6 +491,9 @@ class RunRecorder:
 
     def shutdown(self, timeout_s: float = 30.0) -> bool:
         return self.shutdown_report(timeout_s).completed
+
+    def shutdown_raw_capture(self, timeout_s: float = 5.0) -> bool:
+        return self._raw_capture.shutdown(timeout_s)
 
     async def run(self) -> None:
         await _recorder_runtime.run_loop(self, logger=LOGGER)

--- a/apps/server/vibesensor/use_cases/run/post_analysis_input.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_input.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.strength_bands import bucket_for_strength
@@ -27,6 +27,7 @@ class PostAnalysisRunInput:
     stride: int
     raw_capture_available: bool
     raw_backed_sample_count: int
+    summary_samples: tuple[Sample, ...] = field(default_factory=tuple)
 
     @property
     def run_id(self) -> str:
@@ -61,6 +62,7 @@ def build_post_analysis_input(loaded: LoadedPostAnalysisRun) -> PostAnalysisRunI
         stride=loaded.stride,
         raw_capture_available=loaded.raw_capture is not None,
         raw_backed_sample_count=raw_backed_sample_count,
+        summary_samples=tuple(loaded.samples),
     )
 
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_input.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_input.py
@@ -14,6 +14,7 @@ from vibesensor.use_cases.diagnostics._types import Sample
 from vibesensor.vibration_strength import vibration_strength_db_scalar
 
 from .post_analysis_loader import LoadedPostAnalysisRun
+from .raw_capture_replay import build_raw_backed_samples
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,6 +25,8 @@ class PostAnalysisRunInput:
     language: str
     total_sample_count: int
     stride: int
+    raw_capture_available: bool
+    raw_backed_sample_count: int
 
     @property
     def run_id(self) -> str:
@@ -41,7 +44,12 @@ class PostAnalysisRunInput:
 def build_post_analysis_input(loaded: LoadedPostAnalysisRun) -> PostAnalysisRunInput:
     """Normalize one loaded persisted run into canonical diagnostics input."""
 
-    samples = tuple(_ensure_strength_metrics(sample) for sample in loaded.samples)
+    replayed_samples, raw_backed_sample_count = build_raw_backed_samples(
+        samples=tuple(loaded.samples),
+        metadata=loaded.metadata,
+        raw_capture=loaded.raw_capture,
+    )
+    samples = tuple(_ensure_strength_metrics(sample) for sample in replayed_samples)
     return PostAnalysisRunInput(
         diagnostics_run=build_diagnostics_run_input(
             loaded.metadata,
@@ -51,6 +59,8 @@ def build_post_analysis_input(loaded: LoadedPostAnalysisRun) -> PostAnalysisRunI
         language=loaded.language,
         total_sample_count=loaded.total_sample_count,
         stride=loaded.stride,
+        raw_capture_available=loaded.raw_capture is not None,
+        raw_backed_sample_count=raw_backed_sample_count,
     )
 
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_loader.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_loader.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from math import ceil
 
 from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.types.raw_capture import RawRunCapture
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 
@@ -20,6 +21,7 @@ class LoadedPostAnalysisRun:
     samples: list[SensorFrame]
     total_sample_count: int
     stride: int
+    raw_capture: RawRunCapture | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,6 +83,8 @@ def load_post_analysis_run(
                 run_id=run_id,
                 error_message="No samples collected during run",
             )
+        load_raw_capture = getattr(db, "aload_raw_capture", None)
+        raw_capture = await load_raw_capture(run_id) if callable(load_raw_capture) else None
 
         return LoadedPostAnalysisRun(
             run_id=run_id,
@@ -89,6 +93,7 @@ def load_post_analysis_run(
             samples=samples,
             total_sample_count=total_sample_count,
             stride=stride,
+            raw_capture=raw_capture,
         )
 
     runner = getattr(db, "_run_on_engine_loop", None)

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -48,6 +48,9 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         "analyzed_sample_count": len(run.samples),
         "total_sample_count": run.total_sample_count,
         "sampling_method": "full" if run.stride == 1 else f"stride_{run.stride}",
+        "raw_capture_available": run.raw_capture_available,
+        "raw_backed_sample_count": run.raw_backed_sample_count,
+        "raw_capture_mode": "raw_backed" if run.raw_backed_sample_count > 0 else "summary_only",
     }
     summary_payload["analysis_metadata"] = payload_object_from_json(analysis_metadata)
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from vibesensor.shared.boundaries.analysis_payloads import analysis_result_to_summary
+from vibesensor.shared.boundaries.summary_serialization._location_intensity import (
+    serialize_location_intensity_rows,
+)
 from vibesensor.shared.json_utils import payload_object_from_json
 from vibesensor.shared.types.history_analysis_contracts import RunSuitabilityCheck
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.use_cases.diagnostics.run_analysis_projection import build_sensor_analysis
 from vibesensor.use_cases.run.post_analysis_input import PostAnalysisRunInput
 
 _MIN_POST_ANALYSIS_DURATION_S = 1.0
@@ -25,6 +29,20 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         include_samples=False,
     ).summarize()
     summary_payload = analysis_result_to_summary(result)
+    prepared = getattr(result, "prepared", None)
+    if prepared is not None and hasattr(prepared, "per_sample_phases"):
+        source_samples = run.summary_samples if run.summary_samples else run.samples
+        sensor_locations, connected_locations, sensor_intensity = build_sensor_analysis(
+            samples=source_samples,
+            language=run.language,
+            per_sample_phases=list(prepared.per_sample_phases),
+        )
+        summary_payload["sensor_locations"] = sensor_locations
+        summary_payload["sensor_locations_connected_throughout"] = sorted(connected_locations)
+        summary_payload["sensor_count_used"] = len(sensor_locations)
+        summary_payload["sensor_intensity_by_location"] = serialize_location_intensity_rows(
+            sensor_intensity,
+        )
     summary_payload["case_id"] = result.diagnostic_case.case_id
 
     def append_run_suitability_warning(

--- a/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
@@ -1,0 +1,129 @@
+"""Raw-capture replay helpers for post-stop analysis."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+
+from vibesensor.domain.strength_metrics import StrengthMetrics
+from vibesensor.shared.boundaries.codecs import strength_metrics_from_mapping
+from vibesensor.shared.constants.dsp import SPECTRUM_MAX_HZ, SPECTRUM_MIN_HZ
+from vibesensor.shared.types.raw_capture import RawRunCapture
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
+from vibesensor.vibration_strength import combined_spectrum_amp_g, compute_vibration_strength_db
+
+__all__ = ["build_raw_backed_samples"]
+
+
+def build_raw_backed_samples(
+    *,
+    samples: tuple[SensorFrame, ...],
+    metadata: RunMetadata,
+    raw_capture: RawRunCapture | None,
+) -> tuple[tuple[SensorFrame, ...], int]:
+    """Replace summary strength metrics with raw-backed metrics when possible."""
+
+    if raw_capture is None:
+        return samples, 0
+    fft_n = int(metadata.fft_window_size_samples or 0)
+    if fft_n <= 0:
+        return samples, 0
+    replayed: list[SensorFrame] = []
+    raw_backed_count = 0
+    scale = metadata.accel_scale_g_per_lsb
+    for sample in samples:
+        rebuilt = _rebuild_sample(
+            sample=sample,
+            raw_capture=raw_capture,
+            fft_n=fft_n,
+            accel_scale_g_per_lsb=scale,
+        )
+        if rebuilt is not sample:
+            raw_backed_count += 1
+        replayed.append(rebuilt)
+    return tuple(replayed), raw_backed_count
+
+
+def _rebuild_sample(
+    *,
+    sample: SensorFrame,
+    raw_capture: RawRunCapture,
+    fft_n: int,
+    accel_scale_g_per_lsb: float | None,
+) -> SensorFrame:
+    sensor_data = raw_capture.sensor_data(sample.client_id)
+    if sensor_data is None:
+        return sample
+    sample_rate_hz = int(sample.sample_rate_hz or sensor_data.manifest.sample_rate_hz or 0)
+    if sample_rate_hz <= 0:
+        return sample
+    target_end = _target_end_index(
+        t_s=sample.t_s,
+        sample_rate_hz=sample_rate_hz,
+        available_samples=sensor_data.samples_i16.shape[0],
+    )
+    if target_end is None or target_end < fft_n:
+        return sample
+    window_i16 = sensor_data.samples_i16[target_end - fft_n : target_end]
+    if window_i16.shape[0] != fft_n:
+        return sample
+    window_f32 = window_i16.astype(np.float32, copy=True)
+    if accel_scale_g_per_lsb is not None and accel_scale_g_per_lsb > 0:
+        window_f32 *= np.float32(accel_scale_g_per_lsb)
+    domain_strength = _compute_strength_metrics(window_f32, sample_rate_hz)
+    top_peaks = tuple(peak for peak in domain_strength.top_peaks if peak.is_valid)
+    last_xyz = window_f32[-1]
+    return replace(
+        sample,
+        accel_x_g=float(last_xyz[0]),
+        accel_y_g=float(last_xyz[1]),
+        accel_z_g=float(last_xyz[2]),
+        dominant_freq_hz=domain_strength.dominant_hz,
+        top_peaks=top_peaks,
+        vibration_strength_db=domain_strength.vibration_strength_db,
+        strength_bucket=domain_strength.strength_bucket,
+        strength_peak_amp_g=domain_strength.peak_amp_g,
+        strength_floor_amp_g=domain_strength.noise_floor_amp_g,
+    )
+
+
+def _target_end_index(
+    *,
+    t_s: float | None,
+    sample_rate_hz: int,
+    available_samples: int,
+) -> int | None:
+    if available_samples <= 0:
+        return None
+    if t_s is None or t_s <= 0:
+        return None
+    target = int(round(float(t_s) * float(sample_rate_hz)))
+    if target <= 0:
+        return None
+    return min(target, available_samples)
+
+
+def _compute_strength_metrics(window_f32: np.ndarray, sample_rate_hz: int) -> StrengthMetrics:
+    axes_by_time = window_f32.T
+    detrended = axes_by_time - np.mean(axes_by_time, axis=1, keepdims=True, dtype=np.float32)
+    fft_window = np.asarray(np.hanning(window_f32.shape[0]), dtype=np.float32)
+    if fft_window.size <= 0:
+        return strength_metrics_from_mapping(None)
+    scale = float(2.0 / max(1.0, float(np.sum(fft_window))))
+    transformed = np.fft.rfft(detrended * fft_window, axis=1)
+    freqs = np.fft.rfftfreq(window_f32.shape[0], d=1.0 / sample_rate_hz)
+    valid = (freqs >= SPECTRUM_MIN_HZ) & (freqs <= SPECTRUM_MAX_HZ)
+    if not np.any(valid):
+        return strength_metrics_from_mapping(None)
+    axis_spectra = np.abs(transformed[:, valid]).astype(np.float64, copy=False) * scale
+    combined = np.asarray(
+        combined_spectrum_amp_g(axis_spectra_amp_g=axis_spectra, axis_count_for_mean=3),
+        dtype=np.float64,
+    )
+    raw_strength = compute_vibration_strength_db(
+        freq_hz=freqs[valid],
+        combined_spectrum_amp_g_values=combined,
+    )
+    return strength_metrics_from_mapping(raw_strength)

--- a/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
@@ -1,0 +1,185 @@
+"""Recorder-owned raw waveform sideband capture writer."""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import numpy as np
+
+from vibesensor.shared.ports import RunPersistence
+from vibesensor.shared.types.raw_capture import RawCaptureChunk, RawCaptureManifest
+
+__all__ = ["RunRawCaptureWriter"]
+
+_QUEUE_MAXSIZE = 2048
+
+
+def _sync_call(db: Any, coro: Any) -> object:
+    runner = getattr(db, "_run_on_engine_loop", None)
+    if callable(runner):
+        return runner(coro)
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+@dataclass(slots=True)
+class _FinalizeRequest:
+    run_id: str
+    done: threading.Event = field(default_factory=threading.Event)
+    manifest: RawCaptureManifest | None = None
+    error: BaseException | None = None
+
+
+@dataclass(slots=True)
+class _ShutdownRequest:
+    done: threading.Event = field(default_factory=threading.Event)
+
+
+class RunRawCaptureWriter:
+    """Capture raw UDP chunks for the active run without blocking ingress."""
+
+    __slots__ = (
+        "_active_run_id",
+        "_history_db",
+        "_lock",
+        "_logger",
+        "_queue",
+        "_thread",
+    )
+
+    def __init__(
+        self,
+        *,
+        history_db: RunPersistence | None,
+        logger: logging.Logger,
+    ) -> None:
+        self._history_db = (
+            history_db
+            if history_db is not None
+            and callable(getattr(history_db, "aappend_raw_capture_chunk", None))
+            and callable(getattr(history_db, "afinalize_raw_capture", None))
+            else None
+        )
+        self._logger = logger
+        self._lock = threading.RLock()
+        self._queue: queue.Queue[
+            tuple[str, RawCaptureChunk] | _FinalizeRequest | _ShutdownRequest
+        ] = queue.Queue(maxsize=_QUEUE_MAXSIZE)
+        self._active_run_id: str | None = None
+        self._thread: threading.Thread | None = None
+        if self._history_db is not None:
+            self._thread = threading.Thread(
+                target=self._worker_loop,
+                name="raw-capture-writer",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def start_run(self, run_id: str) -> None:
+        with self._lock:
+            self._active_run_id = run_id
+
+    def capture_raw_samples(
+        self,
+        *,
+        client_id: str,
+        sample_rate_hz: int | None,
+        t0_us: int,
+        samples: np.ndarray,
+    ) -> None:
+        history_db = self._history_db
+        if history_db is None:
+            return
+        with self._lock:
+            run_id = self._active_run_id
+        if run_id is None:
+            return
+        normalized_rate = int(sample_rate_hz or 0)
+        if normalized_rate <= 0:
+            return
+        samples_i16 = np.ascontiguousarray(samples, dtype=np.int16)
+        if samples_i16.ndim != 2 or samples_i16.shape[1] != 3 or samples_i16.shape[0] <= 0:
+            return
+        try:
+            self._queue.put_nowait(
+                (
+                    run_id,
+                    RawCaptureChunk(
+                        client_id=client_id,
+                        sample_rate_hz=normalized_rate,
+                        t0_us=int(t0_us),
+                        sample_count=int(samples_i16.shape[0]),
+                        samples_i16le=samples_i16.tobytes(order="C"),
+                    ),
+                )
+            )
+        except queue.Full:
+            self._logger.error(
+                "Raw capture queue full for run %s; dropping raw chunk for %s",
+                run_id,
+                client_id,
+            )
+
+    def finalize_run(self, run_id: str) -> RawCaptureManifest | None:
+        if self._history_db is None or self._thread is None:
+            return None
+        with self._lock:
+            if self._active_run_id == run_id:
+                self._active_run_id = None
+        request = _FinalizeRequest(run_id=run_id)
+        self._queue.put(request)
+        request.done.wait()
+        if request.error is not None:
+            raise RuntimeError(f"raw capture finalize failed for {run_id}") from request.error
+        return request.manifest
+
+    def shutdown(self, timeout_s: float = 5.0) -> bool:
+        thread = self._thread
+        if thread is None:
+            return True
+        request = _ShutdownRequest()
+        self._queue.put(request)
+        finished = request.done.wait(timeout=max(0.1, timeout_s))
+        thread.join(timeout=max(0.1, timeout_s))
+        self._thread = None
+        return finished and not thread.is_alive()
+
+    def _worker_loop(self) -> None:
+        history_db = self._history_db
+        assert history_db is not None
+        while True:
+            item = self._queue.get()
+            try:
+                if isinstance(item, _ShutdownRequest):
+                    item.done.set()
+                    return
+                if isinstance(item, _FinalizeRequest):
+                    try:
+                        item.manifest = cast(
+                            RawCaptureManifest | None,
+                            _sync_call(
+                                history_db,
+                                history_db.afinalize_raw_capture(item.run_id),
+                            ),
+                        )
+                    except BaseException as exc:  # noqa: BLE001
+                        item.error = exc
+                        self._logger.error(
+                            "Failed to finalize raw capture for run %s",
+                            item.run_id,
+                            exc_info=True,
+                        )
+                    finally:
+                        item.done.set()
+                    continue
+                run_id, chunk = item
+                _sync_call(history_db, history_db.aappend_raw_capture_chunk(run_id, chunk))
+            except BaseException:  # noqa: BLE001
+                self._logger.error("Raw capture worker failed", exc_info=True)
+            finally:
+                self._queue.task_done()

--- a/docs/analysis_pipeline.md
+++ b/docs/analysis_pipeline.md
@@ -30,7 +30,7 @@ Scope: architecture and data flow for the post-stop diagnostics pipeline in
 | | Live Processing (`infra/processing/`) | Post-Stop Analysis (`use_cases/diagnostics/`) |
 |-|----------------------------------------|------------------------------------------------|
 | **When** | Continuously during recording (5–10 Hz) | Once, after recording stops |
-| **Input** | Raw accelerometer frames from UDP | Stored sample records from history DB |
+| **Input** | Raw accelerometer frames from UDP | Stored sample records from history DB, plus optional raw-capture artifacts for replay |
 | **Output** | Per-tick metrics: FFT spectrum, peaks, strength_db, RMS, P2P | Diagnostic findings, rankings, reports |
 | **Purpose** | Data acquisition — transform raw signals into structured metrics | Diagnostic reasoning — classify, rank, and explain vibration causes |
 | **Stateless?** | Yes — each tick processes the current rolling window | Yes — processes all stored samples in one pass |
@@ -60,7 +60,9 @@ RunRecorder.stop_recording()            # use_cases/run/logger.py
        └─ PostAnalysisWorker.schedule() # use_cases/run/post_analysis.py
             └─ _worker_loop()           # daemon thread, sequential queue
                  └─ _run_post_analysis(run_id)
-                      ├─ load metadata + samples via injected RunPersistence
+                      ├─ load metadata + samples (+ raw capture when present) via injected RunPersistence
+                      ├─ build_post_analysis_input(...)
+                      │    └─ raw_capture_replay.py rebuilds FFT-derived strength fields from raw windows when possible
                       ├─ analysis_runner(...)
                       │    ← injected by RunRecorder
                       │      └─ RunAnalysis(metadata, samples, …).summarize()
@@ -184,13 +186,17 @@ Output: AnalysisResult (TestRun, DiagnosticCase, diagnostics-local artifacts)
 
 After `RunAnalysis.summarize()` returns, `PostAnalysisWorker`:
 
-1. Adds `analysis_metadata` (sample count, stride info).
+1. Adds `analysis_metadata` (sample count, stride info, and whether raw-backed
+   replay was used).
 2. Adds language-neutral trust warnings when the captured run context
    was incomplete for confident order analysis.
 3. Stores the summary via `history_db.store_analysis()` as a
    versioned persistence envelope.
 
-History readers unwrap the envelope back to the summary shape. The core
+History readers unwrap the envelope back to the summary shape. When a run has a
+raw capture bundle, the persisted analysis summary already reflects raw-backed
+strength/peak metrics from post-stop replay; report/history readers still stay
+persistence-only and never re-run diagnostics. The core
 history/report projection is derived from persisted run data plus the persisted
 analysis summary only; any comparison against current mutable car settings is an
 explicit advisory overlay at the history delivery boundary, not a hidden input

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -9,15 +9,16 @@ The report generation pipeline has two distinct phases:
    then created at the boundary by `vibesensor.shared.boundaries.analysis_payloads`
    / `vibesensor.adapters.analysis_summary`.
 2. **History request loading + reporting-boundary preparation + rendering**
-     (`vibesensor.use_cases.history` →
-     `vibesensor.shared.boundaries.reporting` →
-     `vibesensor.adapters.pdf`) — loads the persisted analysis object, shapes
-     runtime warnings and cache metadata, prepares one explicit
+      (`vibesensor.use_cases.history` →
+      `vibesensor.shared.boundaries.reporting` →
+      `vibesensor.adapters.pdf`) — loads the persisted analysis object, shapes
+      runtime warnings and cache metadata, prepares one explicit
      `PreparedReportInput` with an authoritative reconstructed domain aggregate
      plus precomputed semantic report facts, builds one canonical
      `ReportDocument`, and renders a PDF. This phase performs **zero
-     analysis** — it only shapes persisted report data and formats pre-computed
-     results.
+      analysis** — it only shapes persisted report data and formats pre-computed
+      results. If a run had raw capture available, that evidence was already
+      folded into the persisted analysis during post-stop replay.
 
 ```text
 Recording stops

--- a/docs/run_lifecycle.md
+++ b/docs/run_lifecycle.md
@@ -9,6 +9,8 @@ one big state-machine class:
 - `RunLifecycleState` owns only the in-memory active-run gate and timing fields.
 - `RunPersistenceWriter` owns history-run creation, sample append retries, and
   finalization.
+- `RunRawCaptureWriter` owns the recorder-side raw UDP chunk handoff and
+  artifact finalization for the active run.
 - `PostAnalysisWorker` owns the background queue and retry policy after a run
   stops.
 - `CaptureReadinessTracker` owns the backend pre-record readiness checklist for
@@ -22,6 +24,7 @@ one big state-machine class:
 | `RunLifecycleState` | `use_cases/run/lifecycle_state.py` | Active run identity, start timing, frame-progress tracking, and auto-stop gating. |
 | `SampleFlushOrchestrator` | `use_cases/run/sample_flush.py` | Build `SensorFrame` rows, refresh recent metrics, and decide when to flush or auto-stop. |
 | `RunPersistenceWriter` | `use_cases/run/persistence_writer.py` | Create the persisted run, append sample rows with retries, and finalize the run metadata. |
+| `RunRawCaptureWriter` | `use_cases/run/raw_capture_writer.py` | Buffer raw UDP chunks for the active run and finalize the raw artifact manifest into history. |
 | `CaptureReadinessTracker` | `use_cases/run/capture_readiness.py` | Evaluate live-sensor readiness, reference freshness, steady-speed dwell, and recent integrity quiet windows for the idle recording gate. |
 | `RunRecorder` | `use_cases/run/logger.py` | Start/stop entrypoint and coordinator for lifecycle, persistence, and post-analysis. |
 | `PostAnalysisWorker` | `use_cases/run/post_analysis.py` | Non-evicting queue and single daemon thread for completed runs. |
@@ -62,6 +65,9 @@ During recording:
 - `current_run.is_recording` is true
 - `SampleFlushOrchestrator` periodically builds `SensorFrame` rows from the
   registry, processor metrics, and resolved speed context
+- raw UDP ingress also streams full-run `int16` chunks through
+  `RunRawCaptureWriter`, which writes per-run artifacts under the history data
+  directory without bloating `samples_v2`
 - `refresh_data_progress()` / `mark_rows_written()` keep the no-data timeout
   clock moving
 - auto-stop is based on elapsed monotonic time since the last data progress, not
@@ -72,12 +78,14 @@ During recording:
 `RunRecorder.stop_recording()` performs the stop handoff in this order:
 
 1. capture one last pending flush if new data exists
-2. ask `RunPersistenceWriter.ready_for_analysis()` whether the run has both a
+2. finalize the raw artifact bundle and persist its compact manifest on the run
+   row when raw chunks were captured
+3. ask `RunPersistenceWriter.ready_for_analysis()` whether the run has both a
    created history row and at least one written sample
-3. call `RunPersistenceWriter.finalize_run()`
-4. call `RunLifecycleState.stop()` and clear the active run context
-5. reset the persistence helper for the next live run
-6. schedule post-analysis only when `ready_for_analysis()` returned the run ID
+4. call `RunPersistenceWriter.finalize_run()`
+5. call `RunLifecycleState.stop()` and clear the active run context
+6. reset the persistence helper for the next live run
+7. schedule post-analysis only when `ready_for_analysis()` returned the run ID
 
 If `finalize_run()` fails, `RunRecorder` still schedules post-analysis when the
 run was otherwise ready. The persistence layer handles that fallback path by
@@ -116,6 +124,10 @@ because there is nothing persistent to close.
   `_RETRY_DELAYS_S = (0.5, 1.0, 2.0)`
 - `execute_post_analysis()` loads the stored run, calls the injected analysis
   runner, and stores either analysis output or an analysis error record
+- the loaded post-stop input can now include both persisted summary rows and the
+  optional raw-capture bundle; the raw replay path rebuilds FFT-derived
+  strength/peak fields from raw windows when the bundle exists and falls back to
+  summary-only rows otherwise
 
 The worker also exposes `PostAnalysisHealthSnapshot`, which is what the health
 surface uses for queue depth, active run ID, and the most recent completion
@@ -169,6 +181,8 @@ task/timeout helpers:
 | `apps/server/vibesensor/use_cases/run/lifecycle_state.py` | In-memory active-run gate and timeout fields. |
 | `apps/server/vibesensor/use_cases/run/sample_flush.py` | Flush decisions, live metric refresh, and sample-row building. |
 | `apps/server/vibesensor/use_cases/run/persistence_writer.py` | History-run creation, append retries, counters, and finalize flow. |
+| `apps/server/vibesensor/use_cases/run/raw_capture_writer.py` | Recorder-side raw chunk queue and raw manifest finalization. |
 | `apps/server/vibesensor/use_cases/run/logger.py` | Public recording start/stop entrypoint. |
 | `apps/server/vibesensor/use_cases/run/post_analysis.py` | Queue, worker-thread, retry, and health behavior. |
 | `apps/server/vibesensor/use_cases/run/post_analysis_executor.py` | Load -> analyze -> store execution path. |
+| `apps/server/vibesensor/use_cases/run/raw_capture_replay.py` | Raw-window replay for post-stop strength/peak rebuilding before diagnostics. |


### PR DESCRIPTION
## what changed
- add per-run raw waveform artifact storage under `raw-runs/<run_id>` with a v13 run-row manifest
- stream UDP `int16` chunks through a recorder-owned raw writer and finalize raw capture on stop/restart
- load optional raw capture during post-stop analysis and rebuild FFT-derived strength/peak fields from raw windows before diagnostics
- add focused persistence/replay tests and update run/analysis/report docs for the raw-backed path

## why
- summary rows alone are not trustworthy enough for offline forensic analysis
- keep the fast summary history/report path lightweight while giving post-stop diagnostics deterministic raw evidence when it exists

## validation
- `pytest -q apps/server/tests/use_cases/run/test_post_analysis_loader.py apps/server/tests/use_cases/run/test_post_analysis_summary.py apps/server/tests/use_cases/run/test_raw_capture_replay.py apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py apps/server/tests/integration/test_contract_analysis_persistence_http.py`
- `pytest -q apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/run/test_post_analysis_worker.py apps/server/tests/use_cases/run/test_post_analysis_executor.py apps/server/tests/use_cases/run/test_pipeline_resilience.py apps/server/tests/infra/runtime/test_udp_transport_lifecycle.py`
- `make test-changed`
- `make lint`
- `make typecheck-backend`
- `make docs-lint`

## risks / tradeoffs / edge cases
- raw replay aligns by persisted sample timestamp and FFT window size; rows without a full raw window still fall back to stored summary metrics
- raw capture grows with run duration, so delete/prune paths now own artifact cleanup too
- fallback stays intact for summary-only runs and for persistence test doubles that do not implement the new raw methods

## follow-ups
- #3066-#3069 build on this raw-backed evidence foundation for report-facing proof and confidence work
