### PR TITLE
Add whole-run window planner

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_window_planner.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_window_planner.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.use_cases.diagnostics.whole_run_windows import plan_whole_run_windows
+
+
+def _metadata(
+    *,
+    raw_sample_rate_hz: int | None = 800,
+    feature_interval_s: float | None = 0.25,
+    fft_window_size_samples: int | None = 2048,
+) -> RunMetadata:
+    return RunMetadata.create(
+        run_id="run-1",
+        start_time_utc="2025-01-01T00:00:00Z",
+        sensor_model="fixture-sensor",
+        raw_sample_rate_hz=raw_sample_rate_hz,
+        feature_interval_s=feature_interval_s,
+        fft_window_size_samples=fft_window_size_samples,
+        accel_scale_g_per_lsb=0.001,
+    )
+
+
+def test_window_planner_builds_deterministic_grid_from_metadata() -> None:
+    plan = plan_whole_run_windows(metadata=_metadata(), total_sample_count=2648)
+
+    assert plan.total_window_count == 4
+    assert [window.window_index for window in plan.windows] == [0, 1, 2, 3]
+    assert [window.sample_start for window in plan.windows] == [0, 200, 400, 600]
+    assert [window.sample_end for window in plan.windows] == [2048, 2248, 2448, 2648]
+    assert plan.window(3) == plan.windows[3]
+    assert plan.window(4) is None
+    assert plan.expected_sensor_sample_count == 2048
+    assert plan.expected_sensor_coverage_start == 0
+    assert plan.expected_sensor_coverage_end == 2648
+    assert plan.dropped_trailing_samples == 0
+    assert plan.trailing_window_policy == "drop_incomplete_trailing"
+
+
+def test_window_planner_drops_incomplete_trailing_window_samples() -> None:
+    plan = plan_whole_run_windows(
+        metadata=_metadata(),
+        total_sample_count=2048 + 199,
+    )
+
+    assert plan.total_window_count == 1
+    assert plan.windows[0].sample_start == 0
+    assert plan.windows[0].sample_end == 2048
+    assert plan.expected_sensor_coverage_end == 2048
+    assert plan.dropped_trailing_samples == 199
+
+
+def test_window_planner_returns_empty_grid_for_short_runs() -> None:
+    plan = plan_whole_run_windows(metadata=_metadata(), total_sample_count=1024)
+
+    assert plan.windows == ()
+    assert plan.total_window_count == 0
+    assert plan.expected_sensor_coverage_start is None
+    assert plan.expected_sensor_coverage_end is None
+    assert plan.dropped_trailing_samples == 1024
+
+
+def test_window_planner_handles_exact_boundary_for_second_window() -> None:
+    plan = plan_whole_run_windows(
+        metadata=_metadata(),
+        total_sample_count=2048 + 200,
+    )
+
+    assert plan.total_window_count == 2
+    assert [window.sample_start for window in plan.windows] == [0, 200]
+    assert plan.dropped_trailing_samples == 0
+
+
+def test_window_planner_rejects_negative_total_sample_count() -> None:
+    with pytest.raises(ValueError, match="total_sample_count >= 0"):
+        plan_whole_run_windows(metadata=_metadata(), total_sample_count=-1)

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_windows.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_windows.py
@@ -1,0 +1,96 @@
+"""Deterministic whole-run window planning over persisted run metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunWindowDescriptor,
+    WholeRunWindowPolicy,
+)
+
+type TrailingWindowPolicy = Literal["drop_incomplete_trailing"]
+
+__all__ = [
+    "TrailingWindowPolicy",
+    "WholeRunWindowPlan",
+    "plan_whole_run_windows",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunWindowPlan:
+    """Deterministic whole-run window grid shared by later offline analysis stages."""
+
+    policy: WholeRunWindowPolicy
+    total_sample_count: int
+    windows: tuple[WholeRunWindowDescriptor, ...]
+    trailing_window_policy: TrailingWindowPolicy = "drop_incomplete_trailing"
+
+    @property
+    def total_window_count(self) -> int:
+        return len(self.windows)
+
+    @property
+    def expected_sensor_sample_count(self) -> int:
+        return self.policy.window_size_samples
+
+    @property
+    def expected_sensor_coverage_start(self) -> int | None:
+        if not self.windows:
+            return None
+        return self.windows[0].sample_start
+
+    @property
+    def expected_sensor_coverage_end(self) -> int | None:
+        if not self.windows:
+            return None
+        return self.windows[-1].sample_end
+
+    @property
+    def dropped_trailing_samples(self) -> int:
+        expected_end = self.expected_sensor_coverage_end
+        if expected_end is None:
+            return self.total_sample_count
+        return max(0, self.total_sample_count - expected_end)
+
+    def window(self, window_index: int) -> WholeRunWindowDescriptor | None:
+        if window_index < 0 or window_index >= len(self.windows):
+            return None
+        return self.windows[window_index]
+
+
+def plan_whole_run_windows(
+    *,
+    metadata: RunMetadata,
+    total_sample_count: int,
+) -> WholeRunWindowPlan:
+    """Return the canonical whole-run window grid for one persisted run."""
+
+    if total_sample_count < 0:
+        raise ValueError("whole-run window planner requires total_sample_count >= 0")
+    policy = WholeRunWindowPolicy.from_metadata(metadata)
+    if total_sample_count < policy.window_size_samples:
+        return WholeRunWindowPlan(
+            policy=policy,
+            total_sample_count=total_sample_count,
+            windows=(),
+        )
+    max_sample_start = total_sample_count - policy.window_size_samples
+    windows = tuple(
+        WholeRunWindowDescriptor.from_policy(
+            window_index=window_index,
+            sample_start=sample_start,
+            policy=policy,
+        )
+        for window_index, sample_start in enumerate(
+            range(0, max_sample_start + 1, policy.stride_samples)
+        )
+    )
+    return WholeRunWindowPlan(
+        policy=policy,
+        total_sample_count=total_sample_count,
+        windows=windows,
+    )

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -189,6 +189,11 @@ Each `window_index` should also carry:
 Context segments then refer to window index ranges, and order/spatial/fusion
 layers join against the same key instead of ad hoc timestamp matching.
 
+The canonical planner now lives in
+`apps/server/vibesensor/use_cases/diagnostics/whole_run_windows.py` and uses an
+explicit **drop incomplete trailing windows** policy. Runs shorter than one FFT
+window produce an empty grid instead of padded or synthetic windows.
+
 ### Order-trace contract
 
 Whole-run order tracking should separate dense trace points from persisted
@@ -252,6 +257,7 @@ explainable factors that reporting can consume directly.
 | Contract | Suggested owner | Notes |
 |---|---|---|
 | `WholeRunWindowPolicy` / `WholeRunWindowDescriptor` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` | Canonical sample-space policy and deterministic window identity for every later whole-run stage |
+| `WholeRunWindowPlan` / `plan_whole_run_windows(...)` | `apps/server/vibesensor/use_cases/diagnostics/whole_run_windows.py` | Deterministic window grid planner with explicit trailing-window policy |
 | `WholeRunWindowSpectralSummary` | `use_cases/diagnostics/` with compact persisted projection | Per-window FFT/strength/top-peak outputs |
 | `WholeRunArtifactManifest` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` + later persistence store under `adapters/persistence/history_db/` | Sidecar manifest for dense whole-run artifacts; mirror the raw-capture pattern |
 | `RunContextInterval` / `WindowContextLabel` | `use_cases/diagnostics/` with report-facing projection in `shared/types/history_analysis_contracts.py` | Whole-run segments and per-window labels |


### PR DESCRIPTION
Closes #3082.

## What changed
- add `use_cases/diagnostics/whole_run_windows.py` with `WholeRunWindowPlan` and `plan_whole_run_windows(...)`
- derive the deterministic whole-run window grid from the existing `WholeRunWindowPolicy` / run metadata contract
- make the trailing-window rule explicit: drop incomplete trailing windows instead of padding or inventing synthetic samples
- expose stable per-window sample/time bounds and plan-level sensor coverage expectations for downstream joins
- add focused diagnostics tests for deterministic ordering, short runs, exact-boundary behavior, trailing drops, and invalid sample-count input
- update the whole-run design doc to point at the live planner module and the selected trailing-window policy

## Why
Later context, order, spatial, and executor stages need one canonical window grid. This lands that planner first and keeps reads, FFT work, and persistence plumbing out of scope.

## Validation
- `cd apps/server && /workspace/VibeSensor/.venv/bin/python -m pytest -q -o addopts= tests/use_cases/diagnostics/test_whole_run_window_planner.py`\n- `make typecheck-backend`\n- `make test-changed`\n- `make lint`\n\n## Risks / tradeoffs\n- runs shorter than one FFT window now plan to zero windows instead of padded fallback windows\n- incomplete trailing coverage is dropped on purpose; if a later issue wants padding, it should be an explicit contract change instead of planner drift\n