### PR TITLE
Persist whole-run spatial summaries

### DIFF
--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -181,6 +181,9 @@ def test_export_schema_contains_typed_analysis_summary_for_history_run(
     assert analysis_summary["properties"]["whole_run_order_summaries"]["items"] == {
         "$ref": "#/components/schemas/OrderTraceSummaryResponse",
     }
+    assert analysis_summary["properties"]["whole_run_spatial_summaries"]["items"] == {
+        "$ref": "#/components/schemas/SpatialEvidenceSummaryResponse",
+    }
     assert analysis_summary["properties"]["speed_stats"] == {
         "$ref": "#/components/schemas/SpeedStatsResponse",
     }

--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -286,3 +286,55 @@ async def test_whole_run_order_summaries_survive_persistence_and_http_layers() -
         insights_response["whole_run_order_summaries"]
         == restored_summary["whole_run_order_summaries"]
     )
+
+
+@pytest.mark.asyncio
+async def test_whole_run_spatial_summaries_survive_persistence_and_http_layers() -> None:
+    summary = _representative_summary()
+    summary["whole_run_spatial_summaries"] = [
+        {
+            "candidate_key": "wheel_1x",
+            "suspected_source": "wheel/tire",
+            "proof_basis": "supporting_windows_raw_backed",
+            "total_window_count": 8,
+            "supporting_window_count": 6,
+            "supporting_sensor_count": 2,
+            "coherent_window_count": 4,
+            "coherence_ratio": 0.67,
+            "dominant_location": "front-left",
+            "runner_up_location": "front-right",
+            "location_separation_db": 2.5,
+            "dominance_ratio": 1.5,
+            "ambiguous_location": False,
+            "weak_spatial_separation": False,
+            "location_summaries": [
+                {
+                    "location": "front-left",
+                    "sensor_ids": ["sensor-front"],
+                    "supporting_window_count": 6,
+                    "support_ratio": 1.0,
+                    "coherent_window_count": 4,
+                    "coherence_ratio": 0.67,
+                    "peak_intensity_db": 18.0,
+                    "mean_vibration_strength_db": 11.5,
+                }
+            ],
+        }
+    ]
+    stored_run, restored_summary = _stored_run_from_summary(summary)
+
+    service = ProjectedHistoryRunService(HistoryRunService(_RunPersistenceStub(stored_run)))
+
+    run_response = await service.get_run(stored_run.run_id)
+    insights_response = await service.get_insights(stored_run.run_id, requested_lang="en")
+
+    assert run_response.analysis is not None
+    assert insights_response is not None
+    assert (
+        run_response.analysis["whole_run_spatial_summaries"]
+        == restored_summary["whole_run_spatial_summaries"]
+    )
+    assert (
+        insights_response["whole_run_spatial_summaries"]
+        == restored_summary["whole_run_spatial_summaries"]
+    )

--- a/apps/server/tests/shared/boundaries/test_report_payload.py
+++ b/apps/server/tests/shared/boundaries/test_report_payload.py
@@ -49,6 +49,7 @@ def test_report_summary_from_mapping_defaults_without_nested_metadata() -> None:
     assert summary.peak_table_rows == ()
     assert summary.timeline_intervals == ()
     assert summary.whole_run_order_summaries == ()
+    assert summary.whole_run_spatial_summaries == ()
 
 
 def test_report_summary_from_mapping_projects_canonical_metadata_and_rows() -> None:
@@ -178,6 +179,52 @@ def test_report_summary_from_mapping_normalizes_whole_run_order_summaries() -> N
     assert order_summary.harmonic_summaries[0].harmonic == 1
     assert order_summary.stable_frequency_min_hz == 13.1
     assert order_summary.ref_sources == ("speed+tire",)
+
+
+def test_report_summary_from_mapping_normalizes_whole_run_spatial_summaries() -> None:
+    summary = report_summary_from_mapping(
+        {
+            "run_id": "run-123",
+            "metadata": {"run_id": "run-123"},
+            "whole_run_spatial_summaries": [
+                {
+                    "candidate_key": "wheel_1x",
+                    "suspected_source": "wheel/tire",
+                    "proof_basis": "supporting_windows_raw_backed",
+                    "total_window_count": 8,
+                    "supporting_window_count": 6,
+                    "supporting_sensor_count": 2,
+                    "coherent_window_count": 4,
+                    "coherence_ratio": 0.67,
+                    "dominant_location": "front-left",
+                    "runner_up_location": "front-right",
+                    "location_separation_db": 2.5,
+                    "dominance_ratio": 1.5,
+                    "ambiguous_location": False,
+                    "weak_spatial_separation": False,
+                    "location_summaries": [
+                        {
+                            "location": "front-left",
+                            "sensor_ids": ["sensor-front"],
+                            "supporting_window_count": 6,
+                            "support_ratio": 1.0,
+                            "coherent_window_count": 4,
+                            "coherence_ratio": 0.67,
+                            "peak_intensity_db": 18.0,
+                            "mean_vibration_strength_db": 11.5,
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert len(summary.whole_run_spatial_summaries) == 1
+    spatial_summary = summary.whole_run_spatial_summaries[0]
+    assert spatial_summary.candidate_key == "wheel_1x"
+    assert spatial_summary.proof_basis == "supporting_windows_raw_backed"
+    assert spatial_summary.dominant_location == "front-left"
+    assert spatial_summary.location_summaries[0].sensor_ids == ("sensor-front",)
 
 
 def test_report_summary_requires_connected_active_locations() -> None:

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py
@@ -268,6 +268,7 @@ def test_execute_post_analysis_persists_whole_run_spatial_coherence_sidecar_and_
     artifact_contents = stored["whole_run_artifact_contents"]
     assert WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY in artifact_contents
     analysis_metadata = stored["analysis"]["analysis_metadata"]
+    spatial_summaries = stored["analysis"]["whole_run_spatial_summaries"]
     assert analysis_metadata["whole_run_spatial_coherence_available"] is True
     assert analysis_metadata["whole_run_spatial_coherence_window_count"] == 4
     assert analysis_metadata["whole_run_spatial_coherence_candidate_count"] == 1
@@ -276,3 +277,10 @@ def test_execute_post_analysis_persists_whole_run_spatial_coherence_sidecar_and_
         analysis_metadata["whole_run_spatial_coherence_artifact_key"]
         == WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY
     )
+    assert len(spatial_summaries) == 1
+    assert spatial_summaries[0]["candidate_key"] == "wheel_1x"
+    assert spatial_summaries[0]["proof_basis"] == "supporting_windows_raw_backed"
+    assert spatial_summaries[0]["dominant_location"] == "front-left"
+    assert spatial_summaries[0]["supporting_window_count"] == 2
+    assert spatial_summaries[0]["coherent_window_count"] == 2
+    assert len(spatial_summaries[0]["location_summaries"]) == 2

--- a/apps/server/vibesensor/adapters/http/models/history.py
+++ b/apps/server/vibesensor/adapters/http/models/history.py
@@ -48,6 +48,7 @@ from vibesensor.shared.types.history_analysis_contracts import (
     PhaseSegmentSummaryResponse,
     PhaseTimelineEntryResponse,
     RunSuitabilityCheck,
+    SpatialEvidenceSummaryResponse,
     SpeedStatsResponse,
     StrengthBucketDistributionResponse,
     SummaryWarningResponse,
@@ -186,6 +187,7 @@ class _HistoryInsightsCoreResponse(TypedDict, total=False):
     phase_timeline: Required[list[PhaseTimelineEntryResponse]]
     whole_run_context_intervals: list[WholeRunContextIntervalResponse]
     whole_run_order_summaries: list[OrderTraceSummaryResponse]
+    whole_run_spatial_summaries: list[SpatialEvidenceSummaryResponse]
     speed_stats: Required[SpeedStatsResponse]
     speed_stats_by_phase: Required[dict[str, SpeedStatsResponse]]
     phase_info: Required[PhaseInfoResponse]

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -17,6 +17,7 @@ from vibesensor.shared.boundaries.summary_fields.hotspot import (
     location_intensity_summaries_from_rows,
 )
 from vibesensor.shared.types.analysis_views import PeakTableRow
+from vibesensor.shared.types.history_analysis_contracts import LocationProofBasis
 from vibesensor.shared.types.run_schema import RunMetadata
 
 __all__ = [
@@ -24,8 +25,10 @@ __all__ = [
     "ReportOrderHarmonicEvidenceSummary",
     "ReportOrderTracePhaseSupport",
     "ReportOrderTraceSupportInterval",
+    "ReportSpatialLocationSummary",
     "ReportWholeRunContextInterval",
     "ReportWholeRunOrderSummary",
+    "ReportWholeRunSpatialSummary",
     "ReportSummaryNormalizer",
     "ReportTimelineInterval",
     "has_projectable_report_payload",
@@ -149,6 +152,41 @@ class ReportWholeRunOrderSummary:
 
 
 @dataclass(frozen=True, slots=True)
+class ReportSpatialLocationSummary:
+    """Typed persisted per-location spatial evidence row for report/history reload."""
+
+    location: str
+    sensor_ids: tuple[str, ...]
+    supporting_window_count: int
+    support_ratio: float
+    coherent_window_count: int
+    coherence_ratio: float | None
+    peak_intensity_db: float | None
+    mean_vibration_strength_db: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class ReportWholeRunSpatialSummary:
+    """Typed persisted whole-run spatial summary for report/history reload paths."""
+
+    candidate_key: str
+    suspected_source: str
+    proof_basis: LocationProofBasis
+    total_window_count: int
+    supporting_window_count: int
+    supporting_sensor_count: int
+    coherent_window_count: int
+    coherence_ratio: float | None
+    dominant_location: str | None
+    runner_up_location: str | None
+    location_separation_db: float | None
+    dominance_ratio: float | None
+    ambiguous_location: bool
+    weak_spatial_separation: bool
+    location_summaries: tuple[ReportSpatialLocationSummary, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class NormalizedReportSummary:
     """Typed report boundary object shared by report facts and renderer mapping."""
 
@@ -167,6 +205,7 @@ class NormalizedReportSummary:
     timeline_intervals: tuple[ReportTimelineInterval, ...]
     whole_run_context_intervals: tuple[ReportWholeRunContextInterval, ...]
     whole_run_order_summaries: tuple[ReportWholeRunOrderSummary, ...]
+    whole_run_spatial_summaries: tuple[ReportWholeRunSpatialSummary, ...]
 
 
 class ReportSummaryNormalizer:
@@ -195,6 +234,7 @@ class ReportSummaryNormalizer:
             timeline_intervals=self._timeline_intervals(),
             whole_run_context_intervals=self._whole_run_context_intervals(),
             whole_run_order_summaries=self._whole_run_order_summaries(),
+            whole_run_spatial_summaries=self._whole_run_spatial_summaries(),
         )
 
     def _summary_run_metadata(self) -> RunMetadata | None:
@@ -363,6 +403,42 @@ class ReportSummaryNormalizer:
             )
         return tuple(summaries)
 
+    def _whole_run_spatial_summaries(self) -> tuple[ReportWholeRunSpatialSummary, ...]:
+        raw_summaries = self._payload.get("whole_run_spatial_summaries")
+        if not isinstance(raw_summaries, list):
+            return ()
+        summaries: list[ReportWholeRunSpatialSummary] = []
+        for row in raw_summaries:
+            if not isinstance(row, Mapping):
+                continue
+            candidate_key = text_or_none(row.get("candidate_key"))
+            suspected_source = text_or_none(row.get("suspected_source"))
+            proof_basis = self._proof_basis(row.get("proof_basis"))
+            if candidate_key is None or suspected_source is None or proof_basis is None:
+                continue
+            summaries.append(
+                ReportWholeRunSpatialSummary(
+                    candidate_key=candidate_key,
+                    suspected_source=suspected_source,
+                    proof_basis=proof_basis,
+                    total_window_count=coerce_count(row.get("total_window_count")),
+                    supporting_window_count=coerce_count(row.get("supporting_window_count")),
+                    supporting_sensor_count=coerce_count(row.get("supporting_sensor_count")),
+                    coherent_window_count=coerce_count(row.get("coherent_window_count")),
+                    coherence_ratio=optional_float(row.get("coherence_ratio")),
+                    dominant_location=text_or_none(row.get("dominant_location")),
+                    runner_up_location=text_or_none(row.get("runner_up_location")),
+                    location_separation_db=optional_float(row.get("location_separation_db")),
+                    dominance_ratio=optional_float(row.get("dominance_ratio")),
+                    ambiguous_location=bool(row.get("ambiguous_location")),
+                    weak_spatial_separation=bool(row.get("weak_spatial_separation")),
+                    location_summaries=self._spatial_location_summaries(
+                        row.get("location_summaries")
+                    ),
+                )
+            )
+        return tuple(summaries)
+
     def _order_support_intervals(
         self,
         raw_intervals: object,
@@ -465,6 +541,54 @@ class ReportSummaryNormalizer:
             return coerce_count(raw_value)
         except (TypeError, ValueError):
             return None
+
+    def _spatial_location_summaries(
+        self,
+        raw_summaries: object,
+    ) -> tuple[ReportSpatialLocationSummary, ...]:
+        if not isinstance(raw_summaries, list):
+            return ()
+        summaries: list[ReportSpatialLocationSummary] = []
+        for row in raw_summaries:
+            if not isinstance(row, Mapping):
+                continue
+            location = text_or_none(row.get("location"))
+            if location is None:
+                continue
+            summaries.append(
+                ReportSpatialLocationSummary(
+                    location=location,
+                    sensor_ids=self._text_tuple(row.get("sensor_ids")),
+                    supporting_window_count=coerce_count(row.get("supporting_window_count")),
+                    support_ratio=optional_float(row.get("support_ratio")) or 0.0,
+                    coherent_window_count=coerce_count(row.get("coherent_window_count")),
+                    coherence_ratio=optional_float(row.get("coherence_ratio")),
+                    peak_intensity_db=optional_float(row.get("peak_intensity_db")),
+                    mean_vibration_strength_db=optional_float(
+                        row.get("mean_vibration_strength_db")
+                    ),
+                )
+            )
+        return tuple(summaries)
+
+    def _text_tuple(self, raw_values: object) -> tuple[str, ...]:
+        if not isinstance(raw_values, list):
+            return ()
+        return tuple(
+            value
+            for value in (text_or_none(raw_value) for raw_value in raw_values)
+            if value is not None
+        )
+
+    def _proof_basis(self, raw_value: object) -> LocationProofBasis | None:
+        value = text_or_none(raw_value)
+        if value not in {
+            "whole_run_summary",
+            "supporting_windows_raw_backed",
+            "supporting_windows_summary_only",
+        }:
+            return None
+        return cast(LocationProofBasis, value)
 
 
 def has_projectable_report_payload(payload: Mapping[str, object]) -> bool:

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -377,6 +377,7 @@ class AnalysisSummaryCoreResponse(TypedDict, total=False):
     phase_timeline: Required[list[PhaseTimelineEntryResponse]]
     whole_run_context_intervals: list[WholeRunContextIntervalResponse]
     whole_run_order_summaries: list[OrderTraceSummaryResponse]
+    whole_run_spatial_summaries: list[SpatialEvidenceSummaryResponse]
     speed_stats: Required[SpeedStatsResponse]
     speed_stats_by_phase: Required[dict[str, SpeedStatsResponse]]
     phase_info: Required[PhaseInfoResponse]

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -34,6 +34,9 @@ from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
     WholeRunOrderTraceArtifactBundle,
     build_whole_run_order_trace_artifact_bundle,
 )
+from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
+    SpatialEvidenceSummary,
+)
 from vibesensor.use_cases.diagnostics.whole_run_context import (
     WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
     WholeRunContextArtifactBundle,
@@ -385,6 +388,11 @@ def execute_post_analysis(
                 summary = _append_whole_run_order_family_summary_metadata(
                     summary,
                     order_family_summary_bundle,
+                )
+            if spatial_coherence_bundle is not None:
+                summary = _append_whole_run_spatial_summaries(
+                    summary,
+                    spatial_coherence_bundle,
                 )
             if spatial_coherence_bundle is not None:
                 summary = _append_whole_run_spatial_coherence_metadata(
@@ -852,6 +860,17 @@ def _append_whole_run_order_summaries(
     return PersistedAnalysis.from_json_object(payload)
 
 
+def _append_whole_run_spatial_summaries(
+    summary: PersistedAnalysis,
+    bundle: WholeRunSpatialCoherenceArtifactBundle,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    payload["whole_run_spatial_summaries"] = [
+        row.to_json_object() for row in _ranked_whole_run_spatial_summaries(bundle.summaries)
+    ]
+    return PersistedAnalysis.from_json_object(payload)
+
+
 def _ranked_whole_run_order_summaries(
     summaries: tuple[OrderTraceSummary, ...],
 ) -> tuple[OrderTraceSummary, ...]:
@@ -865,6 +884,28 @@ def _ranked_whole_run_order_summaries(
                 -(summary.peak_intensity_db if summary.peak_intensity_db is not None else -1.0),
                 -summary.reference_coverage_ratio,
                 summary.hypothesis_key,
+            ),
+        )
+    )
+
+
+def _ranked_whole_run_spatial_summaries(
+    summaries: tuple[SpatialEvidenceSummary, ...],
+) -> tuple[SpatialEvidenceSummary, ...]:
+    return tuple(
+        sorted(
+            summaries,
+            key=lambda summary: (
+                -summary.coherent_window_count,
+                -summary.supporting_window_count,
+                -(summary.coherence_ratio if summary.coherence_ratio is not None else -1.0),
+                -(
+                    summary.location_separation_db
+                    if summary.location_separation_db is not None
+                    else -1.0
+                ),
+                -(summary.dominance_ratio if summary.dominance_ratio is not None else -1.0),
+                summary.candidate_key,
             ),
         )
     )

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -775,6 +775,13 @@
             },
             "title": "Whole Run Order Summaries",
             "type": "array"
+          },
+          "whole_run_spatial_summaries": {
+            "items": {
+              "$ref": "#/components/schemas/SpatialEvidenceSummaryResponse"
+            },
+            "title": "Whole Run Spatial Summaries",
+            "type": "array"
           }
         },
         "required": [
@@ -3446,6 +3453,13 @@
             },
             "title": "Whole Run Order Summaries",
             "type": "array"
+          },
+          "whole_run_spatial_summaries": {
+            "items": {
+              "$ref": "#/components/schemas/SpatialEvidenceSummaryResponse"
+            },
+            "title": "Whole Run Spatial Summaries",
+            "type": "array"
           }
         },
         "required": [
@@ -3978,6 +3992,14 @@
         ],
         "title": "LocationOptionResponse",
         "type": "object"
+      },
+      "LocationProofBasis": {
+        "enum": [
+          "whole_run_summary",
+          "supporting_windows_raw_backed",
+          "supporting_windows_summary_only"
+        ],
+        "type": "string"
       },
       "MatchedAmpVsSpeedSeries": {
         "description": "Typed HTTP contract for one finding's amp-vs-speed series.",
@@ -5993,6 +6015,192 @@
           "location_code"
         ],
         "title": "SetLocationRequest",
+        "type": "object"
+      },
+      "SpatialEvidenceSummaryResponse": {
+        "description": "Future persisted/report-facing summary shape for whole-run spatial evidence.",
+        "properties": {
+          "ambiguous_location": {
+            "title": "Ambiguous Location",
+            "type": "boolean"
+          },
+          "candidate_key": {
+            "title": "Candidate Key",
+            "type": "string"
+          },
+          "coherence_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Coherence Ratio"
+          },
+          "coherent_window_count": {
+            "title": "Coherent Window Count",
+            "type": "integer"
+          },
+          "dominance_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dominance Ratio"
+          },
+          "dominant_location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dominant Location"
+          },
+          "location_separation_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Separation Db"
+          },
+          "location_summaries": {
+            "items": {
+              "$ref": "#/components/schemas/SpatialLocationSummaryResponse"
+            },
+            "title": "Location Summaries",
+            "type": "array"
+          },
+          "proof_basis": {
+            "$ref": "#/components/schemas/LocationProofBasis"
+          },
+          "runner_up_location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runner Up Location"
+          },
+          "supporting_sensor_count": {
+            "title": "Supporting Sensor Count",
+            "type": "integer"
+          },
+          "supporting_window_count": {
+            "title": "Supporting Window Count",
+            "type": "integer"
+          },
+          "suspected_source": {
+            "title": "Suspected Source",
+            "type": "string"
+          },
+          "total_window_count": {
+            "title": "Total Window Count",
+            "type": "integer"
+          },
+          "weak_spatial_separation": {
+            "title": "Weak Spatial Separation",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "candidate_key",
+          "suspected_source",
+          "proof_basis",
+          "total_window_count",
+          "supporting_window_count",
+          "supporting_sensor_count",
+          "coherent_window_count",
+          "ambiguous_location",
+          "weak_spatial_separation",
+          "location_summaries"
+        ],
+        "title": "SpatialEvidenceSummaryResponse",
+        "type": "object"
+      },
+      "SpatialLocationSummaryResponse": {
+        "description": "Compact per-location support row for persisted spatial evidence.",
+        "properties": {
+          "coherence_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Coherence Ratio"
+          },
+          "coherent_window_count": {
+            "title": "Coherent Window Count",
+            "type": "integer"
+          },
+          "location": {
+            "title": "Location",
+            "type": "string"
+          },
+          "mean_vibration_strength_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Vibration Strength Db"
+          },
+          "peak_intensity_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Peak Intensity Db"
+          },
+          "sensor_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Sensor Ids",
+            "type": "array"
+          },
+          "support_ratio": {
+            "title": "Support Ratio",
+            "type": "number"
+          },
+          "supporting_window_count": {
+            "title": "Supporting Window Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "location",
+          "sensor_ids",
+          "supporting_window_count",
+          "support_ratio",
+          "coherent_window_count"
+        ],
+        "title": "SpatialLocationSummaryResponse",
         "type": "object"
       },
       "SpectrogramResult": {


### PR DESCRIPTION
Closes #3100

## What changed
- persist ranked `whole_run_spatial_summaries` from the spatial coherence bundle into `analysis_json`
- extend shared history/HTTP/report-normalization contracts so compact spatial summaries reload without dense sidecar reads
- sync the generated HTTP schema artifact and add focused run/report/integration/schema regressions

## Why
- 3098 and 3099 built the dense spatial sidecar plus compact hotspot summaries, but downstream fusion and report/history reload paths still had no durable compact source
- this lands the compact persisted surface that 3079 can consume directly instead of reloading dense sidecars or recomputing spatial proof

## Validation
- `./.venv/bin/pytest -q apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py apps/server/tests/shared/boundaries/test_report_payload.py apps/server/tests/integration/test_contract_analysis_persistence_http.py apps/server/tests/adapters/http/test_http_api_schema_export.py`
- `make sync-contracts`
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- `make ui-typecheck`
- `make test-changed`

## Risks / tradeoffs
- this PR persists and normalizes compact spatial summaries, but it does not yet switch report preparation to prefer them over existing supporting-window heuristics; that stays for later report/fusion work
- legacy summary-only behavior stays intact by leaving the new field optional and keeping the old fallback path alive when it is absent