### PR TITLE
Define whole-run context contracts

### DIFF
--- a/apps/server/tests/shared/types/test_whole_run_analysis.py
+++ b/apps/server/tests/shared/types/test_whole_run_analysis.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import pytest
 
+from vibesensor.domain import DrivingPhase
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.whole_run_analysis import (
     WHOLE_RUN_ARTIFACT_SCHEMA_VERSION,
     WholeRunArtifactFile,
     WholeRunArtifactManifest,
+    WholeRunContextInterval,
+    WholeRunContextWindowLabel,
     WholeRunWindowDescriptor,
     WholeRunWindowPolicy,
 )
@@ -109,3 +112,73 @@ def test_whole_run_artifact_manifest_round_trips_with_window_policy() -> None:
     assert restored == manifest
     assert restored.schema_version == WHOLE_RUN_ARTIFACT_SCHEMA_VERSION
     assert restored.artifact("window_spectra_sensor-a") == manifest.artifacts[1]
+
+
+def test_context_window_label_round_trips_with_explicit_quality_states() -> None:
+    label = WholeRunContextWindowLabel(
+        window_index=12,
+        segment_index=3,
+        phase=DrivingPhase.CRUISE,
+        context_coverage="partial",
+        speed_validity="assumed",
+        rpm_validity="estimated",
+        load_state="steady",
+        speed_kmh=63.5,
+        speed_band="60-70 km/h",
+        speed_source="manual",
+        engine_rpm=1825.0,
+        engine_rpm_source="estimated_from_speed_and_ratios",
+    )
+
+    restored = WholeRunContextWindowLabel.from_mapping(label.to_json_object())
+
+    assert restored == label
+
+
+def test_context_window_label_rejects_negative_indices() -> None:
+    with pytest.raises(ValueError, match="window_index >= 0"):
+        WholeRunContextWindowLabel(
+            window_index=-1,
+            segment_index=None,
+            phase=DrivingPhase.SPEED_UNKNOWN,
+            context_coverage="missing",
+            speed_validity="missing",
+            rpm_validity="missing",
+            load_state="unknown",
+        )
+
+
+def test_context_interval_round_trips_with_window_range_summary() -> None:
+    interval = WholeRunContextInterval(
+        segment_index=2,
+        phase=DrivingPhase.ACCELERATION,
+        load_state="transient",
+        start_window_index=8,
+        end_window_index=14,
+        start_t_s=2.0,
+        end_t_s=5.5,
+        speed_min_kmh=18.0,
+        speed_max_kmh=46.0,
+        speed_band="10-50 km/h",
+        full_context_window_count=4,
+        partial_context_window_count=2,
+        missing_context_window_count=1,
+    )
+
+    restored = WholeRunContextInterval.from_mapping(interval.to_json_object())
+
+    assert restored == interval
+    assert restored.window_count == 7
+
+
+def test_context_interval_rejects_inverted_window_ranges() -> None:
+    with pytest.raises(ValueError, match="end_window_index >= start_window_index"):
+        WholeRunContextInterval(
+            segment_index=0,
+            phase=DrivingPhase.CRUISE,
+            load_state="steady",
+            start_window_index=4,
+            end_window_index=3,
+            start_t_s=1.0,
+            end_t_s=1.5,
+        )

--- a/apps/server/vibesensor/shared/types/whole_run_analysis.py
+++ b/apps/server/vibesensor/shared/types/whole_run_analysis.py
@@ -1,10 +1,12 @@
-"""Shared whole-run post-analysis contracts for window identity and sidecar artifacts."""
+"""Shared whole-run post-analysis contracts for window identity, context, and sidecars."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from math import isclose
+from typing import Literal
 
+from vibesensor.domain import DrivingPhase
 from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
 from vibesensor.shared.types.run_schema import RunMetadata
 
@@ -13,6 +15,12 @@ __all__ = [
     "WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME",
     "WholeRunArtifactFile",
     "WholeRunArtifactManifest",
+    "WholeRunContextCoverage",
+    "WholeRunContextInterval",
+    "WholeRunContextLoadState",
+    "WholeRunContextWindowLabel",
+    "WholeRunRpmValidity",
+    "WholeRunSpeedValidity",
     "WholeRunWindowDescriptor",
     "WholeRunWindowPolicy",
 ]
@@ -20,6 +28,11 @@ __all__ = [
 WHOLE_RUN_ARTIFACT_SCHEMA_VERSION = 1
 WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME = "whole-run-artifacts"
 _WHOLE_RUN_ARTIFACT_STORAGE_TYPE = "run-directory-v1"
+
+type WholeRunContextCoverage = Literal["full", "partial", "missing"]
+type WholeRunSpeedValidity = Literal["measured", "assumed", "missing"]
+type WholeRunRpmValidity = Literal["measured", "estimated", "missing"]
+type WholeRunContextLoadState = Literal["idle", "steady", "transient", "unknown"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -250,6 +263,157 @@ class WholeRunArtifactManifest:
         return None
 
 
+@dataclass(frozen=True, slots=True)
+class WholeRunContextWindowLabel:
+    """Per-window context keyed to the canonical whole-run ``window_index``."""
+
+    window_index: int
+    segment_index: int | None
+    phase: DrivingPhase
+    context_coverage: WholeRunContextCoverage
+    speed_validity: WholeRunSpeedValidity
+    rpm_validity: WholeRunRpmValidity
+    load_state: WholeRunContextLoadState
+    speed_kmh: float | None = None
+    speed_band: str | None = None
+    speed_source: str | None = None
+    engine_rpm: float | None = None
+    engine_rpm_source: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.window_index < 0:
+            raise ValueError("whole-run context window label requires window_index >= 0")
+        if self.segment_index is not None and self.segment_index < 0:
+            raise ValueError("whole-run context window label requires segment_index >= 0")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "window_index": self.window_index,
+            "phase": self.phase.value,
+            "context_coverage": self.context_coverage,
+            "speed_validity": self.speed_validity,
+            "rpm_validity": self.rpm_validity,
+            "load_state": self.load_state,
+        }
+        if self.segment_index is not None:
+            payload["segment_index"] = self.segment_index
+        if self.speed_kmh is not None:
+            payload["speed_kmh"] = self.speed_kmh
+        if self.speed_band is not None:
+            payload["speed_band"] = self.speed_band
+        if self.speed_source is not None:
+            payload["speed_source"] = self.speed_source
+        if self.engine_rpm is not None:
+            payload["engine_rpm"] = self.engine_rpm
+        if self.engine_rpm_source is not None:
+            payload["engine_rpm_source"] = self.engine_rpm_source
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunContextWindowLabel:
+        return cls(
+            window_index=_int_from_json(data.get("window_index")),
+            segment_index=_int_or_none(data.get("segment_index")),
+            phase=_driving_phase_from_json(data.get("phase")),
+            context_coverage=_context_coverage_from_json(data.get("context_coverage")),
+            speed_validity=_speed_validity_from_json(data.get("speed_validity")),
+            rpm_validity=_rpm_validity_from_json(data.get("rpm_validity")),
+            load_state=_load_state_from_json(data.get("load_state")),
+            speed_kmh=_float_or_none(data.get("speed_kmh")),
+            speed_band=_str_or_none(data.get("speed_band")),
+            speed_source=_str_or_none(data.get("speed_source")),
+            engine_rpm=_float_or_none(data.get("engine_rpm")),
+            engine_rpm_source=_str_or_none(data.get("engine_rpm_source")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunContextInterval:
+    """Compact segment summary aligned to a contiguous range of whole-run windows."""
+
+    segment_index: int
+    phase: DrivingPhase
+    load_state: WholeRunContextLoadState
+    start_window_index: int
+    end_window_index: int
+    start_t_s: float | None
+    end_t_s: float | None
+    speed_min_kmh: float | None = None
+    speed_max_kmh: float | None = None
+    speed_band: str | None = None
+    full_context_window_count: int = 0
+    partial_context_window_count: int = 0
+    missing_context_window_count: int = 0
+
+    def __post_init__(self) -> None:
+        if self.segment_index < 0:
+            raise ValueError("whole-run context interval requires segment_index >= 0")
+        if self.start_window_index < 0:
+            raise ValueError("whole-run context interval requires start_window_index >= 0")
+        if self.end_window_index < self.start_window_index:
+            raise ValueError(
+                "whole-run context interval requires end_window_index >= start_window_index"
+            )
+        for field_name in (
+            "full_context_window_count",
+            "partial_context_window_count",
+            "missing_context_window_count",
+        ):
+            if getattr(self, field_name) < 0:
+                raise ValueError(f"whole-run context interval requires {field_name} >= 0")
+        if (
+            self.start_t_s is not None
+            and self.end_t_s is not None
+            and self.start_t_s > self.end_t_s
+        ):
+            raise ValueError("whole-run context interval requires start_t_s <= end_t_s")
+
+    @property
+    def window_count(self) -> int:
+        return (self.end_window_index - self.start_window_index) + 1
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "segment_index": self.segment_index,
+            "phase": self.phase.value,
+            "load_state": self.load_state,
+            "start_window_index": self.start_window_index,
+            "end_window_index": self.end_window_index,
+            "full_context_window_count": self.full_context_window_count,
+            "partial_context_window_count": self.partial_context_window_count,
+            "missing_context_window_count": self.missing_context_window_count,
+        }
+        if self.start_t_s is not None:
+            payload["start_t_s"] = self.start_t_s
+        if self.end_t_s is not None:
+            payload["end_t_s"] = self.end_t_s
+        if self.speed_min_kmh is not None:
+            payload["speed_min_kmh"] = self.speed_min_kmh
+        if self.speed_max_kmh is not None:
+            payload["speed_max_kmh"] = self.speed_max_kmh
+        if self.speed_band is not None:
+            payload["speed_band"] = self.speed_band
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunContextInterval:
+        return cls(
+            segment_index=_int_from_json(data.get("segment_index")),
+            phase=_driving_phase_from_json(data.get("phase")),
+            load_state=_load_state_from_json(data.get("load_state")),
+            start_window_index=_int_from_json(data.get("start_window_index")),
+            end_window_index=_int_from_json(data.get("end_window_index")),
+            start_t_s=_float_or_none(data.get("start_t_s")),
+            end_t_s=_float_or_none(data.get("end_t_s")),
+            speed_min_kmh=_float_or_none(data.get("speed_min_kmh")),
+            speed_max_kmh=_float_or_none(data.get("speed_max_kmh")),
+            speed_band=_str_or_none(data.get("speed_band")),
+            full_context_window_count=_int_from_json(data.get("full_context_window_count")),
+            partial_context_window_count=_int_from_json(data.get("partial_context_window_count")),
+            missing_context_window_count=_int_from_json(data.get("missing_context_window_count")),
+        )
+
+
 def _int_or_none(value: JsonValue | object) -> int | None:
     if isinstance(value, bool) or value is None:
         return None
@@ -277,9 +441,68 @@ def _float_from_json(value: JsonValue | object, default: float = 0.0) -> float:
     return default
 
 
+def _float_or_none(value: JsonValue | object) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float, str)):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
 def _str_from_json(value: JsonValue | object, default: str = "") -> str:
     return value if isinstance(value, str) else default
 
 
 def _str_or_none(value: JsonValue | object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _driving_phase_from_json(value: JsonValue | object) -> DrivingPhase:
+    raw = _str_or_none(value)
+    if raw is None:
+        return DrivingPhase.SPEED_UNKNOWN
+    try:
+        return DrivingPhase(raw)
+    except ValueError:
+        return DrivingPhase.SPEED_UNKNOWN
+
+
+def _context_coverage_from_json(value: JsonValue | object) -> WholeRunContextCoverage:
+    raw = _str_or_none(value)
+    if raw == "full":
+        return "full"
+    if raw == "partial":
+        return "partial"
+    return "missing"
+
+
+def _speed_validity_from_json(value: JsonValue | object) -> WholeRunSpeedValidity:
+    raw = _str_or_none(value)
+    if raw == "measured":
+        return "measured"
+    if raw == "assumed":
+        return "assumed"
+    return "missing"
+
+
+def _rpm_validity_from_json(value: JsonValue | object) -> WholeRunRpmValidity:
+    raw = _str_or_none(value)
+    if raw == "measured":
+        return "measured"
+    if raw == "estimated":
+        return "estimated"
+    return "missing"
+
+
+def _load_state_from_json(value: JsonValue | object) -> WholeRunContextLoadState:
+    raw = _str_or_none(value)
+    if raw == "idle":
+        return "idle"
+    if raw == "steady":
+        return "steady"
+    if raw == "transient":
+        return "transient"
+    return "unknown"

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -262,10 +262,24 @@ explainable factors that reporting can consume directly.
 | `WholeRunWindowPlan` / `plan_whole_run_windows(...)` | `apps/server/vibesensor/use_cases/diagnostics/whole_run_windows.py` | Deterministic window grid planner with explicit trailing-window policy |
 | `WholeRunWindowSpectralSummary` | `use_cases/diagnostics/` with compact persisted projection | Per-window FFT/strength/top-peak outputs |
 | `WholeRunArtifactManifest` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` + `apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py` | Sidecar manifest for dense whole-run artifacts; mirror the raw-capture pattern |
-| `RunContextInterval` / `WindowContextLabel` | `use_cases/diagnostics/` with report-facing projection in `shared/types/history_analysis_contracts.py` | Whole-run segments and per-window labels |
+| `WholeRunContextInterval` / `WholeRunContextWindowLabel` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` with compact report-facing projection in `shared/types/history_analysis_contracts.py` | Whole-run segments and per-window labels keyed to the canonical `window_index` grid |
 | `OrderTracePoint` / `OrderTraceSummary` | `use_cases/diagnostics/orders/` with persisted summary projection | Dense trace vs compact report/history summary split |
 | `SpatialEvidenceSummary` | `use_cases/diagnostics/` with persisted summary projection | Candidate-level coherence and location separation |
 | `DiagnosisFactor` / `DiagnosisSummary` | diagnostics domain/use-case layer plus persisted projection | Explainable support and counterevidence for final ranking |
+
+For the context track:
+
+1. `WholeRunContextWindowLabel` is the dense internal join surface for later
+   order, spatial, and fusion work. It carries explicit `context_coverage`,
+   `speed_validity`, `rpm_validity`, `load_state`, and optional raw context
+   values/source labels keyed by `window_index`.
+2. `WholeRunContextInterval` is the compact segment summary surface. It uses
+   `start_window_index` / `end_window_index` as the canonical range identity and
+   can be projected later into persisted analysis/report payloads without
+   forcing report consumers to load every window label.
+3. Report-facing persisted summaries should keep only compact segment fields and
+   coarse completeness signals. Dense per-window labels remain sidecar/internal
+   artifacts unless a future consumer proves otherwise.
 
 ## Persistence strategy
 


### PR DESCRIPTION
## What changed
- add `WholeRunContextWindowLabel` and `WholeRunContextInterval` to `apps/server/vibesensor/shared/types/whole_run_analysis.py`
- make context coverage plus speed/RPM/load quality explicit on the whole-run window grid
- add focused round-trip / guard tests and update the whole-run design doc with internal-vs-persisted context guidance

## Why
- #3086 needs a stable contract before normalization, segmentation, order traces, spatial joins, and fusion start depending on inferred fields
- window-range segment identity now lives on `start_window_index` / `end_window_index` instead of timestamp-only summaries
- speed band stays string-based on purpose so this contract reuses the repo's existing speed-band outputs instead of inventing a second taxonomy

## Validation
- `python -m pytest -q apps/server/tests/shared/types/test_whole_run_analysis.py`
- `make typecheck-backend`
- `make lint`
- `make test-changed`
- `make docs-lint`

## Risks / tradeoffs
- contract only; normalization and segmentation logic still land in follow-up issues
- no report/history payload changes yet; this PR only defines the shared owner and documents the later projection boundary
