### PR TITLE
Expose fused diagnosis evidence in reports

### DIFF
--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
@@ -170,3 +170,141 @@ def test_build_report_document_prefers_persisted_whole_run_diagnosis_surfaces() 
         "18.2" in row.value and "18.6" in row.value
         for row in document.verdict_page.proof_snapshot_rows
     )
+
+
+def test_build_report_document_uses_matching_persisted_source_when_top_row_is_ambiguous() -> None:
+    wheel = make_finding_payload(
+        finding_id="F_WHEEL",
+        suspected_source="wheel/tire",
+        confidence=0.81,
+        strongest_location="Front Left",
+        strongest_speed_band="100-110 km/h",
+        dominant_phase="cruise",
+    )
+    driveline = make_finding_payload(
+        finding_id="F_DRIVELINE",
+        suspected_source="driveline",
+        confidence=0.72,
+        strongest_location="Front Left",
+        strongest_speed_band="100-110 km/h",
+        dominant_phase="cruise",
+    )
+    summary = minimal_summary(
+        run_id="whole-run-ambiguous-report",
+        lang="en",
+        metadata={
+            "run_id": "whole-run-ambiguous-report",
+            "record_type": "metadata",
+            "schema_version": "v2-jsonl",
+            "feature_interval_s": 0.5,
+        },
+        sensor_count_used=4,
+        sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        sensor_locations_connected_throughout=[
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        findings=[wheel, driveline],
+        top_causes=[wheel, driveline],
+        analysis_metadata={
+            "raw_backed_sample_count": 84,
+            "raw_capture_mode": "raw_backed",
+            "whole_run_diagnosis_summaries_available": True,
+            "whole_run_diagnosis_summary_count": 3,
+        },
+        whole_run_diagnosis_summaries=[
+            {
+                "diagnosis_key": "driveshaft",
+                "suspected_source": "driveline",
+                "rank": 1,
+                "data_basis": "raw_backed",
+                "support_score": 0.36,
+                "counterevidence_score": 0.16,
+                "total_score": 0.80,
+                "supporting_window_count": 22,
+                "stable_frequency_min_hz": 39.8,
+                "stable_frequency_max_hz": 39.8,
+                "dominant_location": "Front Left",
+                "dominant_phase": "cruise",
+                "dominant_speed_band": "100-110 km/h",
+                "alternative_source": "engine",
+                "confidence_gap_to_alternative": 0.0,
+                "ambiguous_diagnosis": True,
+                "ambiguous_location": False,
+                "suspicious": True,
+                "weak_spatial_separation": False,
+                "has_reference_gap": False,
+                "uses_summary_fallback": False,
+                "support_factors": [],
+                "counterevidence_factors": [],
+                "exemplar_references": [],
+            },
+            {
+                "diagnosis_key": "engine",
+                "suspected_source": "engine",
+                "rank": 2,
+                "data_basis": "raw_backed",
+                "support_score": 0.36,
+                "counterevidence_score": 0.16,
+                "total_score": 0.80,
+                "supporting_window_count": 22,
+                "stable_frequency_min_hz": 51.2,
+                "stable_frequency_max_hz": 51.2,
+                "dominant_location": "Front Left",
+                "dominant_phase": "cruise",
+                "dominant_speed_band": "100-110 km/h",
+                "alternative_source": "driveline",
+                "confidence_gap_to_alternative": 0.0,
+                "ambiguous_diagnosis": True,
+                "ambiguous_location": False,
+                "suspicious": True,
+                "weak_spatial_separation": False,
+                "has_reference_gap": False,
+                "uses_summary_fallback": False,
+                "support_factors": [],
+                "counterevidence_factors": [],
+                "exemplar_references": [],
+            },
+            {
+                "diagnosis_key": "wheel",
+                "suspected_source": "wheel/tire",
+                "rank": 3,
+                "data_basis": "raw_backed",
+                "support_score": 0.36,
+                "counterevidence_score": 0.16,
+                "total_score": 0.80,
+                "supporting_window_count": 22,
+                "stable_frequency_min_hz": 12.9,
+                "stable_frequency_max_hz": 12.9,
+                "dominant_location": "Front Left",
+                "dominant_phase": "cruise",
+                "dominant_speed_band": "100-110 km/h",
+                "alternative_source": "driveline",
+                "confidence_gap_to_alternative": 0.0,
+                "ambiguous_diagnosis": True,
+                "ambiguous_location": False,
+                "suspicious": True,
+                "weak_spatial_separation": False,
+                "has_reference_gap": False,
+                "uses_summary_fallback": False,
+                "support_factors": [],
+                "counterevidence_factors": [],
+                "exemplar_references": [],
+            },
+        ],
+    )
+
+    document = build_report_document(prepare_report_input(summary))
+
+    assert document.verdict_page.suspected_source == "Wheel / Tire"
+    assert document.verdict_page.inspect_first == "Front-Left"
+    assert document.verdict_page.also_consider == "Driveline"
+    assert document.appendix_a.ranked_candidates[0].source_name == "Wheel / Tire"
+    assert document.appendix_a.ranked_candidates[1].source_name == "Driveline"
+    assert any(
+        "12.9" in row.value
+        for row in document.verdict_page.proof_snapshot_rows
+        if row.label == "Stable frequency"
+    )

--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from test_support.findings import make_finding_payload
+from test_support.report_helpers import minimal_summary
+
+from vibesensor.shared.boundaries.reporting import prepare_report_input
+from vibesensor.use_cases.history.report_document import build_report_document
+
+
+def test_build_report_document_prefers_persisted_whole_run_diagnosis_surfaces() -> None:
+    wheel = make_finding_payload(
+        finding_id="F_WHEEL",
+        suspected_source="wheel/tire",
+        confidence=0.81,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        dominant_phase="cruise",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.12,
+            }
+        ],
+        evidence_metrics={
+            "mean_relative_error": 0.03,
+            "snr_db": 8.0,
+            "matched_samples": 1,
+        },
+    )
+    driveline = make_finding_payload(
+        finding_id="F_DRIVELINE",
+        suspected_source="driveline",
+        confidence=0.72,
+        strongest_location="Rear Right",
+        strongest_speed_band="80-100 km/h",
+        dominant_phase="accel",
+    )
+    summary = minimal_summary(
+        run_id="whole-run-report",
+        lang="en",
+        metadata={
+            "run_id": "whole-run-report",
+            "record_type": "metadata",
+            "schema_version": "v2-jsonl",
+            "feature_interval_s": 0.5,
+        },
+        sensor_count_used=4,
+        sensor_locations=["Front Left", "Front Right", "Rear Left", "Rear Right"],
+        sensor_locations_connected_throughout=[
+            "Front Left",
+            "Front Right",
+            "Rear Left",
+            "Rear Right",
+        ],
+        sensor_intensity_by_location=[
+            {"location": "Front Left", "p95_intensity_db": 15.0, "peak_intensity_db": 18.0},
+            {"location": "Front Right", "p95_intensity_db": 12.0, "peak_intensity_db": 15.0},
+            {"location": "Rear Left", "p95_intensity_db": 14.0, "peak_intensity_db": 16.5},
+            {"location": "Rear Right", "p95_intensity_db": 17.0, "peak_intensity_db": 20.0},
+        ],
+        findings=[wheel, driveline],
+        top_causes=[wheel, driveline],
+        analysis_metadata={
+            "raw_backed_sample_count": 64,
+            "raw_capture_mode": "raw_backed",
+            "whole_run_diagnosis_summaries_available": True,
+            "whole_run_diagnosis_summary_count": 2,
+        },
+        whole_run_diagnosis_summaries=[
+            {
+                "diagnosis_key": "driveline_1x",
+                "suspected_source": "driveline",
+                "rank": 1,
+                "data_basis": "raw_backed",
+                "support_score": 0.86,
+                "counterevidence_score": 0.08,
+                "total_score": 0.78,
+                "location_proof_basis": "supporting_windows_raw_backed",
+                "supporting_window_count": 12,
+                "supporting_duration_s": 6.0,
+                "supporting_sensor_count": 2,
+                "stable_frequency_min_hz": 18.2,
+                "stable_frequency_max_hz": 18.6,
+                "dominant_location": "Rear Right",
+                "runner_up_location": "Front Left",
+                "dominant_phase": "accel",
+                "dominant_speed_band": "80-100 km/h",
+                "location_separation_db": 3.6,
+                "dominance_ratio": 1.8,
+                "alternative_source": "wheel/tire",
+                "confidence_gap_to_alternative": 0.08,
+                "ambiguous_diagnosis": False,
+                "ambiguous_location": False,
+                "suspicious": False,
+                "weak_spatial_separation": False,
+                "has_reference_gap": False,
+                "uses_summary_fallback": False,
+                "support_factors": [
+                    {
+                        "factor_key": "raw_backed",
+                        "polarity": "support",
+                        "severity": "high",
+                        "weight": 0.10,
+                        "details": {"raw_backed_sample_count": 64},
+                    }
+                ],
+                "counterevidence_factors": [
+                    {
+                        "factor_key": "close_alternative",
+                        "polarity": "counterevidence",
+                        "severity": "low",
+                        "weight": 0.08,
+                        "details": {"alternative_source": "wheel/tire"},
+                    }
+                ],
+                "exemplar_references": [],
+            },
+            {
+                "diagnosis_key": "wheel_1x",
+                "suspected_source": "wheel/tire",
+                "rank": 2,
+                "data_basis": "raw_backed",
+                "support_score": 0.72,
+                "counterevidence_score": 0.12,
+                "total_score": 0.70,
+                "location_proof_basis": "supporting_windows_raw_backed",
+                "supporting_window_count": 9,
+                "supporting_duration_s": 4.5,
+                "supporting_sensor_count": 2,
+                "stable_frequency_min_hz": 15.0,
+                "stable_frequency_max_hz": 15.3,
+                "dominant_location": "Front Left",
+                "runner_up_location": "Rear Right",
+                "dominant_phase": "cruise",
+                "dominant_speed_band": "60-80 km/h",
+                "location_separation_db": 2.4,
+                "dominance_ratio": 1.4,
+                "ambiguous_diagnosis": False,
+                "ambiguous_location": False,
+                "suspicious": False,
+                "weak_spatial_separation": False,
+                "has_reference_gap": False,
+                "uses_summary_fallback": False,
+                "support_factors": [],
+                "counterevidence_factors": [],
+                "exemplar_references": [],
+            },
+        ],
+    )
+
+    document = build_report_document(prepare_report_input(summary))
+
+    assert document.verdict_page.suspected_source == "Driveline"
+    assert document.verdict_page.inspect_first == "Rear-Right"
+    assert document.verdict_page.also_consider == "Wheel / Tire"
+    assert document.appendix_b.dominant_corner == "Rear-Right"
+    assert document.appendix_b.runner_up_corner == "Front-Left"
+    assert document.appendix_a.ranked_candidates[0].source_name == "Driveline"
+    assert document.appendix_a.ranked_candidates[1].source_name == "Wheel / Tire"
+    assert any(
+        "12" in row.value and "6.0" in row.value
+        for row in document.verdict_page.proof_snapshot_rows
+    )
+    assert any(
+        "18.2" in row.value and "18.6" in row.value
+        for row in document.verdict_page.proof_snapshot_rows
+    )

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -152,10 +152,40 @@ class PreparedReportFacts:
     findings: PreparedReportFindings
 
     @property
-    def primary_diagnosis(self) -> ReportWholeRunDiagnosisSummary | None:
+    def report_surface_diagnosis_summaries(
+        self,
+    ) -> tuple[ReportWholeRunDiagnosisSummary, ...]:
         if not self.whole_run_diagnosis_summaries:
+            return ()
+        primary = self.whole_run_diagnosis_summaries[0]
+        if primary.uses_summary_fallback or (
+            not primary.ambiguous_diagnosis and not primary.suspicious
+        ):
+            return self.whole_run_diagnosis_summaries
+        summary_primary_source = str(self.decision.primary_candidate.primary_source or "").strip()
+        if not summary_primary_source:
+            return ()
+        for index, diagnosis in enumerate(self.whole_run_diagnosis_summaries):
+            if diagnosis.suspected_source != summary_primary_source:
+                continue
+            if index == 0:
+                return self.whole_run_diagnosis_summaries
+            return (
+                diagnosis,
+                *(
+                    row
+                    for row_index, row in enumerate(self.whole_run_diagnosis_summaries)
+                    if row_index != index
+                ),
+            )
+        return ()
+
+    @property
+    def primary_diagnosis(self) -> ReportWholeRunDiagnosisSummary | None:
+        report_surface = self.report_surface_diagnosis_summaries
+        if not report_surface:
             return None
-        return self.whole_run_diagnosis_summaries[0]
+        return report_surface[0]
 
 
 def prepare_report_facts(

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -151,6 +151,12 @@ class PreparedReportFacts:
     whole_run_diagnosis_summaries: tuple[ReportWholeRunDiagnosisSummary, ...]
     findings: PreparedReportFindings
 
+    @property
+    def primary_diagnosis(self) -> ReportWholeRunDiagnosisSummary | None:
+        if not self.whole_run_diagnosis_summaries:
+            return None
+        return self.whole_run_diagnosis_summaries[0]
+
 
 def prepare_report_facts(
     payload: Mapping[str, object],

--- a/apps/server/vibesensor/use_cases/history/report_document/_candidate_resolver.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/_candidate_resolver.py
@@ -17,6 +17,7 @@ from vibesensor.shared.report_presentation import (
 
 if TYPE_CHECKING:
     from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
+    from vibesensor.shared.boundaries.reporting.summary import ReportWholeRunDiagnosisSummary
 
 __all__ = [
     "PrimaryCandidateContext",
@@ -53,16 +54,26 @@ def resolve_primary_report_candidate(
     aggregate: TestRun,
     facts: PrimaryReportFacts,
     confidence_facts: ReportConfidenceFacts | None = None,
+    diagnosis_summary: ReportWholeRunDiagnosisSummary | None = None,
     tr: Callable[..., str],
     lang: str,
 ) -> PrimaryCandidateContext:
     """Resolve the primary candidate and all derived certainty fields."""
     primary_candidate = facts.domain_primary or _top_report_candidate(aggregate)
-    primary_system = (
-        human_source(facts.primary_source, tr=tr) if facts.primary_source else tr("UNKNOWN")
+    primary_source = (
+        diagnosis_summary.suspected_source if diagnosis_summary else facts.primary_source
     )
-    primary_location = facts.primary_location or tr("UNKNOWN")
-    primary_speed = str(facts.primary_speed or tr("UNKNOWN"))
+    primary_system = human_source(primary_source, tr=tr) if primary_source else tr("UNKNOWN")
+    primary_location = (
+        diagnosis_summary.dominant_location
+        if diagnosis_summary and diagnosis_summary.dominant_location
+        else facts.primary_location or tr("UNKNOWN")
+    )
+    primary_speed = str(
+        diagnosis_summary.dominant_speed_band
+        if diagnosis_summary and diagnosis_summary.dominant_speed_band
+        else facts.primary_speed or tr("UNKNOWN")
+    )
     strength_text_value = strength_text(facts.strength_db, lang=lang)
     strength_band_key = (
         strength_label(facts.strength_db)[0] if facts.strength_db is not None else None
@@ -89,18 +100,26 @@ def resolve_primary_report_candidate(
         tier = "A"
     return PrimaryCandidateContext(
         primary_candidate=primary_candidate,
-        primary_source=facts.primary_source,
+        primary_source=primary_source,
         primary_system=primary_system,
         primary_location=primary_location,
         primary_speed=primary_speed,
-        confidence=facts.confidence,
+        confidence=(
+            diagnosis_summary.total_score
+            if diagnosis_summary and diagnosis_summary.total_score is not None
+            else facts.confidence
+        ),
         sensor_count=facts.sensor_count,
         weak_spatial=facts.weak_spatial,
         has_reference_gaps=facts.has_reference_gaps,
         strength_db=facts.strength_db,
         strength_text=strength_text_value,
         strength_band_key=strength_band_key,
-        dominance_ratio=facts.dominance_ratio,
+        dominance_ratio=(
+            diagnosis_summary.dominance_ratio
+            if diagnosis_summary and diagnosis_summary.dominance_ratio is not None
+            else facts.dominance_ratio
+        ),
         certainty_key=certainty_key,
         certainty_label_text=certainty_label_text,
         certainty_pct=certainty_pct,

--- a/apps/server/vibesensor/use_cases/history/report_document/document_context.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_context.py
@@ -157,7 +157,7 @@ def build_report_document_context(prepared: PreparedReportInput) -> ReportDocume
             alternative_source_visible=decision_facts.alternative_source_visible,
             ranked_candidates=build_ranked_candidates(
                 test_run,
-                diagnosis_summaries=report_facts.whole_run_diagnosis_summaries,
+                diagnosis_summaries=report_facts.report_surface_diagnosis_summaries,
                 tr=tr,
             ),
             recapture=recapture,

--- a/apps/server/vibesensor/use_cases/history/report_document/document_context.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_context.py
@@ -14,6 +14,7 @@ from vibesensor.shared.boundaries.reporting.findings import FindingPresentation
 from vibesensor.shared.report_presentation import (
     coverage_label,
     coverage_notes,
+    display_location,
     proof_caveat_text,
     runner_up_corner,
 )
@@ -97,8 +98,17 @@ def build_report_document_context(prepared: PreparedReportInput) -> ReportDocume
         location_confidence_key=decision_facts.location_confidence_key,
         tr=tr,
     )
-    runner_up = runner_up_corner(sensor_facts.proof_intensity, tr=tr)
-    speed_window_label = str(decision_facts.primary_candidate.primary_speed or "").strip() or None
+    primary_diagnosis = report_facts.primary_diagnosis
+    runner_up = (
+        display_location(primary_diagnosis.runner_up_location, tr=tr)
+        if primary_diagnosis is not None and primary_diagnosis.runner_up_location
+        else runner_up_corner(sensor_facts.proof_intensity, tr=tr)
+    )
+    speed_window_label = (
+        str(primary_diagnosis.dominant_speed_band or "").strip()
+        if primary_diagnosis is not None
+        else str(decision_facts.primary_candidate.primary_speed or "").strip()
+    ) or None
     recapture = build_recapture_assessment(
         aggregate=test_run,
         primary_candidate_facts=decision_facts.primary_candidate,
@@ -115,6 +125,7 @@ def build_report_document_context(prepared: PreparedReportInput) -> ReportDocume
         aggregate=test_run,
         facts=decision_facts.primary_candidate,
         confidence_facts=report_facts.confidence,
+        diagnosis_summary=primary_diagnosis,
         tr=tr,
         lang=lang,
     )
@@ -144,7 +155,11 @@ def build_report_document_context(prepared: PreparedReportInput) -> ReportDocume
         appendix_a_context=AppendixAContext(
             action_status_key=decision_facts.action_status_key,
             alternative_source_visible=decision_facts.alternative_source_visible,
-            ranked_candidates=build_ranked_candidates(test_run, tr=tr),
+            ranked_candidates=build_ranked_candidates(
+                test_run,
+                diagnosis_summaries=report_facts.whole_run_diagnosis_summaries,
+                tr=tr,
+            ),
             recapture=recapture,
         ),
         appendix_b_context=AppendixBContext(

--- a/apps/server/vibesensor/use_cases/history/report_document/document_sections.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/document_sections.py
@@ -64,6 +64,7 @@ def build_report_document_sections(
         primary_candidate_facts=context.decision_facts.primary_candidate,
         active_sensor_intensity=context.sensor_facts.proof_intensity,
         proof_basis=context.sensor_facts.proof_basis,
+        diagnosis_summary=context.report_facts.primary_diagnosis,
         appendix_context=context.appendix_b_context,
         tr=context.tr,
     )
@@ -93,6 +94,7 @@ def build_report_document_sections(
             aggregate=context.test_run,
             origin=context.run_facts.origin,
             primary=context.primary,
+            diagnosis_summaries=context.report_facts.whole_run_diagnosis_summaries,
             lang=context.lang,
             tr=context.tr,
         ),

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from vibesensor.report_i18n import human_source
 from vibesensor.shared.boundaries.reporting import PreparedReportFacts
@@ -13,6 +14,9 @@ from vibesensor.shared.report_presentation import (
 )
 
 __all__ = ["build_evidence_snapshot_rows"]
+
+if TYPE_CHECKING:
+    from vibesensor.shared.boundaries.reporting.summary import ReportWholeRunDiagnosisSummary
 
 
 def build_evidence_snapshot_rows(
@@ -58,6 +62,22 @@ def build_evidence_snapshot_rows(
 
 
 def _data_basis_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+    diagnosis = report_facts.primary_diagnosis
+    if diagnosis is not None and diagnosis.data_basis == "raw_backed":
+        raw_backed_samples = 0
+        for factor in diagnosis.support_factors:
+            if (
+                factor.factor_key == "raw_backed"
+                and factor.details.raw_backed_sample_count is not None
+            ):
+                raw_backed_samples = factor.details.raw_backed_sample_count
+                break
+        return tr(
+            "REPORT_EVIDENCE_BASIS_RAW",
+            samples=str(max(0, raw_backed_samples)),
+        )
+    if diagnosis is not None and diagnosis.data_basis == "summary_only":
+        return tr("REPORT_EVIDENCE_BASIS_SUMMARY")
     evidence = report_facts.evidence
     if evidence.data_basis == "raw_backed":
         return tr(
@@ -68,6 +88,19 @@ def _data_basis_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str
 
 
 def _support_window_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+    diagnosis = report_facts.primary_diagnosis
+    if diagnosis is not None:
+        count = diagnosis.supporting_window_count
+        duration_s = diagnosis.supporting_duration_s
+        if count is None or count <= 0:
+            return tr("REPORT_SUPPORT_WINDOW_SUMMARY_NONE")
+        if duration_s is not None and duration_s > 0:
+            return tr(
+                "REPORT_SUPPORT_WINDOW_SUMMARY_FULL",
+                count=str(count),
+                duration=f"{duration_s:.1f}",
+            )
+        return tr("REPORT_SUPPORT_WINDOW_SUMMARY_COUNT_ONLY", count=str(count))
     evidence = report_facts.evidence
     count = evidence.supporting_window_count
     duration_s = evidence.supporting_duration_s
@@ -83,6 +116,15 @@ def _support_window_text(report_facts: PreparedReportFacts, *, tr: Callable[...,
 
 
 def _stable_frequency_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+    diagnosis = report_facts.primary_diagnosis
+    if diagnosis is not None:
+        low = diagnosis.stable_frequency_min_hz
+        high = diagnosis.stable_frequency_max_hz
+        if low is None or high is None:
+            return tr("REPORT_STABLE_FREQUENCY_UNKNOWN")
+        if abs(high - low) < 0.05:
+            return tr("REPORT_STABLE_FREQUENCY_SINGLE", hz=f"{low:.1f}")
+        return tr("REPORT_STABLE_FREQUENCY_BAND", low=f"{low:.1f}", high=f"{high:.1f}")
     evidence = report_facts.evidence
     low = evidence.stable_frequency_min_hz
     high = evidence.stable_frequency_max_hz
@@ -94,6 +136,16 @@ def _stable_frequency_text(report_facts: PreparedReportFacts, *, tr: Callable[..
 
 
 def _supporting_sensors_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+    diagnosis = report_facts.primary_diagnosis
+    if diagnosis is not None and diagnosis.supporting_sensor_count is not None:
+        if diagnosis.dominant_location:
+            return tr(
+                "REPORT_SUPPORTING_SENSOR_ENTRY",
+                location=display_location(diagnosis.dominant_location, tr=tr),
+                count=str(diagnosis.supporting_sensor_count),
+            )
+        if diagnosis.supporting_sensor_count <= 0:
+            return tr("REPORT_SUPPORTING_SENSORS_NONE")
     evidence = report_facts.evidence
     if not evidence.supporting_location_counts:
         return tr("REPORT_SUPPORTING_SENSORS_NONE")
@@ -109,6 +161,11 @@ def _supporting_sensors_text(report_facts: PreparedReportFacts, *, tr: Callable[
 
 
 def _counterevidence_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
+    diagnosis = report_facts.primary_diagnosis
+    if diagnosis is not None:
+        diagnosis_notes = _diagnosis_counterevidence_texts(diagnosis=diagnosis, tr=tr)
+        if diagnosis_notes:
+            return "; ".join(diagnosis_notes[:2])
     evidence = report_facts.evidence
     notes: list[str] = []
     if evidence.alternative_source is not None:
@@ -125,3 +182,32 @@ def _counterevidence_text(report_facts: PreparedReportFacts, *, tr: Callable[...
     if not notes:
         return tr("REPORT_COUNTEREVIDENCE_NONE")
     return "; ".join(notes)
+
+
+def _diagnosis_counterevidence_texts(
+    *,
+    diagnosis: ReportWholeRunDiagnosisSummary,
+    tr: Callable[..., str],
+) -> tuple[str, ...]:
+    notes: list[str] = []
+    counter_keys = {factor.factor_key for factor in diagnosis.counterevidence_factors}
+    if "close_alternative" in counter_keys and diagnosis.alternative_source is not None:
+        notes.append(
+            tr(
+                "REPORT_COUNTEREVIDENCE_ALT_SOURCE",
+                source=human_source(diagnosis.alternative_source, tr=tr),
+            )
+        )
+    if "weak_spatial" in counter_keys or diagnosis.weak_spatial_separation:
+        notes.append(tr("REPORT_COUNTEREVIDENCE_WEAK_SPATIAL"))
+    if "incomplete_reference" in counter_keys or diagnosis.has_reference_gap:
+        notes.append(tr("REPORT_COUNTEREVIDENCE_REFERENCE_GAP"))
+    if "summary_only" in counter_keys:
+        notes.append(tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY"))
+    if "legacy_context" in counter_keys:
+        notes.append(tr("REPORT_CONFIDENCE_CAVEAT_LEGACY_CONTEXT"))
+    if "speed_context_gaps" in counter_keys:
+        notes.append(tr("REPORT_CONFIDENCE_CAVEAT_SPEED_CONTEXT_GAPS"))
+    if "rpm_context_gaps" in counter_keys:
+        notes.append(tr("REPORT_CONFIDENCE_CAVEAT_RPM_CONTEXT_GAPS"))
+    return tuple(notes)

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -137,7 +137,11 @@ def _stable_frequency_text(report_facts: PreparedReportFacts, *, tr: Callable[..
 
 def _supporting_sensors_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
     diagnosis = report_facts.primary_diagnosis
-    if diagnosis is not None and diagnosis.supporting_sensor_count is not None:
+    if (
+        diagnosis is not None
+        and not diagnosis.uses_summary_fallback
+        and diagnosis.supporting_sensor_count is not None
+    ):
         if diagnosis.dominant_location:
             return tr(
                 "REPORT_SUPPORTING_SENSOR_ENTRY",

--- a/apps/server/vibesensor/use_cases/history/report_document/location_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/location_appendix.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
 
 from vibesensor.domain import LocationIntensitySummary, TestRun
 from vibesensor.shared.boundaries.reporting.document import AppendixBData, TopologyIntensityRow
@@ -18,6 +19,9 @@ from vibesensor.use_cases.history.report_observation_matrix import (
 
 from .section_context import AppendixBContext
 
+if TYPE_CHECKING:
+    from vibesensor.shared.boundaries.reporting.summary import ReportWholeRunDiagnosisSummary
+
 __all__ = ["build_appendix_b_data"]
 
 
@@ -27,15 +31,26 @@ def build_appendix_b_data(
     primary_candidate_facts: PrimaryReportFacts,
     active_sensor_intensity: Sequence[LocationIntensitySummary],
     proof_basis: str,
+    diagnosis_summary: ReportWholeRunDiagnosisSummary | None = None,
     appendix_context: AppendixBContext,
     tr: Callable[..., str],
 ) -> AppendixBData:
+    dominant_location = (
+        diagnosis_summary.dominant_location
+        if diagnosis_summary is not None and diagnosis_summary.dominant_location
+        else primary_candidate_facts.primary_location
+    )
+    dominance_ratio = (
+        diagnosis_summary.dominance_ratio
+        if diagnosis_summary is not None and diagnosis_summary.dominance_ratio is not None
+        else primary_candidate_facts.dominance_ratio
+    )
     dominance_ratio_text = (
         tr(
             "REPORT_DOMINANCE_RATIO_TEXT",
-            ratio=f"{primary_candidate_facts.dominance_ratio:.2f}",
+            ratio=f"{dominance_ratio:.2f}",
         )
-        if primary_candidate_facts.dominance_ratio is not None
+        if dominance_ratio is not None
         else tr("REPORT_DOMINANCE_RATIO_UNKNOWN")
     )
     ranked_rows = sorted(
@@ -58,10 +73,17 @@ def build_appendix_b_data(
         for row in ranked_rows
     ]
     return AppendixBData(
-        dominant_corner=display_location(primary_candidate_facts.primary_location, tr=tr),
+        dominant_corner=display_location(dominant_location, tr=tr),
         runner_up_corner=appendix_context.runner_up_corner,
         dominance_ratio_text=dominance_ratio_text,
-        proof_basis_note=_location_proof_basis_note(proof_basis, tr=tr),
+        proof_basis_note=_location_proof_basis_note(
+            (
+                diagnosis_summary.location_proof_basis
+                if diagnosis_summary is not None and diagnosis_summary.location_proof_basis
+                else proof_basis
+            ),
+            tr=tr,
+        ),
         location_confidence=location_confidence_text(
             presented_location_confidence_key(
                 action_status_key=appendix_context.action_status_key,

--- a/apps/server/vibesensor/use_cases/history/report_document/pattern_evidence.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/pattern_evidence.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 from vibesensor.domain import Finding, TestRun, VibrationOrigin
 from vibesensor.report_i18n import human_source, resolve_i18n
 from vibesensor.shared.boundaries.reporting.document import PatternEvidence
+from vibesensor.shared.boundaries.reporting.summary import ReportWholeRunDiagnosisSummary
 from vibesensor.shared.boundaries.summary_fields.origin import build_origin_explanation
 from vibesensor.shared.report_presentation import display_location, order_label_human
 from vibesensor.use_cases.history.report_document._candidate_resolver import PrimaryCandidateContext
@@ -24,13 +25,18 @@ def build_pattern_evidence(
     aggregate: TestRun,
     origin: VibrationOrigin | None,
     primary: PrimaryCandidateContext,
+    diagnosis_summaries: Sequence[ReportWholeRunDiagnosisSummary],
     lang: str,
     tr: Callable[..., str],
 ) -> PatternEvidence:
     """Build the pattern-evidence block for the report template."""
     effective = aggregate.effective_top_causes()
     domain_primary = effective[0] if effective else aggregate.primary_finding
-    systems_raw = [human_source(str(f.suspected_source), tr=tr) for f in effective[:3]]
+    systems_raw = (
+        [human_source(summary.suspected_source, tr=tr) for summary in diagnosis_summaries[:3]]
+        if diagnosis_summaries
+        else [human_source(str(f.suspected_source), tr=tr) for f in effective[:3]]
+    )
     systems = list(dict.fromkeys(systems_raw))
     interpretation = resolve_interpretation(origin, lang=lang, tr=tr)
     source_for_why, order_label_for_why = resolve_parts_context(

--- a/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
@@ -147,7 +147,7 @@ def build_verdict_page(*, context: ReportDocumentContext) -> VerdictPageData:
         aggregate=context.test_run,
         primary=context.primary,
         report_confidence=context.report_facts.confidence,
-        diagnosis_summaries=context.report_facts.whole_run_diagnosis_summaries,
+        diagnosis_summaries=context.report_facts.report_surface_diagnosis_summaries,
         duration_text=context.run_facts.duration_text,
         verdict_context=context.verdict_page_context,
         suitability_checks=context.decision_facts.suitability_checks,

--- a/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/verdict_page.py
@@ -27,6 +27,8 @@ from .section_context import VerdictPageContext
 from .timeline_graph import build_timeline_graph_data
 
 if TYPE_CHECKING:
+    from vibesensor.shared.boundaries.reporting.summary import ReportWholeRunDiagnosisSummary
+
     from .document_context import ReportDocumentContext
 
 __all__ = ["build_observed_signature", "build_verdict_page", "build_verdict_page_data"]
@@ -54,6 +56,7 @@ def build_verdict_page_data(
     aggregate: TestRun,
     primary: PrimaryCandidateContext,
     report_confidence: ReportConfidenceFacts,
+    diagnosis_summaries: Sequence[ReportWholeRunDiagnosisSummary],
     duration_text: str | None,
     verdict_context: VerdictPageContext,
     suitability_checks: Sequence[SuitabilityCheck],
@@ -108,10 +111,14 @@ def build_verdict_page_data(
         ),
         coverage_label=verdict_context.coverage_label,
         also_consider=(
-            human_source(aggregate.effective_top_causes()[1].suspected_source, tr=tr)
-            if not recapture_before_acting
-            and verdict_context.alternative_source_visible
-            and len(aggregate.effective_top_causes()) > 1
+            (
+                human_source(diagnosis_summaries[1].suspected_source, tr=tr)
+                if len(diagnosis_summaries) > 1
+                else human_source(aggregate.effective_top_causes()[1].suspected_source, tr=tr)
+                if len(aggregate.effective_top_causes()) > 1
+                else None
+            )
+            if not recapture_before_acting and verdict_context.alternative_source_visible
             else None
         ),
         proof_caveat=verdict_context.proof_caveat,
@@ -140,6 +147,7 @@ def build_verdict_page(*, context: ReportDocumentContext) -> VerdictPageData:
         aggregate=context.test_run,
         primary=context.primary,
         report_confidence=context.report_facts.confidence,
+        diagnosis_summaries=context.report_facts.whole_run_diagnosis_summaries,
         duration_text=context.run_facts.duration_text,
         verdict_context=context.verdict_page_context,
         suitability_checks=context.decision_facts.suitability_checks,

--- a/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
@@ -105,7 +105,7 @@ def build_ranked_candidates(
     diagnosis_summaries: Sequence[ReportWholeRunDiagnosisSummary] = (),
     tr: Callable[..., str],
 ) -> tuple[RankedCandidateRow, ...]:
-    if diagnosis_summaries:
+    if diagnosis_summaries and not diagnosis_summaries[0].uses_summary_fallback:
         return tuple(
             _ranked_candidate_row_from_diagnosis_summary(
                 aggregate,

--- a/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/workflow_appendix.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
 
 from vibesensor.domain import Finding, SuitabilityCheck, TestRun
 from vibesensor.report_i18n import human_source
@@ -23,6 +24,9 @@ from vibesensor.shared.report_presentation import (
 from vibesensor.shared.run_context_warning import RunContextWarning
 
 from .section_context import AppendixAContext, RecaptureAssessment
+
+if TYPE_CHECKING:
+    from vibesensor.shared.boundaries.reporting.summary import ReportWholeRunDiagnosisSummary
 
 __all__ = [
     "build_appendix_a_data",
@@ -98,8 +102,19 @@ def build_appendix_a_data(
 def build_ranked_candidates(
     aggregate: TestRun,
     *,
+    diagnosis_summaries: Sequence[ReportWholeRunDiagnosisSummary] = (),
     tr: Callable[..., str],
 ) -> tuple[RankedCandidateRow, ...]:
+    if diagnosis_summaries:
+        return tuple(
+            _ranked_candidate_row_from_diagnosis_summary(
+                aggregate,
+                summary=summary,
+                index=index,
+                tr=tr,
+            )
+            for index, summary in enumerate(diagnosis_summaries[:3])
+        )
     candidates = list(aggregate.effective_top_causes()[:3])
     rows: list[RankedCandidateRow] = []
     primary_finding = candidates[0] if candidates else None
@@ -123,6 +138,36 @@ def build_ranked_candidates(
             ),
         )
     return tuple(rows)
+
+
+def _ranked_candidate_row_from_diagnosis_summary(
+    aggregate: TestRun,
+    *,
+    summary: ReportWholeRunDiagnosisSummary,
+    index: int,
+    tr: Callable[..., str],
+) -> RankedCandidateRow:
+    matched_finding = _finding_for_diagnosis_summary(aggregate, summary=summary)
+    inspect_first = (
+        display_location(summary.dominant_location, tr=tr)
+        if summary.dominant_location
+        else (
+            display_location(matched_finding.strongest_location, tr=tr)
+            if matched_finding is not None
+            else tr("UNKNOWN")
+        )
+    )
+    return RankedCandidateRow(
+        source_name=human_source(summary.suspected_source, tr=tr),
+        confidence_pct=(
+            f"{max(0.0, summary.total_score or 0.0) * 100:.0f}%"
+            if summary.total_score is not None
+            else ""
+        ),
+        inspect_first=inspect_first,
+        path_role=f"{index + 1}. {_path_role_text(index, tr=tr)}",
+        reason=_diagnosis_summary_reason_text(summary, matched_finding=matched_finding, tr=tr),
+    )
 
 
 def build_recapture_assessment(
@@ -292,6 +337,42 @@ def _candidate_reason_text(
         location=location,
         speed=speed_window or tr("UNKNOWN"),
     )
+
+
+def _finding_for_diagnosis_summary(
+    aggregate: TestRun,
+    *,
+    summary: ReportWholeRunDiagnosisSummary,
+) -> Finding | None:
+    for finding in aggregate.effective_top_causes():
+        if str(finding.suspected_source) == summary.suspected_source:
+            return finding
+    for finding in aggregate.findings:
+        if str(finding.suspected_source) == summary.suspected_source:
+            return finding
+    return None
+
+
+def _diagnosis_summary_reason_text(
+    summary: ReportWholeRunDiagnosisSummary,
+    *,
+    matched_finding: Finding | None,
+    tr: Callable[..., str],
+) -> str:
+    if summary.supporting_duration_s is not None and summary.supporting_window_count is not None:
+        return tr(
+            "REPORT_SUPPORT_WINDOW_SUMMARY_FULL",
+            count=str(summary.supporting_window_count),
+            duration=f"{summary.supporting_duration_s:.1f}",
+        )
+    if summary.supporting_window_count is not None and summary.supporting_window_count > 0:
+        return tr(
+            "REPORT_SUPPORT_WINDOW_SUMMARY_COUNT_ONLY",
+            count=str(summary.supporting_window_count),
+        )
+    if matched_finding is not None:
+        return _candidate_reason_text(matched_finding, tr=tr)
+    return tr("REPORT_SIGNAL_FALLBACK")
 
 
 def _path_role_text(index: int, *, tr: Callable[..., str]) -> str:

--- a/docs/designs/whole-run-post-analysis-program.md
+++ b/docs/designs/whole-run-post-analysis-program.md
@@ -544,6 +544,12 @@ Current #3085 baseline:
   `confidence_facts.py` and carrying an explicit `fallback_reason` that
   distinguishes summary-only legacy replay from raw-backed partial-artifact
   replay.
+- When persisted `whole_run_diagnosis_summaries` are present, report/history/PDF
+  consumers should treat them as the canonical fused proof surface for primary
+  source ordering, dominant/runner-up location, proof basis, support-window
+  counts, stable-frequency text, and counterevidence rows. Legacy domain
+  `Finding` objects remain the fallback narrative source only when fused rows are
+  absent or when a surface still needs text that the fused row does not carry.
 - Persisted `analysis_metadata` should carry whole-run context completeness counts
   (full/partial/missing plus speed/RPM gap counts) so history/report preparation
   can project caveats without loading dense sidecar labels during report render.


### PR DESCRIPTION
Closes #3105

## What changed
- switch report-document consumers over to `PreparedReportFacts.whole_run_diagnosis_summaries` when fused rows exist
- prefer persisted fused diagnosis data for primary source ordering, dominant/runner-up location, proof basis, support-window and stable-frequency proof rows, ranked candidate ordering, and counterevidence text
- keep the #3104 synthesized fallback rows working so legacy and partial-artifact runs still flow through the same report/document surfaces
- add focused report-document coverage proving the persisted fused diagnosis can override the summary-era top-cause ordering
- update the whole-run design doc with the report/PDF ownership split

## Why
- report/history/PDF surfaces were still reconstructing key proof fields from summary-era findings even after persisted fused diagnosis summaries existed
- this makes the persisted whole-run diagnosis row the canonical report proof surface while preserving the fallback path for older runs

## Validation
- focused report-document pytest slice
- `make format`
- `make typecheck-backend`
- `make lint`
- `make docs-lint`
- `make ui-typecheck`
- `make test-changed`

## Risks / tradeoffs
- some report narrative text still falls back to domain `Finding` wording when the fused row does not carry an equivalent text field; this keeps the switchover bounded instead of inventing a second narrative layer here
- Appendix A reasons now use fused support-window counts when available, which is less detailed than some finding-specific narrative but keeps the ranking order aligned with the persisted fused diagnosis surface