### PR TITLE
Segment whole-run phase timelines

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_phase_segmentation.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_phase_segmentation.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.domain import AnalysisSettingsSnapshot, DrivingPhase
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_analysis import WholeRunContextWindowLabel
+from vibesensor.use_cases.diagnostics.phase_segmentation import (
+    segment_whole_run_context,
+)
+from vibesensor.use_cases.diagnostics.whole_run_context import (
+    normalize_whole_run_context_labels,
+)
+from vibesensor.use_cases.diagnostics.whole_run_windows import plan_whole_run_windows
+
+
+def _metadata() -> RunMetadata:
+    return RunMetadata.create(
+        run_id="run-1",
+        start_time_utc="2025-01-01T00:00:00Z",
+        sensor_model="fixture-sensor",
+        raw_sample_rate_hz=800,
+        feature_interval_s=0.25,
+        fft_window_size_samples=2048,
+        accel_scale_g_per_lsb=0.001,
+        analysis_settings=AnalysisSettingsSnapshot(**AnalysisSettingsSnapshot.DEFAULTS),
+    )
+
+
+def test_segment_whole_run_context_builds_deterministic_intervals() -> None:
+    metadata = _metadata()
+    window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=3248)
+    samples = sensor_frames_from_mappings(
+        [
+            {"t_s": 1.28, "client_id": "sensor-a", "speed_kmh": 0.0, "speed_source": "gps"},
+            {"t_s": 1.53, "client_id": "sensor-a", "speed_kmh": 0.0, "speed_source": "gps"},
+            {"t_s": 1.78, "client_id": "sensor-a", "speed_kmh": 20.0, "speed_source": "gps"},
+            {"t_s": 2.03, "client_id": "sensor-a", "speed_kmh": 40.0, "speed_source": "gps"},
+            {"t_s": 2.28, "client_id": "sensor-a", "speed_kmh": 60.0, "speed_source": "gps"},
+            {"t_s": 2.53, "client_id": "sensor-a", "speed_kmh": 60.0, "speed_source": "gps"},
+            {"t_s": 2.78, "client_id": "sensor-a", "speed_kmh": 60.0, "speed_source": "gps"},
+        ]
+    )
+    labels = normalize_whole_run_context_labels(
+        metadata=metadata,
+        samples=samples,
+        window_plan=window_plan,
+    )
+
+    result = segment_whole_run_context(labels=labels, window_plan=window_plan)
+
+    assert [label.phase for label in result.labels] == [
+        DrivingPhase.IDLE,
+        DrivingPhase.IDLE,
+        DrivingPhase.ACCELERATION,
+        DrivingPhase.ACCELERATION,
+        DrivingPhase.ACCELERATION,
+        DrivingPhase.CRUISE,
+        DrivingPhase.CRUISE,
+    ]
+    assert [label.segment_index for label in result.labels] == [0, 0, 1, 1, 1, 2, 2]
+    assert [interval.phase for interval in result.intervals] == [
+        DrivingPhase.IDLE,
+        DrivingPhase.ACCELERATION,
+        DrivingPhase.CRUISE,
+    ]
+    assert [
+        (interval.start_window_index, interval.end_window_index) for interval in result.intervals
+    ] == [(0, 1), (2, 4), (5, 6)]
+    assert result.intervals[1].load_state == "transient"
+    assert result.intervals[2].load_state == "steady"
+
+
+def test_segment_whole_run_context_interpolates_missing_speed_gaps() -> None:
+    metadata = _metadata()
+    window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=2848)
+    labels = tuple(
+        WholeRunContextWindowLabel(
+            window_index=window.window_index,
+            segment_index=None,
+            phase=DrivingPhase.SPEED_UNKNOWN,
+            context_coverage=("missing" if window.window_index in {1, 2} else "partial"),
+            speed_validity=("missing" if window.window_index in {1, 2} else "measured"),
+            rpm_validity="missing",
+            load_state="unknown",
+            speed_kmh=(None if window.window_index in {1, 2} else 60.0),
+            speed_band=(None if window.window_index in {1, 2} else "60-70 km/h"),
+            speed_source=(None if window.window_index in {1, 2} else "gps"),
+        )
+        for window in window_plan.windows
+    )
+
+    result = segment_whole_run_context(labels=labels, window_plan=window_plan)
+
+    assert [label.phase for label in result.labels] == [DrivingPhase.CRUISE] * 5
+    assert [label.context_coverage for label in result.labels] == [
+        "partial",
+        "missing",
+        "missing",
+        "partial",
+        "partial",
+    ]
+    assert len(result.intervals) == 1
+    assert result.intervals[0].phase == DrivingPhase.CRUISE
+    assert result.intervals[0].missing_context_window_count == 2
+
+
+def test_segment_whole_run_context_handles_empty_sequences() -> None:
+    metadata = _metadata()
+    window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=1024)
+
+    result = segment_whole_run_context(labels=(), window_plan=window_plan)
+
+    assert result.labels == ()
+    assert result.intervals == ()
+
+
+def test_segment_whole_run_context_rejects_window_plan_mismatch() -> None:
+    metadata = _metadata()
+    window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=2248)
+    labels = normalize_whole_run_context_labels(
+        metadata=metadata,
+        samples=sensor_frames_from_mappings(
+            [{"t_s": 1.28, "client_id": "sensor-a", "speed_kmh": 10.0, "speed_source": "gps"}]
+        ),
+        window_plan=window_plan,
+    )
+
+    with pytest.raises(ValueError, match="one label per planned window"):
+        segment_whole_run_context(labels=labels[:-1], window_plan=window_plan)

--- a/apps/server/vibesensor/use_cases/diagnostics/phase_segmentation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/phase_segmentation.py
@@ -16,12 +16,18 @@ from __future__ import annotations
 
 import math
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
-from vibesensor.domain import DrivingPhase
+from vibesensor.domain import DrivingPhase, speed_band_sort_key
 from vibesensor.domain.driving_phase_summary import DrivingPhaseSummary
 from vibesensor.domain.driving_segment import DrivingPhaseSegment
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunContextInterval,
+    WholeRunContextLoadState,
+    WholeRunContextWindowLabel,
+)
 from vibesensor.use_cases.diagnostics._types import Sample
+from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
 
 # Thresholds (tuneable)
 _IDLE_SPEED_KMH = 3.0  # below this → IDLE
@@ -42,6 +48,14 @@ class PhaseSegment:
     speed_min_kmh: float | None = None
     speed_max_kmh: float | None = None
     sample_count: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunPhaseSegmentation:
+    """Whole-run phase segmentation result over normalized window context."""
+
+    labels: tuple[WholeRunContextWindowLabel, ...]
+    intervals: tuple[WholeRunContextInterval, ...]
 
 
 def _find_nearest_valid(
@@ -272,6 +286,138 @@ def segment_run_phases(
         seg_start = i
 
     return per_sample, segments
+
+
+def segment_whole_run_context(
+    *,
+    labels: Sequence[WholeRunContextWindowLabel],
+    window_plan: WholeRunWindowPlan,
+) -> WholeRunPhaseSegmentation:
+    """Segment normalized whole-run labels into deterministic phase intervals."""
+
+    if not labels:
+        return WholeRunPhaseSegmentation(labels=(), intervals=())
+    windows = window_plan.windows
+    if len(labels) != len(windows):
+        raise ValueError("whole-run phase segmentation requires one label per planned window")
+    for label, window in zip(labels, windows, strict=True):
+        if label.window_index != window.window_index:
+            raise ValueError("whole-run phase segmentation requires labels ordered by window_index")
+
+    speeds: list[float | None] = [
+        label.speed_kmh
+        if (
+            label.speed_kmh is not None
+            and not label.speed_is_stale
+            and label.speed_validity != "missing"
+        )
+        else None
+        for label in labels
+    ]
+    times: list[float | None] = [window.center_t_s for window in windows]
+    per_window_phases: list[DrivingPhase] = []
+    for index in range(len(labels)):
+        deriv = _estimate_speed_derivative(speeds, times, index)
+        per_window_phases.append(classify_sample_phase(speeds[index], deriv))
+    _interpolate_speed_unknown(per_window_phases)
+
+    intervals: list[WholeRunContextInterval] = []
+    updated_labels: list[WholeRunContextWindowLabel] = []
+    segment_start = 0
+    for index in range(1, len(per_window_phases) + 1):
+        if (
+            index < len(per_window_phases)
+            and per_window_phases[index] == per_window_phases[segment_start]
+        ):
+            continue
+        segment_end = index - 1
+        phase = per_window_phases[segment_start]
+        interval = _build_whole_run_context_interval(
+            segment_index=len(intervals),
+            phase=phase,
+            labels=labels[segment_start : segment_end + 1],
+            windows=windows[segment_start : segment_end + 1],
+        )
+        intervals.append(interval)
+        load_state = _load_state_from_phase(phase)
+        for label_index in range(segment_start, segment_end + 1):
+            updated_labels.append(
+                replace(
+                    labels[label_index],
+                    phase=phase,
+                    load_state=load_state,
+                    segment_index=interval.segment_index,
+                )
+            )
+        segment_start = index
+
+    return WholeRunPhaseSegmentation(labels=tuple(updated_labels), intervals=tuple(intervals))
+
+
+def _build_whole_run_context_interval(
+    *,
+    segment_index: int,
+    phase: DrivingPhase,
+    labels: Sequence[WholeRunContextWindowLabel],
+    windows: Sequence,
+) -> WholeRunContextInterval:
+    fresh_speeds = [
+        label.speed_kmh
+        for label in labels
+        if (
+            label.speed_kmh is not None
+            and not label.speed_is_stale
+            and label.speed_validity != "missing"
+        )
+    ]
+    coverage_counts = {
+        "full": sum(1 for label in labels if label.context_coverage == "full"),
+        "partial": sum(1 for label in labels if label.context_coverage == "partial"),
+        "missing": sum(1 for label in labels if label.context_coverage == "missing"),
+    }
+    return WholeRunContextInterval(
+        segment_index=segment_index,
+        phase=phase,
+        load_state=_load_state_from_phase(phase),
+        start_window_index=windows[0].window_index,
+        end_window_index=windows[-1].window_index,
+        start_t_s=windows[0].start_t_s,
+        end_t_s=windows[-1].end_t_s,
+        speed_min_kmh=min(fresh_speeds) if fresh_speeds else None,
+        speed_max_kmh=max(fresh_speeds) if fresh_speeds else None,
+        speed_band=_dominant_speed_band(labels),
+        full_context_window_count=coverage_counts["full"],
+        partial_context_window_count=coverage_counts["partial"],
+        missing_context_window_count=coverage_counts["missing"],
+    )
+
+
+def _dominant_speed_band(labels: Sequence[WholeRunContextWindowLabel]) -> str | None:
+    band_counts: dict[str, int] = {}
+    for label in labels:
+        if label.speed_band is None or label.speed_is_stale:
+            continue
+        band_counts[label.speed_band] = band_counts.get(label.speed_band, 0) + 1
+    if not band_counts:
+        return None
+    return max(
+        band_counts.items(),
+        key=lambda item: (item[1], speed_band_sort_key(item[0])),
+    )[0]
+
+
+def _load_state_from_phase(phase: DrivingPhase) -> WholeRunContextLoadState:
+    if phase is DrivingPhase.IDLE:
+        return "idle"
+    if phase in {
+        DrivingPhase.ACCELERATION,
+        DrivingPhase.DECELERATION,
+        DrivingPhase.COAST_DOWN,
+    }:
+        return "transient"
+    if phase is DrivingPhase.CRUISE:
+        return "steady"
+    return "unknown"
 
 
 def phase_summary(segments: list[PhaseSegment]) -> DrivingPhaseSummary:


### PR DESCRIPTION
## What changed
- extend `use_cases/diagnostics/phase_segmentation.py` with whole-run segmentation over normalized window labels
- reuse the existing derivative, phase classification, and speed-unknown interpolation rules instead of inventing a second phase engine
- emit updated per-window labels plus compact `WholeRunContextInterval` segments with stable window ranges and coverage counts

## Why
- #3088 needs deterministic whole-run phase intervals on top of the normalized context timeline from #3087
- reusing the existing classifier keeps summary-era and whole-run phase logic aligned instead of drifting into two similar-but-different systems
- downstream persistence, order traces, and fusion now get both a dense per-window phase view and compact segment summaries keyed to the same window grid

## Validation
- `python -m pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_phase_segmentation.py apps/server/tests/use_cases/diagnostics/test_whole_run_context.py apps/server/tests/use_cases/diagnostics/test_phase_segmentation.py`
- `make typecheck-backend`
- `make lint`
- `make test-changed`
- `make docs-lint`

## Risks / tradeoffs
- the whole-run path intentionally inherits the current speed-unknown interpolation behavior; if that policy changes later, both summary and whole-run segmentation should change together
- this PR stops at in-memory segmentation; persistence and report/history projection still land in follow-up issues
