### PR TITLE
Add indexed raw-capture range reads

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
@@ -41,6 +41,24 @@ def _load_raw_capture(db, run_id: str):
     return db.run_repository._run_sync(db.run_repository.aload_raw_capture(run_id))
 
 
+def _load_raw_capture_range(
+    db,
+    *,
+    run_id: str,
+    client_id: str,
+    sample_start: int,
+    sample_count: int,
+):
+    return db.run_repository._run_sync(
+        db.run_repository.aload_raw_capture_sensor_range(
+            run_id,
+            client_id,
+            sample_start=sample_start,
+            sample_count=sample_count,
+        )
+    )
+
+
 def test_raw_capture_round_trip_persists_manifest_and_samples(tmp_path: Path) -> None:
     db = build_history_db(tmp_path)
     create_recording_run(db, "run-raw")
@@ -85,6 +103,71 @@ def test_delete_run_removes_raw_capture_artifacts(tmp_path: Path) -> None:
     db.run_repository.delete_run("run-delete")
 
     assert not raw_dir.exists()
+
+
+def test_raw_capture_range_read_spans_chunk_boundaries_without_loading_full_capture(
+    tmp_path: Path,
+) -> None:
+    db = build_history_db(tmp_path)
+    create_recording_run(db, "run-range")
+    first = np.asarray([[1, 2, 3], [4, 5, 6]], dtype=np.int16)
+    second = np.asarray([[7, 8, 9], [10, 11, 12], [13, 14, 15]], dtype=np.int16)
+
+    _append_chunk(db, run_id="run-range", client_id="sensor-a", t0_us=1000, samples=first)
+    _append_chunk(db, run_id="run-range", client_id="sensor-a", t0_us=2000, samples=second)
+    manifest = _finalize_raw_capture(db, "run-range")
+
+    assert manifest is not None
+    loaded = _load_raw_capture_range(
+        db,
+        run_id="run-range",
+        client_id="sensor-a",
+        sample_start=1,
+        sample_count=3,
+    )
+
+    assert loaded is not None
+    assert loaded.coverage_state == "full"
+    assert loaded.returned_sample_start == 1
+    assert loaded.returned_sample_count == 3
+    assert len(loaded.chunks) == 2
+    assert np.array_equal(loaded.samples_i16, np.vstack([first[1:], second[:2]]))
+
+
+def test_raw_capture_range_read_marks_partial_and_missing_coverage(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    create_recording_run(db, "run-partial")
+    samples = np.asarray([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.int16)
+
+    _append_chunk(db, run_id="run-partial", client_id="sensor-a", t0_us=1000, samples=samples)
+    manifest = _finalize_raw_capture(db, "run-partial")
+
+    assert manifest is not None
+    partial = _load_raw_capture_range(
+        db,
+        run_id="run-partial",
+        client_id="sensor-a",
+        sample_start=2,
+        sample_count=3,
+    )
+    missing = _load_raw_capture_range(
+        db,
+        run_id="run-partial",
+        client_id="sensor-b",
+        sample_start=0,
+        sample_count=2,
+    )
+
+    assert partial is not None
+    assert partial.coverage_state == "partial"
+    assert partial.returned_sample_start == 2
+    assert partial.returned_sample_count == 1
+    assert np.array_equal(partial.samples_i16, samples[2:])
+
+    assert missing is not None
+    assert missing.coverage_state == "missing"
+    assert missing.returned_sample_start is None
+    assert missing.returned_sample_count == 0
 
 
 def test_prune_terminal_runs_removes_raw_capture_artifacts(tmp_path: Path) -> None:

--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -22,7 +22,11 @@ from vibesensor.shared.types.persisted_analysis import (
     PERSISTED_ANALYSIS_SCHEMA_VERSION,
     PersistedAnalysis,
 )
-from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureManifest,
+    RawCaptureSensorRange,
+    RawRunCapture,
+)
 from vibesensor.use_cases.history.runs import HistoryRunService
 
 pytestmark = pytest.mark.smoke
@@ -42,6 +46,20 @@ class _RunPersistenceStub:
 
     async def aload_raw_capture(self, _run_id: str) -> RawRunCapture | None:
         return None
+
+    async def aload_raw_capture_sensor_range(
+        self,
+        _run_id: str,
+        client_id: str,
+        *,
+        sample_start: int,
+        sample_count: int,
+    ) -> RawCaptureSensorRange | None:
+        return RawCaptureSensorRange.missing(
+            client_id=client_id,
+            requested_sample_start=sample_start,
+            requested_sample_count=sample_count,
+        )
 
 
 def _representative_summary() -> AnalysisSummary:

--- a/apps/server/tests/use_cases/run/test_post_analysis_loader.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_loader.py
@@ -6,6 +6,7 @@ import pytest
 
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.types.raw_capture import RawCaptureSensorRange
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.use_cases.run.post_analysis_loader import (
     EmptyPostAnalysisSamples,
@@ -57,6 +58,20 @@ def test_load_post_analysis_run_returns_loaded_run() -> None:
         async def aload_raw_capture(self, _run_id):
             return None
 
+        async def aload_raw_capture_sensor_range(
+            self,
+            _run_id,
+            client_id,
+            *,
+            sample_start,
+            sample_count,
+        ):
+            return RawCaptureSensorRange.missing(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+            )
+
     result = load_post_analysis_run(run_id="run-ok", db=FakeDB())
 
     assert isinstance(result, LoadedPostAnalysisRun)
@@ -78,6 +93,20 @@ def test_load_post_analysis_run_handles_missing_metadata() -> None:
         async def aload_raw_capture(self, _run_id):
             return None
 
+        async def aload_raw_capture_sensor_range(
+            self,
+            _run_id,
+            client_id,
+            *,
+            sample_start,
+            sample_count,
+        ):
+            return RawCaptureSensorRange.missing(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+            )
+
     result = load_post_analysis_run(run_id="run-missing", db=FakeDB())
 
     assert isinstance(result, MissingPostAnalysisMetadata)
@@ -97,6 +126,20 @@ def test_load_post_analysis_run_handles_no_samples() -> None:
 
         async def aload_raw_capture(self, _run_id):
             return None
+
+        async def aload_raw_capture_sensor_range(
+            self,
+            _run_id,
+            client_id,
+            *,
+            sample_start,
+            sample_count,
+        ):
+            return RawCaptureSensorRange.missing(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+            )
 
     result = load_post_analysis_run(run_id="run-empty", db=FakeDB())
 
@@ -130,6 +173,20 @@ def test_load_post_analysis_run_applies_upfront_stride(
         async def aload_raw_capture(self, _run_id):
             return None
 
+        async def aload_raw_capture_sensor_range(
+            self,
+            _run_id,
+            client_id,
+            *,
+            sample_start,
+            sample_count,
+        ):
+            return RawCaptureSensorRange.missing(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+            )
+
     result = load_post_analysis_run(run_id="run-capped", db=FakeDB())
 
     assert isinstance(result, LoadedPostAnalysisRun)
@@ -153,6 +210,20 @@ def test_load_post_analysis_run_defaults_language_to_en() -> None:
 
         async def aload_raw_capture(self, _run_id):
             return None
+
+        async def aload_raw_capture_sensor_range(
+            self,
+            _run_id,
+            client_id,
+            *,
+            sample_start,
+            sample_count,
+        ):
+            return RawCaptureSensorRange.missing(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+            )
 
     result = load_post_analysis_run(run_id="run-lang", db=FakeDB())
 

--- a/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
@@ -27,7 +27,11 @@ from vibesensor.shared.types.history_records import (
 )
 from vibesensor.shared.types.json_types import is_json_object
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
-from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureManifest,
+    RawCaptureSensorRange,
+    RawRunCapture,
+)
 from vibesensor.shared.types.run_schema import RunMetadata
 
 LOGGER = logging.getLogger(__name__)
@@ -253,6 +257,25 @@ class _HistoryDBQueryMixin:
         if manifest is None:
             return None
         return await asyncio.to_thread(self._raw_capture_store.load_capture, manifest)
+
+    async def aload_raw_capture_sensor_range(
+        self,
+        run_id: str,
+        client_id: str,
+        *,
+        sample_start: int,
+        sample_count: int,
+    ) -> RawCaptureSensorRange | None:
+        manifest = await self.aget_raw_capture_manifest(run_id)
+        if manifest is None:
+            return None
+        return await asyncio.to_thread(
+            self._raw_capture_store.load_sensor_range,
+            manifest,
+            client_id=client_id,
+            sample_start=sample_start,
+            sample_count=sample_count,
+        )
 
     def get_run_metadata(self, run_id: str) -> RunMetadata | None:
         return self._run_sync(self.aget_run_metadata(run_id))

--- a/apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py
@@ -16,12 +16,17 @@ from vibesensor.shared.types.json_types import is_json_object
 from vibesensor.shared.types.raw_capture import (
     RawCaptureChunk,
     RawCaptureChunkIndex,
+    RawCaptureCoverageState,
     RawCaptureManifest,
     RawCaptureSensorData,
     RawCaptureSensorManifest,
+    RawCaptureSensorRange,
     RawRunCapture,
 )
 
+_AXIS_COUNT = 3
+_BYTES_PER_AXIS = 2
+_BYTES_PER_SAMPLE = _AXIS_COUNT * _BYTES_PER_AXIS
 _MANIFEST_FILE_NAME = "manifest.json"
 _RAW_CAPTURE_DIR_NAME = "raw-runs"
 
@@ -127,20 +132,9 @@ class HistoryRawCaptureStore:
         sensors: list[RawCaptureSensorData] = []
         for sensor_manifest in manifest.sensors:
             data_path = run_dir / sensor_manifest.data_file
-            raw_bytes = data_path.read_bytes()
-            samples_i16 = np.frombuffer(raw_bytes, dtype=np.dtype("<i2")).copy()
-            if samples_i16.size % 3 != 0:
-                raise ValueError(
-                    f"raw capture {data_path} length {samples_i16.size} is not divisible by 3 axes"
-                )
-            reshaped = samples_i16.reshape(-1, 3)
             index_path = run_dir / sensor_manifest.index_file
-            chunk_indexes: list[RawCaptureChunkIndex] = []
-            if index_path.exists():
-                for line in index_path.read_text(encoding="utf-8").splitlines():
-                    parsed = safe_json_loads(line, context=f"raw capture index {index_path}")
-                    if is_json_object(parsed):
-                        chunk_indexes.append(RawCaptureChunkIndex.from_mapping(parsed))
+            reshaped = self._read_all_sensor_samples(data_path)
+            chunk_indexes = self._load_chunk_indexes(index_path)
             sensors.append(
                 RawCaptureSensorData(
                     manifest=sensor_manifest,
@@ -149,6 +143,88 @@ class HistoryRawCaptureStore:
                 )
             )
         return RawRunCapture(manifest=manifest, sensors=tuple(sensors))
+
+    def load_sensor_range(
+        self,
+        manifest: RawCaptureManifest,
+        *,
+        client_id: str,
+        sample_start: int,
+        sample_count: int,
+    ) -> RawCaptureSensorRange:
+        if sample_start < 0:
+            raise ValueError("raw capture range requires sample_start >= 0")
+        if sample_count <= 0:
+            raise ValueError("raw capture range requires sample_count > 0")
+        sensor_manifest = manifest.sensor_manifest(client_id)
+        if sensor_manifest is None:
+            return RawCaptureSensorRange.missing(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+            )
+        available_count = max(0, int(sensor_manifest.sample_count))
+        if sample_start >= available_count:
+            return RawCaptureSensorRange(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+                coverage_state="empty",
+                samples_i16=np.empty((0, _AXIS_COUNT), dtype=np.int16),
+                manifest=sensor_manifest,
+                returned_sample_start=sample_start,
+            )
+        actual_start = sample_start
+        actual_end = min(sample_start + sample_count, available_count)
+        actual_count = max(0, actual_end - actual_start)
+        if actual_count <= 0:
+            return RawCaptureSensorRange(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+                coverage_state="empty",
+                samples_i16=np.empty((0, _AXIS_COUNT), dtype=np.int16),
+                manifest=sensor_manifest,
+                returned_sample_start=sample_start,
+            )
+        run_dir = self._data_dir / manifest.relative_dir
+        index_path = run_dir / sensor_manifest.index_file
+        chunk_indexes = tuple(self._load_chunk_indexes(index_path))
+        overlapping_chunks = _overlapping_chunks(
+            chunk_indexes,
+            sample_start=actual_start,
+            sample_end=actual_end,
+        )
+        if not overlapping_chunks:
+            raise ValueError(
+                f"raw capture index {index_path} has no chunk coverage for "
+                f"{client_id} samples [{actual_start}, {actual_end})"
+            )
+        first_chunk = overlapping_chunks[0]
+        byte_offset = first_chunk.byte_offset + (
+            (actual_start - first_chunk.sample_start) * _BYTES_PER_SAMPLE
+        )
+        samples_i16 = self._read_sensor_range_samples(
+            run_dir / sensor_manifest.data_file,
+            byte_offset=byte_offset,
+            sample_count=actual_count,
+        )
+        returned_count = int(samples_i16.shape[0])
+        coverage_state: RawCaptureCoverageState = (
+            "full" if returned_count == sample_count else "partial"
+        )
+        if returned_count <= 0:
+            coverage_state = "empty"
+        return RawCaptureSensorRange(
+            client_id=client_id,
+            requested_sample_start=sample_start,
+            requested_sample_count=sample_count,
+            coverage_state=coverage_state,
+            samples_i16=samples_i16,
+            manifest=sensor_manifest,
+            returned_sample_start=actual_start,
+            chunks=overlapping_chunks,
+        )
 
     def delete_run_artifacts(self, run_id: str) -> None:
         with self._lock:
@@ -161,6 +237,39 @@ class HistoryRawCaptureStore:
 
     def run_dir(self, run_id: str) -> Path:
         return self._base_dir / run_id
+
+    def _load_chunk_indexes(self, index_path: Path) -> list[RawCaptureChunkIndex]:
+        chunk_indexes: list[RawCaptureChunkIndex] = []
+        if not index_path.exists():
+            return chunk_indexes
+        for line in index_path.read_text(encoding="utf-8").splitlines():
+            parsed = safe_json_loads(line, context=f"raw capture index {index_path}")
+            if is_json_object(parsed):
+                chunk_indexes.append(RawCaptureChunkIndex.from_mapping(parsed))
+        return chunk_indexes
+
+    def _read_all_sensor_samples(self, data_path: Path) -> np.ndarray:
+        return self._reshape_samples(raw_bytes=data_path.read_bytes(), data_path=data_path)
+
+    def _read_sensor_range_samples(
+        self,
+        data_path: Path,
+        *,
+        byte_offset: int,
+        sample_count: int,
+    ) -> np.ndarray:
+        with data_path.open("rb") as handle:
+            handle.seek(byte_offset)
+            raw_bytes = handle.read(sample_count * _BYTES_PER_SAMPLE)
+        return self._reshape_samples(raw_bytes=raw_bytes, data_path=data_path)
+
+    def _reshape_samples(self, *, raw_bytes: bytes, data_path: Path) -> np.ndarray:
+        samples_i16 = np.frombuffer(raw_bytes, dtype=np.dtype("<i2")).copy()
+        if samples_i16.size % _AXIS_COUNT != 0:
+            raise ValueError(
+                f"raw capture {data_path} length {samples_i16.size} is not divisible by 3 axes"
+            )
+        return samples_i16.reshape(-1, _AXIS_COUNT)
 
     def _ensure_stream(
         self,
@@ -186,3 +295,17 @@ class HistoryRawCaptureStore:
         )
         run_streams[client_id] = stream
         return stream
+
+
+def _overlapping_chunks(
+    chunks: tuple[RawCaptureChunkIndex, ...],
+    *,
+    sample_start: int,
+    sample_end: int,
+) -> tuple[RawCaptureChunkIndex, ...]:
+    return tuple(
+        chunk
+        for chunk in chunks
+        if chunk.sample_start < sample_end
+        and (chunk.sample_start + chunk.sample_count) > sample_start
+    )

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -17,6 +17,7 @@ from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.raw_capture import (
     RawCaptureChunk,
     RawCaptureManifest,
+    RawCaptureSensorRange,
     RawRunCapture,
 )
 from vibesensor.shared.types.run_schema import RunMetadata
@@ -116,6 +117,15 @@ class RunPersistence(Protocol):
     async def aget_raw_capture_manifest(self, run_id: str) -> RawCaptureManifest | None: ...
 
     async def aload_raw_capture(self, run_id: str) -> RawRunCapture | None: ...
+
+    async def aload_raw_capture_sensor_range(
+        self,
+        run_id: str,
+        client_id: str,
+        *,
+        sample_start: int,
+        sample_count: int,
+    ) -> RawCaptureSensorRange | None: ...
 
     async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]: ...
 

--- a/apps/server/vibesensor/shared/types/raw_capture.py
+++ b/apps/server/vibesensor/shared/types/raw_capture.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -15,10 +16,12 @@ __all__ = [
     "RawCaptureManifest",
     "RawCaptureSensorData",
     "RawCaptureSensorManifest",
+    "RawCaptureSensorRange",
     "RawRunCapture",
 ]
 
 type Int16Array = npt.NDArray[np.int16]
+type RawCaptureCoverageState = Literal["missing", "empty", "partial", "full"]
 
 _RAW_CAPTURE_SCHEMA_VERSION = 1
 _RAW_CAPTURE_STORAGE_TYPE = "run-directory-v1"
@@ -172,6 +175,56 @@ class RawCaptureSensorData:
 
 
 @dataclass(frozen=True, slots=True)
+class RawCaptureSensorRange:
+    """One manifest-aware raw-capture range read with explicit coverage state."""
+
+    client_id: str
+    requested_sample_start: int
+    requested_sample_count: int
+    coverage_state: RawCaptureCoverageState
+    samples_i16: Int16Array
+    manifest: RawCaptureSensorManifest | None = None
+    returned_sample_start: int | None = None
+    chunks: tuple[RawCaptureChunkIndex, ...] = ()
+
+    @classmethod
+    def missing(
+        cls,
+        *,
+        client_id: str,
+        requested_sample_start: int,
+        requested_sample_count: int,
+    ) -> RawCaptureSensorRange:
+        return cls(
+            client_id=client_id,
+            requested_sample_start=requested_sample_start,
+            requested_sample_count=requested_sample_count,
+            coverage_state="missing",
+            samples_i16=_empty_i16_samples(),
+        )
+
+    @property
+    def returned_sample_count(self) -> int:
+        if self.samples_i16.ndim <= 0:
+            return 0
+        return int(self.samples_i16.shape[0])
+
+    @property
+    def requested_sample_end(self) -> int:
+        return self.requested_sample_start + self.requested_sample_count
+
+    @property
+    def returned_sample_end(self) -> int | None:
+        if self.returned_sample_start is None:
+            return None
+        return self.returned_sample_start + self.returned_sample_count
+
+    @property
+    def has_full_coverage(self) -> bool:
+        return self.coverage_state == "full"
+
+
+@dataclass(frozen=True, slots=True)
 class RawRunCapture:
     """Fully loaded raw capture bundle for one run."""
 
@@ -203,3 +256,7 @@ def _int_from_json(value: JsonValue | object, default: int = 0) -> int:
 
 def _str_from_json(value: JsonValue | object, default: str = "") -> str:
     return value if isinstance(value, str) else default
+
+
+def _empty_i16_samples() -> Int16Array:
+    return np.empty((0, 3), dtype=np.int16)


### PR DESCRIPTION
Closes #3081.

## What changed
- add `RawCaptureSensorRange` so raw range reads return explicit `full` / `partial` / `empty` / `missing` coverage instead of a silent slice
- add `aload_raw_capture_sensor_range(...)` to the `RunPersistence` boundary and the history-db query adapter
- teach `HistoryRawCaptureStore` to read exact sample ranges from the existing `.raw.i16le` + `.index.jsonl` artifacts without loading whole sensor arrays
- use chunk indexes to locate overlapping chunks and support deterministic reads across chunk boundaries
- extend history-db raw-capture tests for cross-chunk reads, partial trailing coverage, and missing sensor coverage
- update typed test doubles that implement `RunPersistence`

## Why
Whole-run analysis needs exact raw windows. The old path only had `aload_raw_capture()`, which loads the whole sensor stream into memory. This lands the smaller boundary first and keeps the existing write format unchanged.

## Validation
- `cd apps/server && /workspace/VibeSensor/.venv/bin/python -m pytest -q -o addopts= tests/adapters/persistence/history_db/test_history_db_raw_capture.py tests/use_cases/run/test_post_analysis_loader.py tests/integration/test_contract_analysis_persistence_http.py`\n- `make typecheck-backend`\n- `make test-changed`\n- `make lint`\n\n## Risks / tradeoffs\n- missing run-level raw capture still returns `None`; missing sensor coverage inside an existing raw bundle is now explicit in `RawCaptureSensorRange`\n- this does not build the window planner or spectral executor yet; it only lands the read primitive they need\n