### PR TITLE
Implement whole-run diagnosis ranker

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_ranking.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_ranking.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+from vibesensor.domain import DrivingPhase
+from vibesensor.shared.types.whole_run_analysis import WholeRunContextInterval
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
+    OrderTraceSummary,
+    OrderTraceSupportInterval,
+)
+from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
+    SpatialEvidenceSummary,
+    SpatialLocationSummary,
+)
+from vibesensor.use_cases.diagnostics.whole_run_diagnosis_ranking import (
+    build_whole_run_diagnosis_summaries,
+)
+
+
+def test_build_whole_run_diagnosis_summaries_ranks_candidates_and_projects_exemplars() -> None:
+    summaries = build_whole_run_diagnosis_summaries(
+        analysis_metadata={
+            "raw_backed_sample_count": 96,
+            "raw_capture_mode": "raw_backed",
+            "whole_run_context_available": True,
+        },
+        context_intervals=(
+            WholeRunContextInterval(
+                segment_index=0,
+                phase=DrivingPhase.CRUISE,
+                load_state="steady",
+                start_window_index=0,
+                end_window_index=7,
+                start_t_s=0.0,
+                end_t_s=4.0,
+                speed_min_kmh=58.0,
+                speed_max_kmh=72.0,
+                speed_band="60-80 km/h",
+                full_context_window_count=8,
+            ),
+        ),
+        order_summaries=(
+            OrderTraceSummary(
+                hypothesis_key="wheel_1x",
+                suspected_source="wheel/tire",
+                order_family="wheel",
+                order_label="1x wheel",
+                total_window_count=8,
+                eligible_window_count=8,
+                matched_window_count=6,
+                support_ratio=0.75,
+                reference_coverage_ratio=0.9,
+                longest_contiguous_support_window_count=4,
+                contiguous_support_ratio=0.5,
+                support_intervals=(
+                    OrderTraceSupportInterval(
+                        interval_index=0,
+                        start_window_index=1,
+                        end_window_index=4,
+                        matched_window_count=4,
+                        support_ratio=1.0,
+                        start_t_s=0.5,
+                        end_t_s=2.0,
+                        phase="cruise",
+                        speed_band="60-80 km/h",
+                        mean_relative_error=0.03,
+                    ),
+                ),
+                stable_frequency_min_hz=13.1,
+                stable_frequency_max_hz=13.4,
+                exemplar_interval_index=0,
+                dominant_phase="cruise",
+                dominant_speed_band="60-80 km/h",
+                strongest_location="front-left",
+                mean_relative_error=0.03,
+                drift_score=0.1,
+                lock_score=0.8,
+                peak_intensity_db=18.0,
+                mean_vibration_strength_db=10.0,
+                ref_sources=("speed+tire",),
+            ),
+            OrderTraceSummary(
+                hypothesis_key="driveshaft_1x",
+                suspected_source="driveshaft",
+                order_family="driveshaft",
+                order_label="1x driveshaft",
+                total_window_count=8,
+                eligible_window_count=8,
+                matched_window_count=5,
+                support_ratio=0.7,
+                reference_coverage_ratio=0.85,
+                longest_contiguous_support_window_count=3,
+                contiguous_support_ratio=0.4,
+                support_intervals=(
+                    OrderTraceSupportInterval(
+                        interval_index=0,
+                        start_window_index=2,
+                        end_window_index=4,
+                        matched_window_count=3,
+                        support_ratio=1.0,
+                        start_t_s=1.0,
+                        end_t_s=2.0,
+                        phase="cruise",
+                        speed_band="60-80 km/h",
+                        mean_relative_error=0.04,
+                    ),
+                ),
+                stable_frequency_min_hz=12.8,
+                stable_frequency_max_hz=13.4,
+                exemplar_interval_index=0,
+                dominant_phase="cruise",
+                dominant_speed_band="60-80 km/h",
+                strongest_location="rear-left",
+                mean_relative_error=0.04,
+                drift_score=0.12,
+                lock_score=0.78,
+                peak_intensity_db=16.0,
+                mean_vibration_strength_db=9.2,
+                ref_sources=("speed+driveshaft",),
+            ),
+        ),
+        spatial_summaries=(
+            SpatialEvidenceSummary(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                proof_basis="supporting_windows_raw_backed",
+                total_window_count=8,
+                supporting_window_count=6,
+                supporting_sensor_count=2,
+                coherent_window_count=5,
+                coherence_ratio=0.83,
+                dominant_location="front-left",
+                runner_up_location="front-right",
+                location_separation_db=3.0,
+                dominance_ratio=1.4,
+                location_summaries=(
+                    SpatialLocationSummary(
+                        location="front-left",
+                        sensor_ids=("front",),
+                        supporting_window_count=5,
+                        support_ratio=0.83,
+                        coherent_window_count=4,
+                        coherence_ratio=0.8,
+                    ),
+                    SpatialLocationSummary(
+                        location="front-right",
+                        sensor_ids=("right",),
+                        supporting_window_count=1,
+                        support_ratio=0.17,
+                        coherent_window_count=1,
+                        coherence_ratio=1.0,
+                    ),
+                ),
+            ),
+            SpatialEvidenceSummary(
+                candidate_key="driveshaft_1x",
+                suspected_source="driveshaft",
+                proof_basis="supporting_windows_raw_backed",
+                total_window_count=8,
+                supporting_window_count=5,
+                supporting_sensor_count=2,
+                coherent_window_count=4,
+                coherence_ratio=0.8,
+                dominant_location="rear-left",
+                runner_up_location="rear-right",
+                location_separation_db=2.6,
+                dominance_ratio=1.25,
+                location_summaries=(
+                    SpatialLocationSummary(
+                        location="rear-left",
+                        sensor_ids=("rear",),
+                        supporting_window_count=4,
+                        support_ratio=0.8,
+                        coherent_window_count=3,
+                        coherence_ratio=0.75,
+                    ),
+                    SpatialLocationSummary(
+                        location="rear-right",
+                        sensor_ids=("rear-right",),
+                        supporting_window_count=1,
+                        support_ratio=0.2,
+                        coherent_window_count=1,
+                        coherence_ratio=1.0,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert [summary.diagnosis_key for summary in summaries] == ["wheel_1x", "driveshaft_1x"]
+    top_summary = summaries[0]
+    assert top_summary.rank == 1
+    assert top_summary.order_hypothesis_key == "wheel_1x"
+    assert top_summary.spatial_candidate_key == "wheel_1x"
+    assert top_summary.location_proof_basis == "supporting_windows_raw_backed"
+    assert top_summary.alternative_source == "driveshaft"
+    assert top_summary.confidence_gap_to_alternative is not None
+    assert "close_alternative" in {
+        factor.factor_key for factor in top_summary.counterevidence_factors
+    }
+    assert [reference.kind for reference in top_summary.exemplar_references] == [
+        "order_support_interval",
+        "spatial_location",
+        "whole_run_context_interval",
+    ]
+    assert "raw_backed" in {factor.factor_key for factor in top_summary.support_factors}
+    assert "incomplete_reference" in {
+        factor.factor_key for factor in top_summary.counterevidence_factors
+    }
+
+
+def test_diagnosis_ranking_marks_context_gaps_and_weak_spatial_as_suspicious() -> None:
+    summaries = build_whole_run_diagnosis_summaries(
+        analysis_metadata={
+            "raw_backed_sample_count": 48,
+            "raw_capture_mode": "raw_backed",
+            "whole_run_context_available": True,
+            "whole_run_context_missing_speed_window_count": 1,
+            "whole_run_context_stale_speed_window_count": 1,
+            "whole_run_context_missing_rpm_window_count": 0,
+            "whole_run_context_stale_rpm_window_count": 1,
+        },
+        context_intervals=(
+            WholeRunContextInterval(
+                segment_index=0,
+                phase=DrivingPhase.ACCELERATION,
+                load_state="pulling",
+                start_window_index=0,
+                end_window_index=3,
+                start_t_s=0.0,
+                end_t_s=2.0,
+                speed_band="40-70 km/h",
+                full_context_window_count=2,
+                partial_context_window_count=1,
+                missing_context_window_count=1,
+            ),
+        ),
+        order_summaries=(
+            OrderTraceSummary(
+                hypothesis_key="engine_2x",
+                suspected_source="engine",
+                order_family="engine",
+                order_label="2x engine",
+                total_window_count=4,
+                eligible_window_count=4,
+                matched_window_count=2,
+                support_ratio=0.5,
+                reference_coverage_ratio=0.7,
+                longest_contiguous_support_window_count=1,
+                contiguous_support_ratio=0.25,
+                support_intervals=(
+                    OrderTraceSupportInterval(
+                        interval_index=0,
+                        start_window_index=1,
+                        end_window_index=2,
+                        matched_window_count=2,
+                        support_ratio=1.0,
+                        start_t_s=0.5,
+                        end_t_s=1.0,
+                        phase="accel",
+                        speed_band="40-70 km/h",
+                        mean_relative_error=0.16,
+                    ),
+                ),
+                stable_frequency_min_hz=22.0,
+                stable_frequency_max_hz=24.2,
+                exemplar_interval_index=0,
+                dominant_phase="accel",
+                dominant_speed_band="40-70 km/h",
+                strongest_location="front-right",
+                mean_relative_error=0.16,
+                drift_score=0.4,
+                lock_score=0.35,
+                peak_intensity_db=12.0,
+                mean_vibration_strength_db=10.2,
+                ref_sources=("speed+engine",),
+            ),
+        ),
+        spatial_summaries=(
+            SpatialEvidenceSummary(
+                candidate_key="engine_2x",
+                suspected_source="engine",
+                proof_basis="supporting_windows_raw_backed",
+                total_window_count=4,
+                supporting_window_count=2,
+                supporting_sensor_count=2,
+                coherent_window_count=1,
+                coherence_ratio=0.5,
+                dominant_location="front-right",
+                runner_up_location="rear-right",
+                location_separation_db=0.8,
+                dominance_ratio=1.05,
+                ambiguous_location=True,
+                weak_spatial_separation=True,
+                location_summaries=(
+                    SpatialLocationSummary(
+                        location="front-right",
+                        sensor_ids=("front",),
+                        supporting_window_count=1,
+                        support_ratio=0.5,
+                        coherent_window_count=1,
+                        coherence_ratio=1.0,
+                    ),
+                    SpatialLocationSummary(
+                        location="rear-right",
+                        sensor_ids=("rear",),
+                        supporting_window_count=1,
+                        support_ratio=0.5,
+                        coherent_window_count=0,
+                        coherence_ratio=0.0,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary.suspicious is True
+    assert summary.ambiguous_location is True
+    assert summary.weak_spatial_separation is True
+    assert "speed_context_gaps" in {factor.factor_key for factor in summary.counterevidence_factors}
+    assert "rpm_context_gaps" in {factor.factor_key for factor in summary.counterevidence_factors}
+    assert "weak_spatial" in {factor.factor_key for factor in summary.counterevidence_factors}

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+from test_support.persisted_analysis import make_persisted_analysis
+
+from vibesensor.domain import DrivingPhase
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.types.raw_capture import RawCaptureManifest
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunContextInterval,
+    WholeRunContextWindowLabel,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
+    OrderTracePoint,
+    OrderTraceSummary,
+    OrderTraceSupportInterval,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_family_summaries import (
+    WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY,
+    WholeRunOrderFamilySummaryArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
+    WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY,
+    WholeRunOrderTraceSummaryArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+    WholeRunOrderTraceArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
+    SpatialEvidenceSummary,
+    SpatialLocationSummary,
+)
+from vibesensor.use_cases.diagnostics.whole_run_context import (
+    WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
+    WholeRunContextArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
+    WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
+    WholeRunSpatialCoherenceArtifactBundle,
+)
+from vibesensor.use_cases.run.post_analysis_executor import execute_post_analysis
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionSuccess
+
+
+def _run_metadata(run_id: str):
+    return run_metadata_from_mapping(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": 800,
+            "sample_rate_hz": 800,
+            "feature_interval_s": 1.0,
+            "language": "en",
+        }
+    )
+
+
+def _samples():
+    return sensor_frames_from_mappings([{"t_s": 1.0, "vibration_strength_db": 10.0}])
+
+
+def test_execute_post_analysis_persists_whole_run_diagnosis_summaries() -> None:
+    stored: dict[str, object] = {}
+    raw_capture_manifest = RawCaptureManifest(
+        run_id="run-diagnosis-ranking",
+        relative_dir="raw-runs/run-diagnosis-ranking",
+        sensors=(),
+        total_samples=0,
+        total_bytes=0,
+        created_at="2025-01-01T00:00:00Z",
+    )
+    window_policy = WholeRunWindowPolicy(
+        sample_rate_hz=800,
+        window_size_samples=2048,
+        stride_samples=200,
+        overlap_samples=1848,
+        feature_interval_s=0.25,
+    )
+    spectral_manifest = WholeRunArtifactManifest(
+        run_id="run-diagnosis-ranking",
+        relative_dir="whole-run-artifacts/run-diagnosis-ranking",
+        window_policy=window_policy,
+        total_window_count=4,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-a",
+                relative_path="spectra/sensor-a/windows.jsonl",
+                file_format="jsonl",
+                record_count=4,
+                sensor_id="sensor-a",
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+    context_bundle = WholeRunContextArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-diagnosis-ranking",
+            relative_dir="whole-run-artifacts/run-diagnosis-ranking",
+            window_policy=window_policy,
+            total_window_count=4,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
+                    relative_path="context/window-labels.jsonl",
+                    file_format="jsonl",
+                    record_count=4,
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={
+            WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY: b'{"window_index":0}\n{"window_index":1}\n',
+        },
+        labels=(
+            WholeRunContextWindowLabel(
+                window_index=0,
+                segment_index=0,
+                phase=DrivingPhase.CRUISE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="steady",
+                speed_kmh=60.0,
+                speed_band="60-80 km/h",
+                speed_source="gps",
+                engine_rpm=1200.0,
+                engine_rpm_source="obd2",
+            ),
+            WholeRunContextWindowLabel(
+                window_index=1,
+                segment_index=0,
+                phase=DrivingPhase.CRUISE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="steady",
+                speed_kmh=64.0,
+                speed_band="60-80 km/h",
+                speed_source="gps",
+                engine_rpm=1240.0,
+                engine_rpm_source="obd2",
+            ),
+            WholeRunContextWindowLabel(
+                window_index=2,
+                segment_index=0,
+                phase=DrivingPhase.CRUISE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="steady",
+                speed_kmh=68.0,
+                speed_band="60-80 km/h",
+                speed_source="gps",
+                engine_rpm=1280.0,
+                engine_rpm_source="obd2",
+            ),
+            WholeRunContextWindowLabel(
+                window_index=3,
+                segment_index=0,
+                phase=DrivingPhase.CRUISE,
+                context_coverage="full",
+                speed_validity="measured",
+                rpm_validity="measured",
+                load_state="steady",
+                speed_kmh=70.0,
+                speed_band="60-80 km/h",
+                speed_source="gps",
+                engine_rpm=1300.0,
+                engine_rpm_source="obd2",
+            ),
+        ),
+        intervals=(
+            WholeRunContextInterval(
+                segment_index=0,
+                phase=DrivingPhase.CRUISE,
+                load_state="steady",
+                start_window_index=0,
+                end_window_index=3,
+                start_t_s=0.0,
+                end_t_s=2.0,
+                speed_min_kmh=60.0,
+                speed_max_kmh=70.0,
+                speed_band="60-80 km/h",
+                full_context_window_count=4,
+            ),
+        ),
+    )
+    order_trace_bundle = WholeRunOrderTraceArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-diagnosis-ranking",
+            relative_dir="whole-run-artifacts/run-diagnosis-ranking",
+            window_policy=window_policy,
+            total_window_count=4,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+                    relative_path="orders/traces.jsonl",
+                    file_format="jsonl",
+                    record_count=1,
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY: b"{}\n"},
+        points=(
+            OrderTracePoint(
+                hypothesis_key="wheel_1x",
+                suspected_source="wheel/tire",
+                order_family="wheel",
+                harmonic=1,
+                order_label="1x wheel",
+                window_index=0,
+                eligible=True,
+                matched=True,
+                predicted_hz=13.0,
+                matched_hz=13.1,
+                relative_error=0.03,
+                peak_intensity_db=18.0,
+                vibration_strength_db=10.0,
+                ref_source="speed+tire",
+                strongest_location="front-left",
+            ),
+        ),
+    )
+    order_summaries = (
+        OrderTraceSummary(
+            hypothesis_key="wheel_1x",
+            suspected_source="wheel/tire",
+            order_family="wheel",
+            order_label="1x wheel",
+            total_window_count=4,
+            eligible_window_count=4,
+            matched_window_count=3,
+            support_ratio=0.75,
+            reference_coverage_ratio=0.9,
+            longest_contiguous_support_window_count=3,
+            contiguous_support_ratio=0.75,
+            support_intervals=(
+                OrderTraceSupportInterval(
+                    interval_index=0,
+                    start_window_index=0,
+                    end_window_index=2,
+                    matched_window_count=3,
+                    support_ratio=1.0,
+                    start_t_s=0.0,
+                    end_t_s=1.5,
+                    phase="cruise",
+                    speed_band="60-80 km/h",
+                    mean_relative_error=0.03,
+                ),
+            ),
+            stable_frequency_min_hz=13.1,
+            stable_frequency_max_hz=13.4,
+            exemplar_interval_index=0,
+            dominant_phase="cruise",
+            dominant_speed_band="60-80 km/h",
+            strongest_location="front-left",
+            mean_relative_error=0.03,
+            drift_score=0.1,
+            lock_score=0.8,
+            peak_intensity_db=18.0,
+            mean_vibration_strength_db=10.0,
+            ref_sources=("speed+tire",),
+        ),
+    )
+    order_trace_summary_bundle = WholeRunOrderTraceSummaryArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-diagnosis-ranking",
+            relative_dir="whole-run-artifacts/run-diagnosis-ranking",
+            window_policy=window_policy,
+            total_window_count=4,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY,
+                    relative_path="orders/trace-summaries.jsonl",
+                    file_format="jsonl",
+                    record_count=1,
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY: b"{}\n"},
+        summaries=order_summaries,
+    )
+    order_family_bundle = WholeRunOrderFamilySummaryArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-diagnosis-ranking",
+            relative_dir="whole-run-artifacts/run-diagnosis-ranking",
+            window_policy=window_policy,
+            total_window_count=4,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY,
+                    relative_path="orders/family-summaries.jsonl",
+                    file_format="jsonl",
+                    record_count=1,
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY: b"{}\n"},
+        summaries=order_summaries,
+    )
+    spatial_bundle = WholeRunSpatialCoherenceArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-diagnosis-ranking",
+            relative_dir="whole-run-artifacts/run-diagnosis-ranking",
+            window_policy=window_policy,
+            total_window_count=4,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
+                    relative_path="spatial/coherence-windows.jsonl",
+                    file_format="jsonl",
+                    record_count=1,
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY: b"{}\n"},
+        windows=(),
+        summaries=(
+            SpatialEvidenceSummary(
+                candidate_key="wheel_1x",
+                suspected_source="wheel/tire",
+                proof_basis="supporting_windows_raw_backed",
+                total_window_count=4,
+                supporting_window_count=3,
+                supporting_sensor_count=2,
+                coherent_window_count=3,
+                coherence_ratio=1.0,
+                dominant_location="front-left",
+                runner_up_location="rear-left",
+                location_separation_db=3.2,
+                dominance_ratio=1.6,
+                location_summaries=(
+                    SpatialLocationSummary(
+                        location="front-left",
+                        sensor_ids=("front",),
+                        supporting_window_count=3,
+                        support_ratio=1.0,
+                        coherent_window_count=3,
+                        coherence_ratio=1.0,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    result = execute_post_analysis(
+        run_id="run-diagnosis-ranking",
+        db=type(
+            "DB",
+            (),
+            {
+                "astore_whole_run_artifacts": lambda _self, _run_id, manifest, artifact_contents: (
+                    stored.setdefault("whole_run_manifest", manifest),
+                    stored.setdefault("whole_run_artifact_contents", artifact_contents),
+                    manifest,
+                )[2],
+                "astore_analysis": lambda _self, _run_id, summary: stored.setdefault(
+                    "analysis", summary.to_json_object()
+                ),
+            },
+        )(),
+        load_run=lambda *, run_id, db: LoadedPostAnalysisRun(
+            run_id="run-diagnosis-ranking",
+            metadata=_run_metadata("run-diagnosis-ranking"),
+            language="en",
+            samples=_samples(),
+            total_sample_count=1,
+            stride=1,
+            context_samples=_samples(),
+            raw_capture_manifest=raw_capture_manifest,
+        ),
+        whole_run_artifact_builder=lambda **_kwargs: type(
+            "Bundle",
+            (),
+            {
+                "manifest": spectral_manifest,
+                "artifact_contents": {"spectral-summary:sensor-a": b"{}\n"},
+            },
+        )(),
+        whole_run_context_builder=lambda **_kwargs: context_bundle,
+        whole_run_order_trace_builder=lambda **_kwargs: order_trace_bundle,
+        whole_run_order_trace_summary_builder=lambda **_kwargs: order_trace_summary_bundle,
+        whole_run_order_family_summary_builder=lambda **_kwargs: order_family_bundle,
+        whole_run_spatial_coherence_builder=lambda **_kwargs: spatial_bundle,
+        analysis_runner=lambda _run: make_persisted_analysis(
+            {
+                "analysis_metadata": {
+                    "analyzed_sample_count": 1,
+                    "total_sample_count": 1,
+                    "sampling_method": "full",
+                    "raw_backed_sample_count": 48,
+                    "raw_capture_mode": "raw_backed",
+                },
+                "run_suitability": [],
+            }
+        ),
+    )
+
+    assert isinstance(result, PostAnalysisExecutionSuccess)
+    analysis_metadata = stored["analysis"]["analysis_metadata"]
+    diagnosis_summaries = stored["analysis"]["whole_run_diagnosis_summaries"]
+    assert analysis_metadata["whole_run_diagnosis_summaries_available"] is True
+    assert analysis_metadata["whole_run_diagnosis_summary_count"] == 1
+    assert diagnosis_summaries[0]["diagnosis_key"] == "wheel_1x"
+    assert diagnosis_summaries[0]["rank"] == 1
+    assert diagnosis_summaries[0]["location_proof_basis"] == "supporting_windows_raw_backed"
+    assert diagnosis_summaries[0]["support_factors"][0]["factor_key"] == "raw_backed"

--- a/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
@@ -23,8 +23,10 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ReportConfidenceFacts",
+    "ReportConfidenceScoringInputs",
     "build_report_confidence_facts",
     "project_whole_run_diagnosis_factors",
+    "score_report_confidence_inputs",
 ]
 
 
@@ -57,6 +59,31 @@ class ReportConfidenceFacts:
     caveat_keys: tuple[str, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class ReportConfidenceScoringInputs:
+    """Normalized inputs for deterministic non-fallback confidence scoring."""
+
+    base_confidence: float
+    data_basis: str
+    raw_backed_sample_count: int
+    supporting_window_count: int | None
+    supporting_duration_s: float | None
+    stable_frequency_min_hz: float | None
+    stable_frequency_max_hz: float | None
+    supporting_location_count: int
+    top_support_location: str | None
+    top_support_share: float | None
+    mean_relative_error: float | None
+    snr_db: float | None
+    alternative_source: str | None
+    has_reference_gap: bool
+    weak_spatial: bool
+    context_traceable: bool
+    context_source: str
+    speed_gap_window_count: int
+    rpm_gap_window_count: int
+
+
 def build_report_confidence_facts(
     *,
     has_explicit_analysis_metadata: bool,
@@ -76,10 +103,6 @@ def build_report_confidence_facts(
     supporting_duration_s = evidence_facts.supporting_duration_s
     stable_frequency_min_hz = evidence_facts.stable_frequency_min_hz
     stable_frequency_max_hz = evidence_facts.stable_frequency_max_hz
-    frequency_span_hz = _frequency_span_hz(
-        stable_frequency_min_hz=stable_frequency_min_hz,
-        stable_frequency_max_hz=stable_frequency_max_hz,
-    )
     supporting_location_count, top_support_location, top_support_share = _support_location_summary(
         evidence_facts=evidence_facts,
     )
@@ -108,149 +131,30 @@ def build_report_confidence_facts(
             top_support_share=top_support_share,
         )
 
-    score = (
-        max(0.0, min(0.70, 0.25 + (primary_candidate.confidence * 0.40)))
-        if primary_candidate.domain_primary is not None
-        else 0.0
-    )
-    signal_keys: list[str] = []
-    caveat_keys: list[str] = []
-
-    if evidence_facts.data_basis == "raw_backed":
-        score += 0.10
-        signal_keys.append("raw_backed")
-    else:
-        score -= 0.05
-        caveat_keys.append("summary_only")
-
-    if context_facts.traceable:
-        if context_facts.source == "legacy":
-            score -= 0.05
-            caveat_keys.append("legacy_context")
-        else:
-            if context_facts.has_speed_gaps:
-                score -= 0.04
-                caveat_keys.append("speed_context_gaps")
-            if context_facts.has_rpm_gaps:
-                score -= 0.04
-                caveat_keys.append("rpm_context_gaps")
-
-    if supporting_window_count is not None:
-        if supporting_window_count >= 4:
-            score += 0.10
-            signal_keys.append("repeated_support")
-        elif supporting_window_count >= 2:
-            score += 0.05
-            signal_keys.append("repeated_support")
-        elif supporting_window_count <= 1:
-            score -= 0.10
-            caveat_keys.append("sparse_support")
-
-    if supporting_duration_s is not None:
-        if supporting_duration_s >= 1.0:
-            score += 0.08
-            signal_keys.append("sustained_support")
-        elif supporting_duration_s >= 0.5:
-            score += 0.04
-            signal_keys.append("sustained_support")
-        elif supporting_duration_s > 0:
-            score -= 0.06
-            caveat_keys.append("brief_support")
-
-    if frequency_span_hz is not None:
-        if frequency_span_hz <= 0.5:
-            score += 0.08
-            signal_keys.append("stable_frequency")
-        elif frequency_span_hz <= 1.0:
-            score += 0.04
-            signal_keys.append("stable_frequency")
-        elif frequency_span_hz > 1.5:
-            score -= 0.06
-            caveat_keys.append("drifting_frequency")
-
-    if mean_relative_error is not None:
-        if mean_relative_error <= 0.05:
-            score += 0.08
-            signal_keys.append("tight_order_lock")
-        elif mean_relative_error >= 0.15:
-            score -= 0.08
-            caveat_keys.append("loose_order_lock")
-
-    if top_support_share is not None:
-        if top_support_share >= 0.67:
-            score += 0.08
-            signal_keys.append("localized_support")
-        elif supporting_location_count > 1 and top_support_share < 0.55:
-            score -= 0.10
-            caveat_keys.append("mixed_support_locations")
-
-    if snr_db is not None:
-        if snr_db >= 6.0:
-            score += 0.05
-            signal_keys.append("clean_signal")
-        elif snr_db < 3.0:
-            score -= 0.06
-            caveat_keys.append("noisy_signal")
-
-    if primary_candidate.weak_spatial:
-        score -= 0.10
-        caveat_keys.append("weak_spatial")
-
-    if alternative_source is not None:
-        score -= 0.10
-        caveat_keys.append("close_alternative")
-
-    if evidence_facts.has_reference_gap:
-        score -= 0.06
-        caveat_keys.append("incomplete_reference")
-
-    rounded_score = _rounded_score(score)
-    label_key = _label_key_for_score(rounded_score)
-    caveat_key_set = set(caveat_keys)
-    tier = (
-        "C"
-        if label_key == "CONFIDENCE_HIGH"
-        and not caveat_key_set.intersection(
-            {
-                "summary_only",
-                "drifting_frequency",
-                "loose_order_lock",
-                "mixed_support_locations",
-                "weak_spatial",
-                "close_alternative",
-                "incomplete_reference",
-                "legacy_context",
-                "speed_context_gaps",
-                "rpm_context_gaps",
-                "noisy_signal",
-            }
+    return score_report_confidence_inputs(
+        ReportConfidenceScoringInputs(
+            base_confidence=primary_candidate.confidence
+            if primary_candidate.domain_primary
+            else 0.0,
+            data_basis=evidence_facts.data_basis,
+            raw_backed_sample_count=evidence_facts.raw_backed_sample_count,
+            supporting_window_count=supporting_window_count,
+            supporting_duration_s=supporting_duration_s,
+            stable_frequency_min_hz=stable_frequency_min_hz,
+            stable_frequency_max_hz=stable_frequency_max_hz,
+            supporting_location_count=supporting_location_count,
+            top_support_location=top_support_location,
+            top_support_share=top_support_share,
+            mean_relative_error=mean_relative_error,
+            snr_db=snr_db,
+            alternative_source=alternative_source,
+            has_reference_gap=evidence_facts.has_reference_gap,
+            weak_spatial=primary_candidate.weak_spatial,
+            context_traceable=context_facts.traceable,
+            context_source=context_facts.source,
+            speed_gap_window_count=context_facts.speed_gap_window_count,
+            rpm_gap_window_count=context_facts.rpm_gap_window_count,
         )
-        else ("B" if label_key != "CONFIDENCE_LOW" else "A")
-    )
-    return ReportConfidenceFacts(
-        score_0_to_1=rounded_score,
-        label_key=label_key,
-        pct_text=f"{rounded_score * 100:.0f}%",
-        tier=tier,
-        data_basis=evidence_facts.data_basis,
-        raw_backed_sample_count=evidence_facts.raw_backed_sample_count,
-        supporting_window_count=supporting_window_count,
-        supporting_duration_s=supporting_duration_s,
-        stable_frequency_min_hz=stable_frequency_min_hz,
-        stable_frequency_max_hz=stable_frequency_max_hz,
-        supporting_location_count=supporting_location_count,
-        top_support_location=top_support_location,
-        top_support_share=top_support_share,
-        mean_relative_error=mean_relative_error,
-        snr_db=snr_db,
-        alternative_source=alternative_source,
-        has_reference_gap=evidence_facts.has_reference_gap,
-        speed_gap_window_count=context_facts.speed_gap_window_count,
-        rpm_gap_window_count=context_facts.rpm_gap_window_count,
-        uses_summary_fallback=False,
-        fallback_reason=None,
-        signal_keys=tuple(dict.fromkeys(signal_keys)),
-        caveat_keys=tuple(dict.fromkeys(caveat_keys)),
     )
 
 
@@ -387,6 +291,159 @@ def project_whole_run_diagnosis_factors(
         )
 
     return (tuple(support_factors), tuple(counter_factors))
+
+
+def score_report_confidence_inputs(
+    inputs: ReportConfidenceScoringInputs,
+) -> ReportConfidenceFacts:
+    """Apply canonical non-fallback confidence scoring to normalized signal inputs."""
+
+    score = max(0.0, min(0.70, 0.25 + (inputs.base_confidence * 0.40)))
+    signal_keys: list[str] = []
+    caveat_keys: list[str] = []
+    frequency_span_hz = _frequency_span_hz(
+        stable_frequency_min_hz=inputs.stable_frequency_min_hz,
+        stable_frequency_max_hz=inputs.stable_frequency_max_hz,
+    )
+
+    if inputs.data_basis == "raw_backed":
+        score += 0.10
+        signal_keys.append("raw_backed")
+    else:
+        score -= 0.05
+        caveat_keys.append("summary_only")
+
+    if inputs.context_traceable:
+        if inputs.context_source == "legacy":
+            score -= 0.05
+            caveat_keys.append("legacy_context")
+        else:
+            if inputs.speed_gap_window_count > 0:
+                score -= 0.04
+                caveat_keys.append("speed_context_gaps")
+            if inputs.rpm_gap_window_count > 0:
+                score -= 0.04
+                caveat_keys.append("rpm_context_gaps")
+
+    supporting_window_count = inputs.supporting_window_count
+    if supporting_window_count is not None:
+        if supporting_window_count >= 4:
+            score += 0.10
+            signal_keys.append("repeated_support")
+        elif supporting_window_count >= 2:
+            score += 0.05
+            signal_keys.append("repeated_support")
+        elif supporting_window_count <= 1:
+            score -= 0.10
+            caveat_keys.append("sparse_support")
+
+    supporting_duration_s = inputs.supporting_duration_s
+    if supporting_duration_s is not None:
+        if supporting_duration_s >= 1.0:
+            score += 0.08
+            signal_keys.append("sustained_support")
+        elif supporting_duration_s >= 0.5:
+            score += 0.04
+            signal_keys.append("sustained_support")
+        elif supporting_duration_s > 0:
+            score -= 0.06
+            caveat_keys.append("brief_support")
+
+    if frequency_span_hz is not None:
+        if frequency_span_hz <= 0.5:
+            score += 0.08
+            signal_keys.append("stable_frequency")
+        elif frequency_span_hz <= 1.0:
+            score += 0.04
+            signal_keys.append("stable_frequency")
+        elif frequency_span_hz > 1.5:
+            score -= 0.06
+            caveat_keys.append("drifting_frequency")
+
+    if inputs.mean_relative_error is not None:
+        if inputs.mean_relative_error <= 0.05:
+            score += 0.08
+            signal_keys.append("tight_order_lock")
+        elif inputs.mean_relative_error >= 0.15:
+            score -= 0.08
+            caveat_keys.append("loose_order_lock")
+
+    if inputs.top_support_share is not None:
+        if inputs.top_support_share >= 0.67:
+            score += 0.08
+            signal_keys.append("localized_support")
+        elif inputs.supporting_location_count > 1 and inputs.top_support_share < 0.55:
+            score -= 0.10
+            caveat_keys.append("mixed_support_locations")
+
+    if inputs.snr_db is not None:
+        if inputs.snr_db >= 6.0:
+            score += 0.05
+            signal_keys.append("clean_signal")
+        elif inputs.snr_db < 3.0:
+            score -= 0.06
+            caveat_keys.append("noisy_signal")
+
+    if inputs.weak_spatial:
+        score -= 0.10
+        caveat_keys.append("weak_spatial")
+
+    if inputs.alternative_source is not None:
+        score -= 0.10
+        caveat_keys.append("close_alternative")
+
+    if inputs.has_reference_gap:
+        score -= 0.06
+        caveat_keys.append("incomplete_reference")
+
+    rounded_score = _rounded_score(score)
+    label_key = _label_key_for_score(rounded_score)
+    caveat_key_set = set(caveat_keys)
+    tier = (
+        "C"
+        if label_key == "CONFIDENCE_HIGH"
+        and not caveat_key_set.intersection(
+            {
+                "summary_only",
+                "drifting_frequency",
+                "loose_order_lock",
+                "mixed_support_locations",
+                "weak_spatial",
+                "close_alternative",
+                "incomplete_reference",
+                "legacy_context",
+                "speed_context_gaps",
+                "rpm_context_gaps",
+                "noisy_signal",
+            }
+        )
+        else ("B" if label_key != "CONFIDENCE_LOW" else "A")
+    )
+    return ReportConfidenceFacts(
+        score_0_to_1=rounded_score,
+        label_key=label_key,
+        pct_text=f"{rounded_score * 100:.0f}%",
+        tier=tier,
+        data_basis=inputs.data_basis,
+        raw_backed_sample_count=inputs.raw_backed_sample_count,
+        supporting_window_count=inputs.supporting_window_count,
+        supporting_duration_s=inputs.supporting_duration_s,
+        stable_frequency_min_hz=inputs.stable_frequency_min_hz,
+        stable_frequency_max_hz=inputs.stable_frequency_max_hz,
+        supporting_location_count=inputs.supporting_location_count,
+        top_support_location=inputs.top_support_location,
+        top_support_share=inputs.top_support_share,
+        mean_relative_error=inputs.mean_relative_error,
+        snr_db=inputs.snr_db,
+        alternative_source=inputs.alternative_source,
+        has_reference_gap=inputs.has_reference_gap,
+        speed_gap_window_count=inputs.speed_gap_window_count,
+        rpm_gap_window_count=inputs.rpm_gap_window_count,
+        uses_summary_fallback=False,
+        fallback_reason=None,
+        signal_keys=tuple(dict.fromkeys(signal_keys)),
+        caveat_keys=tuple(dict.fromkeys(caveat_keys)),
+    )
 
 
 def _frequency_span_hz(

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
@@ -1,0 +1,490 @@
+"""Deterministic whole-run diagnosis ranking over persisted context/order/spatial summaries."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from vibesensor.shared.boundaries.reporting.confidence_facts import (
+    ReportConfidenceFacts,
+    ReportConfidenceScoringInputs,
+    project_whole_run_diagnosis_factors,
+    score_report_confidence_inputs,
+)
+from vibesensor.shared.types.whole_run_analysis import WholeRunContextInterval
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTraceSummary
+from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import SpatialEvidenceSummary
+from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
+    DiagnosisExemplarReference,
+    DiagnosisFactor,
+    DiagnosisFactorDetails,
+    WholeRunDiagnosisSummary,
+)
+
+__all__ = ["build_whole_run_diagnosis_summaries"]
+
+_CLOSE_ALTERNATIVE_SCORE_GAP = 0.10
+_AMBIGUOUS_DIAGNOSIS_SCORE_GAP = 0.05
+
+
+@dataclass(frozen=True, slots=True)
+class _CandidateEvaluation:
+    order_summary: OrderTraceSummary
+    spatial_summary: SpatialEvidenceSummary | None
+    confidence: ReportConfidenceFacts
+    support_factors: tuple[DiagnosisFactor, ...]
+    counterevidence_factors: tuple[DiagnosisFactor, ...]
+    alternative_source: str | None
+    confidence_gap_to_alternative: float | None
+
+
+def build_whole_run_diagnosis_summaries(
+    *,
+    analysis_metadata: Mapping[str, object],
+    context_intervals: tuple[WholeRunContextInterval, ...],
+    order_summaries: tuple[OrderTraceSummary, ...],
+    spatial_summaries: tuple[SpatialEvidenceSummary, ...],
+) -> tuple[WholeRunDiagnosisSummary, ...]:
+    """Rank persisted whole-run candidates into compact diagnosis summaries."""
+
+    if not order_summaries:
+        return ()
+    spatial_by_key = {summary.candidate_key: summary for summary in spatial_summaries}
+    initial = tuple(
+        _evaluate_candidate(
+            analysis_metadata=analysis_metadata,
+            order_summary=order_summary,
+            spatial_summary=spatial_by_key.get(order_summary.hypothesis_key),
+            alternative_source=None,
+            confidence_gap_to_alternative=None,
+        )
+        for order_summary in order_summaries
+    )
+    final = tuple(
+        _reevaluate_with_alternative(candidate, initial, analysis_metadata) for candidate in initial
+    )
+    ranked = sorted(
+        final,
+        key=lambda candidate: (
+            -candidate.confidence.score_0_to_1,
+            -_factor_weight_sum(candidate.support_factors),
+            _factor_weight_sum(candidate.counterevidence_factors),
+            -candidate.order_summary.lock_score,
+            -candidate.order_summary.support_ratio,
+            candidate.order_summary.hypothesis_key,
+        ),
+    )
+    summaries: list[WholeRunDiagnosisSummary] = []
+    for rank, candidate in enumerate(ranked, start=1):
+        summaries.append(
+            WholeRunDiagnosisSummary(
+                diagnosis_key=candidate.order_summary.hypothesis_key,
+                suspected_source=candidate.order_summary.suspected_source,
+                rank=rank,
+                data_basis=candidate.confidence.data_basis,  # type: ignore[arg-type]
+                support_score=round(_factor_weight_sum(candidate.support_factors), 2),
+                counterevidence_score=round(
+                    _factor_weight_sum(candidate.counterevidence_factors), 2
+                ),
+                total_score=round(candidate.confidence.score_0_to_1, 2),
+                order_hypothesis_key=candidate.order_summary.hypothesis_key,
+                spatial_candidate_key=(
+                    candidate.spatial_summary.candidate_key
+                    if candidate.spatial_summary is not None
+                    else None
+                ),
+                location_proof_basis=(
+                    candidate.spatial_summary.proof_basis
+                    if candidate.spatial_summary is not None
+                    else None
+                ),
+                supporting_window_count=candidate.order_summary.matched_window_count,
+                supporting_duration_s=_supporting_duration_s(candidate.order_summary),
+                supporting_sensor_count=(
+                    candidate.spatial_summary.supporting_sensor_count
+                    if candidate.spatial_summary is not None
+                    else None
+                ),
+                stable_frequency_min_hz=candidate.order_summary.stable_frequency_min_hz,
+                stable_frequency_max_hz=candidate.order_summary.stable_frequency_max_hz,
+                dominant_location=(
+                    candidate.spatial_summary.dominant_location
+                    if candidate.spatial_summary is not None
+                    else None
+                ),
+                runner_up_location=(
+                    candidate.spatial_summary.runner_up_location
+                    if candidate.spatial_summary is not None
+                    else None
+                ),
+                dominant_phase=candidate.order_summary.dominant_phase,
+                dominant_speed_band=candidate.order_summary.dominant_speed_band,
+                location_separation_db=(
+                    candidate.spatial_summary.location_separation_db
+                    if candidate.spatial_summary is not None
+                    else None
+                ),
+                dominance_ratio=(
+                    candidate.spatial_summary.dominance_ratio
+                    if candidate.spatial_summary is not None
+                    else None
+                ),
+                alternative_source=candidate.alternative_source,
+                confidence_gap_to_alternative=candidate.confidence_gap_to_alternative,
+                ambiguous_diagnosis=bool(
+                    candidate.confidence_gap_to_alternative is not None
+                    and candidate.confidence_gap_to_alternative <= _AMBIGUOUS_DIAGNOSIS_SCORE_GAP
+                ),
+                ambiguous_location=(
+                    candidate.spatial_summary.ambiguous_location
+                    if candidate.spatial_summary is not None
+                    else False
+                ),
+                suspicious=_is_suspicious(candidate),
+                weak_spatial_separation=(
+                    candidate.spatial_summary.weak_spatial_separation
+                    if candidate.spatial_summary is not None
+                    else False
+                ),
+                has_reference_gap=candidate.confidence.has_reference_gap,
+                uses_summary_fallback=candidate.confidence.uses_summary_fallback,
+                fallback_reason=candidate.confidence.fallback_reason,
+                exemplar_references=_exemplar_references(candidate, context_intervals),
+                support_factors=candidate.support_factors,
+                counterevidence_factors=candidate.counterevidence_factors,
+            )
+        )
+    return tuple(summaries)
+
+
+def _reevaluate_with_alternative(
+    candidate: _CandidateEvaluation,
+    initial: tuple[_CandidateEvaluation, ...],
+    analysis_metadata: Mapping[str, object],
+) -> _CandidateEvaluation:
+    alternative = _closest_alternative_candidate(candidate, initial)
+    if alternative is None:
+        return candidate
+    score_gap = abs(candidate.confidence.score_0_to_1 - alternative.confidence.score_0_to_1)
+    if score_gap > _CLOSE_ALTERNATIVE_SCORE_GAP:
+        return candidate
+    return _evaluate_candidate(
+        analysis_metadata=analysis_metadata,
+        order_summary=candidate.order_summary,
+        spatial_summary=candidate.spatial_summary,
+        alternative_source=alternative.order_summary.suspected_source,
+        confidence_gap_to_alternative=round(score_gap, 2),
+    )
+
+
+def _closest_alternative_candidate(
+    candidate: _CandidateEvaluation,
+    evaluations: tuple[_CandidateEvaluation, ...],
+) -> _CandidateEvaluation | None:
+    alternatives = [
+        other
+        for other in evaluations
+        if other.order_summary.hypothesis_key != candidate.order_summary.hypothesis_key
+        and other.order_summary.suspected_source != candidate.order_summary.suspected_source
+    ]
+    if not alternatives:
+        return None
+    return min(
+        alternatives,
+        key=lambda other: (
+            abs(candidate.confidence.score_0_to_1 - other.confidence.score_0_to_1),
+            -other.confidence.score_0_to_1,
+            other.order_summary.hypothesis_key,
+        ),
+    )
+
+
+def _evaluate_candidate(
+    *,
+    analysis_metadata: Mapping[str, object],
+    order_summary: OrderTraceSummary,
+    spatial_summary: SpatialEvidenceSummary | None,
+    alternative_source: str | None,
+    confidence_gap_to_alternative: float | None,
+) -> _CandidateEvaluation:
+    scoring_inputs = ReportConfidenceScoringInputs(
+        base_confidence=_base_confidence(order_summary, spatial_summary),
+        data_basis=_data_basis(analysis_metadata, spatial_summary),
+        raw_backed_sample_count=_count(analysis_metadata.get("raw_backed_sample_count")),
+        supporting_window_count=order_summary.matched_window_count,
+        supporting_duration_s=_supporting_duration_s(order_summary),
+        stable_frequency_min_hz=order_summary.stable_frequency_min_hz,
+        stable_frequency_max_hz=order_summary.stable_frequency_max_hz,
+        supporting_location_count=_supporting_location_count(spatial_summary),
+        top_support_location=_top_support_location(spatial_summary),
+        top_support_share=_top_support_share(spatial_summary),
+        mean_relative_error=order_summary.mean_relative_error,
+        snr_db=_snr_db(order_summary),
+        alternative_source=alternative_source,
+        has_reference_gap=_has_reference_gap(order_summary),
+        weak_spatial=bool(spatial_summary and spatial_summary.weak_spatial_separation),
+        context_traceable=True,
+        context_source=_context_source(analysis_metadata),
+        speed_gap_window_count=_count(
+            analysis_metadata.get("whole_run_context_missing_speed_window_count")
+        )
+        + _count(analysis_metadata.get("whole_run_context_stale_speed_window_count")),
+        rpm_gap_window_count=_count(
+            analysis_metadata.get("whole_run_context_missing_rpm_window_count")
+        )
+        + _count(analysis_metadata.get("whole_run_context_stale_rpm_window_count")),
+    )
+    confidence = score_report_confidence_inputs(scoring_inputs)
+    support_payloads, counter_payloads = project_whole_run_diagnosis_factors(confidence)
+    return _CandidateEvaluation(
+        order_summary=order_summary,
+        spatial_summary=spatial_summary,
+        confidence=confidence,
+        support_factors=tuple(_diagnosis_factor_from_payload(row) for row in support_payloads),
+        counterevidence_factors=tuple(
+            _diagnosis_factor_from_payload(row) for row in counter_payloads
+        ),
+        alternative_source=alternative_source,
+        confidence_gap_to_alternative=confidence_gap_to_alternative,
+    )
+
+
+def _base_confidence(
+    order_summary: OrderTraceSummary,
+    spatial_summary: SpatialEvidenceSummary | None,
+) -> float:
+    components = [
+        order_summary.support_ratio,
+        order_summary.reference_coverage_ratio,
+        order_summary.contiguous_support_ratio,
+        order_summary.lock_score,
+        max(0.0, 1.0 - order_summary.drift_score),
+    ]
+    if order_summary.mean_relative_error is not None:
+        components.append(max(0.0, 1.0 - min(order_summary.mean_relative_error / 0.25, 1.0)))
+    if spatial_summary is not None:
+        if spatial_summary.coherence_ratio is not None:
+            components.append(spatial_summary.coherence_ratio)
+        components.append(
+            min(
+                1.0,
+                spatial_summary.supporting_window_count
+                / max(1, spatial_summary.total_window_count),
+            )
+        )
+        if spatial_summary.dominance_ratio is not None:
+            components.append(min(1.0, max(0.0, spatial_summary.dominance_ratio - 1.0)))
+    return sum(components) / len(components) if components else 0.0
+
+
+def _data_basis(
+    analysis_metadata: Mapping[str, object],
+    spatial_summary: SpatialEvidenceSummary | None,
+) -> str:
+    raw_capture_mode = str(analysis_metadata.get("raw_capture_mode") or "").strip().lower()
+    if raw_capture_mode in {"raw_backed", "summary_only"}:
+        return raw_capture_mode
+    if (
+        spatial_summary is not None
+        and spatial_summary.proof_basis == "supporting_windows_summary_only"
+    ):
+        return "summary_only"
+    return "raw_backed"
+
+
+def _context_source(analysis_metadata: Mapping[str, object]) -> str:
+    if bool(analysis_metadata.get("whole_run_context_available")):
+        return "whole_run"
+    if _data_basis(analysis_metadata, None) == "summary_only":
+        return "summary_only"
+    return "legacy"
+
+
+def _supporting_duration_s(order_summary: OrderTraceSummary) -> float | None:
+    durations = [
+        interval.end_t_s - interval.start_t_s
+        for interval in order_summary.support_intervals
+        if interval.start_t_s is not None
+        and interval.end_t_s is not None
+        and interval.end_t_s >= interval.start_t_s
+    ]
+    if not durations:
+        return None
+    return sum(durations)
+
+
+def _snr_db(order_summary: OrderTraceSummary) -> float | None:
+    if order_summary.peak_intensity_db is None or order_summary.mean_vibration_strength_db is None:
+        return None
+    return order_summary.peak_intensity_db - order_summary.mean_vibration_strength_db
+
+
+def _has_reference_gap(order_summary: OrderTraceSummary) -> bool:
+    return order_summary.reference_coverage_ratio < 0.999
+
+
+def _supporting_location_count(spatial_summary: SpatialEvidenceSummary | None) -> int:
+    if spatial_summary is None:
+        return 0
+    return len(
+        [row for row in spatial_summary.location_summaries if row.supporting_window_count > 0]
+    )
+
+
+def _top_support_location(spatial_summary: SpatialEvidenceSummary | None) -> str | None:
+    if spatial_summary is None or not spatial_summary.location_summaries:
+        return None
+    return spatial_summary.location_summaries[0].location
+
+
+def _top_support_share(spatial_summary: SpatialEvidenceSummary | None) -> float | None:
+    if spatial_summary is None or not spatial_summary.location_summaries:
+        return None
+    total = sum(row.supporting_window_count for row in spatial_summary.location_summaries)
+    if total <= 0:
+        return None
+    return spatial_summary.location_summaries[0].supporting_window_count / total
+
+
+def _diagnosis_factor_from_payload(payload: Mapping[str, object]) -> DiagnosisFactor:
+    details_payload = payload.get("details")
+    details_mapping = details_payload if isinstance(details_payload, Mapping) else {}
+    return DiagnosisFactor(
+        factor_key=str(payload.get("factor_key")),  # type: ignore[arg-type]
+        polarity=str(payload.get("polarity")),  # type: ignore[arg-type]
+        severity=str(payload.get("severity")),  # type: ignore[arg-type]
+        weight=_optional_float(payload.get("weight")) or 0.0,
+        details=DiagnosisFactorDetails(
+            raw_backed_sample_count=_optional_count(details_mapping.get("raw_backed_sample_count")),
+            supporting_window_count=_optional_count(details_mapping.get("supporting_window_count")),
+            supporting_duration_s=_optional_float(details_mapping.get("supporting_duration_s")),
+            stable_frequency_min_hz=_optional_float(details_mapping.get("stable_frequency_min_hz")),
+            stable_frequency_max_hz=_optional_float(details_mapping.get("stable_frequency_max_hz")),
+            frequency_span_hz=_optional_float(details_mapping.get("frequency_span_hz")),
+            supporting_location_count=_optional_count(
+                details_mapping.get("supporting_location_count")
+            ),
+            top_support_location=_optional_text(details_mapping.get("top_support_location")),
+            top_support_share=_optional_float(details_mapping.get("top_support_share")),
+            mean_relative_error=_optional_float(details_mapping.get("mean_relative_error")),
+            snr_db=_optional_float(details_mapping.get("snr_db")),
+            alternative_source=_optional_text(details_mapping.get("alternative_source")),
+            speed_gap_window_count=_optional_count(details_mapping.get("speed_gap_window_count")),
+            rpm_gap_window_count=_optional_count(details_mapping.get("rpm_gap_window_count")),
+            fallback_reason=_optional_text(details_mapping.get("fallback_reason")),
+        ),
+    )
+
+
+def _exemplar_references(
+    candidate: _CandidateEvaluation,
+    context_intervals: tuple[WholeRunContextInterval, ...],
+) -> tuple[DiagnosisExemplarReference, ...]:
+    references: list[DiagnosisExemplarReference] = []
+    order_summary = candidate.order_summary
+    if order_summary.exemplar_interval_index is not None:
+        references.append(
+            DiagnosisExemplarReference(
+                kind="order_support_interval",
+                order_hypothesis_key=order_summary.hypothesis_key,
+                support_interval_index=order_summary.exemplar_interval_index,
+                phase=order_summary.dominant_phase,
+                speed_band=order_summary.dominant_speed_band,
+            )
+        )
+    if (
+        candidate.spatial_summary is not None
+        and candidate.spatial_summary.dominant_location is not None
+    ):
+        references.append(
+            DiagnosisExemplarReference(
+                kind="spatial_location",
+                spatial_candidate_key=candidate.spatial_summary.candidate_key,
+                location=candidate.spatial_summary.dominant_location,
+            )
+        )
+    context_interval = _matching_context_interval(order_summary, context_intervals)
+    if context_interval is not None:
+        references.append(
+            DiagnosisExemplarReference(
+                kind="whole_run_context_interval",
+                context_segment_index=context_interval.segment_index,
+                phase=context_interval.phase.value,
+                speed_band=context_interval.speed_band,
+            )
+        )
+    return tuple(references)
+
+
+def _matching_context_interval(
+    order_summary: OrderTraceSummary,
+    context_intervals: tuple[WholeRunContextInterval, ...],
+) -> WholeRunContextInterval | None:
+    if not context_intervals:
+        return None
+    desired_phase = _normalized_text(order_summary.dominant_phase)
+    desired_speed_band = _normalized_speed_band(order_summary.dominant_speed_band)
+    for interval in context_intervals:
+        if desired_phase and _normalized_text(interval.phase.value) != desired_phase:
+            continue
+        if desired_speed_band:
+            interval_band = _normalized_speed_band(interval.speed_band)
+            if interval_band and interval_band != desired_speed_band:
+                continue
+        return interval
+    if desired_phase:
+        for interval in context_intervals:
+            if _normalized_text(interval.phase.value) == desired_phase:
+                return interval
+    return context_intervals[0]
+
+
+def _is_suspicious(candidate: _CandidateEvaluation) -> bool:
+    suspicious_factor_keys = {
+        "drifting_frequency",
+        "mixed_support_locations",
+        "weak_spatial",
+        "close_alternative",
+    }
+    if (
+        candidate.confidence_gap_to_alternative is not None
+        and candidate.confidence_gap_to_alternative <= _AMBIGUOUS_DIAGNOSIS_SCORE_GAP
+    ):
+        return True
+    return any(
+        factor.factor_key in suspicious_factor_keys for factor in candidate.counterevidence_factors
+    )
+
+
+def _factor_weight_sum(factors: tuple[DiagnosisFactor, ...]) -> float:
+    return sum(factor.weight for factor in factors)
+
+
+def _count(value: object) -> int:
+    return int(value) if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _optional_count(value: object) -> int | None:
+    return int(value) if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _optional_float(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _optional_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _normalized_text(value: str | None) -> str:
+    return str(value or "").strip().lower()
+
+
+def _normalized_speed_band(value: str | None) -> str:
+    text = _normalized_text(value)
+    return text.replace("km/h", "").replace(" ", "")

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Protocol, cast
 
@@ -41,6 +42,12 @@ from vibesensor.use_cases.diagnostics.whole_run_context import (
     WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
     WholeRunContextArtifactBundle,
     build_whole_run_context_artifact_bundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
+    WholeRunDiagnosisSummary,
+)
+from vibesensor.use_cases.diagnostics.whole_run_diagnosis_ranking import (
+    build_whole_run_diagnosis_summaries,
 )
 from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
     WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
@@ -93,10 +100,18 @@ def _sync_call(db: Any, method_name: str, *args: Any, **kwargs: Any) -> Any:
     return result
 
 
+def _coerce_persisted_analysis(
+    summary: PersistedAnalysis | Mapping[str, object],
+) -> PersistedAnalysis:
+    if isinstance(summary, PersistedAnalysis):
+        return summary
+    return PersistedAnalysis.from_json_object(summary)
+
+
 class PostAnalysisRunner(Protocol):
     """Injected boundary for building the stored post-stop analysis summary."""
 
-    def __call__(self, run: PostAnalysisRunInput) -> PersistedAnalysis: ...
+    def __call__(self, run: PostAnalysisRunInput) -> PersistedAnalysis | Mapping[str, object]: ...
 
 
 class PostAnalysisLoader(Protocol):
@@ -182,6 +197,19 @@ class WholeRunSpatialCoherenceBuilder(Protocol):
     ) -> WholeRunSpatialCoherenceArtifactBundle | None: ...
 
 
+class WholeRunDiagnosisSummaryBuilder(Protocol):
+    """Injected boundary for building compact fused whole-run diagnosis summaries."""
+
+    def __call__(
+        self,
+        *,
+        analysis_metadata: Mapping[str, object],
+        context_bundle: WholeRunContextArtifactBundle,
+        order_summaries: tuple[OrderTraceSummary, ...],
+        spatial_summaries: tuple[SpatialEvidenceSummary, ...],
+    ) -> tuple[WholeRunDiagnosisSummary, ...]: ...
+
+
 @dataclass(frozen=True, slots=True)
 class _StoredWholeRunArtifactBundle:
     """Generic sidecar bundle shape for final manifest persistence."""
@@ -202,6 +230,7 @@ def execute_post_analysis(
     whole_run_order_trace_summary_builder: WholeRunOrderTraceSummaryBuilder | None = None,
     whole_run_order_family_summary_builder: WholeRunOrderFamilySummaryBuilder | None = None,
     whole_run_spatial_coherence_builder: WholeRunSpatialCoherenceBuilder | None = None,
+    whole_run_diagnosis_summary_builder: WholeRunDiagnosisSummaryBuilder | None = None,
     defer_retryable_error_storage: bool = False,
 ) -> PostAnalysisAttemptResult:
     analysis_start = time.monotonic()
@@ -234,6 +263,11 @@ def execute_post_analysis(
         _build_whole_run_spatial_coherence_artifacts
         if whole_run_spatial_coherence_builder is None
         else whole_run_spatial_coherence_builder
+    )
+    resolved_whole_run_diagnosis_summary_builder = (
+        _build_whole_run_diagnosis_summaries
+        if whole_run_diagnosis_summary_builder is None
+        else whole_run_diagnosis_summary_builder
     )
     with start_span(
         __name__,
@@ -372,9 +406,16 @@ def execute_post_analysis(
                             f"Failed to persist whole-run artifacts for run {loaded.run_id}"
                         )
             span.set_attribute("vibesensor.sample_count", len(run_input.samples))
-            summary = analysis_runner(run_input)
+            summary = _coerce_persisted_analysis(analysis_runner(run_input))
             if context_bundle is not None:
                 summary = _append_whole_run_context(summary, context_bundle)
+            analysis_payload = summary.to_json_object()
+            analysis_metadata_payload = analysis_payload.get("analysis_metadata")
+            analysis_metadata = (
+                dict(analysis_metadata_payload)
+                if isinstance(analysis_metadata_payload, dict)
+                else {}
+            )
             if order_trace_bundle is not None:
                 summary = _append_whole_run_order_trace_metadata(summary, order_trace_bundle)
             if order_trace_summary_bundle is not None:
@@ -399,6 +440,25 @@ def execute_post_analysis(
                     summary,
                     spatial_coherence_bundle,
                 )
+            if context_bundle is not None and order_family_summary_bundle is not None:
+                diagnosis_summaries = resolved_whole_run_diagnosis_summary_builder(
+                    analysis_metadata=analysis_metadata,
+                    context_bundle=context_bundle,
+                    order_summaries=_ranked_whole_run_order_summaries(
+                        order_family_summary_bundle.summaries
+                    ),
+                    spatial_summaries=(
+                        _ranked_whole_run_spatial_summaries(spatial_coherence_bundle.summaries)
+                        if spatial_coherence_bundle is not None
+                        else ()
+                    ),
+                )
+                if diagnosis_summaries:
+                    summary = _append_whole_run_diagnosis_summaries(summary, diagnosis_summaries)
+                    summary = _append_whole_run_diagnosis_summary_metadata(
+                        summary,
+                        diagnosis_summaries,
+                    )
             if stored_artifact_manifest is not None:
                 summary = _append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
             _sync_call(db, "astore_analysis", loaded.run_id, summary)
@@ -869,6 +929,44 @@ def _append_whole_run_spatial_summaries(
         row.to_json_object() for row in _ranked_whole_run_spatial_summaries(bundle.summaries)
     ]
     return PersistedAnalysis.from_json_object(payload)
+
+
+def _append_whole_run_diagnosis_summaries(
+    summary: PersistedAnalysis,
+    diagnosis_summaries: tuple[WholeRunDiagnosisSummary, ...],
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    payload["whole_run_diagnosis_summaries"] = [row.to_json_object() for row in diagnosis_summaries]
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def _append_whole_run_diagnosis_summary_metadata(
+    summary: PersistedAnalysis,
+    diagnosis_summaries: tuple[WholeRunDiagnosisSummary, ...],
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    analysis_metadata["whole_run_diagnosis_summaries_available"] = True
+    analysis_metadata["whole_run_diagnosis_summary_count"] = len(diagnosis_summaries)
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def _build_whole_run_diagnosis_summaries(
+    *,
+    analysis_metadata: Mapping[str, object],
+    context_bundle: WholeRunContextArtifactBundle,
+    order_summaries: tuple[OrderTraceSummary, ...],
+    spatial_summaries: tuple[SpatialEvidenceSummary, ...],
+) -> tuple[WholeRunDiagnosisSummary, ...]:
+    return build_whole_run_diagnosis_summaries(
+        analysis_metadata=analysis_metadata,
+        context_intervals=context_bundle.intervals,
+        order_summaries=order_summaries,
+        spatial_summaries=spatial_summaries,
+    )
 
 
 def _ranked_whole_run_order_summaries(

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -369,6 +369,16 @@ That layer should settle:
   thresholds and score deltas already used by `ReportConfidenceFacts`, so the
   fused whole-run path does not drift from current report confidence semantics
 
+The actual ranker should live alongside that contract in
+`apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py`.
+Its first job is to join persisted `OrderTraceSummary`,
+`SpatialEvidenceSummary`, and `WholeRunContextInterval` rows by candidate key
+and segment context, then feed normalized signal inputs through the shared
+non-fallback scorer in
+`apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py`. That
+keeps whole-run ranking and the current report-confidence caveat language on one
+scoring path instead of creating a second threshold table.
+
 ## Shared contracts to settle early
 
 | Contract | Suggested owner | Notes |


### PR DESCRIPTION
Closes #3103

## What changed
- add `use_cases/diagnostics/whole_run_diagnosis_ranking.py` to rank persisted whole-run context, order, and spatial summaries into compact `WholeRunDiagnosisSummary` rows
- reuse the shared non-fallback report-confidence scorer instead of creating a second threshold table for whole-run ranking
- wire `post_analysis_executor.py` to persist `whole_run_diagnosis_summaries` plus availability/count metadata after context, order, and spatial summaries exist
- keep injected dict-style `analysis_runner` test doubles working by coercing them to `PersistedAnalysis` before whole-run enrichment
- add focused diagnostics/run regressions and update the whole-run design doc

## Why
- whole-run diagnosis contracts and stable factor keys already existed, but nothing actually produced ranked diagnosis rows from the persisted whole-run summaries
- this lands the first real ranking path without drifting from the existing report-confidence semantics

## Validation
- focused whole-run diagnosis ranker and executor pytest slice
- `make format`
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- `make ui-typecheck`
- `make test-changed`

## Risks / tradeoffs
- confidence still starts from compact order/spatial summary metrics, so summary-only and partial-artifact legacy fallback behavior stays deferred to #3104
- close-alternative and ambiguity handling is deterministic, but the score-gap thresholds may still need tuning once more cross-scenario regression coverage lands in #3106