### PR TITLE
Fix #3090: surface whole-run context completeness in reports

### DIFF
--- a/apps/server/tests/use_cases/history/test_report_confidence_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_confidence_facts.py
@@ -78,7 +78,34 @@ def test_prepare_persisted_report_input_builds_high_confidence_from_raw_backed_s
                 analysis_metadata={
                     "raw_backed_sample_count": 48,
                     "raw_capture_mode": "raw_backed",
+                    "whole_run_context_available": True,
+                    "whole_run_context_window_count": 8,
+                    "whole_run_context_interval_count": 1,
+                    "whole_run_context_full_window_count": 8,
+                    "whole_run_context_partial_window_count": 0,
+                    "whole_run_context_missing_window_count": 0,
+                    "whole_run_context_missing_speed_window_count": 0,
+                    "whole_run_context_missing_rpm_window_count": 0,
+                    "whole_run_context_stale_speed_window_count": 0,
+                    "whole_run_context_stale_rpm_window_count": 0,
                 },
+                whole_run_context_intervals=[
+                    {
+                        "segment_index": 0,
+                        "phase": "cruise",
+                        "load_state": "light",
+                        "start_window_index": 0,
+                        "end_window_index": 7,
+                        "start_t_s": 0.0,
+                        "end_t_s": 4.0,
+                        "speed_min_kmh": 58.0,
+                        "speed_max_kmh": 70.0,
+                        "speed_band": "50-70",
+                        "full_context_window_count": 8,
+                        "partial_context_window_count": 0,
+                        "missing_context_window_count": 0,
+                    }
+                ],
             )
         )
     )
@@ -181,3 +208,218 @@ def test_prepare_persisted_report_input_builds_low_confidence_from_mixed_summary
     assert "only summary-level evidence was available" in data.observed.certainty_reason
     assert "matched frequency drifted across 12.1-15.6 Hz" in data.observed.certainty_reason
     assert data.verdict_page.also_consider == "Driveline"
+
+
+def test_prepare_persisted_report_input_adds_whole_run_context_gap_caveats() -> None:
+    primary = make_finding_payload(
+        finding_id="F_CONTEXT_GAPS",
+        suspected_source="wheel/tire",
+        confidence=0.78,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.1,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.0,
+                "speed_kmh": 68.0,
+                "predicted_hz": 15.2,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.5,
+                "speed_kmh": 70.0,
+                "predicted_hz": 15.3,
+                "matched_hz": 15.3,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.09,
+            },
+        ],
+        evidence_metrics={
+            "mean_relative_error": 0.03,
+            "snr_db": 8.0,
+            "matched_samples": 4,
+        },
+    )
+    prepared = prepare_persisted_report_input(
+        PersistedAnalysis.from_json_object(
+            minimal_summary(
+                run_id="context-gaps",
+                lang="en",
+                metadata={
+                    "run_id": "context-gaps",
+                    "record_type": "metadata",
+                    "schema_version": "v2-jsonl",
+                    "feature_interval_s": 0.5,
+                },
+                sensor_count_used=2,
+                sensor_locations=["Front Left", "Rear Left"],
+                sensor_locations_connected_throughout=["Front Left", "Rear Left"],
+                findings=[primary],
+                top_causes=[primary],
+                analysis_metadata={
+                    "raw_backed_sample_count": 48,
+                    "raw_capture_mode": "raw_backed",
+                    "whole_run_context_available": True,
+                    "whole_run_context_window_count": 12,
+                    "whole_run_context_interval_count": 2,
+                    "whole_run_context_full_window_count": 9,
+                    "whole_run_context_partial_window_count": 2,
+                    "whole_run_context_missing_window_count": 1,
+                    "whole_run_context_missing_speed_window_count": 1,
+                    "whole_run_context_missing_rpm_window_count": 0,
+                    "whole_run_context_stale_speed_window_count": 1,
+                    "whole_run_context_stale_rpm_window_count": 1,
+                },
+                whole_run_context_intervals=[
+                    {
+                        "segment_index": 0,
+                        "phase": "cruise",
+                        "load_state": "light",
+                        "start_window_index": 0,
+                        "end_window_index": 7,
+                        "start_t_s": 0.0,
+                        "end_t_s": 4.0,
+                        "speed_min_kmh": 58.0,
+                        "speed_max_kmh": 68.0,
+                        "speed_band": "50-70",
+                        "full_context_window_count": 8,
+                        "partial_context_window_count": 0,
+                        "missing_context_window_count": 0,
+                    },
+                    {
+                        "segment_index": 1,
+                        "phase": "accel",
+                        "load_state": "pulling",
+                        "start_window_index": 8,
+                        "end_window_index": 11,
+                        "start_t_s": 4.0,
+                        "end_t_s": 6.0,
+                        "full_context_window_count": 1,
+                        "partial_context_window_count": 2,
+                        "missing_context_window_count": 1,
+                    },
+                ],
+            )
+        )
+    )
+
+    confidence = prepared.report_facts.confidence
+    data = build_report_document(prepared)
+
+    assert prepared.report_facts.context.source == "whole_run"
+    assert prepared.report_facts.context.has_incomplete_context is True
+    assert "speed_context_gaps" in confidence.caveat_keys
+    assert "rpm_context_gaps" in confidence.caveat_keys
+    assert [warning.code for warning in prepared.report_facts.decision.warnings] == [
+        "whole_run_context_incomplete"
+    ]
+    assert "speed context was missing or stale" in data.observed.certainty_reason
+    assert "RPM context was missing or stale" in data.observed.certainty_reason
+
+
+def test_prepare_persisted_report_input_marks_legacy_raw_backed_context_fallback() -> None:
+    primary = make_finding_payload(
+        finding_id="F_CONTEXT_LEGACY",
+        suspected_source="wheel/tire",
+        confidence=0.78,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.1,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.0,
+                "speed_kmh": 68.0,
+                "predicted_hz": 15.2,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.5,
+                "speed_kmh": 70.0,
+                "predicted_hz": 15.3,
+                "matched_hz": 15.3,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.09,
+            },
+        ],
+        evidence_metrics={
+            "mean_relative_error": 0.03,
+            "snr_db": 8.0,
+            "matched_samples": 4,
+        },
+    )
+    prepared = prepare_persisted_report_input(
+        PersistedAnalysis.from_json_object(
+            minimal_summary(
+                run_id="context-legacy",
+                lang="en",
+                metadata={
+                    "run_id": "context-legacy",
+                    "record_type": "metadata",
+                    "schema_version": "v2-jsonl",
+                    "feature_interval_s": 0.5,
+                },
+                sensor_count_used=2,
+                sensor_locations=["Front Left", "Rear Left"],
+                sensor_locations_connected_throughout=["Front Left", "Rear Left"],
+                findings=[primary],
+                top_causes=[primary],
+                analysis_metadata={
+                    "raw_backed_sample_count": 48,
+                    "raw_capture_mode": "raw_backed",
+                },
+            )
+        )
+    )
+
+    confidence = prepared.report_facts.confidence
+    data = build_report_document(prepared)
+
+    assert prepared.report_facts.context.source == "legacy"
+    assert "legacy_context" in confidence.caveat_keys
+    assert "summary_only" not in confidence.caveat_keys
+    assert [warning.code for warning in prepared.report_facts.decision.warnings] == [
+        "whole_run_context_legacy_fallback"
+    ]
+    assert "predates whole-run context coverage tracking" in data.observed.certainty_reason

--- a/apps/server/tests/use_cases/history/test_report_facts.py
+++ b/apps/server/tests/use_cases/history/test_report_facts.py
@@ -242,6 +242,67 @@ def test_prepare_report_facts_keeps_phase_timeline_intervals() -> None:
     assert facts.run.timeline_intervals[1].has_fault_evidence is True
 
 
+def test_prepare_report_facts_projects_whole_run_context_facts_from_persisted_analysis() -> None:
+    summary = _summary()
+    summary["analysis_metadata"] = {
+        "raw_backed_sample_count": 24,
+        "raw_capture_mode": "raw_backed",
+        "whole_run_context_available": True,
+        "whole_run_context_window_count": 6,
+        "whole_run_context_interval_count": 2,
+        "whole_run_context_full_window_count": 4,
+        "whole_run_context_partial_window_count": 1,
+        "whole_run_context_missing_window_count": 1,
+        "whole_run_context_missing_speed_window_count": 1,
+        "whole_run_context_missing_rpm_window_count": 0,
+        "whole_run_context_stale_speed_window_count": 0,
+        "whole_run_context_stale_rpm_window_count": 1,
+    }
+    summary["whole_run_context_intervals"] = [
+        {
+            "segment_index": 0,
+            "phase": "cruise",
+            "load_state": "light",
+            "start_window_index": 0,
+            "end_window_index": 2,
+            "start_t_s": 0.0,
+            "end_t_s": 1.5,
+            "speed_min_kmh": 58.0,
+            "speed_max_kmh": 62.0,
+            "speed_band": "50-70",
+            "full_context_window_count": 3,
+            "partial_context_window_count": 0,
+            "missing_context_window_count": 0,
+        },
+        {
+            "segment_index": 1,
+            "phase": "accel",
+            "load_state": "pulling",
+            "start_window_index": 3,
+            "end_window_index": 5,
+            "start_t_s": 1.5,
+            "end_t_s": 3.0,
+            "full_context_window_count": 1,
+            "partial_context_window_count": 1,
+            "missing_context_window_count": 1,
+        },
+    ]
+
+    facts = _prepare_facts(summary)
+
+    assert facts.context.traceable is True
+    assert facts.context.source == "whole_run"
+    assert facts.context.interval_count == 2
+    assert facts.context.window_count == 6
+    assert facts.context.has_incomplete_context is True
+    assert facts.context.has_speed_gaps is True
+    assert facts.context.has_rpm_gaps is True
+    assert len(facts.context.intervals) == 2
+    assert facts.context.intervals[0].phase == "cruise"
+    assert facts.context.intervals[1].missing_context_window_count == 1
+    assert [warning.code for warning in facts.decision.warnings] == ["whole_run_context_incomplete"]
+
+
 def test_build_report_document_builds_workflow_document_sections() -> None:
     summary = _summary()
     document = _prepare_document(summary)

--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -202,6 +202,45 @@ def test_prepare_report_input_tolerates_invalid_count_strings() -> None:
     assert prepared.report_facts.run.sensor_count == 0
 
 
+def test_prepare_report_input_does_not_invent_traceable_whole_run_context() -> None:
+    prepared = prepare_report_input(
+        {
+            "run_id": "implicit-context",
+            "rows": 24,
+            "sensor_count_used": 2,
+            "lang": "en",
+            "metadata": {"run_id": "implicit-context"},
+            "report_date": "",
+            "record_length": "",
+            "start_time_utc": "",
+            "end_time_utc": "",
+            "findings": [],
+            "top_causes": [],
+            "sensor_locations": ["front-left", "rear-right"],
+            "sensor_locations_connected_throughout": ["front-left", "rear-right"],
+            "most_likely_origin": {},
+            "run_suitability": [],
+            "whole_run_context_intervals": [
+                {
+                    "segment_index": 0,
+                    "phase": "cruise",
+                    "load_state": "light",
+                    "start_window_index": 0,
+                    "end_window_index": 3,
+                    "full_context_window_count": 4,
+                    "partial_context_window_count": 0,
+                    "missing_context_window_count": 0,
+                }
+            ],
+        }
+    )
+
+    assert prepared.report_facts.context.traceable is False
+    assert prepared.report_facts.context.source == "implicit"
+    assert prepared.report_facts.context.intervals == ()
+    assert prepared.report_facts.decision.warnings == ()
+
+
 def test_prepare_persisted_report_input_builds_evidence_facts_from_raw_backed_summary() -> None:
     primary = make_finding_payload(
         finding_id="F_PRIMARY",

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor.py
@@ -485,6 +485,32 @@ def test_execute_post_analysis_persists_whole_run_context_summary_and_sidecar() 
                 engine_rpm=800.0,
                 engine_rpm_source="obd2",
             ),
+            WholeRunContextWindowLabel(
+                window_index=1,
+                segment_index=0,
+                phase=DrivingPhase.IDLE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="idle",
+                speed_kmh=0.0,
+                speed_source="gps",
+                engine_rpm=800.0,
+                engine_rpm_source="obd2",
+            ),
+            WholeRunContextWindowLabel(
+                window_index=2,
+                segment_index=0,
+                phase=DrivingPhase.IDLE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="idle",
+                speed_kmh=0.0,
+                speed_source="gps",
+                engine_rpm=800.0,
+                engine_rpm_source="obd2",
+            ),
         ),
         intervals=(
             WholeRunContextInterval(
@@ -577,6 +603,19 @@ def test_execute_post_analysis_persists_whole_run_context_summary_and_sidecar() 
     assert stored["analysis"]["analysis_metadata"]["whole_run_context_available"] is True
     assert stored["analysis"]["analysis_metadata"]["whole_run_context_window_count"] == 3
     assert stored["analysis"]["analysis_metadata"]["whole_run_context_interval_count"] == 1
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_full_window_count"] == 3
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_partial_window_count"] == 0
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_missing_window_count"] == 0
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_context_missing_speed_window_count"] == 0
+    )
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_context_missing_rpm_window_count"] == 0
+    )
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_context_stale_speed_window_count"] == 0
+    )
+    assert stored["analysis"]["analysis_metadata"]["whole_run_context_stale_rpm_window_count"] == 0
     assert (
         stored["analysis"]["analysis_metadata"]["whole_run_context_labels_artifact_key"]
         == WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -263,6 +263,18 @@
     "en": "only summary-level evidence was available",
     "nl": "alleen samenvattingsniveau-bewijs was beschikbaar"
   },
+  "REPORT_CONFIDENCE_CAVEAT_LEGACY_CONTEXT": {
+    "en": "this run predates whole-run context coverage tracking",
+    "nl": "deze run is ouder dan de whole-run contextdekkingsregistratie"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_SPEED_CONTEXT_GAPS": {
+    "en": "speed context was missing or stale for part of the run",
+    "nl": "snelheidscontext ontbrak of was verouderd voor een deel van de run"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_RPM_CONTEXT_GAPS": {
+    "en": "RPM context was missing or stale for part of the run",
+    "nl": "toerentalcontext ontbrak of was verouderd voor een deel van de run"
+  },
   "REPORT_CONFIDENCE_CAVEAT_WEAK_SPATIAL": {
     "en": "support spread too widely across the car",
     "nl": "de steun verspreidde zich te breed over de auto"
@@ -1654,6 +1666,22 @@
   "RUN_CONTEXT_WARNING_REFERENCE_INCOMPLETE_TITLE": {
     "en": "Order-analysis reference context was incomplete for this run",
     "nl": "De referentiecontext voor ordeanalyse was onvolledig voor deze run"
+  },
+  "RUN_CONTEXT_WARNING_WHOLE_RUN_CONTEXT_INCOMPLETE_DETAIL": {
+    "en": "Whole-run context was persisted for this run, but {partial_windows} windows had partial context and {missing_windows} windows had none. Speed context gaps affected {speed_gap_windows} windows and RPM context gaps affected {rpm_gap_windows} windows.",
+    "nl": "Whole-run context is voor deze run bewaard, maar {partial_windows} vensters hadden slechts gedeeltelijke context en {missing_windows} vensters helemaal geen. Snelheidscontext-hiaten raakten {speed_gap_windows} vensters en toerentalcontext-hiaten raakten {rpm_gap_windows} vensters."
+  },
+  "RUN_CONTEXT_WARNING_WHOLE_RUN_CONTEXT_INCOMPLETE_TITLE": {
+    "en": "Whole-run context coverage was incomplete for this run",
+    "nl": "De whole-run contextdekking was onvolledig voor deze run"
+  },
+  "RUN_CONTEXT_WARNING_WHOLE_RUN_CONTEXT_LEGACY_DETAIL": {
+    "en": "This persisted run predates whole-run context coverage tracking, so report caveats fall back to older summary-era context signals.",
+    "nl": "Deze bewaarde run dateert van voor de whole-run contextdekkingsregistratie, dus rapportkanttekeningen vallen terug op oudere signalen uit het samenvattingstijdperk."
+  },
+  "RUN_CONTEXT_WARNING_WHOLE_RUN_CONTEXT_LEGACY_TITLE": {
+    "en": "Whole-run context coverage was not captured for this persisted run",
+    "nl": "Whole-run contextdekking is niet vastgelegd voor deze bewaarde run"
   },
   "WORKSHOP_SUMMARY": {
     "en": "Workshop Summary",

--- a/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
@@ -8,6 +8,7 @@ from .facts import (
     ActionStatusKey,
     LocationConfidenceKey,
     PreparedReportFacts,
+    ReportContextFacts,
     ReportRunFacts,
     prepare_report_facts,
 )
@@ -26,6 +27,7 @@ from .sensor_facts import ReportCoverageSummary, ReportSensorFacts, sensor_fallb
 from .summary import (
     NormalizedReportSummary,
     ReportTimelineInterval,
+    ReportWholeRunContextInterval,
     has_projectable_report_payload,
     report_summary_from_mapping,
     require_projectable_report_payload,
@@ -40,6 +42,7 @@ __all__ = [
     "NormalizedReportSummary",
     "ReportConfidenceFacts",
     "PreparedReportFacts",
+    "ReportContextFacts",
     "PreparedReportFindings",
     "PreparedReportInput",
     "PrimaryReportFacts",
@@ -47,6 +50,7 @@ __all__ = [
     "ReportCoverageSummary",
     "ReportRunFacts",
     "ReportSensorFacts",
+    "ReportWholeRunContextInterval",
     "ReportTimelineInterval",
     "has_projectable_report_payload",
     "normalize_origin_location",

--- a/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from vibesensor.domain import Finding
 from vibesensor.shared.boundaries.reporting.decision_facts import ReportDecisionFacts
 from vibesensor.shared.boundaries.reporting.evidence_facts import ReportEvidenceFacts
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
+
+if TYPE_CHECKING:
+    from vibesensor.shared.boundaries.reporting.facts import ReportContextFacts
 
 __all__ = [
     "ReportConfidenceFacts",
@@ -49,6 +53,7 @@ def build_report_confidence_facts(
     primary_candidate: PrimaryReportFacts,
     evidence_facts: ReportEvidenceFacts,
     decision_facts: ReportDecisionFacts,
+    context_facts: ReportContextFacts,
 ) -> ReportConfidenceFacts:
     """Build bounded report confidence from explicit persisted evidence signals."""
 
@@ -107,6 +112,18 @@ def build_report_confidence_facts(
     else:
         score -= 0.05
         caveat_keys.append("summary_only")
+
+    if context_facts.traceable:
+        if context_facts.source == "legacy":
+            score -= 0.05
+            caveat_keys.append("legacy_context")
+        else:
+            if context_facts.has_speed_gaps:
+                score -= 0.04
+                caveat_keys.append("speed_context_gaps")
+            if context_facts.has_rpm_gaps:
+                score -= 0.04
+                caveat_keys.append("rpm_context_gaps")
 
     if supporting_window_count is not None:
         if supporting_window_count >= 4:
@@ -192,6 +209,9 @@ def build_report_confidence_facts(
                 "weak_spatial",
                 "close_alternative",
                 "incomplete_reference",
+                "legacy_context",
+                "speed_context_gaps",
+                "rpm_context_gaps",
                 "noisy_signal",
             }
         )

--- a/apps/server/vibesensor/shared/boundaries/reporting/decision_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/decision_facts.py
@@ -21,6 +21,7 @@ from vibesensor.shared.report_diagnostics import report_suitability_checks, repo
 
 if TYPE_CHECKING:
     from vibesensor.domain import RecommendedAction, SuitabilityCheck, TestRun
+    from vibesensor.shared.boundaries.reporting.facts import ReportContextFacts
     from vibesensor.shared.boundaries.reporting.sensor_facts import ReportSensorFacts
     from vibesensor.shared.run_context_warning import RunContextWarning, RunContextWarningsInput
 
@@ -53,6 +54,7 @@ def build_report_decision_facts(
     test_run: TestRun,
     origin_location: str,
     sensor_facts: ReportSensorFacts,
+    context_facts: ReportContextFacts,
     warnings: RunContextWarningsInput = None,
 ) -> ReportDecisionFacts:
     """Build decision-facing report facts from canonical run and sensor facts."""
@@ -64,7 +66,10 @@ def build_report_decision_facts(
         sensor_intensity=sensor_facts.active_intensity,
     )
     suitability_checks = report_suitability_checks(test_run.suitability)
-    warning_models = report_warnings(payload, warnings=warnings)
+    warning_models = _merge_warnings(
+        report_warnings(payload, warnings=warnings),
+        context_facts.warnings,
+    )
     location_confidence_key = resolve_location_confidence_key(
         primary_candidate_facts=primary_candidate,
         coverage_summary=sensor_facts.coverage,
@@ -93,3 +98,18 @@ def build_report_decision_facts(
         alternative_source_visible=alternative_source_visible,
         confidence_gap_to_alternative=confidence_gap_to_alternative,
     )
+
+
+def _merge_warnings(
+    primary: tuple[RunContextWarning, ...],
+    extra: tuple[RunContextWarning, ...],
+) -> tuple[RunContextWarning, ...]:
+    merged: list[RunContextWarning] = []
+    seen_codes: set[str] = set()
+    for warning in (*primary, *extra):
+        normalized_code = warning.code.strip().lower()
+        if normalized_code in seen_codes:
+            continue
+        seen_codes.add(normalized_code)
+        merged.append(warning)
+    return tuple(merged)

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -6,6 +6,14 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from vibesensor.shared.boundaries.codecs.scalars import coerce_count, text_or_none
+from vibesensor.shared.json_utils import i18n_ref
+from vibesensor.shared.run_context_warning import (
+    WARNING_CODE_WHOLE_RUN_CONTEXT_INCOMPLETE,
+    WARNING_CODE_WHOLE_RUN_CONTEXT_LEGACY_FALLBACK,
+    RunContextWarning,
+)
+
 if TYPE_CHECKING:
     from vibesensor.domain import (
         TestRun,
@@ -19,8 +27,8 @@ if TYPE_CHECKING:
     from vibesensor.shared.boundaries.reporting.summary import (
         NormalizedReportSummary,
         ReportTimelineInterval,
+        ReportWholeRunContextInterval,
     )
-    from vibesensor.shared.run_context_warning import RunContextWarningsInput
     from vibesensor.shared.types.analysis_views import PeakTableRow
 
 from vibesensor.shared.boundaries.reporting.confidence_facts import build_report_confidence_facts
@@ -42,10 +50,12 @@ from vibesensor.shared.boundaries.reporting.sensor_facts import (
     build_report_sensor_facts,
     enrich_location_proof_sensor_facts,
 )
+from vibesensor.shared.run_context_warning import RunContextWarningsInput
 
 __all__ = [
     "ActionStatusKey",
     "LocationConfidenceKey",
+    "ReportContextFacts",
     "PreparedReportFacts",
     "ReportRunFacts",
     "prepare_report_facts",
@@ -78,10 +88,54 @@ class ReportRunFacts:
 
 
 @dataclass(frozen=True, slots=True)
+class ReportContextFacts:
+    """Traceability-friendly whole-run context facts for persisted history/report prep."""
+
+    traceable: bool
+    source: str
+    interval_count: int
+    intervals: tuple[ReportWholeRunContextInterval, ...]
+    window_count: int | None
+    full_window_count: int
+    partial_window_count: int
+    missing_window_count: int
+    missing_speed_window_count: int
+    missing_rpm_window_count: int
+    stale_speed_window_count: int
+    stale_rpm_window_count: int
+    warnings: tuple[RunContextWarning, ...]
+
+    @property
+    def has_incomplete_context(self) -> bool:
+        return (
+            self.traceable
+            and self.source == "whole_run"
+            and (self.partial_window_count > 0 or self.missing_window_count > 0)
+        )
+
+    @property
+    def speed_gap_window_count(self) -> int:
+        return self.missing_speed_window_count + self.stale_speed_window_count
+
+    @property
+    def rpm_gap_window_count(self) -> int:
+        return self.missing_rpm_window_count + self.stale_rpm_window_count
+
+    @property
+    def has_speed_gaps(self) -> bool:
+        return self.traceable and self.source == "whole_run" and self.speed_gap_window_count > 0
+
+    @property
+    def has_rpm_gaps(self) -> bool:
+        return self.traceable and self.source == "whole_run" and self.rpm_gap_window_count > 0
+
+
+@dataclass(frozen=True, slots=True)
 class PreparedReportFacts:
     """Canonical grouped report facts for run, sensor, and decision concerns."""
 
     run: ReportRunFacts
+    context: ReportContextFacts
     sensor: ReportSensorFacts
     decision: ReportDecisionFacts
     evidence: ReportEvidenceFacts
@@ -101,6 +155,7 @@ def prepare_report_facts(
     origin = resolve_report_origin(test_run)
     origin_location = normalize_origin_location(origin)
     config_snap = test_run.capture.setup.configuration_snapshot
+    context_facts = _build_report_context_facts(payload, summary=summary)
     sensor_facts = build_report_sensor_facts(
         test_run=test_run,
         sensor_locations_active=summary.active_sensor_locations,
@@ -111,6 +166,7 @@ def prepare_report_facts(
         test_run=test_run,
         origin_location=origin_location,
         sensor_facts=sensor_facts,
+        context_facts=context_facts,
         warnings=warnings,
     )
     evidence_facts = build_report_evidence_facts(
@@ -129,6 +185,7 @@ def prepare_report_facts(
         primary_candidate=decision_facts.primary_candidate,
         evidence_facts=evidence_facts,
         decision_facts=decision_facts,
+        context_facts=context_facts,
     )
     return PreparedReportFacts(
         run=ReportRunFacts(
@@ -160,6 +217,7 @@ def prepare_report_facts(
             timeline_intervals=summary.timeline_intervals,
             peak_table_rows=summary.peak_table_rows,
         ),
+        context=context_facts,
         sensor=sensor_facts,
         decision=decision_facts,
         evidence=evidence_facts,
@@ -176,3 +234,168 @@ def _tire_spec_text(tire_spec: object) -> str | None:
     if tire_spec.width_mm <= 0 or tire_spec.aspect_pct <= 0 or tire_spec.rim_in <= 0:
         return None
     return f"{tire_spec.width_mm:g}/{tire_spec.aspect_pct:g}R{tire_spec.rim_in:g}"
+
+
+def _build_report_context_facts(
+    payload: Mapping[str, object],
+    *,
+    summary: NormalizedReportSummary,
+) -> ReportContextFacts:
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, Mapping):
+        return ReportContextFacts(
+            traceable=False,
+            source="implicit",
+            interval_count=0,
+            intervals=(),
+            window_count=None,
+            full_window_count=0,
+            partial_window_count=0,
+            missing_window_count=0,
+            missing_speed_window_count=0,
+            missing_rpm_window_count=0,
+            stale_speed_window_count=0,
+            stale_rpm_window_count=0,
+            warnings=(),
+        )
+    whole_run_available = bool(analysis_metadata.get("whole_run_context_available")) or bool(
+        summary.whole_run_context_intervals
+    )
+    if whole_run_available:
+        source = "whole_run"
+    elif _is_summary_only_context_fallback(analysis_metadata):
+        source = "summary_only"
+    else:
+        source = "legacy"
+    intervals = summary.whole_run_context_intervals if whole_run_available else ()
+    full_window_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_full_window_count",
+        default=sum(interval.full_context_window_count for interval in intervals),
+    )
+    partial_window_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_partial_window_count",
+        default=sum(interval.partial_context_window_count for interval in intervals),
+    )
+    missing_window_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_missing_window_count",
+        default=sum(interval.missing_context_window_count for interval in intervals),
+    )
+    missing_speed_window_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_missing_speed_window_count",
+    )
+    missing_rpm_window_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_missing_rpm_window_count",
+    )
+    stale_speed_window_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_stale_speed_window_count",
+    )
+    stale_rpm_window_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_stale_rpm_window_count",
+    )
+    default_window_count = (
+        sum(interval.window_count for interval in intervals) if intervals else None
+    )
+    window_count = _analysis_metadata_optional_count(
+        analysis_metadata,
+        "whole_run_context_window_count",
+        default=default_window_count,
+    )
+    interval_count = _analysis_metadata_count(
+        analysis_metadata,
+        "whole_run_context_interval_count",
+        default=len(intervals),
+    )
+    return ReportContextFacts(
+        traceable=True,
+        source=source,
+        interval_count=interval_count,
+        intervals=intervals,
+        window_count=window_count,
+        full_window_count=full_window_count,
+        partial_window_count=partial_window_count,
+        missing_window_count=missing_window_count,
+        missing_speed_window_count=missing_speed_window_count,
+        missing_rpm_window_count=missing_rpm_window_count,
+        stale_speed_window_count=stale_speed_window_count,
+        stale_rpm_window_count=stale_rpm_window_count,
+        warnings=_report_context_warnings(
+            source=source,
+            partial_window_count=partial_window_count,
+            missing_window_count=missing_window_count,
+            speed_gap_window_count=missing_speed_window_count + stale_speed_window_count,
+            rpm_gap_window_count=missing_rpm_window_count + stale_rpm_window_count,
+        ),
+    )
+
+
+def _is_summary_only_context_fallback(analysis_metadata: Mapping[str, object]) -> bool:
+    raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
+    if raw_capture_mode == "summary_only":
+        return True
+    if raw_capture_mode == "raw_backed":
+        return False
+    return coerce_count(analysis_metadata.get("raw_backed_sample_count")) <= 0
+
+
+def _analysis_metadata_count(
+    analysis_metadata: Mapping[str, object],
+    key: str,
+    *,
+    default: int = 0,
+) -> int:
+    return coerce_count(analysis_metadata.get(key)) if key in analysis_metadata else default
+
+
+def _analysis_metadata_optional_count(
+    analysis_metadata: Mapping[str, object],
+    key: str,
+    *,
+    default: int | None,
+) -> int | None:
+    if key not in analysis_metadata:
+        return default
+    return coerce_count(analysis_metadata.get(key))
+
+
+def _report_context_warnings(
+    *,
+    source: str,
+    partial_window_count: int,
+    missing_window_count: int,
+    speed_gap_window_count: int,
+    rpm_gap_window_count: int,
+) -> tuple[RunContextWarning, ...]:
+    if source == "legacy":
+        return (
+            RunContextWarning(
+                code=WARNING_CODE_WHOLE_RUN_CONTEXT_LEGACY_FALLBACK,
+                severity="warn",
+                applies_to="report",
+                title=i18n_ref("RUN_CONTEXT_WARNING_WHOLE_RUN_CONTEXT_LEGACY_TITLE"),
+                detail=i18n_ref("RUN_CONTEXT_WARNING_WHOLE_RUN_CONTEXT_LEGACY_DETAIL"),
+            ),
+        )
+    if source != "whole_run" or (partial_window_count <= 0 and missing_window_count <= 0):
+        return ()
+    return (
+        RunContextWarning(
+            code=WARNING_CODE_WHOLE_RUN_CONTEXT_INCOMPLETE,
+            severity="warn",
+            applies_to="report",
+            title=i18n_ref("RUN_CONTEXT_WARNING_WHOLE_RUN_CONTEXT_INCOMPLETE_TITLE"),
+            detail=i18n_ref(
+                "RUN_CONTEXT_WARNING_WHOLE_RUN_CONTEXT_INCOMPLETE_DETAIL",
+                partial_windows=str(max(0, partial_window_count)),
+                missing_windows=str(max(0, missing_window_count)),
+                speed_gap_windows=str(max(0, speed_gap_window_count)),
+                rpm_gap_windows=str(max(0, rpm_gap_window_count)),
+            ),
+        ),
+    )

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -21,6 +21,7 @@ from vibesensor.shared.types.run_schema import RunMetadata
 
 __all__ = [
     "NormalizedReportSummary",
+    "ReportWholeRunContextInterval",
     "ReportSummaryNormalizer",
     "ReportTimelineInterval",
     "has_projectable_report_payload",
@@ -42,6 +43,29 @@ class ReportTimelineInterval:
 
 
 @dataclass(frozen=True, slots=True)
+class ReportWholeRunContextInterval:
+    """Typed whole-run context interval normalized for report/history preparation."""
+
+    segment_index: int
+    phase: str
+    load_state: str
+    start_window_index: int
+    end_window_index: int
+    start_t_s: float | None
+    end_t_s: float | None
+    speed_min_kmh: float | None
+    speed_max_kmh: float | None
+    speed_band: str | None
+    full_context_window_count: int
+    partial_context_window_count: int
+    missing_context_window_count: int
+
+    @property
+    def window_count(self) -> int:
+        return (self.end_window_index - self.start_window_index) + 1
+
+
+@dataclass(frozen=True, slots=True)
 class NormalizedReportSummary:
     """Typed report boundary object shared by report facts and renderer mapping."""
 
@@ -58,6 +82,7 @@ class NormalizedReportSummary:
     sensor_intensity_rows: tuple[LocationIntensitySummary, ...]
     peak_table_rows: tuple[PeakTableRow, ...]
     timeline_intervals: tuple[ReportTimelineInterval, ...]
+    whole_run_context_intervals: tuple[ReportWholeRunContextInterval, ...]
 
 
 class ReportSummaryNormalizer:
@@ -84,6 +109,7 @@ class ReportSummaryNormalizer:
             sensor_intensity_rows=self._sensor_intensity_rows(),
             peak_table_rows=self._peak_table_rows(),
             timeline_intervals=self._timeline_intervals(),
+            whole_run_context_intervals=self._whole_run_context_intervals(),
         )
 
     def _summary_run_metadata(self) -> RunMetadata | None:
@@ -151,6 +177,41 @@ class ReportSummaryNormalizer:
                     speed_min_kmh=optional_float(row.get("speed_min_kmh")),
                     speed_max_kmh=optional_float(row.get("speed_max_kmh")),
                     has_fault_evidence=bool(row.get("has_fault_evidence")),
+                )
+            )
+        return tuple(intervals)
+
+    def _whole_run_context_intervals(self) -> tuple[ReportWholeRunContextInterval, ...]:
+        raw_intervals = self._payload.get("whole_run_context_intervals")
+        if not isinstance(raw_intervals, list):
+            return ()
+        intervals: list[ReportWholeRunContextInterval] = []
+        for row in raw_intervals:
+            if not isinstance(row, Mapping):
+                continue
+            phase = text_or_none(row.get("phase"))
+            load_state = text_or_none(row.get("load_state"))
+            if phase is None or load_state is None:
+                continue
+            intervals.append(
+                ReportWholeRunContextInterval(
+                    segment_index=coerce_count(row.get("segment_index")),
+                    phase=phase,
+                    load_state=load_state,
+                    start_window_index=coerce_count(row.get("start_window_index")),
+                    end_window_index=coerce_count(row.get("end_window_index")),
+                    start_t_s=optional_float(row.get("start_t_s")),
+                    end_t_s=optional_float(row.get("end_t_s")),
+                    speed_min_kmh=optional_float(row.get("speed_min_kmh")),
+                    speed_max_kmh=optional_float(row.get("speed_max_kmh")),
+                    speed_band=text_or_none(row.get("speed_band")),
+                    full_context_window_count=coerce_count(row.get("full_context_window_count")),
+                    partial_context_window_count=coerce_count(
+                        row.get("partial_context_window_count")
+                    ),
+                    missing_context_window_count=coerce_count(
+                        row.get("missing_context_window_count")
+                    ),
                 )
             )
         return tuple(intervals)

--- a/apps/server/vibesensor/shared/report_presentation.py
+++ b/apps/server/vibesensor/shared/report_presentation.py
@@ -414,6 +414,8 @@ def _confidence_caveat_texts(
     for key in confidence_facts.caveat_keys:
         if key == "summary_only":
             parts.append(tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY"))
+        elif key == "legacy_context":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_LEGACY_CONTEXT"))
         elif key == "sparse_support":
             parts.append(
                 tr(
@@ -421,6 +423,10 @@ def _confidence_caveat_texts(
                     count=str(max(0, confidence_facts.supporting_window_count or 0)),
                 )
             )
+        elif key == "speed_context_gaps":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_SPEED_CONTEXT_GAPS"))
+        elif key == "rpm_context_gaps":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_RPM_CONTEXT_GAPS"))
         elif key == "brief_support" and confidence_facts.supporting_duration_s is not None:
             parts.append(
                 tr(

--- a/apps/server/vibesensor/shared/run_context_warning.py
+++ b/apps/server/vibesensor/shared/run_context_warning.py
@@ -11,6 +11,8 @@ from vibesensor.shared.types.json_types import JsonValue, is_json_object
 
 WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE = "reference_context_incomplete"
 WARNING_CODE_CAR_SETTINGS_CHANGED = "car_settings_changed"
+WARNING_CODE_WHOLE_RUN_CONTEXT_INCOMPLETE = "whole_run_context_incomplete"
+WARNING_CODE_WHOLE_RUN_CONTEXT_LEGACY_FALLBACK = "whole_run_context_legacy_fallback"
 WarningSeverity = Literal["warn", "error"]
 
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -522,6 +522,27 @@ def _append_whole_run_context(
     analysis_metadata["whole_run_context_available"] = True
     analysis_metadata["whole_run_context_window_count"] = int(bundle.manifest.total_window_count)
     analysis_metadata["whole_run_context_interval_count"] = len(bundle.intervals)
+    analysis_metadata["whole_run_context_full_window_count"] = sum(
+        1 for label in bundle.labels if label.context_coverage == "full"
+    )
+    analysis_metadata["whole_run_context_partial_window_count"] = sum(
+        1 for label in bundle.labels if label.context_coverage == "partial"
+    )
+    analysis_metadata["whole_run_context_missing_window_count"] = sum(
+        1 for label in bundle.labels if label.context_coverage == "missing"
+    )
+    analysis_metadata["whole_run_context_missing_speed_window_count"] = sum(
+        1 for label in bundle.labels if label.speed_validity == "missing"
+    )
+    analysis_metadata["whole_run_context_missing_rpm_window_count"] = sum(
+        1 for label in bundle.labels if label.rpm_validity == "missing"
+    )
+    analysis_metadata["whole_run_context_stale_speed_window_count"] = sum(
+        1 for label in bundle.labels if label.speed_is_stale
+    )
+    analysis_metadata["whole_run_context_stale_rpm_window_count"] = sum(
+        1 for label in bundle.labels if label.rpm_is_stale
+    )
     analysis_metadata["whole_run_context_labels_artifact_key"] = (
         WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY
     )

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -410,6 +410,9 @@ Current #3085 baseline:
 - Legacy persisted analyses must remain readable by history/report code.
 - New whole-run report facts should degrade to existing summary-only language and
   confidence caveats where necessary.
+- Persisted `analysis_metadata` should carry whole-run context completeness counts
+  (full/partial/missing plus speed/RPM gap counts) so history/report preparation
+  can project caveats without loading dense sidecar labels during report render.
 
 ## Recommended implementation order
 


### PR DESCRIPTION
## What changed
- project persisted whole-run context intervals and completeness counts into `shared/boundaries/reporting/`
- add legacy raw-backed fallback plus speed/RPM gap caveats through the existing warning/confidence paths
- persist whole-run context completeness counts in `analysis_metadata` so report prep does not need dense sidecar loads
- add focused regressions for whole-run, legacy, summary-only, and executor metadata paths
- update report i18n and the whole-run design doc

## Why
#3089 persisted the context outputs. #3090 needs history/report prep to consume them directly, keep renderer code thin, and keep older persisted runs explicit about fallback state instead of looking equivalent to whole-run-complete runs.

## Validation
- `make format`
- focused pytest for history/report prep and post-analysis executor
- `make typecheck-backend`
- `make lint`
- `make test-changed`
- `make docs-lint`

## Risks / tradeoffs
- legacy raw-backed persisted runs now show an explicit caveat instead of appearing equivalent to fresh whole-run-complete runs
- report prep only projects traceable whole-run context when explicit persisted metadata exists; direct summary payloads stay on the old path