### PR TITLE
Add whole-run artifact sidecar storage

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_whole_run_artifacts.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_whole_run_artifacts.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from test_support.history_db_async import execute_statements as _execute_statements
+from test_support.history_db_lifecycle import (
+    build_history_db,
+    create_completed_run,
+    create_recording_run,
+)
+
+from vibesensor.shared.types.whole_run_analysis import (
+    WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME,
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunWindowPolicy,
+)
+
+
+def _manifest(run_id: str) -> WholeRunArtifactManifest:
+    return WholeRunArtifactManifest(
+        run_id=run_id,
+        relative_dir=f"{WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME}/{run_id}",
+        window_policy=WholeRunWindowPolicy(
+            sample_rate_hz=800,
+            window_size_samples=2048,
+            stride_samples=200,
+            overlap_samples=1848,
+            feature_interval_s=0.25,
+        ),
+        total_window_count=4,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="window-spectra",
+                relative_path="window-spectra.bin",
+                file_format="bin",
+                record_count=4,
+            ),
+            WholeRunArtifactFile(
+                artifact_key="order-traces",
+                relative_path="orders/order-traces.jsonl",
+                file_format="jsonl",
+                record_count=7,
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+
+
+def _store_whole_run_artifacts(
+    db,
+    run_id: str,
+    manifest: WholeRunArtifactManifest,
+) -> WholeRunArtifactManifest | None:
+    return db.run_repository._run_sync(
+        db.run_repository.astore_whole_run_artifacts(
+            run_id,
+            manifest,
+            artifact_contents={
+                "window-spectra": b"spec-data",
+                "order-traces": b'{"window_index":0}\n',
+            },
+        )
+    )
+
+
+def test_whole_run_artifact_round_trip_persists_manifest_and_bytes(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    create_recording_run(db, "run-artifacts")
+    manifest = _manifest("run-artifacts")
+
+    stored_manifest = _store_whole_run_artifacts(db, "run-artifacts", manifest)
+
+    assert stored_manifest == manifest
+    stored_run = db.run_repository.get_run("run-artifacts")
+    assert stored_run is not None
+    assert stored_run.whole_run_artifact_manifest == manifest
+    loaded_manifest = db.run_repository._run_sync(
+        db.run_repository.aget_whole_run_artifact_manifest("run-artifacts")
+    )
+    assert loaded_manifest == manifest
+    loaded_bytes = db.run_repository._run_sync(
+        db.run_repository.aload_whole_run_artifact("run-artifacts", "window-spectra")
+    )
+    assert loaded_bytes == b"spec-data"
+
+
+def test_legacy_run_without_whole_run_sidecar_remains_readable(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    create_completed_run(db, "run-legacy")
+
+    stored_run = db.run_repository.get_run("run-legacy")
+
+    assert stored_run is not None
+    assert stored_run.whole_run_artifact_manifest is None
+    assert (
+        db.run_repository._run_sync(
+            db.run_repository.aget_whole_run_artifact_manifest("run-legacy")
+        )
+        is None
+    )
+
+
+def test_delete_run_removes_whole_run_artifacts(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    create_recording_run(db, "run-delete")
+    manifest = _manifest("run-delete")
+
+    stored_manifest = _store_whole_run_artifacts(db, "run-delete", manifest)
+
+    assert stored_manifest is not None
+    artifact_dir = tmp_path / WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME / "run-delete"
+    assert artifact_dir.exists()
+
+    db.run_repository.delete_run("run-delete")
+
+    assert not artifact_dir.exists()
+
+
+def test_store_whole_run_artifacts_cleans_up_when_run_is_missing(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    manifest = _manifest("run-missing")
+
+    stored_manifest = _store_whole_run_artifacts(db, "run-missing", manifest)
+
+    assert stored_manifest is None
+    artifact_dir = tmp_path / WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME / "run-missing"
+    assert not artifact_dir.exists()
+
+
+def test_prune_terminal_runs_removes_whole_run_artifacts(tmp_path: Path) -> None:
+    db = build_history_db(tmp_path)
+    create_completed_run(db, "run-prune")
+    manifest = _manifest("run-prune")
+
+    stored_manifest = _store_whole_run_artifacts(db, "run-prune", manifest)
+
+    assert stored_manifest is not None
+    artifact_dir = tmp_path / WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME / "run-prune"
+    assert artifact_dir.exists()
+
+    old_timestamp = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+    _execute_statements(
+        db.lifecycle,
+        (
+            "UPDATE runs SET analysis_completed_at = ?, end_time_utc = ? WHERE run_id = ?",
+            (old_timestamp, old_timestamp, "run-prune"),
+        ),
+    )
+
+    db.run_repository.prune_terminal_runs_older_than_days(1)
+
+    assert not artifact_dir.exists()

--- a/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/__init__.py
@@ -18,10 +18,14 @@ from vibesensor.adapters.persistence.history_db._run_repository import RunHistor
 from vibesensor.adapters.persistence.history_db._settings_repository import (
     SettingsSnapshotRepository,
 )
+from vibesensor.adapters.persistence.history_db._whole_run_artifact_store import (
+    HistoryWholeRunArtifactStore,
+)
 
 __all__ = [
     "ClientNameRepository",
     "HistoryPersistenceAdapters",
+    "HistoryWholeRunArtifactStore",
     "RunHistoryRepository",
     "SQLiteHistoryEngine",
     "SettingsSnapshotRepository",
@@ -59,6 +63,7 @@ def _build_history_persistence_adapters(
     )
     cursor_provider = lifecycle._cursor
     raw_capture_store = HistoryRawCaptureStore(data_dir=db_path.parent)
+    whole_run_artifact_store = HistoryWholeRunArtifactStore(data_dir=db_path.parent)
     return HistoryPersistenceAdapters(
         lifecycle=lifecycle,
         run_repository=RunHistoryRepository(
@@ -66,6 +71,7 @@ def _build_history_persistence_adapters(
             cursor_provider=cursor_provider,
             write_transaction_cursor_provider=lifecycle.write_transaction_cursor,
             raw_capture_store=raw_capture_store,
+            whole_run_artifact_store=whole_run_artifact_store,
         ),
         settings_snapshot_repository=SettingsSnapshotRepository(
             engine=lifecycle,

--- a/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_engine.py
@@ -352,9 +352,14 @@ class SQLiteHistoryEngine:
         if version == 11:
             await self._migrate_v11_to_v12()
             await self._migrate_v12_to_v13()
+            await self._migrate_v13_to_v14()
             return
         if version == 12:
             await self._migrate_v12_to_v13()
+            await self._migrate_v13_to_v14()
+            return
+        if version == 13:
+            await self._migrate_v13_to_v14()
             return
         if version > SCHEMA_VERSION:
             raise RuntimeError(
@@ -401,6 +406,19 @@ class SQLiteHistoryEngine:
         if "raw_capture_manifest_json" not in columns:
             async with self._cursor() as cur:
                 await cur.execute("ALTER TABLE runs ADD COLUMN raw_capture_manifest_json TEXT")
+        async with self._cursor() as cur:
+            await cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+
+    async def _migrate_v13_to_v14(self) -> None:
+        LOGGER.info("Migrating history DB schema v13 -> v14")
+        async with self._cursor(commit=False) as cur:
+            await cur.execute("PRAGMA table_info(runs)")
+            columns = {str(row[1]) for row in await cur.fetchall()}
+        if "whole_run_artifact_manifest_json" not in columns:
+            async with self._cursor() as cur:
+                await cur.execute(
+                    "ALTER TABLE runs ADD COLUMN whole_run_artifact_manifest_json TEXT"
+                )
         async with self._cursor() as cur:
             await cur.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 

--- a/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
@@ -14,6 +14,9 @@ import aiosqlite
 from vibesensor.adapters.persistence.history_db._raw_capture_store import (
     HistoryRawCaptureStore,
 )
+from vibesensor.adapters.persistence.history_db._whole_run_artifact_store import (
+    HistoryWholeRunArtifactStore,
+)
 from vibesensor.domain.run_status import RunStatus
 from vibesensor.shared.boundaries.analysis_payloads import (
     persisted_analysis_from_storage_json_object,
@@ -33,6 +36,7 @@ from vibesensor.shared.types.raw_capture import (
     RawRunCapture,
 )
 from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
 
 LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +45,7 @@ _T = TypeVar("_T")
 
 class _HistoryDBQueryMixin:
     _raw_capture_store: HistoryRawCaptureStore
+    _whole_run_artifact_store: HistoryWholeRunArtifactStore
 
     def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         raise NotImplementedError
@@ -116,6 +121,28 @@ class _HistoryDBQueryMixin:
             return None
         return RawCaptureManifest.from_mapping(parsed)
 
+    def _coerce_whole_run_artifact_manifest(
+        self,
+        *,
+        run_id: str,
+        manifest_json: str | None,
+        source: str,
+    ) -> WholeRunArtifactManifest | None:
+        parsed = safe_json_loads(
+            manifest_json,
+            context=f"run {run_id} whole_run_artifact_manifest",
+        )
+        if not is_json_object(parsed):
+            if parsed is not None:
+                LOGGER.warning(
+                    "%s: run %s whole_run_artifact_manifest_json parsed to %s, expected dict",
+                    source,
+                    run_id,
+                    type(parsed).__name__,
+                )
+            return None
+        return WholeRunArtifactManifest.from_mapping(parsed)
+
     def list_runs(self, limit: int = 500) -> list[HistoryRunListEntry]:
         return self._run_sync(self.alist_runs(limit))
 
@@ -163,7 +190,8 @@ class _HistoryDBQueryMixin:
         async with self._cursor(commit=False) as cur:
             await cur.execute(
                 "SELECT run_id, case_id, status, start_time_utc, end_time_utc, "
-                "metadata_json, raw_capture_manifest_json, analysis_json, "
+                "metadata_json, raw_capture_manifest_json, whole_run_artifact_manifest_json, "
+                "analysis_json, "
                 "error_message, created_at, "
                 "sample_count, analysis_started_at, analysis_completed_at "
                 "FROM runs WHERE run_id = ?",
@@ -180,6 +208,7 @@ class _HistoryDBQueryMixin:
             end,
             meta_json,
             raw_capture_manifest_json,
+            whole_run_artifact_manifest_json,
             analysis_json,
             error,
             created,
@@ -201,6 +230,13 @@ class _HistoryDBQueryMixin:
             run_id=str(rid),
             manifest_json=str(raw_capture_manifest_json)
             if raw_capture_manifest_json is not None
+            else None,
+            source="get_run",
+        )
+        whole_run_artifact_manifest = self._coerce_whole_run_artifact_manifest(
+            run_id=str(rid),
+            manifest_json=str(whole_run_artifact_manifest_json)
+            if whole_run_artifact_manifest_json is not None
             else None,
             source="get_run",
         )
@@ -229,6 +265,7 @@ class _HistoryDBQueryMixin:
             metadata=metadata,
             analysis=analysis,
             raw_capture_manifest=raw_capture_manifest,
+            whole_run_artifact_manifest=whole_run_artifact_manifest,
             analysis_corrupt=analysis_corrupt,
             error_message=str(error) if error else None,
             created_at=str(created),
@@ -252,11 +289,43 @@ class _HistoryDBQueryMixin:
             source="get_raw_capture_manifest",
         )
 
+    async def aget_whole_run_artifact_manifest(
+        self,
+        run_id: str,
+    ) -> WholeRunArtifactManifest | None:
+        async with self._cursor(commit=False) as cur:
+            await cur.execute(
+                "SELECT whole_run_artifact_manifest_json FROM runs WHERE run_id = ?",
+                (run_id,),
+            )
+            row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        return self._coerce_whole_run_artifact_manifest(
+            run_id=run_id,
+            manifest_json=str(row[0]),
+            source="get_whole_run_artifact_manifest",
+        )
+
     async def aload_raw_capture(self, run_id: str) -> RawRunCapture | None:
         manifest = await self.aget_raw_capture_manifest(run_id)
         if manifest is None:
             return None
         return await asyncio.to_thread(self._raw_capture_store.load_capture, manifest)
+
+    async def aload_whole_run_artifact(
+        self,
+        run_id: str,
+        artifact_key: str,
+    ) -> bytes | None:
+        manifest = await self.aget_whole_run_artifact_manifest(run_id)
+        if manifest is None:
+            return None
+        return await asyncio.to_thread(
+            self._whole_run_artifact_store.load_artifact_bytes,
+            manifest,
+            artifact_key=artifact_key,
+        )
 
     async def aload_raw_capture_sensor_range(
         self,

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
@@ -15,6 +15,9 @@ from vibesensor.adapters.persistence.history_db._raw_capture_store import (
     HistoryRawCaptureStore,
 )
 from vibesensor.adapters.persistence.history_db._samples import V2_INSERT_SQL, sample_to_v2_row
+from vibesensor.adapters.persistence.history_db._whole_run_artifact_store import (
+    HistoryWholeRunArtifactStore,
+)
 from vibesensor.domain.run_status import RunStatus, is_run_deletable, transition_run
 from vibesensor.shared.boundaries.analysis_payloads import (
     persisted_analysis_to_storage_json_object,
@@ -26,6 +29,7 @@ from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.raw_capture import RawCaptureChunk, RawCaptureManifest
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
+from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +41,7 @@ _T = TypeVar("_T")
 
 class _HistoryDBRunLifecycleMixin:
     _raw_capture_store: HistoryRawCaptureStore
+    _whole_run_artifact_store: HistoryWholeRunArtifactStore
 
     def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         raise NotImplementedError
@@ -163,6 +168,36 @@ class _HistoryDBRunLifecycleMixin:
                 return None
         return manifest
 
+    async def astore_whole_run_artifacts(
+        self,
+        run_id: str,
+        manifest: WholeRunArtifactManifest,
+        *,
+        artifact_contents: dict[str, bytes],
+    ) -> WholeRunArtifactManifest | None:
+        if manifest.run_id != run_id:
+            raise ValueError("whole-run artifact manifest run_id does not match persistence target")
+        stored_manifest = cast(
+            WholeRunArtifactManifest,
+            await asyncio.to_thread(
+                self._whole_run_artifact_store.store_run,
+                manifest,
+                artifact_contents=artifact_contents,
+            ),
+        )
+        async with self._cursor() as cur:
+            await cur.execute(
+                "UPDATE runs SET whole_run_artifact_manifest_json = ? WHERE run_id = ?",
+                (safe_json_dumps(stored_manifest.to_json_object()), run_id),
+            )
+            if int(cur.rowcount) <= 0:
+                await asyncio.to_thread(
+                    self._whole_run_artifact_store.delete_run_artifacts,
+                    run_id,
+                )
+                return None
+        return stored_manifest
+
     def finalize_run(
         self,
         run_id: str,
@@ -247,6 +282,7 @@ class _HistoryDBRunLifecycleMixin:
             deleted = bool(int(cur.rowcount) > 0)
         if deleted:
             await asyncio.to_thread(self._raw_capture_store.delete_run_artifacts, run_id)
+            await asyncio.to_thread(self._whole_run_artifact_store.delete_run_artifacts, run_id)
         return deleted, None
 
     def store_analysis(self, run_id: str, analysis: PersistedAnalysis) -> bool:
@@ -335,6 +371,7 @@ class _HistoryDBRunLifecycleMixin:
             deleted = bool(int(cur.rowcount) > 0)
         if deleted:
             await asyncio.to_thread(self._raw_capture_store.delete_run_artifacts, run_id)
+            await asyncio.to_thread(self._whole_run_artifact_store.delete_run_artifacts, run_id)
         return deleted
 
     def recover_stale_recording_runs(self) -> int:
@@ -374,6 +411,7 @@ class _HistoryDBRunLifecycleMixin:
             )
         for run_id in run_ids:
             await asyncio.to_thread(self._raw_capture_store.delete_run_artifacts, run_id)
+            await asyncio.to_thread(self._whole_run_artifact_store.delete_run_artifacts, run_id)
         return len(run_ids)
 
 

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_repository.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_repository.py
@@ -15,6 +15,9 @@ from vibesensor.adapters.persistence.history_db._raw_capture_store import (
 )
 from vibesensor.adapters.persistence.history_db._run_lifecycle import _HistoryDBRunLifecycleMixin
 from vibesensor.adapters.persistence.history_db._sample_io import _HistoryDBSampleIOMixin
+from vibesensor.adapters.persistence.history_db._whole_run_artifact_store import (
+    HistoryWholeRunArtifactStore,
+)
 
 __all__ = ["RunHistoryRepository"]
 
@@ -34,6 +37,7 @@ class RunHistoryRepository(
         "_cursor_provider",
         "_engine",
         "_raw_capture_store",
+        "_whole_run_artifact_store",
         "_write_transaction_cursor_provider",
     )
 
@@ -44,11 +48,13 @@ class RunHistoryRepository(
         cursor_provider: CursorProvider,
         write_transaction_cursor_provider: WriteTransactionCursorProvider,
         raw_capture_store: HistoryRawCaptureStore,
+        whole_run_artifact_store: HistoryWholeRunArtifactStore,
     ) -> None:
         self._engine = engine
         self._cursor_provider = cursor_provider
         self._write_transaction_cursor_provider = write_transaction_cursor_provider
         self._raw_capture_store = raw_capture_store
+        self._whole_run_artifact_store = whole_run_artifact_store
 
     def _cursor(self, *, commit: bool = True) -> AbstractAsyncContextManager[aiosqlite.Cursor]:
         return self._cursor_provider(commit=commit)

--- a/apps/server/vibesensor/adapters/persistence/history_db/_schema.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_schema.py
@@ -7,7 +7,7 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS runs (
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS runs (
     metadata_json           TEXT NOT NULL,
     car_name                TEXT,
     raw_capture_manifest_json TEXT,
+    whole_run_artifact_manifest_json TEXT,
     analysis_json           TEXT,
     error_message           TEXT,
     sample_count            INTEGER NOT NULL DEFAULT 0,

--- a/apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py
@@ -1,0 +1,79 @@
+"""File-backed whole-run artifact sidecar store for dense post-analysis outputs."""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Mapping
+from pathlib import Path
+from threading import RLock
+
+from vibesensor.shared.json_utils import safe_json_dumps
+from vibesensor.shared.types.whole_run_analysis import (
+    WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME,
+    WholeRunArtifactManifest,
+)
+
+_MANIFEST_FILE_NAME = "manifest.json"
+
+
+class HistoryWholeRunArtifactStore:
+    """Store dense whole-run artifacts in deterministic per-run directories."""
+
+    __slots__ = ("_base_dir", "_data_dir", "_lock")
+
+    def __init__(self, *, data_dir: Path) -> None:
+        self._data_dir = data_dir
+        self._base_dir = data_dir / WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME
+        self._lock = RLock()
+
+    def store_run(
+        self,
+        manifest: WholeRunArtifactManifest,
+        *,
+        artifact_contents: Mapping[str, bytes],
+    ) -> WholeRunArtifactManifest:
+        run_dir = self._data_dir / manifest.relative_dir
+        with self._lock:
+            if run_dir.exists():
+                shutil.rmtree(run_dir)
+            missing = [
+                artifact.artifact_key
+                for artifact in manifest.artifacts
+                if artifact.artifact_key not in artifact_contents
+            ]
+            if missing:
+                raise ValueError(
+                    "whole-run artifact store missing contents for keys: "
+                    + ", ".join(sorted(missing))
+                )
+            run_dir.mkdir(parents=True, exist_ok=True)
+            for artifact in manifest.artifacts:
+                artifact_path = run_dir / artifact.relative_path
+                artifact_path.parent.mkdir(parents=True, exist_ok=True)
+                artifact_path.write_bytes(bytes(artifact_contents[artifact.artifact_key]))
+            (run_dir / _MANIFEST_FILE_NAME).write_text(
+                safe_json_dumps(manifest.to_json_object()),
+                encoding="utf-8",
+            )
+        return manifest
+
+    def load_artifact_bytes(
+        self,
+        manifest: WholeRunArtifactManifest,
+        *,
+        artifact_key: str,
+    ) -> bytes | None:
+        artifact = manifest.artifact(artifact_key)
+        if artifact is None:
+            return None
+        artifact_path = self._data_dir / manifest.relative_dir / artifact.relative_path
+        if not artifact_path.exists():
+            return None
+        return artifact_path.read_bytes()
+
+    def delete_run_artifacts(self, run_id: str) -> None:
+        with self._lock:
+            shutil.rmtree(self.run_dir(run_id), ignore_errors=True)
+
+    def run_dir(self, run_id: str) -> Path:
+        return self._base_dir / run_id

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -35,6 +35,7 @@ from vibesensor.shared.types.speed_source_config import (
     SpeedSourcePayload,
     SpeedSourceUpdatePayload,
 )
+from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
 
 __all__ = [
     "ActiveCarReader",
@@ -126,6 +127,25 @@ class RunPersistence(Protocol):
         sample_start: int,
         sample_count: int,
     ) -> RawCaptureSensorRange | None: ...
+
+    async def astore_whole_run_artifacts(
+        self,
+        run_id: str,
+        manifest: WholeRunArtifactManifest,
+        *,
+        artifact_contents: dict[str, bytes],
+    ) -> WholeRunArtifactManifest | None: ...
+
+    async def aget_whole_run_artifact_manifest(
+        self,
+        run_id: str,
+    ) -> WholeRunArtifactManifest | None: ...
+
+    async def aload_whole_run_artifact(
+        self,
+        run_id: str,
+        artifact_key: str,
+    ) -> bytes | None: ...
 
     async def adelete_run_if_safe(self, run_id: str) -> tuple[bool, str | None]: ...
 

--- a/apps/server/vibesensor/shared/types/history_records.py
+++ b/apps/server/vibesensor/shared/types/history_records.py
@@ -10,6 +10,7 @@ from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.raw_capture import RawCaptureManifest
 from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
 
 __all__ = [
     "AnalyzingRunHealth",
@@ -62,6 +63,7 @@ class StoredHistoryRun:
     case_id: str | None = None
     analysis: PersistedAnalysis | None = None
     raw_capture_manifest: RawCaptureManifest | None = None
+    whole_run_artifact_manifest: WholeRunArtifactManifest | None = None
     analysis_corrupt: bool = False
     error_message: str | None = None
     analysis_started_at: str | None = None
@@ -84,6 +86,10 @@ class StoredHistoryRun:
             payload["analysis"] = self.analysis.to_json_object()
         if self.raw_capture_manifest is not None:
             payload["raw_capture_manifest"] = self.raw_capture_manifest.to_json_object()
+        if self.whole_run_artifact_manifest is not None:
+            payload["whole_run_artifact_manifest"] = (
+                self.whole_run_artifact_manifest.to_json_object()
+            )
         if self.analysis_corrupt:
             payload["analysis_corrupt"] = True
         if self.error_message is not None:

--- a/apps/server/vibesensor/shared/types/whole_run_analysis.py
+++ b/apps/server/vibesensor/shared/types/whole_run_analysis.py
@@ -10,6 +10,7 @@ from vibesensor.shared.types.run_schema import RunMetadata
 
 __all__ = [
     "WHOLE_RUN_ARTIFACT_SCHEMA_VERSION",
+    "WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME",
     "WholeRunArtifactFile",
     "WholeRunArtifactManifest",
     "WholeRunWindowDescriptor",
@@ -17,6 +18,7 @@ __all__ = [
 ]
 
 WHOLE_RUN_ARTIFACT_SCHEMA_VERSION = 1
+WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME = "whole-run-artifacts"
 _WHOLE_RUN_ARTIFACT_STORAGE_TYPE = "run-directory-v1"
 
 

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -45,8 +45,10 @@ shared contracts that must settle early, and the recommended execution order.
 - Persistence uses `data/raw-runs/{run_id}/` with per-sensor
   `.raw.i16le` and `.index.jsonl` files via
   `apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py`.
-- The current read path is all-or-nothing:
-  `aload_raw_capture()` loads the full sensor arrays into memory before replay.
+- Whole-run foundations now include indexed raw range reads via
+  `RunPersistence.aload_raw_capture_sensor_range(...)`, but there is still no
+  canonical offline executor that walks the full run as a deterministic window
+  graph.
 
 ### Persisted analysis and reporting
 
@@ -259,7 +261,7 @@ explainable factors that reporting can consume directly.
 | `WholeRunWindowPolicy` / `WholeRunWindowDescriptor` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` | Canonical sample-space policy and deterministic window identity for every later whole-run stage |
 | `WholeRunWindowPlan` / `plan_whole_run_windows(...)` | `apps/server/vibesensor/use_cases/diagnostics/whole_run_windows.py` | Deterministic window grid planner with explicit trailing-window policy |
 | `WholeRunWindowSpectralSummary` | `use_cases/diagnostics/` with compact persisted projection | Per-window FFT/strength/top-peak outputs |
-| `WholeRunArtifactManifest` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` + later persistence store under `adapters/persistence/history_db/` | Sidecar manifest for dense whole-run artifacts; mirror the raw-capture pattern |
+| `WholeRunArtifactManifest` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` + `apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py` | Sidecar manifest for dense whole-run artifacts; mirror the raw-capture pattern |
 | `RunContextInterval` / `WindowContextLabel` | `use_cases/diagnostics/` with report-facing projection in `shared/types/history_analysis_contracts.py` | Whole-run segments and per-window labels |
 | `OrderTracePoint` / `OrderTraceSummary` | `use_cases/diagnostics/orders/` with persisted summary projection | Dense trace vs compact report/history summary split |
 | `SpatialEvidenceSummary` | `use_cases/diagnostics/` with persisted summary projection | Candidate-level coherence and location separation |
@@ -269,14 +271,21 @@ explainable factors that reporting can consume directly.
 
 The current `runs.analysis_json` payload should stay compact and report-facing.
 
-Recommended additions:
+Current foundation:
 
-1. Add a file-backed whole-run artifact store, parallel to
-   `HistoryRawCaptureStore`.
-2. Add a manifest reference on the run record (or another explicit persistence
-   seam) for dense analysis artifacts.
-3. Keep `PersistedAnalysis` as the stable history/report summary boundary.
-4. Store only compact summaries and exemplars in `PersistedAnalysis`.
+1. `apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py`
+   mirrors `HistoryRawCaptureStore` with a deterministic
+   `data/whole-run-artifacts/{run_id}/` sidecar layout.
+2. The `runs` row now carries `whole_run_artifact_manifest_json`, and
+   `StoredHistoryRun` exposes that manifest as
+   `whole_run_artifact_manifest`.
+
+Recommended follow-on behavior:
+
+1. Keep `PersistedAnalysis` as the stable history/report summary boundary.
+2. Store only compact summaries and exemplars in `PersistedAnalysis`.
+3. Use the whole-run sidecar only for dense artifacts such as spectra, traces,
+   matrices, and debug payloads.
 
 This keeps legacy report loading cheap and avoids turning the history DB blob
 into a large binary transport.


### PR DESCRIPTION
Fixes #3083.

## What changed
- add `HistoryWholeRunArtifactStore` for dense whole-run sidecars under `data/whole-run-artifacts/{run_id}/`
- persist `whole_run_artifact_manifest_json` on the `runs` row and expose it through `StoredHistoryRun` / `RunPersistence`
- add load/store seams for whole-run artifact manifests and artifact bytes, plus delete/prune cleanup that mirrors raw capture
- add focused history-db coverage for round-trip, legacy-no-manifest reads, missing-run cleanup, and delete/prune removal
- update the whole-run design doc to point at the real storage seam

## Why
Whole-run spectra, traces, and later spatial/fusion artifacts need a real sidecar home. They are too dense for `analysis_json`, but later stages still need a stable manifest seam on the run record.

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/adapters/persistence/history_db/test_history_db_whole_run_artifacts.py`
- `make typecheck-backend`
- `make lint`
- `make test-changed`
- `make docs-lint`

## Risks / tradeoffs
- this lands storage/plumbing only; no executor writes these artifacts yet
- the sidecar API is intentionally narrow for now: manifest + keyed artifact byte loads, not higher-level readers
- legacy runs keep working because missing manifests decode to `None`

## Follow-ups
- #3084 will be the first real producer of these sidecars
- later order/context/spatial tracks can hang dense artifacts off the same manifest seam without expanding `PersistedAnalysis`