### PR TITLE
Add whole-run spatial hotspot summaries

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py
@@ -14,9 +14,13 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
     WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
     WholeRunOrderTraceArtifactBundle,
 )
+from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
+    SpatialEvidenceWindow,
+)
 from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
     WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
     build_whole_run_spatial_coherence_artifact_bundle,
+    summarize_whole_run_spatial_coherence,
 )
 from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunWindowSpectralSummary,
@@ -273,3 +277,327 @@ def test_build_whole_run_spatial_coherence_artifact_bundle_is_deterministic() ->
     assert first.artifact_contents == second.artifact_contents
     assert first.windows == second.windows
     assert first.summaries == second.summaries
+
+
+def test_summarize_whole_run_spatial_coherence_builds_clear_hotspot_location_summary() -> None:
+    summary = summarize_whole_run_spatial_coherence(
+        (
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=0,
+                sensor_id="sensor-front-left",
+                location="front-left",
+                supporting=True,
+                coherent=True,
+                peak_intensity_db=32.0,
+                vibration_strength_db=28.0,
+                matched_frequency_hz=10.0,
+                coherence_score=1.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=0,
+                sensor_id="sensor-front-right",
+                location="front-right",
+                supporting=True,
+                coherent=True,
+                peak_intensity_db=29.0,
+                vibration_strength_db=25.0,
+                matched_frequency_hz=10.0,
+                coherence_score=1.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=0,
+                sensor_id="sensor-rear-left",
+                location="rear-left",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=20.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=1,
+                sensor_id="sensor-front-left",
+                location="front-left",
+                supporting=True,
+                coherent=True,
+                peak_intensity_db=31.0,
+                vibration_strength_db=27.0,
+                matched_frequency_hz=12.0,
+                coherence_score=1.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=1,
+                sensor_id="sensor-front-right",
+                location="front-right",
+                supporting=True,
+                coherent=True,
+                peak_intensity_db=28.0,
+                vibration_strength_db=24.0,
+                matched_frequency_hz=12.0,
+                coherence_score=1.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=1,
+                sensor_id="sensor-rear-left",
+                location="rear-left",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=20.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=2,
+                sensor_id="sensor-front-left",
+                location="front-left",
+                supporting=True,
+                coherent=True,
+                peak_intensity_db=31.0,
+                vibration_strength_db=27.0,
+                matched_frequency_hz=14.0,
+                coherence_score=1.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=2,
+                sensor_id="sensor-front-right",
+                location="front-right",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=21.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=2,
+                sensor_id="sensor-rear-left",
+                location="rear-left",
+                supporting=True,
+                coherent=True,
+                peak_intensity_db=26.0,
+                vibration_strength_db=23.0,
+                matched_frequency_hz=14.0,
+                coherence_score=1.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=3,
+                sensor_id="sensor-front-left",
+                location="front-left",
+                supporting=True,
+                coherent=False,
+                peak_intensity_db=30.0,
+                vibration_strength_db=26.0,
+                matched_frequency_hz=16.0,
+                coherence_score=0.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=3,
+                sensor_id="sensor-front-right",
+                location="front-right",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=21.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=3,
+                sensor_id="sensor-rear-left",
+                location="rear-left",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=20.0,
+            ),
+        )
+    )[0]
+
+    assert summary.supporting_window_count == 4
+    assert summary.coherent_window_count == 3
+    assert summary.coherence_ratio == 0.75
+    assert summary.dominant_location == "front-left"
+    assert summary.runner_up_location == "front-right"
+    assert summary.dominance_ratio == 2.0
+    assert summary.location_separation_db == 2.5
+    assert summary.ambiguous_location is False
+    assert summary.weak_spatial_separation is False
+    assert [location.location for location in summary.location_summaries] == [
+        "front-left",
+        "front-right",
+        "rear-left",
+    ]
+    assert summary.location_summaries[0].support_ratio == 1.0
+    assert summary.location_summaries[0].coherence_ratio == 0.75
+
+
+def test_summarize_whole_run_spatial_coherence_marks_near_tied_locations_ambiguous() -> None:
+    summary = summarize_whole_run_spatial_coherence(
+        (
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=0,
+                sensor_id="sensor-front-left",
+                location="front-left",
+                supporting=True,
+                coherent=False,
+                peak_intensity_db=30.0,
+                vibration_strength_db=25.0,
+                matched_frequency_hz=10.0,
+                coherence_score=0.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=0,
+                sensor_id="sensor-front-right",
+                location="front-right",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=22.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=0,
+                sensor_id="sensor-rear-left",
+                location="rear-left",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=20.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=1,
+                sensor_id="sensor-front-left",
+                location="front-left",
+                supporting=True,
+                coherent=True,
+                peak_intensity_db=30.0,
+                vibration_strength_db=25.0,
+                matched_frequency_hz=12.0,
+                coherence_score=1.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=1,
+                sensor_id="sensor-front-right",
+                location="front-right",
+                supporting=True,
+                coherent=True,
+                peak_intensity_db=29.0,
+                vibration_strength_db=24.0,
+                matched_frequency_hz=12.0,
+                coherence_score=1.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=1,
+                sensor_id="sensor-rear-left",
+                location="rear-left",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=20.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=2,
+                sensor_id="sensor-front-left",
+                location="front-left",
+                supporting=True,
+                coherent=True,
+                peak_intensity_db=30.0,
+                vibration_strength_db=25.0,
+                matched_frequency_hz=14.0,
+                coherence_score=1.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=2,
+                sensor_id="sensor-front-right",
+                location="front-right",
+                supporting=True,
+                coherent=True,
+                peak_intensity_db=29.0,
+                vibration_strength_db=24.0,
+                matched_frequency_hz=14.0,
+                coherence_score=1.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=2,
+                sensor_id="sensor-rear-left",
+                location="rear-left",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=20.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=3,
+                sensor_id="sensor-front-left",
+                location="front-left",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=22.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=3,
+                sensor_id="sensor-front-right",
+                location="front-right",
+                supporting=True,
+                coherent=False,
+                peak_intensity_db=29.0,
+                vibration_strength_db=24.0,
+                matched_frequency_hz=16.0,
+                coherence_score=0.0,
+            ),
+            SpatialEvidenceWindow(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                window_index=3,
+                sensor_id="sensor-rear-left",
+                location="rear-left",
+                supporting=False,
+                coherent=False,
+                vibration_strength_db=20.0,
+            ),
+        )
+    )[0]
+
+    assert summary.supporting_window_count == 4
+    assert summary.coherent_window_count == 2
+    assert summary.coherence_ratio == 0.5
+    assert summary.dominant_location == "front-left"
+    assert summary.runner_up_location == "front-right"
+    assert summary.dominance_ratio == 1.0
+    assert summary.location_separation_db == 1.0
+    assert summary.ambiguous_location is True
+    assert summary.weak_spatial_separation is True
+    assert [location.supporting_window_count for location in summary.location_summaries[:2]] == [
+        3,
+        3,
+    ]

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_coherence.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from statistics import mean as _mean
 
+from vibesensor.domain import LocationHotspot
 from vibesensor.shared.json_utils import safe_json_dumps, safe_json_loads
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.json_types import is_json_object
@@ -15,6 +17,9 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunContextWindowLabel,
 )
 from vibesensor.use_cases.diagnostics._types import Sample
+from vibesensor.use_cases.diagnostics.location_scoring import (
+    NEAR_TIE_DOMINANCE_THRESHOLD,
+)
 from vibesensor.use_cases.diagnostics.orders.matching import (
     best_order_peak_match,
     filtered_peak_pairs,
@@ -28,6 +33,7 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
 from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
     SpatialEvidenceSummary,
     SpatialEvidenceWindow,
+    SpatialLocationSummary,
 )
 from vibesensor.use_cases.diagnostics.whole_run_spatial_alignment import (
     AlignedSpatialWindow,
@@ -178,25 +184,53 @@ def summarize_whole_run_spatial_coherence(
         windows_by_index: dict[int, list[SpatialEvidenceWindow]] = defaultdict(list)
         for row in candidate_rows:
             windows_by_index[row.window_index].append(row)
-        coherence_scores = [
-            max((row.coherence_score or 0.0) for row in window_rows if row.supporting)
+        supporting_window_count = sum(
+            1
             for window_rows in windows_by_index.values()
             if any(row.supporting for row in window_rows)
-        ]
+        )
+        coherent_window_count = sum(
+            1
+            for window_rows in windows_by_index.values()
+            if any(row.coherent for row in window_rows)
+        )
+        location_summaries = _summarize_location_support(
+            candidate_rows,
+            supporting_window_count=supporting_window_count,
+        )
+        dominant_location = location_summaries[0].location if location_summaries else None
+        runner_up_location = location_summaries[1].location if len(location_summaries) > 1 else None
+        dominance_ratio = _location_dominance_ratio(location_summaries)
+        weak_spatial_separation = _weak_spatial_separation(
+            location_summaries,
+            dominance_ratio=dominance_ratio,
+        )
         summaries.append(
             SpatialEvidenceSummary(
                 candidate_key=candidate_key,
                 suspected_source=source_by_candidate[candidate_key],
                 proof_basis="supporting_windows_raw_backed",
                 total_window_count=len(windows_by_index),
-                supporting_window_count=len(coherence_scores),
+                supporting_window_count=supporting_window_count,
                 supporting_sensor_count=len(
                     {row.sensor_id for row in candidate_rows if row.supporting}
                 ),
-                coherent_window_count=sum(1 for score in coherence_scores if score > 0.0),
+                coherent_window_count=coherent_window_count,
                 coherence_ratio=(
-                    sum(coherence_scores) / len(coherence_scores) if coherence_scores else 0.0
+                    coherent_window_count / supporting_window_count
+                    if supporting_window_count > 0
+                    else 0.0
                 ),
+                dominant_location=dominant_location,
+                runner_up_location=runner_up_location,
+                location_separation_db=_location_separation_db(location_summaries),
+                dominance_ratio=dominance_ratio,
+                ambiguous_location=_ambiguous_location(
+                    location_summaries,
+                    dominance_ratio=dominance_ratio,
+                ),
+                weak_spatial_separation=weak_spatial_separation,
+                location_summaries=location_summaries,
             )
         )
     return tuple(summaries)
@@ -337,3 +371,120 @@ def _ordered_candidate_keys(rows_by_candidate: Mapping[str, object]) -> tuple[st
 def _peak_intensity_db(peak: Mapping[str, object]) -> float | None:
     value = peak.get("vibration_strength_db")
     return float(value) if isinstance(value, (int, float)) else None
+
+
+def _summarize_location_support(
+    candidate_rows: Sequence[SpatialEvidenceWindow],
+    *,
+    supporting_window_count: int,
+) -> tuple[SpatialLocationSummary, ...]:
+    rows_by_location: dict[str, list[SpatialEvidenceWindow]] = defaultdict(list)
+    for row in candidate_rows:
+        if row.supporting:
+            rows_by_location[row.location].append(row)
+    summaries = [
+        _build_location_summary(
+            location,
+            rows,
+            supporting_window_count=supporting_window_count,
+        )
+        for location, rows in rows_by_location.items()
+    ]
+    return tuple(
+        sorted(
+            summaries,
+            key=lambda summary: (
+                -summary.support_ratio,
+                -summary.coherent_window_count,
+                -(summary.coherence_ratio or 0.0),
+                -_sortable_metric(summary.mean_vibration_strength_db),
+                -_sortable_metric(summary.peak_intensity_db),
+                summary.location.lower(),
+            ),
+        )
+    )
+
+
+def _build_location_summary(
+    location: str,
+    rows: Sequence[SpatialEvidenceWindow],
+    *,
+    supporting_window_count: int,
+) -> SpatialLocationSummary:
+    support_windows = {row.window_index for row in rows}
+    coherent_windows = {row.window_index for row in rows if row.coherent}
+    vibration_strengths = [
+        row.vibration_strength_db for row in rows if row.vibration_strength_db is not None
+    ]
+    peak_intensities = [row.peak_intensity_db for row in rows if row.peak_intensity_db is not None]
+    return SpatialLocationSummary(
+        location=location,
+        sensor_ids=tuple(sorted({row.sensor_id for row in rows})),
+        supporting_window_count=len(support_windows),
+        support_ratio=(
+            len(support_windows) / supporting_window_count if supporting_window_count > 0 else 0.0
+        ),
+        coherent_window_count=len(coherent_windows),
+        coherence_ratio=(len(coherent_windows) / len(support_windows) if support_windows else 0.0),
+        peak_intensity_db=max(peak_intensities) if peak_intensities else None,
+        mean_vibration_strength_db=(_mean(vibration_strengths) if vibration_strengths else None),
+    )
+
+
+def _location_dominance_ratio(
+    location_summaries: Sequence[SpatialLocationSummary],
+) -> float | None:
+    if len(location_summaries) < 2:
+        return None
+    top_support = location_summaries[0].support_ratio
+    runner_up_support = location_summaries[1].support_ratio
+    if runner_up_support <= 0.0:
+        return None
+    return top_support / runner_up_support
+
+
+def _location_separation_db(
+    location_summaries: Sequence[SpatialLocationSummary],
+) -> float | None:
+    if len(location_summaries) < 2:
+        return None
+    top = _location_reference_db(location_summaries[0])
+    runner_up = _location_reference_db(location_summaries[1])
+    if top is None or runner_up is None:
+        return None
+    return top - runner_up
+
+
+def _location_reference_db(summary: SpatialLocationSummary) -> float | None:
+    if summary.mean_vibration_strength_db is not None:
+        return summary.mean_vibration_strength_db
+    return summary.peak_intensity_db
+
+
+def _ambiguous_location(
+    location_summaries: Sequence[SpatialLocationSummary],
+    *,
+    dominance_ratio: float | None,
+) -> bool:
+    return (
+        len(location_summaries) > 1
+        and dominance_ratio is not None
+        and dominance_ratio < NEAR_TIE_DOMINANCE_THRESHOLD
+    )
+
+
+def _weak_spatial_separation(
+    location_summaries: Sequence[SpatialLocationSummary],
+    *,
+    dominance_ratio: float | None,
+) -> bool:
+    if not location_summaries:
+        return True
+    if len(location_summaries) < 2 or dominance_ratio is None:
+        return False
+    threshold = LocationHotspot.weak_spatial_threshold(len(location_summaries))
+    return dominance_ratio < threshold
+
+
+def _sortable_metric(value: float | None) -> float:
+    return value if value is not None else float("-inf")

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -305,8 +305,10 @@ whole-run order trace catalog in
 That stage reuses `OrderTracePoint.hypothesis_key` as the candidate identity,
 scores cross-sensor agreement with the same order tolerance logic already used
 by `orders/matching.py`, emits dense `SpatialEvidenceWindow` rows to a
-`spatial-coherence-windows` sidecar, and leaves dominant-location /
-runner-up-location summarization for the later hotspot-specific issue.
+`spatial-coherence-windows` sidecar, and now also builds compact
+`SpatialLocationSummary` / `SpatialEvidenceSummary` hotspot outputs with
+dominant location, runner-up, location separation, and weak/ambiguous flags
+derived from supporting-window evidence.
 
 ### Counterevidence model
 


### PR DESCRIPTION
Closes #3099

## What changed
- extend `whole_run_spatial_coherence.py` so compact spatial summaries now include per-location support/coherence rows, dominant and runner-up locations, dB separation, and weak/ambiguous hotspot flags
- rank hotspot locations deterministically from supporting-window evidence while reusing the existing location ambiguity / weak-separation vocabulary
- add focused diagnostics regressions for clear-hotspot and near-tied cases and update the whole-run design doc

## Why
- 3098 landed candidate-level cross-sensor coherence, but 3078 still needed one canonical summary of how strongly a candidate points at one location versus competing locations
- this gives 3100 a compact hotspot summary surface to persist instead of forcing later work to recompute location separation from dense rows

## Validation
- `./.venv/bin/pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_spatial_coherence.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py`
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- `make test-changed`

## Risks / tradeoffs
- hotspot ranking is support-driven first, with intensity used as a deterministic tie-breaker; if later fusion wants a different scoring blend, it should extend this owner instead of reintroducing parallel scoring paths
- proof-basis fallback stays deferred to #3100; this PR only makes weak/ambiguous hotspot proof explicit and keeps the compact summary ready for persistence