### PR TITLE
Normalize whole-run window context

### DIFF
--- a/apps/server/tests/shared/types/test_whole_run_analysis.py
+++ b/apps/server/tests/shared/types/test_whole_run_analysis.py
@@ -126,8 +126,10 @@ def test_context_window_label_round_trips_with_explicit_quality_states() -> None
         speed_kmh=63.5,
         speed_band="60-70 km/h",
         speed_source="manual",
+        speed_is_stale=True,
         engine_rpm=1825.0,
         engine_rpm_source="estimated_from_speed_and_ratios",
+        rpm_is_stale=False,
     )
 
     restored = WholeRunContextWindowLabel.from_mapping(label.to_json_object())

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_context.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_context.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from vibesensor.domain import AnalysisSettingsSnapshot, DrivingPhase
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.use_cases.diagnostics.whole_run_context import (
+    normalize_whole_run_context_labels,
+)
+from vibesensor.use_cases.diagnostics.whole_run_windows import plan_whole_run_windows
+
+
+def _metadata() -> RunMetadata:
+    return RunMetadata.create(
+        run_id="run-1",
+        start_time_utc="2025-01-01T00:00:00Z",
+        sensor_model="fixture-sensor",
+        raw_sample_rate_hz=800,
+        feature_interval_s=0.25,
+        fft_window_size_samples=2048,
+        accel_scale_g_per_lsb=0.001,
+        analysis_settings=AnalysisSettingsSnapshot(**AnalysisSettingsSnapshot.DEFAULTS),
+    )
+
+
+def test_normalize_whole_run_context_labels_aligns_to_centers_and_groups_rows() -> None:
+    metadata = _metadata()
+    window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=2448)
+    samples = sensor_frames_from_mappings(
+        [
+            {
+                "t_s": 1.28,
+                "client_id": "sensor-a",
+                "speed_kmh": 12.0,
+                "speed_source": "gps",
+                "engine_rpm": 1100.0,
+                "engine_rpm_source": "obd2",
+            },
+            {
+                "t_s": 1.53,
+                "client_id": "sensor-a",
+                "speed_kmh": 45.0,
+                "speed_source": "manual",
+                "gear": 0.64,
+                "final_drive_ratio": 3.08,
+            },
+            {
+                "t_s": 1.78,
+                "client_id": "sensor-a",
+                "speed_source": "none",
+            },
+            {
+                "t_s": 1.78,
+                "client_id": "sensor-b",
+                "speed_kmh": 65.0,
+                "speed_source": "gps",
+                "gear": 0.64,
+                "final_drive_ratio": 3.08,
+            },
+        ]
+    )
+
+    labels = normalize_whole_run_context_labels(
+        metadata=metadata,
+        samples=samples,
+        window_plan=window_plan,
+    )
+
+    assert [label.window_index for label in labels] == [0, 1, 2]
+
+    assert labels[0].context_coverage == "full"
+    assert labels[0].speed_validity == "measured"
+    assert labels[0].rpm_validity == "measured"
+    assert labels[0].speed_source == "gps"
+    assert labels[0].engine_rpm_source == "obd2"
+    assert labels[0].speed_is_stale is False
+    assert labels[0].rpm_is_stale is False
+    assert labels[0].phase == DrivingPhase.SPEED_UNKNOWN
+
+    assert labels[1].context_coverage == "full"
+    assert labels[1].speed_validity == "assumed"
+    assert labels[1].rpm_validity == "estimated"
+    assert labels[1].speed_source == "manual"
+    assert labels[1].engine_rpm_source == "estimated_from_speed_and_ratios"
+    assert labels[1].speed_band == "40-50 km/h"
+
+    assert labels[2].context_coverage == "full"
+    assert labels[2].speed_validity == "measured"
+    assert labels[2].rpm_validity == "estimated"
+    assert labels[2].speed_source == "gps"
+    assert labels[2].engine_rpm_source == "estimated_from_speed_and_ratios"
+
+
+def test_normalize_whole_run_context_labels_marks_stale_context_explicitly() -> None:
+    metadata = _metadata()
+    window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=2048)
+    samples = sensor_frames_from_mappings(
+        [
+            {
+                "t_s": 0.50,
+                "client_id": "sensor-a",
+                "speed_kmh": 30.0,
+                "speed_source": "manual",
+                "gear": 0.64,
+                "final_drive_ratio": 3.08,
+            }
+        ]
+    )
+
+    label = normalize_whole_run_context_labels(
+        metadata=metadata,
+        samples=samples,
+        window_plan=window_plan,
+    )[0]
+
+    assert label.context_coverage == "partial"
+    assert label.speed_validity == "assumed"
+    assert label.rpm_validity == "estimated"
+    assert label.speed_is_stale is True
+    assert label.rpm_is_stale is True
+    assert label.phase == DrivingPhase.SPEED_UNKNOWN
+    assert label.load_state == "unknown"
+
+
+def test_normalize_whole_run_context_labels_keeps_missing_windows_explicit() -> None:
+    metadata = _metadata()
+    window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=2048)
+
+    label = normalize_whole_run_context_labels(
+        metadata=metadata,
+        samples=(),
+        window_plan=window_plan,
+    )[0]
+
+    assert label.context_coverage == "missing"
+    assert label.speed_validity == "missing"
+    assert label.rpm_validity == "missing"
+    assert label.speed_source is None
+    assert label.engine_rpm_source is None
+    assert label.speed_is_stale is False
+    assert label.rpm_is_stale is False
+    assert label.phase == DrivingPhase.SPEED_UNKNOWN
+
+
+def test_normalize_whole_run_context_labels_marks_idle_when_fresh_speed_is_zero() -> None:
+    metadata = _metadata()
+    window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=2048)
+    samples = sensor_frames_from_mappings(
+        [
+            {
+                "t_s": 1.28,
+                "client_id": "sensor-a",
+                "speed_kmh": 0.0,
+                "speed_source": "gps",
+            }
+        ]
+    )
+
+    label = normalize_whole_run_context_labels(
+        metadata=metadata,
+        samples=samples,
+        window_plan=window_plan,
+    )[0]
+
+    assert label.phase == DrivingPhase.IDLE
+    assert label.load_state == "idle"

--- a/apps/server/vibesensor/shared/types/whole_run_analysis.py
+++ b/apps/server/vibesensor/shared/types/whole_run_analysis.py
@@ -277,8 +277,10 @@ class WholeRunContextWindowLabel:
     speed_kmh: float | None = None
     speed_band: str | None = None
     speed_source: str | None = None
+    speed_is_stale: bool = False
     engine_rpm: float | None = None
     engine_rpm_source: str | None = None
+    rpm_is_stale: bool = False
 
     def __post_init__(self) -> None:
         if self.window_index < 0:
@@ -294,6 +296,8 @@ class WholeRunContextWindowLabel:
             "speed_validity": self.speed_validity,
             "rpm_validity": self.rpm_validity,
             "load_state": self.load_state,
+            "speed_is_stale": self.speed_is_stale,
+            "rpm_is_stale": self.rpm_is_stale,
         }
         if self.segment_index is not None:
             payload["segment_index"] = self.segment_index
@@ -322,8 +326,10 @@ class WholeRunContextWindowLabel:
             speed_kmh=_float_or_none(data.get("speed_kmh")),
             speed_band=_str_or_none(data.get("speed_band")),
             speed_source=_str_or_none(data.get("speed_source")),
+            speed_is_stale=_bool_from_json(data.get("speed_is_stale")),
             engine_rpm=_float_or_none(data.get("engine_rpm")),
             engine_rpm_source=_str_or_none(data.get("engine_rpm_source")),
+            rpm_is_stale=_bool_from_json(data.get("rpm_is_stale")),
         )
 
 
@@ -468,6 +474,10 @@ def _driving_phase_from_json(value: JsonValue | object) -> DrivingPhase:
         return DrivingPhase(raw)
     except ValueError:
         return DrivingPhase.SPEED_UNKNOWN
+
+
+def _bool_from_json(value: JsonValue | object) -> bool:
+    return value is True
 
 
 def _context_coverage_from_json(value: JsonValue | object) -> WholeRunContextCoverage:

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py
@@ -1,0 +1,312 @@
+"""Whole-run speed and RPM normalization onto the canonical window grid."""
+
+from __future__ import annotations
+
+from bisect import bisect_left
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from math import isfinite
+
+from vibesensor.domain import DrivingPhase, speed_bin_label
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunContextCoverage,
+    WholeRunContextLoadState,
+    WholeRunContextWindowLabel,
+    WholeRunRpmValidity,
+    WholeRunSpeedValidity,
+)
+
+from ._reference_resolution import _effective_engine_rpm, _tire_reference_from_context
+from ._types import Sample
+from .whole_run_windows import WholeRunWindowPlan
+
+__all__ = ["normalize_whole_run_context_labels"]
+
+_SPEED_VALIDITY_RANK: dict[WholeRunSpeedValidity, int] = {
+    "missing": 0,
+    "assumed": 1,
+    "measured": 2,
+}
+_RPM_VALIDITY_RANK: dict[WholeRunRpmValidity, int] = {
+    "missing": 0,
+    "estimated": 1,
+    "measured": 2,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _SpeedObservation:
+    t_s: float
+    speed_kmh: float
+    speed_source: str
+    speed_validity: WholeRunSpeedValidity
+
+
+@dataclass(frozen=True, slots=True)
+class _RpmObservation:
+    t_s: float
+    engine_rpm: float
+    engine_rpm_source: str
+    rpm_validity: WholeRunRpmValidity
+
+
+def normalize_whole_run_context_labels(
+    *,
+    metadata: RunMetadata,
+    samples: Sequence[Sample],
+    window_plan: WholeRunWindowPlan,
+) -> tuple[WholeRunContextWindowLabel, ...]:
+    """Project persisted speed/RPM context onto the canonical whole-run grid.
+
+    The join target is each window's center time so the resulting label reflects
+    the middle of the analyzed raw window rather than just its trailing edge.
+    """
+
+    speed_observations, rpm_observations = _collect_context_observations(
+        metadata=metadata,
+        samples=samples,
+    )
+    freshness_limit_s = max(1e-9, window_plan.policy.stride_duration_s)
+    labels: list[WholeRunContextWindowLabel] = []
+    for window in window_plan.windows:
+        speed_index = _nearest_observation_index(
+            target_t_s=window.center_t_s,
+            observation_times=[observation.t_s for observation in speed_observations],
+        )
+        rpm_index = _nearest_observation_index(
+            target_t_s=window.center_t_s,
+            observation_times=[observation.t_s for observation in rpm_observations],
+        )
+        speed_observation = speed_observations[speed_index] if speed_index is not None else None
+        rpm_observation = rpm_observations[rpm_index] if rpm_index is not None else None
+        speed_age_s = (
+            abs(speed_observation.t_s - window.center_t_s)
+            if speed_observation is not None
+            else None
+        )
+        rpm_age_s = (
+            abs(rpm_observation.t_s - window.center_t_s) if rpm_observation is not None else None
+        )
+        speed_is_stale = speed_age_s is not None and speed_age_s > freshness_limit_s
+        rpm_is_stale = rpm_age_s is not None and rpm_age_s > freshness_limit_s
+        speed_kmh = speed_observation.speed_kmh if speed_observation is not None else None
+        speed_validity = (
+            speed_observation.speed_validity if speed_observation is not None else "missing"
+        )
+        rpm_validity = rpm_observation.rpm_validity if rpm_observation is not None else "missing"
+        phase, load_state = _baseline_phase_state(
+            speed_kmh=speed_kmh,
+            speed_validity=speed_validity,
+            speed_is_stale=speed_is_stale,
+        )
+        labels.append(
+            WholeRunContextWindowLabel(
+                window_index=window.window_index,
+                segment_index=None,
+                phase=phase,
+                context_coverage=_context_coverage(
+                    speed_validity=speed_validity,
+                    speed_is_stale=speed_is_stale,
+                    rpm_validity=rpm_validity,
+                    rpm_is_stale=rpm_is_stale,
+                ),
+                speed_validity=speed_validity,
+                rpm_validity=rpm_validity,
+                load_state=load_state,
+                speed_kmh=speed_kmh,
+                speed_band=(
+                    speed_bin_label(speed_kmh)
+                    if speed_kmh is not None and not speed_is_stale
+                    else None
+                ),
+                speed_source=(
+                    speed_observation.speed_source if speed_observation is not None else None
+                ),
+                speed_is_stale=speed_is_stale,
+                engine_rpm=(rpm_observation.engine_rpm if rpm_observation is not None else None),
+                engine_rpm_source=(
+                    rpm_observation.engine_rpm_source if rpm_observation is not None else None
+                ),
+                rpm_is_stale=rpm_is_stale,
+            )
+        )
+    return tuple(labels)
+
+
+def _collect_context_observations(
+    *,
+    metadata: RunMetadata,
+    samples: Sequence[Sample],
+) -> tuple[tuple[_SpeedObservation, ...], tuple[_RpmObservation, ...]]:
+    samples_by_t_s: dict[float, list[Sample]] = defaultdict(list)
+    for sample in samples:
+        t_s = sample.t_s
+        if t_s is None or not isfinite(t_s) or t_s < 0.0:
+            continue
+        samples_by_t_s[float(t_s)].append(sample)
+    tire_circumference_m, _ = _tire_reference_from_context(metadata)
+    speed_observations: list[_SpeedObservation] = []
+    rpm_observations: list[_RpmObservation] = []
+    for t_s in sorted(samples_by_t_s):
+        group = samples_by_t_s[t_s]
+        speed_observation = _best_speed_observation(t_s=t_s, samples=group)
+        if speed_observation is not None:
+            speed_observations.append(speed_observation)
+        rpm_observation = _best_rpm_observation(
+            t_s=t_s,
+            samples=group,
+            metadata=metadata,
+            tire_circumference_m=tire_circumference_m,
+        )
+        if rpm_observation is not None:
+            rpm_observations.append(rpm_observation)
+    return tuple(speed_observations), tuple(rpm_observations)
+
+
+def _best_speed_observation(
+    *,
+    t_s: float,
+    samples: Sequence[Sample],
+) -> _SpeedObservation | None:
+    best: _SpeedObservation | None = None
+    best_key: tuple[int, int, str] | None = None
+    for sample in samples:
+        speed_kmh = sample.speed_kmh
+        if speed_kmh is None or not isfinite(speed_kmh) or speed_kmh < 0.0:
+            continue
+        speed_source = str(sample.speed_source or "none")
+        speed_validity = _speed_validity_for_source(speed_source)
+        if speed_validity == "missing":
+            continue
+        key = (
+            _SPEED_VALIDITY_RANK[speed_validity],
+            _speed_source_rank(speed_source),
+            str(sample.client_id),
+        )
+        if best_key is None or key > best_key:
+            best_key = key
+            best = _SpeedObservation(
+                t_s=t_s,
+                speed_kmh=float(speed_kmh),
+                speed_source=speed_source,
+                speed_validity=speed_validity,
+            )
+    return best
+
+
+def _best_rpm_observation(
+    *,
+    t_s: float,
+    samples: Sequence[Sample],
+    metadata: RunMetadata,
+    tire_circumference_m: float | None,
+) -> _RpmObservation | None:
+    best: _RpmObservation | None = None
+    best_key: tuple[int, str, str] | None = None
+    for sample in samples:
+        engine_rpm, engine_rpm_source = _effective_engine_rpm(
+            sample=sample,
+            context=metadata,
+            tire_circumference_m=tire_circumference_m,
+        )
+        if engine_rpm is None or not isfinite(engine_rpm) or engine_rpm <= 0.0:
+            continue
+        rpm_validity = _rpm_validity_for_source(engine_rpm_source)
+        if rpm_validity == "missing":
+            continue
+        key = (
+            _RPM_VALIDITY_RANK[rpm_validity],
+            engine_rpm_source,
+            str(sample.client_id),
+        )
+        if best_key is None or key > best_key:
+            best_key = key
+            best = _RpmObservation(
+                t_s=t_s,
+                engine_rpm=float(engine_rpm),
+                engine_rpm_source=engine_rpm_source,
+                rpm_validity=rpm_validity,
+            )
+    return best
+
+
+def _nearest_observation_index(
+    *,
+    target_t_s: float,
+    observation_times: Sequence[float],
+) -> int | None:
+    if not observation_times:
+        return None
+    index = bisect_left(observation_times, target_t_s)
+    candidates: list[int] = []
+    if index < len(observation_times):
+        candidates.append(index)
+    if index > 0:
+        candidates.append(index - 1)
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        key=lambda candidate_index: (
+            abs(observation_times[candidate_index] - target_t_s),
+            observation_times[candidate_index],
+        ),
+    )
+
+
+def _context_coverage(
+    *,
+    speed_validity: WholeRunSpeedValidity,
+    speed_is_stale: bool,
+    rpm_validity: WholeRunRpmValidity,
+    rpm_is_stale: bool,
+) -> WholeRunContextCoverage:
+    fresh_speed = speed_validity != "missing" and not speed_is_stale
+    fresh_rpm = rpm_validity != "missing" and not rpm_is_stale
+    if fresh_speed and fresh_rpm:
+        return "full"
+    if speed_validity != "missing" or rpm_validity != "missing":
+        return "partial"
+    return "missing"
+
+
+def _baseline_phase_state(
+    *,
+    speed_kmh: float | None,
+    speed_validity: WholeRunSpeedValidity,
+    speed_is_stale: bool,
+) -> tuple[DrivingPhase, WholeRunContextLoadState]:
+    if (
+        speed_validity != "missing"
+        and not speed_is_stale
+        and speed_kmh is not None
+        and speed_kmh < 3.0
+    ):
+        return DrivingPhase.IDLE, "idle"
+    return DrivingPhase.SPEED_UNKNOWN, "unknown"
+
+
+def _speed_validity_for_source(source: str) -> WholeRunSpeedValidity:
+    if source in {"gps", "obd2"}:
+        return "measured"
+    if source == "manual":
+        return "assumed"
+    return "missing"
+
+
+def _rpm_validity_for_source(source: str) -> WholeRunRpmValidity:
+    if source == "estimated_from_speed_and_ratios":
+        return "estimated"
+    if source == "missing":
+        return "missing"
+    return "measured"
+
+
+def _speed_source_rank(source: str) -> int:
+    if source in {"gps", "obd2"}:
+        return 2
+    if source == "manual":
+        return 1
+    return 0

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -271,8 +271,9 @@ For the context track:
 
 1. `WholeRunContextWindowLabel` is the dense internal join surface for later
    order, spatial, and fusion work. It carries explicit `context_coverage`,
-   `speed_validity`, `rpm_validity`, `load_state`, and optional raw context
-   values/source labels keyed by `window_index`.
+   `speed_validity`, `rpm_validity`, `speed_is_stale`, `rpm_is_stale`,
+   `load_state`, and optional raw context values/source labels keyed by
+   `window_index`.
 2. `WholeRunContextInterval` is the compact segment summary surface. It uses
    `start_window_index` / `end_window_index` as the canonical range identity and
    can be projected later into persisted analysis/report payloads without


### PR DESCRIPTION
## What changed
- add `use_cases/diagnostics/whole_run_context.py` to normalize persisted speed/RPM context onto `WholeRunWindowPlan`
- align context to each window center with deterministic nearest-valid lookup, duplicate-row grouping, and explicit stale handling
- extend `WholeRunContextWindowLabel` with `speed_is_stale` / `rpm_is_stale`, add focused shared-type + normalization tests, and update the whole-run design doc

## Why
- #3087 needs real per-window context labels before segmentation, order traces, and spatial joins can stop inferring speed/RPM state from summary rows
- stale context had to become first-class on the contract; without that, downstream code would have to reverse-engineer freshness from missing values or timing gaps
- the normalizer stays separate from segmentation so #3088 can build phase rules on top of a stable, deterministic context surface

## Validation
- `python -m pytest -q apps/server/tests/shared/types/test_whole_run_analysis.py apps/server/tests/use_cases/diagnostics/test_whole_run_context.py`
- `make format`
- `make typecheck-backend`
- `make lint`
- `make test-changed`
- `make docs-lint`

## Risks / tradeoffs
- phase output is intentionally conservative here: only fresh zero-speed windows become `idle`; richer phase boundaries still belong to #3088
- speed/RPM are normalized independently to keep missing/partial context explicit; later segmentation/fusion layers must treat the two freshness flags separately
