### PR TITLE
Harden report boundary validation

### DIFF
--- a/apps/server/tests/adapters/pdf/test_report_analysis_separation.py
+++ b/apps/server/tests/adapters/pdf/test_report_analysis_separation.py
@@ -110,6 +110,7 @@ def test_build_report_pdf_accepts_report_template_data() -> None:
     """build_report_pdf must accept a ReportDocument directly."""
     data = ReportDocument(
         title="Test Report",
+        run_id="report-template",
         pattern_evidence=PatternEvidence(),
         lang="en",
     )
@@ -126,6 +127,7 @@ def test_report_output_matches_template_data() -> None:
     """Key facts from ReportDocument appear in the rendered PDF text."""
     data = ReportDocument(
         title="VibeSensor Diagnostic Report",
+        run_id="report-output-match",
         run_datetime="2026-01-15 10:30:00",
         sensor_count=4,
         verdict_page=VerdictPageData(
@@ -187,6 +189,7 @@ def test_report_keeps_strongest_sensor_on_page_one_when_no_system_cards() -> Non
     """Page one keeps the dominant corner visible even without worksheet rows."""
     data = ReportDocument(
         title="VibeSensor Diagnostic Report",
+        run_id="strongest-sensor-page-one",
         verdict_page=VerdictPageData(
             suspected_source="Unknown resonance",
             inspect_first="Rear-Right",
@@ -224,6 +227,7 @@ def test_report_cards_switch_to_check_first_summary_when_parts_exist() -> None:
     """Workflow appendix surfaces primary path context and concrete action rows."""
     data = ReportDocument(
         title="VibeSensor Diagnostic Report",
+        run_id="cards-check-first-summary",
         verdict_page=VerdictPageData(
             suspected_source="Wheel / Tire",
             inspect_first="Front-Left",

--- a/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_content_rendering.py
@@ -111,6 +111,7 @@ def test_full_report_template_contains_peak_db_column_labels() -> None:
     i18n = json.loads(_I18N_JSON.read_text(encoding="utf-8"))
     data = ReportDocument(
         title="Diagnostic worksheet",
+        run_id="peak-db-columns",
         lang="en",
         verdict_page=VerdictPageData(
             suspected_source="Wheel / Tire",
@@ -168,6 +169,7 @@ def test_full_report_template_contains_peak_db_column_labels() -> None:
 def test_pdf_additional_observations_heading_for_transient_findings() -> None:
     data = ReportDocument(
         title="Diagnostic worksheet",
+        run_id="additional-observations",
         pattern_evidence=PatternEvidence(),
         lang="en",
         appendix_c=AppendixCData(
@@ -452,6 +454,7 @@ def test_pdf_workflow_appendix_a_headings_render(lang: str) -> None:
     i18n = json.loads(_I18N_JSON.read_text(encoding="utf-8"))
     data = ReportDocument(
         title="Diagnostic worksheet",
+        run_id=f"workflow-headings-{lang}",
         lang=lang,
         appendix_a=AppendixAData(
             mode="workflow",

--- a/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_rendering.py
@@ -26,7 +26,7 @@ from vibesensor.adapters.analysis_summary import summarize_log
 from vibesensor.adapters.pdf.pdf_diagram_render import car_location_diagram
 from vibesensor.adapters.pdf.pdf_engine import build_report_pdf
 from vibesensor.shared.boundaries.reporting import prepare_report_input
-from vibesensor.shared.boundaries.reporting.document import ReportDocument
+from vibesensor.shared.boundaries.reporting.document import AppendixAData, ReportDocument
 from vibesensor.shared.constants.units import KMH_TO_MPS
 from vibesensor.use_cases.history.report_document import build_report_document
 
@@ -325,7 +325,66 @@ def test_report_pdf_renders_run_timeline_graph_labels() -> None:
 
 def test_report_pdf_rejects_invalid_certainty_tier_key() -> None:
     with pytest.raises(ValueError, match="certainty_tier_key"):
-        build_report_pdf(ReportDocument(certainty_tier_key="Z"))
+        build_report_pdf(
+            ReportDocument(
+                title="VibeSensor Diagnostic Report",
+                run_id="run-invalid-tier",
+                lang="en",
+                certainty_tier_key="Z",
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("document", "message"),
+    [
+        pytest.param(
+            ReportDocument(title="", run_id="run-missing-title", lang="en"),
+            "title must be non-empty",
+            id="missing-title",
+        ),
+        pytest.param(
+            ReportDocument(title="VibeSensor Diagnostic Report", run_id=None, lang="en"),
+            "run_id must be non-empty",
+            id="missing-run-id",
+        ),
+        pytest.param(
+            ReportDocument(
+                title="VibeSensor Diagnostic Report",
+                run_id="run-missing-lang",
+                lang=" ",
+            ),
+            "lang must be non-empty",
+            id="missing-lang",
+        ),
+        pytest.param(
+            ReportDocument(
+                title="VibeSensor Diagnostic Report",
+                run_id="run-bad-mode",
+                lang="en",
+                appendix_a=AppendixAData(mode="unexpected"),
+            ),
+            "appendix_a.mode",
+            id="invalid-appendix-mode",
+        ),
+        pytest.param(
+            ReportDocument(
+                title="VibeSensor Diagnostic Report",
+                run_id="run-negative-samples",
+                lang="en",
+                sample_count=-1,
+            ),
+            "sample_count must be non-negative",
+            id="negative-sample-count",
+        ),
+    ],
+)
+def test_report_pdf_rejects_incomplete_report_document(
+    document: ReportDocument,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        build_report_pdf(document)
 
 
 def test_car_diagram_omits_sensor_labels() -> None:

--- a/apps/server/tests/adapters/pdf/test_report_pdf_workflow_rendering.py
+++ b/apps/server/tests/adapters/pdf/test_report_pdf_workflow_rendering.py
@@ -263,6 +263,7 @@ def test_build_report_pdf_renders_action_ready_status_on_page_one() -> None:
     pdf = build_report_pdf(
         ReportDocument(
             title="VibeSensor Diagnostic Report",
+            run_id="action-ready-page-one",
             verdict_page=VerdictPageData(
                 suspected_source="Wheel / Tire",
                 inspect_first="Front-Left",

--- a/apps/server/tests/use_cases/history/test_report_preparation_contract.py
+++ b/apps/server/tests/use_cases/history/test_report_preparation_contract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 from test_support.findings import make_finding_payload
 
@@ -33,6 +35,60 @@ def test_prepare_report_input_prefers_connected_sensor_locations() -> None:
     )
     assert prepared.report_facts.sensor.active_locations == ("rear-right",)
     assert not hasattr(prepared, "renderer_payload")
+
+
+def test_prepare_report_input_rejects_blank_filename() -> None:
+    prepared = prepare_report_input(
+        {
+            "run_id": "blank-filename",
+            "lang": "en",
+            "metadata": {"run_id": "blank-filename"},
+            "report_date": "",
+            "record_length": "",
+            "start_time_utc": "",
+            "end_time_utc": "",
+            "findings": [],
+            "top_causes": [],
+            "sensor_locations": [],
+            "sensor_locations_connected_throughout": [],
+            "speed_stats": {},
+            "most_likely_origin": {},
+            "run_suitability": [],
+        },
+    )
+
+    with pytest.raises(ValueError, match="filename must be non-empty"):
+        replace(prepared, filename=" ")
+
+
+def test_prepare_report_input_rejects_run_id_mismatch() -> None:
+    prepared = prepare_report_input(
+        {
+            "run_id": "prepared-run",
+            "lang": "en",
+            "metadata": {"run_id": "prepared-run"},
+            "report_date": "",
+            "record_length": "",
+            "start_time_utc": "",
+            "end_time_utc": "",
+            "findings": [],
+            "top_causes": [],
+            "sensor_locations": [],
+            "sensor_locations_connected_throughout": [],
+            "speed_stats": {},
+            "most_likely_origin": {},
+            "run_suitability": [],
+        },
+    )
+
+    with pytest.raises(ValueError, match="run_id mismatch"):
+        replace(
+            prepared,
+            report_facts=replace(
+                prepared.report_facts,
+                run=replace(prepared.report_facts.run, run_id="other-run"),
+            ),
+        )
 
 
 def test_resolve_primary_report_candidate_keeps_summary_confidence_context() -> None:
@@ -174,6 +230,37 @@ def test_prepare_persisted_report_input_uses_persisted_reconstruction_path(
 
     assert prepared.domain_test_run is not None
     assert prepared.domain_test_run.capture.run_id == "persisted-run"
+
+
+def test_prepare_persisted_report_input_falls_back_to_metadata_run_id() -> None:
+    analysis = PersistedAnalysis.from_json_object(
+        {
+            "lang": "en",
+            "metadata": {
+                "run_id": "metadata-run",
+                "active_car_snapshot": {"name": "Track Car", "type": "coupe"},
+            },
+            "report_date": "2026-03-23T07:31:01Z",
+            "record_length": "5m",
+            "rows": 120,
+            "duration_s": 300.0,
+            "sensor_count_used": 2,
+            "sensor_locations": ["front-left", "rear-right"],
+            "sensor_locations_connected_throughout": ["front-left"],
+            "sensor_intensity_by_location": [],
+            "most_likely_origin": {},
+            "run_suitability": [],
+            "test_plan": [],
+            "findings": [],
+            "top_causes": [],
+            "warnings": [],
+        }
+    )
+
+    prepared = prepare_persisted_report_input(analysis)
+
+    assert prepared.report_facts.run.run_id == "metadata-run"
+    assert prepared.domain_test_run.capture.run_id == "metadata-run"
 
 
 def test_prepare_report_input_tolerates_invalid_count_strings() -> None:

--- a/apps/server/vibesensor/adapters/pdf/report_document_validation.py
+++ b/apps/server/vibesensor/adapters/pdf/report_document_validation.py
@@ -3,19 +3,14 @@
 from __future__ import annotations
 
 from vibesensor.shared.boundaries.reporting.document import ReportDocument
+from vibesensor.shared.boundaries.reporting.document import (
+    validate_report_document as _validate_report_document,
+)
 
 __all__ = ["validate_report_document"]
-
-_VALID_CERTAINTY_TIERS = frozenset({"A", "B", "C"})
 
 
 def validate_report_document(data: ReportDocument) -> ReportDocument:
     """Validate one report document before adapter-side layout planning."""
-    if not isinstance(data, ReportDocument):
-        raise TypeError(f"build_report_pdf expects ReportDocument, got {type(data).__name__}")
-    if data.certainty_tier_key not in _VALID_CERTAINTY_TIERS:
-        raise ValueError(
-            "report document certainty_tier_key must be one of "
-            f"{sorted(_VALID_CERTAINTY_TIERS)}, got {data.certainty_tier_key!r}"
-        )
-    return data
+
+    return _validate_report_document(data)

--- a/apps/server/vibesensor/shared/boundaries/analysis_payloads/reconstruction/_test_run_builder.py
+++ b/apps/server/vibesensor/shared/boundaries/analysis_payloads/reconstruction/_test_run_builder.py
@@ -102,6 +102,14 @@ def _findings_from_payloads(raw_findings: object) -> tuple[Finding, ...]:
     )
 
 
+def _resolve_run_id(payload: Mapping[str, object], meta: Mapping[str, object]) -> str:
+    for candidate in (payload.get("run_id"), meta.get("run_id"), payload.get("file_name")):
+        normalized = str(candidate or "").strip()
+        if normalized:
+            return normalized
+    return "unknown"
+
+
 def _test_run_from_payload(payload: Mapping[str, object]) -> TestRun:
     metadata = payload.get("metadata")
     meta = metadata if isinstance(metadata, Mapping) else {}
@@ -207,7 +215,7 @@ def _test_run_from_payload(payload: Mapping[str, object]) -> TestRun:
     except (TypeError, ValueError):
         row_count = 0
     capture = RunCapture(
-        run_id=str(payload.get("run_id") or "unknown"),
+        run_id=_resolve_run_id(payload, meta),
         setup=setup,
         sample_count=row_count,
     )

--- a/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/__init__.py
@@ -13,7 +13,7 @@ from .facts import (
     prepare_report_facts,
 )
 from .findings import FindingPresentation, PreparedReportFindings
-from .input import PreparedReportInput
+from .input import PreparedReportInput, validate_prepared_report_input
 
 # Reconstructed prepared-input entrypoints.
 from .preparation import prepare_persisted_report_input, prepare_report_input
@@ -70,4 +70,5 @@ __all__ = [
     "resolve_primary_report_facts",
     "resolve_report_origin",
     "sensor_fallback_strength_db",
+    "validate_prepared_report_input",
 ]

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/__init__.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/__init__.py
@@ -21,6 +21,7 @@ from .sections import (
     TimelineGraphInterval,
     VerdictPageData,
 )
+from .validation import validate_report_document
 
 __all__ = [
     "AppendixAData",
@@ -44,5 +45,6 @@ __all__ = [
     "TimelineGraphData",
     "TimelineGraphInterval",
     "TopologyIntensityRow",
+    "validate_report_document",
     "VerdictPageData",
 ]

--- a/apps/server/vibesensor/shared/boundaries/reporting/document/validation.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/document/validation.py
@@ -1,0 +1,40 @@
+"""Shared validation helpers for the canonical report-document boundary."""
+
+from __future__ import annotations
+
+from vibesensor.shared.boundaries.reporting.document.document import ReportDocument
+
+__all__ = ["validate_report_document"]
+
+_VALID_CERTAINTY_TIERS = frozenset({"A", "B", "C"})
+_VALID_APPENDIX_A_MODES = frozenset({"workflow", "recapture"})
+
+
+def validate_report_document(data: object) -> ReportDocument:
+    """Validate one canonical report document before render planning."""
+
+    if not isinstance(data, ReportDocument):
+        raise TypeError(f"build_report_pdf expects ReportDocument, got {type(data).__name__}")
+    _require_non_empty_text(data.title, field_name="title")
+    _require_non_empty_text(data.run_id, field_name="run_id")
+    _require_non_empty_text(data.lang, field_name="lang")
+    if data.sample_count < 0:
+        raise ValueError("report document sample_count must be non-negative")
+    if data.sensor_count < 0:
+        raise ValueError("report document sensor_count must be non-negative")
+    if data.certainty_tier_key not in _VALID_CERTAINTY_TIERS:
+        raise ValueError(
+            "report document certainty_tier_key must be one of "
+            f"{sorted(_VALID_CERTAINTY_TIERS)}, got {data.certainty_tier_key!r}"
+        )
+    if data.appendix_a.mode not in _VALID_APPENDIX_A_MODES:
+        raise ValueError(
+            "report document appendix_a.mode must be one of "
+            f"{sorted(_VALID_APPENDIX_A_MODES)}, got {data.appendix_a.mode!r}"
+        )
+    return data
+
+
+def _require_non_empty_text(value: str | None, *, field_name: str) -> None:
+    if value is None or not value.strip():
+        raise ValueError(f"report document {field_name} must be non-empty")

--- a/apps/server/vibesensor/shared/boundaries/reporting/input.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/input.py
@@ -10,7 +10,42 @@ if TYPE_CHECKING:
     from vibesensor.shared.boundaries.reporting.facts import PreparedReportFacts
     from vibesensor.shared.types.report_cache import ReportPdfCacheKey
 
-__all__ = ["PreparedReportInput"]
+__all__ = ["PreparedReportInput", "validate_prepared_report_input"]
+
+
+def validate_prepared_report_input(prepared: object) -> PreparedReportInput:
+    """Validate one canonical prepared report handoff before document assembly."""
+
+    if not isinstance(prepared, PreparedReportInput):
+        raise TypeError(
+            f"build_report_document expects PreparedReportInput, got {type(prepared).__name__}"
+        )
+    _require_non_empty_text(prepared.language, field_name="language")
+    _require_non_empty_text(prepared.filename, field_name="filename")
+    if not prepared.filename.lower().endswith(".pdf"):
+        raise ValueError(
+            f"prepared report input filename must end with .pdf, got {prepared.filename!r}"
+        )
+    report_run_id = _normalized_run_id(prepared.report_facts)
+    test_run_id = prepared.domain_test_run.run_id.strip()
+    if report_run_id != test_run_id:
+        raise ValueError(
+            "prepared report input run_id mismatch between domain_test_run and "
+            f"report_facts.run: {test_run_id!r} != {report_run_id!r}"
+        )
+    return prepared
+
+
+def _require_non_empty_text(value: str, *, field_name: str) -> None:
+    if not value.strip():
+        raise ValueError(f"prepared report input {field_name} must be non-empty")
+
+
+def _normalized_run_id(report_facts: PreparedReportFacts) -> str:
+    run_id = report_facts.run.run_id.strip()
+    if not run_id:
+        raise ValueError("prepared report input report_facts.run.run_id must be non-empty")
+    return run_id
 
 
 @dataclass(frozen=True, slots=True)
@@ -22,3 +57,6 @@ class PreparedReportInput:
     domain_test_run: TestRun
     report_facts: PreparedReportFacts
     cache_key: ReportPdfCacheKey | None = None
+
+    def __post_init__(self) -> None:
+        validate_prepared_report_input(self)

--- a/apps/server/vibesensor/use_cases/history/report_document/builder.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/builder.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
-from vibesensor.shared.boundaries.reporting import PreparedReportInput
-from vibesensor.shared.boundaries.reporting.document import ReportDocument
+from vibesensor.shared.boundaries.reporting import (
+    PreparedReportInput,
+    validate_prepared_report_input,
+)
+from vibesensor.shared.boundaries.reporting.document import (
+    ReportDocument,
+    validate_report_document,
+)
 
 from .composition import compose_report_document
 
@@ -13,4 +19,5 @@ __all__ = ["build_report_document"]
 def build_report_document(prepared: PreparedReportInput) -> ReportDocument:
     """Build the final PDF-facing report document from prepared report input."""
 
-    return compose_report_document(prepared)
+    validated_prepared = validate_prepared_report_input(prepared)
+    return validate_report_document(compose_report_document(validated_prepared))


### PR DESCRIPTION
## Summary
- validate prepared report inputs before document composition and validate report documents before rendering
- keep history reconstruction aligned by falling back to metadata run_id when persisted summaries omit the top-level run id
- add focused regressions for invalid report inputs/documents and update direct PDF fixtures to carry required run ids

## Validation
- make typecheck-backend
- make lint
- make test-changed