### PR TITLE
Define whole-run spatial evidence contracts

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from vibesensor.shared.types.history_analysis_contracts import (
+    SpatialEvidenceSummaryResponse,
+    SpatialLocationSummaryResponse,
+)
+from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
+    SpatialEvidenceSummary,
+    SpatialEvidenceWindow,
+    SpatialLocationSummary,
+)
+
+
+def test_spatial_evidence_window_round_trips_json_shape() -> None:
+    window = SpatialEvidenceWindow(
+        candidate_key="wheel",
+        suspected_source="wheel/tire",
+        window_index=12,
+        sensor_id="front-left",
+        location="Front Left",
+        supporting=True,
+        coherent=True,
+        peak_intensity_db=18.4,
+        vibration_strength_db=11.2,
+        matched_frequency_hz=14.6,
+        coherence_score=0.82,
+    )
+
+    assert SpatialEvidenceWindow.from_mapping(window.to_json_object()) == window
+
+
+def test_spatial_evidence_summary_round_trips_nested_compact_contracts() -> None:
+    summary = SpatialEvidenceSummary(
+        candidate_key="wheel",
+        suspected_source="wheel/tire",
+        proof_basis="supporting_windows_raw_backed",
+        total_window_count=128,
+        supporting_window_count=42,
+        supporting_sensor_count=4,
+        coherent_window_count=30,
+        coherence_ratio=30 / 42,
+        dominant_location="Front Left",
+        runner_up_location="Front Right",
+        location_separation_db=4.5,
+        dominance_ratio=1.42,
+        ambiguous_location=False,
+        weak_spatial_separation=False,
+        location_summaries=(
+            SpatialLocationSummary(
+                location="Front Left",
+                sensor_ids=("front-left",),
+                supporting_window_count=24,
+                support_ratio=24 / 42,
+                coherent_window_count=18,
+                coherence_ratio=18 / 24,
+                peak_intensity_db=19.3,
+                mean_vibration_strength_db=12.1,
+            ),
+            SpatialLocationSummary(
+                location="Front Right",
+                sensor_ids=("front-right",),
+                supporting_window_count=12,
+                support_ratio=12 / 42,
+                coherent_window_count=8,
+                coherence_ratio=8 / 12,
+                peak_intensity_db=14.8,
+                mean_vibration_strength_db=9.4,
+            ),
+        ),
+    )
+
+    assert SpatialEvidenceSummary.from_mapping(summary.to_json_object()) == summary
+
+
+def test_history_spatial_response_contracts_expose_named_summary_fields() -> None:
+    assert set(SpatialLocationSummaryResponse.__annotations__) == {
+        "location",
+        "sensor_ids",
+        "supporting_window_count",
+        "support_ratio",
+        "coherent_window_count",
+        "coherence_ratio",
+        "peak_intensity_db",
+        "mean_vibration_strength_db",
+    }
+    assert set(SpatialEvidenceSummaryResponse.__annotations__) == {
+        "candidate_key",
+        "suspected_source",
+        "proof_basis",
+        "total_window_count",
+        "supporting_window_count",
+        "supporting_sensor_count",
+        "coherent_window_count",
+        "coherence_ratio",
+        "dominant_location",
+        "runner_up_location",
+        "location_separation_db",
+        "dominance_ratio",
+        "ambiguous_location",
+        "weak_spatial_separation",
+        "location_summaries",
+    }

--- a/apps/server/vibesensor/shared/boundaries/reporting/sensor_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/sensor_facts.py
@@ -10,6 +10,7 @@ from statistics import mean as _mean
 from typing import TYPE_CHECKING
 
 from vibesensor.domain import LocationHotspotRow, LocationIntensitySummary, TestRun
+from vibesensor.shared.types.history_analysis_contracts import LocationProofBasis
 from vibesensor.vibration_strength import compute_db, percentile
 
 if TYPE_CHECKING:
@@ -45,7 +46,7 @@ class ReportSensorFacts:
     coverage: ReportCoverageSummary
     proof_intensity: tuple[LocationIntensitySummary, ...]
     proof_location_hotspot_rows: tuple[LocationHotspotRow, ...]
-    proof_basis: str
+    proof_basis: LocationProofBasis
 
 
 def build_report_sensor_facts(
@@ -86,7 +87,7 @@ def enrich_location_proof_sensor_facts(
     proof_intensity = tuple(_supporting_window_location_intensity(primary_candidate))
     if not proof_intensity:
         return sensor_facts
-    proof_basis = (
+    proof_basis: LocationProofBasis = (
         "supporting_windows_raw_backed"
         if evidence_data_basis == "raw_backed"
         else "supporting_windows_summary_only"

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -49,6 +49,7 @@ __all__ = [
     "DataQualitySpeedCoverageResponse",
     "FindingPayload",
     "LocationIntensitySummaryResponse",
+    "LocationProofBasis",
     "OutlierSummaryResponse",
     "OrderHarmonicEvidenceSummaryResponse",
     "OrderTracePhaseSupportResponse",
@@ -65,12 +66,19 @@ __all__ = [
     "StrengthBucketDistributionResponse",
     "SummaryWarningResponse",
     "SuspectedVibrationOriginPayload",
+    "SpatialEvidenceSummaryResponse",
+    "SpatialLocationSummaryResponse",
     "TestPlanStepResponse",
     "WholeRunContextIntervalResponse",
 ]
 
 type PayloadObject = JsonSchemaObject
 type PayloadValue = JsonSchemaValue
+type LocationProofBasis = Literal[
+    "whole_run_summary",
+    "supporting_windows_raw_backed",
+    "supporting_windows_summary_only",
+]
 
 
 _FORBID_EXTRA_TYPEDDICT_CONFIG = ConfigDict(extra="forbid")
@@ -221,6 +229,39 @@ class OrderTraceSummaryResponse(TypedDict, total=False):
     peak_intensity_db: float | None
     mean_vibration_strength_db: float | None
     ref_sources: Required[list[str]]
+
+
+class SpatialLocationSummaryResponse(TypedDict, total=False):
+    """Compact per-location support row for persisted spatial evidence."""
+
+    location: Required[str]
+    sensor_ids: Required[list[str]]
+    supporting_window_count: Required[int]
+    support_ratio: Required[float]
+    coherent_window_count: Required[int]
+    coherence_ratio: float | None
+    peak_intensity_db: float | None
+    mean_vibration_strength_db: float | None
+
+
+class SpatialEvidenceSummaryResponse(TypedDict, total=False):
+    """Future persisted/report-facing summary shape for whole-run spatial evidence."""
+
+    candidate_key: Required[str]
+    suspected_source: Required[str]
+    proof_basis: Required[LocationProofBasis]
+    total_window_count: Required[int]
+    supporting_window_count: Required[int]
+    supporting_sensor_count: Required[int]
+    coherent_window_count: Required[int]
+    coherence_ratio: float | None
+    dominant_location: str | None
+    runner_up_location: str | None
+    location_separation_db: float | None
+    dominance_ratio: float | None
+    ambiguous_location: Required[bool]
+    weak_spatial_separation: Required[bool]
+    location_summaries: Required[list[SpatialLocationSummaryResponse]]
 
 
 class SpeedStatsResponse(TypedDict):
@@ -376,6 +417,8 @@ for _typed_dict in (
     OrderTracePhaseSupportResponse,
     OrderHarmonicEvidenceSummaryResponse,
     OrderTraceSummaryResponse,
+    SpatialLocationSummaryResponse,
+    SpatialEvidenceSummaryResponse,
     SpeedStatsResponse,
     PhaseInfoResponse,
     OutlierSummaryResponse,

--- a/apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py
@@ -1,0 +1,298 @@
+"""Whole-run multi-sensor spatial/coherence contracts.
+
+Dense window rows stay keyed by ``(candidate_key, window_index, sensor_id)`` so
+later execution stages can join aligned per-window sensor outputs without
+inventing a second spatial evidence vocabulary. Compact summaries carry only the
+report/history-facing proof fields needed after persistence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+from vibesensor.shared.types.history_analysis_contracts import LocationProofBasis
+from vibesensor.shared.types.json_types import JsonObject, JsonValue
+
+__all__ = [
+    "LocationProofBasis",
+    "SpatialEvidenceSummary",
+    "SpatialEvidenceWindow",
+    "SpatialLocationSummary",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SpatialEvidenceWindow:
+    """Dense spatial/coherence evidence row for one candidate-window-sensor join."""
+
+    candidate_key: str
+    suspected_source: str
+    window_index: int
+    sensor_id: str
+    location: str
+    supporting: bool
+    coherent: bool
+    peak_intensity_db: float | None = None
+    vibration_strength_db: float | None = None
+    matched_frequency_hz: float | None = None
+    coherence_score: float | None = None
+
+    def __post_init__(self) -> None:
+        _require_text(self.candidate_key, field_name="candidate_key")
+        _require_text(self.suspected_source, field_name="suspected_source")
+        _require_text(self.sensor_id, field_name="sensor_id")
+        _require_text(self.location, field_name="location")
+        _require_nonnegative(self.window_index, field_name="window_index")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "candidate_key": self.candidate_key,
+            "suspected_source": self.suspected_source,
+            "window_index": self.window_index,
+            "sensor_id": self.sensor_id,
+            "location": self.location,
+            "supporting": self.supporting,
+            "coherent": self.coherent,
+        }
+        _set_optional(payload, "peak_intensity_db", self.peak_intensity_db)
+        _set_optional(payload, "vibration_strength_db", self.vibration_strength_db)
+        _set_optional(payload, "matched_frequency_hz", self.matched_frequency_hz)
+        _set_optional(payload, "coherence_score", self.coherence_score)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> SpatialEvidenceWindow:
+        return cls(
+            candidate_key=_required_text(data, "candidate_key"),
+            suspected_source=_required_text(data, "suspected_source"),
+            window_index=_required_int(data, "window_index"),
+            sensor_id=_required_text(data, "sensor_id"),
+            location=_required_text(data, "location"),
+            supporting=_required_bool(data, "supporting"),
+            coherent=_required_bool(data, "coherent"),
+            peak_intensity_db=_optional_float(data.get("peak_intensity_db")),
+            vibration_strength_db=_optional_float(data.get("vibration_strength_db")),
+            matched_frequency_hz=_optional_float(data.get("matched_frequency_hz")),
+            coherence_score=_optional_float(data.get("coherence_score")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SpatialLocationSummary:
+    """Compact per-location support row for persisted spatial evidence."""
+
+    location: str
+    sensor_ids: tuple[str, ...]
+    supporting_window_count: int
+    support_ratio: float
+    coherent_window_count: int = 0
+    coherence_ratio: float | None = None
+    peak_intensity_db: float | None = None
+    mean_vibration_strength_db: float | None = None
+
+    def __post_init__(self) -> None:
+        _require_text(self.location, field_name="location")
+        _require_nonnegative(self.supporting_window_count, field_name="supporting_window_count")
+        _require_nonnegative(self.coherent_window_count, field_name="coherent_window_count")
+        _require_ratio(self.support_ratio, field_name="support_ratio")
+        if self.coherence_ratio is not None:
+            _require_ratio(self.coherence_ratio, field_name="coherence_ratio")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "location": self.location,
+            "sensor_ids": list(self.sensor_ids),
+            "supporting_window_count": self.supporting_window_count,
+            "support_ratio": self.support_ratio,
+            "coherent_window_count": self.coherent_window_count,
+        }
+        _set_optional(payload, "coherence_ratio", self.coherence_ratio)
+        _set_optional(payload, "peak_intensity_db", self.peak_intensity_db)
+        _set_optional(
+            payload,
+            "mean_vibration_strength_db",
+            self.mean_vibration_strength_db,
+        )
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> SpatialLocationSummary:
+        return cls(
+            location=_required_text(data, "location"),
+            sensor_ids=_text_tuple(data.get("sensor_ids")),
+            supporting_window_count=_required_int(data, "supporting_window_count"),
+            support_ratio=_required_float(data, "support_ratio"),
+            coherent_window_count=_required_int(data, "coherent_window_count"),
+            coherence_ratio=_optional_float(data.get("coherence_ratio")),
+            peak_intensity_db=_optional_float(data.get("peak_intensity_db")),
+            mean_vibration_strength_db=_optional_float(data.get("mean_vibration_strength_db")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SpatialEvidenceSummary:
+    """Compact persisted/report-facing whole-run spatial evidence summary."""
+
+    candidate_key: str
+    suspected_source: str
+    proof_basis: LocationProofBasis
+    total_window_count: int
+    supporting_window_count: int
+    supporting_sensor_count: int
+    coherent_window_count: int = 0
+    coherence_ratio: float | None = None
+    dominant_location: str | None = None
+    runner_up_location: str | None = None
+    location_separation_db: float | None = None
+    dominance_ratio: float | None = None
+    ambiguous_location: bool = False
+    weak_spatial_separation: bool = False
+    location_summaries: tuple[SpatialLocationSummary, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_text(self.candidate_key, field_name="candidate_key")
+        _require_text(self.suspected_source, field_name="suspected_source")
+        _require_nonnegative(self.total_window_count, field_name="total_window_count")
+        _require_nonnegative(
+            self.supporting_window_count,
+            field_name="supporting_window_count",
+        )
+        _require_nonnegative(
+            self.supporting_sensor_count,
+            field_name="supporting_sensor_count",
+        )
+        _require_nonnegative(self.coherent_window_count, field_name="coherent_window_count")
+        if self.coherence_ratio is not None:
+            _require_ratio(self.coherence_ratio, field_name="coherence_ratio")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "candidate_key": self.candidate_key,
+            "suspected_source": self.suspected_source,
+            "proof_basis": self.proof_basis,
+            "total_window_count": self.total_window_count,
+            "supporting_window_count": self.supporting_window_count,
+            "supporting_sensor_count": self.supporting_sensor_count,
+            "coherent_window_count": self.coherent_window_count,
+            "ambiguous_location": self.ambiguous_location,
+            "weak_spatial_separation": self.weak_spatial_separation,
+            "location_summaries": [summary.to_json_object() for summary in self.location_summaries],
+        }
+        _set_optional(payload, "coherence_ratio", self.coherence_ratio)
+        _set_optional(payload, "dominant_location", self.dominant_location)
+        _set_optional(payload, "runner_up_location", self.runner_up_location)
+        _set_optional(payload, "location_separation_db", self.location_separation_db)
+        _set_optional(payload, "dominance_ratio", self.dominance_ratio)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> SpatialEvidenceSummary:
+        raw_location_summaries = data.get("location_summaries")
+        location_summaries = (
+            tuple(
+                SpatialLocationSummary.from_mapping(row)
+                for row in raw_location_summaries
+                if isinstance(row, dict)
+            )
+            if isinstance(raw_location_summaries, list)
+            else ()
+        )
+        return cls(
+            candidate_key=_required_text(data, "candidate_key"),
+            suspected_source=_required_text(data, "suspected_source"),
+            proof_basis=_required_proof_basis(data.get("proof_basis")),
+            total_window_count=_required_int(data, "total_window_count"),
+            supporting_window_count=_required_int(data, "supporting_window_count"),
+            supporting_sensor_count=_required_int(data, "supporting_sensor_count"),
+            coherent_window_count=_required_int(data, "coherent_window_count"),
+            coherence_ratio=_optional_float(data.get("coherence_ratio")),
+            dominant_location=_optional_text(data.get("dominant_location")),
+            runner_up_location=_optional_text(data.get("runner_up_location")),
+            location_separation_db=_optional_float(data.get("location_separation_db")),
+            dominance_ratio=_optional_float(data.get("dominance_ratio")),
+            ambiguous_location=_required_bool(data, "ambiguous_location"),
+            weak_spatial_separation=_required_bool(data, "weak_spatial_separation"),
+            location_summaries=location_summaries,
+        )
+
+
+def _require_text(value: object, *, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+
+def _require_nonnegative(value: int, *, field_name: str) -> None:
+    if value < 0:
+        raise ValueError(f"{field_name} must be >= 0")
+
+
+def _require_ratio(value: float, *, field_name: str) -> None:
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{field_name} must be between 0 and 1")
+
+
+def _required_text(data: JsonObject, field_name: str) -> str:
+    value = data.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def _required_int(data: JsonObject, field_name: str) -> int:
+    value = data.get(field_name)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an int")
+    return value
+
+
+def _required_float(data: JsonObject, field_name: str) -> float:
+    value = data.get(field_name)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a number")
+    return float(value)
+
+
+def _required_bool(data: JsonObject, field_name: str) -> bool:
+    value = data.get(field_name)
+    if not isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a bool")
+    return value
+
+
+def _required_proof_basis(value: object) -> LocationProofBasis:
+    if value not in {
+        "whole_run_summary",
+        "supporting_windows_raw_backed",
+        "supporting_windows_summary_only",
+    }:
+        raise ValueError("proof_basis must be a supported location proof basis")
+    return cast(LocationProofBasis, value)
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("optional numeric field must be a number or null")
+    return float(value)
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("optional text field must be a string or null")
+    text = value.strip()
+    return text or None
+
+
+def _text_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(str(item).strip() for item in value if str(item).strip())
+
+
+def _set_optional(payload: JsonObject, key: str, value: JsonValue | None) -> None:
+    if value is not None:
+        payload[key] = value

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -273,6 +273,23 @@ should explicitly separate:
 The report path can still project compact location proof from these summaries,
 but the source artifact should be candidate-aware and whole-run aware.
 
+The current contract owner is
+`apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py`.
+It now settles:
+
+- dense `SpatialEvidenceWindow` rows keyed by
+  `(candidate_key, window_index, sensor_id)` for later aligned sensor joins
+- compact `SpatialLocationSummary` rows for dominant / runner-up location proof
+- compact `SpatialEvidenceSummary` rows for persisted/report-facing proof with
+  `proof_basis`, `location_separation_db`, `dominance_ratio`,
+  `ambiguous_location`, and `weak_spatial_separation`
+
+`shared/types/history_analysis_contracts.py` now owns the future persisted
+response shapes for those compact summaries, and
+`shared/boundaries/reporting/sensor_facts.py` uses the same
+`LocationProofBasis` literal set so later report wiring does not invent a
+second proof-basis vocabulary.
+
 ### Counterevidence model
 
 Counterevidence should become a first-class persisted concept with stable keys,
@@ -303,7 +320,7 @@ explainable factors that reporting can consume directly.
 | `WholeRunArtifactManifest` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` + `apps/server/vibesensor/adapters/persistence/history_db/_whole_run_artifact_store.py` | Sidecar manifest for dense whole-run artifacts; mirror the raw-capture pattern |
 | `WholeRunContextInterval` / `WholeRunContextWindowLabel` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` with compact report-facing projection in `shared/types/history_analysis_contracts.py` | Whole-run segments and per-window labels keyed to the canonical `window_index` grid |
 | `OrderTracePoint` / `OrderTraceSummary` | `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py` with persisted summary projection in `shared/types/history_analysis_contracts.py` | Dense trace vs compact report/history summary split |
-| `SpatialEvidenceSummary` | `use_cases/diagnostics/` with persisted summary projection | Candidate-level coherence and location separation |
+| `SpatialEvidenceSummary` | `apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py` with persisted summary projection in `shared/types/history_analysis_contracts.py` | Candidate-level coherence, location separation, ambiguity flags, and proof basis |
 | `DiagnosisFactor` / `DiagnosisSummary` | diagnostics domain/use-case layer plus persisted projection | Explainable support and counterevidence for final ranking |
 
 For the context track:


### PR DESCRIPTION
Closes #3096

## What changed
- add `spatial_evidence_contracts.py` with dense `SpatialEvidenceWindow` rows and compact `SpatialLocationSummary` / `SpatialEvidenceSummary` contracts
- add future persisted spatial summary response shapes plus shared `LocationProofBasis` literals in `history_analysis_contracts.py`
- align report sensor proof-basis typing to the same literal set
- add focused contract tests and update the whole-run design doc

## Why
- the rest of the #3078 tree needs stable names for candidate-aware spatial proof, ambiguity, separation, and proof-basis fields before join/scoring work starts
- this keeps dense-vs-compact ownership explicit and avoids inventing a second spatial contract later

## Validation
- `./.venv/bin/pytest -q apps/server/tests/use_cases/diagnostics/test_spatial_evidence_contracts.py`
- `make typecheck-backend`
- `make lint`
- `make ui-typecheck`
- `make docs-lint`

## Risks / tradeoffs
- this lands future persisted/report-facing shapes before any runtime producer exists; that is intentional so later #3097-#3100 work can build against one contract
- `make test-changed` would expand this touch set to broad `tests/shared` + `tests/use_cases` sweeps, so CI will provide that broader coverage

## Out of scope
- sensor joins, coherence math, hotspot scoring, and persistence wiring still belong to the later #3097-#3100 issues