### PR TITLE
Join whole-run sensor windows

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_alignment.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_alignment.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from test_support.sample_scenarios import make_analysis_sample
+
+from vibesensor.domain import DrivingPhase
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunContextWindowLabel,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spatial_alignment import (
+    build_whole_run_spatial_alignment_matrix,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    WholeRunWindowSpectralSummary,
+    whole_run_window_spectral_summaries_to_jsonl_bytes,
+)
+
+
+def _window_policy() -> WholeRunWindowPolicy:
+    return WholeRunWindowPolicy(
+        sample_rate_hz=200,
+        window_size_samples=256,
+        stride_samples=100,
+        overlap_samples=156,
+        feature_interval_s=0.5,
+    )
+
+
+def _context_labels() -> tuple[WholeRunContextWindowLabel, ...]:
+    return tuple(
+        WholeRunContextWindowLabel(
+            window_index=index,
+            segment_index=0,
+            phase=DrivingPhase.CRUISE,
+            context_coverage="full",
+            speed_validity="measured",
+            rpm_validity="measured",
+            load_state="steady",
+            speed_kmh=50.0 + index * 10.0,
+            speed_band="50-60",
+            speed_source="gps",
+            engine_rpm=1200.0 + index * 200.0,
+            engine_rpm_source="obd2",
+        )
+        for index in range(3)
+    )
+
+
+def _spectral_manifest() -> WholeRunArtifactManifest:
+    return WholeRunArtifactManifest(
+        run_id="run-spatial-alignment",
+        relative_dir="whole-run-artifacts/run-spatial-alignment",
+        window_policy=_window_policy(),
+        total_window_count=3,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-rear",
+                relative_path="spectra/sensor-rear/windows.jsonl",
+                file_format="jsonl",
+                record_count=3,
+                sensor_id="sensor-rear",
+            ),
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-front",
+                relative_path="spectra/sensor-front/windows.jsonl",
+                file_format="jsonl",
+                record_count=3,
+                sensor_id="sensor-front",
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+
+
+def _summary_rows(
+    *,
+    scale: float,
+    coverage_states: tuple[str, str, str] = ("full", "full", "full"),
+) -> tuple[WholeRunWindowSpectralSummary, ...]:
+    rows: list[WholeRunWindowSpectralSummary] = []
+    for window_index, coverage_state in enumerate(coverage_states):
+        peak = {
+            "hz": 12.0 + window_index,
+            "amp": scale,
+            "vibration_strength_db": 20.0 + scale * 50.0,
+            "strength_bucket": "l3",
+        }
+        rows.append(
+            WholeRunWindowSpectralSummary(
+                window_index=window_index,
+                coverage_state=coverage_state,
+                returned_sample_start=(window_index * 100 if coverage_state != "missing" else None),
+                returned_sample_count=(
+                    256 if coverage_state == "full" else (96 if coverage_state == "partial" else 0)
+                ),
+                dominant_freq_hz=peak["hz"] if coverage_state == "full" else None,
+                vibration_strength_db=peak["vibration_strength_db"]
+                if coverage_state == "full"
+                else None,
+                top_peaks=(peak,) if coverage_state == "full" else (),
+            )
+        )
+    return tuple(rows)
+
+
+def _artifact_contents() -> dict[str, bytes]:
+    return {
+        "spectral-summary:sensor-front": whole_run_window_spectral_summaries_to_jsonl_bytes(
+            _summary_rows(scale=0.14)
+        ),
+        "spectral-summary:sensor-rear": whole_run_window_spectral_summaries_to_jsonl_bytes(
+            _summary_rows(scale=0.08, coverage_states=("full", "empty", "partial"))
+        ),
+    }
+
+
+def _samples(include_extra_sensor: bool = False):
+    rows = [
+        make_analysis_sample(
+            t_s=0.0,
+            speed_kmh=50.0,
+            client_name="rear-left",
+            client_id="sensor-rear",
+            location="rear-left",
+            top_peaks=[{"hz": 8.0, "amp": 0.08}],
+        ),
+        make_analysis_sample(
+            t_s=0.0,
+            speed_kmh=50.0,
+            client_name="front-left",
+            client_id="sensor-front",
+            location="front-left",
+            top_peaks=[{"hz": 8.0, "amp": 0.14}],
+        ),
+    ]
+    if include_extra_sensor:
+        rows.append(
+            make_analysis_sample(
+                t_s=0.0,
+                speed_kmh=50.0,
+                client_name="rear-right",
+                client_id="sensor-extra",
+                location="rear-right",
+                top_peaks=[{"hz": 8.0, "amp": 0.05}],
+            )
+        )
+    return tuple(rows)
+
+
+def test_build_whole_run_spatial_alignment_matrix_is_deterministic() -> None:
+    kwargs = {
+        "spectral_manifest": _spectral_manifest(),
+        "spectral_artifact_contents": _artifact_contents(),
+        "context_labels": tuple(reversed(_context_labels())),
+        "samples": tuple(reversed(_samples())),
+    }
+
+    first = build_whole_run_spatial_alignment_matrix(**kwargs)
+    second = build_whole_run_spatial_alignment_matrix(**kwargs)
+
+    assert first == second
+    assert first.sensor_ids == ("sensor-front", "sensor-rear")
+    assert [window.window_index for window in first.windows] == [0, 1, 2]
+    assert [row.sensor_id for row in first.windows[0].sensor_windows] == [
+        "sensor-front",
+        "sensor-rear",
+    ]
+    assert [row.location for row in first.windows[0].sensor_windows] == [
+        "front-left",
+        "rear-left",
+    ]
+
+
+def test_build_whole_run_spatial_alignment_matrix_tracks_missing_and_partial_sensors() -> None:
+    matrix = build_whole_run_spatial_alignment_matrix(
+        spectral_manifest=_spectral_manifest(),
+        spectral_artifact_contents=_artifact_contents(),
+        context_labels=_context_labels(),
+        samples=_samples(include_extra_sensor=True),
+    )
+
+    assert matrix.sensor_ids == ("sensor-extra", "sensor-front", "sensor-rear")
+
+    second_window = matrix.windows[1]
+    assert second_window.full_sensor_count == 1
+    assert second_window.partial_sensor_count == 0
+    assert second_window.empty_sensor_count == 1
+    assert second_window.missing_sensor_count == 1
+    assert [row.coverage_state for row in second_window.sensor_windows] == [
+        "missing",
+        "full",
+        "empty",
+    ]
+
+    third_window = matrix.windows[2]
+    assert third_window.full_sensor_count == 1
+    assert third_window.partial_sensor_count == 1
+    assert third_window.empty_sensor_count == 0
+    assert third_window.missing_sensor_count == 1
+    missing_row = third_window.sensor_windows[0]
+    assert missing_row.sensor_id == "sensor-extra"
+    assert missing_row.location == "rear-right"
+    assert missing_row.returned_sample_start is None
+    assert missing_row.returned_sample_count == 0
+    assert missing_row.top_peaks == ()

--- a/apps/server/vibesensor/use_cases/diagnostics/_sensor_locations.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_sensor_locations.py
@@ -23,8 +23,31 @@ def _location_label(sample: Sample, *, lang: str = "en") -> str:
         return client_name_raw
     client_id_raw = sample.client_id.strip()
     if client_id_raw:
-        return f"Sensor …{client_id_raw[-4:]}"
+        return fallback_location_label(client_id_raw)
     return "Unknown sensor"
+
+
+def client_locations_by_sensor(
+    samples: Sequence[Sample],
+    *,
+    lang: str = "en",
+) -> dict[str, str]:
+    """Return deterministic location labels keyed by client id."""
+
+    locations: dict[str, str] = {}
+    for sample in samples:
+        client_id = sample.client_id.strip()
+        if not client_id or client_id in locations:
+            continue
+        locations[client_id] = _location_label(sample, lang=lang)
+    return locations
+
+
+def fallback_location_label(client_id: str) -> str:
+    """Return a stable fallback label when no explicit location is available."""
+
+    suffix = client_id[-4:] if len(client_id) >= 4 else client_id
+    return f"Sensor …{suffix}" if suffix else "Unknown sensor"
 
 
 def _locations_connected_throughout_run(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
@@ -16,7 +16,10 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunArtifactManifest,
 )
 from vibesensor.use_cases.diagnostics._reference_resolution import _tire_reference_from_context
-from vibesensor.use_cases.diagnostics._sensor_locations import _location_label
+from vibesensor.use_cases.diagnostics._sensor_locations import (
+    client_locations_by_sensor,
+    fallback_location_label,
+)
 from vibesensor.use_cases.diagnostics.orders.matching import best_order_peak_match
 from vibesensor.use_cases.diagnostics.orders.physics import (
     OrderHypothesis,
@@ -30,7 +33,7 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
 from vibesensor.use_cases.diagnostics.whole_run_context import WholeRunContextWindowLabel
 from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunWindowSpectralSummary,
-    whole_run_window_spectral_summaries_from_jsonl_bytes,
+    whole_run_spectral_summaries_by_sensor,
 )
 
 WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY = "order-trace-points"
@@ -87,7 +90,7 @@ def build_whole_run_order_trace_artifact_bundle(
         artifact_contents=spectral_artifact_contents,
     )
     tire_circumference_m, _ = _tire_reference_from_context(metadata)
-    client_locations = _client_locations(samples, lang=lang)
+    client_locations = client_locations_by_sensor(samples, lang=lang)
     window_inputs = tuple(
         _window_context_sample(
             run_id=run_id,
@@ -225,7 +228,7 @@ def _best_sensor_peak_match(
         source_peak = summary.top_peaks[peak_index[peak_match.peak_index]]
         candidate = _SensorPeakMatch(
             client_id=client_id,
-            location=client_locations.get(client_id, _fallback_location(client_id)),
+            location=client_locations.get(client_id, fallback_location_label(client_id)),
             matched_hz=peak_match.matched_hz,
             amplitude_g=peak_match.amplitude_g,
             relative_error=peak_match.relative_error,
@@ -242,30 +245,10 @@ def _spectral_summaries_by_sensor(
     manifest: WholeRunArtifactManifest,
     artifact_contents: Mapping[str, bytes],
 ) -> dict[str, tuple[WholeRunWindowSpectralSummary, ...]]:
-    summaries_by_sensor: dict[str, tuple[WholeRunWindowSpectralSummary, ...]] = {}
-    summary_artifacts = sorted(
-        (
-            artifact
-            for artifact in manifest.artifacts
-            if artifact.artifact_key.startswith("spectral-summary:")
-        ),
-        key=lambda artifact: (artifact.sensor_id or "", artifact.artifact_key),
+    summaries_by_sensor = whole_run_spectral_summaries_by_sensor(
+        manifest=manifest,
+        artifact_contents=artifact_contents,
     )
-    for artifact in summary_artifacts:
-        if artifact.sensor_id is None:
-            raise ValueError(
-                "whole-run order traces require spectral summary artifacts with sensor_id"
-            )
-        payload = artifact_contents.get(artifact.artifact_key)
-        if payload is None:
-            raise ValueError(f"whole-run order traces missing bytes for {artifact.artifact_key}")
-        summaries = whole_run_window_spectral_summaries_from_jsonl_bytes(payload)
-        if len(summaries) != manifest.total_window_count:
-            raise ValueError(
-                "whole-run order traces require one spectral summary row per window "
-                f"for {artifact.artifact_key}"
-            )
-        summaries_by_sensor[artifact.sensor_id] = summaries
     if not summaries_by_sensor:
         raise ValueError("whole-run order traces require at least one spectral summary artifact")
     return summaries_by_sensor
@@ -308,16 +291,6 @@ def _window_context_sample(
     )
 
 
-def _client_locations(samples: Sequence[SensorFrame], *, lang: str) -> dict[str, str]:
-    locations: dict[str, str] = {}
-    for sample in samples:
-        client_id = sample.client_id.strip()
-        if not client_id or client_id in locations:
-            continue
-        locations[client_id] = _location_label(sample, lang=lang)
-    return locations
-
-
 def _filtered_peak_pairs(
     peaks: Sequence[Mapping[str, object]],
 ) -> tuple[tuple[int, ...], tuple[tuple[float, float], ...]]:
@@ -337,8 +310,3 @@ def _filtered_peak_pairs(
 
 def _sensor_match_rank(match: _SensorPeakMatch) -> tuple[float, float, str]:
     return (match.amplitude_g, -match.relative_error, match.client_id)
-
-
-def _fallback_location(client_id: str) -> str:
-    suffix = client_id[-4:] if len(client_id) >= 4 else client_id
-    return f"Sensor …{suffix}" if suffix else "Unknown sensor"

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_alignment.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_alignment.py
@@ -1,0 +1,165 @@
+"""Deterministic whole-run multi-sensor window joins for spatial analysis."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from vibesensor.shared.types.raw_capture import RawCaptureCoverageState
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactManifest,
+    WholeRunContextWindowLabel,
+)
+from vibesensor.use_cases.diagnostics._sensor_locations import (
+    client_locations_by_sensor,
+    fallback_location_label,
+)
+from vibesensor.use_cases.diagnostics._types import Sample
+from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    WholeRunWindowSpectralSummary,
+    whole_run_spectral_summaries_by_sensor,
+)
+from vibesensor.vibration_strength import StrengthPeak
+
+__all__ = [
+    "AlignedSpatialSensorWindow",
+    "AlignedSpatialWindow",
+    "WholeRunSpatialAlignmentMatrix",
+    "build_whole_run_spatial_alignment_matrix",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class AlignedSpatialSensorWindow:
+    """One sensor's spectral summary aligned to a canonical whole-run window."""
+
+    sensor_id: str
+    location: str
+    coverage_state: RawCaptureCoverageState
+    returned_sample_start: int | None
+    returned_sample_count: int
+    dominant_freq_hz: float | None = None
+    vibration_strength_db: float | None = None
+    top_peaks: tuple[StrengthPeak, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class AlignedSpatialWindow:
+    """All sensor rows aligned to one canonical whole-run context window."""
+
+    window_index: int
+    label: WholeRunContextWindowLabel
+    sensor_windows: tuple[AlignedSpatialSensorWindow, ...]
+    full_sensor_count: int
+    partial_sensor_count: int
+    empty_sensor_count: int
+    missing_sensor_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunSpatialAlignmentMatrix:
+    """Deterministic multi-sensor join surface for later coherence/hotspot scoring."""
+
+    sensor_ids: tuple[str, ...]
+    windows: tuple[AlignedSpatialWindow, ...]
+
+
+def build_whole_run_spatial_alignment_matrix(
+    *,
+    spectral_manifest: WholeRunArtifactManifest,
+    spectral_artifact_contents: Mapping[str, bytes],
+    context_labels: Sequence[WholeRunContextWindowLabel],
+    samples: Sequence[Sample],
+    lang: str = "en",
+) -> WholeRunSpatialAlignmentMatrix:
+    """Join spectral summaries and context labels onto one deterministic window grid."""
+
+    ordered_labels = _ordered_context_labels(
+        context_labels=context_labels,
+        expected_window_count=spectral_manifest.total_window_count,
+    )
+    summaries_by_sensor = whole_run_spectral_summaries_by_sensor(
+        manifest=spectral_manifest,
+        artifact_contents=spectral_artifact_contents,
+    )
+    client_locations = client_locations_by_sensor(samples, lang=lang)
+    sensor_ids = tuple(sorted(set(summaries_by_sensor) | set(client_locations)))
+    if not sensor_ids:
+        raise ValueError("whole-run spatial alignment requires at least one sensor")
+    windows = tuple(
+        _aligned_window(
+            label=label,
+            sensor_ids=sensor_ids,
+            summaries_by_sensor=summaries_by_sensor,
+            client_locations=client_locations,
+        )
+        for label in ordered_labels
+    )
+    return WholeRunSpatialAlignmentMatrix(sensor_ids=sensor_ids, windows=windows)
+
+
+def _ordered_context_labels(
+    *,
+    context_labels: Sequence[WholeRunContextWindowLabel],
+    expected_window_count: int,
+) -> tuple[WholeRunContextWindowLabel, ...]:
+    ordered_labels = tuple(sorted(context_labels, key=lambda label: label.window_index))
+    if len(ordered_labels) != expected_window_count:
+        raise ValueError("whole-run spatial alignment requires one context label per window")
+    if any(label.window_index != index for index, label in enumerate(ordered_labels)):
+        raise ValueError("whole-run spatial alignment requires contiguous ordered context labels")
+    return ordered_labels
+
+
+def _aligned_window(
+    *,
+    label: WholeRunContextWindowLabel,
+    sensor_ids: Sequence[str],
+    summaries_by_sensor: Mapping[str, Sequence[WholeRunWindowSpectralSummary]],
+    client_locations: Mapping[str, str],
+) -> AlignedSpatialWindow:
+    sensor_windows: list[AlignedSpatialSensorWindow] = []
+    full_sensor_count = 0
+    partial_sensor_count = 0
+    empty_sensor_count = 0
+    missing_sensor_count = 0
+    for sensor_id in sensor_ids:
+        summaries = summaries_by_sensor.get(sensor_id)
+        if summaries is None:
+            sensor_window = AlignedSpatialSensorWindow(
+                sensor_id=sensor_id,
+                location=client_locations.get(sensor_id, fallback_location_label(sensor_id)),
+                coverage_state="missing",
+                returned_sample_start=None,
+                returned_sample_count=0,
+            )
+        else:
+            summary = summaries[label.window_index]
+            sensor_window = AlignedSpatialSensorWindow(
+                sensor_id=sensor_id,
+                location=client_locations.get(sensor_id, fallback_location_label(sensor_id)),
+                coverage_state=summary.coverage_state,
+                returned_sample_start=summary.returned_sample_start,
+                returned_sample_count=summary.returned_sample_count,
+                dominant_freq_hz=summary.dominant_freq_hz,
+                vibration_strength_db=summary.vibration_strength_db,
+                top_peaks=summary.top_peaks,
+            )
+        if sensor_window.coverage_state == "full":
+            full_sensor_count += 1
+        elif sensor_window.coverage_state == "partial":
+            partial_sensor_count += 1
+        elif sensor_window.coverage_state == "empty":
+            empty_sensor_count += 1
+        else:
+            missing_sensor_count += 1
+        sensor_windows.append(sensor_window)
+    return AlignedSpatialWindow(
+        window_index=label.window_index,
+        label=label,
+        sensor_windows=tuple(sensor_windows),
+        full_sensor_count=full_sensor_count,
+        partial_sensor_count=partial_sensor_count,
+        empty_sensor_count=empty_sensor_count,
+        missing_sensor_count=missing_sensor_count,
+    )

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from io import BytesIO
@@ -42,6 +42,7 @@ __all__ = [
     "WholeRunSpectralArtifactBundle",
     "WholeRunWindowSpectralSummary",
     "build_whole_run_spectral_artifact_bundle",
+    "whole_run_spectral_summaries_by_sensor",
     "whole_run_window_spectral_summaries_from_jsonl_bytes",
     "whole_run_window_spectral_summaries_to_jsonl_bytes",
 ]
@@ -581,6 +582,40 @@ def whole_run_window_spectral_summaries_from_jsonl_bytes(
             raise ValueError("whole-run spectral summary line must decode to a JSON object")
         summaries.append(WholeRunWindowSpectralSummary.from_mapping(parsed))
     return tuple(summaries)
+
+
+def whole_run_spectral_summaries_by_sensor(
+    *,
+    manifest: WholeRunArtifactManifest,
+    artifact_contents: Mapping[str, bytes],
+) -> dict[str, tuple[WholeRunWindowSpectralSummary, ...]]:
+    """Load deterministic whole-run spectral summary rows keyed by sensor id."""
+
+    summaries_by_sensor: dict[str, tuple[WholeRunWindowSpectralSummary, ...]] = {}
+    summary_artifacts = sorted(
+        (
+            artifact
+            for artifact in manifest.artifacts
+            if artifact.artifact_key.startswith("spectral-summary:")
+        ),
+        key=lambda artifact: (artifact.sensor_id or "", artifact.artifact_key),
+    )
+    for artifact in summary_artifacts:
+        if artifact.sensor_id is None:
+            raise ValueError("whole-run spectral summary artifacts require sensor_id for loading")
+        payload = artifact_contents.get(artifact.artifact_key)
+        if payload is None:
+            raise ValueError(
+                f"whole-run spectral summaries missing bytes for {artifact.artifact_key}"
+            )
+        summaries = whole_run_window_spectral_summaries_from_jsonl_bytes(payload)
+        if len(summaries) != manifest.total_window_count:
+            raise ValueError(
+                "whole-run spectral summaries require one row per window "
+                f"for {artifact.artifact_key}"
+            )
+        summaries_by_sensor[artifact.sensor_id] = summaries
+    return summaries_by_sensor
 
 
 def _float_or_none(value: object) -> float | None:

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -290,6 +290,15 @@ response shapes for those compact summaries, and
 `LocationProofBasis` literal set so later report wiring does not invent a
 second proof-basis vocabulary.
 
+The aligned multi-sensor join owner now lives in
+`apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_alignment.py`.
+It builds deterministic `window_index`-ordered joins from persisted
+`spectral-summary:*` sidecars plus `WholeRunContextWindowLabel` rows, keeps
+sensor ordering canonical by `sensor_id`, and exposes explicit
+`full` / `partial` / `empty` / `missing` coverage counts per window so later
+coherence and hotspot scoring stages do not have to infer missing-data rules
+ad hoc.
+
 ### Counterevidence model
 
 Counterevidence should become a first-class persisted concept with stable keys,
@@ -321,6 +330,7 @@ explainable factors that reporting can consume directly.
 | `WholeRunContextInterval` / `WholeRunContextWindowLabel` | `apps/server/vibesensor/shared/types/whole_run_analysis.py` with compact report-facing projection in `shared/types/history_analysis_contracts.py` | Whole-run segments and per-window labels keyed to the canonical `window_index` grid |
 | `OrderTracePoint` / `OrderTraceSummary` | `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py` with persisted summary projection in `shared/types/history_analysis_contracts.py` | Dense trace vs compact report/history summary split |
 | `SpatialEvidenceSummary` | `apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py` with persisted summary projection in `shared/types/history_analysis_contracts.py` | Candidate-level coherence, location separation, ambiguity flags, and proof basis |
+| `WholeRunSpatialAlignmentMatrix` / `AlignedSpatialWindow` | `apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_alignment.py` | Deterministic per-window sensor joins with explicit coverage-state semantics for later spatial scoring |
 | `DiagnosisFactor` / `DiagnosisSummary` | diagnostics domain/use-case layer plus persisted projection | Explainable support and counterevidence for final ranking |
 
 For the context track:


### PR DESCRIPTION
Closes #3097

## What changed
- add `whole_run_spatial_alignment.py` as the deterministic join owner over `spectral-summary:*` sidecars plus ordered whole-run context labels
- expose explicit per-window `full` / `partial` / `empty` / `missing` sensor counts and stable sensor-ordered rows for later coherence and hotspot scoring
- extract reusable sensor-location and spectral-summary loaders, and reuse them from the whole-run order trace path instead of keeping duplicate helpers
- add focused diagnostics coverage for deterministic ordering and missing-data semantics
- update the whole-run design doc with the new join owner and coverage rules

## Why
- #3098 and #3099 both need one canonical multi-sensor window join surface
- missing and partial sensor coverage must be explicit before later spatial scoring starts, otherwise every scorer will invent its own gap rules
- extracting the shared loaders now keeps the order and spatial whole-run paths on one artifact-reading contract

## Validation
- `./.venv/bin/pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_alignment.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py apps/server/tests/use_cases/diagnostics/test_whole_run_spectra.py`
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- `make test-changed`

## Risks / tradeoffs
- this lands an internal aligned-window matrix, not persisted candidate-level spatial evidence yet; the candidate scoring/persistence work still belongs to #3098-#3100
- sensor ordering is canonical by `sensor_id`; later scoring layers should group by `location` explicitly instead of assuming location-sort order

## Out of scope
- candidate coherence metrics
- hotspot dominance/separation scoring
- persisted spatial evidence summaries