### PR TITLE
Fix #3091: define whole-run order trace contracts

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from vibesensor.shared.types.history_analysis_contracts import (
+    OrderHarmonicEvidenceSummaryResponse,
+    OrderTracePhaseSupportResponse,
+    OrderTraceSummaryResponse,
+    OrderTraceSupportIntervalResponse,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
+    OrderHarmonicEvidenceSummary,
+    OrderTracePhaseSupport,
+    OrderTracePoint,
+    OrderTraceSummary,
+    OrderTraceSupportInterval,
+)
+
+
+def test_order_trace_point_round_trips_json_shape() -> None:
+    point = OrderTracePoint(
+        hypothesis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        order_family="wheel",
+        harmonic=1,
+        order_label="1x wheel",
+        window_index=42,
+        eligible=True,
+        matched=True,
+        predicted_hz=14.8,
+        matched_hz=14.9,
+        relative_error=0.0067,
+        peak_intensity_db=18.2,
+        vibration_strength_db=11.5,
+        ref_source="speed+tire",
+        strongest_location="Front Left",
+    )
+
+    assert OrderTracePoint.from_mapping(point.to_json_object()) == point
+
+
+def test_order_trace_summary_round_trips_nested_compact_contracts() -> None:
+    summary = OrderTraceSummary(
+        hypothesis_key="engine_2x",
+        suspected_source="engine",
+        order_family="engine",
+        order_label="2x engine",
+        total_window_count=128,
+        eligible_window_count=96,
+        matched_window_count=52,
+        support_ratio=52 / 96,
+        longest_contiguous_support_window_count=12,
+        support_intervals=(
+            OrderTraceSupportInterval(
+                interval_index=0,
+                start_window_index=8,
+                end_window_index=19,
+                matched_window_count=12,
+                support_ratio=1.0,
+                start_t_s=4.0,
+                end_t_s=10.0,
+                phase="cruise",
+                load_state="pulling",
+                speed_band="70-90 km/h",
+                mean_relative_error=0.03,
+            ),
+        ),
+        phase_support=(
+            OrderTracePhaseSupport(
+                phase="cruise",
+                eligible_window_count=48,
+                matched_window_count=30,
+                support_ratio=30 / 48,
+            ),
+        ),
+        harmonic_summaries=(
+            OrderHarmonicEvidenceSummary(
+                harmonic=2,
+                order_label="2x engine",
+                eligible_window_count=96,
+                matched_window_count=52,
+                support_ratio=52 / 96,
+                mean_relative_error=0.04,
+                peak_intensity_db=19.7,
+                mean_vibration_strength_db=12.4,
+            ),
+        ),
+        dominant_phase="cruise",
+        dominant_speed_band="70-90 km/h",
+        strongest_location="Front Right",
+        mean_relative_error=0.04,
+        peak_intensity_db=19.7,
+        mean_vibration_strength_db=12.4,
+        ref_sources=("obd2",),
+    )
+
+    assert OrderTraceSummary.from_mapping(summary.to_json_object()) == summary
+
+
+def test_history_order_trace_response_contracts_expose_named_summary_fields() -> None:
+    assert set(OrderTraceSupportIntervalResponse.__annotations__) == {
+        "interval_index",
+        "start_window_index",
+        "end_window_index",
+        "matched_window_count",
+        "support_ratio",
+        "start_t_s",
+        "end_t_s",
+        "phase",
+        "load_state",
+        "speed_band",
+        "mean_relative_error",
+    }
+    assert set(OrderTracePhaseSupportResponse.__annotations__) == {
+        "phase",
+        "eligible_window_count",
+        "matched_window_count",
+        "support_ratio",
+    }
+    assert set(OrderHarmonicEvidenceSummaryResponse.__annotations__) == {
+        "harmonic",
+        "order_label",
+        "eligible_window_count",
+        "matched_window_count",
+        "support_ratio",
+        "mean_relative_error",
+        "peak_intensity_db",
+        "mean_vibration_strength_db",
+    }
+    assert set(OrderTraceSummaryResponse.__annotations__) == {
+        "hypothesis_key",
+        "suspected_source",
+        "order_family",
+        "order_label",
+        "total_window_count",
+        "eligible_window_count",
+        "matched_window_count",
+        "support_ratio",
+        "longest_contiguous_support_window_count",
+        "support_intervals",
+        "phase_support",
+        "harmonic_summaries",
+        "dominant_phase",
+        "dominant_speed_band",
+        "strongest_location",
+        "mean_relative_error",
+        "peak_intensity_db",
+        "mean_vibration_strength_db",
+        "ref_sources",
+    }

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -50,6 +50,10 @@ __all__ = [
     "FindingPayload",
     "LocationIntensitySummaryResponse",
     "OutlierSummaryResponse",
+    "OrderHarmonicEvidenceSummaryResponse",
+    "OrderTracePhaseSupportResponse",
+    "OrderTraceSummaryResponse",
+    "OrderTraceSupportIntervalResponse",
     "PayloadObject",
     "PayloadValue",
     "PhaseInfoResponse",
@@ -142,6 +146,68 @@ class WholeRunContextIntervalResponse(TypedDict, total=False):
     full_context_window_count: Required[int]
     partial_context_window_count: Required[int]
     missing_context_window_count: Required[int]
+
+
+class OrderTraceSupportIntervalResponse(TypedDict, total=False):
+    """Compact persisted support interval derived from dense whole-run order traces."""
+
+    interval_index: Required[int]
+    start_window_index: Required[int]
+    end_window_index: Required[int]
+    matched_window_count: Required[int]
+    support_ratio: Required[float]
+    start_t_s: float | None
+    end_t_s: float | None
+    phase: str | None
+    load_state: str | None
+    speed_band: str | None
+    mean_relative_error: float | None
+
+
+class OrderTracePhaseSupportResponse(TypedDict, total=False):
+    """Phase-aware support row for a compact whole-run order-trace summary."""
+
+    phase: Required[str]
+    eligible_window_count: Required[int]
+    matched_window_count: Required[int]
+    support_ratio: Required[float]
+
+
+class OrderHarmonicEvidenceSummaryResponse(TypedDict, total=False):
+    """Compact harmonic-specific evidence row for a whole-run order-trace summary."""
+
+    harmonic: Required[int]
+    order_label: Required[str]
+    eligible_window_count: Required[int]
+    matched_window_count: Required[int]
+    support_ratio: Required[float]
+    mean_relative_error: float | None
+    peak_intensity_db: float | None
+    mean_vibration_strength_db: float | None
+
+
+class OrderTraceSummaryResponse(TypedDict, total=False):
+    """Future persisted/report-facing summary shape for whole-run order traces."""
+
+    hypothesis_key: Required[str]
+    suspected_source: Required[str]
+    order_family: Required[str]
+    order_label: Required[str]
+    total_window_count: Required[int]
+    eligible_window_count: Required[int]
+    matched_window_count: Required[int]
+    support_ratio: Required[float]
+    longest_contiguous_support_window_count: Required[int]
+    support_intervals: Required[list[OrderTraceSupportIntervalResponse]]
+    phase_support: Required[list[OrderTracePhaseSupportResponse]]
+    harmonic_summaries: Required[list[OrderHarmonicEvidenceSummaryResponse]]
+    dominant_phase: str | None
+    dominant_speed_band: str | None
+    strongest_location: str | None
+    mean_relative_error: float | None
+    peak_intensity_db: float | None
+    mean_vibration_strength_db: float | None
+    ref_sources: Required[list[str]]
 
 
 class SpeedStatsResponse(TypedDict):
@@ -292,6 +358,10 @@ for _typed_dict in (
     PhaseTimelineEntryResponse,
     PhaseSegmentSummaryResponse,
     WholeRunContextIntervalResponse,
+    OrderTraceSupportIntervalResponse,
+    OrderTracePhaseSupportResponse,
+    OrderHarmonicEvidenceSummaryResponse,
+    OrderTraceSummaryResponse,
     SpeedStatsResponse,
     PhaseInfoResponse,
     OutlierSummaryResponse,

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py
@@ -1,0 +1,424 @@
+"""Whole-run order-trace contracts for dense sidecars and compact summaries.
+
+The dense trace stays keyed by ``(hypothesis_key, harmonic, window_index)`` so
+later execution stages can join directly against the canonical whole-run window
+grid without inventing a second order model. Compact summaries collapse those
+dense points into persisted/report-facing support intervals, phase support, and
+harmonic evidence rows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from vibesensor.shared.types.json_types import JsonObject, JsonValue
+
+__all__ = [
+    "OrderHarmonicEvidenceSummary",
+    "OrderTraceFamily",
+    "OrderTracePhaseSupport",
+    "OrderTracePoint",
+    "OrderTraceSummary",
+    "OrderTraceSupportInterval",
+]
+
+type OrderTraceFamily = Literal["wheel", "driveshaft", "engine"]
+
+
+@dataclass(frozen=True, slots=True)
+class OrderTracePoint:
+    """Dense whole-run order-trace point keyed to one candidate, harmonic, and window."""
+
+    hypothesis_key: str
+    suspected_source: str
+    order_family: OrderTraceFamily
+    harmonic: int
+    order_label: str
+    window_index: int
+    eligible: bool
+    matched: bool
+    predicted_hz: float | None = None
+    matched_hz: float | None = None
+    relative_error: float | None = None
+    peak_intensity_db: float | None = None
+    vibration_strength_db: float | None = None
+    ref_source: str | None = None
+    strongest_location: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_nonnegative(self.window_index, field_name="window_index")
+        _require_positive(self.harmonic, field_name="harmonic")
+        _require_text(self.hypothesis_key, field_name="hypothesis_key")
+        _require_text(self.order_label, field_name="order_label")
+        _require_text(self.suspected_source, field_name="suspected_source")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "hypothesis_key": self.hypothesis_key,
+            "suspected_source": self.suspected_source,
+            "order_family": self.order_family,
+            "harmonic": self.harmonic,
+            "order_label": self.order_label,
+            "window_index": self.window_index,
+            "eligible": self.eligible,
+            "matched": self.matched,
+        }
+        _set_optional(payload, "predicted_hz", self.predicted_hz)
+        _set_optional(payload, "matched_hz", self.matched_hz)
+        _set_optional(payload, "relative_error", self.relative_error)
+        _set_optional(payload, "peak_intensity_db", self.peak_intensity_db)
+        _set_optional(payload, "vibration_strength_db", self.vibration_strength_db)
+        _set_optional(payload, "ref_source", self.ref_source)
+        _set_optional(payload, "strongest_location", self.strongest_location)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> OrderTracePoint:
+        return cls(
+            hypothesis_key=_required_text(data, "hypothesis_key"),
+            suspected_source=_required_text(data, "suspected_source"),
+            order_family=_order_family(data.get("order_family")),
+            harmonic=_required_int(data, "harmonic"),
+            order_label=_required_text(data, "order_label"),
+            window_index=_required_int(data, "window_index"),
+            eligible=_required_bool(data, "eligible"),
+            matched=_required_bool(data, "matched"),
+            predicted_hz=_optional_float(data.get("predicted_hz")),
+            matched_hz=_optional_float(data.get("matched_hz")),
+            relative_error=_optional_float(data.get("relative_error")),
+            peak_intensity_db=_optional_float(data.get("peak_intensity_db")),
+            vibration_strength_db=_optional_float(data.get("vibration_strength_db")),
+            ref_source=_optional_text(data.get("ref_source")),
+            strongest_location=_optional_text(data.get("strongest_location")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OrderTraceSupportInterval:
+    """Compact contiguous support interval derived from dense whole-run trace points."""
+
+    interval_index: int
+    start_window_index: int
+    end_window_index: int
+    matched_window_count: int
+    support_ratio: float
+    start_t_s: float | None = None
+    end_t_s: float | None = None
+    phase: str | None = None
+    load_state: str | None = None
+    speed_band: str | None = None
+    mean_relative_error: float | None = None
+
+    def __post_init__(self) -> None:
+        _require_nonnegative(self.interval_index, field_name="interval_index")
+        _require_nonnegative(self.start_window_index, field_name="start_window_index")
+        _require_nonnegative(self.end_window_index, field_name="end_window_index")
+        if self.end_window_index < self.start_window_index:
+            raise ValueError("end_window_index must be >= start_window_index")
+        _require_nonnegative(self.matched_window_count, field_name="matched_window_count")
+        _require_ratio(self.support_ratio, field_name="support_ratio")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "interval_index": self.interval_index,
+            "start_window_index": self.start_window_index,
+            "end_window_index": self.end_window_index,
+            "matched_window_count": self.matched_window_count,
+            "support_ratio": self.support_ratio,
+        }
+        _set_optional(payload, "start_t_s", self.start_t_s)
+        _set_optional(payload, "end_t_s", self.end_t_s)
+        _set_optional(payload, "phase", self.phase)
+        _set_optional(payload, "load_state", self.load_state)
+        _set_optional(payload, "speed_band", self.speed_band)
+        _set_optional(payload, "mean_relative_error", self.mean_relative_error)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> OrderTraceSupportInterval:
+        return cls(
+            interval_index=_required_int(data, "interval_index"),
+            start_window_index=_required_int(data, "start_window_index"),
+            end_window_index=_required_int(data, "end_window_index"),
+            matched_window_count=_required_int(data, "matched_window_count"),
+            support_ratio=_required_float(data, "support_ratio"),
+            start_t_s=_optional_float(data.get("start_t_s")),
+            end_t_s=_optional_float(data.get("end_t_s")),
+            phase=_optional_text(data.get("phase")),
+            load_state=_optional_text(data.get("load_state")),
+            speed_band=_optional_text(data.get("speed_band")),
+            mean_relative_error=_optional_float(data.get("mean_relative_error")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OrderTracePhaseSupport:
+    """Compact phase-aware support row for one order-trace summary."""
+
+    phase: str
+    eligible_window_count: int
+    matched_window_count: int
+    support_ratio: float
+
+    def __post_init__(self) -> None:
+        _require_text(self.phase, field_name="phase")
+        _require_nonnegative(self.eligible_window_count, field_name="eligible_window_count")
+        _require_nonnegative(self.matched_window_count, field_name="matched_window_count")
+        _require_ratio(self.support_ratio, field_name="support_ratio")
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "phase": self.phase,
+            "eligible_window_count": self.eligible_window_count,
+            "matched_window_count": self.matched_window_count,
+            "support_ratio": self.support_ratio,
+        }
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> OrderTracePhaseSupport:
+        return cls(
+            phase=_required_text(data, "phase"),
+            eligible_window_count=_required_int(data, "eligible_window_count"),
+            matched_window_count=_required_int(data, "matched_window_count"),
+            support_ratio=_required_float(data, "support_ratio"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OrderHarmonicEvidenceSummary:
+    """Compact harmonic-specific evidence row for one order-trace summary."""
+
+    harmonic: int
+    order_label: str
+    eligible_window_count: int
+    matched_window_count: int
+    support_ratio: float
+    mean_relative_error: float | None = None
+    peak_intensity_db: float | None = None
+    mean_vibration_strength_db: float | None = None
+
+    def __post_init__(self) -> None:
+        _require_positive(self.harmonic, field_name="harmonic")
+        _require_text(self.order_label, field_name="order_label")
+        _require_nonnegative(self.eligible_window_count, field_name="eligible_window_count")
+        _require_nonnegative(self.matched_window_count, field_name="matched_window_count")
+        _require_ratio(self.support_ratio, field_name="support_ratio")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "harmonic": self.harmonic,
+            "order_label": self.order_label,
+            "eligible_window_count": self.eligible_window_count,
+            "matched_window_count": self.matched_window_count,
+            "support_ratio": self.support_ratio,
+        }
+        _set_optional(payload, "mean_relative_error", self.mean_relative_error)
+        _set_optional(payload, "peak_intensity_db", self.peak_intensity_db)
+        _set_optional(payload, "mean_vibration_strength_db", self.mean_vibration_strength_db)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> OrderHarmonicEvidenceSummary:
+        return cls(
+            harmonic=_required_int(data, "harmonic"),
+            order_label=_required_text(data, "order_label"),
+            eligible_window_count=_required_int(data, "eligible_window_count"),
+            matched_window_count=_required_int(data, "matched_window_count"),
+            support_ratio=_required_float(data, "support_ratio"),
+            mean_relative_error=_optional_float(data.get("mean_relative_error")),
+            peak_intensity_db=_optional_float(data.get("peak_intensity_db")),
+            mean_vibration_strength_db=_optional_float(data.get("mean_vibration_strength_db")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OrderTraceSummary:
+    """Compact persisted/report-facing summary derived from dense whole-run order traces."""
+
+    hypothesis_key: str
+    suspected_source: str
+    order_family: OrderTraceFamily
+    order_label: str
+    total_window_count: int
+    eligible_window_count: int
+    matched_window_count: int
+    support_ratio: float
+    longest_contiguous_support_window_count: int
+    support_intervals: tuple[OrderTraceSupportInterval, ...] = ()
+    phase_support: tuple[OrderTracePhaseSupport, ...] = ()
+    harmonic_summaries: tuple[OrderHarmonicEvidenceSummary, ...] = ()
+    dominant_phase: str | None = None
+    dominant_speed_band: str | None = None
+    strongest_location: str | None = None
+    mean_relative_error: float | None = None
+    peak_intensity_db: float | None = None
+    mean_vibration_strength_db: float | None = None
+    ref_sources: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_text(self.hypothesis_key, field_name="hypothesis_key")
+        _require_text(self.suspected_source, field_name="suspected_source")
+        _require_text(self.order_label, field_name="order_label")
+        _require_nonnegative(self.total_window_count, field_name="total_window_count")
+        _require_nonnegative(self.eligible_window_count, field_name="eligible_window_count")
+        _require_nonnegative(self.matched_window_count, field_name="matched_window_count")
+        _require_nonnegative(
+            self.longest_contiguous_support_window_count,
+            field_name="longest_contiguous_support_window_count",
+        )
+        _require_ratio(self.support_ratio, field_name="support_ratio")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "hypothesis_key": self.hypothesis_key,
+            "suspected_source": self.suspected_source,
+            "order_family": self.order_family,
+            "order_label": self.order_label,
+            "total_window_count": self.total_window_count,
+            "eligible_window_count": self.eligible_window_count,
+            "matched_window_count": self.matched_window_count,
+            "support_ratio": self.support_ratio,
+            "longest_contiguous_support_window_count": self.longest_contiguous_support_window_count,
+            "support_intervals": [interval.to_json_object() for interval in self.support_intervals],
+            "phase_support": [row.to_json_object() for row in self.phase_support],
+            "harmonic_summaries": [summary.to_json_object() for summary in self.harmonic_summaries],
+            "ref_sources": list(self.ref_sources),
+        }
+        _set_optional(payload, "dominant_phase", self.dominant_phase)
+        _set_optional(payload, "dominant_speed_band", self.dominant_speed_band)
+        _set_optional(payload, "strongest_location", self.strongest_location)
+        _set_optional(payload, "mean_relative_error", self.mean_relative_error)
+        _set_optional(payload, "peak_intensity_db", self.peak_intensity_db)
+        _set_optional(payload, "mean_vibration_strength_db", self.mean_vibration_strength_db)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> OrderTraceSummary:
+        return cls(
+            hypothesis_key=_required_text(data, "hypothesis_key"),
+            suspected_source=_required_text(data, "suspected_source"),
+            order_family=_order_family(data.get("order_family")),
+            order_label=_required_text(data, "order_label"),
+            total_window_count=_required_int(data, "total_window_count"),
+            eligible_window_count=_required_int(data, "eligible_window_count"),
+            matched_window_count=_required_int(data, "matched_window_count"),
+            support_ratio=_required_float(data, "support_ratio"),
+            longest_contiguous_support_window_count=_required_int(
+                data,
+                "longest_contiguous_support_window_count",
+            ),
+            support_intervals=_support_intervals(data.get("support_intervals")),
+            phase_support=_phase_support_rows(data.get("phase_support")),
+            harmonic_summaries=_harmonic_summaries(data.get("harmonic_summaries")),
+            dominant_phase=_optional_text(data.get("dominant_phase")),
+            dominant_speed_band=_optional_text(data.get("dominant_speed_band")),
+            strongest_location=_optional_text(data.get("strongest_location")),
+            mean_relative_error=_optional_float(data.get("mean_relative_error")),
+            peak_intensity_db=_optional_float(data.get("peak_intensity_db")),
+            mean_vibration_strength_db=_optional_float(data.get("mean_vibration_strength_db")),
+            ref_sources=_text_tuple(data.get("ref_sources")),
+        )
+
+
+def _support_intervals(value: object) -> tuple[OrderTraceSupportInterval, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(
+        OrderTraceSupportInterval.from_mapping(item) for item in value if isinstance(item, dict)
+    )
+
+
+def _phase_support_rows(value: object) -> tuple[OrderTracePhaseSupport, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(
+        OrderTracePhaseSupport.from_mapping(item) for item in value if isinstance(item, dict)
+    )
+
+
+def _harmonic_summaries(value: object) -> tuple[OrderHarmonicEvidenceSummary, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(
+        OrderHarmonicEvidenceSummary.from_mapping(item) for item in value if isinstance(item, dict)
+    )
+
+
+def _text_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(text for raw in value if (text := _optional_text(raw)) is not None)
+
+
+def _required_text(data: JsonObject, field: str) -> str:
+    value = _optional_text(data.get(field))
+    if value is None:
+        raise ValueError(f"{field} requires a non-empty string")
+    return value
+
+
+def _optional_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _required_bool(data: JsonObject, field: str) -> bool:
+    value = data.get(field)
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} requires a boolean value")
+    return value
+
+
+def _required_int(data: JsonObject, field: str) -> int:
+    value = data.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} requires an integer value")
+    return value
+
+
+def _required_float(data: JsonObject, field: str) -> float:
+    value = _optional_float(data.get(field))
+    if value is None:
+        raise ValueError(f"{field} requires a numeric value")
+    return value
+
+
+def _optional_float(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _order_family(value: object) -> OrderTraceFamily:
+    family = _optional_text(value)
+    if family not in {"wheel", "driveshaft", "engine"}:
+        raise ValueError(f"Unsupported order_family {value!r}")
+    return cast(OrderTraceFamily, family)
+
+
+def _require_nonnegative(value: int, *, field_name: str) -> None:
+    if value < 0:
+        raise ValueError(f"{field_name} must be >= 0")
+
+
+def _require_positive(value: int, *, field_name: str) -> None:
+    if value <= 0:
+        raise ValueError(f"{field_name} must be > 0")
+
+
+def _require_text(value: str, *, field_name: str) -> None:
+    if not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+
+def _require_ratio(value: float, *, field_name: str) -> None:
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{field_name} must be in [0, 1]")
+
+
+def _set_optional(payload: JsonObject, field: str, value: object) -> None:
+    if value is not None:
+        payload[field] = cast(JsonValue, value)

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -263,7 +263,7 @@ explainable factors that reporting can consume directly.
 | `WholeRunWindowSpectralSummary` | `use_cases/diagnostics/` with compact persisted projection | Per-window FFT/strength/top-peak outputs |
 | `WholeRunArtifactManifest` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` + `apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py` | Sidecar manifest for dense whole-run artifacts; mirror the raw-capture pattern |
 | `WholeRunContextInterval` / `WholeRunContextWindowLabel` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` with compact report-facing projection in `shared/types/history_analysis_contracts.py` | Whole-run segments and per-window labels keyed to the canonical `window_index` grid |
-| `OrderTracePoint` / `OrderTraceSummary` | `use_cases/diagnostics/orders/` with persisted summary projection | Dense trace vs compact report/history summary split |
+| `OrderTracePoint` / `OrderTraceSummary` | `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py` with persisted summary projection in `shared/types/history_analysis_contracts.py` | Dense trace vs compact report/history summary split |
 | `SpatialEvidenceSummary` | `use_cases/diagnostics/` with persisted summary projection | Candidate-level coherence and location separation |
 | `DiagnosisFactor` / `DiagnosisSummary` | diagnostics domain/use-case layer plus persisted projection | Explainable support and counterevidence for final ranking |
 

--- a/docs/order_tracking.md
+++ b/docs/order_tracking.md
@@ -143,3 +143,22 @@ That shared ownership is why `shared/order_bands.py` exists outside
 | `apps/server/vibesensor/use_cases/diagnostics/orders/scoring.py` | Convert matched evidence into confidence and ranking score. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/finding_builder.py` | Project scored evidence into domain `Finding` objects. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/pipeline.py` | Coordinate the full order-analysis pass. |
+| `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py` | Dense whole-run order-trace points plus compact summary/support contracts for later full-run work. |
+
+## Whole-run order trace contract split
+
+Whole-run order work keeps one order model and changes only the sampling grid:
+
+- dense sidecars use `OrderTracePoint` in
+  `use_cases/diagnostics/orders/whole_run_contracts.py`, keyed by
+  `(hypothesis_key, harmonic, window_index)` so later execution can join
+  directly against the canonical whole-run window grid
+- compact persisted/report-facing projections use the future summary shapes in
+  `shared/types/history_analysis_contracts.py`
+- the compact summary contract carries support intervals, phase support, and
+  harmonic evidence rows, while the dense point contract keeps per-window
+  predicted/matched frequency evidence
+
+This keeps whole-run traces aligned with the existing `OrderHypothesis`,
+`OrderMatchObservation`, and `FindingEvidence` concepts instead of creating a
+second order-analysis vocabulary.


### PR DESCRIPTION
## What changed
- add `use_cases/diagnostics/orders/whole_run_contracts.py` with dense whole-run order trace point, support-interval, phase-support, harmonic-summary, and compact summary dataclasses plus JSON round-trips
- add future compact persisted summary response shapes in `shared/types/history_analysis_contracts.py` without prematurely wiring them into current history/report payloads
- document the dense-vs-compact split in `docs/order_tracking.md` and update the whole-run program design doc to point at the new owner
- add focused regression coverage for the new contracts

## Why
#3091 is the contract-settling step for the whole-run order track. Later issues need stable dense sidecar shapes and stable compact summary shapes that fit the existing `OrderHypothesis`, `OrderMatchObservation`, and `FindingEvidence` model instead of creating a second order-analysis vocabulary.

## Validation
- `make format`
- `pytest -q apps/server/tests/use_cases/diagnostics/test_order_trace_contracts.py`
- `make typecheck-backend`
- `make lint`
- `make test-changed`
- `make docs-lint`

## Risks / tradeoffs
- this lands the contract owners first and leaves actual trace generation/persistence wiring to follow-up issues (#3092-#3095)
- the future compact response shapes are defined now but not yet exposed on live history/report payloads, which keeps this PR contract-only and avoids premature API drift