### PR TITLE
Add diagnosis fallback scoring for legacy runs

### DIFF
--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_fallback.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from test_support.findings import make_finding_payload
+from test_support.report_helpers import minimal_summary
+
+from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
+from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+
+
+def _primary_finding() -> dict[str, object]:
+    return make_finding_payload(
+        finding_id="F_PRIMARY",
+        suspected_source="wheel/tire",
+        confidence=0.78,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        dominant_phase="cruise",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.1,
+                "matched_hz": 15.2,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 2.0,
+                "speed_kmh": 68.0,
+                "predicted_hz": 15.2,
+                "matched_hz": 15.2,
+                "location": "Rear Left",
+                "phase": "cruise",
+                "amp": 0.04,
+            },
+        ],
+        evidence_metrics={
+            "mean_relative_error": 0.03,
+            "snr_db": 8.0,
+            "matched_samples": 3,
+        },
+    )
+
+
+def _alternative_finding() -> dict[str, object]:
+    return make_finding_payload(
+        finding_id="F_ALT",
+        suspected_source="driveline",
+        confidence=0.72,
+        strongest_location="Rear Right",
+        strongest_speed_band="60-80 km/h",
+    )
+
+
+def _prepared_report_input(
+    *,
+    analysis_metadata: dict[str, object],
+    whole_run_context_intervals: list[dict[str, object]] | None = None,
+    whole_run_diagnosis_summaries: list[dict[str, object]] | None = None,
+    findings: list[dict[str, object]] | None = None,
+    top_causes: list[dict[str, object]] | None = None,
+) -> object:
+    primary = _primary_finding()
+    summary = minimal_summary(
+        run_id="fallback-run",
+        lang="en",
+        metadata={
+            "run_id": "fallback-run",
+            "record_type": "metadata",
+            "schema_version": "v2-jsonl",
+            "feature_interval_s": 0.5,
+        },
+        sensor_count_used=2,
+        sensor_locations=["Front Left", "Rear Left"],
+        sensor_locations_connected_throughout=["Front Left", "Rear Left"],
+        sensor_intensity_by_location=[
+            {"location": "Front Left", "p95_intensity_db": 16.0, "peak_intensity_db": 18.5},
+            {"location": "Rear Left", "p95_intensity_db": 9.0, "peak_intensity_db": 11.0},
+        ],
+        findings=findings if findings is not None else [primary, _alternative_finding()],
+        top_causes=top_causes if top_causes is not None else [primary, _alternative_finding()],
+        analysis_metadata=analysis_metadata,
+    )
+    if whole_run_context_intervals is not None:
+        summary["whole_run_context_intervals"] = whole_run_context_intervals
+    if whole_run_diagnosis_summaries is not None:
+        summary["whole_run_diagnosis_summaries"] = whole_run_diagnosis_summaries
+    return prepare_persisted_report_input(PersistedAnalysis.from_json_object(summary))
+
+
+def test_prepare_persisted_report_input_builds_summary_only_fallback_diagnosis_summary() -> None:
+    prepared = _prepared_report_input(
+        analysis_metadata={
+            "raw_backed_sample_count": 0,
+            "raw_capture_mode": "summary_only",
+        }
+    )
+
+    diagnosis = prepared.report_facts.whole_run_diagnosis_summaries
+
+    assert len(diagnosis) == 1
+    assert diagnosis[0].data_basis == "summary_only"
+    assert diagnosis[0].uses_summary_fallback is True
+    assert diagnosis[0].fallback_reason == "summary-only legacy confidence"
+    assert {factor.factor_key for factor in diagnosis[0].counterevidence_factors} >= {
+        "summary_only",
+        "close_alternative",
+    }
+
+
+def test_prepare_persisted_report_input_builds_raw_backed_legacy_fallback_diagnosis_summary() -> (
+    None
+):
+    prepared = _prepared_report_input(
+        analysis_metadata={
+            "raw_backed_sample_count": 48,
+            "raw_capture_mode": "raw_backed",
+        }
+    )
+
+    diagnosis = prepared.report_facts.whole_run_diagnosis_summaries
+
+    assert len(diagnosis) == 1
+    assert diagnosis[0].data_basis == "raw_backed"
+    assert diagnosis[0].uses_summary_fallback is True
+    assert (
+        diagnosis[0].fallback_reason
+        == "whole-run artifacts unavailable; replayed summary-era evidence"
+    )
+    assert diagnosis[0].location_proof_basis == "supporting_windows_raw_backed"
+    assert "summary_only" not in {
+        factor.factor_key for factor in diagnosis[0].counterevidence_factors
+    }
+    assert "legacy_context" in {
+        factor.factor_key for factor in diagnosis[0].counterevidence_factors
+    }
+
+
+def test_prepare_persisted_report_input_marks_partial_whole_run_inputs_as_incomplete_fallback() -> (
+    None
+):
+    prepared = _prepared_report_input(
+        analysis_metadata={
+            "raw_backed_sample_count": 48,
+            "raw_capture_mode": "raw_backed",
+            "whole_run_artifacts_available": True,
+            "whole_run_context_available": True,
+            "whole_run_context_window_count": 6,
+            "whole_run_context_interval_count": 1,
+            "whole_run_context_full_window_count": 6,
+            "whole_run_context_partial_window_count": 0,
+            "whole_run_context_missing_window_count": 0,
+        },
+        whole_run_context_intervals=[
+            {
+                "segment_index": 0,
+                "phase": "cruise",
+                "load_state": "light",
+                "start_window_index": 0,
+                "end_window_index": 5,
+                "start_t_s": 0.0,
+                "end_t_s": 3.0,
+                "speed_min_kmh": 58.0,
+                "speed_max_kmh": 68.0,
+                "speed_band": "50-70",
+                "full_context_window_count": 6,
+                "partial_context_window_count": 0,
+                "missing_context_window_count": 0,
+            }
+        ],
+    )
+
+    diagnosis = prepared.report_facts.whole_run_diagnosis_summaries
+
+    assert len(diagnosis) == 1
+    assert diagnosis[0].uses_summary_fallback is True
+    assert (
+        diagnosis[0].fallback_reason
+        == "whole-run diagnosis inputs incomplete; replayed summary-era evidence"
+    )
+    assert diagnosis[0].exemplar_references[0].kind == "whole_run_context_interval"
+    assert diagnosis[0].exemplar_references[0].context_segment_index == 0
+
+
+def test_prepare_persisted_report_input_keeps_persisted_whole_run_diagnosis_summaries() -> None:
+    prepared = _prepared_report_input(
+        analysis_metadata={
+            "raw_backed_sample_count": 48,
+            "raw_capture_mode": "raw_backed",
+            "whole_run_diagnosis_summaries_available": True,
+            "whole_run_diagnosis_summary_count": 1,
+        },
+        whole_run_diagnosis_summaries=[
+            {
+                "diagnosis_key": "wheel_1x",
+                "suspected_source": "wheel/tire",
+                "rank": 1,
+                "data_basis": "raw_backed",
+                "support_score": 0.78,
+                "counterevidence_score": 0.12,
+                "total_score": 0.66,
+                "location_proof_basis": "supporting_windows_raw_backed",
+                "supporting_window_count": 6,
+                "supporting_duration_s": 3.0,
+                "supporting_sensor_count": 2,
+                "dominant_location": "Front Left",
+                "dominant_phase": "cruise",
+                "dominant_speed_band": "60-80 km/h",
+                "ambiguous_diagnosis": False,
+                "ambiguous_location": False,
+                "suspicious": False,
+                "weak_spatial_separation": False,
+                "has_reference_gap": False,
+                "uses_summary_fallback": False,
+                "support_factors": [],
+                "counterevidence_factors": [],
+                "exemplar_references": [],
+            }
+        ],
+    )
+
+    diagnosis = prepared.report_facts.whole_run_diagnosis_summaries
+
+    assert len(diagnosis) == 1
+    assert diagnosis[0].diagnosis_key == "wheel_1x"
+    assert diagnosis[0].uses_summary_fallback is False

--- a/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, cast
 
 from vibesensor.domain import Finding
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from vibesensor.shared.boundaries.reporting.facts import ReportContextFacts
 
 __all__ = [
+    "apply_report_confidence_fallback",
     "ReportConfidenceFacts",
     "ReportConfidenceScoringInputs",
     "build_report_confidence_facts",
@@ -231,6 +232,24 @@ def _summary_fallback_confidence(
         fallback_reason=fallback_reason,
         signal_keys=(),
         caveat_keys=caveat_keys,
+    )
+
+
+def apply_report_confidence_fallback(
+    facts: ReportConfidenceFacts,
+    *,
+    fallback_reason: str,
+) -> ReportConfidenceFacts:
+    """Mark report confidence as an explicit fallback without changing its core score."""
+
+    caveat_keys = list(facts.caveat_keys)
+    if facts.data_basis == "summary_only" and "summary_only" not in caveat_keys:
+        caveat_keys.append("summary_only")
+    return replace(
+        facts,
+        uses_summary_fallback=True,
+        fallback_reason=fallback_reason,
+        caveat_keys=tuple(caveat_keys),
     )
 
 

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -28,10 +28,15 @@ if TYPE_CHECKING:
         NormalizedReportSummary,
         ReportTimelineInterval,
         ReportWholeRunContextInterval,
+        ReportWholeRunDiagnosisSummary,
     )
     from vibesensor.shared.types.analysis_views import PeakTableRow
 
-from vibesensor.shared.boundaries.reporting.confidence_facts import build_report_confidence_facts
+from vibesensor.shared.boundaries.reporting.confidence_facts import (
+    apply_report_confidence_fallback,
+    build_report_confidence_facts,
+    project_whole_run_diagnosis_factors,
+)
 from vibesensor.shared.boundaries.reporting.decision_facts import (
     ActionStatusKey,
     LocationConfidenceKey,
@@ -43,6 +48,7 @@ from vibesensor.shared.boundaries.reporting.findings import (
     prepare_report_findings,
 )
 from vibesensor.shared.boundaries.reporting.projection import (
+    PrimaryReportFacts,
     normalize_origin_location,
     resolve_report_origin,
 )
@@ -50,7 +56,9 @@ from vibesensor.shared.boundaries.reporting.sensor_facts import (
     build_report_sensor_facts,
     enrich_location_proof_sensor_facts,
 )
+from vibesensor.shared.boundaries.reporting.summary import report_summary_from_mapping
 from vibesensor.shared.run_context_warning import RunContextWarningsInput
+from vibesensor.shared.types.history_analysis_contracts import DiagnosisFactorResponse
 
 __all__ = [
     "ActionStatusKey",
@@ -140,6 +148,7 @@ class PreparedReportFacts:
     decision: ReportDecisionFacts
     evidence: ReportEvidenceFacts
     confidence: ReportConfidenceFacts
+    whole_run_diagnosis_summaries: tuple[ReportWholeRunDiagnosisSummary, ...]
     findings: PreparedReportFindings
 
 
@@ -187,6 +196,15 @@ def prepare_report_facts(
         decision_facts=decision_facts,
         context_facts=context_facts,
     )
+    whole_run_diagnosis_summaries = _report_whole_run_diagnosis_summaries(
+        payload,
+        summary=summary,
+        sensor_facts=sensor_facts,
+        decision_facts=decision_facts,
+        evidence_facts=evidence_facts,
+        confidence_facts=confidence_facts,
+        context_facts=context_facts,
+    )
     return PreparedReportFacts(
         run=ReportRunFacts(
             run_id=summary.run_id,
@@ -222,6 +240,7 @@ def prepare_report_facts(
         decision=decision_facts,
         evidence=evidence_facts,
         confidence=confidence_facts,
+        whole_run_diagnosis_summaries=whole_run_diagnosis_summaries,
         findings=prepare_report_findings(test_run),
     )
 
@@ -332,6 +351,162 @@ def _build_report_context_facts(
             speed_gap_window_count=missing_speed_window_count + stale_speed_window_count,
             rpm_gap_window_count=missing_rpm_window_count + stale_rpm_window_count,
         ),
+    )
+
+
+def _report_whole_run_diagnosis_summaries(
+    payload: Mapping[str, object],
+    *,
+    summary: NormalizedReportSummary,
+    sensor_facts: ReportSensorFacts,
+    decision_facts: ReportDecisionFacts,
+    evidence_facts: ReportEvidenceFacts,
+    confidence_facts: ReportConfidenceFacts,
+    context_facts: ReportContextFacts,
+) -> tuple[ReportWholeRunDiagnosisSummary, ...]:
+    if summary.whole_run_diagnosis_summaries:
+        return summary.whole_run_diagnosis_summaries
+    primary_candidate = decision_facts.primary_candidate
+    if primary_candidate.domain_primary is None or primary_candidate.primary_source is None:
+        return ()
+    fallback_reason = _whole_run_diagnosis_fallback_reason(payload, summary=summary)
+    if fallback_reason is None:
+        return ()
+    fallback_confidence = apply_report_confidence_fallback(
+        confidence_facts,
+        fallback_reason=fallback_reason,
+    )
+    support_factors, counterevidence_factors = project_whole_run_diagnosis_factors(
+        fallback_confidence
+    )
+    dominant_location = primary_candidate.primary_location or _proof_location(sensor_facts, index=0)
+    diagnosis_payload: dict[str, object] = {
+        "diagnosis_key": _fallback_diagnosis_key(primary_candidate),
+        "suspected_source": str(primary_candidate.primary_source),
+        "rank": 1,
+        "data_basis": fallback_confidence.data_basis,
+        "support_score": round(_factor_weight_sum(support_factors), 2),
+        "counterevidence_score": round(_factor_weight_sum(counterevidence_factors), 2),
+        "total_score": round(fallback_confidence.score_0_to_1, 2),
+        "location_proof_basis": sensor_facts.proof_basis,
+        "supporting_window_count": evidence_facts.supporting_window_count,
+        "supporting_duration_s": evidence_facts.supporting_duration_s,
+        "supporting_sensor_count": primary_candidate.sensor_count,
+        "stable_frequency_min_hz": evidence_facts.stable_frequency_min_hz,
+        "stable_frequency_max_hz": evidence_facts.stable_frequency_max_hz,
+        "dominant_location": dominant_location,
+        "runner_up_location": _proof_location(sensor_facts, index=1),
+        "dominant_phase": primary_candidate.domain_primary.dominant_phase,
+        "dominant_speed_band": primary_candidate.primary_speed,
+        "location_separation_db": _proof_location_separation_db(sensor_facts),
+        "dominance_ratio": primary_candidate.dominance_ratio,
+        "alternative_source": (
+            decision_facts.alternative_source if decision_facts.alternative_source_visible else None
+        ),
+        "confidence_gap_to_alternative": decision_facts.confidence_gap_to_alternative,
+        "ambiguous_diagnosis": bool(
+            decision_facts.confidence_gap_to_alternative is not None
+            and decision_facts.confidence_gap_to_alternative <= 0.05
+        ),
+        "ambiguous_location": False,
+        "suspicious": _fallback_diagnosis_is_suspicious(
+            counterevidence_factors=counterevidence_factors,
+            weak_spatial=primary_candidate.weak_spatial,
+        ),
+        "weak_spatial_separation": primary_candidate.weak_spatial,
+        "has_reference_gap": evidence_facts.has_reference_gap,
+        "uses_summary_fallback": fallback_confidence.uses_summary_fallback,
+        "fallback_reason": fallback_confidence.fallback_reason,
+        "exemplar_references": [],
+        "support_factors": list(support_factors),
+        "counterevidence_factors": list(counterevidence_factors),
+    }
+    if context_facts.source == "whole_run" and context_facts.intervals:
+        first_interval = context_facts.intervals[0]
+        diagnosis_payload["exemplar_references"] = [
+            {
+                "kind": "whole_run_context_interval",
+                "context_segment_index": first_interval.segment_index,
+                "phase": first_interval.phase,
+                "speed_band": first_interval.speed_band,
+            }
+        ]
+    normalized = report_summary_from_mapping({"whole_run_diagnosis_summaries": [diagnosis_payload]})
+    return normalized.whole_run_diagnosis_summaries
+
+
+def _whole_run_diagnosis_fallback_reason(
+    payload: Mapping[str, object],
+    *,
+    summary: NormalizedReportSummary,
+) -> str | None:
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, Mapping):
+        return "analysis metadata missing; replayed summary-era evidence"
+    raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
+    raw_backed_sample_count = coerce_count(analysis_metadata.get("raw_backed_sample_count"))
+    if raw_capture_mode == "summary_only" or raw_backed_sample_count <= 0:
+        return "summary-only legacy confidence"
+    has_partial_whole_run_inputs = bool(
+        summary.whole_run_context_intervals
+        or summary.whole_run_order_summaries
+        or summary.whole_run_spatial_summaries
+        or analysis_metadata.get("whole_run_artifacts_available")
+        or analysis_metadata.get("whole_run_context_available")
+        or analysis_metadata.get("whole_run_order_family_summaries_available")
+        or analysis_metadata.get("whole_run_spatial_coherence_available")
+    )
+    if has_partial_whole_run_inputs:
+        return "whole-run diagnosis inputs incomplete; replayed summary-era evidence"
+    return "whole-run artifacts unavailable; replayed summary-era evidence"
+
+
+def _factor_weight_sum(rows: tuple[DiagnosisFactorResponse, ...]) -> float:
+    return sum(
+        float(weight) for row in rows if isinstance((weight := row.get("weight")), int | float)
+    )
+
+
+def _proof_location(sensor_facts: ReportSensorFacts, *, index: int) -> str | None:
+    if index >= len(sensor_facts.proof_location_hotspot_rows):
+        return None
+    return sensor_facts.proof_location_hotspot_rows[index].location
+
+
+def _proof_location_separation_db(sensor_facts: ReportSensorFacts) -> float | None:
+    rows = sensor_facts.proof_location_hotspot_rows
+    if len(rows) < 2:
+        return None
+    return round(rows[0].peak_value - rows[1].peak_value, 2)
+
+
+def _fallback_diagnosis_key(primary_candidate: PrimaryReportFacts) -> str:
+    finding = primary_candidate.domain_primary
+    if finding is not None:
+        if finding.finding_key:
+            return finding.finding_key
+        if finding.finding_id:
+            return finding.finding_id
+    primary_source = str(primary_candidate.primary_source or "unknown").strip().lower()
+    return f"summary:{primary_source or 'unknown'}"
+
+
+def _fallback_diagnosis_is_suspicious(
+    *,
+    counterevidence_factors: tuple[DiagnosisFactorResponse, ...],
+    weak_spatial: bool,
+) -> bool:
+    counter_keys = {
+        str(factor_key)
+        for row in counterevidence_factors
+        if (factor_key := row.get("factor_key")) is not None
+    }
+    return bool(
+        weak_spatial
+        or "close_alternative" in counter_keys
+        or "mixed_support_locations" in counter_keys
+        or "weak_spatial" in counter_keys
+        or "drifting_frequency" in counter_keys
     )
 
 

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -536,6 +536,14 @@ Current #3085 baseline:
 - Legacy persisted analyses must remain readable by history/report code.
 - New whole-run report facts should degrade to existing summary-only language and
   confidence caveats where necessary.
+- When persisted `whole_run_diagnosis_summaries` are absent, the report-prep
+  boundary should synthesize exactly one fallback diagnosis row from the current
+  summary-era primary candidate plus report confidence/evidence facts instead of
+  pretending full whole-run fusion ran. The owner for that synthesis should stay
+  in `apps/server/vibesensor/shared/boundaries/reporting/facts.py`, reusing
+  `confidence_facts.py` and carrying an explicit `fallback_reason` that
+  distinguishes summary-only legacy replay from raw-backed partial-artifact
+  replay.
 - Persisted `analysis_metadata` should carry whole-run context completeness counts
   (full/partial/missing plus speed/RPM gap counts) so history/report preparation
   can project caveats without loading dense sidecar labels during report render.


### PR DESCRIPTION
Closes #3104

## What changed
- add explicit fallback marking in `reporting/confidence_facts.py` so report-prep can flag replayed summary-era diagnosis scoring without changing the underlying score
- extend `PreparedReportFacts` with `whole_run_diagnosis_summaries` and synthesize one fallback diagnosis row in `reporting/facts.py` when persisted whole-run diagnoses are missing
- distinguish three fallback reasons: summary-only legacy replay, raw-backed runs with no whole-run artifacts, and raw-backed runs with incomplete whole-run diagnosis inputs
- keep persisted whole-run diagnosis rows untouched when they already exist
- add focused history/report regressions and update the whole-run design doc

## Why
- #3103 made full whole-run diagnosis rows possible, but legacy and partial-artifact runs still had no diagnosis-summary surface to carry explicit fallback semantics
- this keeps old runs explainable without pretending full whole-run fusion happened

## Validation
- focused history/report fallback pytest slice
- `make format`
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- `make ui-typecheck`
- `make test-changed`

## Risks / tradeoffs
- fallback diagnosis rows are synthesized from the current summary-era primary candidate and report facts, so they intentionally do not claim dense whole-run order/spatial exemplars
- `uses_summary_fallback` now covers any replay of the summary-era path, including raw-backed partial-artifact runs; the exact reason stays explicit in `fallback_reason`