### PR TITLE
Define whole-run diagnosis summary contracts

### DIFF
--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -184,6 +184,9 @@ def test_export_schema_contains_typed_analysis_summary_for_history_run(
     assert analysis_summary["properties"]["whole_run_spatial_summaries"]["items"] == {
         "$ref": "#/components/schemas/SpatialEvidenceSummaryResponse",
     }
+    assert analysis_summary["properties"]["whole_run_diagnosis_summaries"]["items"] == {
+        "$ref": "#/components/schemas/WholeRunDiagnosisSummaryResponse",
+    }
     assert analysis_summary["properties"]["speed_stats"] == {
         "$ref": "#/components/schemas/SpeedStatsResponse",
     }

--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -338,3 +338,67 @@ async def test_whole_run_spatial_summaries_survive_persistence_and_http_layers()
         insights_response["whole_run_spatial_summaries"]
         == restored_summary["whole_run_spatial_summaries"]
     )
+
+
+@pytest.mark.asyncio
+async def test_whole_run_diagnosis_summaries_survive_persistence_and_http_layers() -> None:
+    summary = _representative_summary()
+    summary["whole_run_diagnosis_summaries"] = [
+        {
+            "diagnosis_key": "wheel_1x",
+            "suspected_source": "wheel/tire",
+            "rank": 1,
+            "data_basis": "raw_backed",
+            "support_score": 0.78,
+            "counterevidence_score": 0.16,
+            "total_score": 0.62,
+            "order_hypothesis_key": "wheel_1x",
+            "spatial_candidate_key": "wheel_1x",
+            "location_proof_basis": "supporting_windows_raw_backed",
+            "supporting_window_count": 8,
+            "supporting_duration_s": 4.0,
+            "supporting_sensor_count": 2,
+            "stable_frequency_min_hz": 13.1,
+            "stable_frequency_max_hz": 13.6,
+            "dominant_location": "front-left",
+            "runner_up_location": "front-right",
+            "dominant_phase": "cruise",
+            "dominant_speed_band": "60-80 km/h",
+            "location_separation_db": 3.2,
+            "dominance_ratio": 1.4,
+            "alternative_source": "driveshaft",
+            "confidence_gap_to_alternative": 0.18,
+            "ambiguous_diagnosis": False,
+            "ambiguous_location": False,
+            "suspicious": False,
+            "weak_spatial_separation": False,
+            "has_reference_gap": True,
+            "uses_summary_fallback": False,
+            "exemplar_references": [
+                {
+                    "kind": "order_support_interval",
+                    "order_hypothesis_key": "wheel_1x",
+                    "support_interval_index": 0,
+                    "phase": "cruise",
+                    "speed_band": "60-80 km/h",
+                }
+            ],
+        }
+    ]
+    stored_run, restored_summary = _stored_run_from_summary(summary)
+
+    service = ProjectedHistoryRunService(HistoryRunService(_RunPersistenceStub(stored_run)))
+
+    run_response = await service.get_run(stored_run.run_id)
+    insights_response = await service.get_insights(stored_run.run_id, requested_lang="en")
+
+    assert run_response.analysis is not None
+    assert insights_response is not None
+    assert (
+        run_response.analysis["whole_run_diagnosis_summaries"]
+        == restored_summary["whole_run_diagnosis_summaries"]
+    )
+    assert (
+        insights_response["whole_run_diagnosis_summaries"]
+        == restored_summary["whole_run_diagnosis_summaries"]
+    )

--- a/apps/server/tests/shared/boundaries/test_report_payload.py
+++ b/apps/server/tests/shared/boundaries/test_report_payload.py
@@ -50,6 +50,7 @@ def test_report_summary_from_mapping_defaults_without_nested_metadata() -> None:
     assert summary.timeline_intervals == ()
     assert summary.whole_run_order_summaries == ()
     assert summary.whole_run_spatial_summaries == ()
+    assert summary.whole_run_diagnosis_summaries == ()
 
 
 def test_report_summary_from_mapping_projects_canonical_metadata_and_rows() -> None:
@@ -225,6 +226,64 @@ def test_report_summary_from_mapping_normalizes_whole_run_spatial_summaries() ->
     assert spatial_summary.proof_basis == "supporting_windows_raw_backed"
     assert spatial_summary.dominant_location == "front-left"
     assert spatial_summary.location_summaries[0].sensor_ids == ("sensor-front",)
+
+
+def test_report_summary_from_mapping_normalizes_whole_run_diagnosis_summaries() -> None:
+    summary = report_summary_from_mapping(
+        {
+            "run_id": "run-123",
+            "metadata": {"run_id": "run-123"},
+            "whole_run_diagnosis_summaries": [
+                {
+                    "diagnosis_key": "wheel_1x",
+                    "suspected_source": "wheel/tire",
+                    "rank": 1,
+                    "data_basis": "raw_backed",
+                    "support_score": 0.78,
+                    "counterevidence_score": 0.16,
+                    "total_score": 0.62,
+                    "order_hypothesis_key": "wheel_1x",
+                    "spatial_candidate_key": "wheel_1x",
+                    "location_proof_basis": "supporting_windows_raw_backed",
+                    "supporting_window_count": 8,
+                    "supporting_duration_s": 4.0,
+                    "supporting_sensor_count": 2,
+                    "stable_frequency_min_hz": 13.1,
+                    "stable_frequency_max_hz": 13.6,
+                    "dominant_location": "front-left",
+                    "runner_up_location": "front-right",
+                    "dominant_phase": "cruise",
+                    "dominant_speed_band": "60-80 km/h",
+                    "location_separation_db": 3.2,
+                    "dominance_ratio": 1.4,
+                    "alternative_source": "driveshaft",
+                    "confidence_gap_to_alternative": 0.18,
+                    "ambiguous_diagnosis": False,
+                    "ambiguous_location": False,
+                    "suspicious": False,
+                    "weak_spatial_separation": False,
+                    "has_reference_gap": True,
+                    "uses_summary_fallback": False,
+                    "exemplar_references": [
+                        {
+                            "kind": "order_support_interval",
+                            "order_hypothesis_key": "wheel_1x",
+                            "support_interval_index": 0,
+                            "phase": "cruise",
+                            "speed_band": "60-80 km/h",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert len(summary.whole_run_diagnosis_summaries) == 1
+    diagnosis_summary = summary.whole_run_diagnosis_summaries[0]
+    assert diagnosis_summary.diagnosis_key == "wheel_1x"
+    assert diagnosis_summary.data_basis == "raw_backed"
+    assert diagnosis_summary.location_proof_basis == "supporting_windows_raw_backed"
+    assert diagnosis_summary.exemplar_references[0].kind == "order_support_interval"
 
 
 def test_report_summary_requires_connected_active_locations() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from vibesensor.shared.types.history_analysis_contracts import (
+    DiagnosisExemplarReferenceResponse,
+    WholeRunDiagnosisSummaryResponse,
+)
+from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
+    DiagnosisExemplarReference,
+    WholeRunDiagnosisSummary,
+)
+
+
+def test_diagnosis_exemplar_reference_round_trips_json_shape() -> None:
+    exemplar = DiagnosisExemplarReference(
+        kind="order_support_interval",
+        order_hypothesis_key="wheel_1x",
+        support_interval_index=1,
+        phase="cruise",
+        speed_band="60-80 km/h",
+    )
+
+    assert DiagnosisExemplarReference.from_mapping(exemplar.to_json_object()) == exemplar
+
+
+def test_whole_run_diagnosis_summary_round_trips_nested_compact_contracts() -> None:
+    summary = WholeRunDiagnosisSummary(
+        diagnosis_key="wheel_1x",
+        suspected_source="wheel/tire",
+        rank=1,
+        data_basis="raw_backed",
+        support_score=0.78,
+        counterevidence_score=0.16,
+        total_score=0.62,
+        order_hypothesis_key="wheel_1x",
+        spatial_candidate_key="wheel_1x",
+        location_proof_basis="supporting_windows_raw_backed",
+        supporting_window_count=8,
+        supporting_duration_s=4.0,
+        supporting_sensor_count=2,
+        stable_frequency_min_hz=13.1,
+        stable_frequency_max_hz=13.6,
+        dominant_location="front-left",
+        runner_up_location="front-right",
+        dominant_phase="cruise",
+        dominant_speed_band="60-80 km/h",
+        location_separation_db=3.2,
+        dominance_ratio=1.4,
+        alternative_source="driveshaft",
+        confidence_gap_to_alternative=0.18,
+        ambiguous_diagnosis=False,
+        ambiguous_location=False,
+        suspicious=False,
+        weak_spatial_separation=False,
+        has_reference_gap=True,
+        uses_summary_fallback=False,
+        exemplar_references=(
+            DiagnosisExemplarReference(
+                kind="order_support_interval",
+                order_hypothesis_key="wheel_1x",
+                support_interval_index=0,
+                phase="cruise",
+                speed_band="60-80 km/h",
+            ),
+            DiagnosisExemplarReference(
+                kind="spatial_location",
+                spatial_candidate_key="wheel_1x",
+                location="front-left",
+            ),
+            DiagnosisExemplarReference(
+                kind="whole_run_context_interval",
+                context_segment_index=2,
+                phase="cruise",
+                speed_band="60-80 km/h",
+            ),
+        ),
+    )
+
+    assert WholeRunDiagnosisSummary.from_mapping(summary.to_json_object()) == summary
+
+
+def test_history_diagnosis_response_contracts_expose_named_summary_fields() -> None:
+    assert set(DiagnosisExemplarReferenceResponse.__annotations__) == {
+        "kind",
+        "order_hypothesis_key",
+        "support_interval_index",
+        "spatial_candidate_key",
+        "context_segment_index",
+        "location",
+        "phase",
+        "speed_band",
+    }
+    assert set(WholeRunDiagnosisSummaryResponse.__annotations__) == {
+        "diagnosis_key",
+        "suspected_source",
+        "rank",
+        "data_basis",
+        "support_score",
+        "counterevidence_score",
+        "total_score",
+        "order_hypothesis_key",
+        "spatial_candidate_key",
+        "location_proof_basis",
+        "supporting_window_count",
+        "supporting_duration_s",
+        "supporting_sensor_count",
+        "stable_frequency_min_hz",
+        "stable_frequency_max_hz",
+        "dominant_location",
+        "runner_up_location",
+        "dominant_phase",
+        "dominant_speed_band",
+        "location_separation_db",
+        "dominance_ratio",
+        "alternative_source",
+        "confidence_gap_to_alternative",
+        "ambiguous_diagnosis",
+        "ambiguous_location",
+        "suspicious",
+        "weak_spatial_separation",
+        "has_reference_gap",
+        "uses_summary_fallback",
+        "fallback_reason",
+        "exemplar_references",
+    }

--- a/apps/server/vibesensor/adapters/http/models/history.py
+++ b/apps/server/vibesensor/adapters/http/models/history.py
@@ -55,6 +55,7 @@ from vibesensor.shared.types.history_analysis_contracts import (
     SuspectedVibrationOriginPayload,
     TestPlanStepResponse,
     WholeRunContextIntervalResponse,
+    WholeRunDiagnosisSummaryResponse,
 )
 from vibesensor.shared.types.history_analysis_contracts import (
     AnalysisSummaryResponse as _SharedAnalysisSummaryResponse,
@@ -188,6 +189,7 @@ class _HistoryInsightsCoreResponse(TypedDict, total=False):
     whole_run_context_intervals: list[WholeRunContextIntervalResponse]
     whole_run_order_summaries: list[OrderTraceSummaryResponse]
     whole_run_spatial_summaries: list[SpatialEvidenceSummaryResponse]
+    whole_run_diagnosis_summaries: list[WholeRunDiagnosisSummaryResponse]
     speed_stats: Required[SpeedStatsResponse]
     speed_stats_by_phase: Required[dict[str, SpeedStatsResponse]]
     phase_info: Required[PhaseInfoResponse]

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -17,16 +17,22 @@ from vibesensor.shared.boundaries.summary_fields.hotspot import (
     location_intensity_summaries_from_rows,
 )
 from vibesensor.shared.types.analysis_views import PeakTableRow
-from vibesensor.shared.types.history_analysis_contracts import LocationProofBasis
+from vibesensor.shared.types.history_analysis_contracts import (
+    DiagnosisExemplarKind,
+    LocationProofBasis,
+    WholeRunDiagnosisDataBasis,
+)
 from vibesensor.shared.types.run_schema import RunMetadata
 
 __all__ = [
     "NormalizedReportSummary",
+    "ReportDiagnosisExemplarReference",
     "ReportOrderHarmonicEvidenceSummary",
     "ReportOrderTracePhaseSupport",
     "ReportOrderTraceSupportInterval",
     "ReportSpatialLocationSummary",
     "ReportWholeRunContextInterval",
+    "ReportWholeRunDiagnosisSummary",
     "ReportWholeRunOrderSummary",
     "ReportWholeRunSpatialSummary",
     "ReportSummaryNormalizer",
@@ -152,6 +158,20 @@ class ReportWholeRunOrderSummary:
 
 
 @dataclass(frozen=True, slots=True)
+class ReportDiagnosisExemplarReference:
+    """Typed persisted exemplar reference for one fused whole-run diagnosis."""
+
+    kind: DiagnosisExemplarKind
+    order_hypothesis_key: str | None
+    support_interval_index: int | None
+    spatial_candidate_key: str | None
+    context_segment_index: int | None
+    location: str | None
+    phase: str | None
+    speed_band: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class ReportSpatialLocationSummary:
     """Typed persisted per-location spatial evidence row for report/history reload."""
 
@@ -187,6 +207,43 @@ class ReportWholeRunSpatialSummary:
 
 
 @dataclass(frozen=True, slots=True)
+class ReportWholeRunDiagnosisSummary:
+    """Typed persisted fused diagnosis summary for report/history reload paths."""
+
+    diagnosis_key: str
+    suspected_source: str
+    rank: int
+    data_basis: WholeRunDiagnosisDataBasis
+    support_score: float | None
+    counterevidence_score: float | None
+    total_score: float | None
+    order_hypothesis_key: str | None
+    spatial_candidate_key: str | None
+    location_proof_basis: LocationProofBasis | None
+    supporting_window_count: int | None
+    supporting_duration_s: float | None
+    supporting_sensor_count: int | None
+    stable_frequency_min_hz: float | None
+    stable_frequency_max_hz: float | None
+    dominant_location: str | None
+    runner_up_location: str | None
+    dominant_phase: str | None
+    dominant_speed_band: str | None
+    location_separation_db: float | None
+    dominance_ratio: float | None
+    alternative_source: str | None
+    confidence_gap_to_alternative: float | None
+    ambiguous_diagnosis: bool
+    ambiguous_location: bool
+    suspicious: bool
+    weak_spatial_separation: bool
+    has_reference_gap: bool
+    uses_summary_fallback: bool
+    fallback_reason: str | None
+    exemplar_references: tuple[ReportDiagnosisExemplarReference, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class NormalizedReportSummary:
     """Typed report boundary object shared by report facts and renderer mapping."""
 
@@ -206,6 +263,7 @@ class NormalizedReportSummary:
     whole_run_context_intervals: tuple[ReportWholeRunContextInterval, ...]
     whole_run_order_summaries: tuple[ReportWholeRunOrderSummary, ...]
     whole_run_spatial_summaries: tuple[ReportWholeRunSpatialSummary, ...]
+    whole_run_diagnosis_summaries: tuple[ReportWholeRunDiagnosisSummary, ...]
 
 
 class ReportSummaryNormalizer:
@@ -235,6 +293,7 @@ class ReportSummaryNormalizer:
             whole_run_context_intervals=self._whole_run_context_intervals(),
             whole_run_order_summaries=self._whole_run_order_summaries(),
             whole_run_spatial_summaries=self._whole_run_spatial_summaries(),
+            whole_run_diagnosis_summaries=self._whole_run_diagnosis_summaries(),
         )
 
     def _summary_run_metadata(self) -> RunMetadata | None:
@@ -439,6 +498,64 @@ class ReportSummaryNormalizer:
             )
         return tuple(summaries)
 
+    def _whole_run_diagnosis_summaries(self) -> tuple[ReportWholeRunDiagnosisSummary, ...]:
+        raw_summaries = self._payload.get("whole_run_diagnosis_summaries")
+        if not isinstance(raw_summaries, list):
+            return ()
+        summaries: list[ReportWholeRunDiagnosisSummary] = []
+        for row in raw_summaries:
+            if not isinstance(row, Mapping):
+                continue
+            diagnosis_key = text_or_none(row.get("diagnosis_key"))
+            suspected_source = text_or_none(row.get("suspected_source"))
+            data_basis = self._diagnosis_data_basis(row.get("data_basis"))
+            if diagnosis_key is None or suspected_source is None or data_basis is None:
+                continue
+            summaries.append(
+                ReportWholeRunDiagnosisSummary(
+                    diagnosis_key=diagnosis_key,
+                    suspected_source=suspected_source,
+                    rank=coerce_count(row.get("rank")),
+                    data_basis=data_basis,
+                    support_score=optional_float(row.get("support_score")),
+                    counterevidence_score=optional_float(row.get("counterevidence_score")),
+                    total_score=optional_float(row.get("total_score")),
+                    order_hypothesis_key=text_or_none(row.get("order_hypothesis_key")),
+                    spatial_candidate_key=text_or_none(row.get("spatial_candidate_key")),
+                    location_proof_basis=self._proof_basis(row.get("location_proof_basis")),
+                    supporting_window_count=self._optional_count(
+                        row.get("supporting_window_count")
+                    ),
+                    supporting_duration_s=optional_float(row.get("supporting_duration_s")),
+                    supporting_sensor_count=self._optional_count(
+                        row.get("supporting_sensor_count")
+                    ),
+                    stable_frequency_min_hz=optional_float(row.get("stable_frequency_min_hz")),
+                    stable_frequency_max_hz=optional_float(row.get("stable_frequency_max_hz")),
+                    dominant_location=text_or_none(row.get("dominant_location")),
+                    runner_up_location=text_or_none(row.get("runner_up_location")),
+                    dominant_phase=text_or_none(row.get("dominant_phase")),
+                    dominant_speed_band=text_or_none(row.get("dominant_speed_band")),
+                    location_separation_db=optional_float(row.get("location_separation_db")),
+                    dominance_ratio=optional_float(row.get("dominance_ratio")),
+                    alternative_source=text_or_none(row.get("alternative_source")),
+                    confidence_gap_to_alternative=optional_float(
+                        row.get("confidence_gap_to_alternative")
+                    ),
+                    ambiguous_diagnosis=bool(row.get("ambiguous_diagnosis")),
+                    ambiguous_location=bool(row.get("ambiguous_location")),
+                    suspicious=bool(row.get("suspicious")),
+                    weak_spatial_separation=bool(row.get("weak_spatial_separation")),
+                    has_reference_gap=bool(row.get("has_reference_gap")),
+                    uses_summary_fallback=bool(row.get("uses_summary_fallback")),
+                    fallback_reason=text_or_none(row.get("fallback_reason")),
+                    exemplar_references=self._diagnosis_exemplar_references(
+                        row.get("exemplar_references")
+                    ),
+                )
+            )
+        return tuple(summaries)
+
     def _order_support_intervals(
         self,
         raw_intervals: object,
@@ -571,6 +688,33 @@ class ReportSummaryNormalizer:
             )
         return tuple(summaries)
 
+    def _diagnosis_exemplar_references(
+        self,
+        raw_exemplars: object,
+    ) -> tuple[ReportDiagnosisExemplarReference, ...]:
+        if not isinstance(raw_exemplars, list):
+            return ()
+        exemplars: list[ReportDiagnosisExemplarReference] = []
+        for row in raw_exemplars:
+            if not isinstance(row, Mapping):
+                continue
+            kind = self._diagnosis_exemplar_kind(row.get("kind"))
+            if kind is None:
+                continue
+            exemplars.append(
+                ReportDiagnosisExemplarReference(
+                    kind=kind,
+                    order_hypothesis_key=text_or_none(row.get("order_hypothesis_key")),
+                    support_interval_index=self._optional_count(row.get("support_interval_index")),
+                    spatial_candidate_key=text_or_none(row.get("spatial_candidate_key")),
+                    context_segment_index=self._optional_count(row.get("context_segment_index")),
+                    location=text_or_none(row.get("location")),
+                    phase=text_or_none(row.get("phase")),
+                    speed_band=text_or_none(row.get("speed_band")),
+                )
+            )
+        return tuple(exemplars)
+
     def _text_tuple(self, raw_values: object) -> tuple[str, ...]:
         if not isinstance(raw_values, list):
             return ()
@@ -589,6 +733,22 @@ class ReportSummaryNormalizer:
         }:
             return None
         return cast(LocationProofBasis, value)
+
+    def _diagnosis_exemplar_kind(self, raw_value: object) -> DiagnosisExemplarKind | None:
+        value = text_or_none(raw_value)
+        if value not in {
+            "order_support_interval",
+            "whole_run_context_interval",
+            "spatial_location",
+        }:
+            return None
+        return cast(DiagnosisExemplarKind, value)
+
+    def _diagnosis_data_basis(self, raw_value: object) -> WholeRunDiagnosisDataBasis | None:
+        value = text_or_none(raw_value)
+        if value not in {"raw_backed", "summary_only"}:
+            return None
+        return cast(WholeRunDiagnosisDataBasis, value)
 
 
 def has_projectable_report_payload(payload: Mapping[str, object]) -> bool:

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -48,8 +48,12 @@ __all__ = [
     "DataQualityResponse",
     "DataQualitySpeedCoverageResponse",
     "FindingPayload",
+    "DiagnosisExemplarKind",
+    "DiagnosisExemplarReferenceResponse",
     "LocationIntensitySummaryResponse",
     "LocationProofBasis",
+    "WholeRunDiagnosisDataBasis",
+    "WholeRunDiagnosisSummaryResponse",
     "OutlierSummaryResponse",
     "OrderHarmonicEvidenceSummaryResponse",
     "OrderTracePhaseSupportResponse",
@@ -74,6 +78,12 @@ __all__ = [
 
 type PayloadObject = JsonSchemaObject
 type PayloadValue = JsonSchemaValue
+type DiagnosisExemplarKind = Literal[
+    "order_support_interval",
+    "whole_run_context_interval",
+    "spatial_location",
+]
+type WholeRunDiagnosisDataBasis = Literal["raw_backed", "summary_only"]
 type LocationProofBasis = Literal[
     "whole_run_summary",
     "supporting_windows_raw_backed",
@@ -264,6 +274,55 @@ class SpatialEvidenceSummaryResponse(TypedDict, total=False):
     location_summaries: Required[list[SpatialLocationSummaryResponse]]
 
 
+class DiagnosisExemplarReferenceResponse(TypedDict, total=False):
+    """Compact reference to one persisted exemplar used by a fused diagnosis."""
+
+    kind: Required[DiagnosisExemplarKind]
+    order_hypothesis_key: str | None
+    support_interval_index: int | None
+    spatial_candidate_key: str | None
+    context_segment_index: int | None
+    location: str | None
+    phase: str | None
+    speed_band: str | None
+
+
+class WholeRunDiagnosisSummaryResponse(TypedDict, total=False):
+    """Future persisted/report-facing summary shape for fused whole-run diagnoses."""
+
+    diagnosis_key: Required[str]
+    suspected_source: Required[str]
+    rank: Required[int]
+    data_basis: Required[WholeRunDiagnosisDataBasis]
+    support_score: float | None
+    counterevidence_score: float | None
+    total_score: float | None
+    order_hypothesis_key: str | None
+    spatial_candidate_key: str | None
+    location_proof_basis: LocationProofBasis | None
+    supporting_window_count: int | None
+    supporting_duration_s: float | None
+    supporting_sensor_count: int | None
+    stable_frequency_min_hz: float | None
+    stable_frequency_max_hz: float | None
+    dominant_location: str | None
+    runner_up_location: str | None
+    dominant_phase: str | None
+    dominant_speed_band: str | None
+    location_separation_db: float | None
+    dominance_ratio: float | None
+    alternative_source: str | None
+    confidence_gap_to_alternative: float | None
+    ambiguous_diagnosis: Required[bool]
+    ambiguous_location: Required[bool]
+    suspicious: Required[bool]
+    weak_spatial_separation: Required[bool]
+    has_reference_gap: Required[bool]
+    uses_summary_fallback: Required[bool]
+    fallback_reason: str | None
+    exemplar_references: Required[list[DiagnosisExemplarReferenceResponse]]
+
+
 class SpeedStatsResponse(TypedDict):
     """Response body for one summarized speed-profile snapshot."""
 
@@ -378,6 +437,7 @@ class AnalysisSummaryCoreResponse(TypedDict, total=False):
     whole_run_context_intervals: list[WholeRunContextIntervalResponse]
     whole_run_order_summaries: list[OrderTraceSummaryResponse]
     whole_run_spatial_summaries: list[SpatialEvidenceSummaryResponse]
+    whole_run_diagnosis_summaries: list[WholeRunDiagnosisSummaryResponse]
     speed_stats: Required[SpeedStatsResponse]
     speed_stats_by_phase: Required[dict[str, SpeedStatsResponse]]
     phase_info: Required[PhaseInfoResponse]
@@ -420,6 +480,8 @@ for _typed_dict in (
     OrderTraceSummaryResponse,
     SpatialLocationSummaryResponse,
     SpatialEvidenceSummaryResponse,
+    DiagnosisExemplarReferenceResponse,
+    WholeRunDiagnosisSummaryResponse,
     SpeedStatsResponse,
     PhaseInfoResponse,
     OutlierSummaryResponse,

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
@@ -1,0 +1,295 @@
+"""Whole-run fused diagnosis contracts for persisted summaries and exemplars.
+
+These compact contracts sit above the whole-run context, order, and spatial
+summary layers. They intentionally define the diagnosis shell, ambiguity flags,
+fallback markers, and exemplar references before later issues settle the stable
+support/counterevidence factor vocabulary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+from vibesensor.shared.types.history_analysis_contracts import (
+    DiagnosisExemplarKind,
+    LocationProofBasis,
+    WholeRunDiagnosisDataBasis,
+)
+from vibesensor.shared.types.json_types import JsonObject, JsonValue
+
+__all__ = [
+    "DiagnosisExemplarReference",
+    "WholeRunDiagnosisSummary",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisExemplarReference:
+    """Compact reference to one persisted exemplar for a fused diagnosis."""
+
+    kind: DiagnosisExemplarKind
+    order_hypothesis_key: str | None = None
+    support_interval_index: int | None = None
+    spatial_candidate_key: str | None = None
+    context_segment_index: int | None = None
+    location: str | None = None
+    phase: str | None = None
+    speed_band: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind == "order_support_interval":
+            _require_text(self.order_hypothesis_key, field_name="order_hypothesis_key")
+        elif self.kind == "whole_run_context_interval":
+            if self.context_segment_index is None:
+                raise ValueError("context_segment_index is required for whole_run_context_interval")
+        elif self.kind == "spatial_location":
+            _require_text(self.spatial_candidate_key, field_name="spatial_candidate_key")
+            _require_text(self.location, field_name="location")
+        if self.support_interval_index is not None:
+            _require_nonnegative(self.support_interval_index, field_name="support_interval_index")
+        if self.context_segment_index is not None:
+            _require_nonnegative(self.context_segment_index, field_name="context_segment_index")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {"kind": self.kind}
+        _set_optional(payload, "order_hypothesis_key", self.order_hypothesis_key)
+        _set_optional(payload, "support_interval_index", self.support_interval_index)
+        _set_optional(payload, "spatial_candidate_key", self.spatial_candidate_key)
+        _set_optional(payload, "context_segment_index", self.context_segment_index)
+        _set_optional(payload, "location", self.location)
+        _set_optional(payload, "phase", self.phase)
+        _set_optional(payload, "speed_band", self.speed_band)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> DiagnosisExemplarReference:
+        return cls(
+            kind=_required_exemplar_kind(data.get("kind")),
+            order_hypothesis_key=_optional_text(data.get("order_hypothesis_key")),
+            support_interval_index=_optional_int(data.get("support_interval_index")),
+            spatial_candidate_key=_optional_text(data.get("spatial_candidate_key")),
+            context_segment_index=_optional_int(data.get("context_segment_index")),
+            location=_optional_text(data.get("location")),
+            phase=_optional_text(data.get("phase")),
+            speed_band=_optional_text(data.get("speed_band")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunDiagnosisSummary:
+    """Compact persisted/report-facing summary for one fused whole-run diagnosis."""
+
+    diagnosis_key: str
+    suspected_source: str
+    rank: int
+    data_basis: WholeRunDiagnosisDataBasis
+    support_score: float | None = None
+    counterevidence_score: float | None = None
+    total_score: float | None = None
+    order_hypothesis_key: str | None = None
+    spatial_candidate_key: str | None = None
+    location_proof_basis: LocationProofBasis | None = None
+    supporting_window_count: int | None = None
+    supporting_duration_s: float | None = None
+    supporting_sensor_count: int | None = None
+    stable_frequency_min_hz: float | None = None
+    stable_frequency_max_hz: float | None = None
+    dominant_location: str | None = None
+    runner_up_location: str | None = None
+    dominant_phase: str | None = None
+    dominant_speed_band: str | None = None
+    location_separation_db: float | None = None
+    dominance_ratio: float | None = None
+    alternative_source: str | None = None
+    confidence_gap_to_alternative: float | None = None
+    ambiguous_diagnosis: bool = False
+    ambiguous_location: bool = False
+    suspicious: bool = False
+    weak_spatial_separation: bool = False
+    has_reference_gap: bool = False
+    uses_summary_fallback: bool = False
+    fallback_reason: str | None = None
+    exemplar_references: tuple[DiagnosisExemplarReference, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_text(self.diagnosis_key, field_name="diagnosis_key")
+        _require_text(self.suspected_source, field_name="suspected_source")
+        _require_nonnegative(self.rank, field_name="rank")
+        if self.supporting_window_count is not None:
+            _require_nonnegative(self.supporting_window_count, field_name="supporting_window_count")
+        if self.supporting_sensor_count is not None:
+            _require_nonnegative(self.supporting_sensor_count, field_name="supporting_sensor_count")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "diagnosis_key": self.diagnosis_key,
+            "suspected_source": self.suspected_source,
+            "rank": self.rank,
+            "data_basis": self.data_basis,
+            "ambiguous_diagnosis": self.ambiguous_diagnosis,
+            "ambiguous_location": self.ambiguous_location,
+            "suspicious": self.suspicious,
+            "weak_spatial_separation": self.weak_spatial_separation,
+            "has_reference_gap": self.has_reference_gap,
+            "uses_summary_fallback": self.uses_summary_fallback,
+            "exemplar_references": [
+                exemplar.to_json_object() for exemplar in self.exemplar_references
+            ],
+        }
+        _set_optional(payload, "support_score", self.support_score)
+        _set_optional(payload, "counterevidence_score", self.counterevidence_score)
+        _set_optional(payload, "total_score", self.total_score)
+        _set_optional(payload, "order_hypothesis_key", self.order_hypothesis_key)
+        _set_optional(payload, "spatial_candidate_key", self.spatial_candidate_key)
+        _set_optional(payload, "location_proof_basis", self.location_proof_basis)
+        _set_optional(payload, "supporting_window_count", self.supporting_window_count)
+        _set_optional(payload, "supporting_duration_s", self.supporting_duration_s)
+        _set_optional(payload, "supporting_sensor_count", self.supporting_sensor_count)
+        _set_optional(payload, "stable_frequency_min_hz", self.stable_frequency_min_hz)
+        _set_optional(payload, "stable_frequency_max_hz", self.stable_frequency_max_hz)
+        _set_optional(payload, "dominant_location", self.dominant_location)
+        _set_optional(payload, "runner_up_location", self.runner_up_location)
+        _set_optional(payload, "dominant_phase", self.dominant_phase)
+        _set_optional(payload, "dominant_speed_band", self.dominant_speed_band)
+        _set_optional(payload, "location_separation_db", self.location_separation_db)
+        _set_optional(payload, "dominance_ratio", self.dominance_ratio)
+        _set_optional(payload, "alternative_source", self.alternative_source)
+        _set_optional(payload, "confidence_gap_to_alternative", self.confidence_gap_to_alternative)
+        _set_optional(payload, "fallback_reason", self.fallback_reason)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunDiagnosisSummary:
+        raw_exemplars = data.get("exemplar_references")
+        exemplars = (
+            tuple(
+                DiagnosisExemplarReference.from_mapping(row)
+                for row in raw_exemplars
+                if isinstance(row, dict)
+            )
+            if isinstance(raw_exemplars, list)
+            else ()
+        )
+        return cls(
+            diagnosis_key=_required_text(data, "diagnosis_key"),
+            suspected_source=_required_text(data, "suspected_source"),
+            rank=_required_int(data, "rank"),
+            data_basis=_required_data_basis(data.get("data_basis")),
+            support_score=_optional_float(data.get("support_score")),
+            counterevidence_score=_optional_float(data.get("counterevidence_score")),
+            total_score=_optional_float(data.get("total_score")),
+            order_hypothesis_key=_optional_text(data.get("order_hypothesis_key")),
+            spatial_candidate_key=_optional_text(data.get("spatial_candidate_key")),
+            location_proof_basis=_optional_proof_basis(data.get("location_proof_basis")),
+            supporting_window_count=_optional_int(data.get("supporting_window_count")),
+            supporting_duration_s=_optional_float(data.get("supporting_duration_s")),
+            supporting_sensor_count=_optional_int(data.get("supporting_sensor_count")),
+            stable_frequency_min_hz=_optional_float(data.get("stable_frequency_min_hz")),
+            stable_frequency_max_hz=_optional_float(data.get("stable_frequency_max_hz")),
+            dominant_location=_optional_text(data.get("dominant_location")),
+            runner_up_location=_optional_text(data.get("runner_up_location")),
+            dominant_phase=_optional_text(data.get("dominant_phase")),
+            dominant_speed_band=_optional_text(data.get("dominant_speed_band")),
+            location_separation_db=_optional_float(data.get("location_separation_db")),
+            dominance_ratio=_optional_float(data.get("dominance_ratio")),
+            alternative_source=_optional_text(data.get("alternative_source")),
+            confidence_gap_to_alternative=_optional_float(
+                data.get("confidence_gap_to_alternative")
+            ),
+            ambiguous_diagnosis=_required_bool(data, "ambiguous_diagnosis"),
+            ambiguous_location=_required_bool(data, "ambiguous_location"),
+            suspicious=_required_bool(data, "suspicious"),
+            weak_spatial_separation=_required_bool(data, "weak_spatial_separation"),
+            has_reference_gap=_required_bool(data, "has_reference_gap"),
+            uses_summary_fallback=_required_bool(data, "uses_summary_fallback"),
+            fallback_reason=_optional_text(data.get("fallback_reason")),
+            exemplar_references=exemplars,
+        )
+
+
+def _require_text(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def _require_nonnegative(value: int, *, field_name: str) -> None:
+    if value < 0:
+        raise ValueError(f"{field_name} must be >= 0")
+
+
+def _required_text(data: JsonObject, field_name: str) -> str:
+    return _require_text(data.get(field_name), field_name=field_name)
+
+
+def _required_int(data: JsonObject, field_name: str) -> int:
+    value = data.get(field_name)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an int")
+    return value
+
+
+def _required_bool(data: JsonObject, field_name: str) -> bool:
+    value = data.get(field_name)
+    if not isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a bool")
+    return value
+
+
+def _required_exemplar_kind(value: object) -> DiagnosisExemplarKind:
+    if value not in {
+        "order_support_interval",
+        "whole_run_context_interval",
+        "spatial_location",
+    }:
+        raise ValueError("kind must be a supported diagnosis exemplar kind")
+    return cast(DiagnosisExemplarKind, value)
+
+
+def _required_data_basis(value: object) -> WholeRunDiagnosisDataBasis:
+    if value not in {"raw_backed", "summary_only"}:
+        raise ValueError("data_basis must be a supported whole-run diagnosis data basis")
+    return cast(WholeRunDiagnosisDataBasis, value)
+
+
+def _optional_proof_basis(value: object) -> LocationProofBasis | None:
+    if value is None:
+        return None
+    if value not in {
+        "whole_run_summary",
+        "supporting_windows_raw_backed",
+        "supporting_windows_summary_only",
+    }:
+        raise ValueError("location_proof_basis must be a supported location proof basis")
+    return cast(LocationProofBasis, value)
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("optional numeric field must be a number or null")
+    return float(value)
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError("optional int field must be an int or null")
+    return value
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("optional text field must be a string or null")
+    text = value.strip()
+    return text or None
+
+
+def _set_optional(payload: JsonObject, key: str, value: JsonValue | None) -> None:
+    if value is not None:
+        payload[key] = value

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -769,6 +769,13 @@
             "title": "Whole Run Context Intervals",
             "type": "array"
           },
+          "whole_run_diagnosis_summaries": {
+            "items": {
+              "$ref": "#/components/schemas/WholeRunDiagnosisSummaryResponse"
+            },
+            "title": "Whole Run Diagnosis Summaries",
+            "type": "array"
+          },
           "whole_run_order_summaries": {
             "items": {
               "$ref": "#/components/schemas/OrderTraceSummaryResponse"
@@ -1720,6 +1727,104 @@
           "status"
         ],
         "title": "DeleteHistoryRunResponse",
+        "type": "object"
+      },
+      "DiagnosisExemplarKind": {
+        "enum": [
+          "order_support_interval",
+          "whole_run_context_interval",
+          "spatial_location"
+        ],
+        "type": "string"
+      },
+      "DiagnosisExemplarReferenceResponse": {
+        "description": "Compact reference to one persisted exemplar used by a fused diagnosis.",
+        "properties": {
+          "context_segment_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Context Segment Index"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/DiagnosisExemplarKind"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "order_hypothesis_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Hypothesis Key"
+          },
+          "phase": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase"
+          },
+          "spatial_candidate_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spatial Candidate Key"
+          },
+          "speed_band": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed Band"
+          },
+          "support_interval_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Support Interval Index"
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "title": "DiagnosisExemplarReferenceResponse",
         "type": "object"
       },
       "EspFlashCancelResponse": {
@@ -3445,6 +3550,13 @@
               "$ref": "#/components/schemas/WholeRunContextIntervalResponse"
             },
             "title": "Whole Run Context Intervals",
+            "type": "array"
+          },
+          "whole_run_diagnosis_summaries": {
+            "items": {
+              "$ref": "#/components/schemas/WholeRunDiagnosisSummaryResponse"
+            },
+            "title": "Whole Run Diagnosis Summaries",
             "type": "array"
           },
           "whole_run_order_summaries": {
@@ -7573,6 +7685,298 @@
           "missing_context_window_count"
         ],
         "title": "WholeRunContextIntervalResponse",
+        "type": "object"
+      },
+      "WholeRunDiagnosisDataBasis": {
+        "enum": [
+          "raw_backed",
+          "summary_only"
+        ],
+        "type": "string"
+      },
+      "WholeRunDiagnosisSummaryResponse": {
+        "description": "Future persisted/report-facing summary shape for fused whole-run diagnoses.",
+        "properties": {
+          "alternative_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alternative Source"
+          },
+          "ambiguous_diagnosis": {
+            "title": "Ambiguous Diagnosis",
+            "type": "boolean"
+          },
+          "ambiguous_location": {
+            "title": "Ambiguous Location",
+            "type": "boolean"
+          },
+          "confidence_gap_to_alternative": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence Gap To Alternative"
+          },
+          "counterevidence_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Counterevidence Score"
+          },
+          "data_basis": {
+            "$ref": "#/components/schemas/WholeRunDiagnosisDataBasis"
+          },
+          "diagnosis_key": {
+            "title": "Diagnosis Key",
+            "type": "string"
+          },
+          "dominance_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dominance Ratio"
+          },
+          "dominant_location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dominant Location"
+          },
+          "dominant_phase": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dominant Phase"
+          },
+          "dominant_speed_band": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dominant Speed Band"
+          },
+          "exemplar_references": {
+            "items": {
+              "$ref": "#/components/schemas/DiagnosisExemplarReferenceResponse"
+            },
+            "title": "Exemplar References",
+            "type": "array"
+          },
+          "fallback_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fallback Reason"
+          },
+          "has_reference_gap": {
+            "title": "Has Reference Gap",
+            "type": "boolean"
+          },
+          "location_proof_basis": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LocationProofBasis"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "location_separation_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Separation Db"
+          },
+          "order_hypothesis_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Order Hypothesis Key"
+          },
+          "rank": {
+            "title": "Rank",
+            "type": "integer"
+          },
+          "runner_up_location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runner Up Location"
+          },
+          "spatial_candidate_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spatial Candidate Key"
+          },
+          "stable_frequency_max_hz": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stable Frequency Max Hz"
+          },
+          "stable_frequency_min_hz": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stable Frequency Min Hz"
+          },
+          "support_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Support Score"
+          },
+          "supporting_duration_s": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supporting Duration S"
+          },
+          "supporting_sensor_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supporting Sensor Count"
+          },
+          "supporting_window_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supporting Window Count"
+          },
+          "suspected_source": {
+            "title": "Suspected Source",
+            "type": "string"
+          },
+          "suspicious": {
+            "title": "Suspicious",
+            "type": "boolean"
+          },
+          "total_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Score"
+          },
+          "uses_summary_fallback": {
+            "title": "Uses Summary Fallback",
+            "type": "boolean"
+          },
+          "weak_spatial_separation": {
+            "title": "Weak Spatial Separation",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "diagnosis_key",
+          "suspected_source",
+          "rank",
+          "data_basis",
+          "ambiguous_diagnosis",
+          "ambiguous_location",
+          "suspicious",
+          "weak_spatial_separation",
+          "has_reference_gap",
+          "uses_summary_fallback",
+          "exemplar_references"
+        ],
+        "title": "WholeRunDiagnosisSummaryResponse",
         "type": "object"
       }
     }

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -330,6 +330,23 @@ not just renderer-time prose. Good initial keys fit the current
 Whole-run fusion can add new stable keys, but should continue producing compact,
 explainable factors that reporting can consume directly.
 
+The contract owner for the fused output should now live in
+`apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py`.
+That layer should settle:
+
+- compact `WholeRunDiagnosisSummary` rows persisted as
+  `whole_run_diagnosis_summaries`
+- structured `DiagnosisExemplarReference` links back to compact order support
+  intervals, spatial hotspot rows, and context intervals already persisted
+  elsewhere
+- explicit top-level ambiguity, suspicious-case, and fallback markers that later
+  report/history consumers can project without inventing a second diagnosis
+  wrapper
+
+Stable support-factor and counterevidence-factor vocabularies still belong to
+the follow-on factor issue; this contract stage should define the diagnosis shell
+without burying those semantics in renderer-only prose.
+
 ## Shared contracts to settle early
 
 | Contract | Suggested owner | Notes |
@@ -342,7 +359,7 @@ explainable factors that reporting can consume directly.
 | `OrderTracePoint` / `OrderTraceSummary` | `apps/server/vibesensor/use_cases/diagnostics/orders/whole_run_contracts.py` with persisted summary projection in `shared/types/history_analysis_contracts.py` | Dense trace vs compact report/history summary split |
 | `SpatialEvidenceSummary` | `apps/server/vibesensor/use_cases/diagnostics/spatial_evidence_contracts.py` with persisted summary projection in `shared/types/history_analysis_contracts.py` | Candidate-level coherence, location separation, ambiguity flags, and proof basis |
 | `WholeRunSpatialAlignmentMatrix` / `AlignedSpatialWindow` | `apps/server/vibesensor/use_cases/diagnostics/whole_run_spatial_alignment.py` | Deterministic per-window sensor joins with explicit coverage-state semantics for later spatial scoring |
-| `DiagnosisFactor` / `DiagnosisSummary` | diagnostics domain/use-case layer plus persisted projection | Explainable support and counterevidence for final ranking |
+| `DiagnosisExemplarReference` / `WholeRunDiagnosisSummary` | `apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py` with persisted projection in `shared/types/history_analysis_contracts.py` | Fused diagnosis shell, exemplar links to compact order/spatial/context summaries, and explicit ambiguity/fallback markers for later ranking/report wiring |
 
 For the context track:
 


### PR DESCRIPTION
Closes #3101

## What changed
- add `whole_run_diagnosis_contracts.py` with compact `WholeRunDiagnosisSummary` and `DiagnosisExemplarReference` owners
- extend persisted/history/HTTP/report-normalization contracts with `whole_run_diagnosis_summaries`
- sync the generated HTTP schema artifact and add focused contract, report-boundary, integration, and schema regressions
- document that 3101 lands the diagnosis shell now while 3102 still owns stable support/counterevidence factor keys

## Why
- order and spatial summaries now exist, but 3079 still had no durable diagnosis summary contract tying rank, fallback state, ambiguity, and exemplar links together
- this gives later fusion, fallback, and report work one persisted diagnosis shape instead of inventing ad hoc JSON at each boundary

## Validation
- `./.venv/bin/pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py apps/server/tests/shared/boundaries/test_report_payload.py apps/server/tests/integration/test_contract_analysis_persistence_http.py apps/server/tests/adapters/http/test_http_api_schema_export.py`
- `make format`
- `make sync-contracts`
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- `make ui-typecheck`
- `make test-changed`

## Risks / tradeoffs
- this PR defines the persisted diagnosis shell, but it does not yet define stable support/counterevidence factor keys or implement the ranker; those stay in 3102 and 3103
- the new field is optional so old payloads still decode cleanly and report/history paths can stay empty until the ranker starts populating it