### PR TITLE
Add whole-run spatial coherence metrics

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from test_support.sample_scenarios import make_analysis_sample
+
+from vibesensor.domain import DrivingPhase
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunContextWindowLabel,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTracePoint
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+    WholeRunOrderTraceArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
+    WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
+    build_whole_run_spatial_coherence_artifact_bundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    WholeRunWindowSpectralSummary,
+    whole_run_window_spectral_summaries_to_jsonl_bytes,
+)
+
+
+def _window_policy() -> WholeRunWindowPolicy:
+    return WholeRunWindowPolicy(
+        sample_rate_hz=200,
+        window_size_samples=256,
+        stride_samples=100,
+        overlap_samples=156,
+        feature_interval_s=0.5,
+    )
+
+
+def _context_labels() -> tuple[WholeRunContextWindowLabel, ...]:
+    return tuple(
+        WholeRunContextWindowLabel(
+            window_index=index,
+            segment_index=0,
+            phase=DrivingPhase.CRUISE,
+            context_coverage="full",
+            speed_validity="measured",
+            rpm_validity="measured",
+            load_state="steady",
+            speed_kmh=50.0 + index * 10.0,
+            speed_band="50-60",
+            speed_source="gps",
+            engine_rpm=1200.0 + index * 200.0,
+            engine_rpm_source="obd2",
+        )
+        for index in range(3)
+    )
+
+
+def _spectral_manifest() -> WholeRunArtifactManifest:
+    return WholeRunArtifactManifest(
+        run_id="run-spatial-coherence",
+        relative_dir="whole-run-artifacts/run-spatial-coherence",
+        window_policy=_window_policy(),
+        total_window_count=3,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-front",
+                relative_path="spectra/sensor-front/windows.jsonl",
+                file_format="jsonl",
+                record_count=3,
+                sensor_id="sensor-front",
+            ),
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-rear",
+                relative_path="spectra/sensor-rear/windows.jsonl",
+                file_format="jsonl",
+                record_count=3,
+                sensor_id="sensor-rear",
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+
+
+def _artifact_contents() -> dict[str, bytes]:
+    front_rows: list[WholeRunWindowSpectralSummary] = []
+    rear_rows: list[WholeRunWindowSpectralSummary] = []
+    for window_index, (wheel_hz, engine_hz) in enumerate(
+        ((10.0, 30.0), (12.0, 32.0), (14.0, 34.0))
+    ):
+        front_rows.append(
+            WholeRunWindowSpectralSummary(
+                window_index=window_index,
+                coverage_state="full",
+                returned_sample_start=window_index * 100,
+                returned_sample_count=256,
+                dominant_freq_hz=wheel_hz,
+                vibration_strength_db=28.0,
+                top_peaks=(
+                    {
+                        "hz": wheel_hz,
+                        "amp": 0.14,
+                        "vibration_strength_db": 32.0,
+                        "strength_bucket": "l3",
+                    },
+                    {
+                        "hz": engine_hz,
+                        "amp": 0.11,
+                        "vibration_strength_db": 29.0,
+                        "strength_bucket": "l3",
+                    },
+                ),
+            )
+        )
+        rear_rows.append(
+            WholeRunWindowSpectralSummary(
+                window_index=window_index,
+                coverage_state="full",
+                returned_sample_start=window_index * 100,
+                returned_sample_count=256,
+                dominant_freq_hz=wheel_hz,
+                vibration_strength_db=25.0,
+                top_peaks=(
+                    {
+                        "hz": wheel_hz,
+                        "amp": 0.10,
+                        "vibration_strength_db": 27.0,
+                        "strength_bucket": "l2",
+                    },
+                ),
+            )
+        )
+    return {
+        "spectral-summary:sensor-front": whole_run_window_spectral_summaries_to_jsonl_bytes(
+            tuple(front_rows)
+        ),
+        "spectral-summary:sensor-rear": whole_run_window_spectral_summaries_to_jsonl_bytes(
+            tuple(rear_rows)
+        ),
+    }
+
+
+def _samples():
+    return (
+        make_analysis_sample(
+            t_s=0.0,
+            speed_kmh=50.0,
+            client_name="front-left",
+            client_id="sensor-front",
+            location="front-left",
+            top_peaks=[{"hz": 10.0, "amp": 0.14}],
+        ),
+        make_analysis_sample(
+            t_s=0.0,
+            speed_kmh=50.0,
+            client_name="rear-left",
+            client_id="sensor-rear",
+            location="rear-left",
+            top_peaks=[{"hz": 10.0, "amp": 0.10}],
+        ),
+    )
+
+
+def _order_trace_bundle() -> WholeRunOrderTraceArtifactBundle:
+    points = [
+        OrderTracePoint(
+            hypothesis_key="wheel_1x",
+            suspected_source="wheel/tire",
+            order_family="wheel",
+            harmonic=1,
+            order_label="1x wheel",
+            window_index=index,
+            eligible=True,
+            matched=True,
+            predicted_hz=hz,
+        )
+        for index, hz in enumerate((10.0, 12.0, 14.0))
+    ]
+    points.extend(
+        OrderTracePoint(
+            hypothesis_key="engine_1x",
+            suspected_source="engine",
+            order_family="engine",
+            harmonic=1,
+            order_label="1x engine",
+            window_index=index,
+            eligible=True,
+            matched=(index == 0),
+            predicted_hz=hz,
+        )
+        for index, hz in enumerate((30.0, 32.0, 34.0))
+    )
+    return WholeRunOrderTraceArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-spatial-coherence",
+            relative_dir="whole-run-artifacts/run-spatial-coherence",
+            window_policy=_window_policy(),
+            total_window_count=3,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+                    relative_path="orders/trace-points.jsonl",
+                    file_format="jsonl",
+                    record_count=len(points),
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY: b""},
+        points=tuple(points),
+    )
+
+
+def test_build_whole_run_spatial_coherence_artifact_bundle_scores_candidates() -> None:
+    bundle = build_whole_run_spatial_coherence_artifact_bundle(
+        order_trace_bundle=_order_trace_bundle(),
+        spectral_manifest=_spectral_manifest(),
+        spectral_artifact_contents=_artifact_contents(),
+        context_labels=_context_labels(),
+        samples=_samples(),
+    )
+
+    assert bundle.manifest.artifact(WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY) is not None
+    assert bundle.artifact_contents[WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY].count(b"\n") == len(
+        bundle.windows
+    )
+    assert [summary.candidate_key for summary in bundle.summaries] == ["wheel_1x", "engine_1x"]
+
+    wheel_summary = bundle.summaries[0]
+    assert wheel_summary.supporting_window_count == 3
+    assert wheel_summary.coherent_window_count == 3
+    assert wheel_summary.supporting_sensor_count == 2
+    assert wheel_summary.coherence_ratio == 1.0
+    assert wheel_summary.proof_basis == "supporting_windows_raw_backed"
+
+    engine_summary = bundle.summaries[1]
+    assert engine_summary.supporting_window_count == 3
+    assert engine_summary.coherent_window_count == 0
+    assert engine_summary.supporting_sensor_count == 1
+    assert engine_summary.coherence_ratio == 0.0
+
+    wheel_rows = [
+        row
+        for row in bundle.windows
+        if row.candidate_key == "wheel_1x" and row.sensor_id == "sensor-rear"
+    ]
+    assert len(wheel_rows) == 3
+    assert all(row.supporting for row in wheel_rows)
+    assert all(row.coherent for row in wheel_rows)
+    assert all(row.coherence_score == 1.0 for row in wheel_rows)
+
+    engine_rear_rows = [
+        row
+        for row in bundle.windows
+        if row.candidate_key == "engine_1x" and row.sensor_id == "sensor-rear"
+    ]
+    assert len(engine_rear_rows) == 3
+    assert not any(row.supporting for row in engine_rear_rows)
+    assert not any(row.coherent for row in engine_rear_rows)
+
+
+def test_build_whole_run_spatial_coherence_artifact_bundle_is_deterministic() -> None:
+    kwargs = {
+        "order_trace_bundle": _order_trace_bundle(),
+        "spectral_manifest": _spectral_manifest(),
+        "spectral_artifact_contents": _artifact_contents(),
+        "context_labels": tuple(reversed(_context_labels())),
+        "samples": tuple(reversed(_samples())),
+    }
+
+    first = build_whole_run_spatial_coherence_artifact_bundle(**kwargs)
+    second = build_whole_run_spatial_coherence_artifact_bundle(**kwargs)
+
+    assert first.manifest == second.manifest
+    assert first.artifact_contents == second.artifact_contents
+    assert first.windows == second.windows
+    assert first.summaries == second.summaries

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py
@@ -13,12 +13,6 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunWindowPolicy,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTracePoint
-from vibesensor.use_cases.diagnostics.orders.whole_run_family_summaries import (
-    WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY,
-)
-from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
-    WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY,
-)
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
     WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
     WholeRunOrderTraceArtifactBundle,
@@ -26,6 +20,9 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
 from vibesensor.use_cases.diagnostics.whole_run_context import (
     WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
     WholeRunContextArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
+    WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
 )
 from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
 from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
@@ -47,14 +44,29 @@ def _run_metadata(run_id: str):
 
 
 def _samples():
-    return sensor_frames_from_mappings([{"t_s": 1.0, "vibration_strength_db": 10.0}])
+    return sensor_frames_from_mappings(
+        [
+            {
+                "t_s": 0.0,
+                "client_id": "sensor-front",
+                "location": "front-left",
+                "vibration_strength_db": 10.0,
+            },
+            {
+                "t_s": 0.0,
+                "client_id": "sensor-rear",
+                "location": "rear-left",
+                "vibration_strength_db": 9.0,
+            },
+        ]
+    )
 
 
-def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metadata() -> None:
+def test_execute_post_analysis_persists_whole_run_spatial_coherence_sidecar_and_metadata() -> None:
     stored: dict[str, object] = {}
     raw_capture_manifest = RawCaptureManifest(
-        run_id="run-order-traces",
-        relative_dir="raw-runs/run-order-traces",
+        run_id="run-spatial-coherence",
+        relative_dir="raw-runs/run-spatial-coherence",
         sensors=(),
         total_samples=0,
         total_bytes=0,
@@ -68,25 +80,32 @@ def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metada
         feature_interval_s=0.25,
     )
     spectral_manifest = WholeRunArtifactManifest(
-        run_id="run-order-traces",
-        relative_dir="whole-run-artifacts/run-order-traces",
+        run_id="run-spatial-coherence",
+        relative_dir="whole-run-artifacts/run-spatial-coherence",
         window_policy=window_policy,
         total_window_count=2,
         artifacts=(
             WholeRunArtifactFile(
-                artifact_key="spectral-summary:sensor-a",
-                relative_path="spectra/sensor-a/windows.jsonl",
+                artifact_key="spectral-summary:sensor-front",
+                relative_path="spectra/sensor-front/windows.jsonl",
                 file_format="jsonl",
                 record_count=2,
-                sensor_id="sensor-a",
+                sensor_id="sensor-front",
+            ),
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-rear",
+                relative_path="spectra/sensor-rear/windows.jsonl",
+                file_format="jsonl",
+                record_count=2,
+                sensor_id="sensor-rear",
             ),
         ),
         created_at="2025-01-01T00:00:00Z",
     )
     context_bundle = WholeRunContextArtifactBundle(
         manifest=WholeRunArtifactManifest(
-            run_id="run-order-traces",
-            relative_dir="whole-run-artifacts/run-order-traces",
+            run_id="run-spatial-coherence",
+            relative_dir="whole-run-artifacts/run-spatial-coherence",
             window_policy=window_policy,
             total_window_count=2,
             artifacts=(
@@ -134,8 +153,8 @@ def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metada
     )
     order_trace_bundle = WholeRunOrderTraceArtifactBundle(
         manifest=WholeRunArtifactManifest(
-            run_id="run-order-traces",
-            relative_dir="whole-run-artifacts/run-order-traces",
+            run_id="run-spatial-coherence",
+            relative_dir="whole-run-artifacts/run-spatial-coherence",
             window_policy=window_policy,
             total_window_count=2,
             artifacts=(
@@ -148,11 +167,7 @@ def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metada
             ),
             created_at="2025-01-01T00:00:00Z",
         ),
-        artifact_contents={
-            WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY: (
-                b'{"hypothesis_key":"wheel_1x","harmonic":1,"window_index":0}\n'
-            ),
-        },
+        artifact_contents={WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY: b""},
         points=(
             OrderTracePoint(
                 hypothesis_key="wheel_1x",
@@ -164,12 +179,6 @@ def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metada
                 eligible=True,
                 matched=True,
                 predicted_hz=5.0,
-                matched_hz=5.1,
-                relative_error=0.02,
-                peak_intensity_db=30.0,
-                vibration_strength_db=24.0,
-                ref_source="speed+tire",
-                strongest_location="Front Left",
             ),
             OrderTracePoint(
                 hypothesis_key="wheel_1x",
@@ -179,9 +188,8 @@ def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metada
                 order_label="1x wheel",
                 window_index=1,
                 eligible=True,
-                matched=False,
+                matched=True,
                 predicted_hz=6.0,
-                ref_source="speed+tire",
             ),
         ),
     )
@@ -201,14 +209,14 @@ def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metada
             raise AssertionError(f"unexpected store_analysis_error({run_id}, {error})")
 
     result = execute_post_analysis(
-        run_id="run-order-traces",
+        run_id="run-spatial-coherence",
         db=FakeDB(),
         load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
             run_id=run_id,
             metadata=_run_metadata(run_id),
             language="en",
             samples=_samples(),
-            total_sample_count=1,
+            total_sample_count=2,
             stride=1,
             raw_capture_manifest=raw_capture_manifest,
         ),
@@ -217,17 +225,35 @@ def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metada
             (),
             {
                 "manifest": spectral_manifest,
-                "artifact_contents": {"spectral-summary:sensor-a": b"{}\n{}\n"},
+                "artifact_contents": {
+                    "spectral-summary:sensor-front": (
+                        b'{"window_index":0,"coverage_state":"full","returned_sample_start":0,'
+                        b'"returned_sample_count":256,"top_peaks":[{"hz":5.0,"amp":0.2,'
+                        b'"vibration_strength_db":31.0}]}\n'
+                        b'{"window_index":1,"coverage_state":"full","returned_sample_start":200,'
+                        b'"returned_sample_count":256,"top_peaks":[{"hz":6.0,"amp":0.2,'
+                        b'"vibration_strength_db":31.0}]}\n'
+                    ),
+                    "spectral-summary:sensor-rear": (
+                        b'{"window_index":0,"coverage_state":"full","returned_sample_start":0,'
+                        b'"returned_sample_count":256,"top_peaks":[{"hz":5.05,"amp":0.15,'
+                        b'"vibration_strength_db":29.0}]}\n'
+                        b'{"window_index":1,"coverage_state":"full","returned_sample_start":200,'
+                        b'"returned_sample_count":256,"top_peaks":[{"hz":6.05,"amp":0.15,'
+                        b'"vibration_strength_db":29.0}]}\n'
+                    ),
+                },
             },
         )(),
         whole_run_context_builder=lambda **_kwargs: context_bundle,
         whole_run_order_trace_builder=lambda **_kwargs: order_trace_bundle,
-        whole_run_spatial_coherence_builder=lambda **_kwargs: None,
+        whole_run_order_trace_summary_builder=lambda **_kwargs: None,
+        whole_run_order_family_summary_builder=lambda **_kwargs: None,
         analysis_runner=lambda _run: make_persisted_analysis(
             {
                 "analysis_metadata": {
-                    "analyzed_sample_count": 1,
-                    "total_sample_count": 1,
+                    "analyzed_sample_count": 2,
+                    "total_sample_count": 2,
                     "sampling_method": "full",
                 },
                 "run_suitability": [],
@@ -238,42 +264,15 @@ def test_execute_post_analysis_persists_whole_run_order_trace_sidecar_and_metada
     assert isinstance(result, PostAnalysisExecutionSuccess)
     merged_manifest = stored["whole_run_manifest"]
     assert isinstance(merged_manifest, WholeRunArtifactManifest)
-    assert merged_manifest.artifact(WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY) is not None
-    assert merged_manifest.artifact(WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY) is not None
-    assert merged_manifest.artifact(WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY) is not None
-    assert stored["analysis"]["analysis_metadata"]["whole_run_order_traces_available"] is True
-    assert stored["analysis"]["analysis_metadata"]["whole_run_order_trace_point_count"] == 2
-    assert stored["analysis"]["analysis_metadata"]["whole_run_order_trace_candidate_count"] == 1
+    assert merged_manifest.artifact(WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY) is not None
+    artifact_contents = stored["whole_run_artifact_contents"]
+    assert WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY in artifact_contents
+    analysis_metadata = stored["analysis"]["analysis_metadata"]
+    assert analysis_metadata["whole_run_spatial_coherence_available"] is True
+    assert analysis_metadata["whole_run_spatial_coherence_window_count"] == 4
+    assert analysis_metadata["whole_run_spatial_coherence_candidate_count"] == 1
+    assert analysis_metadata["whole_run_spatial_coherence_summary_count"] == 1
     assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_order_trace_artifact_key"]
-        == WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY
+        analysis_metadata["whole_run_spatial_coherence_artifact_key"]
+        == WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY
     )
-    assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_order_trace_summaries_available"] is True
-    )
-    assert stored["analysis"]["analysis_metadata"]["whole_run_order_trace_summary_count"] == 1
-    assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_order_trace_summary_artifact_key"]
-        == WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY
-    )
-    assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_order_family_summaries_available"]
-        is True
-    )
-    assert stored["analysis"]["analysis_metadata"]["whole_run_order_family_summary_count"] == 1
-    assert (
-        stored["analysis"]["analysis_metadata"]["whole_run_order_family_summary_artifact_key"]
-        == WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY
-    )
-    assert len(stored["analysis"]["whole_run_order_summaries"]) == 1
-    order_summary = stored["analysis"]["whole_run_order_summaries"][0]
-    assert order_summary["hypothesis_key"] == "wheel"
-    assert order_summary["suspected_source"] == "wheel/tire"
-    assert order_summary["matched_window_count"] == 1
-    assert order_summary["support_intervals"][0]["phase"] == "cruise"
-    assert order_summary["phase_support"][0]["matched_window_count"] == 1
-    assert order_summary["harmonic_summaries"][0]["harmonic"] == 1
-    assert order_summary["stable_frequency_min_hz"] == 5.1
-    assert order_summary["exemplar_interval_index"] == 0
-    assert order_summary["ref_sources"] == ["speed+tire"]
-    assert stored["analysis"]["analysis_metadata"]["whole_run_artifact_count"] == 5

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/matching.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/matching.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 from vibesensor.domain import OrderMatchObservation, speed_bin_label
 from vibesensor.shared.constants.analysis import (
+    MIN_ANALYSIS_FREQ_HZ,
     ORDER_MIN_CONTIGUOUS_MATCH_DURATION_S,
     ORDER_MIN_COVERAGE_DURATION_S,
     ORDER_MIN_COVERAGE_POINTS,
@@ -141,10 +142,9 @@ def best_order_peak_match(
 
     if predicted_hz <= 0 or not peaks:
         return None
-    compliance_scale = path_compliance**0.5
-    tolerance_hz = max(
-        ORDER_TOLERANCE_MIN_HZ,
-        predicted_hz * ORDER_TOLERANCE_REL * compliance_scale,
+    tolerance_hz = order_peak_tolerance_hz(
+        predicted_hz=predicted_hz,
+        path_compliance=path_compliance,
     )
     peak_index, (best_hz, best_amp) = min(
         enumerate(peaks),
@@ -159,6 +159,37 @@ def best_order_peak_match(
         amplitude_g=best_amp,
         relative_error=delta_hz / max(1e-9, predicted_hz),
     )
+
+
+def order_peak_tolerance_hz(*, predicted_hz: float, path_compliance: float) -> float:
+    """Return the match tolerance for one predicted order frequency."""
+
+    compliance_scale = path_compliance**0.5
+    return float(
+        max(
+            ORDER_TOLERANCE_MIN_HZ,
+            predicted_hz * ORDER_TOLERANCE_REL * compliance_scale,
+        )
+    )
+
+
+def filtered_peak_pairs(
+    peaks: Sequence[Mapping[str, object]],
+) -> tuple[tuple[int, ...], tuple[tuple[float, float], ...]]:
+    """Return valid ``(hz, amp)`` peak pairs plus their source indexes."""
+
+    indexes: list[int] = []
+    filtered: list[tuple[float, float]] = []
+    for peak_index, peak in enumerate(peaks):
+        hz = peak.get("hz")
+        amp = peak.get("amp")
+        if not isinstance(hz, (int, float)) or not isinstance(amp, (int, float)):
+            continue
+        if hz <= 0 or amp <= 0 or hz < MIN_ANALYSIS_FREQ_HZ:
+            continue
+        indexes.append(peak_index)
+        filtered.append((float(hz), float(amp)))
+    return tuple(indexes), tuple(filtered)
 
 
 def match_samples_for_hypothesis(

--- a/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_traces.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import cast
 
-from vibesensor.shared.constants.analysis import MIN_ANALYSIS_FREQ_HZ
 from vibesensor.shared.json_utils import safe_json_dumps
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.run_schema import RunMetadata
@@ -20,7 +19,10 @@ from vibesensor.use_cases.diagnostics._sensor_locations import (
     client_locations_by_sensor,
     fallback_location_label,
 )
-from vibesensor.use_cases.diagnostics.orders.matching import best_order_peak_match
+from vibesensor.use_cases.diagnostics.orders.matching import (
+    best_order_peak_match,
+    filtered_peak_pairs,
+)
 from vibesensor.use_cases.diagnostics.orders.physics import (
     OrderHypothesis,
     _order_hypotheses,
@@ -217,7 +219,7 @@ def _best_sensor_peak_match(
         summary = summaries[window_index]
         if summary.coverage_state != "full":
             continue
-        peak_index, peak_pairs = _filtered_peak_pairs(summary.top_peaks)
+        peak_index, peak_pairs = filtered_peak_pairs(summary.top_peaks)
         peak_match = best_order_peak_match(
             peak_pairs,
             predicted_hz=predicted_hz,
@@ -289,23 +291,6 @@ def _window_context_sample(
         frames_dropped_total=0,
         queue_overflow_drops=0,
     )
-
-
-def _filtered_peak_pairs(
-    peaks: Sequence[Mapping[str, object]],
-) -> tuple[tuple[int, ...], tuple[tuple[float, float], ...]]:
-    indexes: list[int] = []
-    filtered: list[tuple[float, float]] = []
-    for peak_index, peak in enumerate(peaks):
-        hz = peak.get("hz")
-        amp = peak.get("amp")
-        if not isinstance(hz, (int, float)) or not isinstance(amp, (int, float)):
-            continue
-        if hz <= 0 or amp <= 0 or hz < MIN_ANALYSIS_FREQ_HZ:
-            continue
-        indexes.append(peak_index)
-        filtered.append((float(hz), float(amp)))
-    return tuple(indexes), tuple(filtered)
 
 
 def _sensor_match_rank(match: _SensorPeakMatch) -> tuple[float, float, str]:

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
@@ -1,0 +1,339 @@
+"""Whole-run candidate-level spatial coherence over aligned multi-sensor windows."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
+from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.types.json_types import is_json_object
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunContextWindowLabel,
+)
+from vibesensor.use_cases.diagnostics._types import Sample
+from vibesensor.use_cases.diagnostics.orders.matching import (
+    best_order_peak_match,
+    filtered_peak_pairs,
+    order_peak_tolerance_hz,
+)
+from vibesensor.use_cases.diagnostics.orders.physics import _order_hypotheses
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTracePoint
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WholeRunOrderTraceArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
+    SpatialEvidenceSummary,
+    SpatialEvidenceWindow,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spatial_alignment import (
+    AlignedSpatialWindow,
+    WholeRunSpatialAlignmentMatrix,
+    build_whole_run_spatial_alignment_matrix,
+)
+
+WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY = "spatial-coherence-windows"
+_WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_PATH = "spatial/coherence-windows.jsonl"
+
+__all__ = [
+    "WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY",
+    "WholeRunSpatialCoherenceArtifactBundle",
+    "build_whole_run_spatial_coherence_artifact_bundle",
+    "build_whole_run_spatial_evidence_windows",
+    "summarize_whole_run_spatial_coherence",
+    "whole_run_spatial_evidence_windows_from_jsonl_bytes",
+    "whole_run_spatial_evidence_windows_to_jsonl_bytes",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunSpatialCoherenceArtifactBundle:
+    """Dense per-candidate spatial evidence windows plus compact coherence summaries."""
+
+    manifest: WholeRunArtifactManifest
+    artifact_contents: dict[str, bytes]
+    windows: tuple[SpatialEvidenceWindow, ...]
+    summaries: tuple[SpatialEvidenceSummary, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _CandidateSensorSupport:
+    sensor_id: str
+    location: str
+    matched_frequency_hz: float
+    peak_intensity_db: float | None
+    vibration_strength_db: float | None
+
+
+def build_whole_run_spatial_coherence_artifact_bundle(
+    *,
+    order_trace_bundle: WholeRunOrderTraceArtifactBundle,
+    spectral_manifest: WholeRunArtifactManifest,
+    spectral_artifact_contents: Mapping[str, bytes],
+    context_labels: Sequence[WholeRunContextWindowLabel],
+    samples: Sequence[Sample],
+    lang: str = "en",
+    created_at: str | None = None,
+) -> WholeRunSpatialCoherenceArtifactBundle:
+    """Build dense candidate-level spatial coherence rows from aligned windows."""
+
+    alignment_matrix = build_whole_run_spatial_alignment_matrix(
+        spectral_manifest=spectral_manifest,
+        spectral_artifact_contents=spectral_artifact_contents,
+        context_labels=context_labels,
+        samples=samples,
+        lang=lang,
+    )
+    windows = build_whole_run_spatial_evidence_windows(
+        alignment_matrix=alignment_matrix,
+        order_points=order_trace_bundle.points,
+    )
+    summaries = summarize_whole_run_spatial_coherence(windows)
+    artifact = WholeRunArtifactFile(
+        artifact_key=WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
+        relative_path=_WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_PATH,
+        file_format="jsonl",
+        record_count=len(windows),
+    )
+    manifest = WholeRunArtifactManifest(
+        run_id=order_trace_bundle.manifest.run_id,
+        relative_dir=order_trace_bundle.manifest.relative_dir,
+        window_policy=order_trace_bundle.manifest.window_policy,
+        total_window_count=order_trace_bundle.manifest.total_window_count,
+        artifacts=(artifact,),
+        created_at=created_at or order_trace_bundle.manifest.created_at or utc_now_iso(),
+        schema_version=order_trace_bundle.manifest.schema_version,
+        storage_type=order_trace_bundle.manifest.storage_type,
+    )
+    return WholeRunSpatialCoherenceArtifactBundle(
+        manifest=manifest,
+        artifact_contents={
+            WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY: (
+                whole_run_spatial_evidence_windows_to_jsonl_bytes(windows)
+            )
+        },
+        windows=windows,
+        summaries=summaries,
+    )
+
+
+def build_whole_run_spatial_evidence_windows(
+    *,
+    alignment_matrix: WholeRunSpatialAlignmentMatrix,
+    order_points: Sequence[OrderTracePoint],
+) -> tuple[SpatialEvidenceWindow, ...]:
+    """Join order candidates against aligned sensor windows into dense spatial rows."""
+
+    windows_by_index = {window.window_index: window for window in alignment_matrix.windows}
+    path_compliance_by_key = {
+        hypothesis.key: hypothesis.path_compliance for hypothesis in _order_hypotheses()
+    }
+    points_by_candidate: dict[str, list[OrderTracePoint]] = defaultdict(list)
+    for point in order_points:
+        if point.eligible and point.predicted_hz is not None and point.predicted_hz > 0:
+            points_by_candidate[point.hypothesis_key].append(point)
+    candidate_rows: list[SpatialEvidenceWindow] = []
+    for candidate_key in _ordered_candidate_keys(points_by_candidate):
+        candidate_points = sorted(
+            points_by_candidate[candidate_key],
+            key=lambda point: point.window_index,
+        )
+        path_compliance = path_compliance_by_key.get(candidate_key, 1.0)
+        for point in candidate_points:
+            alignment_window = windows_by_index.get(point.window_index)
+            if alignment_window is None:
+                raise ValueError(
+                    "whole-run spatial coherence requires aligned sensor rows for every "
+                    f"candidate window, missing {point.window_index}"
+                )
+            candidate_rows.extend(
+                _candidate_window_rows(
+                    point=point,
+                    alignment_window=alignment_window,
+                    path_compliance=path_compliance,
+                )
+            )
+    return tuple(candidate_rows)
+
+
+def summarize_whole_run_spatial_coherence(
+    windows: Sequence[SpatialEvidenceWindow],
+) -> tuple[SpatialEvidenceSummary, ...]:
+    """Collapse dense candidate-level rows into compact coherence summaries."""
+
+    rows_by_candidate: dict[str, list[SpatialEvidenceWindow]] = defaultdict(list)
+    source_by_candidate: dict[str, str] = {}
+    for row in windows:
+        rows_by_candidate[row.candidate_key].append(row)
+        source_by_candidate.setdefault(row.candidate_key, row.suspected_source)
+    summaries: list[SpatialEvidenceSummary] = []
+    for candidate_key in _ordered_candidate_keys(rows_by_candidate):
+        candidate_rows = sorted(
+            rows_by_candidate[candidate_key],
+            key=lambda row: (row.window_index, row.sensor_id),
+        )
+        windows_by_index: dict[int, list[SpatialEvidenceWindow]] = defaultdict(list)
+        for row in candidate_rows:
+            windows_by_index[row.window_index].append(row)
+        coherence_scores = [
+            max((row.coherence_score or 0.0) for row in window_rows if row.supporting)
+            for window_rows in windows_by_index.values()
+            if any(row.supporting for row in window_rows)
+        ]
+        summaries.append(
+            SpatialEvidenceSummary(
+                candidate_key=candidate_key,
+                suspected_source=source_by_candidate[candidate_key],
+                proof_basis="supporting_windows_raw_backed",
+                total_window_count=len(windows_by_index),
+                supporting_window_count=len(coherence_scores),
+                supporting_sensor_count=len(
+                    {row.sensor_id for row in candidate_rows if row.supporting}
+                ),
+                coherent_window_count=sum(1 for score in coherence_scores if score > 0.0),
+                coherence_ratio=(
+                    sum(coherence_scores) / len(coherence_scores) if coherence_scores else 0.0
+                ),
+            )
+        )
+    return tuple(summaries)
+
+
+def whole_run_spatial_evidence_windows_to_jsonl_bytes(
+    windows: Sequence[SpatialEvidenceWindow],
+) -> bytes:
+    """Serialize dense whole-run spatial evidence rows into sidecar JSONL bytes."""
+
+    if not windows:
+        return b""
+    lines = [safe_json_dumps(window.to_json_object()).encode("utf-8") for window in windows]
+    return b"\n".join(lines) + b"\n"
+
+
+def whole_run_spatial_evidence_windows_from_jsonl_bytes(
+    payload: bytes,
+) -> tuple[SpatialEvidenceWindow, ...]:
+    """Reconstruct persisted dense whole-run spatial evidence rows from JSONL bytes."""
+
+    if not payload:
+        return ()
+    windows: list[SpatialEvidenceWindow] = []
+    for raw_line in payload.decode("utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parsed = safe_json_loads(line, context="whole-run spatial evidence windows")
+        if not is_json_object(parsed):
+            raise ValueError("whole-run spatial evidence line must decode to a JSON object")
+        windows.append(SpatialEvidenceWindow.from_mapping(parsed))
+    return tuple(windows)
+
+
+def _candidate_window_rows(
+    *,
+    point: OrderTracePoint,
+    alignment_window: AlignedSpatialWindow,
+    path_compliance: float,
+) -> tuple[SpatialEvidenceWindow, ...]:
+    support_by_sensor: dict[str, _CandidateSensorSupport] = {}
+    for sensor_window in alignment_window.sensor_windows:
+        if sensor_window.coverage_state != "full" or point.predicted_hz is None:
+            continue
+        peak_indexes, peak_pairs = filtered_peak_pairs(sensor_window.top_peaks)
+        peak_match = best_order_peak_match(
+            peak_pairs,
+            predicted_hz=point.predicted_hz,
+            path_compliance=path_compliance,
+        )
+        if peak_match is None:
+            continue
+        source_peak = sensor_window.top_peaks[peak_indexes[peak_match.peak_index]]
+        support_by_sensor[sensor_window.sensor_id] = _CandidateSensorSupport(
+            sensor_id=sensor_window.sensor_id,
+            location=sensor_window.location,
+            matched_frequency_hz=peak_match.matched_hz,
+            peak_intensity_db=_peak_intensity_db(source_peak),
+            vibration_strength_db=sensor_window.vibration_strength_db,
+        )
+    window_coherence_score = _window_coherence_score(
+        predicted_hz=point.predicted_hz,
+        path_compliance=path_compliance,
+        full_sensor_count=alignment_window.full_sensor_count,
+        supporting_matches=tuple(support_by_sensor.values()),
+    )
+    coherent_sensor_ids = set(support_by_sensor) if window_coherence_score > 0.0 else set()
+    rows: list[SpatialEvidenceWindow] = []
+    for sensor_window in alignment_window.sensor_windows:
+        sensor_support = support_by_sensor.get(sensor_window.sensor_id)
+        rows.append(
+            SpatialEvidenceWindow(
+                candidate_key=point.hypothesis_key,
+                suspected_source=point.suspected_source,
+                window_index=alignment_window.window_index,
+                sensor_id=sensor_window.sensor_id,
+                location=sensor_window.location,
+                supporting=sensor_support is not None,
+                coherent=sensor_window.sensor_id in coherent_sensor_ids,
+                peak_intensity_db=(
+                    sensor_support.peak_intensity_db if sensor_support is not None else None
+                ),
+                vibration_strength_db=(
+                    sensor_support.vibration_strength_db
+                    if sensor_support is not None
+                    else sensor_window.vibration_strength_db
+                ),
+                matched_frequency_hz=(
+                    sensor_support.matched_frequency_hz if sensor_support is not None else None
+                ),
+                coherence_score=(window_coherence_score if sensor_support is not None else None),
+            )
+        )
+    return tuple(rows)
+
+
+def _window_coherence_score(
+    *,
+    predicted_hz: float | None,
+    path_compliance: float,
+    full_sensor_count: int,
+    supporting_matches: Sequence[_CandidateSensorSupport],
+) -> float:
+    if (
+        predicted_hz is None
+        or predicted_hz <= 0.0
+        or full_sensor_count < 2
+        or len(supporting_matches) < 2
+    ):
+        return 0.0
+    tolerance_hz = order_peak_tolerance_hz(
+        predicted_hz=predicted_hz,
+        path_compliance=path_compliance,
+    )
+    matched_hz = sorted(match.matched_frequency_hz for match in supporting_matches)
+    spread_hz = matched_hz[-1] - matched_hz[0]
+    if spread_hz > tolerance_hz:
+        return 0.0
+    coverage_ratio = len(supporting_matches) / max(1, full_sensor_count)
+    spread_score = max(0.0, 1.0 - (spread_hz / max(1e-9, tolerance_hz)))
+    return max(0.0, min(1.0, coverage_ratio * spread_score))
+
+
+def _ordered_candidate_keys(rows_by_candidate: Mapping[str, object]) -> tuple[str, ...]:
+    catalog_order = {hypothesis.key: index for index, hypothesis in enumerate(_order_hypotheses())}
+    return tuple(
+        sorted(
+            rows_by_candidate,
+            key=lambda candidate_key: (
+                catalog_order.get(candidate_key, len(catalog_order)),
+                candidate_key,
+            ),
+        )
+    )
+
+
+def _peak_intensity_db(peak: Mapping[str, object]) -> float | None:
+    value = peak.get("vibration_strength_db")
+    return float(value) if isinstance(value, (int, float)) else None

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -39,6 +39,11 @@ from vibesensor.use_cases.diagnostics.whole_run_context import (
     WholeRunContextArtifactBundle,
     build_whole_run_context_artifact_bundle,
 )
+from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
+    WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
+    WholeRunSpatialCoherenceArtifactBundle,
+    build_whole_run_spatial_coherence_artifact_bundle,
+)
 from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunSpectralArtifactBundle,
     build_whole_run_spectral_artifact_bundle,
@@ -161,6 +166,19 @@ class WholeRunOrderFamilySummaryBuilder(Protocol):
     ) -> WholeRunOrderFamilySummaryArtifactBundle | None: ...
 
 
+class WholeRunSpatialCoherenceBuilder(Protocol):
+    """Injected boundary for building candidate-level whole-run spatial coherence."""
+
+    def __call__(
+        self,
+        *,
+        run: PostAnalysisRunInput,
+        spectral_bundle: WholeRunSpectralArtifactBundle,
+        context_bundle: WholeRunContextArtifactBundle,
+        order_trace_bundle: WholeRunOrderTraceArtifactBundle,
+    ) -> WholeRunSpatialCoherenceArtifactBundle | None: ...
+
+
 @dataclass(frozen=True, slots=True)
 class _StoredWholeRunArtifactBundle:
     """Generic sidecar bundle shape for final manifest persistence."""
@@ -180,6 +198,7 @@ def execute_post_analysis(
     whole_run_order_trace_builder: WholeRunOrderTraceBuilder | None = None,
     whole_run_order_trace_summary_builder: WholeRunOrderTraceSummaryBuilder | None = None,
     whole_run_order_family_summary_builder: WholeRunOrderFamilySummaryBuilder | None = None,
+    whole_run_spatial_coherence_builder: WholeRunSpatialCoherenceBuilder | None = None,
     defer_retryable_error_storage: bool = False,
 ) -> PostAnalysisAttemptResult:
     analysis_start = time.monotonic()
@@ -207,6 +226,11 @@ def execute_post_analysis(
         _build_whole_run_order_family_summary_artifacts
         if whole_run_order_family_summary_builder is None
         else whole_run_order_family_summary_builder
+    )
+    resolved_whole_run_spatial_coherence_builder = (
+        _build_whole_run_spatial_coherence_artifacts
+        if whole_run_spatial_coherence_builder is None
+        else whole_run_spatial_coherence_builder
     )
     with start_span(
         __name__,
@@ -280,6 +304,7 @@ def execute_post_analysis(
             order_trace_bundle: WholeRunOrderTraceArtifactBundle | None = None
             order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle | None = None
             order_family_summary_bundle: WholeRunOrderFamilySummaryArtifactBundle | None = None
+            spatial_coherence_bundle: WholeRunSpatialCoherenceArtifactBundle | None = None
             if loaded.raw_capture_manifest is not None:
                 spectral_bundle = resolved_whole_run_artifact_builder(
                     run_id=loaded.run_id,
@@ -312,12 +337,24 @@ def execute_post_analysis(
                         order_trace_summary_bundle=order_trace_summary_bundle,
                         context_bundle=context_bundle,
                     )
+                if (
+                    spectral_bundle is not None
+                    and context_bundle is not None
+                    and order_trace_bundle is not None
+                ):
+                    spatial_coherence_bundle = resolved_whole_run_spatial_coherence_builder(
+                        run=run_input,
+                        spectral_bundle=spectral_bundle,
+                        context_bundle=context_bundle,
+                        order_trace_bundle=order_trace_bundle,
+                    )
                 merged_bundle = _merge_whole_run_artifact_bundles(
                     spectral_bundle,
                     context_bundle,
                     order_trace_bundle,
                     order_trace_summary_bundle,
                     order_family_summary_bundle,
+                    spatial_coherence_bundle,
                 )
                 if merged_bundle is not None:
                     stored_artifact_manifest = _sync_call(
@@ -348,6 +385,11 @@ def execute_post_analysis(
                 summary = _append_whole_run_order_family_summary_metadata(
                     summary,
                     order_family_summary_bundle,
+                )
+            if spatial_coherence_bundle is not None:
+                summary = _append_whole_run_spatial_coherence_metadata(
+                    summary,
+                    spatial_coherence_bundle,
                 )
             if stored_artifact_manifest is not None:
                 summary = _append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
@@ -593,6 +635,25 @@ def _build_whole_run_order_family_summary_artifacts(
     )
 
 
+def _build_whole_run_spatial_coherence_artifacts(
+    *,
+    run: PostAnalysisRunInput,
+    spectral_bundle: WholeRunSpectralArtifactBundle,
+    context_bundle: WholeRunContextArtifactBundle,
+    order_trace_bundle: WholeRunOrderTraceArtifactBundle,
+) -> WholeRunSpatialCoherenceArtifactBundle | None:
+    if not order_trace_bundle.points:
+        return None
+    return build_whole_run_spatial_coherence_artifact_bundle(
+        order_trace_bundle=order_trace_bundle,
+        spectral_manifest=spectral_bundle.manifest,
+        spectral_artifact_contents=spectral_bundle.artifact_contents,
+        context_labels=context_bundle.labels,
+        samples=run.samples,
+        lang=run.language,
+    )
+
+
 def _merge_whole_run_artifact_bundles(
     *bundles: (
         WholeRunSpectralArtifactBundle
@@ -600,6 +661,7 @@ def _merge_whole_run_artifact_bundles(
         | WholeRunOrderTraceArtifactBundle
         | WholeRunOrderTraceSummaryArtifactBundle
         | WholeRunOrderFamilySummaryArtifactBundle
+        | WholeRunSpatialCoherenceArtifactBundle
         | None
     ),
 ) -> _StoredWholeRunArtifactBundle | None:
@@ -754,6 +816,27 @@ def _append_whole_run_order_family_summary_metadata(
     analysis_metadata["whole_run_order_family_summary_count"] = len(bundle.summaries)
     analysis_metadata["whole_run_order_family_summary_artifact_key"] = (
         WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY
+    )
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def _append_whole_run_spatial_coherence_metadata(
+    summary: PersistedAnalysis,
+    bundle: WholeRunSpatialCoherenceArtifactBundle,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    analysis_metadata["whole_run_spatial_coherence_available"] = True
+    analysis_metadata["whole_run_spatial_coherence_window_count"] = len(bundle.windows)
+    analysis_metadata["whole_run_spatial_coherence_candidate_count"] = len(
+        {row.candidate_key for row in bundle.windows}
+    )
+    analysis_metadata["whole_run_spatial_coherence_summary_count"] = len(bundle.summaries)
+    analysis_metadata["whole_run_spatial_coherence_artifact_key"] = (
+        WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY
     )
     return PersistedAnalysis.from_json_object(payload)
 

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -299,6 +299,15 @@ sensor ordering canonical by `sensor_id`, and exposes explicit
 coherence and hotspot scoring stages do not have to infer missing-data rules
 ad hoc.
 
+Candidate-level coherence now builds on that aligned matrix plus the existing
+whole-run order trace catalog in
+`apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py`.
+That stage reuses `OrderTracePoint.hypothesis_key` as the candidate identity,
+scores cross-sensor agreement with the same order tolerance logic already used
+by `orders/matching.py`, emits dense `SpatialEvidenceWindow` rows to a
+`spatial-coherence-windows` sidecar, and leaves dominant-location /
+runner-up-location summarization for the later hotspot-specific issue.
+
 ### Counterevidence model
 
 Counterevidence should become a first-class persisted concept with stable keys,


### PR DESCRIPTION
Closes #3098

## What changed
- add `whole_run_spatial_coherence.py` as the whole-run candidate-level spatial coherence owner over the aligned sensor window matrix
- reuse whole-run order trace `hypothesis_key` as the spatial candidate key and share peak filtering / tolerance logic with the order trace path
- wire the new `spatial-coherence-windows` sidecar and analysis metadata into `post_analysis_executor.py`
- add focused diagnostics and run-level regressions and update the whole-run design doc

## Why
- 3097 gave us deterministic aligned multi-sensor windows, but 3078 still had no canonical place to score cross-sensor agreement for a candidate across the full run
- this lands one deterministic coherence surface that later hotspot and persistence issues can reuse instead of re-joining spectra and re-inventing matching rules

## Validation
- `./.venv/bin/pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py apps/server/tests/use_cases/diagnostics/test_whole_run_order_traces.py`
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- `make test-changed`

## Risks / tradeoffs
- spatial coherence now depends on the whole-run order trace catalog for candidate identity; that keeps one candidate taxonomy, but it means later spatial work builds on the order stage instead of a fully independent catalog
- this PR only adds candidate-level coherence sidecars + metadata; compact persisted spatial summaries stay for follow-up issues