### PR TITLE
Model stable whole-run diagnosis factors

### DIFF
--- a/apps/server/tests/adapters/http/test_http_api_schema_export.py
+++ b/apps/server/tests/adapters/http/test_http_api_schema_export.py
@@ -118,6 +118,8 @@ def test_export_schema_contains_typed_analysis_summary_for_history_run(
 ) -> None:
     history_run = schema_dict["components"]["schemas"]["HistoryRunResponse"]
     analysis_summary = schema_dict["components"]["schemas"]["AnalysisSummaryResponse"]
+    diagnosis_summary = schema_dict["components"]["schemas"]["WholeRunDiagnosisSummaryResponse"]
+    diagnosis_factor = schema_dict["components"]["schemas"]["DiagnosisFactorResponse"]
     finding_payload = schema_dict["components"]["schemas"]["FindingPayload"]
     car_gearbox = schema_dict["components"]["schemas"]["CarLibraryGearboxEntry"]
     plot_data = schema_dict["components"]["schemas"]["PlotDataResult"]
@@ -186,6 +188,15 @@ def test_export_schema_contains_typed_analysis_summary_for_history_run(
     }
     assert analysis_summary["properties"]["whole_run_diagnosis_summaries"]["items"] == {
         "$ref": "#/components/schemas/WholeRunDiagnosisSummaryResponse",
+    }
+    assert diagnosis_summary["properties"]["support_factors"]["items"] == {
+        "$ref": "#/components/schemas/DiagnosisFactorResponse",
+    }
+    assert diagnosis_summary["properties"]["counterevidence_factors"]["items"] == {
+        "$ref": "#/components/schemas/DiagnosisFactorResponse",
+    }
+    assert diagnosis_factor["properties"]["details"] == {
+        "$ref": "#/components/schemas/DiagnosisFactorDetailsResponse",
     }
     assert analysis_summary["properties"]["speed_stats"] == {
         "$ref": "#/components/schemas/SpeedStatsResponse",

--- a/apps/server/tests/integration/test_contract_analysis_persistence_http.py
+++ b/apps/server/tests/integration/test_contract_analysis_persistence_http.py
@@ -374,6 +374,24 @@ async def test_whole_run_diagnosis_summaries_survive_persistence_and_http_layers
             "weak_spatial_separation": False,
             "has_reference_gap": True,
             "uses_summary_fallback": False,
+            "support_factors": [
+                {
+                    "factor_key": "raw_backed",
+                    "polarity": "support",
+                    "severity": "high",
+                    "weight": 0.1,
+                    "details": {"raw_backed_sample_count": 48},
+                }
+            ],
+            "counterevidence_factors": [
+                {
+                    "factor_key": "incomplete_reference",
+                    "polarity": "counterevidence",
+                    "severity": "low",
+                    "weight": 0.06,
+                    "details": {},
+                }
+            ],
             "exemplar_references": [
                 {
                     "kind": "order_support_interval",
@@ -402,3 +420,6 @@ async def test_whole_run_diagnosis_summaries_survive_persistence_and_http_layers
         insights_response["whole_run_diagnosis_summaries"]
         == restored_summary["whole_run_diagnosis_summaries"]
     )
+    diagnosis_summary = insights_response["whole_run_diagnosis_summaries"][0]
+    assert diagnosis_summary["support_factors"][0]["factor_key"] == "raw_backed"
+    assert diagnosis_summary["counterevidence_factors"][0]["factor_key"] == "incomplete_reference"

--- a/apps/server/tests/shared/boundaries/test_report_payload.py
+++ b/apps/server/tests/shared/boundaries/test_report_payload.py
@@ -264,6 +264,24 @@ def test_report_summary_from_mapping_normalizes_whole_run_diagnosis_summaries() 
                     "weak_spatial_separation": False,
                     "has_reference_gap": True,
                     "uses_summary_fallback": False,
+                    "support_factors": [
+                        {
+                            "factor_key": "raw_backed",
+                            "polarity": "support",
+                            "severity": "high",
+                            "weight": 0.1,
+                            "details": {"raw_backed_sample_count": 48},
+                        }
+                    ],
+                    "counterevidence_factors": [
+                        {
+                            "factor_key": "incomplete_reference",
+                            "polarity": "counterevidence",
+                            "severity": "low",
+                            "weight": 0.06,
+                            "details": {},
+                        }
+                    ],
                     "exemplar_references": [
                         {
                             "kind": "order_support_interval",
@@ -283,6 +301,8 @@ def test_report_summary_from_mapping_normalizes_whole_run_diagnosis_summaries() 
     assert diagnosis_summary.diagnosis_key == "wheel_1x"
     assert diagnosis_summary.data_basis == "raw_backed"
     assert diagnosis_summary.location_proof_basis == "supporting_windows_raw_backed"
+    assert diagnosis_summary.support_factors[0].factor_key == "raw_backed"
+    assert diagnosis_summary.counterevidence_factors[0].factor_key == "incomplete_reference"
     assert diagnosis_summary.exemplar_references[0].kind == "order_support_interval"
 
 

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from vibesensor.shared.types.history_analysis_contracts import (
     DiagnosisExemplarReferenceResponse,
+    DiagnosisFactorDetailsResponse,
+    DiagnosisFactorResponse,
     WholeRunDiagnosisSummaryResponse,
 )
 from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
     DiagnosisExemplarReference,
+    DiagnosisFactor,
+    DiagnosisFactorDetails,
     WholeRunDiagnosisSummary,
 )
 
@@ -73,6 +77,24 @@ def test_whole_run_diagnosis_summary_round_trips_nested_compact_contracts() -> N
                 speed_band="60-80 km/h",
             ),
         ),
+        support_factors=(
+            DiagnosisFactor(
+                factor_key="raw_backed",
+                polarity="support",
+                severity="high",
+                weight=0.10,
+                details=DiagnosisFactorDetails(raw_backed_sample_count=48),
+            ),
+        ),
+        counterevidence_factors=(
+            DiagnosisFactor(
+                factor_key="incomplete_reference",
+                polarity="counterevidence",
+                severity="low",
+                weight=0.06,
+                details=DiagnosisFactorDetails(),
+            ),
+        ),
     )
 
     assert WholeRunDiagnosisSummary.from_mapping(summary.to_json_object()) == summary
@@ -88,6 +110,30 @@ def test_history_diagnosis_response_contracts_expose_named_summary_fields() -> N
         "location",
         "phase",
         "speed_band",
+    }
+    assert set(DiagnosisFactorDetailsResponse.__annotations__) == {
+        "raw_backed_sample_count",
+        "supporting_window_count",
+        "supporting_duration_s",
+        "stable_frequency_min_hz",
+        "stable_frequency_max_hz",
+        "frequency_span_hz",
+        "supporting_location_count",
+        "top_support_location",
+        "top_support_share",
+        "mean_relative_error",
+        "snr_db",
+        "alternative_source",
+        "speed_gap_window_count",
+        "rpm_gap_window_count",
+        "fallback_reason",
+    }
+    assert set(DiagnosisFactorResponse.__annotations__) == {
+        "factor_key",
+        "polarity",
+        "severity",
+        "weight",
+        "details",
     }
     assert set(WholeRunDiagnosisSummaryResponse.__annotations__) == {
         "diagnosis_key",
@@ -121,4 +167,6 @@ def test_history_diagnosis_response_contracts_expose_named_summary_fields() -> N
         "uses_summary_fallback",
         "fallback_reason",
         "exemplar_references",
+        "support_factors",
+        "counterevidence_factors",
     }

--- a/apps/server/tests/use_cases/history/test_whole_run_diagnosis_factors.py
+++ b/apps/server/tests/use_cases/history/test_whole_run_diagnosis_factors.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.shared.boundaries.reporting.confidence_facts import (
+    ReportConfidenceFacts,
+    project_whole_run_diagnosis_factors,
+)
+
+
+def test_project_whole_run_diagnosis_factors_maps_support_signals_to_stable_rows() -> None:
+    support_factors, counter_factors = project_whole_run_diagnosis_factors(
+        ReportConfidenceFacts(
+            score_0_to_1=0.9,
+            label_key="CONFIDENCE_HIGH",
+            pct_text="90%",
+            tier="C",
+            data_basis="raw_backed",
+            raw_backed_sample_count=48,
+            supporting_window_count=6,
+            supporting_duration_s=3.0,
+            stable_frequency_min_hz=13.1,
+            stable_frequency_max_hz=13.4,
+            supporting_location_count=1,
+            top_support_location="front-left",
+            top_support_share=0.9,
+            mean_relative_error=0.03,
+            snr_db=8.5,
+            alternative_source=None,
+            has_reference_gap=False,
+            speed_gap_window_count=0,
+            rpm_gap_window_count=0,
+            uses_summary_fallback=False,
+            fallback_reason=None,
+            signal_keys=(
+                "raw_backed",
+                "repeated_support",
+                "sustained_support",
+                "stable_frequency",
+                "tight_order_lock",
+                "localized_support",
+                "clean_signal",
+            ),
+            caveat_keys=(),
+        )
+    )
+
+    assert counter_factors == ()
+    assert [factor["factor_key"] for factor in support_factors] == [
+        "raw_backed",
+        "repeated_support",
+        "sustained_support",
+        "stable_frequency",
+        "tight_order_lock",
+        "localized_support",
+        "clean_signal",
+    ]
+    assert support_factors[0]["weight"] == 0.10
+    assert support_factors[0]["details"]["raw_backed_sample_count"] == 48
+    assert support_factors[3]["details"]["frequency_span_hz"] == pytest.approx(0.3)
+    assert support_factors[5]["details"]["top_support_location"] == "front-left"
+
+
+def test_project_whole_run_diagnosis_factors_maps_counterevidence_signals_to_stable_rows() -> None:
+    support_factors, counter_factors = project_whole_run_diagnosis_factors(
+        ReportConfidenceFacts(
+            score_0_to_1=0.3,
+            label_key="CONFIDENCE_LOW",
+            pct_text="30%",
+            tier="A",
+            data_basis="summary_only",
+            raw_backed_sample_count=0,
+            supporting_window_count=1,
+            supporting_duration_s=0.2,
+            stable_frequency_min_hz=12.0,
+            stable_frequency_max_hz=14.2,
+            supporting_location_count=2,
+            top_support_location="front-left",
+            top_support_share=0.5,
+            mean_relative_error=0.22,
+            snr_db=2.5,
+            alternative_source="driveshaft",
+            has_reference_gap=True,
+            speed_gap_window_count=3,
+            rpm_gap_window_count=2,
+            uses_summary_fallback=True,
+            fallback_reason="summary-only legacy confidence",
+            signal_keys=(),
+            caveat_keys=(
+                "summary_only",
+                "speed_context_gaps",
+                "rpm_context_gaps",
+                "sparse_support",
+                "brief_support",
+                "drifting_frequency",
+                "loose_order_lock",
+                "mixed_support_locations",
+                "noisy_signal",
+                "weak_spatial",
+                "close_alternative",
+                "incomplete_reference",
+            ),
+        )
+    )
+
+    assert support_factors == ()
+    assert [factor["factor_key"] for factor in counter_factors] == [
+        "summary_only",
+        "speed_context_gaps",
+        "rpm_context_gaps",
+        "sparse_support",
+        "brief_support",
+        "drifting_frequency",
+        "loose_order_lock",
+        "mixed_support_locations",
+        "noisy_signal",
+        "weak_spatial",
+        "close_alternative",
+        "incomplete_reference",
+    ]
+    assert counter_factors[0]["details"]["fallback_reason"] == "summary-only legacy confidence"
+    assert counter_factors[1]["details"]["speed_gap_window_count"] == 3
+    assert counter_factors[5]["details"]["frequency_span_hz"] == pytest.approx(2.2)
+    assert counter_factors[10]["details"]["alternative_source"] == "driveshaft"

--- a/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from vibesensor.domain import Finding
 from vibesensor.shared.boundaries.reporting.decision_facts import ReportDecisionFacts
 from vibesensor.shared.boundaries.reporting.evidence_facts import ReportEvidenceFacts
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
+from vibesensor.shared.types.history_analysis_contracts import (
+    DiagnosisFactorDetailsResponse,
+    DiagnosisFactorKey,
+    DiagnosisFactorPolarity,
+    DiagnosisFactorResponse,
+    DiagnosisFactorSeverity,
+)
 
 if TYPE_CHECKING:
     from vibesensor.shared.boundaries.reporting.facts import ReportContextFacts
@@ -17,6 +24,7 @@ if TYPE_CHECKING:
 __all__ = [
     "ReportConfidenceFacts",
     "build_report_confidence_facts",
+    "project_whole_run_diagnosis_factors",
 ]
 
 
@@ -41,6 +49,8 @@ class ReportConfidenceFacts:
     snr_db: float | None
     alternative_source: str | None
     has_reference_gap: bool
+    speed_gap_window_count: int
+    rpm_gap_window_count: int
     uses_summary_fallback: bool
     fallback_reason: str | None
     signal_keys: tuple[str, ...]
@@ -235,6 +245,8 @@ def build_report_confidence_facts(
         snr_db=snr_db,
         alternative_source=alternative_source,
         has_reference_gap=evidence_facts.has_reference_gap,
+        speed_gap_window_count=context_facts.speed_gap_window_count,
+        rpm_gap_window_count=context_facts.rpm_gap_window_count,
         uses_summary_fallback=False,
         fallback_reason=None,
         signal_keys=tuple(dict.fromkeys(signal_keys)),
@@ -309,11 +321,72 @@ def _summary_fallback_confidence(
         snr_db=snr_db,
         alternative_source=alternative_source,
         has_reference_gap=evidence_facts.has_reference_gap,
+        speed_gap_window_count=0,
+        rpm_gap_window_count=0,
         uses_summary_fallback=True,
         fallback_reason=fallback_reason,
         signal_keys=(),
         caveat_keys=caveat_keys,
     )
+
+
+def project_whole_run_diagnosis_factors(
+    confidence_facts: ReportConfidenceFacts,
+) -> tuple[tuple[DiagnosisFactorResponse, ...], tuple[DiagnosisFactorResponse, ...]]:
+    """Project stable support and counterevidence factors from current confidence facts."""
+
+    support_factors: list[DiagnosisFactorResponse] = []
+    counter_factors: list[DiagnosisFactorResponse] = []
+    signal_keys = set(confidence_facts.signal_keys)
+    caveat_keys = set(confidence_facts.caveat_keys)
+
+    for factor_key in (
+        "raw_backed",
+        "repeated_support",
+        "sustained_support",
+        "stable_frequency",
+        "tight_order_lock",
+        "localized_support",
+        "clean_signal",
+    ):
+        if factor_key not in signal_keys:
+            continue
+        support_factors.append(
+            _factor_payload(
+                factor_key=cast(DiagnosisFactorKey, factor_key),
+                polarity="support",
+                weight=_support_factor_weight(factor_key, confidence_facts),
+                details=_factor_details(factor_key, confidence_facts),
+            )
+        )
+
+    for factor_key in (
+        "summary_only",
+        "legacy_context",
+        "speed_context_gaps",
+        "rpm_context_gaps",
+        "sparse_support",
+        "brief_support",
+        "drifting_frequency",
+        "loose_order_lock",
+        "mixed_support_locations",
+        "noisy_signal",
+        "weak_spatial",
+        "close_alternative",
+        "incomplete_reference",
+    ):
+        if factor_key not in caveat_keys:
+            continue
+        counter_factors.append(
+            _factor_payload(
+                factor_key=cast(DiagnosisFactorKey, factor_key),
+                polarity="counterevidence",
+                weight=_counter_factor_weight(factor_key, confidence_facts),
+                details=_factor_details(factor_key, confidence_facts),
+            )
+        )
+
+    return (tuple(support_factors), tuple(counter_factors))
 
 
 def _frequency_span_hz(
@@ -359,3 +432,117 @@ def _label_key_for_score(score: float) -> str:
     if score >= Finding.CONFIDENCE_MEDIUM_THRESHOLD:
         return "CONFIDENCE_MEDIUM"
     return "CONFIDENCE_LOW"
+
+
+def _factor_payload(
+    *,
+    factor_key: DiagnosisFactorKey,
+    polarity: DiagnosisFactorPolarity,
+    weight: float,
+    details: DiagnosisFactorDetailsResponse,
+) -> DiagnosisFactorResponse:
+    return {
+        "factor_key": factor_key,
+        "polarity": polarity,
+        "severity": _factor_severity(weight),
+        "weight": weight,
+        "details": details,
+    }
+
+
+def _factor_severity(weight: float) -> DiagnosisFactorSeverity:
+    if weight >= 0.10:
+        return "high"
+    if weight >= 0.07:
+        return "medium"
+    return "low"
+
+
+def _support_factor_weight(factor_key: str, facts: ReportConfidenceFacts) -> float:
+    if factor_key == "raw_backed":
+        return 0.10
+    if factor_key == "repeated_support":
+        if facts.supporting_window_count is not None and facts.supporting_window_count >= 4:
+            return 0.10
+        return 0.05
+    if factor_key == "sustained_support":
+        if facts.supporting_duration_s is not None and facts.supporting_duration_s >= 1.0:
+            return 0.08
+        return 0.04
+    if factor_key == "stable_frequency":
+        frequency_span_hz = _frequency_span_hz(
+            stable_frequency_min_hz=facts.stable_frequency_min_hz,
+            stable_frequency_max_hz=facts.stable_frequency_max_hz,
+        )
+        if frequency_span_hz is not None and frequency_span_hz <= 0.5:
+            return 0.08
+        return 0.04
+    if factor_key == "tight_order_lock":
+        return 0.08
+    if factor_key == "localized_support":
+        return 0.08
+    if factor_key == "clean_signal":
+        return 0.05
+    raise ValueError(f"unsupported support factor key: {factor_key}")
+
+
+def _counter_factor_weight(factor_key: str, facts: ReportConfidenceFacts) -> float:
+    if factor_key in {"summary_only", "legacy_context"}:
+        return 0.05
+    if factor_key in {"speed_context_gaps", "rpm_context_gaps"}:
+        return 0.04
+    if factor_key in {
+        "brief_support",
+        "drifting_frequency",
+        "noisy_signal",
+        "incomplete_reference",
+    }:
+        return 0.06
+    if factor_key in {
+        "sparse_support",
+        "loose_order_lock",
+        "mixed_support_locations",
+        "weak_spatial",
+        "close_alternative",
+    }:
+        return 0.10 if factor_key != "loose_order_lock" else 0.08
+    if factor_key == "summary_only" and facts.uses_summary_fallback:
+        return 0.05
+    raise ValueError(f"unsupported counterevidence factor key: {factor_key}")
+
+
+def _factor_details(
+    factor_key: str,
+    facts: ReportConfidenceFacts,
+) -> DiagnosisFactorDetailsResponse:
+    details: DiagnosisFactorDetailsResponse = {}
+    if factor_key == "raw_backed":
+        details["raw_backed_sample_count"] = facts.raw_backed_sample_count
+    elif factor_key in {"repeated_support", "sparse_support"}:
+        details["supporting_window_count"] = facts.supporting_window_count
+    elif factor_key == "sustained_support" or factor_key == "brief_support":
+        details["supporting_duration_s"] = facts.supporting_duration_s
+    elif factor_key in {"stable_frequency", "drifting_frequency"}:
+        details["stable_frequency_min_hz"] = facts.stable_frequency_min_hz
+        details["stable_frequency_max_hz"] = facts.stable_frequency_max_hz
+        details["frequency_span_hz"] = _frequency_span_hz(
+            stable_frequency_min_hz=facts.stable_frequency_min_hz,
+            stable_frequency_max_hz=facts.stable_frequency_max_hz,
+        )
+    elif factor_key == "tight_order_lock" or factor_key == "loose_order_lock":
+        details["mean_relative_error"] = facts.mean_relative_error
+    elif factor_key == "localized_support" or factor_key == "mixed_support_locations":
+        details["supporting_location_count"] = facts.supporting_location_count
+        details["top_support_location"] = facts.top_support_location
+        details["top_support_share"] = facts.top_support_share
+    elif factor_key == "clean_signal" or factor_key == "noisy_signal":
+        details["snr_db"] = facts.snr_db
+    elif factor_key == "close_alternative":
+        details["alternative_source"] = facts.alternative_source
+    elif factor_key == "speed_context_gaps":
+        details["speed_gap_window_count"] = facts.speed_gap_window_count
+    elif factor_key == "rpm_context_gaps":
+        details["rpm_gap_window_count"] = facts.rpm_gap_window_count
+    elif factor_key == "summary_only" and facts.uses_summary_fallback:
+        details["fallback_reason"] = facts.fallback_reason
+    return details

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -19,6 +19,9 @@ from vibesensor.shared.boundaries.summary_fields.hotspot import (
 from vibesensor.shared.types.analysis_views import PeakTableRow
 from vibesensor.shared.types.history_analysis_contracts import (
     DiagnosisExemplarKind,
+    DiagnosisFactorKey,
+    DiagnosisFactorPolarity,
+    DiagnosisFactorSeverity,
     LocationProofBasis,
     WholeRunDiagnosisDataBasis,
 )
@@ -27,6 +30,8 @@ from vibesensor.shared.types.run_schema import RunMetadata
 __all__ = [
     "NormalizedReportSummary",
     "ReportDiagnosisExemplarReference",
+    "ReportDiagnosisFactor",
+    "ReportDiagnosisFactorDetails",
     "ReportOrderHarmonicEvidenceSummary",
     "ReportOrderTracePhaseSupport",
     "ReportOrderTraceSupportInterval",
@@ -172,6 +177,38 @@ class ReportDiagnosisExemplarReference:
 
 
 @dataclass(frozen=True, slots=True)
+class ReportDiagnosisFactorDetails:
+    """Typed structured details for one persisted diagnosis factor row."""
+
+    raw_backed_sample_count: int | None
+    supporting_window_count: int | None
+    supporting_duration_s: float | None
+    stable_frequency_min_hz: float | None
+    stable_frequency_max_hz: float | None
+    frequency_span_hz: float | None
+    supporting_location_count: int | None
+    top_support_location: str | None
+    top_support_share: float | None
+    mean_relative_error: float | None
+    snr_db: float | None
+    alternative_source: str | None
+    speed_gap_window_count: int | None
+    rpm_gap_window_count: int | None
+    fallback_reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ReportDiagnosisFactor:
+    """Typed support or counterevidence factor for one fused diagnosis."""
+
+    factor_key: DiagnosisFactorKey
+    polarity: DiagnosisFactorPolarity
+    severity: DiagnosisFactorSeverity
+    weight: float
+    details: ReportDiagnosisFactorDetails
+
+
+@dataclass(frozen=True, slots=True)
 class ReportSpatialLocationSummary:
     """Typed persisted per-location spatial evidence row for report/history reload."""
 
@@ -241,6 +278,8 @@ class ReportWholeRunDiagnosisSummary:
     uses_summary_fallback: bool
     fallback_reason: str | None
     exemplar_references: tuple[ReportDiagnosisExemplarReference, ...]
+    support_factors: tuple[ReportDiagnosisFactor, ...]
+    counterevidence_factors: tuple[ReportDiagnosisFactor, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -552,6 +591,10 @@ class ReportSummaryNormalizer:
                     exemplar_references=self._diagnosis_exemplar_references(
                         row.get("exemplar_references")
                     ),
+                    support_factors=self._diagnosis_factors(row.get("support_factors")),
+                    counterevidence_factors=self._diagnosis_factors(
+                        row.get("counterevidence_factors")
+                    ),
                 )
             )
         return tuple(summaries)
@@ -715,6 +758,66 @@ class ReportSummaryNormalizer:
             )
         return tuple(exemplars)
 
+    def _diagnosis_factors(
+        self,
+        raw_factors: object,
+    ) -> tuple[ReportDiagnosisFactor, ...]:
+        if not isinstance(raw_factors, list):
+            return ()
+        factors: list[ReportDiagnosisFactor] = []
+        for row in raw_factors:
+            if not isinstance(row, Mapping):
+                continue
+            factor_key = self._diagnosis_factor_key(row.get("factor_key"))
+            polarity = self._diagnosis_factor_polarity(row.get("polarity"))
+            severity = self._diagnosis_factor_severity(row.get("severity"))
+            if factor_key is None or polarity is None or severity is None:
+                continue
+            raw_details = row.get("details")
+            details_row = raw_details if isinstance(raw_details, Mapping) else {}
+            factors.append(
+                ReportDiagnosisFactor(
+                    factor_key=factor_key,
+                    polarity=polarity,
+                    severity=severity,
+                    weight=optional_float(row.get("weight")) or 0.0,
+                    details=ReportDiagnosisFactorDetails(
+                        raw_backed_sample_count=self._optional_count(
+                            details_row.get("raw_backed_sample_count")
+                        ),
+                        supporting_window_count=self._optional_count(
+                            details_row.get("supporting_window_count")
+                        ),
+                        supporting_duration_s=optional_float(
+                            details_row.get("supporting_duration_s")
+                        ),
+                        stable_frequency_min_hz=optional_float(
+                            details_row.get("stable_frequency_min_hz")
+                        ),
+                        stable_frequency_max_hz=optional_float(
+                            details_row.get("stable_frequency_max_hz")
+                        ),
+                        frequency_span_hz=optional_float(details_row.get("frequency_span_hz")),
+                        supporting_location_count=self._optional_count(
+                            details_row.get("supporting_location_count")
+                        ),
+                        top_support_location=text_or_none(details_row.get("top_support_location")),
+                        top_support_share=optional_float(details_row.get("top_support_share")),
+                        mean_relative_error=optional_float(details_row.get("mean_relative_error")),
+                        snr_db=optional_float(details_row.get("snr_db")),
+                        alternative_source=text_or_none(details_row.get("alternative_source")),
+                        speed_gap_window_count=self._optional_count(
+                            details_row.get("speed_gap_window_count")
+                        ),
+                        rpm_gap_window_count=self._optional_count(
+                            details_row.get("rpm_gap_window_count")
+                        ),
+                        fallback_reason=text_or_none(details_row.get("fallback_reason")),
+                    ),
+                )
+            )
+        return tuple(factors)
+
     def _text_tuple(self, raw_values: object) -> tuple[str, ...]:
         if not isinstance(raw_values, list):
             return ()
@@ -749,6 +852,45 @@ class ReportSummaryNormalizer:
         if value not in {"raw_backed", "summary_only"}:
             return None
         return cast(WholeRunDiagnosisDataBasis, value)
+
+    def _diagnosis_factor_key(self, raw_value: object) -> DiagnosisFactorKey | None:
+        value = text_or_none(raw_value)
+        if value not in {
+            "raw_backed",
+            "repeated_support",
+            "sustained_support",
+            "stable_frequency",
+            "tight_order_lock",
+            "localized_support",
+            "clean_signal",
+            "summary_only",
+            "legacy_context",
+            "speed_context_gaps",
+            "rpm_context_gaps",
+            "sparse_support",
+            "brief_support",
+            "drifting_frequency",
+            "loose_order_lock",
+            "mixed_support_locations",
+            "noisy_signal",
+            "weak_spatial",
+            "close_alternative",
+            "incomplete_reference",
+        }:
+            return None
+        return cast(DiagnosisFactorKey, value)
+
+    def _diagnosis_factor_polarity(self, raw_value: object) -> DiagnosisFactorPolarity | None:
+        value = text_or_none(raw_value)
+        if value not in {"support", "counterevidence"}:
+            return None
+        return cast(DiagnosisFactorPolarity, value)
+
+    def _diagnosis_factor_severity(self, raw_value: object) -> DiagnosisFactorSeverity | None:
+        value = text_or_none(raw_value)
+        if value not in {"low", "medium", "high"}:
+            return None
+        return cast(DiagnosisFactorSeverity, value)
 
 
 def has_projectable_report_payload(payload: Mapping[str, object]) -> bool:

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -47,6 +47,11 @@ __all__ = [
     "DataQualityRequiredMissingPctResponse",
     "DataQualityResponse",
     "DataQualitySpeedCoverageResponse",
+    "DiagnosisFactorDetailsResponse",
+    "DiagnosisFactorKey",
+    "DiagnosisFactorPolarity",
+    "DiagnosisFactorResponse",
+    "DiagnosisFactorSeverity",
     "FindingPayload",
     "DiagnosisExemplarKind",
     "DiagnosisExemplarReferenceResponse",
@@ -83,6 +88,30 @@ type DiagnosisExemplarKind = Literal[
     "whole_run_context_interval",
     "spatial_location",
 ]
+type DiagnosisFactorKey = Literal[
+    "raw_backed",
+    "repeated_support",
+    "sustained_support",
+    "stable_frequency",
+    "tight_order_lock",
+    "localized_support",
+    "clean_signal",
+    "summary_only",
+    "legacy_context",
+    "speed_context_gaps",
+    "rpm_context_gaps",
+    "sparse_support",
+    "brief_support",
+    "drifting_frequency",
+    "loose_order_lock",
+    "mixed_support_locations",
+    "noisy_signal",
+    "weak_spatial",
+    "close_alternative",
+    "incomplete_reference",
+]
+type DiagnosisFactorPolarity = Literal["support", "counterevidence"]
+type DiagnosisFactorSeverity = Literal["low", "medium", "high"]
 type WholeRunDiagnosisDataBasis = Literal["raw_backed", "summary_only"]
 type LocationProofBasis = Literal[
     "whole_run_summary",
@@ -287,6 +316,36 @@ class DiagnosisExemplarReferenceResponse(TypedDict, total=False):
     speed_band: str | None
 
 
+class DiagnosisFactorDetailsResponse(TypedDict, total=False):
+    """Structured details carried by one persisted diagnosis factor row."""
+
+    raw_backed_sample_count: int | None
+    supporting_window_count: int | None
+    supporting_duration_s: float | None
+    stable_frequency_min_hz: float | None
+    stable_frequency_max_hz: float | None
+    frequency_span_hz: float | None
+    supporting_location_count: int | None
+    top_support_location: str | None
+    top_support_share: float | None
+    mean_relative_error: float | None
+    snr_db: float | None
+    alternative_source: str | None
+    speed_gap_window_count: int | None
+    rpm_gap_window_count: int | None
+    fallback_reason: str | None
+
+
+class DiagnosisFactorResponse(TypedDict, total=False):
+    """One stable support or counterevidence factor for a fused diagnosis."""
+
+    factor_key: Required[DiagnosisFactorKey]
+    polarity: Required[DiagnosisFactorPolarity]
+    severity: Required[DiagnosisFactorSeverity]
+    weight: Required[float]
+    details: Required[DiagnosisFactorDetailsResponse]
+
+
 class WholeRunDiagnosisSummaryResponse(TypedDict, total=False):
     """Future persisted/report-facing summary shape for fused whole-run diagnoses."""
 
@@ -321,6 +380,8 @@ class WholeRunDiagnosisSummaryResponse(TypedDict, total=False):
     uses_summary_fallback: Required[bool]
     fallback_reason: str | None
     exemplar_references: Required[list[DiagnosisExemplarReferenceResponse]]
+    support_factors: Required[list[DiagnosisFactorResponse]]
+    counterevidence_factors: Required[list[DiagnosisFactorResponse]]
 
 
 class SpeedStatsResponse(TypedDict):
@@ -481,6 +542,8 @@ for _typed_dict in (
     SpatialLocationSummaryResponse,
     SpatialEvidenceSummaryResponse,
     DiagnosisExemplarReferenceResponse,
+    DiagnosisFactorDetailsResponse,
+    DiagnosisFactorResponse,
     WholeRunDiagnosisSummaryResponse,
     SpeedStatsResponse,
     PhaseInfoResponse,

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
@@ -13,6 +13,9 @@ from typing import cast
 
 from vibesensor.shared.types.history_analysis_contracts import (
     DiagnosisExemplarKind,
+    DiagnosisFactorKey,
+    DiagnosisFactorPolarity,
+    DiagnosisFactorSeverity,
     LocationProofBasis,
     WholeRunDiagnosisDataBasis,
 )
@@ -20,6 +23,8 @@ from vibesensor.shared.types.json_types import JsonObject, JsonValue
 
 __all__ = [
     "DiagnosisExemplarReference",
+    "DiagnosisFactor",
+    "DiagnosisFactorDetails",
     "WholeRunDiagnosisSummary",
 ]
 
@@ -77,6 +82,124 @@ class DiagnosisExemplarReference:
 
 
 @dataclass(frozen=True, slots=True)
+class DiagnosisFactorDetails:
+    """Structured details carried by one persisted diagnosis factor row."""
+
+    raw_backed_sample_count: int | None = None
+    supporting_window_count: int | None = None
+    supporting_duration_s: float | None = None
+    stable_frequency_min_hz: float | None = None
+    stable_frequency_max_hz: float | None = None
+    frequency_span_hz: float | None = None
+    supporting_location_count: int | None = None
+    top_support_location: str | None = None
+    top_support_share: float | None = None
+    mean_relative_error: float | None = None
+    snr_db: float | None = None
+    alternative_source: str | None = None
+    speed_gap_window_count: int | None = None
+    rpm_gap_window_count: int | None = None
+    fallback_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.raw_backed_sample_count is not None:
+            _require_nonnegative(self.raw_backed_sample_count, field_name="raw_backed_sample_count")
+        if self.supporting_window_count is not None:
+            _require_nonnegative(self.supporting_window_count, field_name="supporting_window_count")
+        if self.supporting_location_count is not None:
+            _require_nonnegative(
+                self.supporting_location_count,
+                field_name="supporting_location_count",
+            )
+        if self.speed_gap_window_count is not None:
+            _require_nonnegative(self.speed_gap_window_count, field_name="speed_gap_window_count")
+        if self.rpm_gap_window_count is not None:
+            _require_nonnegative(self.rpm_gap_window_count, field_name="rpm_gap_window_count")
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {}
+        _set_optional(payload, "raw_backed_sample_count", self.raw_backed_sample_count)
+        _set_optional(payload, "supporting_window_count", self.supporting_window_count)
+        _set_optional(payload, "supporting_duration_s", self.supporting_duration_s)
+        _set_optional(payload, "stable_frequency_min_hz", self.stable_frequency_min_hz)
+        _set_optional(payload, "stable_frequency_max_hz", self.stable_frequency_max_hz)
+        _set_optional(payload, "frequency_span_hz", self.frequency_span_hz)
+        _set_optional(payload, "supporting_location_count", self.supporting_location_count)
+        _set_optional(payload, "top_support_location", self.top_support_location)
+        _set_optional(payload, "top_support_share", self.top_support_share)
+        _set_optional(payload, "mean_relative_error", self.mean_relative_error)
+        _set_optional(payload, "snr_db", self.snr_db)
+        _set_optional(payload, "alternative_source", self.alternative_source)
+        _set_optional(payload, "speed_gap_window_count", self.speed_gap_window_count)
+        _set_optional(payload, "rpm_gap_window_count", self.rpm_gap_window_count)
+        _set_optional(payload, "fallback_reason", self.fallback_reason)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> DiagnosisFactorDetails:
+        return cls(
+            raw_backed_sample_count=_optional_int(data.get("raw_backed_sample_count")),
+            supporting_window_count=_optional_int(data.get("supporting_window_count")),
+            supporting_duration_s=_optional_float(data.get("supporting_duration_s")),
+            stable_frequency_min_hz=_optional_float(data.get("stable_frequency_min_hz")),
+            stable_frequency_max_hz=_optional_float(data.get("stable_frequency_max_hz")),
+            frequency_span_hz=_optional_float(data.get("frequency_span_hz")),
+            supporting_location_count=_optional_int(data.get("supporting_location_count")),
+            top_support_location=_optional_text(data.get("top_support_location")),
+            top_support_share=_optional_float(data.get("top_support_share")),
+            mean_relative_error=_optional_float(data.get("mean_relative_error")),
+            snr_db=_optional_float(data.get("snr_db")),
+            alternative_source=_optional_text(data.get("alternative_source")),
+            speed_gap_window_count=_optional_int(data.get("speed_gap_window_count")),
+            rpm_gap_window_count=_optional_int(data.get("rpm_gap_window_count")),
+            fallback_reason=_optional_text(data.get("fallback_reason")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisFactor:
+    """One stable support or counterevidence factor for a fused diagnosis."""
+
+    factor_key: DiagnosisFactorKey
+    polarity: DiagnosisFactorPolarity
+    severity: DiagnosisFactorSeverity
+    weight: float
+    details: DiagnosisFactorDetails = DiagnosisFactorDetails()
+
+    def __post_init__(self) -> None:
+        _require_factor_key(self.factor_key)
+        _require_factor_polarity(self.polarity)
+        _require_factor_severity(self.severity)
+        if self.weight < 0:
+            raise ValueError("weight must be >= 0")
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "factor_key": self.factor_key,
+            "polarity": self.polarity,
+            "severity": self.severity,
+            "weight": self.weight,
+            "details": self.details.to_json_object(),
+        }
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> DiagnosisFactor:
+        raw_details = data.get("details")
+        details = (
+            DiagnosisFactorDetails.from_mapping(raw_details)
+            if isinstance(raw_details, dict)
+            else DiagnosisFactorDetails()
+        )
+        return cls(
+            factor_key=_required_factor_key(data.get("factor_key")),
+            polarity=_required_factor_polarity(data.get("polarity")),
+            severity=_required_factor_severity(data.get("severity")),
+            weight=_required_numeric(data, "weight"),
+            details=details,
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class WholeRunDiagnosisSummary:
     """Compact persisted/report-facing summary for one fused whole-run diagnosis."""
 
@@ -111,6 +234,8 @@ class WholeRunDiagnosisSummary:
     uses_summary_fallback: bool = False
     fallback_reason: str | None = None
     exemplar_references: tuple[DiagnosisExemplarReference, ...] = ()
+    support_factors: tuple[DiagnosisFactor, ...] = ()
+    counterevidence_factors: tuple[DiagnosisFactor, ...] = ()
 
     def __post_init__(self) -> None:
         _require_text(self.diagnosis_key, field_name="diagnosis_key")
@@ -135,6 +260,10 @@ class WholeRunDiagnosisSummary:
             "uses_summary_fallback": self.uses_summary_fallback,
             "exemplar_references": [
                 exemplar.to_json_object() for exemplar in self.exemplar_references
+            ],
+            "support_factors": [factor.to_json_object() for factor in self.support_factors],
+            "counterevidence_factors": [
+                factor.to_json_object() for factor in self.counterevidence_factors
             ],
         }
         _set_optional(payload, "support_score", self.support_score)
@@ -171,6 +300,26 @@ class WholeRunDiagnosisSummary:
             if isinstance(raw_exemplars, list)
             else ()
         )
+        raw_support_factors = data.get("support_factors")
+        support_factors = (
+            tuple(
+                DiagnosisFactor.from_mapping(row)
+                for row in raw_support_factors
+                if isinstance(row, dict)
+            )
+            if isinstance(raw_support_factors, list)
+            else ()
+        )
+        raw_counter_factors = data.get("counterevidence_factors")
+        counter_factors = (
+            tuple(
+                DiagnosisFactor.from_mapping(row)
+                for row in raw_counter_factors
+                if isinstance(row, dict)
+            )
+            if isinstance(raw_counter_factors, list)
+            else ()
+        )
         return cls(
             diagnosis_key=_required_text(data, "diagnosis_key"),
             suspected_source=_required_text(data, "suspected_source"),
@@ -205,6 +354,8 @@ class WholeRunDiagnosisSummary:
             uses_summary_fallback=_required_bool(data, "uses_summary_fallback"),
             fallback_reason=_optional_text(data.get("fallback_reason")),
             exemplar_references=exemplars,
+            support_factors=support_factors,
+            counterevidence_factors=counter_factors,
         )
 
 
@@ -237,6 +388,13 @@ def _required_bool(data: JsonObject, field_name: str) -> bool:
     return value
 
 
+def _required_numeric(data: JsonObject, field_name: str) -> float:
+    value = data.get(field_name)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a number")
+    return float(value)
+
+
 def _required_exemplar_kind(value: object) -> DiagnosisExemplarKind:
     if value not in {
         "order_support_interval",
@@ -245,6 +403,57 @@ def _required_exemplar_kind(value: object) -> DiagnosisExemplarKind:
     }:
         raise ValueError("kind must be a supported diagnosis exemplar kind")
     return cast(DiagnosisExemplarKind, value)
+
+
+def _require_factor_key(value: DiagnosisFactorKey) -> None:
+    _required_factor_key(value)
+
+
+def _required_factor_key(value: object) -> DiagnosisFactorKey:
+    if value not in {
+        "raw_backed",
+        "repeated_support",
+        "sustained_support",
+        "stable_frequency",
+        "tight_order_lock",
+        "localized_support",
+        "clean_signal",
+        "summary_only",
+        "legacy_context",
+        "speed_context_gaps",
+        "rpm_context_gaps",
+        "sparse_support",
+        "brief_support",
+        "drifting_frequency",
+        "loose_order_lock",
+        "mixed_support_locations",
+        "noisy_signal",
+        "weak_spatial",
+        "close_alternative",
+        "incomplete_reference",
+    }:
+        raise ValueError("factor_key must be a supported diagnosis factor key")
+    return cast(DiagnosisFactorKey, value)
+
+
+def _require_factor_polarity(value: DiagnosisFactorPolarity) -> None:
+    _required_factor_polarity(value)
+
+
+def _required_factor_polarity(value: object) -> DiagnosisFactorPolarity:
+    if value not in {"support", "counterevidence"}:
+        raise ValueError("polarity must be a supported diagnosis factor polarity")
+    return cast(DiagnosisFactorPolarity, value)
+
+
+def _require_factor_severity(value: DiagnosisFactorSeverity) -> None:
+    _required_factor_severity(value)
+
+
+def _required_factor_severity(value: object) -> DiagnosisFactorSeverity:
+    if value not in {"low", "medium", "high"}:
+        raise ValueError("severity must be a supported diagnosis factor severity")
+    return cast(DiagnosisFactorSeverity, value)
 
 
 def _required_data_basis(value: object) -> WholeRunDiagnosisDataBasis:

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -1827,6 +1827,248 @@
         "title": "DiagnosisExemplarReferenceResponse",
         "type": "object"
       },
+      "DiagnosisFactorDetailsResponse": {
+        "description": "Structured details carried by one persisted diagnosis factor row.",
+        "properties": {
+          "alternative_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alternative Source"
+          },
+          "fallback_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fallback Reason"
+          },
+          "frequency_span_hz": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Span Hz"
+          },
+          "mean_relative_error": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Relative Error"
+          },
+          "raw_backed_sample_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Raw Backed Sample Count"
+          },
+          "rpm_gap_window_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rpm Gap Window Count"
+          },
+          "snr_db": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snr Db"
+          },
+          "speed_gap_window_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed Gap Window Count"
+          },
+          "stable_frequency_max_hz": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stable Frequency Max Hz"
+          },
+          "stable_frequency_min_hz": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stable Frequency Min Hz"
+          },
+          "supporting_duration_s": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supporting Duration S"
+          },
+          "supporting_location_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supporting Location Count"
+          },
+          "supporting_window_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Supporting Window Count"
+          },
+          "top_support_location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top Support Location"
+          },
+          "top_support_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top Support Share"
+          }
+        },
+        "title": "DiagnosisFactorDetailsResponse",
+        "type": "object"
+      },
+      "DiagnosisFactorKey": {
+        "enum": [
+          "raw_backed",
+          "repeated_support",
+          "sustained_support",
+          "stable_frequency",
+          "tight_order_lock",
+          "localized_support",
+          "clean_signal",
+          "summary_only",
+          "legacy_context",
+          "speed_context_gaps",
+          "rpm_context_gaps",
+          "sparse_support",
+          "brief_support",
+          "drifting_frequency",
+          "loose_order_lock",
+          "mixed_support_locations",
+          "noisy_signal",
+          "weak_spatial",
+          "close_alternative",
+          "incomplete_reference"
+        ],
+        "type": "string"
+      },
+      "DiagnosisFactorPolarity": {
+        "enum": [
+          "support",
+          "counterevidence"
+        ],
+        "type": "string"
+      },
+      "DiagnosisFactorResponse": {
+        "description": "One stable support or counterevidence factor for a fused diagnosis.",
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/DiagnosisFactorDetailsResponse"
+          },
+          "factor_key": {
+            "$ref": "#/components/schemas/DiagnosisFactorKey"
+          },
+          "polarity": {
+            "$ref": "#/components/schemas/DiagnosisFactorPolarity"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/DiagnosisFactorSeverity"
+          },
+          "weight": {
+            "title": "Weight",
+            "type": "number"
+          }
+        },
+        "required": [
+          "factor_key",
+          "polarity",
+          "severity",
+          "weight",
+          "details"
+        ],
+        "title": "DiagnosisFactorResponse",
+        "type": "object"
+      },
+      "DiagnosisFactorSeverity": {
+        "enum": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "type": "string"
+      },
       "EspFlashCancelResponse": {
         "description": "Response body confirming whether an ESP32 flash job was cancelled.",
         "properties": {
@@ -7727,6 +7969,13 @@
             ],
             "title": "Confidence Gap To Alternative"
           },
+          "counterevidence_factors": {
+            "items": {
+              "$ref": "#/components/schemas/DiagnosisFactorResponse"
+            },
+            "title": "Counterevidence Factors",
+            "type": "array"
+          },
           "counterevidence_score": {
             "anyOf": [
               {
@@ -7891,6 +8140,13 @@
             ],
             "title": "Stable Frequency Min Hz"
           },
+          "support_factors": {
+            "items": {
+              "$ref": "#/components/schemas/DiagnosisFactorResponse"
+            },
+            "title": "Support Factors",
+            "type": "array"
+          },
           "support_score": {
             "anyOf": [
               {
@@ -7974,7 +8230,9 @@
           "weak_spatial_separation",
           "has_reference_gap",
           "uses_summary_fallback",
-          "exemplar_references"
+          "exemplar_references",
+          "support_factors",
+          "counterevidence_factors"
         ],
         "title": "WholeRunDiagnosisSummaryResponse",
         "type": "object"

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -310,25 +310,48 @@ by `orders/matching.py`, emits dense `SpatialEvidenceWindow` rows to a
 dominant location, runner-up, location separation, and weak/ambiguous flags
 derived from supporting-window evidence.
 
-### Counterevidence model
+### Counterevidence and support factor model
 
-Counterevidence should become a first-class persisted concept with stable keys,
-not just renderer-time prose. Good initial keys fit the current
-`confidence_facts.py` vocabulary:
+Support and counterevidence now use one shared persisted vocabulary instead of
+renderer-only prose. The canonical owner is the combination of:
+
+- `apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py`
+  for compact persisted diagnosis rows
+- `apps/server/vibesensor/shared/types/history_analysis_contracts.py` for the
+  outward history/report/schema contract
+- `apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py` for
+  the projection from the existing report-confidence thresholds and score deltas
+  into stable factor rows
+
+The current stable support keys are:
+
+- `raw_backed`
+- `repeated_support`
+- `sustained_support`
+- `stable_frequency`
+- `tight_order_lock`
+- `localized_support`
+- `clean_signal`
+
+The current stable counterevidence keys are:
 
 - `summary_only`
+- `legacy_context`
+- `speed_context_gaps`
+- `rpm_context_gaps`
 - `sparse_support`
 - `brief_support`
 - `drifting_frequency`
 - `loose_order_lock`
 - `mixed_support_locations`
+- `noisy_signal`
 - `weak_spatial`
 - `close_alternative`
 - `incomplete_reference`
-- `noisy_signal`
 
-Whole-run fusion can add new stable keys, but should continue producing compact,
-explainable factors that reporting can consume directly.
+Each factor row carries stable key, polarity, severity, numeric weight, and a
+typed details payload so later fusion/report work can explain why a diagnosis
+ranked where it did without reparsing report prose.
 
 The contract owner for the fused output should now live in
 `apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py`.
@@ -342,10 +365,9 @@ That layer should settle:
 - explicit top-level ambiguity, suspicious-case, and fallback markers that later
   report/history consumers can project without inventing a second diagnosis
   wrapper
-
-Stable support-factor and counterevidence-factor vocabularies still belong to
-the follow-on factor issue; this contract stage should define the diagnosis shell
-without burying those semantics in renderer-only prose.
+- typed `support_factors` and `counterevidence_factors` rows built from the same
+  thresholds and score deltas already used by `ReportConfidenceFacts`, so the
+  fused whole-run path does not drift from current report confidence semantics
 
 ## Shared contracts to settle early
 


### PR DESCRIPTION
Closes #3102

## What changed
- add typed support/counterevidence factor contracts and detail payloads to the whole-run diagnosis summary surfaces
- project the existing report confidence/caveat vocabulary in `confidence_facts.py` into stable weighted factor rows instead of inventing a second explanation model
- teach report/history normalization and persistence/schema tests to round-trip the new factor arrays
- document the canonical factor owners and stable key set in the whole-run design doc

## Why
- whole-run fusion needs stable machine-readable factor rows before the ranker lands
- reusing the current confidence thresholds and score deltas keeps whole-run explanations aligned with live report semantics

## Validation
- focused pytest for diagnosis contracts, factor projection, report payloads, persistence/http, and schema export
- `make format`
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- `make ui-typecheck`
- `make test-changed`

## Risks / tradeoffs
- this lands the stable factor vocabulary and projection seam only; later issues still need to build the actual diagnosis ranker and fallback scoring on top
- factor weights stay tied to today's report-confidence scoring deltas on purpose, so future scoring changes need to update this projection in lockstep