### PR TITLE
Build per-candidate whole-run order traces

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from test_support.report_helpers import diagnostics_context, wheel_metadata
+from test_support.sample_scenarios import make_analysis_sample
+
+from vibesensor.domain import DrivingPhase
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunContextWindowLabel,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.orders.physics import _order_hypotheses
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+    build_whole_run_order_trace_artifact_bundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    WholeRunWindowSpectralSummary,
+    whole_run_window_spectral_summaries_to_jsonl_bytes,
+)
+
+
+def _metadata():
+    return diagnostics_context(
+        wheel_metadata(
+            raw_sample_rate_hz=200.0,
+            final_drive_ratio=2.0,
+            current_gear_ratio=1.5,
+        ),
+        run_id="run-order-traces",
+        feature_interval_s=0.5,
+        fft_window_size_samples=256,
+    )
+
+
+def _window_policy() -> WholeRunWindowPolicy:
+    return WholeRunWindowPolicy(
+        sample_rate_hz=200,
+        window_size_samples=256,
+        stride_samples=100,
+        overlap_samples=156,
+        feature_interval_s=0.5,
+    )
+
+
+def _context_labels() -> tuple[WholeRunContextWindowLabel, ...]:
+    speeds = (40.0, 60.0, 80.0)
+    rpm_values = (1000.0, 1500.0, 2000.0)
+    return tuple(
+        WholeRunContextWindowLabel(
+            window_index=index,
+            segment_index=0,
+            phase=DrivingPhase.CRUISE,
+            context_coverage="full",
+            speed_validity="measured",
+            rpm_validity="measured",
+            load_state="steady",
+            speed_kmh=speed_kmh,
+            speed_band="40-50",
+            speed_source="gps",
+            engine_rpm=engine_rpm,
+            engine_rpm_source="obd2",
+        )
+        for index, (speed_kmh, engine_rpm) in enumerate(zip(speeds, rpm_values, strict=True))
+    )
+
+
+def _spectral_manifest() -> WholeRunArtifactManifest:
+    return WholeRunArtifactManifest(
+        run_id="run-order-traces",
+        relative_dir="whole-run-artifacts/run-order-traces",
+        window_policy=_window_policy(),
+        total_window_count=3,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-front",
+                relative_path="spectra/sensor-front/windows.jsonl",
+                file_format="jsonl",
+                record_count=3,
+                sensor_id="sensor-front",
+            ),
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-rear",
+                relative_path="spectra/sensor-rear/windows.jsonl",
+                file_format="jsonl",
+                record_count=3,
+                sensor_id="sensor-rear",
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+
+
+def _context_sample(window_index: int, *, speed_kmh: float, engine_rpm: float):
+    return make_analysis_sample(
+        t_s=float(window_index) * 0.5,
+        speed_kmh=speed_kmh,
+        engine_rpm=engine_rpm,
+        client_name="context",
+        client_id="context",
+        location="",
+        top_peaks=[],
+    )
+
+
+def _summary_rows(*, sensor_scale: float) -> tuple[WholeRunWindowSpectralSummary, ...]:
+    metadata = _metadata()
+    rows: list[WholeRunWindowSpectralSummary] = []
+    for label in _context_labels():
+        context_sample = _context_sample(
+            label.window_index,
+            speed_kmh=float(label.speed_kmh or 0.0),
+            engine_rpm=float(label.engine_rpm or 0.0),
+        )
+        peaks = []
+        for hypothesis in _order_hypotheses():
+            predicted_hz, _ = hypothesis.predicted_hz(
+                context_sample,
+                metadata,
+                metadata.tire_circumference_m,
+            )
+            if predicted_hz is None or predicted_hz <= 0:
+                continue
+            amplitude = sensor_scale / max(1, hypothesis.order)
+            peaks.append(
+                {
+                    "hz": float(predicted_hz),
+                    "amp": amplitude,
+                    "vibration_strength_db": 30.0 + amplitude * 50.0,
+                    "strength_bucket": "l3",
+                }
+            )
+        rows.append(
+            WholeRunWindowSpectralSummary(
+                window_index=label.window_index,
+                coverage_state="full",
+                returned_sample_start=label.window_index * 100,
+                returned_sample_count=256,
+                dominant_freq_hz=peaks[0]["hz"],
+                vibration_strength_db=24.0 + sensor_scale * 10.0,
+                strength_peak_amp_g=max(float(peak["amp"]) for peak in peaks),
+                strength_floor_amp_g=0.01,
+                strength_bucket="l3",
+                top_peaks=tuple(peaks),
+            )
+        )
+    return tuple(rows)
+
+
+def _artifact_contents() -> dict[str, bytes]:
+    return {
+        "spectral-summary:sensor-front": whole_run_window_spectral_summaries_to_jsonl_bytes(
+            _summary_rows(sensor_scale=0.14)
+        ),
+        "spectral-summary:sensor-rear": whole_run_window_spectral_summaries_to_jsonl_bytes(
+            _summary_rows(sensor_scale=0.08)
+        ),
+    }
+
+
+def _samples():
+    return (
+        make_analysis_sample(
+            t_s=0.0,
+            speed_kmh=36.0,
+            client_name="front-left",
+            client_id="sensor-front",
+            location="front-left",
+            top_peaks=[{"hz": 5.0, "amp": 0.14}],
+        ),
+        make_analysis_sample(
+            t_s=0.0,
+            speed_kmh=36.0,
+            client_name="rear-left",
+            client_id="sensor-rear",
+            location="rear-left",
+            top_peaks=[{"hz": 5.0, "amp": 0.08}],
+        ),
+    )
+
+
+def test_build_whole_run_order_trace_artifact_bundle_emits_supported_candidate_traces() -> None:
+    bundle = build_whole_run_order_trace_artifact_bundle(
+        run_id="run-order-traces",
+        metadata=_metadata(),
+        spectral_manifest=_spectral_manifest(),
+        spectral_artifact_contents=_artifact_contents(),
+        context_labels=_context_labels(),
+        samples=_samples(),
+    )
+
+    assert bundle.manifest.artifact(WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY) is not None
+    assert bundle.artifact_contents[WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY].count(b"\n") == len(
+        bundle.points
+    )
+    assert {point.order_family for point in bundle.points} == {"wheel", "driveshaft", "engine"}
+    wheel_1x = [
+        point
+        for point in bundle.points
+        if point.hypothesis_key == "wheel_1x" and point.harmonic == 1
+    ]
+    assert len(wheel_1x) == 3
+    assert [point.window_index for point in wheel_1x] == [0, 1, 2]
+    assert all(point.eligible for point in wheel_1x)
+    assert all(point.matched for point in wheel_1x)
+    assert all(point.strongest_location == "front-left" for point in wheel_1x)
+
+
+def test_build_whole_run_order_trace_artifact_bundle_is_deterministic() -> None:
+    kwargs = {
+        "run_id": "run-order-traces",
+        "metadata": _metadata(),
+        "spectral_manifest": _spectral_manifest(),
+        "spectral_artifact_contents": _artifact_contents(),
+        "context_labels": tuple(reversed(_context_labels())),
+        "samples": tuple(reversed(_samples())),
+    }
+
+    first = build_whole_run_order_trace_artifact_bundle(**kwargs)
+    second = build_whole_run_order_trace_artifact_bundle(**kwargs)
+
+    assert first.manifest == second.manifest
+    assert first.artifact_contents == second.artifact_contents
+    assert first.points == second.points

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor.py
@@ -566,6 +566,7 @@ def test_execute_post_analysis_persists_whole_run_context_summary_and_sidecar() 
             },
         )(),
         whole_run_context_builder=lambda **_kwargs: context_bundle,
+        whole_run_order_trace_builder=lambda **_kwargs: None,
         analysis_runner=lambda _run: make_persisted_analysis(
             {
                 "analysis_metadata": {

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from test_support.persisted_analysis import make_persisted_analysis
+
+from vibesensor.domain import DrivingPhase
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.types.raw_capture import RawCaptureManifest
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunContextWindowLabel,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTracePoint
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+    WholeRunOrderTraceArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_context import (
+    WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
+    WholeRunContextArtifactBundle,
+)
+from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
+
+
+def _run_metadata(run_id: str):
+    return run_metadata_from_mapping(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": 800,
+            "sample_rate_hz": 800,
+            "feature_interval_s": 1.0,
+            "language": "en",
+        }
+    )
+
+
+def _samples():
+    return sensor_frames_from_mappings([{"t_s": 1.0, "vibration_strength_db": 10.0}])
+
+
+def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metadata() -> None:
+    stored: dict[str, object] = {}
+    raw_capture_manifest = RawCaptureManifest(
+        run_id="run-order-traces",
+        relative_dir="raw-runs/run-order-traces",
+        sensors=(),
+        total_samples=0,
+        total_bytes=0,
+        created_at="2025-01-01T00:00:00Z",
+    )
+    window_policy = WholeRunWindowPolicy(
+        sample_rate_hz=800,
+        window_size_samples=2048,
+        stride_samples=200,
+        overlap_samples=1848,
+        feature_interval_s=0.25,
+    )
+    spectral_manifest = WholeRunArtifactManifest(
+        run_id="run-order-traces",
+        relative_dir="whole-run-artifacts/run-order-traces",
+        window_policy=window_policy,
+        total_window_count=2,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-a",
+                relative_path="spectra/sensor-a/windows.jsonl",
+                file_format="jsonl",
+                record_count=2,
+                sensor_id="sensor-a",
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+    context_bundle = WholeRunContextArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-order-traces",
+            relative_dir="whole-run-artifacts/run-order-traces",
+            window_policy=window_policy,
+            total_window_count=2,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
+                    relative_path="context/window-labels.jsonl",
+                    file_format="jsonl",
+                    record_count=2,
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={
+            WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY: b'{"window_index":0}\n{"window_index":1}\n',
+        },
+        labels=(
+            WholeRunContextWindowLabel(
+                window_index=0,
+                segment_index=0,
+                phase=DrivingPhase.CRUISE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="steady",
+                speed_kmh=40.0,
+                speed_source="gps",
+                engine_rpm=1200.0,
+                engine_rpm_source="obd2",
+            ),
+            WholeRunContextWindowLabel(
+                window_index=1,
+                segment_index=0,
+                phase=DrivingPhase.CRUISE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="steady",
+                speed_kmh=50.0,
+                speed_source="gps",
+                engine_rpm=1500.0,
+                engine_rpm_source="obd2",
+            ),
+        ),
+        intervals=(),
+    )
+    order_trace_bundle = WholeRunOrderTraceArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-order-traces",
+            relative_dir="whole-run-artifacts/run-order-traces",
+            window_policy=window_policy,
+            total_window_count=2,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+                    relative_path="orders/trace-points.jsonl",
+                    file_format="jsonl",
+                    record_count=2,
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={
+            WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY: (
+                b'{"hypothesis_key":"wheel_1x","harmonic":1,"window_index":0}\n'
+            ),
+        },
+        points=(
+            OrderTracePoint(
+                hypothesis_key="wheel_1x",
+                suspected_source="wheel/tire",
+                order_family="wheel",
+                harmonic=1,
+                order_label="1x wheel",
+                window_index=0,
+                eligible=True,
+                matched=True,
+                predicted_hz=5.0,
+                matched_hz=5.1,
+                relative_error=0.02,
+                peak_intensity_db=30.0,
+                vibration_strength_db=24.0,
+                ref_source="speed+tire",
+                strongest_location="Front Left",
+            ),
+            OrderTracePoint(
+                hypothesis_key="wheel_1x",
+                suspected_source="wheel/tire",
+                order_family="wheel",
+                harmonic=1,
+                order_label="1x wheel",
+                window_index=1,
+                eligible=True,
+                matched=False,
+                predicted_hz=6.0,
+                ref_source="speed+tire",
+            ),
+        ),
+    )
+
+    class FakeDB:
+        async def astore_whole_run_artifacts(self, run_id, manifest, *, artifact_contents):
+            stored["whole_run_run_id"] = run_id
+            stored["whole_run_manifest"] = manifest
+            stored["whole_run_artifact_contents"] = artifact_contents
+            return manifest
+
+        async def astore_analysis(self, run_id, analysis):
+            stored["analysis_run_id"] = run_id
+            stored["analysis"] = analysis
+
+        async def astore_analysis_error(self, run_id, error):
+            raise AssertionError(f"unexpected store_analysis_error({run_id}, {error})")
+
+    result = execute_post_analysis(
+        run_id="run-order-traces",
+        db=FakeDB(),
+        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+            run_id=run_id,
+            metadata=_run_metadata(run_id),
+            language="en",
+            samples=_samples(),
+            total_sample_count=1,
+            stride=1,
+            raw_capture_manifest=raw_capture_manifest,
+        ),
+        whole_run_artifact_builder=lambda **_kwargs: type(
+            "Bundle",
+            (),
+            {
+                "manifest": spectral_manifest,
+                "artifact_contents": {"spectral-summary:sensor-a": b"{}\n{}\n"},
+            },
+        )(),
+        whole_run_context_builder=lambda **_kwargs: context_bundle,
+        whole_run_order_trace_builder=lambda **_kwargs: order_trace_bundle,
+        analysis_runner=lambda _run: make_persisted_analysis(
+            {
+                "analysis_metadata": {
+                    "analyzed_sample_count": 1,
+                    "total_sample_count": 1,
+                    "sampling_method": "full",
+                },
+                "run_suitability": [],
+            }
+        ),
+    )
+
+    assert isinstance(result, PostAnalysisExecutionSuccess)
+    merged_manifest = stored["whole_run_manifest"]
+    assert isinstance(merged_manifest, WholeRunArtifactManifest)
+    assert merged_manifest.artifact(WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY) is not None
+    assert stored["analysis"]["analysis_metadata"]["whole_run_order_traces_available"] is True
+    assert stored["analysis"]["analysis_metadata"]["whole_run_order_trace_point_count"] == 2
+    assert stored["analysis"]["analysis_metadata"]["whole_run_order_trace_candidate_count"] == 1
+    assert (
+        stored["analysis"]["analysis_metadata"]["whole_run_order_trace_artifact_key"]
+        == WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY
+    )
+    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_count"] == 3

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/matching.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/matching.py
@@ -121,6 +121,46 @@ class OrderMatchAccumulator:
         return max(longest, current)
 
 
+@dataclass(frozen=True)
+class OrderPeakMatch:
+    """Best matching spectral peak for one predicted order frequency."""
+
+    peak_index: int
+    matched_hz: float
+    amplitude_g: float
+    relative_error: float
+
+
+def best_order_peak_match(
+    peaks: Sequence[tuple[float, float]],
+    *,
+    predicted_hz: float,
+    path_compliance: float,
+) -> OrderPeakMatch | None:
+    """Return the closest peak within the hypothesis tolerance window."""
+
+    if predicted_hz <= 0 or not peaks:
+        return None
+    compliance_scale = path_compliance**0.5
+    tolerance_hz = max(
+        ORDER_TOLERANCE_MIN_HZ,
+        predicted_hz * ORDER_TOLERANCE_REL * compliance_scale,
+    )
+    peak_index, (best_hz, best_amp) = min(
+        enumerate(peaks),
+        key=lambda item: abs(item[1][0] - predicted_hz),
+    )
+    delta_hz = abs(best_hz - predicted_hz)
+    if delta_hz > tolerance_hz:
+        return None
+    return OrderPeakMatch(
+        peak_index=peak_index,
+        matched_hz=best_hz,
+        amplitude_g=best_amp,
+        relative_error=delta_hz / max(1e-9, predicted_hz),
+    )
+
+
 def match_samples_for_hypothesis(
     samples: Sequence[Sample],
     cached_peaks: list[list[tuple[float, float]]],
@@ -149,7 +189,6 @@ def match_samples_for_hypothesis(
     matched_by_location: dict[str, int] = defaultdict(int)
     has_phases = per_sample_phases is not None and len(per_sample_phases) == len(samples)
     compliance = getattr(hypothesis, "path_compliance", 1.0)
-    compliance_scale = compliance**0.5
 
     for sample_idx, sample in enumerate(samples):
         peaks = cached_peaks[sample_idx]
@@ -180,13 +219,12 @@ def match_samples_for_hypothesis(
             phase_key = str(phase.value if hasattr(phase, "value") else phase)
             possible_by_phase[phase_key] += 1
 
-        tolerance_hz = max(
-            ORDER_TOLERANCE_MIN_HZ,
-            predicted_hz * ORDER_TOLERANCE_REL * compliance_scale,
+        peak_match = best_order_peak_match(
+            peaks,
+            predicted_hz=predicted_hz,
+            path_compliance=compliance,
         )
-        best_hz, best_amp = min(peaks, key=lambda item: abs(item[0] - predicted_hz))
-        delta_hz = abs(best_hz - predicted_hz)
-        if delta_hz > tolerance_hz:
+        if peak_match is None:
             continue
 
         matched += 1
@@ -198,20 +236,20 @@ def match_samples_for_hypothesis(
         if has_phases and phase_key is not None:
             matched_by_phase[phase_key] += 1
 
-        rel_errors.append(delta_hz / max(1e-9, predicted_hz))
-        matched_amp.append(best_amp)
+        rel_errors.append(peak_match.relative_error)
+        matched_amp.append(peak_match.amplitude_g)
         floor_amp = _estimate_strength_floor_amp_g(sample)
         matched_floor.append(max(0.0, floor_amp if floor_amp is not None else 0.0))
         predicted_vals.append(predicted_hz)
-        measured_vals.append(best_hz)
+        measured_vals.append(peak_match.matched_hz)
         matched_points.append(
             OrderMatchObservation(
                 t_s=sample.t_s,
                 speed_kmh=sample.speed_kmh,
                 predicted_hz=predicted_hz,
-                matched_hz=best_hz,
-                rel_error=delta_hz / max(1e-9, predicted_hz),
-                amp=best_amp,
+                matched_hz=peak_match.matched_hz,
+                rel_error=peak_match.relative_error,
+                amp=peak_match.amplitude_g,
                 location=sample_location,
                 phase=(
                     _phase_to_str(per_sample_phases[sample_idx])

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
@@ -1,0 +1,344 @@
+"""Whole-run order-trace generation over spectral summaries and context labels."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import cast
+
+from vibesensor.shared.constants.analysis import MIN_ANALYSIS_FREQ_HZ
+from vibesensor.shared.json_utils import safe_json_dumps
+from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+)
+from vibesensor.use_cases.diagnostics._reference_resolution import _tire_reference_from_context
+from vibesensor.use_cases.diagnostics._sensor_locations import _location_label
+from vibesensor.use_cases.diagnostics.orders.matching import best_order_peak_match
+from vibesensor.use_cases.diagnostics.orders.physics import (
+    OrderHypothesis,
+    _order_hypotheses,
+    _order_label,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
+    OrderTraceFamily,
+    OrderTracePoint,
+)
+from vibesensor.use_cases.diagnostics.whole_run_context import WholeRunContextWindowLabel
+from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    WholeRunWindowSpectralSummary,
+    whole_run_window_spectral_summaries_from_jsonl_bytes,
+)
+
+WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY = "order-trace-points"
+_WHOLE_RUN_ORDER_TRACE_ARTIFACT_PATH = "orders/trace-points.jsonl"
+
+__all__ = [
+    "WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY",
+    "WholeRunOrderTraceArtifactBundle",
+    "build_whole_run_order_trace_artifact_bundle",
+    "order_trace_points_to_jsonl_bytes",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunOrderTraceArtifactBundle:
+    """Dense whole-run order-trace sidecar payload plus in-memory points."""
+
+    manifest: WholeRunArtifactManifest
+    artifact_contents: dict[str, bytes]
+    points: tuple[OrderTracePoint, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _SensorPeakMatch:
+    client_id: str
+    location: str
+    matched_hz: float
+    amplitude_g: float
+    relative_error: float
+    peak_intensity_db: float | None
+    vibration_strength_db: float | None
+
+
+def build_whole_run_order_trace_artifact_bundle(
+    *,
+    run_id: str,
+    metadata: RunMetadata,
+    spectral_manifest: WholeRunArtifactManifest,
+    spectral_artifact_contents: Mapping[str, bytes],
+    context_labels: Sequence[WholeRunContextWindowLabel],
+    samples: Sequence[SensorFrame],
+    lang: str = "en",
+    created_at: str | None = None,
+) -> WholeRunOrderTraceArtifactBundle:
+    """Build deterministic dense whole-run order traces from persisted sidecars."""
+
+    ordered_labels = tuple(sorted(context_labels, key=lambda label: label.window_index))
+    if len(ordered_labels) != spectral_manifest.total_window_count:
+        raise ValueError("whole-run order traces require context labels for every window")
+    if any(label.window_index != index for index, label in enumerate(ordered_labels)):
+        raise ValueError("whole-run order traces require contiguous ordered context labels")
+    summaries_by_sensor = _spectral_summaries_by_sensor(
+        manifest=spectral_manifest,
+        artifact_contents=spectral_artifact_contents,
+    )
+    tire_circumference_m, _ = _tire_reference_from_context(metadata)
+    client_locations = _client_locations(samples, lang=lang)
+    window_inputs = tuple(
+        _window_context_sample(
+            run_id=run_id,
+            window_index=label.window_index,
+            label=label,
+            sample_rate_hz=spectral_manifest.window_policy.sample_rate_hz,
+        )
+        for label in ordered_labels
+    )
+    points: list[OrderTracePoint] = []
+    for hypothesis in _order_hypotheses():
+        hypothesis_points = _hypothesis_trace_points(
+            hypothesis=hypothesis,
+            metadata=metadata,
+            tire_circumference_m=tire_circumference_m,
+            window_inputs=window_inputs,
+            context_labels=ordered_labels,
+            summaries_by_sensor=summaries_by_sensor,
+            client_locations=client_locations,
+        )
+        if any(point.eligible for point in hypothesis_points):
+            points.extend(hypothesis_points)
+    point_rows = tuple(points)
+    artifact = WholeRunArtifactFile(
+        artifact_key=WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+        relative_path=_WHOLE_RUN_ORDER_TRACE_ARTIFACT_PATH,
+        file_format="jsonl",
+        record_count=len(point_rows),
+    )
+    manifest = WholeRunArtifactManifest(
+        run_id=run_id,
+        relative_dir=spectral_manifest.relative_dir,
+        window_policy=spectral_manifest.window_policy,
+        total_window_count=spectral_manifest.total_window_count,
+        artifacts=(artifact,),
+        created_at=created_at or spectral_manifest.created_at or utc_now_iso(),
+        schema_version=spectral_manifest.schema_version,
+        storage_type=spectral_manifest.storage_type,
+    )
+    return WholeRunOrderTraceArtifactBundle(
+        manifest=manifest,
+        artifact_contents={
+            WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY: order_trace_points_to_jsonl_bytes(point_rows)
+        },
+        points=point_rows,
+    )
+
+
+def order_trace_points_to_jsonl_bytes(points: Sequence[OrderTracePoint]) -> bytes:
+    """Serialize dense whole-run order traces into sidecar JSONL bytes."""
+
+    if not points:
+        return b""
+    lines = [safe_json_dumps(point.to_json_object()).encode("utf-8") for point in points]
+    return b"\n".join(lines) + b"\n"
+
+
+def _hypothesis_trace_points(
+    *,
+    hypothesis: OrderHypothesis,
+    metadata: RunMetadata,
+    tire_circumference_m: float | None,
+    window_inputs: Sequence[SensorFrame],
+    context_labels: Sequence[WholeRunContextWindowLabel],
+    summaries_by_sensor: Mapping[str, Sequence[WholeRunWindowSpectralSummary]],
+    client_locations: Mapping[str, str],
+) -> tuple[OrderTracePoint, ...]:
+    family = cast(OrderTraceFamily, hypothesis.order_label_base)
+    order_label = _order_label(hypothesis.order, hypothesis.order_label_base)
+    points: list[OrderTracePoint] = []
+    for sample, label in zip(window_inputs, context_labels, strict=True):
+        predicted_hz, ref_source = hypothesis.predicted_hz(sample, metadata, tire_circumference_m)
+        eligible = predicted_hz is not None and predicted_hz > 0
+        sensor_match = (
+            _best_sensor_peak_match(
+                summaries_by_sensor=summaries_by_sensor,
+                window_index=label.window_index,
+                predicted_hz=float(predicted_hz),
+                hypothesis=hypothesis,
+                client_locations=client_locations,
+            )
+            if eligible and predicted_hz is not None
+            else None
+        )
+        points.append(
+            OrderTracePoint(
+                hypothesis_key=hypothesis.key,
+                suspected_source=str(hypothesis.suspected_source),
+                order_family=family,
+                harmonic=hypothesis.order,
+                order_label=order_label,
+                window_index=label.window_index,
+                eligible=eligible,
+                matched=sensor_match is not None,
+                predicted_hz=float(predicted_hz) if predicted_hz is not None else None,
+                matched_hz=sensor_match.matched_hz if sensor_match is not None else None,
+                relative_error=sensor_match.relative_error if sensor_match is not None else None,
+                peak_intensity_db=(
+                    sensor_match.peak_intensity_db if sensor_match is not None else None
+                ),
+                vibration_strength_db=(
+                    sensor_match.vibration_strength_db if sensor_match is not None else None
+                ),
+                ref_source=ref_source or None,
+                strongest_location=(sensor_match.location if sensor_match is not None else None),
+            )
+        )
+    return tuple(points)
+
+
+def _best_sensor_peak_match(
+    *,
+    summaries_by_sensor: Mapping[str, Sequence[WholeRunWindowSpectralSummary]],
+    window_index: int,
+    predicted_hz: float,
+    hypothesis: OrderHypothesis,
+    client_locations: Mapping[str, str],
+) -> _SensorPeakMatch | None:
+    best: _SensorPeakMatch | None = None
+    for client_id in sorted(summaries_by_sensor):
+        summaries = summaries_by_sensor[client_id]
+        if window_index < 0 or window_index >= len(summaries):
+            continue
+        summary = summaries[window_index]
+        if summary.coverage_state != "full":
+            continue
+        peak_index, peak_pairs = _filtered_peak_pairs(summary.top_peaks)
+        peak_match = best_order_peak_match(
+            peak_pairs,
+            predicted_hz=predicted_hz,
+            path_compliance=hypothesis.path_compliance,
+        )
+        if peak_match is None:
+            continue
+        source_peak = summary.top_peaks[peak_index[peak_match.peak_index]]
+        candidate = _SensorPeakMatch(
+            client_id=client_id,
+            location=client_locations.get(client_id, _fallback_location(client_id)),
+            matched_hz=peak_match.matched_hz,
+            amplitude_g=peak_match.amplitude_g,
+            relative_error=peak_match.relative_error,
+            peak_intensity_db=source_peak.get("vibration_strength_db"),
+            vibration_strength_db=summary.vibration_strength_db,
+        )
+        if best is None or _sensor_match_rank(candidate) > _sensor_match_rank(best):
+            best = candidate
+    return best
+
+
+def _spectral_summaries_by_sensor(
+    *,
+    manifest: WholeRunArtifactManifest,
+    artifact_contents: Mapping[str, bytes],
+) -> dict[str, tuple[WholeRunWindowSpectralSummary, ...]]:
+    summaries_by_sensor: dict[str, tuple[WholeRunWindowSpectralSummary, ...]] = {}
+    summary_artifacts = sorted(
+        (
+            artifact
+            for artifact in manifest.artifacts
+            if artifact.artifact_key.startswith("spectral-summary:")
+        ),
+        key=lambda artifact: (artifact.sensor_id or "", artifact.artifact_key),
+    )
+    for artifact in summary_artifacts:
+        if artifact.sensor_id is None:
+            raise ValueError(
+                "whole-run order traces require spectral summary artifacts with sensor_id"
+            )
+        payload = artifact_contents.get(artifact.artifact_key)
+        if payload is None:
+            raise ValueError(f"whole-run order traces missing bytes for {artifact.artifact_key}")
+        summaries = whole_run_window_spectral_summaries_from_jsonl_bytes(payload)
+        if len(summaries) != manifest.total_window_count:
+            raise ValueError(
+                "whole-run order traces require one spectral summary row per window "
+                f"for {artifact.artifact_key}"
+            )
+        summaries_by_sensor[artifact.sensor_id] = summaries
+    if not summaries_by_sensor:
+        raise ValueError("whole-run order traces require at least one spectral summary artifact")
+    return summaries_by_sensor
+
+
+def _window_context_sample(
+    *,
+    run_id: str,
+    window_index: int,
+    label: WholeRunContextWindowLabel,
+    sample_rate_hz: int,
+) -> SensorFrame:
+    return SensorFrame(
+        run_id=run_id,
+        timestamp_utc=f"whole-run-window-{window_index}",
+        t_s=None,
+        client_id="",
+        client_name="",
+        location="",
+        sample_rate_hz=sample_rate_hz,
+        speed_kmh=label.speed_kmh,
+        gps_speed_kmh=label.speed_kmh if label.speed_source == "gps" else None,
+        speed_source=label.speed_source or "",
+        engine_rpm=label.engine_rpm,
+        engine_rpm_source=label.engine_rpm_source or "",
+        gear=None,
+        final_drive_ratio=None,
+        accel_x_g=None,
+        accel_y_g=None,
+        accel_z_g=None,
+        dominant_freq_hz=None,
+        dominant_axis="",
+        top_peaks=(),
+        vibration_strength_db=None,
+        strength_bucket=None,
+        strength_peak_amp_g=None,
+        strength_floor_amp_g=None,
+        frames_dropped_total=0,
+        queue_overflow_drops=0,
+    )
+
+
+def _client_locations(samples: Sequence[SensorFrame], *, lang: str) -> dict[str, str]:
+    locations: dict[str, str] = {}
+    for sample in samples:
+        client_id = sample.client_id.strip()
+        if not client_id or client_id in locations:
+            continue
+        locations[client_id] = _location_label(sample, lang=lang)
+    return locations
+
+
+def _filtered_peak_pairs(
+    peaks: Sequence[Mapping[str, object]],
+) -> tuple[tuple[int, ...], tuple[tuple[float, float], ...]]:
+    indexes: list[int] = []
+    filtered: list[tuple[float, float]] = []
+    for peak_index, peak in enumerate(peaks):
+        hz = peak.get("hz")
+        amp = peak.get("amp")
+        if not isinstance(hz, (int, float)) or not isinstance(amp, (int, float)):
+            continue
+        if hz <= 0 or amp <= 0 or hz < MIN_ANALYSIS_FREQ_HZ:
+            continue
+        indexes.append(peak_index)
+        filtered.append((float(hz), float(amp)))
+    return tuple(indexes), tuple(filtered)
+
+
+def _sensor_match_rank(match: _SensorPeakMatch) -> tuple[float, float, str]:
+    return (match.amplitude_g, -match.relative_error, match.client_id)
+
+
+def _fallback_location(client_id: str) -> str:
+    suffix = client_id[-4:] if len(client_id) >= 4 else client_id
+    return f"Sensor …{suffix}" if suffix else "Unknown sensor"

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
@@ -7,15 +7,15 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Protocol
+from typing import Protocol, cast
 
 import numpy as np
 
 from vibesensor.shared.constants.dsp import SPECTRUM_MAX_HZ, SPECTRUM_MIN_HZ
 from vibesensor.shared.fft_analysis import SpectralAnalysisComputer, float_list, medfilt3
-from vibesensor.shared.json_utils import safe_json_dumps
+from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
 from vibesensor.shared.time_utils import utc_now_iso
-from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.json_types import JsonObject, is_json_object
 from vibesensor.shared.types.raw_capture import (
     RawCaptureCoverageState,
     RawCaptureManifest,
@@ -42,6 +42,8 @@ __all__ = [
     "WholeRunSpectralArtifactBundle",
     "WholeRunWindowSpectralSummary",
     "build_whole_run_spectral_artifact_bundle",
+    "whole_run_window_spectral_summaries_from_jsonl_bytes",
+    "whole_run_window_spectral_summaries_to_jsonl_bytes",
 ]
 
 
@@ -100,6 +102,40 @@ class WholeRunWindowSpectralSummary:
         if self.strength_bucket is not None:
             payload["strength_bucket"] = self.strength_bucket
         return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunWindowSpectralSummary:
+        top_peaks_raw = data.get("top_peaks")
+        top_peaks: list[StrengthPeak] = []
+        if isinstance(top_peaks_raw, list):
+            for item in top_peaks_raw:
+                if not is_json_object(item):
+                    continue
+                hz = _float_or_none(item.get("hz"))
+                amp = _float_or_none(item.get("amp"))
+                vibration_strength_db = _float_or_none(item.get("vibration_strength_db"))
+                if hz is None or amp is None or vibration_strength_db is None:
+                    continue
+                top_peaks.append(
+                    {
+                        "hz": hz,
+                        "amp": amp,
+                        "vibration_strength_db": vibration_strength_db,
+                        "strength_bucket": _text_or_none(item.get("strength_bucket")),
+                    }
+                )
+        return cls(
+            window_index=_int_or_default(data.get("window_index"), default=0),
+            coverage_state=_coverage_state(data.get("coverage_state")),
+            returned_sample_start=_int_or_none(data.get("returned_sample_start")),
+            returned_sample_count=_int_or_default(data.get("returned_sample_count"), default=0),
+            dominant_freq_hz=_float_or_none(data.get("dominant_freq_hz")),
+            vibration_strength_db=_float_or_none(data.get("vibration_strength_db")),
+            strength_peak_amp_g=_float_or_none(data.get("strength_peak_amp_g")),
+            strength_floor_amp_g=_float_or_none(data.get("strength_floor_amp_g")),
+            strength_bucket=_text_or_none(data.get("strength_bucket")),
+            top_peaks=tuple(top_peaks),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -447,7 +483,9 @@ def _build_artifact_bundle(
         )
         artifact_contents[freq_artifact_key] = _npy_bytes(freq_hz)
         artifact_contents[matrix_artifact_key] = _npy_bytes(spectrum_rows)
-        artifact_contents[summary_artifact_key] = _summary_jsonl_bytes(summaries)
+        artifact_contents[summary_artifact_key] = (
+            whole_run_window_spectral_summaries_to_jsonl_bytes(summaries)
+        )
     manifest = WholeRunArtifactManifest(
         run_id=run_id,
         relative_dir=f"{WHOLE_RUN_ARTIFACT_STORAGE_DIR_NAME}/{run_id}",
@@ -516,17 +554,64 @@ def _npy_bytes(array: np.ndarray) -> bytes:
     return buffer.getvalue()
 
 
-def _summary_jsonl_bytes(summaries: Sequence[WholeRunWindowSpectralSummary]) -> bytes:
+def whole_run_window_spectral_summaries_to_jsonl_bytes(
+    summaries: Sequence[WholeRunWindowSpectralSummary],
+) -> bytes:
     if not summaries:
         return b""
     lines = [safe_json_dumps(summary.to_json_object()).encode("utf-8") for summary in summaries]
     return b"\n".join(lines) + b"\n"
 
 
+def whole_run_window_spectral_summaries_from_jsonl_bytes(
+    payload: bytes,
+) -> tuple[WholeRunWindowSpectralSummary, ...]:
+    """Reconstruct persisted whole-run spectral summaries from sidecar JSONL bytes."""
+
+    if not payload:
+        return ()
+    summaries: list[WholeRunWindowSpectralSummary] = []
+    text = payload.decode("utf-8")
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parsed = safe_json_loads(line, context="whole-run spectral summaries")
+        if not is_json_object(parsed):
+            raise ValueError("whole-run spectral summary line must decode to a JSON object")
+        summaries.append(WholeRunWindowSpectralSummary.from_mapping(parsed))
+    return tuple(summaries)
+
+
 def _float_or_none(value: object) -> float | None:
     if isinstance(value, (int, float)):
         return float(value)
     return None
+
+
+def _int_or_none(value: object) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
+def _int_or_default(value: object, *, default: int) -> int:
+    parsed = _int_or_none(value)
+    return parsed if parsed is not None else default
+
+
+def _text_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _coverage_state(value: object) -> RawCaptureCoverageState:
+    if value in {"missing", "empty", "partial", "full"}:
+        return cast(RawCaptureCoverageState, value)
+    return "missing"
 
 
 def _default_frequency_grid(*, sample_rate_hz: int, fft_n: int) -> np.ndarray:

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -18,6 +18,11 @@ from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawCaptureSensorRange
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+    WholeRunOrderTraceArtifactBundle,
+    build_whole_run_order_trace_artifact_bundle,
+)
 from vibesensor.use_cases.diagnostics.whole_run_context import (
     WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
     WholeRunContextArtifactBundle,
@@ -110,6 +115,18 @@ class WholeRunContextBuilder(Protocol):
     ) -> WholeRunContextArtifactBundle | None: ...
 
 
+class WholeRunOrderTraceBuilder(Protocol):
+    """Injected boundary for building dense whole-run order-trace sidecars."""
+
+    def __call__(
+        self,
+        *,
+        run: PostAnalysisRunInput,
+        spectral_bundle: WholeRunSpectralArtifactBundle,
+        context_bundle: WholeRunContextArtifactBundle,
+    ) -> WholeRunOrderTraceArtifactBundle | None: ...
+
+
 @dataclass(frozen=True, slots=True)
 class _StoredWholeRunArtifactBundle:
     """Generic sidecar bundle shape for final manifest persistence."""
@@ -126,6 +143,7 @@ def execute_post_analysis(
     load_run: PostAnalysisLoader = load_post_analysis_run,
     whole_run_artifact_builder: WholeRunArtifactBuilder | None = None,
     whole_run_context_builder: WholeRunContextBuilder | None = None,
+    whole_run_order_trace_builder: WholeRunOrderTraceBuilder | None = None,
     defer_retryable_error_storage: bool = False,
 ) -> PostAnalysisAttemptResult:
     analysis_start = time.monotonic()
@@ -138,6 +156,11 @@ def execute_post_analysis(
         _build_whole_run_context_artifacts
         if whole_run_context_builder is None
         else whole_run_context_builder
+    )
+    resolved_whole_run_order_trace_builder = (
+        _build_whole_run_order_trace_artifacts
+        if whole_run_order_trace_builder is None
+        else whole_run_order_trace_builder
     )
     with start_span(
         __name__,
@@ -208,6 +231,7 @@ def execute_post_analysis(
             run_input = build_post_analysis_input(loaded)
             stored_artifact_manifest: WholeRunArtifactManifest | None = None
             context_bundle: WholeRunContextArtifactBundle | None = None
+            order_trace_bundle: WholeRunOrderTraceArtifactBundle | None = None
             if loaded.raw_capture_manifest is not None:
                 spectral_bundle = resolved_whole_run_artifact_builder(
                     run_id=loaded.run_id,
@@ -219,9 +243,16 @@ def execute_post_analysis(
                     run=run_input,
                     total_sample_count=_whole_run_total_sample_count(loaded.raw_capture_manifest),
                 )
+                if spectral_bundle is not None and context_bundle is not None:
+                    order_trace_bundle = resolved_whole_run_order_trace_builder(
+                        run=run_input,
+                        spectral_bundle=spectral_bundle,
+                        context_bundle=context_bundle,
+                    )
                 merged_bundle = _merge_whole_run_artifact_bundles(
                     spectral_bundle,
                     context_bundle,
+                    order_trace_bundle,
                 )
                 if merged_bundle is not None:
                     stored_artifact_manifest = _sync_call(
@@ -239,6 +270,8 @@ def execute_post_analysis(
             summary = analysis_runner(run_input)
             if context_bundle is not None:
                 summary = _append_whole_run_context(summary, context_bundle)
+            if order_trace_bundle is not None:
+                summary = _append_whole_run_order_trace_metadata(summary, order_trace_bundle)
             if stored_artifact_manifest is not None:
                 summary = _append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
             _sync_call(db, "astore_analysis", loaded.run_id, summary)
@@ -442,11 +475,32 @@ def _whole_run_total_sample_count(manifest: RawCaptureManifest) -> int:
     return max(0, int(manifest.total_samples))
 
 
+def _build_whole_run_order_trace_artifacts(
+    *,
+    run: PostAnalysisRunInput,
+    spectral_bundle: WholeRunSpectralArtifactBundle,
+    context_bundle: WholeRunContextArtifactBundle,
+) -> WholeRunOrderTraceArtifactBundle | None:
+    return build_whole_run_order_trace_artifact_bundle(
+        run_id=run.run_id,
+        metadata=run.context,
+        spectral_manifest=spectral_bundle.manifest,
+        spectral_artifact_contents=spectral_bundle.artifact_contents,
+        context_labels=context_bundle.labels,
+        samples=run.context_samples,
+        lang=run.language,
+    )
+
+
 def _merge_whole_run_artifact_bundles(
-    spectral_bundle: WholeRunSpectralArtifactBundle | None,
-    context_bundle: WholeRunContextArtifactBundle | None,
+    *bundles: (
+        WholeRunSpectralArtifactBundle
+        | WholeRunContextArtifactBundle
+        | WholeRunOrderTraceArtifactBundle
+        | None
+    ),
 ) -> _StoredWholeRunArtifactBundle | None:
-    active_bundles = [bundle for bundle in (spectral_bundle, context_bundle) if bundle is not None]
+    active_bundles = [bundle for bundle in bundles if bundle is not None]
     if not active_bundles:
         return None
     base_manifest = active_bundles[0].manifest
@@ -546,4 +600,22 @@ def _append_whole_run_context(
     analysis_metadata["whole_run_context_labels_artifact_key"] = (
         WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY
     )
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def _append_whole_run_order_trace_metadata(
+    summary: PersistedAnalysis,
+    bundle: WholeRunOrderTraceArtifactBundle,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    analysis_metadata["whole_run_order_traces_available"] = True
+    analysis_metadata["whole_run_order_trace_point_count"] = len(bundle.points)
+    analysis_metadata["whole_run_order_trace_candidate_count"] = len(
+        {point.hypothesis_key for point in bundle.points}
+    )
+    analysis_metadata["whole_run_order_trace_artifact_key"] = WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY
     return PersistedAnalysis.from_json_object(payload)

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -202,16 +202,17 @@ Whole-run order tracking should separate dense trace points from persisted
 summaries.
 
 - **Dense trace point**
-  - `candidate_key`
+  - `hypothesis_key`
+  - `harmonic`
   - `window_index`
-  - `sensor_id`
+  - `eligible` / `matched`
   - `predicted_hz`
-  - `observed_hz`
+  - `matched_hz`
   - `relative_error`
-  - `amplitude_g` or derived dB
-  - `snr_db`
-  - `support_state`
-  - `phase_key`
+  - `peak_intensity_db`
+  - `vibration_strength_db`
+  - `ref_source`
+  - `strongest_location`
 - **Persisted summary**
   - support ratio
   - contiguous support intervals
@@ -219,6 +220,12 @@ summaries.
   - phase-specific support
   - stable frequency/order bounds
   - top supporting locations
+
+The dense generation owner now lives in
+`apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py`. It
+reuses `OrderHypothesis.predicted_hz(...)` from `orders/physics.py` and the
+shared `best_order_peak_match()` tolerance logic from `orders/matching.py`, so
+whole-run traces stay aligned with the current live/sample order model.
 
 ### Spatial/coherence contract
 

--- a/docs/order_tracking.md
+++ b/docs/order_tracking.md
@@ -144,6 +144,7 @@ That shared ownership is why `shared/order_bands.py` exists outside
 | `apps/server/vibesensor/use_cases/diagnostics/orders/finding_builder.py` | Project scored evidence into domain `Finding` objects. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/pipeline.py` | Coordinate the full order-analysis pass. |
 | `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py` | Dense whole-run order-trace points plus compact summary/support contracts for later full-run work. |
+| `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py` | Build deterministic dense whole-run order traces from spectral summaries plus context labels. |
 
 ## Whole-run order trace contract split
 
@@ -153,6 +154,10 @@ Whole-run order work keeps one order model and changes only the sampling grid:
   `use_cases/diagnostics/orders/whole_run_contracts.py`, keyed by
   `(hypothesis_key, harmonic, window_index)` so later execution can join
   directly against the canonical whole-run window grid
+- `use_cases/diagnostics/orders/whole_run_traces.py` now builds those dense
+  points from `spectral-summary:*` sidecars plus `context-window-labels`, using
+  the same `OrderHypothesis.predicted_hz(...)` math and `best_order_peak_match()`
+  tolerance logic as the live sample-matching path
 - compact persisted/report-facing projections use the future summary shapes in
   `shared/types/history_analysis_contracts.py`
 - the compact summary contract carries support intervals, phase support, and


### PR DESCRIPTION
## What changed
- build dense whole-run order trace sidecars in `orders/whole_run_traces.py` from `spectral-summary:*` artifacts plus persisted whole-run context labels
- reuse one order matching tolerance rule by extracting `best_order_peak_match()` from `orders/matching.py`
- add spectral summary JSONL reload helpers in `whole_run_spectra.py`
- persist the new order-trace artifact and analysis metadata from `post_analysis_executor.py`
- add focused diagnostics and run tests, and update the order / whole-run design docs

## Why
#3092 needs deterministic per-candidate traces on the canonical whole-run window grid before harmonic scoring and compact order summaries can exist.

## Validation
- `make format`
- `make typecheck-backend`
- `make lint`
- `make test-changed`
- `make docs-lint`

## Risks / tradeoffs
- dense traces intentionally stay internal sidecars; history/report payloads are still untouched in this issue
- strongest-location selection is amplitude-first with deterministic tie-breaking, so later scoring work can refine confidence without changing the trace contract
- whole-run trace generation currently requires one context label and one spectral summary row per window; malformed sidecars fail fast instead of silently drifting

## Out of scope
- harmonic stability scoring and order-lock scoring (#3093)
- compact phase/support interval summaries (#3094)
- persisted ranked order evidence for downstream fusion (#3095)

Fixes #3092
