### PR TITLE
Make report confidence more defensible with raw-backed evidence signals

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_confidence_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_confidence_rendering.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from test_support.core import extract_pdf_text
+from test_support.findings import make_finding_payload
+from test_support.report_helpers import minimal_summary
+
+from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
+from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
+from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.use_cases.history.report_document import build_report_document
+
+
+def test_pdf_renders_confidence_row_and_explicit_caveats() -> None:
+    primary = make_finding_payload(
+        finding_id="F_LOW",
+        suspected_source="engine",
+        confidence=0.74,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        weak_spatial_separation=True,
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 12.0,
+                "matched_hz": 12.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.08,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.6,
+                "location": "Rear Right",
+                "phase": "cruise",
+                "amp": 0.08,
+            },
+        ],
+        evidence_metrics={
+            "mean_relative_error": 0.22,
+            "snr_db": 2.5,
+            "matched_samples": 2,
+        },
+    )
+    alternative = make_finding_payload(
+        finding_id="F_ALT",
+        suspected_source="driveline",
+        confidence=0.72,
+        strongest_location="Rear Right",
+        strongest_speed_band="60-80 km/h",
+    )
+    prepared = prepare_persisted_report_input(
+        PersistedAnalysis.from_json_object(
+            minimal_summary(
+                run_id="confidence-render",
+                lang="en",
+                metadata={
+                    "run_id": "confidence-render",
+                    "record_type": "metadata",
+                    "schema_version": "v2-jsonl",
+                    "feature_interval_s": 0.5,
+                },
+                sensor_count_used=4,
+                sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+                sensor_locations_connected_throughout=[
+                    "Front Left",
+                    "Front Right",
+                    "Rear Left",
+                    "Rear Right",
+                ],
+                findings=[primary, alternative],
+                top_causes=[primary, alternative],
+                analysis_metadata={
+                    "raw_backed_sample_count": 0,
+                    "raw_capture_mode": "summary_only",
+                },
+            )
+        )
+    )
+
+    pdf = build_report_pdf(build_report_document(prepared))
+    text = extract_pdf_text(pdf)
+
+    assert "Confidence" in text
+    assert "only summary-level evidence was available" in text
+    assert "matched frequency drifted across 12.1-15.6 Hz" in text

--- a/apps/server/tests/adapters/pdf/test_report_document_projection.py
+++ b/apps/server/tests/adapters/pdf/test_report_document_projection.py
@@ -180,22 +180,25 @@ def test_build_report_document_surfaces_evidence_snapshot_rows() -> None:
     data = build_report_document(prepared)
 
     assert [row.label for row in data.verdict_page.proof_snapshot_rows] == [
+        "Confidence",
         "Evidence basis",
         "Support",
         "Stable frequency",
     ]
-    assert "Raw-backed replay" in data.verdict_page.proof_snapshot_rows[0].value
-    assert data.verdict_page.proof_snapshot_rows[1].value == "3 supporting windows across 1.5 s"
-    assert data.verdict_page.proof_snapshot_rows[2].value == "15.1-15.4 Hz matched band"
+    assert "Medium (" in data.verdict_page.proof_snapshot_rows[0].value
+    assert "Raw-backed replay" in data.verdict_page.proof_snapshot_rows[1].value
+    assert data.verdict_page.proof_snapshot_rows[2].value == "3 supporting windows across 1.5 s"
+    assert data.verdict_page.proof_snapshot_rows[3].value == "15.1-15.4 Hz matched band"
     assert [row.label for row in data.appendix_c.evidence_snapshot_rows] == [
+        "Confidence",
         "Evidence basis",
         "Support",
         "Stable frequency",
         "Strongest sensors",
         "Caveat",
     ]
-    assert data.appendix_c.evidence_snapshot_rows[3].value == "Front-Left (2), Rear-Left (1)"
-    assert "driveline" in data.appendix_c.evidence_snapshot_rows[4].value.lower()
+    assert data.appendix_c.evidence_snapshot_rows[4].value == "Front-Left (2), Rear-Left (1)"
+    assert "driveline" in data.appendix_c.evidence_snapshot_rows[5].value.lower()
 
 
 def test_build_report_document_focuses_appendix_c_on_primary_proof_windows() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
@@ -256,6 +256,7 @@ def test_pdf_renders_evidence_snapshot_labels_for_raw_backed_report() -> None:
 
     text = extract_pdf_text(pdf)
 
+    assert "Confidence" in text
     assert "Evidence basis" in text
     assert "Support" in text
     assert "Stable frequency" in text

--- a/apps/server/tests/use_cases/history/test_report_confidence_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_confidence_facts.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from test_support.findings import make_finding_payload
+from test_support.report_helpers import minimal_summary
+
+from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
+from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.use_cases.history.report_document import build_report_document
+
+
+def test_prepare_persisted_report_input_builds_high_confidence_from_raw_backed_signals() -> None:
+    primary = make_finding_payload(
+        finding_id="F_CONFIDENT",
+        suspected_source="wheel/tire",
+        confidence=0.78,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.1,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.0,
+                "speed_kmh": 68.0,
+                "predicted_hz": 15.2,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.5,
+                "speed_kmh": 70.0,
+                "predicted_hz": 15.3,
+                "matched_hz": 15.3,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.09,
+            },
+        ],
+        evidence_metrics={
+            "mean_relative_error": 0.03,
+            "snr_db": 8.0,
+            "matched_samples": 4,
+        },
+    )
+    prepared = prepare_persisted_report_input(
+        PersistedAnalysis.from_json_object(
+            minimal_summary(
+                run_id="confidence-high",
+                lang="en",
+                metadata={
+                    "run_id": "confidence-high",
+                    "record_type": "metadata",
+                    "schema_version": "v2-jsonl",
+                    "feature_interval_s": 0.5,
+                },
+                sensor_count_used=2,
+                sensor_locations=["Front Left", "Rear Left"],
+                sensor_locations_connected_throughout=["Front Left", "Rear Left"],
+                findings=[primary],
+                top_causes=[primary],
+                analysis_metadata={
+                    "raw_backed_sample_count": 48,
+                    "raw_capture_mode": "raw_backed",
+                },
+            )
+        )
+    )
+
+    confidence = prepared.report_facts.confidence
+    data = build_report_document(prepared)
+
+    assert confidence.label_key == "CONFIDENCE_HIGH"
+    assert confidence.pct_text == "90%"
+    assert confidence.tier == "C"
+    assert "raw_backed" in confidence.signal_keys
+    assert "stable_frequency" in confidence.signal_keys
+    assert "localized_support" in confidence.signal_keys
+    assert confidence.caveat_keys == ()
+    assert data.observed.certainty_label == "High"
+    assert "raw-backed replay confirmed the match" in data.observed.certainty_reason
+    assert data.verdict_page.proof_snapshot_rows[0].label == "Confidence"
+
+
+def test_prepare_persisted_report_input_builds_low_confidence_from_mixed_summary_only_signals() -> (
+    None
+):
+    primary = make_finding_payload(
+        finding_id="F_LOW",
+        suspected_source="engine",
+        confidence=0.74,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        weak_spatial_separation=True,
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 12.0,
+                "matched_hz": 12.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.08,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.6,
+                "location": "Rear Right",
+                "phase": "cruise",
+                "amp": 0.08,
+            },
+        ],
+        evidence_metrics={
+            "mean_relative_error": 0.22,
+            "snr_db": 2.5,
+            "matched_samples": 2,
+        },
+    )
+    alternative = make_finding_payload(
+        finding_id="F_ALT",
+        suspected_source="driveline",
+        confidence=0.72,
+        strongest_location="Rear Right",
+        strongest_speed_band="60-80 km/h",
+    )
+    prepared = prepare_persisted_report_input(
+        PersistedAnalysis.from_json_object(
+            minimal_summary(
+                run_id="confidence-low",
+                lang="en",
+                metadata={
+                    "run_id": "confidence-low",
+                    "record_type": "metadata",
+                    "schema_version": "v2-jsonl",
+                    "feature_interval_s": 0.5,
+                },
+                sensor_count_used=4,
+                sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+                sensor_locations_connected_throughout=[
+                    "Front Left",
+                    "Front Right",
+                    "Rear Left",
+                    "Rear Right",
+                ],
+                findings=[primary, alternative],
+                top_causes=[primary, alternative],
+                analysis_metadata={
+                    "raw_backed_sample_count": 0,
+                    "raw_capture_mode": "summary_only",
+                },
+            )
+        )
+    )
+
+    confidence = prepared.report_facts.confidence
+    data = build_report_document(prepared)
+
+    assert confidence.label_key == "CONFIDENCE_LOW"
+    assert "summary_only" in confidence.caveat_keys
+    assert "close_alternative" in confidence.caveat_keys
+    assert "mixed_support_locations" in confidence.caveat_keys
+    assert data.observed.certainty_label == "Low"
+    assert "only summary-level evidence was available" in data.observed.certainty_reason
+    assert "matched frequency drifted across 12.1-15.6 Hz" in data.observed.certainty_reason
+    assert data.verdict_page.also_consider == "Driveline"

--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -79,6 +79,7 @@ def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> 
     primary = resolve_primary_report_candidate(
         aggregate=prepared.domain_test_run,
         facts=prepared.report_facts.decision.primary_candidate,
+        confidence_facts=prepared.report_facts.confidence,
         tr=tr,
         lang="en",
     )

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -227,6 +227,86 @@
     "en": "Medium",
     "nl": "Gemiddeld"
   },
+  "REPORT_CONFIDENCE_CAVEAT_BRIEF_SUPPORT": {
+    "en": "support only held for {duration} s",
+    "nl": "de steun hield maar {duration} s aan"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_CLOSE_ALTERNATIVE": {
+    "en": "{source} stayed close as an alternative path",
+    "nl": "{source} bleef dicht in de buurt als alternatief pad"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_DRIFTING_FREQUENCY": {
+    "en": "matched frequency drifted across {low}-{high} Hz",
+    "nl": "de gematchte frequentie verschoof over {low}-{high} Hz"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_LOOSE_ORDER_LOCK": {
+    "en": "order tracking stayed loose around the prediction",
+    "nl": "de ordevolging bleef los rond de voorspelling"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_MIXED_LOCATIONS": {
+    "en": "support stayed split across multiple sensor locations",
+    "nl": "de steun bleef verdeeld over meerdere sensorlocaties"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_NOISY_SIGNAL": {
+    "en": "the signal stayed close to the noise floor",
+    "nl": "het signaal bleef dicht bij de ruisvloer"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_REFERENCE_GAP": {
+    "en": "reference data was incomplete for this path",
+    "nl": "referentiedata was onvolledig voor dit pad"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_SPARSE_SUPPORT": {
+    "en": "only {count} supporting window matched",
+    "nl": "slechts {count} ondersteunend venster matchte"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY": {
+    "en": "only summary-level evidence was available",
+    "nl": "alleen samenvattingsniveau-bewijs was beschikbaar"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_WEAK_SPATIAL": {
+    "en": "support spread too widely across the car",
+    "nl": "de steun verspreidde zich te breed over de auto"
+  },
+  "REPORT_CONFIDENCE_REASON_LIMITED_SUPPORT": {
+    "en": "{caveat}; limited positive signal: {strength}",
+    "nl": "{caveat}; beperkt positief signaal: {strength}"
+  },
+  "REPORT_CONFIDENCE_REASON_WITH_CAVEAT": {
+    "en": "{strength}; caveat: {caveat}",
+    "nl": "{strength}; kanttekening: {caveat}"
+  },
+  "REPORT_CONFIDENCE_SIGNAL_CLEAN_SIGNAL": {
+    "en": "the matched signal stood clear of the noise floor",
+    "nl": "het gematchte signaal stond duidelijk boven de ruisvloer"
+  },
+  "REPORT_CONFIDENCE_SIGNAL_LOCALIZED_SUPPORT": {
+    "en": "support stayed concentrated at {location}",
+    "nl": "de steun bleef geconcentreerd bij {location}"
+  },
+  "REPORT_CONFIDENCE_SIGNAL_RAW_BACKED": {
+    "en": "raw-backed replay confirmed the match from {samples} retained samples",
+    "nl": "raw-backed replay bevestigde de match uit {samples} bewaarde samples"
+  },
+  "REPORT_CONFIDENCE_SIGNAL_REPEATED_SUPPORT": {
+    "en": "{count} supporting windows lined up with the diagnosis",
+    "nl": "{count} ondersteunende vensters vielen samen met de diagnose"
+  },
+  "REPORT_CONFIDENCE_SIGNAL_STABLE_FREQUENCY_BAND": {
+    "en": "the matched band stayed tight at {low}-{high} Hz",
+    "nl": "de gematchte band bleef strak op {low}-{high} Hz"
+  },
+  "REPORT_CONFIDENCE_SIGNAL_STABLE_FREQUENCY_SINGLE": {
+    "en": "the matched band stayed tight around {hz} Hz",
+    "nl": "de gematchte band bleef strak rond {hz} Hz"
+  },
+  "REPORT_CONFIDENCE_SIGNAL_SUSTAINED_SUPPORT": {
+    "en": "support held for {duration} s",
+    "nl": "de steun hield {duration} s aan"
+  },
+  "REPORT_CONFIDENCE_SIGNAL_TIGHT_ORDER_LOCK": {
+    "en": "order tracking stayed locked to the predicted path",
+    "nl": "de ordevolging bleef vergrendeld op het voorspelde pad"
+  },
   "DATA_TRUST_CAVEATS": {
     "en": "Confidence caveats",
     "nl": "Betrouwbaarheidspunten"
@@ -1638,6 +1718,10 @@
   "REPORT_ACTION_STATUS_NOTE_GATE_CAUTION": {
     "en": "This run gives a sensible first inspection, but the source scores stayed close. If the primary path is clean, move to the alternative path rather than treating this as a final call.",
     "nl": "Deze run geeft een zinvolle eerste inspectie, maar de bronscores bleven dicht bij elkaar. Als het primaire pad niets oplevert, ga dan naar het alternatieve pad in plaats van dit als definitieve conclusie te zien."
+  },
+  "REPORT_ACTION_STATUS_NOTE_GATE_CAUTION_WITH_ALTERNATIVE": {
+    "en": "This run gives a sensible first inspection, but {alternative} stayed close to {primary}. Start with the primary path, then move to the alternative if the first check is clean.",
+    "nl": "Deze run geeft een zinvolle eerste inspectie, maar {alternative} bleef dicht bij {primary}. Begin met het primaire pad en ga daarna naar het alternatief als de eerste controle niets oplevert."
   },
   "REPORT_ACTION_STATUS_NOTE_GATE_CAUTION_WITH_SCORES": {
     "en": "This run is a close call: {primary} {primary_confidence} vs {alternative} {alternative_confidence}. Start with the first path, but keep the alternative live if the primary check is clean.",

--- a/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
@@ -2,6 +2,7 @@
 
 # Summary normalization and projectable-payload gates.
 # Fact projections and prepared fact groups.
+from .confidence_facts import ReportConfidenceFacts, build_report_confidence_facts
 from .decision_facts import ReportDecisionFacts, build_report_decision_facts
 from .facts import (
     ActionStatusKey,
@@ -33,9 +34,11 @@ from .summary import (
 __all__ = [
     "ActionStatusKey",
     "build_report_decision_facts",
+    "build_report_confidence_facts",
     "FindingPresentation",
     "LocationConfidenceKey",
     "NormalizedReportSummary",
+    "ReportConfidenceFacts",
     "PreparedReportFacts",
     "PreparedReportFindings",
     "PreparedReportInput",

--- a/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
@@ -1,0 +1,341 @@
+"""Prepared report-confidence facts derived from persisted evidence quality."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from vibesensor.domain import Finding
+from vibesensor.shared.boundaries.reporting.decision_facts import ReportDecisionFacts
+from vibesensor.shared.boundaries.reporting.evidence_facts import ReportEvidenceFacts
+from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
+
+__all__ = [
+    "ReportConfidenceFacts",
+    "build_report_confidence_facts",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ReportConfidenceFacts:
+    """Explicit report-confidence inputs and the bounded score derived from them."""
+
+    score_0_to_1: float
+    label_key: str
+    pct_text: str
+    tier: str
+    data_basis: str
+    raw_backed_sample_count: int
+    supporting_window_count: int | None
+    supporting_duration_s: float | None
+    stable_frequency_min_hz: float | None
+    stable_frequency_max_hz: float | None
+    supporting_location_count: int
+    top_support_location: str | None
+    top_support_share: float | None
+    mean_relative_error: float | None
+    snr_db: float | None
+    alternative_source: str | None
+    has_reference_gap: bool
+    uses_summary_fallback: bool
+    fallback_reason: str | None
+    signal_keys: tuple[str, ...]
+    caveat_keys: tuple[str, ...]
+
+
+def build_report_confidence_facts(
+    *,
+    has_explicit_analysis_metadata: bool,
+    primary_candidate: PrimaryReportFacts,
+    evidence_facts: ReportEvidenceFacts,
+    decision_facts: ReportDecisionFacts,
+) -> ReportConfidenceFacts:
+    """Build bounded report confidence from explicit persisted evidence signals."""
+
+    finding_evidence = (
+        primary_candidate.domain_primary.evidence
+        if primary_candidate.domain_primary is not None
+        else None
+    )
+    supporting_window_count = evidence_facts.supporting_window_count
+    supporting_duration_s = evidence_facts.supporting_duration_s
+    stable_frequency_min_hz = evidence_facts.stable_frequency_min_hz
+    stable_frequency_max_hz = evidence_facts.stable_frequency_max_hz
+    frequency_span_hz = _frequency_span_hz(
+        stable_frequency_min_hz=stable_frequency_min_hz,
+        stable_frequency_max_hz=stable_frequency_max_hz,
+    )
+    supporting_location_count, top_support_location, top_support_share = _support_location_summary(
+        evidence_facts=evidence_facts,
+    )
+    mean_relative_error = (
+        finding_evidence.mean_relative_error if finding_evidence is not None else None
+    )
+    snr_db = finding_evidence.snr_db if finding_evidence is not None else None
+    alternative_source = (
+        decision_facts.alternative_source if decision_facts.alternative_source_visible else None
+    )
+    if _should_use_summary_fallback(
+        has_explicit_analysis_metadata=has_explicit_analysis_metadata,
+        primary_candidate=primary_candidate,
+        evidence_facts=evidence_facts,
+        mean_relative_error=mean_relative_error,
+        snr_db=snr_db,
+    ):
+        return _summary_fallback_confidence(
+            primary_candidate=primary_candidate,
+            evidence_facts=evidence_facts,
+            alternative_source=alternative_source,
+            mean_relative_error=mean_relative_error,
+            snr_db=snr_db,
+            supporting_location_count=supporting_location_count,
+            top_support_location=top_support_location,
+            top_support_share=top_support_share,
+        )
+
+    score = (
+        max(0.0, min(0.70, 0.25 + (primary_candidate.confidence * 0.40)))
+        if primary_candidate.domain_primary is not None
+        else 0.0
+    )
+    signal_keys: list[str] = []
+    caveat_keys: list[str] = []
+
+    if evidence_facts.data_basis == "raw_backed":
+        score += 0.10
+        signal_keys.append("raw_backed")
+    else:
+        score -= 0.05
+        caveat_keys.append("summary_only")
+
+    if supporting_window_count is not None:
+        if supporting_window_count >= 4:
+            score += 0.10
+            signal_keys.append("repeated_support")
+        elif supporting_window_count >= 2:
+            score += 0.05
+            signal_keys.append("repeated_support")
+        elif supporting_window_count <= 1:
+            score -= 0.10
+            caveat_keys.append("sparse_support")
+
+    if supporting_duration_s is not None:
+        if supporting_duration_s >= 1.0:
+            score += 0.08
+            signal_keys.append("sustained_support")
+        elif supporting_duration_s >= 0.5:
+            score += 0.04
+            signal_keys.append("sustained_support")
+        elif supporting_duration_s > 0:
+            score -= 0.06
+            caveat_keys.append("brief_support")
+
+    if frequency_span_hz is not None:
+        if frequency_span_hz <= 0.5:
+            score += 0.08
+            signal_keys.append("stable_frequency")
+        elif frequency_span_hz <= 1.0:
+            score += 0.04
+            signal_keys.append("stable_frequency")
+        elif frequency_span_hz > 1.5:
+            score -= 0.06
+            caveat_keys.append("drifting_frequency")
+
+    if mean_relative_error is not None:
+        if mean_relative_error <= 0.05:
+            score += 0.08
+            signal_keys.append("tight_order_lock")
+        elif mean_relative_error >= 0.15:
+            score -= 0.08
+            caveat_keys.append("loose_order_lock")
+
+    if top_support_share is not None:
+        if top_support_share >= 0.67:
+            score += 0.08
+            signal_keys.append("localized_support")
+        elif supporting_location_count > 1 and top_support_share < 0.55:
+            score -= 0.10
+            caveat_keys.append("mixed_support_locations")
+
+    if snr_db is not None:
+        if snr_db >= 6.0:
+            score += 0.05
+            signal_keys.append("clean_signal")
+        elif snr_db < 3.0:
+            score -= 0.06
+            caveat_keys.append("noisy_signal")
+
+    if primary_candidate.weak_spatial:
+        score -= 0.10
+        caveat_keys.append("weak_spatial")
+
+    if alternative_source is not None:
+        score -= 0.10
+        caveat_keys.append("close_alternative")
+
+    if evidence_facts.has_reference_gap:
+        score -= 0.06
+        caveat_keys.append("incomplete_reference")
+
+    rounded_score = _rounded_score(score)
+    label_key = _label_key_for_score(rounded_score)
+    caveat_key_set = set(caveat_keys)
+    tier = (
+        "C"
+        if label_key == "CONFIDENCE_HIGH"
+        and not caveat_key_set.intersection(
+            {
+                "summary_only",
+                "drifting_frequency",
+                "loose_order_lock",
+                "mixed_support_locations",
+                "weak_spatial",
+                "close_alternative",
+                "incomplete_reference",
+                "noisy_signal",
+            }
+        )
+        else ("B" if label_key != "CONFIDENCE_LOW" else "A")
+    )
+    return ReportConfidenceFacts(
+        score_0_to_1=rounded_score,
+        label_key=label_key,
+        pct_text=f"{rounded_score * 100:.0f}%",
+        tier=tier,
+        data_basis=evidence_facts.data_basis,
+        raw_backed_sample_count=evidence_facts.raw_backed_sample_count,
+        supporting_window_count=supporting_window_count,
+        supporting_duration_s=supporting_duration_s,
+        stable_frequency_min_hz=stable_frequency_min_hz,
+        stable_frequency_max_hz=stable_frequency_max_hz,
+        supporting_location_count=supporting_location_count,
+        top_support_location=top_support_location,
+        top_support_share=top_support_share,
+        mean_relative_error=mean_relative_error,
+        snr_db=snr_db,
+        alternative_source=alternative_source,
+        has_reference_gap=evidence_facts.has_reference_gap,
+        uses_summary_fallback=False,
+        fallback_reason=None,
+        signal_keys=tuple(dict.fromkeys(signal_keys)),
+        caveat_keys=tuple(dict.fromkeys(caveat_keys)),
+    )
+
+
+def _should_use_summary_fallback(
+    *,
+    has_explicit_analysis_metadata: bool,
+    primary_candidate: PrimaryReportFacts,
+    evidence_facts: ReportEvidenceFacts,
+    mean_relative_error: float | None,
+    snr_db: float | None,
+) -> bool:
+    if not has_explicit_analysis_metadata and evidence_facts.data_basis == "summary_only":
+        return True
+    return bool(
+        primary_candidate.domain_primary is not None
+        and evidence_facts.data_basis == "summary_only"
+        and not primary_candidate.domain_primary.matched_points
+        and (
+            evidence_facts.supporting_window_count is None
+            or evidence_facts.supporting_window_count <= 0
+        )
+        and mean_relative_error is None
+        and snr_db is None
+    )
+
+
+def _summary_fallback_confidence(
+    *,
+    primary_candidate: PrimaryReportFacts,
+    evidence_facts: ReportEvidenceFacts,
+    alternative_source: str | None,
+    mean_relative_error: float | None,
+    snr_db: float | None,
+    supporting_location_count: int,
+    top_support_location: str | None,
+    top_support_share: float | None,
+) -> ReportConfidenceFacts:
+    confidence = (
+        primary_candidate.confidence if primary_candidate.domain_primary is not None else 0.0
+    )
+    assessment = (
+        primary_candidate.domain_primary.confidence_assessment
+        if primary_candidate.domain_primary is not None
+        else None
+    )
+    label_key = assessment.label_key if assessment is not None else _label_key_for_score(confidence)
+    pct_text = (
+        assessment.pct_text if assessment is not None else f"{max(0.0, confidence) * 100:.0f}%"
+    )
+    tier = assessment.tier if assessment is not None else ("A" if confidence < 0.40 else "B")
+    fallback_reason = (assessment.reason if assessment is not None else "") or None
+    caveat_keys = ("summary_only",) if evidence_facts.data_basis == "summary_only" else ()
+    return ReportConfidenceFacts(
+        score_0_to_1=max(0.0, min(1.0, confidence)),
+        label_key=label_key,
+        pct_text=pct_text,
+        tier=tier,
+        data_basis=evidence_facts.data_basis,
+        raw_backed_sample_count=evidence_facts.raw_backed_sample_count,
+        supporting_window_count=evidence_facts.supporting_window_count,
+        supporting_duration_s=evidence_facts.supporting_duration_s,
+        stable_frequency_min_hz=evidence_facts.stable_frequency_min_hz,
+        stable_frequency_max_hz=evidence_facts.stable_frequency_max_hz,
+        supporting_location_count=supporting_location_count,
+        top_support_location=top_support_location,
+        top_support_share=top_support_share,
+        mean_relative_error=mean_relative_error,
+        snr_db=snr_db,
+        alternative_source=alternative_source,
+        has_reference_gap=evidence_facts.has_reference_gap,
+        uses_summary_fallback=True,
+        fallback_reason=fallback_reason,
+        signal_keys=(),
+        caveat_keys=caveat_keys,
+    )
+
+
+def _frequency_span_hz(
+    *,
+    stable_frequency_min_hz: float | None,
+    stable_frequency_max_hz: float | None,
+) -> float | None:
+    if stable_frequency_min_hz is None or stable_frequency_max_hz is None:
+        return None
+    span = stable_frequency_max_hz - stable_frequency_min_hz
+    return span if math.isfinite(span) and span >= 0 else None
+
+
+def _support_location_summary(
+    *,
+    evidence_facts: ReportEvidenceFacts,
+) -> tuple[int, str | None, float | None]:
+    if (
+        evidence_facts.supporting_window_count is None
+        or evidence_facts.supporting_window_count <= 0
+        or not evidence_facts.supporting_location_counts
+    ):
+        return (0, None, None)
+    total = sum(count for _, count in evidence_facts.supporting_location_counts)
+    if total <= 0:
+        return (0, None, None)
+    top_location, top_count = evidence_facts.supporting_location_counts[0]
+    return (
+        len(evidence_facts.supporting_location_counts),
+        top_location,
+        top_count / total,
+    )
+
+
+def _rounded_score(score: float) -> float:
+    bounded = max(0.10, min(0.90, score))
+    return round(bounded / 0.05) * 0.05
+
+
+def _label_key_for_score(score: float) -> str:
+    if score >= Finding.CONFIDENCE_HIGH_THRESHOLD:
+        return "CONFIDENCE_HIGH"
+    if score >= Finding.CONFIDENCE_MEDIUM_THRESHOLD:
+        return "CONFIDENCE_MEDIUM"
+    return "CONFIDENCE_LOW"

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
         TestRun,
         VibrationOrigin,
     )
+    from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
     from vibesensor.shared.boundaries.reporting.decision_facts import ReportDecisionFacts
     from vibesensor.shared.boundaries.reporting.evidence_facts import ReportEvidenceFacts
     from vibesensor.shared.boundaries.reporting.findings import PreparedReportFindings
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     from vibesensor.shared.run_context_warning import RunContextWarningsInput
     from vibesensor.shared.types.analysis_views import PeakTableRow
 
+from vibesensor.shared.boundaries.reporting.confidence_facts import build_report_confidence_facts
 from vibesensor.shared.boundaries.reporting.decision_facts import (
     ActionStatusKey,
     LocationConfidenceKey,
@@ -83,6 +85,7 @@ class PreparedReportFacts:
     sensor: ReportSensorFacts
     decision: ReportDecisionFacts
     evidence: ReportEvidenceFacts
+    confidence: ReportConfidenceFacts
     findings: PreparedReportFindings
 
 
@@ -121,6 +124,12 @@ def prepare_report_facts(
         primary_candidate=decision_facts.primary_candidate,
         evidence_data_basis=evidence_facts.data_basis,
     )
+    confidence_facts = build_report_confidence_facts(
+        has_explicit_analysis_metadata=isinstance(payload.get("analysis_metadata"), Mapping),
+        primary_candidate=decision_facts.primary_candidate,
+        evidence_facts=evidence_facts,
+        decision_facts=decision_facts,
+    )
     return PreparedReportFacts(
         run=ReportRunFacts(
             run_id=summary.run_id,
@@ -154,6 +163,7 @@ def prepare_report_facts(
         sensor=sensor_facts,
         decision=decision_facts,
         evidence=evidence_facts,
+        confidence=confidence_facts,
         findings=prepare_report_findings(test_run),
     )
 

--- a/apps/server/vibesensor/shared/report_presentation.py
+++ b/apps/server/vibesensor/shared/report_presentation.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Sequence
 
 from vibesensor.domain import Finding, LocationIntensitySummary, TestRun, VibrationSource
 from vibesensor.report_i18n import human_location, human_source, location_candidates
+from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
 from vibesensor.strength_bands import BANDS
 
@@ -14,7 +15,10 @@ __all__ = [
     "action_status_text",
     "append_unique_line",
     "candidate_signal_text",
+    "confidence_caveat_text",
     "confidence_pct_text",
+    "confidence_reason_text",
+    "confidence_snapshot_text",
     "coverage_label",
     "coverage_notes",
     "display_location",
@@ -233,6 +237,63 @@ def confidence_pct_text(finding: Finding) -> str:
     return finding.confidence_pct_text
 
 
+def confidence_reason_text(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> str:
+    if confidence_facts.uses_summary_fallback:
+        return str(confidence_facts.fallback_reason or "").strip() or (
+            tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY")
+            if confidence_facts.data_basis == "summary_only"
+            else ""
+        )
+    strengths = _confidence_signal_texts(confidence_facts, tr=tr)
+    caveats = _confidence_caveat_texts(confidence_facts, tr=tr)
+    strength = strengths[0] if strengths else ""
+    caveat = "; ".join(caveats[:2])
+    if confidence_facts.label_key == "CONFIDENCE_LOW" and caveat and strength:
+        return tr(
+            "REPORT_CONFIDENCE_REASON_LIMITED_SUPPORT",
+            caveat=caveat,
+            strength=strength,
+        )
+    if strength and caveat:
+        return tr(
+            "REPORT_CONFIDENCE_REASON_WITH_CAVEAT",
+            strength=strength,
+            caveat=caveat,
+        )
+    return strength or caveat
+
+
+def confidence_snapshot_text(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> str:
+    label = tr(confidence_facts.label_key)
+    reason = confidence_reason_text(confidence_facts, tr=tr)
+    if not reason:
+        return f"{label} ({confidence_facts.pct_text})"
+    return f"{label} ({confidence_facts.pct_text}) — {reason}"
+
+
+def confidence_caveat_text(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> str | None:
+    if confidence_facts.uses_summary_fallback:
+        if confidence_facts.data_basis == "summary_only":
+            return tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY")
+        return None
+    caveats = _confidence_caveat_texts(confidence_facts, tr=tr)
+    if not caveats:
+        return None
+    return "; ".join(caveats[:2])
+
+
 def source_with_confidence(finding: Finding, *, tr: Callable[..., str]) -> str:
     return tr(
         "REPORT_SOURCE_WITH_CONFIDENCE",
@@ -261,7 +322,7 @@ def runner_up_corner(
 
 def proof_caveat_text(
     *,
-    primary_candidate_facts: PrimaryReportFacts,
+    confidence_facts: ReportConfidenceFacts,
     action_status_key: str,
     location_confidence_key: str,
     tr: Callable[..., str],
@@ -269,7 +330,7 @@ def proof_caveat_text(
     if action_status_key == "action_ready_caution":
         return None
     reason = (
-        first_confidence_reason_clause(primary_candidate_facts)
+        confidence_caveat_text(confidence_facts, tr=tr)
         if action_status_key != "action_ready"
         else None
     )
@@ -280,6 +341,123 @@ def proof_caveat_text(
     if location_confidence_key == "mixed":
         return tr("REPORT_PROOF_CAVEAT_MIXED")
     return None
+
+
+def _confidence_signal_texts(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> tuple[str, ...]:
+    parts: list[str] = []
+    for key in confidence_facts.signal_keys:
+        if key == "raw_backed":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_SIGNAL_RAW_BACKED",
+                    samples=str(max(0, confidence_facts.raw_backed_sample_count)),
+                )
+            )
+        elif key == "repeated_support":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_SIGNAL_REPEATED_SUPPORT",
+                    count=str(max(0, confidence_facts.supporting_window_count or 0)),
+                )
+            )
+        elif key == "sustained_support" and confidence_facts.supporting_duration_s is not None:
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_SIGNAL_SUSTAINED_SUPPORT",
+                    duration=f"{confidence_facts.supporting_duration_s:.1f}",
+                )
+            )
+        elif key == "stable_frequency":
+            low = confidence_facts.stable_frequency_min_hz
+            high = confidence_facts.stable_frequency_max_hz
+            if low is None or high is None:
+                continue
+            if abs(high - low) < 0.05:
+                parts.append(
+                    tr(
+                        "REPORT_CONFIDENCE_SIGNAL_STABLE_FREQUENCY_SINGLE",
+                        hz=f"{low:.1f}",
+                    )
+                )
+            else:
+                parts.append(
+                    tr(
+                        "REPORT_CONFIDENCE_SIGNAL_STABLE_FREQUENCY_BAND",
+                        low=f"{low:.1f}",
+                        high=f"{high:.1f}",
+                    )
+                )
+        elif key == "tight_order_lock":
+            parts.append(tr("REPORT_CONFIDENCE_SIGNAL_TIGHT_ORDER_LOCK"))
+        elif key == "localized_support" and confidence_facts.top_support_location is not None:
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_SIGNAL_LOCALIZED_SUPPORT",
+                    location=display_location(confidence_facts.top_support_location, tr=tr),
+                )
+            )
+        elif key == "clean_signal":
+            parts.append(tr("REPORT_CONFIDENCE_SIGNAL_CLEAN_SIGNAL"))
+    return tuple(parts)
+
+
+def _confidence_caveat_texts(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> tuple[str, ...]:
+    parts: list[str] = []
+    for key in confidence_facts.caveat_keys:
+        if key == "summary_only":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY"))
+        elif key == "sparse_support":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_SPARSE_SUPPORT",
+                    count=str(max(0, confidence_facts.supporting_window_count or 0)),
+                )
+            )
+        elif key == "brief_support" and confidence_facts.supporting_duration_s is not None:
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_BRIEF_SUPPORT",
+                    duration=f"{confidence_facts.supporting_duration_s:.1f}",
+                )
+            )
+        elif key == "drifting_frequency":
+            low = confidence_facts.stable_frequency_min_hz
+            high = confidence_facts.stable_frequency_max_hz
+            if low is None or high is None:
+                continue
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_DRIFTING_FREQUENCY",
+                    low=f"{low:.1f}",
+                    high=f"{high:.1f}",
+                )
+            )
+        elif key == "loose_order_lock":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_LOOSE_ORDER_LOCK"))
+        elif key == "mixed_support_locations":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_MIXED_LOCATIONS"))
+        elif key == "weak_spatial":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_WEAK_SPATIAL"))
+        elif key == "close_alternative" and confidence_facts.alternative_source is not None:
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_CLOSE_ALTERNATIVE",
+                    source=human_source(confidence_facts.alternative_source, tr=tr),
+                )
+            )
+        elif key == "incomplete_reference":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_REFERENCE_GAP"))
+        elif key == "noisy_signal":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_NOISY_SIGNAL"))
+    return tuple(parts)
 
 
 def append_unique_line(lines: list[str], text: object) -> None:

--- a/apps/server/vibesensor/use_cases/history/report_document/_candidate_resolver.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/_candidate_resolver.py
@@ -6,9 +6,14 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from vibesensor.domain import ConfidenceAssessment, Finding, TestRun
+from vibesensor.domain import Finding, TestRun
 from vibesensor.report_i18n import human_source
-from vibesensor.shared.report_presentation import strength_label, strength_text
+from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
+from vibesensor.shared.report_presentation import (
+    confidence_reason_text,
+    strength_label,
+    strength_text,
+)
 
 if TYPE_CHECKING:
     from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
@@ -40,12 +45,14 @@ class PrimaryCandidateContext:
     certainty_pct: str
     certainty_reason: str
     tier: str
+    dominance_ratio: float | None = None
 
 
 def resolve_primary_report_candidate(
     *,
     aggregate: TestRun,
     facts: PrimaryReportFacts,
+    confidence_facts: ReportConfidenceFacts | None = None,
     tr: Callable[..., str],
     lang: str,
 ) -> PrimaryCandidateContext:
@@ -61,7 +68,13 @@ def resolve_primary_report_candidate(
         strength_label(facts.strength_db)[0] if facts.strength_db is not None else None
     )
 
-    if facts.domain_primary and facts.domain_primary.confidence_assessment:
+    if confidence_facts is not None:
+        certainty_key = confidence_facts.label_key
+        certainty_label_text = tr(confidence_facts.label_key)
+        certainty_pct = confidence_facts.pct_text
+        certainty_reason = confidence_reason_text(confidence_facts, tr=tr)
+        tier = confidence_facts.tier
+    elif facts.domain_primary and facts.domain_primary.confidence_assessment:
         ca = facts.domain_primary.confidence_assessment
         certainty_key = ca.label_key
         certainty_label_text = tr(ca.label_key)
@@ -73,10 +86,7 @@ def resolve_primary_report_candidate(
         certainty_label_text = tr("CONFIDENCE_LOW")
         certainty_pct = "0%"
         certainty_reason = ""
-        tier = ConfidenceAssessment.assess(
-            facts.confidence,
-            strength_band_key=strength_band_key,
-        ).tier
+        tier = "A"
     return PrimaryCandidateContext(
         primary_candidate=primary_candidate,
         primary_source=facts.primary_source,
@@ -90,6 +100,7 @@ def resolve_primary_report_candidate(
         strength_db=facts.strength_db,
         strength_text=strength_text_value,
         strength_band_key=strength_band_key,
+        dominance_ratio=facts.dominance_ratio,
         certainty_key=certainty_key,
         certainty_label_text=certainty_label_text,
         certainty_pct=certainty_pct,

--- a/apps/server/vibesensor/use_cases/history/report_document/document_context.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_context.py
@@ -92,7 +92,7 @@ def build_report_document_context(prepared: PreparedReportInput) -> ReportDocume
         )
     )
     proof_caveat = proof_caveat_text(
-        primary_candidate_facts=decision_facts.primary_candidate,
+        confidence_facts=report_facts.confidence,
         action_status_key=decision_facts.action_status_key,
         location_confidence_key=decision_facts.location_confidence_key,
         tr=tr,
@@ -102,6 +102,7 @@ def build_report_document_context(prepared: PreparedReportInput) -> ReportDocume
     recapture = build_recapture_assessment(
         aggregate=test_run,
         primary_candidate_facts=decision_facts.primary_candidate,
+        confidence_facts=report_facts.confidence,
         location_confidence_key=decision_facts.location_confidence_key,
         expected_locations=coverage.expected_locations,
         active_locations=coverage.active_locations,
@@ -113,6 +114,7 @@ def build_report_document_context(prepared: PreparedReportInput) -> ReportDocume
     primary = resolve_primary_report_candidate(
         aggregate=test_run,
         facts=decision_facts.primary_candidate,
+        confidence_facts=report_facts.confidence,
         tr=tr,
         lang=lang,
     )

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -7,7 +7,10 @@ from collections.abc import Callable
 from vibesensor.report_i18n import human_source
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts
 from vibesensor.shared.boundaries.reporting.document import ReportLabelValueRow
-from vibesensor.shared.report_presentation import display_location
+from vibesensor.shared.report_presentation import (
+    confidence_snapshot_text,
+    display_location,
+)
 
 __all__ = ["build_evidence_snapshot_rows"]
 
@@ -21,6 +24,10 @@ def build_evidence_snapshot_rows(
     """Build localized evidence snapshot rows for report proof surfaces."""
 
     rows: list[ReportLabelValueRow] = [
+        ReportLabelValueRow(
+            label=tr("CONFIDENCE_LABEL"),
+            value=confidence_snapshot_text(report_facts.confidence, tr=tr),
+        ),
         ReportLabelValueRow(
             label=tr("REPORT_EVIDENCE_BASIS_LABEL"),
             value=_data_basis_text(report_facts, tr=tr),

--- a/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
@@ -8,18 +8,15 @@ from typing import TYPE_CHECKING
 
 from vibesensor.domain import SuitabilityCheck, TestRun
 from vibesensor.report_i18n import human_source
+from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.boundaries.reporting.document import PatternEvidence, VerdictPageData
-from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
 from vibesensor.shared.report_diagnostics import first_nonpass_detail
 from vibesensor.shared.report_presentation import (
     action_status_text,
-    confidence_pct_text,
     display_location,
-    first_confidence_reason_clause,
     location_confidence_text,
     presented_location_confidence_key,
     proof_caveat_text,
-    source_with_confidence,
 )
 from vibesensor.shared.run_context_warning import RunContextWarning
 
@@ -55,7 +52,8 @@ def build_observed_signature(
 def build_verdict_page_data(
     *,
     aggregate: TestRun,
-    primary_candidate_facts: PrimaryReportFacts,
+    primary: PrimaryCandidateContext,
+    report_confidence: ReportConfidenceFacts,
     duration_text: str | None,
     verdict_context: VerdictPageContext,
     suitability_checks: Sequence[SuitabilityCheck],
@@ -67,19 +65,16 @@ def build_verdict_page_data(
     return VerdictPageData(
         speed_window_label=verdict_context.speed_window_label,
         suspected_source=(
-            tr("REPORT_INCONCLUSIVE_SOURCE")
-            if recapture_before_acting
-            else _primary_source_text(primary_candidate_facts, tr=tr)
+            tr("REPORT_INCONCLUSIVE_SOURCE") if recapture_before_acting else primary.primary_system
         ),
         inspect_first=(
-            None
-            if recapture_before_acting
-            else display_location(primary_candidate_facts.primary_location, tr=tr)
+            None if recapture_before_acting else display_location(primary.primary_location, tr=tr)
         ),
         action_status=action_status_text(verdict_context.action_status_key, tr=tr),
         action_status_note=_action_status_note_text(
             aggregate=aggregate,
-            primary_candidate_facts=primary_candidate_facts,
+            primary=primary,
+            report_confidence=report_confidence,
             action_status_key=verdict_context.action_status_key,
             location_confidence_key=verdict_context.location_confidence_key,
             alternative_source_visible=verdict_context.alternative_source_visible,
@@ -92,20 +87,20 @@ def build_verdict_page_data(
             verdict_context.recapture.issues[0]
             if recapture_before_acting and verdict_context.recapture.issues
             else _build_primary_reason_sentence(
-                primary_candidate_facts=primary_candidate_facts,
+                primary=primary,
                 active_locations=verdict_context.active_locations,
                 duration_text=duration_text,
                 tr=tr,
             )
         ),
-        dominant_corner=display_location(primary_candidate_facts.primary_location, tr=tr),
+        dominant_corner=display_location(primary.primary_location, tr=tr),
         runner_up_corner=verdict_context.runner_up_corner,
         location_confidence=_location_confidence_display_text(
-            primary_candidate_facts=primary_candidate_facts,
+            primary=primary,
             action_status_key=verdict_context.action_status_key,
             location_confidence_key=verdict_context.location_confidence_key,
             alternative_source_visible=verdict_context.alternative_source_visible,
-            dominance_ratio=primary_candidate_facts.dominance_ratio,
+            dominance_ratio=primary.dominance_ratio,
             suitability_checks=suitability_checks,
             warnings=warnings,
             lang=lang,
@@ -113,7 +108,7 @@ def build_verdict_page_data(
         ),
         coverage_label=verdict_context.coverage_label,
         also_consider=(
-            source_with_confidence(aggregate.effective_top_causes()[1], tr=tr)
+            human_source(aggregate.effective_top_causes()[1].suspected_source, tr=tr)
             if not recapture_before_acting
             and verdict_context.alternative_source_visible
             and len(aggregate.effective_top_causes()) > 1
@@ -143,7 +138,8 @@ def build_verdict_page(*, context: ReportDocumentContext) -> VerdictPageData:
 
     verdict_page = build_verdict_page_data(
         aggregate=context.test_run,
-        primary_candidate_facts=context.decision_facts.primary_candidate,
+        primary=context.primary,
+        report_confidence=context.report_facts.confidence,
         duration_text=context.run_facts.duration_text,
         verdict_context=context.verdict_page_context,
         suitability_checks=context.decision_facts.suitability_checks,
@@ -175,15 +171,15 @@ def build_verdict_page(*, context: ReportDocumentContext) -> VerdictPageData:
 
 def _build_primary_reason_sentence(
     *,
-    primary_candidate_facts: PrimaryReportFacts,
+    primary: PrimaryCandidateContext,
     active_locations: Sequence[str],
     duration_text: str | None,
     tr: Callable[..., str],
 ) -> str:
-    location = display_location(primary_candidate_facts.primary_location, tr=tr)
+    location = display_location(primary.primary_location, tr=tr)
     duration = str(duration_text or "").strip() or tr("UNKNOWN")
-    sensor_count = len(active_locations) or primary_candidate_facts.sensor_count
-    speed_window = str(primary_candidate_facts.primary_speed or "").strip()
+    sensor_count = len(active_locations) or primary.sensor_count
+    speed_window = str(primary.primary_speed or "").strip()
     if speed_window and speed_window != tr("UNKNOWN"):
         return tr(
             "REPORT_REASON_RUN_SUMMARY",
@@ -202,7 +198,7 @@ def _build_primary_reason_sentence(
 
 def _location_confidence_display_text(
     *,
-    primary_candidate_facts: PrimaryReportFacts,
+    primary: PrimaryCandidateContext,
     action_status_key: str,
     location_confidence_key: str,
     alternative_source_visible: bool,
@@ -219,7 +215,7 @@ def _location_confidence_display_text(
     if action_status_key != "action_ready_caution":
         return location_confidence_text(presented_key, tr=tr)
 
-    reason = first_confidence_reason_clause(primary_candidate_facts)
+    reason = str(primary.certainty_reason or "").strip().split(";")[0].rstrip(".")
     if reason:
         return reason
     if alternative_source_visible:
@@ -240,7 +236,8 @@ def _location_confidence_display_text(
 def _action_status_note_text(
     *,
     aggregate: TestRun,
-    primary_candidate_facts: PrimaryReportFacts,
+    primary: PrimaryCandidateContext,
+    report_confidence: ReportConfidenceFacts,
     action_status_key: str,
     location_confidence_key: str,
     alternative_source_visible: bool,
@@ -262,16 +259,14 @@ def _action_status_note_text(
         ranked_candidates = list(aggregate.effective_top_causes()[:2])
         if len(ranked_candidates) > 1:
             score_note = tr(
-                "REPORT_ACTION_STATUS_NOTE_GATE_CAUTION_WITH_SCORES",
+                "REPORT_ACTION_STATUS_NOTE_GATE_CAUTION_WITH_ALTERNATIVE",
                 primary=human_source(ranked_candidates[0].suspected_source, tr=tr),
-                primary_confidence=confidence_pct_text(ranked_candidates[0]),
                 alternative=human_source(ranked_candidates[1].suspected_source, tr=tr),
-                alternative_confidence=confidence_pct_text(ranked_candidates[1]),
             )
         else:
             score_note = tr("REPORT_ACTION_STATUS_NOTE_GATE_CAUTION")
     reason = score_note or proof_caveat_text(
-        primary_candidate_facts=primary_candidate_facts,
+        confidence_facts=report_confidence,
         action_status_key=action_status_key,
         location_confidence_key=location_confidence_key,
         tr=tr,
@@ -287,13 +282,3 @@ def _action_status_note_text(
             )
         return issue
     return issue or reason
-
-
-def _primary_source_text(
-    primary_candidate_facts: PrimaryReportFacts,
-    *,
-    tr: Callable[..., str],
-) -> str:
-    if primary_candidate_facts.primary_source is None:
-        return tr("UNKNOWN")
-    return human_source(primary_candidate_facts.primary_source, tr=tr)

--- a/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Sequence
 
 from vibesensor.domain import Finding, SuitabilityCheck, TestRun
 from vibesensor.report_i18n import human_source
+from vibesensor.shared.boundaries.reporting.confidence_facts import ReportConfidenceFacts
 from vibesensor.shared.boundaries.reporting.document import AppendixAData, RankedCandidateRow
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
 from vibesensor.shared.report_diagnostics import check_state, has_warning_code, nonpass_detail_lines
@@ -128,6 +129,7 @@ def build_recapture_assessment(
     *,
     aggregate: TestRun,
     primary_candidate_facts: PrimaryReportFacts,
+    confidence_facts: ReportConfidenceFacts,
     location_confidence_key: str,
     expected_locations: Sequence[str],
     active_locations: Sequence[str],
@@ -185,7 +187,7 @@ def build_recapture_assessment(
         append_unique_line(issues, detail)
     if not issues:
         note = proof_caveat_text(
-            primary_candidate_facts=primary_candidate_facts,
+            confidence_facts=confidence_facts,
             action_status_key="recapture_before_acting",
             location_confidence_key=location_confidence_key,
             tr=tr,

--- a/docs/metrics_to_report_mapping.md
+++ b/docs/metrics_to_report_mapping.md
@@ -51,9 +51,9 @@ report rendering can localize them at read time.
 | Strongest sensor         | `observed.strongest_location`                   | `most_likely_origin.location` or `top_causes[0].strongest_location` | string |
 | Speed band               | `observed.speed_band`                           | `top_causes[0].strongest_speed_band`         | string (e.g. "80–100 km/h") |
 | Strength                 | `observed.strength_label`, `observed.strength_peak_db` | `_top_strength_values()` → `strength_text()` | `"{Label} ({db:.1f} dB)"` |
-| Certainty                | `observed.certainty_label`, `observed.certainty_pct` | `ConfidenceAssessment.assess()` | `"{Label} ({pct}%)"`  |
-| Certainty reason         | `observed.certainty_reason`                     | `ConfidenceAssessment.assess()` reason     | string                       |
-| Tier indicator           | `certainty_tier_key`                            | `ConfidenceAssessment.tier` → `"A"`, `"B"`, `"C"` | single char               |
+| Certainty                | `observed.certainty_label`, `observed.certainty_pct` | `ReportConfidenceFacts.label_key/pct_text` | `"{Label} ({pct}%)"`  |
+| Certainty reason         | `observed.certainty_reason`                     | `ReportConfidenceFacts` signal/caveat text | string                       |
+| Tier indicator           | `certainty_tier_key`                            | `ReportConfidenceFacts.tier` → `"A"`, `"B"`, `"C"` | single char               |
 
 ### Systems with Findings panel
 

--- a/docs/report_pipeline.md
+++ b/docs/report_pipeline.md
@@ -75,8 +75,9 @@ Canonical report preparation now lives in
 `NormalizedReportSummary` decoding, domain reconstruction, filename/language
 normalization, and grouped semantic fact assembly:
 
-- `facts.py` builds `PreparedReportFacts(run=..., sensor=..., decision=..., findings=...)`
+- `facts.py` builds `PreparedReportFacts(run=..., sensor=..., decision=..., evidence=..., confidence=..., findings=...)`
 - `evidence_facts.py` builds explicit proof facts (data basis, supporting-window count/duration, stable frequency band, strongest supporting sensors, and caveats) from persisted analysis + reconstructed domain findings
+- `confidence_facts.py` converts persisted evidence quality signals into bounded report confidence (raw-backed vs summary-only basis, support count/duration, frequency stability, order-lock quality, spatial concentration, counterevidence, and reference gaps)
 - `findings.py` owns report-facing finding/top-cause presentation shaping
 - `sensor_facts.py` owns sensor/coverage shaping
 - `decision_facts.py` owns primary-candidate, warning, and action-decision shaping
@@ -104,6 +105,7 @@ needs:
 - **Data trust items**: suitability checks
 - **Pattern evidence**: matched systems, certainty label, interpretation
 - **Evidence snapshots**: concise page-1 proof rows plus Appendix-C proof rows built from prepared evidence facts, not renderer-time DSP
+- **Confidence surfaces**: observed certainty, page-1 confidence row, and proof caveats come from prepared `ReportConfidenceFacts`, not renderer-only heuristics
 - **Appendix-C proof pack**: a diagnosis-focused evidence chain plus retained supporting-window exemplars for the selected diagnosis; the older ranked-measurement table is fallback-only when exemplar windows are unavailable
 - **Location proof surfaces**: page-1 and Appendix-B location diagrams/hotspot summaries should use diagnosis-supporting window location facts when they exist, with explicit summary-only / whole-run fallback notes instead of silently reusing whole-run intensity
 - **Peak rows**: top diagnostic peaks with classification


### PR DESCRIPTION
## What changed
- add prepared `ReportConfidenceFacts` so report certainty comes from explicit evidence-quality signals instead of renderer-time heuristics
- score confidence from persisted/raw-backed evidence inputs: basis, support count + duration, stable-band span, order-lock quality, spatial concentration, close alternatives, and reference gaps
- keep summary-only / older runs on the existing domain confidence assessment when explicit raw-backed evidence signals are not available
- add a `Confidence` proof row to page 1 and Appendix C, route certainty/caveat text through the prepared confidence layer, and replace close-call score wording with alternative-path wording
- cover high-confidence raw-backed and reduced-confidence mixed-evidence cases in focused report-facts/document/PDF tests and update report docs

## Why
- report confidence should explain the actual evidence quality behind the diagnosis, not just reuse broad heuristic wording
- raw-backed offline analysis already exposes the inputs needed to make confidence inspectable and proportionate

## Validation
- `.venv/bin/pytest -q apps/server/tests/use_cases/history/test_report_confidence_facts.py apps/server/tests/adapters/pdf/test_report_confidence_rendering.py apps/server/tests/adapters/pdf/test_report_document_projection.py apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py apps/server/tests/use_cases/history/test_report_preparation_contract.py`
- `.venv/bin/pytest -q apps/server/tests/integration/test_contract_analysis_report.py::test_report_certainty_uses_confidence_assessment_reason apps/server/tests/adapters/pdf/test_report_tier_gating.py::TestTierReportOutput::test_dutch_localization_preserves_same_tier_semantics[tier-c] apps/server/tests/adapters/pdf/test_report_tier_gating.py::TestTierReportOutput::test_tier_gating_contracts[tier-c-en] apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py::test_build_system_cards_uses_domain_findings apps/server/tests/hygiene/test_domain_report_mapping_guardrails.py::test_report_mapping_business_functions_use_domain_objects apps/server/tests/adapters/pdf/test_report_pdf_workflow_rendering.py::test_build_report_pdf_replaces_limited_run_context_with_concrete_reason apps/server/tests/adapters/pdf/test_report_metrics_consistency.py::TestScenario3HighSpeedFault::test_high_speed_fault_tracks_high_band_and_uncertainty_reason`
- `make lint`
- `make typecheck-backend`
- `make test-changed`

## Risks / tradeoffs
- confidence is intentionally coarser and more inspectable; the report now favors explicit evidence/caveat wording over old score-only phrasing
- persisted summary-only runs still get the new confidence row, but they deliberately fall back to the old domain confidence assessment when raw-backed evidence signals are absent to avoid inventing false precision

Closes #3069
