### PR TITLE
Make the PDF more evidential, not just more visual

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_document_projection.py
+++ b/apps/server/tests/adapters/pdf/test_report_document_projection.py
@@ -20,10 +20,14 @@ from test_support.report_helpers import report_sample as _base_sample
 
 from vibesensor.adapters.analysis_summary import summarize_log
 from vibesensor.domain import VibrationOrigin
-from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.shared.boundaries.reporting import (
+    prepare_persisted_report_input,
+    prepare_report_input,
+)
 from vibesensor.shared.boundaries.reporting.document import ReportDocument
 from vibesensor.shared.boundaries.summary_fields.finding import finding_from_payload
 from vibesensor.shared.boundaries.summary_fields.origin import build_origin_explanation
+from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.diagnostics.run_analysis import (
     summarize_origin,
 )
@@ -95,6 +99,103 @@ def test_build_report_document_no_top_causes() -> None:
     assert data.system_cards == []
     assert data.certainty_tier_key == "A"
     assert len(data.next_steps) >= 1
+
+
+def test_build_report_document_surfaces_evidence_snapshot_rows() -> None:
+    primary = make_finding_payload(
+        finding_id="F_PRIMARY",
+        suspected_source="wheel/tire",
+        confidence=0.76,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        weak_spatial_separation=True,
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.2,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.0,
+                "speed_kmh": 68.0,
+                "predicted_hz": 15.3,
+                "matched_hz": 15.4,
+                "location": "Rear Left",
+                "phase": "cruise",
+                "amp": 0.09,
+            },
+        ],
+    )
+    alternative = make_finding_payload(
+        finding_id="F_ALT",
+        suspected_source="driveline",
+        confidence=0.72,
+        strongest_location="Rear Left",
+        strongest_speed_band="60-80 km/h",
+    )
+    prepared = prepare_persisted_report_input(
+        PersistedAnalysis.from_json_object(
+            minimal_summary(
+                run_id="evidence-run",
+                lang="en",
+                metadata={
+                    "run_id": "evidence-run",
+                    "record_type": "metadata",
+                    "schema_version": "v2-jsonl",
+                    "start_time_utc": "2026-03-23T07:31:01Z",
+                    "sensor_model": "ADXL345",
+                    "raw_sample_rate_hz": 800,
+                    "feature_interval_s": 0.5,
+                    "fft_window_size_samples": 256,
+                    "peak_picker_method": "fft",
+                    "incomplete_for_order_analysis": False,
+                },
+                sensor_count_used=2,
+                sensor_locations=["Front Left", "Rear Left"],
+                sensor_locations_connected_throughout=["Front Left", "Rear Left"],
+                findings=[primary, alternative],
+                top_causes=[primary, alternative],
+                analysis_metadata={
+                    "raw_capture_available": True,
+                    "raw_backed_sample_count": 24,
+                    "raw_capture_mode": "raw_backed",
+                },
+            )
+        )
+    )
+
+    data = build_report_document(prepared)
+
+    assert [row.label for row in data.verdict_page.proof_snapshot_rows] == [
+        "Evidence basis",
+        "Support",
+        "Stable frequency",
+    ]
+    assert "Raw-backed replay" in data.verdict_page.proof_snapshot_rows[0].value
+    assert data.verdict_page.proof_snapshot_rows[1].value == "3 supporting windows across 1.5 s"
+    assert data.verdict_page.proof_snapshot_rows[2].value == "15.1-15.4 Hz matched band"
+    assert [row.label for row in data.appendix_c.evidence_snapshot_rows] == [
+        "Evidence basis",
+        "Support",
+        "Stable frequency",
+        "Strongest sensors",
+        "Caveat",
+    ]
+    assert data.appendix_c.evidence_snapshot_rows[3].value == "Front-Left (2), Rear-Left (1)"
+    assert "driveline" in data.appendix_c.evidence_snapshot_rows[4].value.lower()
 
 
 def test_build_report_document_uses_domain_action_render_queries_for_next_steps() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
@@ -8,13 +8,21 @@ from pathlib import Path
 import pytest
 from _paths import SERVER_ROOT
 from test_support.core import extract_pdf_text
-from test_support.report_helpers import RUN_END, write_jsonl
+from test_support.findings import make_finding_payload
+from test_support.report_helpers import (
+    RUN_END,
+    minimal_summary,
+    write_jsonl,
+)
 from test_support.report_helpers import report_run_metadata as _run_metadata
 from test_support.report_helpers import report_sample as _base_sample
 
 from vibesensor.adapters.analysis_summary import summarize_log
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
-from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.shared.boundaries.reporting import (
+    prepare_persisted_report_input,
+    prepare_report_input,
+)
 from vibesensor.shared.boundaries.reporting.document import (
     AppendixAData,
     AppendixCData,
@@ -27,6 +35,7 @@ from vibesensor.shared.boundaries.reporting.document import (
     VerdictPageData,
 )
 from vibesensor.shared.constants.units import KMH_TO_MPS
+from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.use_cases.history.report_document import build_report_document
 
 _I18N_JSON = SERVER_ROOT / "vibesensor" / "data" / "report_i18n.json"
@@ -171,6 +180,87 @@ def test_pdf_additional_observations_heading_for_transient_findings() -> None:
     i18n = json.loads(_I18N_JSON.read_text(encoding="utf-8"))
     assert i18n["ADDITIONAL_OBSERVATIONS"]["en"] in text
     assert "(22%)" not in text
+
+
+def test_pdf_renders_evidence_snapshot_labels_for_raw_backed_report() -> None:
+    primary = make_finding_payload(
+        finding_id="F_PRIMARY",
+        suspected_source="wheel/tire",
+        confidence=0.76,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.2,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.0,
+                "speed_kmh": 68.0,
+                "predicted_hz": 15.3,
+                "matched_hz": 15.4,
+                "location": "Rear Left",
+                "phase": "cruise",
+                "amp": 0.09,
+            },
+        ],
+    )
+    pdf = build_report_pdf(
+        build_report_document(
+            prepare_persisted_report_input(
+                PersistedAnalysis.from_json_object(
+                    minimal_summary(
+                        run_id="evidence-run",
+                        lang="en",
+                        metadata={
+                            "run_id": "evidence-run",
+                            "record_type": "metadata",
+                            "schema_version": "v2-jsonl",
+                            "start_time_utc": "2026-03-23T07:31:01Z",
+                            "sensor_model": "ADXL345",
+                            "raw_sample_rate_hz": 800,
+                            "feature_interval_s": 0.5,
+                            "fft_window_size_samples": 256,
+                            "peak_picker_method": "fft",
+                            "incomplete_for_order_analysis": False,
+                        },
+                        sensor_count_used=2,
+                        sensor_locations=["Front Left", "Rear Left"],
+                        sensor_locations_connected_throughout=["Front Left", "Rear Left"],
+                        findings=[primary],
+                        top_causes=[primary],
+                        analysis_metadata={
+                            "raw_capture_available": True,
+                            "raw_backed_sample_count": 24,
+                            "raw_capture_mode": "raw_backed",
+                        },
+                    )
+                )
+            )
+        )
+    )
+
+    text = extract_pdf_text(pdf)
+
+    assert "Evidence basis" in text
+    assert "Support" in text
+    assert "Stable frequency" in text
+    assert "Strongest sensors" in text
+    assert "Raw-backed replay" in text
 
 
 @pytest.mark.parametrize("lang", ["en", "nl"])

--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from test_support.findings import make_finding_payload
 
 from vibesensor.shared.boundaries.reporting import (
     prepare_persisted_report_input,
@@ -198,3 +199,92 @@ def test_prepare_report_input_tolerates_invalid_count_strings() -> None:
 
     assert prepared.report_facts.run.sample_count == 0
     assert prepared.report_facts.run.sensor_count == 0
+
+
+def test_prepare_persisted_report_input_builds_evidence_facts_from_raw_backed_summary() -> None:
+    primary = make_finding_payload(
+        finding_id="F_PRIMARY",
+        suspected_source="wheel/tire",
+        confidence=0.76,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.2,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.0,
+                "speed_kmh": 68.0,
+                "predicted_hz": 15.3,
+                "matched_hz": 15.4,
+                "location": "Rear Left",
+                "phase": "cruise",
+                "amp": 0.09,
+            },
+        ],
+    )
+    analysis = PersistedAnalysis.from_json_object(
+        {
+            "run_id": "persisted-run",
+            "lang": "en",
+            "metadata": {
+                "run_id": "persisted-run",
+                "record_type": "metadata",
+                "schema_version": "v2-jsonl",
+                "start_time_utc": "2026-03-23T07:31:01Z",
+                "sensor_model": "ADXL345",
+                "raw_sample_rate_hz": 800,
+                "feature_interval_s": 0.5,
+                "fft_window_size_samples": 256,
+                "peak_picker_method": "fft",
+                "incomplete_for_order_analysis": False,
+            },
+            "report_date": "2026-03-23T07:31:01Z",
+            "record_length": "5m",
+            "rows": 120,
+            "duration_s": 300.0,
+            "sensor_count_used": 2,
+            "sensor_locations": ["Front Left", "Rear Left"],
+            "sensor_locations_connected_throughout": ["Front Left", "Rear Left"],
+            "sensor_intensity_by_location": [],
+            "most_likely_origin": {},
+            "run_suitability": [],
+            "test_plan": [],
+            "findings": [primary],
+            "top_causes": [primary],
+            "warnings": [],
+            "analysis_metadata": {
+                "raw_capture_available": True,
+                "raw_backed_sample_count": 24,
+                "raw_capture_mode": "raw_backed",
+            },
+        }
+    )
+
+    prepared = prepare_persisted_report_input(analysis)
+
+    assert prepared.report_facts.evidence.data_basis == "raw_backed"
+    assert prepared.report_facts.evidence.raw_backed_sample_count == 24
+    assert prepared.report_facts.evidence.supporting_window_count == 3
+    assert prepared.report_facts.evidence.supporting_duration_s == pytest.approx(1.5)
+    assert prepared.report_facts.evidence.stable_frequency_min_hz == pytest.approx(15.1)
+    assert prepared.report_facts.evidence.stable_frequency_max_hz == pytest.approx(15.4)
+    assert prepared.report_facts.evidence.supporting_location_counts == (
+        ("Front Left", 2),
+        ("Rear Left", 1),
+    )

--- a/apps/server/vibesensor/adapters/pdf/page1_proof.py
+++ b/apps/server/vibesensor/adapters/pdf/page1_proof.py
@@ -84,6 +84,17 @@ def draw_proof_block(
         )
         - 1.5 * mm
     )
+    for snapshot in verdict.proof_snapshot_rows[:3]:
+        text_y = draw_label_value(
+            c,
+            x=text_x,
+            y=text_y,
+            width=text_w,
+            label=snapshot.label,
+            value=snapshot.value or tr("UNKNOWN"),
+            value_size=FS_BODY,
+            max_lines=3,
+        )
     text_y = draw_label_value(
         c,
         x=text_x,

--- a/apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_c.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_c.py
@@ -254,6 +254,16 @@ def _appendix_c_page(c: Canvas, plan: AppendixCRenderPlan) -> None:
             )
             - 1.2 * mm
         )
+    for snapshot in appendix.evidence_snapshot_rows[:5]:
+        block_y = _draw_section_block(
+            c,
+            block_x,
+            block_y,
+            context_w - 8 * mm,
+            snapshot.label,
+            snapshot.value or _tr(plan.lang, "UNKNOWN"),
+            max_lines=3,
+        )
     block_y = _draw_section_block(
         c,
         block_x,

--- a/apps/server/vibesensor/adapters/pdf/pdf_appendices/layout.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_appendices/layout.py
@@ -73,6 +73,8 @@ def _estimate_appendix_c_context_panel_height(plan: AppendixCRenderPlan, *, widt
             )
             + 1.2 * mm
         )
+    for snapshot in appendix_c.evidence_snapshot_rows[:5]:
+        total += _measure_section_block_height(snapshot.value, w=content_w, max_lines=3)
     total += _measure_section_block_height(
         appendix_c.speed_band_summary or _tr(plan.lang, "UNKNOWN"),
         w=content_w,

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1863,6 +1863,18 @@
     "en": "Spatial separation stayed weak.",
     "nl": "Ruimtelijke scheiding bleef zwak."
   },
+  "REPORT_EVIDENCE_BASIS_LABEL": {
+    "en": "Evidence basis",
+    "nl": "Bewijsbasis"
+  },
+  "REPORT_EVIDENCE_BASIS_RAW": {
+    "en": "Raw-backed replay ({samples} analyzed samples)",
+    "nl": "Raw-ondersteunde replay ({samples} geanalyseerde samples)"
+  },
+  "REPORT_EVIDENCE_BASIS_SUMMARY": {
+    "en": "Summary-only fallback",
+    "nl": "Alleen samenvattingsfallback"
+  },
   "REPORT_EXPORT_REFERENCE": {
     "en": "Export package",
     "nl": "Exportpakket"
@@ -1943,6 +1955,22 @@
     "en": "Sensor matches",
     "nl": "Sensormatches"
   },
+  "REPORT_SUPPORT_WINDOW_SUMMARY_LABEL": {
+    "en": "Support",
+    "nl": "Ondersteuning"
+  },
+  "REPORT_SUPPORT_WINDOW_SUMMARY_FULL": {
+    "en": "{count} supporting windows across {duration} s",
+    "nl": "{count} ondersteunende vensters over {duration} s"
+  },
+  "REPORT_SUPPORT_WINDOW_SUMMARY_COUNT_ONLY": {
+    "en": "{count} supporting windows",
+    "nl": "{count} ondersteunende vensters"
+  },
+  "REPORT_SUPPORT_WINDOW_SUMMARY_NONE": {
+    "en": "No retained supporting windows",
+    "nl": "Geen bewaarde ondersteunende vensters"
+  },
   "REPORT_MEASUREMENT_ID_COLUMN": {
     "en": "Measurement",
     "nl": "Meting"
@@ -1987,6 +2015,22 @@
     "en": "Phase summary",
     "nl": "Fase-overzicht"
   },
+  "REPORT_STABLE_FREQUENCY_LABEL": {
+    "en": "Stable frequency",
+    "nl": "Stabiele frequentie"
+  },
+  "REPORT_STABLE_FREQUENCY_BAND": {
+    "en": "{low}-{high} Hz matched band",
+    "nl": "{low}-{high} Hz gematchte band"
+  },
+  "REPORT_STABLE_FREQUENCY_SINGLE": {
+    "en": "{hz} Hz matched center",
+    "nl": "{hz} Hz gematcht centrum"
+  },
+  "REPORT_STABLE_FREQUENCY_UNKNOWN": {
+    "en": "No retained matched-frequency band",
+    "nl": "Geen bewaarde gematchte frequentieband"
+  },
   "REPORT_PHASE_SUMMARY_NONE": {
     "en": "No dominant phase breakdown available.",
     "nl": "Geen dominante faseverdeling beschikbaar."
@@ -2018,6 +2062,38 @@
   "REPORT_SOURCE_CONFIDENCE_NOTE": {
     "en": "The percentages below rank how strongly each source fits this run. They are source-confidence scores for this report, not repair probabilities.",
     "nl": "De percentages hieronder rangschikken hoe sterk elke bron bij deze run past. Het zijn bron-zekerheidsscores voor dit rapport, geen reparatiekansen."
+  },
+  "REPORT_SUPPORTING_SENSORS_LABEL": {
+    "en": "Strongest sensors",
+    "nl": "Sterkste sensoren"
+  },
+  "REPORT_SUPPORTING_SENSOR_ENTRY": {
+    "en": "{location} ({count})",
+    "nl": "{location} ({count})"
+  },
+  "REPORT_SUPPORTING_SENSORS_NONE": {
+    "en": "No retained supporting sensor split",
+    "nl": "Geen bewaarde verdeling van ondersteunende sensoren"
+  },
+  "REPORT_COUNTEREVIDENCE_LABEL": {
+    "en": "Caveat",
+    "nl": "Kanttekening"
+  },
+  "REPORT_COUNTEREVIDENCE_ALT_SOURCE": {
+    "en": "Close alternative remained: {source}",
+    "nl": "Dichtbij alternatief bleef over: {source}"
+  },
+  "REPORT_COUNTEREVIDENCE_WEAK_SPATIAL": {
+    "en": "Location separation stayed weak",
+    "nl": "Locatiescheiding bleef zwak"
+  },
+  "REPORT_COUNTEREVIDENCE_REFERENCE_GAP": {
+    "en": "Reference coverage was incomplete",
+    "nl": "Referentiedekking was onvolledig"
+  },
+  "REPORT_COUNTEREVIDENCE_NONE": {
+    "en": "No major counterevidence remained",
+    "nl": "Er bleef geen belangrijk tegenbewijs over"
   },
   "REPORT_PROOF_CAVEAT_MIXED": {
     "en": "Localization is mixed because either dominance or coverage was not fully clean.",

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/appendices.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/appendices.py
@@ -129,6 +129,7 @@ class AppendixCData:
 
     evidence_chain_rows: list[EvidenceChainRow] = field(default_factory=list)
     measurement_rows: list[MeasurementRow] = field(default_factory=list)
+    evidence_snapshot_rows: list[ReportLabelValueRow] = field(default_factory=list)
     evidence_summary: str | None = None
     measurement_guide: str | None = None
     context_summary: str | None = None

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/sections.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/sections.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .appendices import ReportLabelValueRow
+
 __all__ = [
     "PeakRow",
     "TimelineGraphData",
@@ -75,5 +77,6 @@ class VerdictPageData:
     proof_summary: str | None = None
     proof_caveat: str | None = None
     proof_panel_title: str | None = None
+    proof_snapshot_rows: tuple[ReportLabelValueRow, ...] = ()
     footer_routes: tuple[str, ...] = ()
     timeline_graph: TimelineGraphData | None = None

--- a/apps/server/vibesensor/shared/boundaries/reporting/evidence_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/evidence_facts.py
@@ -1,0 +1,132 @@
+"""Evidence-centric prepared report facts for PDF/report mapping."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from vibesensor.shared.boundaries.codecs.scalars import coerce_count, text_or_none
+from vibesensor.shared.boundaries.reporting.decision_facts import ReportDecisionFacts
+from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
+from vibesensor.shared.boundaries.reporting.summary import NormalizedReportSummary
+
+__all__ = [
+    "ReportEvidenceFacts",
+    "build_report_evidence_facts",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ReportEvidenceFacts:
+    """Prepared evidence facts shared by page-1 proof and Appendix C."""
+
+    data_basis: str
+    raw_backed_sample_count: int
+    supporting_window_count: int | None
+    supporting_duration_s: float | None
+    stable_frequency_min_hz: float | None
+    stable_frequency_max_hz: float | None
+    supporting_location_counts: tuple[tuple[str, int], ...]
+    has_weak_spatial_separation: bool
+    alternative_source: str | None
+    has_reference_gap: bool
+
+
+def build_report_evidence_facts(
+    payload: Mapping[str, object],
+    *,
+    summary: NormalizedReportSummary,
+    primary_candidate: PrimaryReportFacts,
+    decision_facts: ReportDecisionFacts,
+) -> ReportEvidenceFacts:
+    """Build prepared evidence facts from persisted analysis plus domain finding data."""
+
+    metadata = payload.get("analysis_metadata")
+    analysis_metadata = metadata if isinstance(metadata, Mapping) else {}
+    raw_backed_sample_count = coerce_count(analysis_metadata.get("raw_backed_sample_count"))
+    data_basis = _resolve_data_basis(analysis_metadata, raw_backed_sample_count)
+    supporting_window_count = primary_candidate.matched_evidence_window_count
+    duration_s = _supporting_duration_s(
+        supporting_window_count=supporting_window_count,
+        feature_interval_s=(
+            summary.metadata.feature_interval_s if summary.metadata is not None else None
+        ),
+    )
+    frequency_min_hz, frequency_max_hz = _stable_frequency_band(primary_candidate)
+    return ReportEvidenceFacts(
+        data_basis=data_basis,
+        raw_backed_sample_count=raw_backed_sample_count,
+        supporting_window_count=supporting_window_count,
+        supporting_duration_s=duration_s,
+        stable_frequency_min_hz=frequency_min_hz,
+        stable_frequency_max_hz=frequency_max_hz,
+        supporting_location_counts=_supporting_location_counts(primary_candidate),
+        has_weak_spatial_separation=primary_candidate.weak_spatial,
+        alternative_source=(
+            decision_facts.alternative_source if decision_facts.alternative_source_visible else None
+        ),
+        has_reference_gap=primary_candidate.has_reference_gaps,
+    )
+
+
+def _resolve_data_basis(
+    analysis_metadata: Mapping[str, object],
+    raw_backed_sample_count: int,
+) -> str:
+    raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
+    if raw_capture_mode in {"raw_backed", "summary_only"}:
+        return raw_capture_mode
+    return "raw_backed" if raw_backed_sample_count > 0 else "summary_only"
+
+
+def _supporting_duration_s(
+    *,
+    supporting_window_count: int | None,
+    feature_interval_s: float | None,
+) -> float | None:
+    if supporting_window_count is None or supporting_window_count <= 0:
+        return None
+    if feature_interval_s is None or feature_interval_s <= 0:
+        return None
+    return supporting_window_count * feature_interval_s
+
+
+def _stable_frequency_band(
+    primary_candidate: PrimaryReportFacts,
+) -> tuple[float | None, float | None]:
+    finding = primary_candidate.domain_primary
+    if finding is None:
+        return (None, None)
+    matched_hz_values = [
+        observation.matched_hz if observation.matched_hz > 0 else observation.predicted_hz
+        for observation in finding.matched_points
+        if observation.predicted_hz > 0
+    ]
+    if matched_hz_values:
+        return (min(matched_hz_values), max(matched_hz_values))
+    if finding.frequency_hz is not None and finding.frequency_hz > 0:
+        return (finding.frequency_hz, finding.frequency_hz)
+    return (None, None)
+
+
+def _supporting_location_counts(
+    primary_candidate: PrimaryReportFacts,
+) -> tuple[tuple[str, int], ...]:
+    finding = primary_candidate.domain_primary
+    if finding is None:
+        return ()
+    counts: Counter[str] = Counter()
+    order: dict[str, int] = {}
+    for observation in finding.matched_points:
+        location = str(observation.location or "").strip()
+        if not location:
+            continue
+        counts[location] += 1
+        order.setdefault(location, len(order))
+    if counts:
+        ranked = sorted(counts.items(), key=lambda item: (-item[1], order[item[0]], item[0]))
+        return tuple(ranked[:3])
+    if finding.strongest_location:
+        return ((finding.strongest_location, 1),)
+    return ()

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
         VibrationOrigin,
     )
     from vibesensor.shared.boundaries.reporting.decision_facts import ReportDecisionFacts
+    from vibesensor.shared.boundaries.reporting.evidence_facts import ReportEvidenceFacts
     from vibesensor.shared.boundaries.reporting.findings import PreparedReportFindings
     from vibesensor.shared.boundaries.reporting.sensor_facts import ReportSensorFacts
     from vibesensor.shared.boundaries.reporting.summary import (
@@ -26,6 +27,7 @@ from vibesensor.shared.boundaries.reporting.decision_facts import (
     LocationConfidenceKey,
     build_report_decision_facts,
 )
+from vibesensor.shared.boundaries.reporting.evidence_facts import build_report_evidence_facts
 from vibesensor.shared.boundaries.reporting.findings import (
     PreparedReportFindings,
     prepare_report_findings,
@@ -77,6 +79,7 @@ class PreparedReportFacts:
     run: ReportRunFacts
     sensor: ReportSensorFacts
     decision: ReportDecisionFacts
+    evidence: ReportEvidenceFacts
     findings: PreparedReportFindings
 
 
@@ -103,6 +106,12 @@ def prepare_report_facts(
         origin_location=origin_location,
         sensor_facts=sensor_facts,
         warnings=warnings,
+    )
+    evidence_facts = build_report_evidence_facts(
+        payload,
+        summary=summary,
+        primary_candidate=decision_facts.primary_candidate,
+        decision_facts=decision_facts,
     )
     return PreparedReportFacts(
         run=ReportRunFacts(
@@ -136,6 +145,7 @@ def prepare_report_facts(
         ),
         sensor=sensor_facts,
         decision=decision_facts,
+        evidence=evidence_facts,
         findings=prepare_report_findings(test_run),
     )
 

--- a/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/appendix_c.py
@@ -13,6 +13,7 @@ from vibesensor.shared.boundaries.reporting.document import (
 )
 
 from ._candidate_resolver import PrimaryCandidateContext
+from .evidence_snapshot import build_evidence_snapshot_rows
 from .measurements import _evidence_chain_rows
 from .narrative_summaries import (
     _context_summary_text,
@@ -46,6 +47,9 @@ def build_appendix_c_data(
     return AppendixCData(
         evidence_chain_rows=evidence_rows,
         measurement_rows=measurements,
+        evidence_snapshot_rows=list(
+            build_evidence_snapshot_rows(report_facts, compact=False, tr=tr)
+        ),
         evidence_summary=_evidence_summary_text(aggregate, primary, report_facts, tr=tr),
         measurement_guide=tr("REPORT_MEASUREMENT_GUIDE"),
         context_summary=_context_summary_text(primary, report_facts, tr=tr),

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -1,0 +1,120 @@
+"""Evidence snapshot row builders shared by page-1 proof and Appendix C."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from vibesensor.report_i18n import human_source
+from vibesensor.shared.boundaries.reporting import PreparedReportFacts
+from vibesensor.shared.boundaries.reporting.document import ReportLabelValueRow
+from vibesensor.shared.report_presentation import display_location
+
+__all__ = ["build_evidence_snapshot_rows"]
+
+
+def build_evidence_snapshot_rows(
+    report_facts: PreparedReportFacts,
+    *,
+    compact: bool,
+    tr: Callable[..., str],
+) -> tuple[ReportLabelValueRow, ...]:
+    """Build localized evidence snapshot rows for report proof surfaces."""
+
+    rows: list[ReportLabelValueRow] = [
+        ReportLabelValueRow(
+            label=tr("REPORT_EVIDENCE_BASIS_LABEL"),
+            value=_data_basis_text(report_facts, tr=tr),
+        ),
+        ReportLabelValueRow(
+            label=tr("REPORT_SUPPORT_WINDOW_SUMMARY_LABEL"),
+            value=_support_window_text(report_facts, tr=tr),
+        ),
+        ReportLabelValueRow(
+            label=tr("REPORT_STABLE_FREQUENCY_LABEL"),
+            value=_stable_frequency_text(report_facts, tr=tr),
+        ),
+    ]
+    if not compact:
+        rows.extend(
+            [
+                ReportLabelValueRow(
+                    label=tr("REPORT_SUPPORTING_SENSORS_LABEL"),
+                    value=_supporting_sensors_text(report_facts, tr=tr),
+                ),
+                ReportLabelValueRow(
+                    label=tr("REPORT_COUNTEREVIDENCE_LABEL"),
+                    value=_counterevidence_text(report_facts, tr=tr),
+                ),
+            ]
+        )
+    return tuple(row for row in rows if row.value)
+
+
+def _data_basis_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+    evidence = report_facts.evidence
+    if evidence.data_basis == "raw_backed":
+        return tr(
+            "REPORT_EVIDENCE_BASIS_RAW",
+            samples=str(max(0, evidence.raw_backed_sample_count)),
+        )
+    return tr("REPORT_EVIDENCE_BASIS_SUMMARY")
+
+
+def _support_window_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+    evidence = report_facts.evidence
+    count = evidence.supporting_window_count
+    duration_s = evidence.supporting_duration_s
+    if count is None or count <= 0:
+        return tr("REPORT_SUPPORT_WINDOW_SUMMARY_NONE")
+    if duration_s is not None and duration_s > 0:
+        return tr(
+            "REPORT_SUPPORT_WINDOW_SUMMARY_FULL",
+            count=str(count),
+            duration=f"{duration_s:.1f}",
+        )
+    return tr("REPORT_SUPPORT_WINDOW_SUMMARY_COUNT_ONLY", count=str(count))
+
+
+def _stable_frequency_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+    evidence = report_facts.evidence
+    low = evidence.stable_frequency_min_hz
+    high = evidence.stable_frequency_max_hz
+    if low is None or high is None:
+        return tr("REPORT_STABLE_FREQUENCY_UNKNOWN")
+    if abs(high - low) < 0.05:
+        return tr("REPORT_STABLE_FREQUENCY_SINGLE", hz=f"{low:.1f}")
+    return tr("REPORT_STABLE_FREQUENCY_BAND", low=f"{low:.1f}", high=f"{high:.1f}")
+
+
+def _supporting_sensors_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+    evidence = report_facts.evidence
+    if not evidence.supporting_location_counts:
+        return tr("REPORT_SUPPORTING_SENSORS_NONE")
+    parts = [
+        tr(
+            "REPORT_SUPPORTING_SENSOR_ENTRY",
+            location=display_location(location, tr=tr),
+            count=str(count),
+        )
+        for location, count in evidence.supporting_location_counts
+    ]
+    return ", ".join(parts)
+
+
+def _counterevidence_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+    evidence = report_facts.evidence
+    notes: list[str] = []
+    if evidence.alternative_source is not None:
+        notes.append(
+            tr(
+                "REPORT_COUNTEREVIDENCE_ALT_SOURCE",
+                source=human_source(evidence.alternative_source, tr=tr),
+            )
+        )
+    if evidence.has_weak_spatial_separation:
+        notes.append(tr("REPORT_COUNTEREVIDENCE_WEAK_SPATIAL"))
+    if evidence.has_reference_gap:
+        notes.append(tr("REPORT_COUNTEREVIDENCE_REFERENCE_GAP"))
+    if not notes:
+        return tr("REPORT_COUNTEREVIDENCE_NONE")
+    return "; ".join(notes)

--- a/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
@@ -24,6 +24,7 @@ from vibesensor.shared.report_presentation import (
 from vibesensor.shared.run_context_warning import RunContextWarning
 
 from ._candidate_resolver import PrimaryCandidateContext
+from .evidence_snapshot import build_evidence_snapshot_rows
 from .narrative_summaries import _proof_summary_text
 from .section_context import VerdictPageContext
 from .timeline_graph import build_timeline_graph_data
@@ -160,6 +161,11 @@ def build_verdict_page(*, context: ReportDocumentContext) -> VerdictPageData:
     return replace(
         verdict_page,
         proof_summary=proof_summary,
+        proof_snapshot_rows=build_evidence_snapshot_rows(
+            context.report_facts,
+            compact=True,
+            tr=context.tr,
+        ),
         timeline_graph=build_timeline_graph_data(
             context.report_facts,
             duration_s=context.run_facts.duration_s,

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -76,6 +76,7 @@ Canonical report preparation now lives in
 normalization, and grouped semantic fact assembly:
 
 - `facts.py` builds `PreparedReportFacts(run=..., sensor=..., decision=..., findings=...)`
+- `evidence_facts.py` builds explicit proof facts (data basis, supporting-window count/duration, stable frequency band, strongest supporting sensors, and caveats) from persisted analysis + reconstructed domain findings
 - `findings.py` owns report-facing finding/top-cause presentation shaping
 - `sensor_facts.py` owns sensor/coverage shaping
 - `decision_facts.py` owns primary-candidate, warning, and action-decision shaping
@@ -102,6 +103,7 @@ needs:
 - **Next steps**: test plan or capture guidance (tier-dependent)
 - **Data trust items**: suitability checks
 - **Pattern evidence**: matched systems, certainty label, interpretation
+- **Evidence snapshots**: concise page-1 proof rows plus Appendix-C proof rows built from prepared evidence facts, not renderer-time DSP
 - **Peak rows**: top diagnostic peaks with classification
 - **Rendering context**: pre-computed findings (as ``FindingPresentation``
   snapshots), top causes, sensor intensity, location hotspot rows


### PR DESCRIPTION
## what
- add prepared report evidence facts from persisted analysis + reconstructed findings
- show compact proof snapshot rows on page 1 and denser proof rows in Appendix C
- expose data basis, support window count/duration, stable frequency band, strongest sensors, and caveat rows
- cover the path with report-preparation, report-document, and rendered-PDF tests

## why
- report needed explicit proof chain, not just conclusion + charts
- keep renderer thin; all proof data is prepared before PDF rendering
- keep summary-only runs honest with explicit fallback wording

## validation
- `pytest -q apps/server/tests/use_cases/history/test_report_preparation_contract.py apps/server/tests/adapters/pdf/test_report_document_projection.py apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py`
- `make test-changed`
- `make lint`
- `make typecheck-backend`

## risks / edges
- page 1 got denser, so proof snapshot stays capped to three compact rows and Appendix C carries the fuller set
- counterevidence rows only reflect persisted signals we already have today; deeper confidence modeling stays for follow-up issues

Closes #3066
