### PR TITLE
Add deterministic whole-run window contracts

### DIFF
--- a/apps/server/tests/shared/types/test_whole_run_analysis.py
+++ b/apps/server/tests/shared/types/test_whole_run_analysis.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_analysis import (
+    WHOLE_RUN_ARTIFACT_SCHEMA_VERSION,
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunWindowDescriptor,
+    WholeRunWindowPolicy,
+)
+
+
+def _metadata(
+    *,
+    raw_sample_rate_hz: int | None = 800,
+    feature_interval_s: float | None = 0.25,
+    fft_window_size_samples: int | None = 2048,
+) -> RunMetadata:
+    return RunMetadata.create(
+        run_id="run-1",
+        start_time_utc="2025-01-01T00:00:00Z",
+        sensor_model="fixture-sensor",
+        raw_sample_rate_hz=raw_sample_rate_hz,
+        feature_interval_s=feature_interval_s,
+        fft_window_size_samples=fft_window_size_samples,
+        accel_scale_g_per_lsb=0.001,
+    )
+
+
+def test_window_policy_derives_stride_and_overlap_from_run_metadata() -> None:
+    policy = WholeRunWindowPolicy.from_metadata(_metadata())
+
+    assert policy.sample_rate_hz == 800
+    assert policy.window_size_samples == 2048
+    assert policy.stride_samples == 200
+    assert policy.overlap_samples == 1848
+    assert policy.feature_interval_s == pytest.approx(0.25)
+    assert policy.window_duration_s == pytest.approx(2.56)
+    assert policy.stride_duration_s == pytest.approx(0.25)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"raw_sample_rate_hz": None}, "raw_sample_rate_hz"),
+        ({"fft_window_size_samples": None}, "fft_window_size_samples"),
+        ({"feature_interval_s": None}, "feature_interval_s"),
+        ({"raw_sample_rate_hz": 800, "feature_interval_s": 1.0 / 3.0}, "integral sample stride"),
+        (
+            {"fft_window_size_samples": 128, "feature_interval_s": 0.25},
+            "stride_samples <= window_size_samples",
+        ),
+    ],
+)
+def test_window_policy_rejects_invalid_metadata(kwargs: dict[str, object], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        WholeRunWindowPolicy.from_metadata(_metadata(**kwargs))
+
+
+def test_window_descriptor_from_policy_sets_sample_and_time_bounds() -> None:
+    policy = WholeRunWindowPolicy.from_metadata(_metadata())
+
+    descriptor = WholeRunWindowDescriptor.from_policy(
+        window_index=3,
+        sample_start=600,
+        policy=policy,
+    )
+
+    assert descriptor.window_index == 3
+    assert descriptor.sample_start == 600
+    assert descriptor.sample_end == 2648
+    assert descriptor.center_sample == 1624
+    assert descriptor.sample_count == 2048
+    assert descriptor.start_t_s == pytest.approx(0.75)
+    assert descriptor.end_t_s == pytest.approx(3.31)
+    assert descriptor.center_t_s == pytest.approx(2.03)
+    assert WholeRunWindowDescriptor.from_mapping(descriptor.to_json_object()) == descriptor
+
+
+def test_whole_run_artifact_manifest_round_trips_with_window_policy() -> None:
+    policy = WholeRunWindowPolicy.from_metadata(_metadata())
+    manifest = WholeRunArtifactManifest(
+        run_id="run-1",
+        relative_dir="whole-run-artifacts/run-1",
+        window_policy=policy,
+        total_window_count=123,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="window_spectra",
+                relative_path="window-spectra.jsonl",
+                file_format="jsonl",
+                record_count=123,
+            ),
+            WholeRunArtifactFile(
+                artifact_key="window_spectra_sensor-a",
+                relative_path="sensor-a/window-spectra.npz",
+                file_format="npz",
+                record_count=123,
+                sensor_id="sensor-a",
+            ),
+        ),
+        created_at="2025-01-01T00:00:10Z",
+    )
+
+    restored = WholeRunArtifactManifest.from_mapping(manifest.to_json_object())
+
+    assert restored == manifest
+    assert restored.schema_version == WHOLE_RUN_ARTIFACT_SCHEMA_VERSION
+    assert restored.artifact("window_spectra_sensor-a") == manifest.artifacts[1]

--- a/apps/server/vibesensor/shared/types/whole_run_analysis.py
+++ b/apps/server/vibesensor/shared/types/whole_run_analysis.py
@@ -1,0 +1,283 @@
+"""Shared whole-run post-analysis contracts for window identity and sidecar artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isclose
+
+from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
+from vibesensor.shared.types.run_schema import RunMetadata
+
+__all__ = [
+    "WHOLE_RUN_ARTIFACT_SCHEMA_VERSION",
+    "WholeRunArtifactFile",
+    "WholeRunArtifactManifest",
+    "WholeRunWindowDescriptor",
+    "WholeRunWindowPolicy",
+]
+
+WHOLE_RUN_ARTIFACT_SCHEMA_VERSION = 1
+_WHOLE_RUN_ARTIFACT_STORAGE_TYPE = "run-directory-v1"
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunWindowPolicy:
+    """Canonical sample-space policy shared by all whole-run window planners."""
+
+    sample_rate_hz: int
+    window_size_samples: int
+    stride_samples: int
+    overlap_samples: int
+    feature_interval_s: float
+
+    @classmethod
+    def from_metadata(cls, metadata: RunMetadata) -> WholeRunWindowPolicy:
+        sample_rate_hz = int(metadata.raw_sample_rate_hz or 0)
+        if sample_rate_hz <= 0:
+            raise ValueError("whole-run window policy requires raw_sample_rate_hz")
+        window_size_samples = int(metadata.fft_window_size_samples or 0)
+        if window_size_samples <= 0:
+            raise ValueError("whole-run window policy requires fft_window_size_samples")
+        feature_interval_s = float(metadata.feature_interval_s or 0.0)
+        if feature_interval_s <= 0.0:
+            raise ValueError("whole-run window policy requires feature_interval_s")
+        raw_stride_samples = feature_interval_s * float(sample_rate_hz)
+        stride_samples = int(round(raw_stride_samples))
+        if stride_samples <= 0 or not isclose(
+            raw_stride_samples,
+            float(stride_samples),
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise ValueError(
+                "whole-run window policy requires feature_interval_s * raw_sample_rate_hz "
+                "to resolve to an integral sample stride"
+            )
+        if stride_samples > window_size_samples:
+            raise ValueError(
+                "whole-run window policy requires stride_samples <= window_size_samples"
+            )
+        return cls(
+            sample_rate_hz=sample_rate_hz,
+            window_size_samples=window_size_samples,
+            stride_samples=stride_samples,
+            overlap_samples=window_size_samples - stride_samples,
+            feature_interval_s=feature_interval_s,
+        )
+
+    @property
+    def window_duration_s(self) -> float:
+        return float(self.window_size_samples) / float(self.sample_rate_hz)
+
+    @property
+    def stride_duration_s(self) -> float:
+        return float(self.stride_samples) / float(self.sample_rate_hz)
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "sample_rate_hz": self.sample_rate_hz,
+            "window_size_samples": self.window_size_samples,
+            "stride_samples": self.stride_samples,
+            "overlap_samples": self.overlap_samples,
+            "feature_interval_s": self.feature_interval_s,
+        }
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunWindowPolicy:
+        return cls(
+            sample_rate_hz=_int_from_json(data.get("sample_rate_hz")),
+            window_size_samples=_int_from_json(data.get("window_size_samples")),
+            stride_samples=_int_from_json(data.get("stride_samples")),
+            overlap_samples=_int_from_json(data.get("overlap_samples")),
+            feature_interval_s=_float_from_json(data.get("feature_interval_s")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunWindowDescriptor:
+    """Deterministic whole-run window identity used across downstream artifacts."""
+
+    window_index: int
+    sample_start: int
+    sample_end: int
+    center_sample: int
+    start_t_s: float
+    end_t_s: float
+    center_t_s: float
+
+    @classmethod
+    def from_policy(
+        cls,
+        *,
+        window_index: int,
+        sample_start: int,
+        policy: WholeRunWindowPolicy,
+    ) -> WholeRunWindowDescriptor:
+        if window_index < 0:
+            raise ValueError("whole-run window descriptor requires window_index >= 0")
+        if sample_start < 0:
+            raise ValueError("whole-run window descriptor requires sample_start >= 0")
+        sample_end = sample_start + policy.window_size_samples
+        center_sample = sample_start + (policy.window_size_samples // 2)
+        sample_rate_hz = float(policy.sample_rate_hz)
+        return cls(
+            window_index=window_index,
+            sample_start=sample_start,
+            sample_end=sample_end,
+            center_sample=center_sample,
+            start_t_s=float(sample_start) / sample_rate_hz,
+            end_t_s=float(sample_end) / sample_rate_hz,
+            center_t_s=float(center_sample) / sample_rate_hz,
+        )
+
+    @property
+    def sample_count(self) -> int:
+        return self.sample_end - self.sample_start
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "window_index": self.window_index,
+            "sample_start": self.sample_start,
+            "sample_end": self.sample_end,
+            "center_sample": self.center_sample,
+            "start_t_s": self.start_t_s,
+            "end_t_s": self.end_t_s,
+            "center_t_s": self.center_t_s,
+        }
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunWindowDescriptor:
+        return cls(
+            window_index=_int_from_json(data.get("window_index")),
+            sample_start=_int_from_json(data.get("sample_start")),
+            sample_end=_int_from_json(data.get("sample_end")),
+            center_sample=_int_from_json(data.get("center_sample")),
+            start_t_s=_float_from_json(data.get("start_t_s")),
+            end_t_s=_float_from_json(data.get("end_t_s")),
+            center_t_s=_float_from_json(data.get("center_t_s")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunArtifactFile:
+    """One dense whole-run sidecar artifact file owned by a run-level manifest."""
+
+    artifact_key: str
+    relative_path: str
+    file_format: str
+    record_count: int | None = None
+    sensor_id: str | None = None
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "artifact_key": self.artifact_key,
+            "relative_path": self.relative_path,
+            "file_format": self.file_format,
+        }
+        if self.record_count is not None:
+            payload["record_count"] = self.record_count
+        if self.sensor_id is not None:
+            payload["sensor_id"] = self.sensor_id
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunArtifactFile:
+        return cls(
+            artifact_key=_str_from_json(data.get("artifact_key")),
+            relative_path=_str_from_json(data.get("relative_path")),
+            file_format=_str_from_json(data.get("file_format")),
+            record_count=_int_or_none(data.get("record_count")),
+            sensor_id=_str_or_none(data.get("sensor_id")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunArtifactManifest:
+    """Run-level manifest for dense whole-run artifacts stored outside analysis_json."""
+
+    run_id: str
+    relative_dir: str
+    window_policy: WholeRunWindowPolicy
+    total_window_count: int
+    artifacts: tuple[WholeRunArtifactFile, ...]
+    created_at: str
+    schema_version: int = WHOLE_RUN_ARTIFACT_SCHEMA_VERSION
+    storage_type: str = _WHOLE_RUN_ARTIFACT_STORAGE_TYPE
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "schema_version": self.schema_version,
+            "storage_type": self.storage_type,
+            "run_id": self.run_id,
+            "relative_dir": self.relative_dir,
+            "window_policy": self.window_policy.to_json_object(),
+            "total_window_count": self.total_window_count,
+            "artifacts": [artifact.to_json_object() for artifact in self.artifacts],
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunArtifactManifest:
+        policy_data = data.get("window_policy")
+        if not is_json_object(policy_data):
+            raise ValueError("whole-run artifact manifest requires window_policy")
+        artifacts_raw = data.get("artifacts")
+        artifacts: list[WholeRunArtifactFile] = []
+        if isinstance(artifacts_raw, list):
+            for item in artifacts_raw:
+                if is_json_object(item):
+                    artifacts.append(WholeRunArtifactFile.from_mapping(item))
+        return cls(
+            schema_version=_int_from_json(
+                data.get("schema_version"),
+                WHOLE_RUN_ARTIFACT_SCHEMA_VERSION,
+            ),
+            storage_type=_str_from_json(data.get("storage_type"), _WHOLE_RUN_ARTIFACT_STORAGE_TYPE),
+            run_id=_str_from_json(data.get("run_id")),
+            relative_dir=_str_from_json(data.get("relative_dir")),
+            window_policy=WholeRunWindowPolicy.from_mapping(policy_data),
+            total_window_count=_int_from_json(data.get("total_window_count")),
+            artifacts=tuple(artifacts),
+            created_at=_str_from_json(data.get("created_at")),
+        )
+
+    def artifact(self, artifact_key: str) -> WholeRunArtifactFile | None:
+        for artifact in self.artifacts:
+            if artifact.artifact_key == artifact_key:
+                return artifact
+        return None
+
+
+def _int_or_none(value: JsonValue | object) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float, str)):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _int_from_json(value: JsonValue | object, default: int = 0) -> int:
+    parsed = _int_or_none(value)
+    return parsed if parsed is not None else default
+
+
+def _float_from_json(value: JsonValue | object, default: float = 0.0) -> float:
+    if isinstance(value, bool) or value is None:
+        return default
+    if isinstance(value, (int, float, str)):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+    return default
+
+
+def _str_from_json(value: JsonValue | object, default: str = "") -> str:
+    return value if isinstance(value, str) else default
+
+
+def _str_or_none(value: JsonValue | object) -> str | None:
+    return value if isinstance(value, str) else None

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -1,0 +1,424 @@
+# Whole-run post-analysis program
+
+Scope: execution design for parent issues #3075, #3076, #3077, #3078, and
+#3079, using the completed raw-capture work from #3065 as the foundation.
+
+This document is a design and decomposition artifact, not an implementation
+status log. It records the current architecture, the target architecture, the
+shared contracts that must settle early, and the recommended execution order.
+
+## Current state
+
+### Live path
+
+- Raw UDP samples enter through `apps/server/vibesensor/adapters/udp/udp_data_rx.py`.
+- Live FFT/strength computation lives in `apps/server/vibesensor/infra/processing/`.
+- The canonical spectrum window is `FFT_N = 2048` with a Hann window from
+  `apps/server/vibesensor/shared/constants/dsp.py` and
+  `apps/server/vibesensor/infra/processing/compute.py`.
+- Live feature cadence is derived from `feature_interval_s`, which is currently
+  written as `1 / metrics_log_hz` by
+  `apps/server/vibesensor/use_cases/run/run_metadata_builder.py`.
+
+### Run persistence and post-stop analysis
+
+- `apps/server/vibesensor/use_cases/run/logger.py` finalizes a run and schedules
+  `PostAnalysisWorker`.
+- `apps/server/vibesensor/use_cases/run/post_analysis_loader.py` loads persisted
+  samples for a run, but caps analysis input at `_MAX_POST_ANALYSIS_SAMPLES =
+  12_000` and applies an upfront stride when the run is longer.
+- `apps/server/vibesensor/use_cases/run/raw_capture_replay.py` uses raw capture
+  only to rebuild FFT-derived metrics for those already-persisted summary rows.
+- `apps/server/vibesensor/use_cases/diagnostics/run_analysis.py` and
+  `analysis_pipeline.py` still operate on summary-style `SensorFrame` samples,
+  not on a true full-run raw-window graph.
+
+### Raw capture from #3065
+
+- Raw artifacts are already stored separately from `samples_v2`.
+- The canonical storage contract is
+  `apps/server/vibesensor/shared/types/raw_capture.py`:
+  - `RawCaptureManifest`
+  - `RawCaptureSensorManifest`
+  - `RawCaptureChunkIndex`
+  - `RawRunCapture`
+- Persistence uses `data/raw-runs/{run_id}/` with per-sensor
+  `.raw.i16le` and `.index.jsonl` files via
+  `apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py`.
+- The current read path is all-or-nothing:
+  `aload_raw_capture()` loads the full sensor arrays into memory before replay.
+
+### Persisted analysis and reporting
+
+- `apps/server/vibesensor/shared/types/history_analysis_contracts.py` owns the
+  outward persisted analysis/report payload shape.
+- `apps/server/vibesensor/shared/types/persisted_analysis.py` wraps that JSON as
+  `PersistedAnalysis`.
+- Report preparation in `apps/server/vibesensor/shared/boundaries/reporting/`
+  does not re-run diagnostics; it interprets persisted analysis only.
+- `apps/server/vibesensor/use_cases/history/report_document/` composes the final
+  `ReportDocument`, and `adapters/pdf` only renders it.
+
+## Why the current path is insufficient
+
+The current architecture already has strong raw capture and a stable
+reporting boundary, but it still has four blocking limitations for whole-run
+offline analysis:
+
+1. **No full-run raw window engine.** Raw capture is only used to rehydrate the
+   FFT-derived fields of summary rows, not to analyze the full run as a
+   deterministic window graph.
+2. **Long runs are sample-capped.** `post_analysis_loader.py` strides the input
+   once a run exceeds 12k persisted rows, which is incompatible with
+   whole-run trace continuity.
+3. **Summary-shaped contracts dominate.** Orders, phases, and location proof are
+   still derived from per-sample peak summaries and matched points instead of
+   first-class whole-run artifacts.
+4. **Persisted analysis JSON is the wrong place for heavy artifacts.** The
+   report/history path should keep consuming compact summary objects, not
+   tens of thousands of per-window spectra or traces.
+
+## Target architecture
+
+The target shape keeps the current one-time post-stop analysis model, but adds
+an internal whole-run artifact layer between raw capture and persisted
+diagnosis/report summaries.
+
+```text
+raw capture manifest/files (#3065)
+  -> indexed range/window reader
+  -> deterministic window planner
+  -> raw-window spectral executor
+  -> context timeline + segment labels
+  -> order traces / harmonic summaries
+  -> multi-sensor coherence + spatial evidence
+  -> evidence fusion + diagnosis ranking
+  -> compact persisted analysis summary + report-facing facts
+  -> history/report/PDF (no re-analysis)
+```
+
+### Layer responsibilities
+
+| Layer | Owner area | Responsibility |
+|---|---|---|
+| Raw artifact access | `adapters/persistence/history_db/`, `shared/types/raw_capture.py` | Range reads and manifest-aware raw loading without changing the hot write path |
+| Window planning | `use_cases/diagnostics/` | Derive a deterministic whole-run window grid from run metadata |
+| Whole-run spectra | `use_cases/diagnostics/`, `infra/processing/` | Reuse canonical FFT/strength primitives to compute per-window spectral outputs |
+| Context timeline | `use_cases/diagnostics/`, `shared/types/` | Normalize speed/RPM/context into per-window labels and segments |
+| Order traces | `use_cases/diagnostics/orders/` | Track candidate orders across the full run and summarize harmonic stability |
+| Spatial evidence | `use_cases/diagnostics/` | Measure cross-sensor agreement, coherence, and location separation |
+| Fusion/report summary | `use_cases/diagnostics/`, `shared/boundaries/reporting/` | Convert whole-run evidence into ranked diagnoses and compact persisted facts |
+
+## Early design decisions
+
+### Raw artifact shape
+
+Keep the #3065 raw artifact format as the canonical ingest-time storage model:
+
+- `RawCaptureManifest` in the `runs` row
+- `data/raw-runs/{run_id}/`
+- per-sensor `.raw.i16le`
+- per-sensor `.index.jsonl`
+
+Do **not** introduce a second ingest format for whole-run analysis. Add an
+indexed range/window reader on top of the current store instead.
+
+### Canonical whole-run window policy
+
+Whole-run analysis should default to the same spectral semantics the live path
+already records in metadata:
+
+- **window size** = `RunMetadata.fft_window_size_samples`
+- **stride** = `RunMetadata.feature_interval_s * RunMetadata.raw_sample_rate_hz`
+- **overlap** = `window_size - stride`
+- **integrality rule** = `feature_interval_s * raw_sample_rate_hz` must resolve to
+  an integral sample stride; reject non-integral stride metadata instead of
+  silently drifting window alignment
+
+With current defaults this means:
+
+- `fft_window_size_samples = 2048`
+- `feature_interval_s = 0.25`
+- `raw_sample_rate_hz = 800`
+- stride = `200` samples
+- overlap = `1848` samples (~90.2%)
+
+This preserves one canonical DSP interpretation and keeps whole-run outputs
+aligned with existing summary rows and report timing expectations.
+
+### What to persist vs recompute
+
+Persist heavy whole-run artifacts outside `analysis_json`.
+
+- **Persist in compact summary JSON (`PersistedAnalysis`)**
+  - top diagnosis summaries
+  - supporting-window counts and durations
+  - stable frequency bands
+  - phase/context summaries
+  - order-trace summaries
+  - spatial/coherence summaries
+  - support/counterevidence factor keys
+  - exemplar windows or intervals needed for reporting
+- **Persist in sidecar artifact storage**
+  - per-window spectral outputs
+  - dense order traces
+  - per-candidate cross-sensor matrices
+  - any high-cardinality debug/trace data
+- **Recompute from raw capture only when explicitly needed**
+  - full spectra/spectrograms beyond persisted summaries
+  - experimental diagnostics not part of the canonical report/history path
+
+### Join strategy across windows, context, orders, and sensors
+
+The canonical join key should be a deterministic run-level `window_index`
+defined by the window planner. Every downstream artifact should be keyed by:
+
+- `run_id`
+- `window_index`
+- `sensor_id` or sensor location when applicable
+
+Each `window_index` should also carry:
+
+- `sample_start`
+- `sample_end`
+- `center_sample`
+- `start_t_s`
+- `end_t_s`
+- `center_t_s`
+
+Context segments then refer to window index ranges, and order/spatial/fusion
+layers join against the same key instead of ad hoc timestamp matching.
+
+### Order-trace contract
+
+Whole-run order tracking should separate dense trace points from persisted
+summaries.
+
+- **Dense trace point**
+  - `candidate_key`
+  - `window_index`
+  - `sensor_id`
+  - `predicted_hz`
+  - `observed_hz`
+  - `relative_error`
+  - `amplitude_g` or derived dB
+  - `snr_db`
+  - `support_state`
+  - `phase_key`
+- **Persisted summary**
+  - support ratio
+  - contiguous support intervals
+  - harmonic support counts
+  - phase-specific support
+  - stable frequency/order bounds
+  - top supporting locations
+
+### Spatial/coherence contract
+
+Spatial evidence should not be just a whole-run `p95` intensity table. It
+should explicitly separate:
+
+- candidate-specific supporting windows
+- per-window per-sensor support
+- cross-sensor agreement/coherence summary
+- location separation in dB
+- ambiguity flags when the leading location is too close to the next best
+
+The report path can still project compact location proof from these summaries,
+but the source artifact should be candidate-aware and whole-run aware.
+
+### Counterevidence model
+
+Counterevidence should become a first-class persisted concept with stable keys,
+not just renderer-time prose. Good initial keys fit the current
+`confidence_facts.py` vocabulary:
+
+- `summary_only`
+- `sparse_support`
+- `brief_support`
+- `drifting_frequency`
+- `loose_order_lock`
+- `mixed_support_locations`
+- `weak_spatial`
+- `close_alternative`
+- `incomplete_reference`
+- `noisy_signal`
+
+Whole-run fusion can add new stable keys, but should continue producing compact,
+explainable factors that reporting can consume directly.
+
+## Shared contracts to settle early
+
+| Contract | Suggested owner | Notes |
+|---|---|---|
+| `WholeRunWindowPolicy` / `WholeRunWindowDescriptor` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` | Canonical sample-space policy and deterministic window identity for every later whole-run stage |
+| `WholeRunWindowSpectralSummary` | `use_cases/diagnostics/` with compact persisted projection | Per-window FFT/strength/top-peak outputs |
+| `WholeRunArtifactManifest` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` + later persistence store under `adapters/persistence/history_db/` | Sidecar manifest for dense whole-run artifacts; mirror the raw-capture pattern |
+| `RunContextInterval` / `WindowContextLabel` | `use_cases/diagnostics/` with report-facing projection in `shared/types/history_analysis_contracts.py` | Whole-run segments and per-window labels |
+| `OrderTracePoint` / `OrderTraceSummary` | `use_cases/diagnostics/orders/` with persisted summary projection | Dense trace vs compact report/history summary split |
+| `SpatialEvidenceSummary` | `use_cases/diagnostics/` with persisted summary projection | Candidate-level coherence and location separation |
+| `DiagnosisFactor` / `DiagnosisSummary` | diagnostics domain/use-case layer plus persisted projection | Explainable support and counterevidence for final ranking |
+
+## Persistence strategy
+
+The current `runs.analysis_json` payload should stay compact and report-facing.
+
+Recommended additions:
+
+1. Add a file-backed whole-run artifact store, parallel to
+   `HistoryRawCaptureStore`.
+2. Add a manifest reference on the run record (or another explicit persistence
+   seam) for dense analysis artifacts.
+3. Keep `PersistedAnalysis` as the stable history/report summary boundary.
+4. Store only compact summaries and exemplars in `PersistedAnalysis`.
+
+This keeps legacy report loading cheap and avoids turning the history DB blob
+into a large binary transport.
+
+## Performance and determinism
+
+### Likely hot spots
+
+- **I/O-bound**
+  - reading raw capture windows
+  - writing dense whole-run artifact sidecars
+- **CPU-bound**
+  - per-window FFT/strength computation
+  - order-trace evaluation
+  - multi-sensor coherence scoring
+  - fusion across many candidates
+- **Memory-bound**
+  - any design that loads full raw arrays for long multi-sensor runs
+  - retaining dense spectra for all windows in memory at once
+
+### Deterministic rules
+
+Whole-run execution should guarantee:
+
+1. the same raw input yields the same window grid
+2. reducers persist artifacts in stable sort order
+3. parallel workers never decide ordering implicitly
+4. tie-breaking is explicit by stable keys (candidate key, location, window index)
+5. floating-point reductions are gathered in a deterministic order before
+   persistence
+
+### Parallelization guidance
+
+Use existing bounded concurrency infrastructure from
+`apps/server/vibesensor/infra/workers/worker_pool.py` where it fits.
+
+Safe parallel boundaries:
+
+- per-sensor raw range reads
+- per-chunk spectral computation after window planning is fixed
+- per-candidate order trace scoring after spectral artifacts and context labels exist
+- per-candidate spatial scoring after aligned multi-sensor artifacts exist
+- per-diagnosis fusion after upstream summaries are stable
+
+Keep these sequential:
+
+- raw manifest finalization
+- global window planning
+- final persisted artifact ordering and serialization
+
+## Test strategy
+
+### Reuse existing seams
+
+- `apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py`
+- `apps/server/tests/use_cases/run/test_post_analysis_loader.py`
+- `apps/server/tests/use_cases/diagnostics/test_phase_segmentation.py`
+- `apps/server/tests/use_cases/diagnostics/test_analysis_pipeline_integration_regressions.py`
+- `apps/server/tests/use_cases/history/test_report_confidence_facts.py`
+- report separation guardrails in the PDF/history test suites
+
+### Add new coverage
+
+- raw range-reader unit tests over chunk boundaries
+- deterministic window-planner tests
+- whole-run spectral executor regression tests
+- context timeline tests with missing speed/RPM spans
+- order-trace synthetic scenarios with speed variation and harmonic changes
+- spatial/coherence scenarios for clear hotspot vs ambiguous location
+- fusion scenarios for clear, mixed, summary-only, and counterevidence-heavy runs
+
+## Benchmark strategy
+
+Reuse the existing explicit benchmark style:
+
+- `apps/server/tests/infra/workers/benchmark_compute_all.py`
+- `apps/server/tests/infra/processing/benchmark_rfft_backend.py`
+
+Add opt-in benchmarks for:
+
+- raw range-reader throughput
+- whole-run spectral executor throughput by sensor count and run length
+- worker-pool scaling vs sequential execution on Pi-sized datasets
+- order-trace evaluation cost by candidate family count
+- spatial/coherence cost by sensor count
+- end-to-end whole-run analysis memory peak on long runs
+
+## Summary-only and legacy fallback policy
+
+- If raw capture is absent, preserve the current summary-only diagnostics/report
+  path.
+- If raw capture exists but whole-run artifacts do not, continue to support the
+  current raw-backed replay behavior instead of failing the run.
+- Legacy persisted analyses must remain readable by history/report code.
+- New whole-run report facts should degrade to existing summary-only language and
+  confidence caveats where necessary.
+
+## Recommended implementation order
+
+1. Settle whole-run window contracts and sidecar artifact persistence.
+2. Add indexed raw range reads and the deterministic window planner.
+3. Build the raw-window spectral executor and benchmark it.
+4. Build the context timeline and segment labeling on the same window grid.
+5. Build order tracking and spatial/coherence in parallel on top of the shared
+   spectral/context artifacts.
+6. Build fusion, counterevidence, persisted diagnosis summaries, and report
+   wiring last.
+
+## Planned sub-issue breakdown
+
+### Parent #3075 — whole-run engine
+
+1. #3080 Define deterministic whole-run window contracts and artifact manifest
+2. #3081 Add indexed raw-capture range reads for offline window analysis
+3. #3082 Build the canonical whole-run window planner from run metadata
+4. #3083 Add a file-backed whole-run analysis artifact store and manifest plumbing
+5. #3084 Implement the raw-window spectral executor with deterministic chunk scheduling
+6. #3085 Benchmark the whole-run engine on Pi-sized runs
+
+### Parent #3076 — phase segmentation and context timelines
+
+1. #3086 Define whole-run context timeline and segment contracts
+2. #3087 Normalize full-run speed and RPM context onto the window grid
+3. #3088 Implement whole-run phase segmentation over normalized timelines
+4. #3089 Persist segment timelines and per-window context labels
+5. #3090 Surface context completeness and fallback signals to history and report consumers
+
+### Parent #3077 — order tracking and harmonic stability
+
+1. #3091 Define whole-run order-trace and harmonic evidence contracts
+2. #3092 Build per-candidate order traces from window spectra and context labels
+3. #3093 Add harmonic stability and order-lock scoring across the full run
+4. #3094 Summarize order traces by source family, phase, and support intervals
+5. #3095 Persist ranked order-trace summaries and exemplars for downstream fusion
+
+### Parent #3078 — multi-sensor coherence and spatial evidence
+
+1. #3096 Define multi-sensor coherence and spatial evidence contracts
+2. #3097 Join aligned per-window sensor outputs with coverage and missing-data rules
+3. #3098 Implement candidate-level coherence and cross-sensor agreement metrics
+4. #3099 Implement spatial separation and supporting-window hotspot summaries
+5. #3100 Persist spatial evidence and proof-basis summaries for downstream fusion
+
+### Parent #3079 — fusion, counterevidence, and diagnosis ranking
+
+1. #3101 Define persisted whole-run evidence fusion and diagnosis summary contracts
+2. #3102 Model support factors and counterevidence factors with stable keys
+3. #3103 Implement the diagnosis ranker over context, order, and spatial evidence
+4. #3104 Add summary-only and partial-artifact fallback scoring for legacy runs
+5. #3105 Expose fused diagnosis evidence through history and report preparation and PDF surfaces
+6. #3106 Add cross-scenario regression coverage for clear, mixed, and ambiguous whole-run diagnoses


### PR DESCRIPTION
Closes #3080.

## What changed
- add `shared/types/whole_run_analysis.py` for `WholeRunWindowPolicy`, `WholeRunWindowDescriptor`, `WholeRunArtifactFile`, and `WholeRunArtifactManifest`
- derive the whole-run window policy from existing `RunMetadata` fields
- make stride validity explicit: `feature_interval_s * raw_sample_rate_hz` must resolve to an integral sample stride and stay within the FFT window
- add focused shared-type coverage for policy derivation, descriptor timing, and manifest round-trip behavior
- update the whole-run design doc to point at the live contract names and the stride integrality rule

## Why
Later whole-run issues need one canonical window identity and one sidecar artifact manifest boundary. This lands that contract first and keeps raw reads, planner execution, DB plumbing, and scoring logic out of scope.

## Validation
- `make typecheck-backend`
- `make test-changed`
- `make lint`

## Risks / tradeoffs
- whole-run analysis now treats non-integral metadata stride as invalid instead of silently rounding drift into the window grid
- persisted-analysis JSON and DB plumbing are still untouched here; that stays with follow-on artifact-store work
