### PR TITLE
Improve PDF hotspot and location proof using diagnosis-supporting windows

### DIFF
--- a/apps/server/tests/adapters/pdf/test_page1_header.py
+++ b/apps/server/tests/adapters/pdf/test_page1_header.py
@@ -50,6 +50,8 @@ def test_draw_header_strip_truncates_long_car_name_to_single_line(
         sensor_locations=(),
         sensor_intensity_by_location=(),
         location_hotspot_rows=(),
+        proof_sensor_intensity_by_location=(),
+        proof_location_hotspot_rows=(),
         verdict_page=VerdictPageData(speed_window_label="60-90 km/h"),
         next_steps=(),
         findings=(),

--- a/apps/server/tests/adapters/pdf/test_report_document_projection.py
+++ b/apps/server/tests/adapters/pdf/test_report_document_projection.py
@@ -285,6 +285,87 @@ def test_build_report_document_focuses_appendix_c_on_primary_proof_windows() -> 
     assert data.appendix_c.proof_window_rows[2].phase == "Decel"
 
 
+def test_build_report_document_uses_supporting_window_location_proof_in_appendix_b() -> None:
+    primary = make_finding_payload(
+        finding_id="F_LOCATION_PROOF",
+        suspected_source="wheel/tire",
+        confidence=0.81,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.2,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.0,
+                "speed_kmh": 68.0,
+                "predicted_hz": 15.4,
+                "matched_hz": 15.3,
+                "location": "Rear Left",
+                "phase": "cruise",
+                "amp": 0.03,
+            },
+        ],
+    )
+    prepared = prepare_persisted_report_input(
+        PersistedAnalysis.from_json_object(
+            minimal_summary(
+                run_id="appendix-b-location-proof-run",
+                lang="en",
+                metadata={
+                    "run_id": "appendix-b-location-proof-run",
+                    "record_type": "metadata",
+                    "schema_version": "v2-jsonl",
+                    "start_time_utc": "2026-03-23T07:31:01Z",
+                    "sensor_model": "ADXL345",
+                    "raw_sample_rate_hz": 800,
+                    "feature_interval_s": 0.5,
+                    "fft_window_size_samples": 256,
+                    "peak_picker_method": "fft",
+                    "incomplete_for_order_analysis": False,
+                },
+                sensor_count_used=2,
+                sensor_locations=["Front Left", "Rear Left"],
+                sensor_locations_connected_throughout=["Front Left", "Rear Left"],
+                sensor_intensity_by_location=[
+                    {"location": "Front Left", "p95_intensity_db": 11.0, "peak_intensity_db": 16.0},
+                    {"location": "Rear Left", "p95_intensity_db": 24.0, "peak_intensity_db": 30.0},
+                ],
+                findings=[primary],
+                top_causes=[primary],
+                analysis_metadata={
+                    "raw_capture_available": True,
+                    "raw_backed_sample_count": 24,
+                    "raw_capture_mode": "raw_backed",
+                },
+            )
+        )
+    )
+
+    data = build_report_document(prepared)
+
+    assert data.location_hotspot_rows[0].location == "Rear Left"
+    assert data.proof_location_hotspot_rows[0].location == "Front Left"
+    assert data.appendix_b.dominant_corner == "Front-Left"
+    assert data.appendix_b.runner_up_corner == "Rear-Left"
+    assert "raw-backed replay" in (data.appendix_b.proof_basis_note or "").lower()
+
+
 def test_build_report_document_uses_domain_action_render_queries_for_next_steps() -> None:
     summary = minimal_summary(
         findings=[

--- a/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
@@ -354,6 +354,98 @@ def test_pdf_renders_appendix_c_supporting_windows_for_primary_diagnosis() -> No
     assert "Decel" in text
 
 
+def test_pdf_renders_location_proof_basis_from_supporting_windows() -> None:
+    primary = make_finding_payload(
+        finding_id="F_LOCATION_PROOF",
+        suspected_source="wheel/tire",
+        confidence=0.81,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.2,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.0,
+                "speed_kmh": 68.0,
+                "predicted_hz": 15.4,
+                "matched_hz": 15.3,
+                "location": "Rear Left",
+                "phase": "cruise",
+                "amp": 0.03,
+            },
+        ],
+    )
+    pdf = build_report_pdf(
+        build_report_document(
+            prepare_persisted_report_input(
+                PersistedAnalysis.from_json_object(
+                    minimal_summary(
+                        run_id="appendix-b-location-proof-run",
+                        lang="en",
+                        metadata={
+                            "run_id": "appendix-b-location-proof-run",
+                            "record_type": "metadata",
+                            "schema_version": "v2-jsonl",
+                            "start_time_utc": "2026-03-23T07:31:01Z",
+                            "sensor_model": "ADXL345",
+                            "raw_sample_rate_hz": 800,
+                            "feature_interval_s": 0.5,
+                            "fft_window_size_samples": 256,
+                            "peak_picker_method": "fft",
+                            "incomplete_for_order_analysis": False,
+                        },
+                        sensor_count_used=2,
+                        sensor_locations=["Front Left", "Rear Left"],
+                        sensor_locations_connected_throughout=["Front Left", "Rear Left"],
+                        sensor_intensity_by_location=[
+                            {
+                                "location": "Front Left",
+                                "p95_intensity_db": 11.0,
+                                "peak_intensity_db": 16.0,
+                            },
+                            {
+                                "location": "Rear Left",
+                                "p95_intensity_db": 24.0,
+                                "peak_intensity_db": 30.0,
+                            },
+                        ],
+                        findings=[primary],
+                        top_causes=[primary],
+                        analysis_metadata={
+                            "raw_capture_available": True,
+                            "raw_backed_sample_count": 24,
+                            "raw_capture_mode": "raw_backed",
+                        },
+                    )
+                )
+            )
+        )
+    )
+
+    text = extract_pdf_text(pdf)
+
+    assert "Dominant corner" in text
+    assert "Front-Left" in text
+    assert "Location proof uses retained diagnosis-supporting windows rebuilt" in text
+    assert "from raw-backed replay." in text
+
+
 @pytest.mark.parametrize("lang", ["en", "nl"])
 def test_pdf_workflow_appendix_a_headings_render(lang: str) -> None:
     i18n = json.loads(_I18N_JSON.read_text(encoding="utf-8"))

--- a/apps/server/tests/use_cases/history/test_report_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_facts.py
@@ -131,6 +131,70 @@ def test_prepare_report_facts_filters_to_active_sensor_locations() -> None:
     assert facts.run.firmware_version == "1.2.3"
 
 
+def test_prepare_report_facts_prefers_supporting_window_location_proof() -> None:
+    primary = make_finding_payload(
+        finding_id="F_LOCATION_PROOF",
+        suspected_source="wheel/tire",
+        confidence=0.81,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.2,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.0,
+                "speed_kmh": 68.0,
+                "predicted_hz": 15.4,
+                "matched_hz": 15.3,
+                "location": "Rear Left",
+                "phase": "cruise",
+                "amp": 0.03,
+            },
+        ],
+    )
+    summary = minimal_summary(
+        run_id="supporting-window-location-proof",
+        lang="en",
+        sensor_count_used=2,
+        sensor_locations=["Front Left", "Rear Left"],
+        sensor_locations_connected_throughout=["Front Left", "Rear Left"],
+        sensor_intensity_by_location=[
+            {"location": "Front Left", "p95_intensity_db": 11.0, "peak_intensity_db": 16.0},
+            {"location": "Rear Left", "p95_intensity_db": 24.0, "peak_intensity_db": 30.0},
+        ],
+        findings=[primary],
+        top_causes=[primary],
+        analysis_metadata={
+            "raw_capture_available": True,
+            "raw_backed_sample_count": 24,
+            "raw_capture_mode": "raw_backed",
+        },
+    )
+
+    facts = _prepare_facts(summary)
+
+    assert facts.sensor.location_hotspot_rows[0].location == "Rear Left"
+    assert facts.sensor.proof_basis == "supporting_windows_raw_backed"
+    assert [row.location for row in facts.sensor.proof_intensity] == ["Front Left", "Rear Left"]
+    assert facts.sensor.proof_location_hotspot_rows[0].location == "Front Left"
+
+
 def test_prepare_report_facts_keeps_canonical_warning_models() -> None:
     summary = _summary()
     facts = _prepare_facts(

--- a/apps/server/vibesensor/adapters/pdf/page1_proof.py
+++ b/apps/server/vibesensor/adapters/pdf/page1_proof.py
@@ -55,9 +55,9 @@ def draw_proof_block(
         plan.top_causes or plan.findings,
         {
             "sensor_locations": plan.sensor_locations,
-            "sensor_intensity_by_location": plan.sensor_intensity_by_location,
+            "sensor_intensity_by_location": plan.proof_sensor_intensity_by_location,
         },
-        plan.location_hotspot_rows,
+        plan.proof_location_hotspot_rows,
         content_width=w - 8 * mm,
         tr=tr,
         diagram_width=left_w,

--- a/apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_b.py
+++ b/apps/server/vibesensor/adapters/pdf/pdf_appendices/appendix_b.py
@@ -64,9 +64,9 @@ def _appendix_b_page(c: Canvas, plan: AppendixBRenderPlan) -> None:
         plan.top_causes or plan.findings,
         {
             "sensor_locations": plan.sensor_locations,
-            "sensor_intensity_by_location": plan.sensor_intensity_by_location,
+            "sensor_intensity_by_location": plan.proof_sensor_intensity_by_location,
         },
-        plan.location_hotspot_rows,
+        plan.proof_location_hotspot_rows,
         content_width=left_w - 8 * mm,
         tr=lambda key, **kw: _tr(plan.lang, key, **kw),
         diagram_width=left_w - 12 * mm,
@@ -121,6 +121,21 @@ def _appendix_b_page(c: Canvas, plan: AppendixBRenderPlan) -> None:
                 color=SUB_CLR,
                 leading=FS_SMALL + 1.0,
                 max_lines=4,
+            )
+            - 0.8 * mm
+        )
+    if appendix.proof_basis_note:
+        text_y = (
+            _draw_text(
+                c,
+                text_x,
+                text_y,
+                right_w - 8 * mm,
+                appendix.proof_basis_note,
+                size=FS_SMALL,
+                color=SUB_CLR,
+                leading=FS_SMALL + 1.0,
+                max_lines=3,
             )
             - 0.8 * mm
         )
@@ -234,6 +249,7 @@ def _has_appendix_b_content(appendix: AppendixBData) -> bool:
             appendix.dominant_corner,
             appendix.runner_up_corner,
             appendix.dominance_ratio_text,
+            appendix.proof_basis_note,
             appendix.location_confidence,
             appendix.coverage_label,
             appendix.coverage_notes,

--- a/apps/server/vibesensor/adapters/pdf/report_types.py
+++ b/apps/server/vibesensor/adapters/pdf/report_types.py
@@ -44,6 +44,8 @@ class Page1RenderPlan:
     sensor_locations: tuple[str, ...]
     sensor_intensity_by_location: tuple[LocationIntensitySummary, ...]
     location_hotspot_rows: tuple[LocationHotspotRow, ...]
+    proof_sensor_intensity_by_location: tuple[LocationIntensitySummary, ...]
+    proof_location_hotspot_rows: tuple[LocationHotspotRow, ...]
     verdict_page: VerdictPageData
     next_steps: tuple[NextStep, ...]
     findings: tuple[FindingPresentation, ...]
@@ -73,6 +75,8 @@ class AppendixBRenderPlan:
     sensor_locations: tuple[str, ...]
     sensor_intensity_by_location: tuple[LocationIntensitySummary, ...]
     location_hotspot_rows: tuple[LocationHotspotRow, ...]
+    proof_sensor_intensity_by_location: tuple[LocationIntensitySummary, ...]
+    proof_location_hotspot_rows: tuple[LocationHotspotRow, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,6 +105,16 @@ class ReportPdfRenderPlan:
 def build_page1_render_plan(data: ReportDocument) -> Page1RenderPlan:
     """Project the document boundary into the page-1-only render model."""
 
+    proof_sensor_intensity = (
+        tuple(data.proof_sensor_intensity_by_location)
+        if data.proof_sensor_intensity_by_location
+        else tuple(data.sensor_intensity_by_location)
+    )
+    proof_location_hotspot_rows = (
+        tuple(data.proof_location_hotspot_rows)
+        if data.proof_location_hotspot_rows
+        else tuple(data.location_hotspot_rows)
+    )
     return Page1RenderPlan(
         title=data.title,
         lang=data.lang,
@@ -112,6 +126,8 @@ def build_page1_render_plan(data: ReportDocument) -> Page1RenderPlan:
         sensor_locations=tuple(data.sensor_locations),
         sensor_intensity_by_location=tuple(data.sensor_intensity_by_location),
         location_hotspot_rows=tuple(data.location_hotspot_rows),
+        proof_sensor_intensity_by_location=proof_sensor_intensity,
+        proof_location_hotspot_rows=proof_location_hotspot_rows,
         verdict_page=data.verdict_page,
         next_steps=tuple(data.next_steps),
         findings=tuple(data.findings),
@@ -122,6 +138,16 @@ def build_page1_render_plan(data: ReportDocument) -> Page1RenderPlan:
 def build_appendix_b_render_plan(data: ReportDocument) -> AppendixBRenderPlan:
     """Project the document boundary into the spatial-proof appendix model."""
 
+    proof_sensor_intensity = (
+        tuple(data.proof_sensor_intensity_by_location)
+        if data.proof_sensor_intensity_by_location
+        else tuple(data.sensor_intensity_by_location)
+    )
+    proof_location_hotspot_rows = (
+        tuple(data.proof_location_hotspot_rows)
+        if data.proof_location_hotspot_rows
+        else tuple(data.location_hotspot_rows)
+    )
     return AppendixBRenderPlan(
         lang=data.lang,
         appendix=data.appendix_b,
@@ -130,6 +156,8 @@ def build_appendix_b_render_plan(data: ReportDocument) -> AppendixBRenderPlan:
         sensor_locations=tuple(data.sensor_locations),
         sensor_intensity_by_location=tuple(data.sensor_intensity_by_location),
         location_hotspot_rows=tuple(data.location_hotspot_rows),
+        proof_sensor_intensity_by_location=proof_sensor_intensity,
+        proof_location_hotspot_rows=proof_location_hotspot_rows,
     )
 
 

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1815,6 +1815,18 @@
     "en": "Computed from matched-window evidence; compare separately from the p95 dB snapshot below.",
     "nl": "Berekend uit matched-window bewijs; vergelijk dit los van de p95 dB-snapshot hieronder."
   },
+  "REPORT_LOCATION_PROOF_BASIS_SUPPORTING_WINDOWS_RAW": {
+    "en": "Location proof uses retained diagnosis-supporting windows rebuilt from raw-backed replay.",
+    "nl": "Het locatiebewijs gebruikt bewaarde diagnose-ondersteunende vensters die opnieuw zijn opgebouwd uit raw-backed replay."
+  },
+  "REPORT_LOCATION_PROOF_BASIS_SUPPORTING_WINDOWS_SUMMARY": {
+    "en": "Location proof uses retained diagnosis-supporting windows from persisted summary evidence.",
+    "nl": "Het locatiebewijs gebruikt bewaarde diagnose-ondersteunende vensters uit persistente samenvattingsbewijzen."
+  },
+  "REPORT_LOCATION_PROOF_BASIS_WHOLE_RUN": {
+    "en": "No retained diagnosis-supporting windows were available, so location proof falls back to whole-run summary intensity.",
+    "nl": "Er waren geen bewaarde diagnose-ondersteunende vensters beschikbaar, dus het locatiebewijs valt terug op de samenvattingsintensiteit van de hele run."
+  },
   "REPORT_DOMINANCE_RATIO_UNKNOWN": {
     "en": "Not enough location-separation data",
     "nl": "Onvoldoende locatie-scheidingsdata"

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/appendices.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/appendices.py
@@ -129,6 +129,7 @@ class AppendixBData:
     dominant_corner: str | None = None
     runner_up_corner: str | None = None
     dominance_ratio_text: str | None = None
+    proof_basis_note: str | None = None
     location_confidence: str | None = None
     coverage_label: str | None = None
     coverage_notes: list[str] = field(default_factory=list)

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/document.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/document.py
@@ -74,6 +74,8 @@ class ReportDocument:
     top_causes: list[FindingPresentation] = field(default_factory=list)
     sensor_intensity_by_location: list[LocationIntensitySummary] = field(default_factory=list)
     location_hotspot_rows: list[LocationHotspotRow] = field(default_factory=list)
+    proof_sensor_intensity_by_location: list[LocationIntensitySummary] = field(default_factory=list)
+    proof_location_hotspot_rows: list[LocationHotspotRow] = field(default_factory=list)
     verdict_page: VerdictPageData = field(default_factory=VerdictPageData)
     appendix_a: AppendixAData = field(default_factory=AppendixAData)
     appendix_b: AppendixBData = field(default_factory=AppendixBData)

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -36,7 +36,10 @@ from vibesensor.shared.boundaries.reporting.projection import (
     normalize_origin_location,
     resolve_report_origin,
 )
-from vibesensor.shared.boundaries.reporting.sensor_facts import build_report_sensor_facts
+from vibesensor.shared.boundaries.reporting.sensor_facts import (
+    build_report_sensor_facts,
+    enrich_location_proof_sensor_facts,
+)
 
 __all__ = [
     "ActionStatusKey",
@@ -112,6 +115,11 @@ def prepare_report_facts(
         summary=summary,
         primary_candidate=decision_facts.primary_candidate,
         decision_facts=decision_facts,
+    )
+    sensor_facts = enrich_location_proof_sensor_facts(
+        sensor_facts,
+        primary_candidate=decision_facts.primary_candidate,
+        evidence_data_basis=evidence_facts.data_basis,
     )
     return PreparedReportFacts(
         run=ReportRunFacts(

--- a/apps/server/vibesensor/shared/boundaries/reporting/sensor_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/sensor_facts.py
@@ -5,14 +5,21 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
+from math import isfinite
 from statistics import mean as _mean
+from typing import TYPE_CHECKING
 
 from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary, TestRun
+from vibesensor.vibration_strength import compute_db, percentile
+
+if TYPE_CHECKING:
+    from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
 
 __all__ = [
     "ReportCoverageSummary",
     "ReportSensorFacts",
     "build_report_sensor_facts",
+    "enrich_location_proof_sensor_facts",
     "primary_location_has_coverage_gap",
     "sensor_fallback_strength_db",
 ]
@@ -36,6 +43,9 @@ class ReportSensorFacts:
     active_intensity: tuple[LocationIntensitySummary, ...]
     location_hotspot_rows: tuple[LocationHotspotRow, ...]
     coverage: ReportCoverageSummary
+    proof_intensity: tuple[LocationIntensitySummary, ...]
+    proof_location_hotspot_rows: tuple[LocationHotspotRow, ...]
+    proof_basis: str
 
 
 def build_report_sensor_facts(
@@ -59,6 +69,36 @@ def build_report_sensor_facts(
             sensor_locations_active=sensor_locations_active,
             sensor_intensity=active_intensity,
         ),
+        proof_intensity=active_intensity,
+        proof_location_hotspot_rows=tuple(_compute_location_hotspot_rows(active_intensity)),
+        proof_basis="whole_run_summary",
+    )
+
+
+def enrich_location_proof_sensor_facts(
+    sensor_facts: ReportSensorFacts,
+    *,
+    primary_candidate: PrimaryReportFacts,
+    evidence_data_basis: str,
+) -> ReportSensorFacts:
+    """Return sensor facts with diagnosis-supporting location proof when available."""
+
+    proof_intensity = tuple(_supporting_window_location_intensity(primary_candidate))
+    if not proof_intensity:
+        return sensor_facts
+    proof_basis = (
+        "supporting_windows_raw_backed"
+        if evidence_data_basis == "raw_backed"
+        else "supporting_windows_summary_only"
+    )
+    return ReportSensorFacts(
+        active_locations=sensor_facts.active_locations,
+        active_intensity=sensor_facts.active_intensity,
+        location_hotspot_rows=sensor_facts.location_hotspot_rows,
+        coverage=sensor_facts.coverage,
+        proof_intensity=proof_intensity,
+        proof_location_hotspot_rows=tuple(_compute_location_hotspot_rows(proof_intensity)),
+        proof_basis=proof_basis,
     )
 
 
@@ -133,6 +173,51 @@ def _filter_active_sensor_intensity(
         if active_locations and row.location not in active_locations:
             continue
         rows.append(row)
+    return rows
+
+
+def _supporting_window_location_intensity(
+    primary_candidate: PrimaryReportFacts,
+) -> list[LocationIntensitySummary]:
+    finding = primary_candidate.domain_primary
+    if finding is None or not finding.matched_points:
+        return []
+    amp_by_location: dict[str, list[float]] = defaultdict(list)
+    all_amps: list[float] = []
+    for point in finding.matched_points:
+        amp = float(point.amp)
+        if not isfinite(amp) or amp <= 0.0:
+            continue
+        location = str(point.location or "").strip()
+        if not location:
+            continue
+        amp_by_location[location].append(amp)
+        all_amps.append(amp)
+    if not amp_by_location or not all_amps:
+        return []
+    floor_amp = percentile(sorted(all_amps), 0.20)
+    total_points = sum(len(values) for values in amp_by_location.values())
+    rows: list[LocationIntensitySummary] = []
+    for location, values in amp_by_location.items():
+        ordered = sorted(values)
+        sample_count = len(ordered)
+        rows.append(
+            LocationIntensitySummary(
+                location=location,
+                sample_count=sample_count,
+                sample_coverage_ratio=sample_count / max(1, total_points),
+                mean_intensity_db=compute_db(_mean(ordered), floor_amp),
+                p95_intensity_db=compute_db(percentile(ordered, 0.95), floor_amp),
+                max_intensity_db=compute_db(max(ordered), floor_amp),
+            )
+        )
+    rows.sort(
+        key=lambda row: (
+            row.p95_intensity_db if row.p95_intensity_db is not None else float("-inf"),
+            row.mean_intensity_db if row.mean_intensity_db is not None else float("-inf"),
+        ),
+        reverse=True,
+    )
     return rows
 
 

--- a/apps/server/vibesensor/use_cases/history/report_document/document_context.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_context.py
@@ -97,7 +97,7 @@ def build_report_document_context(prepared: PreparedReportInput) -> ReportDocume
         location_confidence_key=decision_facts.location_confidence_key,
         tr=tr,
     )
-    runner_up = runner_up_corner(sensor_facts.active_intensity, tr=tr)
+    runner_up = runner_up_corner(sensor_facts.proof_intensity, tr=tr)
     speed_window_label = str(decision_facts.primary_candidate.primary_speed or "").strip() or None
     recapture = build_recapture_assessment(
         aggregate=test_run,

--- a/apps/server/vibesensor/use_cases/history/report_document/document_output.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_output.py
@@ -47,6 +47,8 @@ def assemble_report_document(
         top_causes=list(context.top_causes),
         sensor_intensity_by_location=list(context.sensor_facts.active_intensity),
         location_hotspot_rows=list(context.sensor_facts.location_hotspot_rows),
+        proof_sensor_intensity_by_location=list(context.sensor_facts.proof_intensity),
+        proof_location_hotspot_rows=list(context.sensor_facts.proof_location_hotspot_rows),
         verdict_page=sections.verdict_page,
         appendix_a=sections.appendix_a,
         appendix_b=sections.appendix_b,

--- a/apps/server/vibesensor/use_cases/history/report_document/document_sections.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_sections.py
@@ -62,7 +62,8 @@ def build_report_document_sections(
     appendix_b = build_appendix_b_data(
         aggregate=context.test_run,
         primary_candidate_facts=context.decision_facts.primary_candidate,
-        active_sensor_intensity=context.sensor_facts.active_intensity,
+        active_sensor_intensity=context.sensor_facts.proof_intensity,
+        proof_basis=context.sensor_facts.proof_basis,
         appendix_context=context.appendix_b_context,
         tr=context.tr,
     )

--- a/apps/server/vibesensor/use_cases/history/report_document/location_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/location_appendix.py
@@ -26,6 +26,7 @@ def build_appendix_b_data(
     aggregate: TestRun,
     primary_candidate_facts: PrimaryReportFacts,
     active_sensor_intensity: Sequence[LocationIntensitySummary],
+    proof_basis: str,
     appendix_context: AppendixBContext,
     tr: Callable[..., str],
 ) -> AppendixBData:
@@ -60,6 +61,7 @@ def build_appendix_b_data(
         dominant_corner=display_location(primary_candidate_facts.primary_location, tr=tr),
         runner_up_corner=appendix_context.runner_up_corner,
         dominance_ratio_text=dominance_ratio_text,
+        proof_basis_note=_location_proof_basis_note(proof_basis, tr=tr),
         location_confidence=location_confidence_text(
             presented_location_confidence_key(
                 action_status_key=appendix_context.action_status_key,
@@ -76,3 +78,11 @@ def build_appendix_b_data(
             tr=tr,
         ),
     )
+
+
+def _location_proof_basis_note(proof_basis: str, *, tr: Callable[..., str]) -> str:
+    if proof_basis == "supporting_windows_raw_backed":
+        return tr("REPORT_LOCATION_PROOF_BASIS_SUPPORTING_WINDOWS_RAW")
+    if proof_basis == "supporting_windows_summary_only":
+        return tr("REPORT_LOCATION_PROOF_BASIS_SUPPORTING_WINDOWS_SUMMARY")
+    return tr("REPORT_LOCATION_PROOF_BASIS_WHOLE_RUN")

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -105,6 +105,7 @@ needs:
 - **Pattern evidence**: matched systems, certainty label, interpretation
 - **Evidence snapshots**: concise page-1 proof rows plus Appendix-C proof rows built from prepared evidence facts, not renderer-time DSP
 - **Appendix-C proof pack**: a diagnosis-focused evidence chain plus retained supporting-window exemplars for the selected diagnosis; the older ranked-measurement table is fallback-only when exemplar windows are unavailable
+- **Location proof surfaces**: page-1 and Appendix-B location diagrams/hotspot summaries should use diagnosis-supporting window location facts when they exist, with explicit summary-only / whole-run fallback notes instead of silently reusing whole-run intensity
 - **Peak rows**: top diagnostic peaks with classification
 - **Rendering context**: pre-computed findings (as ``FindingPresentation``
   snapshots), top causes, sensor intensity, location hotspot rows


### PR DESCRIPTION
## What changed
- build prepared location-proof intensity rows from the winning finding
- feed page 1 and Appendix B hotspot/location proof from those proof rows instead of whole-run intensity
- keep whole-run hotspot rows in the document for non-proof consumers and use them only as fallback when no retained supporting windows exist
- add Appendix B basis notes for raw-backed supporting windows, summary-only supporting windows, and whole-run fallback
- add report-facts, projection, PDF, and header coverage for the location-proof path and the mismatch case where whole-run intensity points somewhere else

## Why
- whole-run hotspot intensity can be diluted by unrelated vibration and should not be the main proof for the selected diagnosis
- the report already had diagnosis-supporting windows; it just was not using them to drive the location proof surfaces

## Validation
- `.venv/bin/pytest -q apps/server/tests/use_cases/history/test_report_facts.py apps/server/tests/adapters/pdf/test_report_document_projection.py apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py apps/server/tests/adapters/pdf/test_page1_header.py`
- `make lint`
- `make typecheck-backend`
- `.venv/bin/pytest -q apps/server/tests/adapters/pdf apps/server/tests/use_cases/history/test_report_facts.py apps/server/tests/use_cases/history/test_report_preparation_contract.py`

## Risks / tradeoffs
- location proof now diverges intentionally from whole-run hotspot rows when supporting windows tell a different story; that is the point of the change, but it makes the fallback boundary explicit
- `make test-changed` stalled in the repo xdist path after lint/typecheck, so the broader report/history pytest slice above was used as the direct local fallback for the touched surface

Closes #3068
