### PR TITLE
Centralize diagnosis assessment policy

### DIFF
--- a/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
+++ b/apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py
@@ -153,7 +153,8 @@ def test_build_report_document_prefers_persisted_whole_run_diagnosis_surfaces() 
         ],
     )
 
-    document = build_report_document(prepare_report_input(summary))
+    prepared = prepare_report_input(summary)
+    document = build_report_document(prepared)
 
     assert document.verdict_page.suspected_source == "Driveline"
     assert document.verdict_page.inspect_first == "Rear-Right"
@@ -162,6 +163,8 @@ def test_build_report_document_prefers_persisted_whole_run_diagnosis_surfaces() 
     assert document.appendix_b.runner_up_corner == "Front-Left"
     assert document.appendix_a.ranked_candidates[0].source_name == "Driveline"
     assert document.appendix_a.ranked_candidates[1].source_name == "Wheel / Tire"
+    assert prepared.report_facts.confidence.signal_keys == ("raw_backed",)
+    assert prepared.report_facts.confidence.caveat_keys == ("close_alternative",)
     assert any(
         "12" in row.value and "6.0" in row.value
         for row in document.verdict_page.proof_snapshot_rows
@@ -289,20 +292,39 @@ def test_build_report_document_uses_matching_persisted_source_when_top_row_is_am
                 "weak_spatial_separation": False,
                 "has_reference_gap": False,
                 "uses_summary_fallback": False,
-                "support_factors": [],
-                "counterevidence_factors": [],
+                "support_factors": [
+                    {
+                        "factor_key": "raw_backed",
+                        "polarity": "support",
+                        "severity": "high",
+                        "weight": 0.10,
+                        "details": {"raw_backed_sample_count": 84},
+                    }
+                ],
+                "counterevidence_factors": [
+                    {
+                        "factor_key": "rpm_context_gaps",
+                        "polarity": "counterevidence",
+                        "severity": "low",
+                        "weight": 0.04,
+                        "details": {"rpm_gap_window_count": 2},
+                    }
+                ],
                 "exemplar_references": [],
             },
         ],
     )
 
-    document = build_report_document(prepare_report_input(summary))
+    prepared = prepare_report_input(summary)
+    document = build_report_document(prepared)
 
     assert document.verdict_page.suspected_source == "Wheel / Tire"
     assert document.verdict_page.inspect_first == "Front-Left"
     assert document.verdict_page.also_consider == "Driveline"
     assert document.appendix_a.ranked_candidates[0].source_name == "Wheel / Tire"
     assert document.appendix_a.ranked_candidates[1].source_name == "Driveline"
+    assert prepared.report_facts.confidence.signal_keys == ("raw_backed",)
+    assert prepared.report_facts.confidence.caveat_keys == ("rpm_context_gaps",)
     assert any(
         "12.9" in row.value
         for row in document.verdict_page.proof_snapshot_rows

--- a/apps/server/tests/use_cases/history/test_whole_run_diagnosis_factors.py
+++ b/apps/server/tests/use_cases/history/test_whole_run_diagnosis_factors.py
@@ -3,45 +3,37 @@ from __future__ import annotations
 import pytest
 
 from vibesensor.shared.boundaries.reporting.confidence_facts import (
-    ReportConfidenceFacts,
+    ReportConfidenceScoringInputs,
+    apply_report_confidence_fallback,
     project_whole_run_diagnosis_factors,
+    score_report_confidence_inputs,
 )
 
 
 def test_project_whole_run_diagnosis_factors_maps_support_signals_to_stable_rows() -> None:
     support_factors, counter_factors = project_whole_run_diagnosis_factors(
-        ReportConfidenceFacts(
-            score_0_to_1=0.9,
-            label_key="CONFIDENCE_HIGH",
-            pct_text="90%",
-            tier="C",
-            data_basis="raw_backed",
-            raw_backed_sample_count=48,
-            supporting_window_count=6,
-            supporting_duration_s=3.0,
-            stable_frequency_min_hz=13.1,
-            stable_frequency_max_hz=13.4,
-            supporting_location_count=1,
-            top_support_location="front-left",
-            top_support_share=0.9,
-            mean_relative_error=0.03,
-            snr_db=8.5,
-            alternative_source=None,
-            has_reference_gap=False,
-            speed_gap_window_count=0,
-            rpm_gap_window_count=0,
-            uses_summary_fallback=False,
-            fallback_reason=None,
-            signal_keys=(
-                "raw_backed",
-                "repeated_support",
-                "sustained_support",
-                "stable_frequency",
-                "tight_order_lock",
-                "localized_support",
-                "clean_signal",
-            ),
-            caveat_keys=(),
+        score_report_confidence_inputs(
+            ReportConfidenceScoringInputs(
+                base_confidence=1.0,
+                data_basis="raw_backed",
+                raw_backed_sample_count=48,
+                supporting_window_count=6,
+                supporting_duration_s=3.0,
+                stable_frequency_min_hz=13.1,
+                stable_frequency_max_hz=13.4,
+                supporting_location_count=1,
+                top_support_location="front-left",
+                top_support_share=0.9,
+                mean_relative_error=0.03,
+                snr_db=8.5,
+                alternative_source=None,
+                has_reference_gap=False,
+                weak_spatial=False,
+                context_traceable=True,
+                context_source="whole_run",
+                speed_gap_window_count=0,
+                rpm_gap_window_count=0,
+            )
         )
     )
 
@@ -63,43 +55,31 @@ def test_project_whole_run_diagnosis_factors_maps_support_signals_to_stable_rows
 
 def test_project_whole_run_diagnosis_factors_maps_counterevidence_signals_to_stable_rows() -> None:
     support_factors, counter_factors = project_whole_run_diagnosis_factors(
-        ReportConfidenceFacts(
-            score_0_to_1=0.3,
-            label_key="CONFIDENCE_LOW",
-            pct_text="30%",
-            tier="A",
-            data_basis="summary_only",
-            raw_backed_sample_count=0,
-            supporting_window_count=1,
-            supporting_duration_s=0.2,
-            stable_frequency_min_hz=12.0,
-            stable_frequency_max_hz=14.2,
-            supporting_location_count=2,
-            top_support_location="front-left",
-            top_support_share=0.5,
-            mean_relative_error=0.22,
-            snr_db=2.5,
-            alternative_source="driveshaft",
-            has_reference_gap=True,
-            speed_gap_window_count=3,
-            rpm_gap_window_count=2,
-            uses_summary_fallback=True,
-            fallback_reason="summary-only legacy confidence",
-            signal_keys=(),
-            caveat_keys=(
-                "summary_only",
-                "speed_context_gaps",
-                "rpm_context_gaps",
-                "sparse_support",
-                "brief_support",
-                "drifting_frequency",
-                "loose_order_lock",
-                "mixed_support_locations",
-                "noisy_signal",
-                "weak_spatial",
-                "close_alternative",
-                "incomplete_reference",
+        apply_report_confidence_fallback(
+            score_report_confidence_inputs(
+                ReportConfidenceScoringInputs(
+                    base_confidence=0.12,
+                    data_basis="summary_only",
+                    raw_backed_sample_count=0,
+                    supporting_window_count=1,
+                    supporting_duration_s=0.2,
+                    stable_frequency_min_hz=12.0,
+                    stable_frequency_max_hz=14.2,
+                    supporting_location_count=2,
+                    top_support_location="front-left",
+                    top_support_share=0.5,
+                    mean_relative_error=0.22,
+                    snr_db=2.5,
+                    alternative_source="driveshaft",
+                    has_reference_gap=True,
+                    weak_spatial=True,
+                    context_traceable=True,
+                    context_source="whole_run",
+                    speed_gap_window_count=3,
+                    rpm_gap_window_count=2,
+                )
             ),
+            fallback_reason="summary-only legacy confidence",
         )
     )
 

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -39,6 +39,17 @@ from .analysis_settings import AnalysisSettingsSnapshot
 from .capture_readiness import CaptureReadiness, CaptureReadinessCheck, CaptureReadinessPolicy
 from .car import Car, CarSnapshot
 from .confidence_assessment import ConfidenceAssessment
+from .diagnosis_assessment import (
+    DIAGNOSIS_AMBIGUOUS_SCORE_GAP,
+    DIAGNOSIS_CLOSE_ALTERNATIVE_REEVALUATION_GAP,
+    DiagnosisAssessment,
+    DiagnosisAssessmentFactor,
+    DiagnosisAssessmentFactorDetails,
+    DiagnosisAssessmentInputs,
+    apply_diagnosis_assessment_fallback,
+    diagnosis_assessment_from_components,
+    score_diagnosis_assessment_inputs,
+)
 from .diagnostic_case import DiagnosticCase, Symptom
 from .driving_phase_summary import DrivingPhaseSummary
 from .driving_segment import DrivingPhase, DrivingPhaseInterval, DrivingPhaseSegment, DrivingSegment
@@ -95,6 +106,10 @@ __all__ = [
     "VibrationReading",
     # Value objects — findings and diagnostics
     "ConfidenceAssessment",
+    "DiagnosisAssessment",
+    "DiagnosisAssessmentFactor",
+    "DiagnosisAssessmentFactorDetails",
+    "DiagnosisAssessmentInputs",
     "Finding",
     "FindingEvidence",
     "FindingKind",
@@ -128,11 +143,16 @@ __all__ = [
     "TestPlan",
     # Functions
     "RUN_TRANSITIONS",
+    "DIAGNOSIS_AMBIGUOUS_SCORE_GAP",
+    "DIAGNOSIS_CLOSE_ALTERNATIVE_REEVALUATION_GAP",
+    "apply_diagnosis_assessment_fallback",
     "coerce_float",
     "coerce_int",
+    "diagnosis_assessment_from_components",
     "is_run_deletable",
     "normalize_sensor_id",
     "plan_test_actions",
+    "score_diagnosis_assessment_inputs",
     "speed_band_sort_key",
     "speed_bin_label",
     "transition_run",

--- a/apps/server/vibesensor/domain/diagnosis_assessment.py
+++ b/apps/server/vibesensor/domain/diagnosis_assessment.py
@@ -1,0 +1,628 @@
+"""Canonical whole-run diagnosis assessment policy and typed results."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field, replace
+
+from .finding import Finding
+
+__all__ = [
+    "DIAGNOSIS_AMBIGUOUS_SCORE_GAP",
+    "DIAGNOSIS_CLOSE_ALTERNATIVE_REEVALUATION_GAP",
+    "DiagnosisAssessment",
+    "DiagnosisAssessmentFactor",
+    "DiagnosisAssessmentFactorDetails",
+    "DiagnosisAssessmentInputs",
+    "apply_diagnosis_assessment_fallback",
+    "diagnosis_assessment_from_components",
+    "score_diagnosis_assessment_inputs",
+]
+
+DIAGNOSIS_CLOSE_ALTERNATIVE_REEVALUATION_GAP = 0.10
+DIAGNOSIS_AMBIGUOUS_SCORE_GAP = 0.05
+_DIAGNOSIS_SUSPICIOUS_CAVEAT_KEYS = frozenset(
+    {
+        "drifting_frequency",
+        "mixed_support_locations",
+        "weak_spatial",
+        "close_alternative",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisAssessmentFactorDetails:
+    """Structured details carried by one diagnosis support/counterevidence factor."""
+
+    raw_backed_sample_count: int | None = None
+    supporting_window_count: int | None = None
+    supporting_duration_s: float | None = None
+    stable_frequency_min_hz: float | None = None
+    stable_frequency_max_hz: float | None = None
+    frequency_span_hz: float | None = None
+    supporting_location_count: int | None = None
+    top_support_location: str | None = None
+    top_support_share: float | None = None
+    mean_relative_error: float | None = None
+    snr_db: float | None = None
+    alternative_source: str | None = None
+    speed_gap_window_count: int | None = None
+    rpm_gap_window_count: int | None = None
+    fallback_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisAssessmentFactor:
+    """One stable diagnosis support or counterevidence factor."""
+
+    factor_key: str
+    polarity: str
+    severity: str
+    weight: float
+    details: DiagnosisAssessmentFactorDetails = field(
+        default_factory=DiagnosisAssessmentFactorDetails
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisAssessmentInputs:
+    """Normalized canonical inputs for whole-run diagnosis scoring."""
+
+    base_confidence: float
+    data_basis: str
+    raw_backed_sample_count: int
+    supporting_window_count: int | None
+    supporting_duration_s: float | None
+    stable_frequency_min_hz: float | None
+    stable_frequency_max_hz: float | None
+    supporting_location_count: int
+    top_support_location: str | None
+    top_support_share: float | None
+    mean_relative_error: float | None
+    snr_db: float | None
+    alternative_source: str | None
+    has_reference_gap: bool
+    weak_spatial: bool
+    context_traceable: bool
+    context_source: str
+    speed_gap_window_count: int
+    rpm_gap_window_count: int
+    confidence_gap_to_alternative: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisAssessment:
+    """Canonical diagnosis confidence, factors, ambiguity, and caveats."""
+
+    score_0_to_1: float
+    label_key: str
+    pct_text: str
+    tier: str
+    data_basis: str
+    raw_backed_sample_count: int
+    supporting_window_count: int | None
+    supporting_duration_s: float | None
+    stable_frequency_min_hz: float | None
+    stable_frequency_max_hz: float | None
+    supporting_location_count: int
+    top_support_location: str | None
+    top_support_share: float | None
+    mean_relative_error: float | None
+    snr_db: float | None
+    alternative_source: str | None
+    has_reference_gap: bool
+    speed_gap_window_count: int
+    rpm_gap_window_count: int
+    uses_summary_fallback: bool
+    fallback_reason: str | None
+    signal_keys: tuple[str, ...]
+    caveat_keys: tuple[str, ...]
+    support_factors: tuple[DiagnosisAssessmentFactor, ...] = ()
+    counterevidence_factors: tuple[DiagnosisAssessmentFactor, ...] = ()
+    confidence_gap_to_alternative: float | None = None
+    ambiguous_diagnosis: bool = False
+    suspicious: bool = False
+
+
+def score_diagnosis_assessment_inputs(inputs: DiagnosisAssessmentInputs) -> DiagnosisAssessment:
+    """Apply the canonical whole-run diagnosis scoring policy."""
+
+    score = max(0.0, min(0.70, 0.25 + (inputs.base_confidence * 0.40)))
+    signal_keys: list[str] = []
+    caveat_keys: list[str] = []
+    frequency_span_hz = _frequency_span_hz(
+        stable_frequency_min_hz=inputs.stable_frequency_min_hz,
+        stable_frequency_max_hz=inputs.stable_frequency_max_hz,
+    )
+
+    if inputs.data_basis == "raw_backed":
+        score += 0.10
+        signal_keys.append("raw_backed")
+    else:
+        score -= 0.05
+        caveat_keys.append("summary_only")
+
+    if inputs.context_traceable:
+        if inputs.context_source == "legacy":
+            score -= 0.05
+            caveat_keys.append("legacy_context")
+        else:
+            if inputs.speed_gap_window_count > 0:
+                score -= 0.04
+                caveat_keys.append("speed_context_gaps")
+            if inputs.rpm_gap_window_count > 0:
+                score -= 0.04
+                caveat_keys.append("rpm_context_gaps")
+
+    if inputs.supporting_window_count is not None:
+        if inputs.supporting_window_count >= 4:
+            score += 0.10
+            signal_keys.append("repeated_support")
+        elif inputs.supporting_window_count >= 2:
+            score += 0.05
+            signal_keys.append("repeated_support")
+        elif inputs.supporting_window_count <= 1:
+            score -= 0.10
+            caveat_keys.append("sparse_support")
+
+    if inputs.supporting_duration_s is not None:
+        if inputs.supporting_duration_s >= 1.0:
+            score += 0.08
+            signal_keys.append("sustained_support")
+        elif inputs.supporting_duration_s >= 0.5:
+            score += 0.04
+            signal_keys.append("sustained_support")
+        elif inputs.supporting_duration_s > 0:
+            score -= 0.06
+            caveat_keys.append("brief_support")
+
+    if frequency_span_hz is not None:
+        if frequency_span_hz <= 0.5:
+            score += 0.08
+            signal_keys.append("stable_frequency")
+        elif frequency_span_hz <= 1.0:
+            score += 0.04
+            signal_keys.append("stable_frequency")
+        elif frequency_span_hz > 1.5:
+            score -= 0.06
+            caveat_keys.append("drifting_frequency")
+
+    if inputs.mean_relative_error is not None:
+        if inputs.mean_relative_error <= 0.05:
+            score += 0.08
+            signal_keys.append("tight_order_lock")
+        elif inputs.mean_relative_error >= 0.15:
+            score -= 0.08
+            caveat_keys.append("loose_order_lock")
+
+    if inputs.top_support_share is not None:
+        if inputs.top_support_share >= 0.67:
+            score += 0.08
+            signal_keys.append("localized_support")
+        elif inputs.supporting_location_count > 1 and inputs.top_support_share < 0.55:
+            score -= 0.10
+            caveat_keys.append("mixed_support_locations")
+
+    if inputs.snr_db is not None:
+        if inputs.snr_db >= 6.0:
+            score += 0.05
+            signal_keys.append("clean_signal")
+        elif inputs.snr_db < 3.0:
+            score -= 0.06
+            caveat_keys.append("noisy_signal")
+
+    if inputs.weak_spatial:
+        score -= 0.10
+        caveat_keys.append("weak_spatial")
+
+    if inputs.alternative_source is not None:
+        score -= 0.10
+        caveat_keys.append("close_alternative")
+
+    if inputs.has_reference_gap:
+        score -= 0.06
+        caveat_keys.append("incomplete_reference")
+
+    return _assessment_from_keys(
+        score_0_to_1=_rounded_score(score),
+        data_basis=inputs.data_basis,
+        raw_backed_sample_count=inputs.raw_backed_sample_count,
+        supporting_window_count=inputs.supporting_window_count,
+        supporting_duration_s=inputs.supporting_duration_s,
+        stable_frequency_min_hz=inputs.stable_frequency_min_hz,
+        stable_frequency_max_hz=inputs.stable_frequency_max_hz,
+        supporting_location_count=inputs.supporting_location_count,
+        top_support_location=inputs.top_support_location,
+        top_support_share=inputs.top_support_share,
+        mean_relative_error=inputs.mean_relative_error,
+        snr_db=inputs.snr_db,
+        alternative_source=inputs.alternative_source,
+        has_reference_gap=inputs.has_reference_gap,
+        speed_gap_window_count=inputs.speed_gap_window_count,
+        rpm_gap_window_count=inputs.rpm_gap_window_count,
+        uses_summary_fallback=False,
+        fallback_reason=None,
+        signal_keys=tuple(dict.fromkeys(signal_keys)),
+        caveat_keys=tuple(dict.fromkeys(caveat_keys)),
+        confidence_gap_to_alternative=inputs.confidence_gap_to_alternative,
+    )
+
+
+def apply_diagnosis_assessment_fallback(
+    assessment: DiagnosisAssessment,
+    *,
+    fallback_reason: str,
+) -> DiagnosisAssessment:
+    """Mark an assessment as an explicit fallback and rebuild its factor rows."""
+
+    caveat_keys = list(assessment.caveat_keys)
+    if assessment.data_basis == "summary_only" and "summary_only" not in caveat_keys:
+        caveat_keys.append("summary_only")
+    return _assessment_from_keys(
+        score_0_to_1=assessment.score_0_to_1,
+        data_basis=assessment.data_basis,
+        raw_backed_sample_count=assessment.raw_backed_sample_count,
+        supporting_window_count=assessment.supporting_window_count,
+        supporting_duration_s=assessment.supporting_duration_s,
+        stable_frequency_min_hz=assessment.stable_frequency_min_hz,
+        stable_frequency_max_hz=assessment.stable_frequency_max_hz,
+        supporting_location_count=assessment.supporting_location_count,
+        top_support_location=assessment.top_support_location,
+        top_support_share=assessment.top_support_share,
+        mean_relative_error=assessment.mean_relative_error,
+        snr_db=assessment.snr_db,
+        alternative_source=assessment.alternative_source,
+        has_reference_gap=assessment.has_reference_gap,
+        speed_gap_window_count=assessment.speed_gap_window_count,
+        rpm_gap_window_count=assessment.rpm_gap_window_count,
+        uses_summary_fallback=True,
+        fallback_reason=fallback_reason,
+        signal_keys=assessment.signal_keys,
+        caveat_keys=tuple(dict.fromkeys(caveat_keys)),
+        confidence_gap_to_alternative=assessment.confidence_gap_to_alternative,
+        ambiguous_diagnosis=assessment.ambiguous_diagnosis,
+        suspicious=assessment.suspicious,
+    )
+
+
+def diagnosis_assessment_from_components(
+    *,
+    score_0_to_1: float,
+    data_basis: str,
+    raw_backed_sample_count: int,
+    supporting_window_count: int | None,
+    supporting_duration_s: float | None,
+    stable_frequency_min_hz: float | None,
+    stable_frequency_max_hz: float | None,
+    supporting_location_count: int,
+    top_support_location: str | None,
+    top_support_share: float | None,
+    mean_relative_error: float | None,
+    snr_db: float | None,
+    alternative_source: str | None,
+    has_reference_gap: bool,
+    speed_gap_window_count: int,
+    rpm_gap_window_count: int,
+    uses_summary_fallback: bool,
+    fallback_reason: str | None,
+    support_factors: tuple[DiagnosisAssessmentFactor, ...],
+    counterevidence_factors: tuple[DiagnosisAssessmentFactor, ...],
+    confidence_gap_to_alternative: float | None = None,
+    ambiguous_diagnosis: bool | None = None,
+    suspicious: bool | None = None,
+) -> DiagnosisAssessment:
+    """Build an assessment from persisted or externally supplied factor rows."""
+
+    label_key = _label_key_for_score(score_0_to_1)
+    signal_keys = tuple(factor.factor_key for factor in support_factors)
+    caveat_keys = tuple(factor.factor_key for factor in counterevidence_factors)
+    derived_ambiguous = (
+        confidence_gap_to_alternative is not None
+        and confidence_gap_to_alternative <= DIAGNOSIS_AMBIGUOUS_SCORE_GAP
+    )
+    derived_suspicious = derived_ambiguous or any(
+        factor.factor_key in _DIAGNOSIS_SUSPICIOUS_CAVEAT_KEYS for factor in counterevidence_factors
+    )
+    return DiagnosisAssessment(
+        score_0_to_1=score_0_to_1,
+        label_key=label_key,
+        pct_text=f"{score_0_to_1 * 100:.0f}%",
+        tier=_tier_for_score(
+            label_key=label_key,
+            score_0_to_1=score_0_to_1,
+            caveat_keys=caveat_keys,
+        ),
+        data_basis=data_basis,
+        raw_backed_sample_count=raw_backed_sample_count,
+        supporting_window_count=supporting_window_count,
+        supporting_duration_s=supporting_duration_s,
+        stable_frequency_min_hz=stable_frequency_min_hz,
+        stable_frequency_max_hz=stable_frequency_max_hz,
+        supporting_location_count=supporting_location_count,
+        top_support_location=top_support_location,
+        top_support_share=top_support_share,
+        mean_relative_error=mean_relative_error,
+        snr_db=snr_db,
+        alternative_source=alternative_source,
+        has_reference_gap=has_reference_gap,
+        speed_gap_window_count=speed_gap_window_count,
+        rpm_gap_window_count=rpm_gap_window_count,
+        uses_summary_fallback=uses_summary_fallback,
+        fallback_reason=fallback_reason,
+        signal_keys=signal_keys,
+        caveat_keys=caveat_keys,
+        support_factors=support_factors,
+        counterevidence_factors=counterevidence_factors,
+        confidence_gap_to_alternative=confidence_gap_to_alternative,
+        ambiguous_diagnosis=(
+            ambiguous_diagnosis if ambiguous_diagnosis is not None else derived_ambiguous
+        ),
+        suspicious=suspicious if suspicious is not None else derived_suspicious,
+    )
+
+
+def _assessment_from_keys(
+    *,
+    score_0_to_1: float,
+    data_basis: str,
+    raw_backed_sample_count: int,
+    supporting_window_count: int | None,
+    supporting_duration_s: float | None,
+    stable_frequency_min_hz: float | None,
+    stable_frequency_max_hz: float | None,
+    supporting_location_count: int,
+    top_support_location: str | None,
+    top_support_share: float | None,
+    mean_relative_error: float | None,
+    snr_db: float | None,
+    alternative_source: str | None,
+    has_reference_gap: bool,
+    speed_gap_window_count: int,
+    rpm_gap_window_count: int,
+    uses_summary_fallback: bool,
+    fallback_reason: str | None,
+    signal_keys: tuple[str, ...],
+    caveat_keys: tuple[str, ...],
+    confidence_gap_to_alternative: float | None,
+    ambiguous_diagnosis: bool | None = None,
+    suspicious: bool | None = None,
+) -> DiagnosisAssessment:
+    assessment = DiagnosisAssessment(
+        score_0_to_1=score_0_to_1,
+        label_key=_label_key_for_score(score_0_to_1),
+        pct_text=f"{score_0_to_1 * 100:.0f}%",
+        tier=_tier_for_score(
+            label_key=_label_key_for_score(score_0_to_1),
+            score_0_to_1=score_0_to_1,
+            caveat_keys=caveat_keys,
+        ),
+        data_basis=data_basis,
+        raw_backed_sample_count=raw_backed_sample_count,
+        supporting_window_count=supporting_window_count,
+        supporting_duration_s=supporting_duration_s,
+        stable_frequency_min_hz=stable_frequency_min_hz,
+        stable_frequency_max_hz=stable_frequency_max_hz,
+        supporting_location_count=supporting_location_count,
+        top_support_location=top_support_location,
+        top_support_share=top_support_share,
+        mean_relative_error=mean_relative_error,
+        snr_db=snr_db,
+        alternative_source=alternative_source,
+        has_reference_gap=has_reference_gap,
+        speed_gap_window_count=speed_gap_window_count,
+        rpm_gap_window_count=rpm_gap_window_count,
+        uses_summary_fallback=uses_summary_fallback,
+        fallback_reason=fallback_reason,
+        signal_keys=signal_keys,
+        caveat_keys=caveat_keys,
+        confidence_gap_to_alternative=confidence_gap_to_alternative,
+        ambiguous_diagnosis=False,
+        suspicious=False,
+    )
+    support_factors = tuple(_support_factor(key, assessment) for key in signal_keys)
+    counterevidence_factors = tuple(_counterevidence_factor(key, assessment) for key in caveat_keys)
+    return diagnosis_assessment_from_components(
+        score_0_to_1=score_0_to_1,
+        data_basis=data_basis,
+        raw_backed_sample_count=raw_backed_sample_count,
+        supporting_window_count=supporting_window_count,
+        supporting_duration_s=supporting_duration_s,
+        stable_frequency_min_hz=stable_frequency_min_hz,
+        stable_frequency_max_hz=stable_frequency_max_hz,
+        supporting_location_count=supporting_location_count,
+        top_support_location=top_support_location,
+        top_support_share=top_support_share,
+        mean_relative_error=mean_relative_error,
+        snr_db=snr_db,
+        alternative_source=alternative_source,
+        has_reference_gap=has_reference_gap,
+        speed_gap_window_count=speed_gap_window_count,
+        rpm_gap_window_count=rpm_gap_window_count,
+        uses_summary_fallback=uses_summary_fallback,
+        fallback_reason=fallback_reason,
+        support_factors=support_factors,
+        counterevidence_factors=counterevidence_factors,
+        confidence_gap_to_alternative=confidence_gap_to_alternative,
+        ambiguous_diagnosis=ambiguous_diagnosis,
+        suspicious=suspicious,
+    )
+
+
+def _support_factor(
+    factor_key: str,
+    assessment: DiagnosisAssessment,
+) -> DiagnosisAssessmentFactor:
+    return DiagnosisAssessmentFactor(
+        factor_key=factor_key,
+        polarity="support",
+        severity=_factor_severity(_support_factor_weight(factor_key, assessment)),
+        weight=_support_factor_weight(factor_key, assessment),
+        details=_factor_details(factor_key, assessment),
+    )
+
+
+def _counterevidence_factor(
+    factor_key: str,
+    assessment: DiagnosisAssessment,
+) -> DiagnosisAssessmentFactor:
+    return DiagnosisAssessmentFactor(
+        factor_key=factor_key,
+        polarity="counterevidence",
+        severity=_factor_severity(_counter_factor_weight(factor_key)),
+        weight=_counter_factor_weight(factor_key),
+        details=_factor_details(factor_key, assessment),
+    )
+
+
+def _factor_severity(weight: float) -> str:
+    if weight >= 0.10:
+        return "high"
+    if weight >= 0.07:
+        return "medium"
+    return "low"
+
+
+def _support_factor_weight(factor_key: str, assessment: DiagnosisAssessment) -> float:
+    if factor_key == "raw_backed":
+        return 0.10
+    if factor_key == "repeated_support":
+        if (
+            assessment.supporting_window_count is not None
+            and assessment.supporting_window_count >= 4
+        ):
+            return 0.10
+        return 0.05
+    if factor_key == "sustained_support":
+        if assessment.supporting_duration_s is not None and assessment.supporting_duration_s >= 1.0:
+            return 0.08
+        return 0.04
+    if factor_key == "stable_frequency":
+        frequency_span_hz = _frequency_span_hz(
+            stable_frequency_min_hz=assessment.stable_frequency_min_hz,
+            stable_frequency_max_hz=assessment.stable_frequency_max_hz,
+        )
+        if frequency_span_hz is not None and frequency_span_hz <= 0.5:
+            return 0.08
+        return 0.04
+    if factor_key == "tight_order_lock":
+        return 0.08
+    if factor_key == "localized_support":
+        return 0.08
+    if factor_key == "clean_signal":
+        return 0.05
+    raise ValueError(f"unsupported support factor key: {factor_key}")
+
+
+def _counter_factor_weight(factor_key: str) -> float:
+    if factor_key in {"summary_only", "legacy_context"}:
+        return 0.05
+    if factor_key in {"speed_context_gaps", "rpm_context_gaps"}:
+        return 0.04
+    if factor_key in {
+        "brief_support",
+        "drifting_frequency",
+        "noisy_signal",
+        "incomplete_reference",
+    }:
+        return 0.06
+    if factor_key in {
+        "sparse_support",
+        "loose_order_lock",
+        "mixed_support_locations",
+        "weak_spatial",
+        "close_alternative",
+    }:
+        return 0.10 if factor_key != "loose_order_lock" else 0.08
+    raise ValueError(f"unsupported counterevidence factor key: {factor_key}")
+
+
+def _factor_details(
+    factor_key: str,
+    assessment: DiagnosisAssessment,
+) -> DiagnosisAssessmentFactorDetails:
+    details = DiagnosisAssessmentFactorDetails()
+    if factor_key == "raw_backed":
+        return replace(details, raw_backed_sample_count=assessment.raw_backed_sample_count)
+    if factor_key in {"repeated_support", "sparse_support"}:
+        return replace(details, supporting_window_count=assessment.supporting_window_count)
+    if factor_key in {"sustained_support", "brief_support"}:
+        return replace(details, supporting_duration_s=assessment.supporting_duration_s)
+    if factor_key in {"stable_frequency", "drifting_frequency"}:
+        return replace(
+            details,
+            stable_frequency_min_hz=assessment.stable_frequency_min_hz,
+            stable_frequency_max_hz=assessment.stable_frequency_max_hz,
+            frequency_span_hz=_frequency_span_hz(
+                stable_frequency_min_hz=assessment.stable_frequency_min_hz,
+                stable_frequency_max_hz=assessment.stable_frequency_max_hz,
+            ),
+        )
+    if factor_key in {"tight_order_lock", "loose_order_lock"}:
+        return replace(details, mean_relative_error=assessment.mean_relative_error)
+    if factor_key in {"localized_support", "mixed_support_locations"}:
+        return replace(
+            details,
+            supporting_location_count=assessment.supporting_location_count,
+            top_support_location=assessment.top_support_location,
+            top_support_share=assessment.top_support_share,
+        )
+    if factor_key in {"clean_signal", "noisy_signal"}:
+        return replace(details, snr_db=assessment.snr_db)
+    if factor_key == "close_alternative":
+        return replace(details, alternative_source=assessment.alternative_source)
+    if factor_key == "speed_context_gaps":
+        return replace(details, speed_gap_window_count=assessment.speed_gap_window_count)
+    if factor_key == "rpm_context_gaps":
+        return replace(details, rpm_gap_window_count=assessment.rpm_gap_window_count)
+    if factor_key == "summary_only" and assessment.uses_summary_fallback:
+        return replace(details, fallback_reason=assessment.fallback_reason)
+    return details
+
+
+def _rounded_score(score: float) -> float:
+    bounded = max(0.10, min(0.90, score))
+    return round(bounded / 0.05) * 0.05
+
+
+def _label_key_for_score(score: float) -> str:
+    if score >= Finding.CONFIDENCE_HIGH_THRESHOLD:
+        return "CONFIDENCE_HIGH"
+    if score >= Finding.CONFIDENCE_MEDIUM_THRESHOLD:
+        return "CONFIDENCE_MEDIUM"
+    return "CONFIDENCE_LOW"
+
+
+def _tier_for_score(*, label_key: str, score_0_to_1: float, caveat_keys: tuple[str, ...]) -> str:
+    if label_key == "CONFIDENCE_LOW":
+        return "A"
+    if score_0_to_1 < Finding.CONFIDENCE_HIGH_THRESHOLD:
+        return "B"
+    if set(caveat_keys).intersection(
+        {
+            "summary_only",
+            "drifting_frequency",
+            "loose_order_lock",
+            "mixed_support_locations",
+            "weak_spatial",
+            "close_alternative",
+            "incomplete_reference",
+            "legacy_context",
+            "speed_context_gaps",
+            "rpm_context_gaps",
+            "noisy_signal",
+        }
+    ):
+        return "B"
+    return "C"
+
+
+def _frequency_span_hz(
+    *,
+    stable_frequency_min_hz: float | None,
+    stable_frequency_max_hz: float | None,
+) -> float | None:
+    if stable_frequency_min_hz is None or stable_frequency_max_hz is None:
+        return None
+    span = stable_frequency_max_hz - stable_frequency_min_hz
+    return span if math.isfinite(span) and span >= 0 else None

--- a/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
@@ -1,12 +1,18 @@
-"""Prepared report-confidence facts derived from persisted evidence quality."""
+"""Prepared report-confidence facts projected from the canonical diagnosis policy."""
 
 from __future__ import annotations
 
-import math
-from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, cast
 
-from vibesensor.domain import Finding
+from vibesensor.domain import (
+    DiagnosisAssessment,
+    DiagnosisAssessmentFactor,
+    DiagnosisAssessmentFactorDetails,
+    DiagnosisAssessmentInputs,
+    apply_diagnosis_assessment_fallback,
+    diagnosis_assessment_from_components,
+    score_diagnosis_assessment_inputs,
+)
 from vibesensor.shared.boundaries.reporting.decision_facts import ReportDecisionFacts
 from vibesensor.shared.boundaries.reporting.evidence_facts import ReportEvidenceFacts
 from vibesensor.shared.boundaries.reporting.projection import PrimaryReportFacts
@@ -20,69 +26,23 @@ from vibesensor.shared.types.history_analysis_contracts import (
 
 if TYPE_CHECKING:
     from vibesensor.shared.boundaries.reporting.facts import ReportContextFacts
+    from vibesensor.shared.boundaries.reporting.summary import (
+        ReportDiagnosisFactor,
+        ReportWholeRunDiagnosisSummary,
+    )
 
 __all__ = [
-    "apply_report_confidence_fallback",
     "ReportConfidenceFacts",
     "ReportConfidenceScoringInputs",
+    "apply_report_confidence_fallback",
     "build_report_confidence_facts",
     "project_whole_run_diagnosis_factors",
+    "report_confidence_from_diagnosis_summary",
     "score_report_confidence_inputs",
 ]
 
-
-@dataclass(frozen=True, slots=True)
-class ReportConfidenceFacts:
-    """Explicit report-confidence inputs and the bounded score derived from them."""
-
-    score_0_to_1: float
-    label_key: str
-    pct_text: str
-    tier: str
-    data_basis: str
-    raw_backed_sample_count: int
-    supporting_window_count: int | None
-    supporting_duration_s: float | None
-    stable_frequency_min_hz: float | None
-    stable_frequency_max_hz: float | None
-    supporting_location_count: int
-    top_support_location: str | None
-    top_support_share: float | None
-    mean_relative_error: float | None
-    snr_db: float | None
-    alternative_source: str | None
-    has_reference_gap: bool
-    speed_gap_window_count: int
-    rpm_gap_window_count: int
-    uses_summary_fallback: bool
-    fallback_reason: str | None
-    signal_keys: tuple[str, ...]
-    caveat_keys: tuple[str, ...]
-
-
-@dataclass(frozen=True, slots=True)
-class ReportConfidenceScoringInputs:
-    """Normalized inputs for deterministic non-fallback confidence scoring."""
-
-    base_confidence: float
-    data_basis: str
-    raw_backed_sample_count: int
-    supporting_window_count: int | None
-    supporting_duration_s: float | None
-    stable_frequency_min_hz: float | None
-    stable_frequency_max_hz: float | None
-    supporting_location_count: int
-    top_support_location: str | None
-    top_support_share: float | None
-    mean_relative_error: float | None
-    snr_db: float | None
-    alternative_source: str | None
-    has_reference_gap: bool
-    weak_spatial: bool
-    context_traceable: bool
-    context_source: str
-    speed_gap_window_count: int
-    rpm_gap_window_count: int
+ReportConfidenceFacts = DiagnosisAssessment
+ReportConfidenceScoringInputs = DiagnosisAssessmentInputs
 
 
 def build_report_confidence_facts(
@@ -93,7 +53,7 @@ def build_report_confidence_facts(
     decision_facts: ReportDecisionFacts,
     context_facts: ReportContextFacts,
 ) -> ReportConfidenceFacts:
-    """Build bounded report confidence from explicit persisted evidence signals."""
+    """Build provisional report confidence from explicit persisted evidence signals."""
 
     finding_evidence = (
         primary_candidate.domain_primary.evidence
@@ -159,6 +119,72 @@ def build_report_confidence_facts(
     )
 
 
+def report_confidence_from_diagnosis_summary(
+    diagnosis_summary: ReportWholeRunDiagnosisSummary,
+) -> ReportConfidenceFacts:
+    """Project report confidence directly from a persisted whole-run diagnosis summary."""
+
+    return diagnosis_assessment_from_components(
+        score_0_to_1=diagnosis_summary.total_score or 0.0,
+        data_basis=diagnosis_summary.data_basis,
+        raw_backed_sample_count=_raw_backed_sample_count(diagnosis_summary.support_factors),
+        supporting_window_count=diagnosis_summary.supporting_window_count,
+        supporting_duration_s=diagnosis_summary.supporting_duration_s,
+        stable_frequency_min_hz=diagnosis_summary.stable_frequency_min_hz,
+        stable_frequency_max_hz=diagnosis_summary.stable_frequency_max_hz,
+        supporting_location_count=_supporting_location_count(diagnosis_summary),
+        top_support_location=_top_support_location(diagnosis_summary),
+        top_support_share=_top_support_share(diagnosis_summary),
+        mean_relative_error=_mean_relative_error(diagnosis_summary),
+        snr_db=_snr_db(diagnosis_summary),
+        alternative_source=diagnosis_summary.alternative_source,
+        has_reference_gap=diagnosis_summary.has_reference_gap,
+        speed_gap_window_count=_speed_gap_window_count(diagnosis_summary),
+        rpm_gap_window_count=_rpm_gap_window_count(diagnosis_summary),
+        uses_summary_fallback=diagnosis_summary.uses_summary_fallback,
+        fallback_reason=diagnosis_summary.fallback_reason,
+        support_factors=tuple(
+            _assessment_factor_from_summary_factor(factor)
+            for factor in diagnosis_summary.support_factors
+        ),
+        counterevidence_factors=tuple(
+            _assessment_factor_from_summary_factor(factor)
+            for factor in diagnosis_summary.counterevidence_factors
+        ),
+        confidence_gap_to_alternative=diagnosis_summary.confidence_gap_to_alternative,
+        ambiguous_diagnosis=diagnosis_summary.ambiguous_diagnosis,
+        suspicious=diagnosis_summary.suspicious,
+    )
+
+
+def apply_report_confidence_fallback(
+    facts: ReportConfidenceFacts,
+    *,
+    fallback_reason: str,
+) -> ReportConfidenceFacts:
+    """Mark report confidence as an explicit fallback without changing its score."""
+
+    return apply_diagnosis_assessment_fallback(facts, fallback_reason=fallback_reason)
+
+
+def project_whole_run_diagnosis_factors(
+    confidence_facts: ReportConfidenceFacts,
+) -> tuple[tuple[DiagnosisFactorResponse, ...], tuple[DiagnosisFactorResponse, ...]]:
+    """Project stable support and counterevidence rows from canonical confidence facts."""
+
+    support = tuple(_factor_payload(factor) for factor in confidence_facts.support_factors)
+    counter = tuple(_factor_payload(factor) for factor in confidence_facts.counterevidence_factors)
+    return (support, counter)
+
+
+def score_report_confidence_inputs(
+    inputs: ReportConfidenceScoringInputs,
+) -> ReportConfidenceFacts:
+    """Apply the canonical diagnosis assessment policy to report inputs."""
+
+    return score_diagnosis_assessment_inputs(inputs)
+
+
 def _should_use_summary_fallback(
     *,
     has_explicit_analysis_metadata: bool,
@@ -201,18 +227,15 @@ def _summary_fallback_confidence(
         if primary_candidate.domain_primary is not None
         else None
     )
-    label_key = assessment.label_key if assessment is not None else _label_key_for_score(confidence)
-    pct_text = (
-        assessment.pct_text if assessment is not None else f"{max(0.0, confidence) * 100:.0f}%"
-    )
-    tier = assessment.tier if assessment is not None else ("A" if confidence < 0.40 else "B")
-    fallback_reason = (assessment.reason if assessment is not None else "") or None
-    caveat_keys = ("summary_only",) if evidence_facts.data_basis == "summary_only" else ()
-    return ReportConfidenceFacts(
+    return DiagnosisAssessment(
         score_0_to_1=max(0.0, min(1.0, confidence)),
-        label_key=label_key,
-        pct_text=pct_text,
-        tier=tier,
+        label_key=(
+            assessment.label_key if assessment is not None else _label_key_for_score(confidence)
+        ),
+        pct_text=(
+            assessment.pct_text if assessment is not None else f"{max(0.0, confidence) * 100:.0f}%"
+        ),
+        tier=assessment.tier if assessment is not None else ("A" if confidence < 0.40 else "B"),
         data_basis=evidence_facts.data_basis,
         raw_backed_sample_count=evidence_facts.raw_backed_sample_count,
         supporting_window_count=evidence_facts.supporting_window_count,
@@ -229,251 +252,10 @@ def _summary_fallback_confidence(
         speed_gap_window_count=0,
         rpm_gap_window_count=0,
         uses_summary_fallback=True,
-        fallback_reason=fallback_reason,
+        fallback_reason=(assessment.reason if assessment is not None else "") or None,
         signal_keys=(),
-        caveat_keys=caveat_keys,
+        caveat_keys=("summary_only",) if evidence_facts.data_basis == "summary_only" else (),
     )
-
-
-def apply_report_confidence_fallback(
-    facts: ReportConfidenceFacts,
-    *,
-    fallback_reason: str,
-) -> ReportConfidenceFacts:
-    """Mark report confidence as an explicit fallback without changing its core score."""
-
-    caveat_keys = list(facts.caveat_keys)
-    if facts.data_basis == "summary_only" and "summary_only" not in caveat_keys:
-        caveat_keys.append("summary_only")
-    return replace(
-        facts,
-        uses_summary_fallback=True,
-        fallback_reason=fallback_reason,
-        caveat_keys=tuple(caveat_keys),
-    )
-
-
-def project_whole_run_diagnosis_factors(
-    confidence_facts: ReportConfidenceFacts,
-) -> tuple[tuple[DiagnosisFactorResponse, ...], tuple[DiagnosisFactorResponse, ...]]:
-    """Project stable support and counterevidence factors from current confidence facts."""
-
-    support_factors: list[DiagnosisFactorResponse] = []
-    counter_factors: list[DiagnosisFactorResponse] = []
-    signal_keys = set(confidence_facts.signal_keys)
-    caveat_keys = set(confidence_facts.caveat_keys)
-
-    for factor_key in (
-        "raw_backed",
-        "repeated_support",
-        "sustained_support",
-        "stable_frequency",
-        "tight_order_lock",
-        "localized_support",
-        "clean_signal",
-    ):
-        if factor_key not in signal_keys:
-            continue
-        support_factors.append(
-            _factor_payload(
-                factor_key=cast(DiagnosisFactorKey, factor_key),
-                polarity="support",
-                weight=_support_factor_weight(factor_key, confidence_facts),
-                details=_factor_details(factor_key, confidence_facts),
-            )
-        )
-
-    for factor_key in (
-        "summary_only",
-        "legacy_context",
-        "speed_context_gaps",
-        "rpm_context_gaps",
-        "sparse_support",
-        "brief_support",
-        "drifting_frequency",
-        "loose_order_lock",
-        "mixed_support_locations",
-        "noisy_signal",
-        "weak_spatial",
-        "close_alternative",
-        "incomplete_reference",
-    ):
-        if factor_key not in caveat_keys:
-            continue
-        counter_factors.append(
-            _factor_payload(
-                factor_key=cast(DiagnosisFactorKey, factor_key),
-                polarity="counterevidence",
-                weight=_counter_factor_weight(factor_key, confidence_facts),
-                details=_factor_details(factor_key, confidence_facts),
-            )
-        )
-
-    return (tuple(support_factors), tuple(counter_factors))
-
-
-def score_report_confidence_inputs(
-    inputs: ReportConfidenceScoringInputs,
-) -> ReportConfidenceFacts:
-    """Apply canonical non-fallback confidence scoring to normalized signal inputs."""
-
-    score = max(0.0, min(0.70, 0.25 + (inputs.base_confidence * 0.40)))
-    signal_keys: list[str] = []
-    caveat_keys: list[str] = []
-    frequency_span_hz = _frequency_span_hz(
-        stable_frequency_min_hz=inputs.stable_frequency_min_hz,
-        stable_frequency_max_hz=inputs.stable_frequency_max_hz,
-    )
-
-    if inputs.data_basis == "raw_backed":
-        score += 0.10
-        signal_keys.append("raw_backed")
-    else:
-        score -= 0.05
-        caveat_keys.append("summary_only")
-
-    if inputs.context_traceable:
-        if inputs.context_source == "legacy":
-            score -= 0.05
-            caveat_keys.append("legacy_context")
-        else:
-            if inputs.speed_gap_window_count > 0:
-                score -= 0.04
-                caveat_keys.append("speed_context_gaps")
-            if inputs.rpm_gap_window_count > 0:
-                score -= 0.04
-                caveat_keys.append("rpm_context_gaps")
-
-    supporting_window_count = inputs.supporting_window_count
-    if supporting_window_count is not None:
-        if supporting_window_count >= 4:
-            score += 0.10
-            signal_keys.append("repeated_support")
-        elif supporting_window_count >= 2:
-            score += 0.05
-            signal_keys.append("repeated_support")
-        elif supporting_window_count <= 1:
-            score -= 0.10
-            caveat_keys.append("sparse_support")
-
-    supporting_duration_s = inputs.supporting_duration_s
-    if supporting_duration_s is not None:
-        if supporting_duration_s >= 1.0:
-            score += 0.08
-            signal_keys.append("sustained_support")
-        elif supporting_duration_s >= 0.5:
-            score += 0.04
-            signal_keys.append("sustained_support")
-        elif supporting_duration_s > 0:
-            score -= 0.06
-            caveat_keys.append("brief_support")
-
-    if frequency_span_hz is not None:
-        if frequency_span_hz <= 0.5:
-            score += 0.08
-            signal_keys.append("stable_frequency")
-        elif frequency_span_hz <= 1.0:
-            score += 0.04
-            signal_keys.append("stable_frequency")
-        elif frequency_span_hz > 1.5:
-            score -= 0.06
-            caveat_keys.append("drifting_frequency")
-
-    if inputs.mean_relative_error is not None:
-        if inputs.mean_relative_error <= 0.05:
-            score += 0.08
-            signal_keys.append("tight_order_lock")
-        elif inputs.mean_relative_error >= 0.15:
-            score -= 0.08
-            caveat_keys.append("loose_order_lock")
-
-    if inputs.top_support_share is not None:
-        if inputs.top_support_share >= 0.67:
-            score += 0.08
-            signal_keys.append("localized_support")
-        elif inputs.supporting_location_count > 1 and inputs.top_support_share < 0.55:
-            score -= 0.10
-            caveat_keys.append("mixed_support_locations")
-
-    if inputs.snr_db is not None:
-        if inputs.snr_db >= 6.0:
-            score += 0.05
-            signal_keys.append("clean_signal")
-        elif inputs.snr_db < 3.0:
-            score -= 0.06
-            caveat_keys.append("noisy_signal")
-
-    if inputs.weak_spatial:
-        score -= 0.10
-        caveat_keys.append("weak_spatial")
-
-    if inputs.alternative_source is not None:
-        score -= 0.10
-        caveat_keys.append("close_alternative")
-
-    if inputs.has_reference_gap:
-        score -= 0.06
-        caveat_keys.append("incomplete_reference")
-
-    rounded_score = _rounded_score(score)
-    label_key = _label_key_for_score(rounded_score)
-    caveat_key_set = set(caveat_keys)
-    tier = (
-        "C"
-        if label_key == "CONFIDENCE_HIGH"
-        and not caveat_key_set.intersection(
-            {
-                "summary_only",
-                "drifting_frequency",
-                "loose_order_lock",
-                "mixed_support_locations",
-                "weak_spatial",
-                "close_alternative",
-                "incomplete_reference",
-                "legacy_context",
-                "speed_context_gaps",
-                "rpm_context_gaps",
-                "noisy_signal",
-            }
-        )
-        else ("B" if label_key != "CONFIDENCE_LOW" else "A")
-    )
-    return ReportConfidenceFacts(
-        score_0_to_1=rounded_score,
-        label_key=label_key,
-        pct_text=f"{rounded_score * 100:.0f}%",
-        tier=tier,
-        data_basis=inputs.data_basis,
-        raw_backed_sample_count=inputs.raw_backed_sample_count,
-        supporting_window_count=inputs.supporting_window_count,
-        supporting_duration_s=inputs.supporting_duration_s,
-        stable_frequency_min_hz=inputs.stable_frequency_min_hz,
-        stable_frequency_max_hz=inputs.stable_frequency_max_hz,
-        supporting_location_count=inputs.supporting_location_count,
-        top_support_location=inputs.top_support_location,
-        top_support_share=inputs.top_support_share,
-        mean_relative_error=inputs.mean_relative_error,
-        snr_db=inputs.snr_db,
-        alternative_source=inputs.alternative_source,
-        has_reference_gap=inputs.has_reference_gap,
-        speed_gap_window_count=inputs.speed_gap_window_count,
-        rpm_gap_window_count=inputs.rpm_gap_window_count,
-        uses_summary_fallback=False,
-        fallback_reason=None,
-        signal_keys=tuple(dict.fromkeys(signal_keys)),
-        caveat_keys=tuple(dict.fromkeys(caveat_keys)),
-    )
-
-
-def _frequency_span_hz(
-    *,
-    stable_frequency_min_hz: float | None,
-    stable_frequency_max_hz: float | None,
-) -> float | None:
-    if stable_frequency_min_hz is None or stable_frequency_max_hz is None:
-        return None
-    span = stable_frequency_max_hz - stable_frequency_min_hz
-    return span if math.isfinite(span) and span >= 0 else None
 
 
 def _support_location_summary(
@@ -497,128 +279,180 @@ def _support_location_summary(
     )
 
 
-def _rounded_score(score: float) -> float:
-    bounded = max(0.10, min(0.90, score))
-    return round(bounded / 0.05) * 0.05
-
-
-def _label_key_for_score(score: float) -> str:
-    if score >= Finding.CONFIDENCE_HIGH_THRESHOLD:
-        return "CONFIDENCE_HIGH"
-    if score >= Finding.CONFIDENCE_MEDIUM_THRESHOLD:
-        return "CONFIDENCE_MEDIUM"
-    return "CONFIDENCE_LOW"
-
-
-def _factor_payload(
-    *,
-    factor_key: DiagnosisFactorKey,
-    polarity: DiagnosisFactorPolarity,
-    weight: float,
-    details: DiagnosisFactorDetailsResponse,
-) -> DiagnosisFactorResponse:
+def _factor_payload(factor: DiagnosisAssessmentFactor) -> DiagnosisFactorResponse:
     return {
-        "factor_key": factor_key,
-        "polarity": polarity,
-        "severity": _factor_severity(weight),
-        "weight": weight,
-        "details": details,
+        "factor_key": cast(DiagnosisFactorKey, factor.factor_key),
+        "polarity": cast(DiagnosisFactorPolarity, factor.polarity),
+        "severity": cast(DiagnosisFactorSeverity, factor.severity),
+        "weight": factor.weight,
+        "details": _factor_details_payload(factor.details),
     }
 
 
-def _factor_severity(weight: float) -> DiagnosisFactorSeverity:
-    if weight >= 0.10:
-        return "high"
-    if weight >= 0.07:
-        return "medium"
-    return "low"
-
-
-def _support_factor_weight(factor_key: str, facts: ReportConfidenceFacts) -> float:
-    if factor_key == "raw_backed":
-        return 0.10
-    if factor_key == "repeated_support":
-        if facts.supporting_window_count is not None and facts.supporting_window_count >= 4:
-            return 0.10
-        return 0.05
-    if factor_key == "sustained_support":
-        if facts.supporting_duration_s is not None and facts.supporting_duration_s >= 1.0:
-            return 0.08
-        return 0.04
-    if factor_key == "stable_frequency":
-        frequency_span_hz = _frequency_span_hz(
-            stable_frequency_min_hz=facts.stable_frequency_min_hz,
-            stable_frequency_max_hz=facts.stable_frequency_max_hz,
-        )
-        if frequency_span_hz is not None and frequency_span_hz <= 0.5:
-            return 0.08
-        return 0.04
-    if factor_key == "tight_order_lock":
-        return 0.08
-    if factor_key == "localized_support":
-        return 0.08
-    if factor_key == "clean_signal":
-        return 0.05
-    raise ValueError(f"unsupported support factor key: {factor_key}")
-
-
-def _counter_factor_weight(factor_key: str, facts: ReportConfidenceFacts) -> float:
-    if factor_key in {"summary_only", "legacy_context"}:
-        return 0.05
-    if factor_key in {"speed_context_gaps", "rpm_context_gaps"}:
-        return 0.04
-    if factor_key in {
-        "brief_support",
-        "drifting_frequency",
-        "noisy_signal",
-        "incomplete_reference",
-    }:
-        return 0.06
-    if factor_key in {
-        "sparse_support",
-        "loose_order_lock",
-        "mixed_support_locations",
-        "weak_spatial",
-        "close_alternative",
-    }:
-        return 0.10 if factor_key != "loose_order_lock" else 0.08
-    if factor_key == "summary_only" and facts.uses_summary_fallback:
-        return 0.05
-    raise ValueError(f"unsupported counterevidence factor key: {factor_key}")
-
-
-def _factor_details(
-    factor_key: str,
-    facts: ReportConfidenceFacts,
+def _factor_details_payload(
+    details: DiagnosisAssessmentFactorDetails,
 ) -> DiagnosisFactorDetailsResponse:
-    details: DiagnosisFactorDetailsResponse = {}
-    if factor_key == "raw_backed":
-        details["raw_backed_sample_count"] = facts.raw_backed_sample_count
-    elif factor_key in {"repeated_support", "sparse_support"}:
-        details["supporting_window_count"] = facts.supporting_window_count
-    elif factor_key == "sustained_support" or factor_key == "brief_support":
-        details["supporting_duration_s"] = facts.supporting_duration_s
-    elif factor_key in {"stable_frequency", "drifting_frequency"}:
-        details["stable_frequency_min_hz"] = facts.stable_frequency_min_hz
-        details["stable_frequency_max_hz"] = facts.stable_frequency_max_hz
-        details["frequency_span_hz"] = _frequency_span_hz(
-            stable_frequency_min_hz=facts.stable_frequency_min_hz,
-            stable_frequency_max_hz=facts.stable_frequency_max_hz,
-        )
-    elif factor_key == "tight_order_lock" or factor_key == "loose_order_lock":
-        details["mean_relative_error"] = facts.mean_relative_error
-    elif factor_key == "localized_support" or factor_key == "mixed_support_locations":
-        details["supporting_location_count"] = facts.supporting_location_count
-        details["top_support_location"] = facts.top_support_location
-        details["top_support_share"] = facts.top_support_share
-    elif factor_key == "clean_signal" or factor_key == "noisy_signal":
-        details["snr_db"] = facts.snr_db
-    elif factor_key == "close_alternative":
-        details["alternative_source"] = facts.alternative_source
-    elif factor_key == "speed_context_gaps":
-        details["speed_gap_window_count"] = facts.speed_gap_window_count
-    elif factor_key == "rpm_context_gaps":
-        details["rpm_gap_window_count"] = facts.rpm_gap_window_count
-    elif factor_key == "summary_only" and facts.uses_summary_fallback:
-        details["fallback_reason"] = facts.fallback_reason
-    return details
+    payload: DiagnosisFactorDetailsResponse = {}
+    if details.raw_backed_sample_count is not None:
+        payload["raw_backed_sample_count"] = details.raw_backed_sample_count
+    if details.supporting_window_count is not None:
+        payload["supporting_window_count"] = details.supporting_window_count
+    if details.supporting_duration_s is not None:
+        payload["supporting_duration_s"] = details.supporting_duration_s
+    if details.stable_frequency_min_hz is not None:
+        payload["stable_frequency_min_hz"] = details.stable_frequency_min_hz
+    if details.stable_frequency_max_hz is not None:
+        payload["stable_frequency_max_hz"] = details.stable_frequency_max_hz
+    if details.frequency_span_hz is not None:
+        payload["frequency_span_hz"] = details.frequency_span_hz
+    if details.supporting_location_count is not None:
+        payload["supporting_location_count"] = details.supporting_location_count
+    if details.top_support_location is not None:
+        payload["top_support_location"] = details.top_support_location
+    if details.top_support_share is not None:
+        payload["top_support_share"] = details.top_support_share
+    if details.mean_relative_error is not None:
+        payload["mean_relative_error"] = details.mean_relative_error
+    if details.snr_db is not None:
+        payload["snr_db"] = details.snr_db
+    if details.alternative_source is not None:
+        payload["alternative_source"] = details.alternative_source
+    if details.speed_gap_window_count is not None:
+        payload["speed_gap_window_count"] = details.speed_gap_window_count
+    if details.rpm_gap_window_count is not None:
+        payload["rpm_gap_window_count"] = details.rpm_gap_window_count
+    if details.fallback_reason is not None:
+        payload["fallback_reason"] = details.fallback_reason
+    return payload
+
+
+def _assessment_factor_from_summary_factor(
+    factor: object,
+) -> DiagnosisAssessmentFactor:
+    typed_factor = cast("ReportDiagnosisFactor", factor)
+    factor_key = cast(str, typed_factor.factor_key)
+    polarity = cast(str, typed_factor.polarity)
+    severity = cast(str, typed_factor.severity)
+    weight = float(typed_factor.weight)
+    raw_details = typed_factor.details
+    details = DiagnosisAssessmentFactorDetails(
+        raw_backed_sample_count=raw_details.raw_backed_sample_count,
+        supporting_window_count=raw_details.supporting_window_count,
+        supporting_duration_s=raw_details.supporting_duration_s,
+        stable_frequency_min_hz=raw_details.stable_frequency_min_hz,
+        stable_frequency_max_hz=raw_details.stable_frequency_max_hz,
+        frequency_span_hz=raw_details.frequency_span_hz,
+        supporting_location_count=raw_details.supporting_location_count,
+        top_support_location=raw_details.top_support_location,
+        top_support_share=raw_details.top_support_share,
+        mean_relative_error=raw_details.mean_relative_error,
+        snr_db=raw_details.snr_db,
+        alternative_source=raw_details.alternative_source,
+        speed_gap_window_count=raw_details.speed_gap_window_count,
+        rpm_gap_window_count=raw_details.rpm_gap_window_count,
+        fallback_reason=raw_details.fallback_reason,
+    )
+    return DiagnosisAssessmentFactor(
+        factor_key=factor_key,
+        polarity=polarity,
+        severity=severity,
+        weight=weight,
+        details=details,
+    )
+
+
+def _raw_backed_sample_count(factors: tuple[object, ...]) -> int:
+    for factor in factors:
+        typed_factor = cast("ReportDiagnosisFactor", factor)
+        if typed_factor.factor_key != "raw_backed":
+            continue
+        count = typed_factor.details.raw_backed_sample_count
+        return int(count) if isinstance(count, int | float) else 0
+    return 0
+
+
+def _supporting_location_count(diagnosis_summary: ReportWholeRunDiagnosisSummary) -> int:
+    for factor in (*diagnosis_summary.support_factors, *diagnosis_summary.counterevidence_factors):
+        if factor.factor_key not in {
+            "localized_support",
+            "mixed_support_locations",
+        }:
+            continue
+        count = factor.details.supporting_location_count
+        if isinstance(count, int | float):
+            return int(count)
+    return diagnosis_summary.supporting_sensor_count or 0
+
+
+def _top_support_location(diagnosis_summary: ReportWholeRunDiagnosisSummary) -> str | None:
+    for factor in (*diagnosis_summary.support_factors, *diagnosis_summary.counterevidence_factors):
+        if factor.factor_key not in {
+            "localized_support",
+            "mixed_support_locations",
+        }:
+            continue
+        value = factor.details.top_support_location
+        if isinstance(value, str) and value.strip():
+            return value
+    return diagnosis_summary.dominant_location
+
+
+def _top_support_share(diagnosis_summary: ReportWholeRunDiagnosisSummary) -> float | None:
+    for factor in (*diagnosis_summary.support_factors, *diagnosis_summary.counterevidence_factors):
+        if factor.factor_key not in {
+            "localized_support",
+            "mixed_support_locations",
+        }:
+            continue
+        value = factor.details.top_support_share
+        if isinstance(value, int | float):
+            return float(value)
+    return None
+
+
+def _mean_relative_error(diagnosis_summary: ReportWholeRunDiagnosisSummary) -> float | None:
+    for factor in (*diagnosis_summary.support_factors, *diagnosis_summary.counterevidence_factors):
+        if factor.factor_key not in {"tight_order_lock", "loose_order_lock"}:
+            continue
+        value = factor.details.mean_relative_error
+        if isinstance(value, int | float):
+            return float(value)
+    return None
+
+
+def _snr_db(diagnosis_summary: ReportWholeRunDiagnosisSummary) -> float | None:
+    for factor in (*diagnosis_summary.support_factors, *diagnosis_summary.counterevidence_factors):
+        if factor.factor_key not in {"clean_signal", "noisy_signal"}:
+            continue
+        value = factor.details.snr_db
+        if isinstance(value, int | float):
+            return float(value)
+    return None
+
+
+def _speed_gap_window_count(diagnosis_summary: ReportWholeRunDiagnosisSummary) -> int:
+    for factor in diagnosis_summary.counterevidence_factors:
+        if factor.factor_key != "speed_context_gaps":
+            continue
+        value = factor.details.speed_gap_window_count
+        if isinstance(value, int | float):
+            return int(value)
+    return 0
+
+
+def _rpm_gap_window_count(diagnosis_summary: ReportWholeRunDiagnosisSummary) -> int:
+    for factor in diagnosis_summary.counterevidence_factors:
+        if factor.factor_key != "rpm_context_gaps":
+            continue
+        value = factor.details.rpm_gap_window_count
+        if isinstance(value, int | float):
+            return int(value)
+    return 0
+
+
+def _label_key_for_score(score: float) -> str:
+    if score >= 0.75:
+        return "CONFIDENCE_HIGH"
+    if score >= 0.45:
+        return "CONFIDENCE_MEDIUM"
+    return "CONFIDENCE_LOW"

--- a/apps/server/vibesensor/shared/boundaries/reporting/facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/facts.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from vibesensor.domain import DIAGNOSIS_AMBIGUOUS_SCORE_GAP
 from vibesensor.shared.boundaries.codecs.scalars import coerce_count, text_or_none
 from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.run_context_warning import (
@@ -36,6 +37,7 @@ from vibesensor.shared.boundaries.reporting.confidence_facts import (
     apply_report_confidence_fallback,
     build_report_confidence_facts,
     project_whole_run_diagnosis_factors,
+    report_confidence_from_diagnosis_summary,
 )
 from vibesensor.shared.boundaries.reporting.decision_facts import (
     ActionStatusKey,
@@ -155,30 +157,10 @@ class PreparedReportFacts:
     def report_surface_diagnosis_summaries(
         self,
     ) -> tuple[ReportWholeRunDiagnosisSummary, ...]:
-        if not self.whole_run_diagnosis_summaries:
-            return ()
-        primary = self.whole_run_diagnosis_summaries[0]
-        if primary.uses_summary_fallback or (
-            not primary.ambiguous_diagnosis and not primary.suspicious
-        ):
-            return self.whole_run_diagnosis_summaries
-        summary_primary_source = str(self.decision.primary_candidate.primary_source or "").strip()
-        if not summary_primary_source:
-            return ()
-        for index, diagnosis in enumerate(self.whole_run_diagnosis_summaries):
-            if diagnosis.suspected_source != summary_primary_source:
-                continue
-            if index == 0:
-                return self.whole_run_diagnosis_summaries
-            return (
-                diagnosis,
-                *(
-                    row
-                    for row_index, row in enumerate(self.whole_run_diagnosis_summaries)
-                    if row_index != index
-                ),
-            )
-        return ()
+        return _report_surface_diagnosis_summaries(
+            self.whole_run_diagnosis_summaries,
+            summary_primary_source=text_or_none(self.decision.primary_candidate.primary_source),
+        )
 
     @property
     def primary_diagnosis(self) -> ReportWholeRunDiagnosisSummary | None:
@@ -225,7 +207,7 @@ def prepare_report_facts(
         primary_candidate=decision_facts.primary_candidate,
         evidence_data_basis=evidence_facts.data_basis,
     )
-    confidence_facts = build_report_confidence_facts(
+    provisional_confidence_facts = build_report_confidence_facts(
         has_explicit_analysis_metadata=isinstance(payload.get("analysis_metadata"), Mapping),
         primary_candidate=decision_facts.primary_candidate,
         evidence_facts=evidence_facts,
@@ -238,8 +220,14 @@ def prepare_report_facts(
         sensor_facts=sensor_facts,
         decision_facts=decision_facts,
         evidence_facts=evidence_facts,
-        confidence_facts=confidence_facts,
+        confidence_facts=provisional_confidence_facts,
         context_facts=context_facts,
+    )
+    confidence_facts = _report_surface_confidence_facts(
+        whole_run_diagnosis_summaries,
+        summary_primary_source=text_or_none(decision_facts.primary_candidate.primary_source),
+        fallback_confidence=provisional_confidence_facts,
+        prefer_summary_projection=bool(summary.whole_run_diagnosis_summaries),
     )
     return PreparedReportFacts(
         run=ReportRunFacts(
@@ -442,7 +430,7 @@ def _report_whole_run_diagnosis_summaries(
         "confidence_gap_to_alternative": decision_facts.confidence_gap_to_alternative,
         "ambiguous_diagnosis": bool(
             decision_facts.confidence_gap_to_alternative is not None
-            and decision_facts.confidence_gap_to_alternative <= 0.05
+            and decision_facts.confidence_gap_to_alternative <= DIAGNOSIS_AMBIGUOUS_SCORE_GAP
         ),
         "ambiguous_location": False,
         "suspicious": _fallback_diagnosis_is_suspicious(
@@ -495,6 +483,55 @@ def _whole_run_diagnosis_fallback_reason(
     if has_partial_whole_run_inputs:
         return "whole-run diagnosis inputs incomplete; replayed summary-era evidence"
     return "whole-run artifacts unavailable; replayed summary-era evidence"
+
+
+def _report_surface_confidence_facts(
+    whole_run_diagnosis_summaries: tuple[ReportWholeRunDiagnosisSummary, ...],
+    *,
+    summary_primary_source: str | None,
+    fallback_confidence: ReportConfidenceFacts,
+    prefer_summary_projection: bool,
+) -> ReportConfidenceFacts:
+    if not prefer_summary_projection:
+        return fallback_confidence
+    report_surface = _report_surface_diagnosis_summaries(
+        whole_run_diagnosis_summaries,
+        summary_primary_source=summary_primary_source,
+    )
+    if not report_surface:
+        return fallback_confidence
+    return report_confidence_from_diagnosis_summary(report_surface[0])
+
+
+def _report_surface_diagnosis_summaries(
+    whole_run_diagnosis_summaries: tuple[ReportWholeRunDiagnosisSummary, ...],
+    *,
+    summary_primary_source: str | None,
+) -> tuple[ReportWholeRunDiagnosisSummary, ...]:
+    if not whole_run_diagnosis_summaries:
+        return ()
+    primary = whole_run_diagnosis_summaries[0]
+    if primary.uses_summary_fallback or (
+        not primary.ambiguous_diagnosis and not primary.suspicious
+    ):
+        return whole_run_diagnosis_summaries
+    normalized_primary_source = str(summary_primary_source or "").strip()
+    if not normalized_primary_source:
+        return ()
+    for index, diagnosis in enumerate(whole_run_diagnosis_summaries):
+        if diagnosis.suspected_source != normalized_primary_source:
+            continue
+        if index == 0:
+            return whole_run_diagnosis_summaries
+        return (
+            diagnosis,
+            *(
+                row
+                for row_index, row in enumerate(whole_run_diagnosis_summaries)
+                if row_index != index
+            ),
+        )
+    return ()
 
 
 def _factor_weight_sum(rows: tuple[DiagnosisFactorResponse, ...]) -> float:

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
-from vibesensor.shared.boundaries.reporting.confidence_facts import (
-    ReportConfidenceFacts,
-    ReportConfidenceScoringInputs,
-    project_whole_run_diagnosis_factors,
-    score_report_confidence_inputs,
+from vibesensor.domain import (
+    DIAGNOSIS_CLOSE_ALTERNATIVE_REEVALUATION_GAP,
+    DiagnosisAssessment,
+    DiagnosisAssessmentFactor,
+    DiagnosisAssessmentInputs,
+    score_diagnosis_assessment_inputs,
 )
 from vibesensor.shared.types.whole_run_analysis import WholeRunContextInterval
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTraceSummary
@@ -23,19 +24,13 @@ from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
 
 __all__ = ["build_whole_run_diagnosis_summaries"]
 
-_CLOSE_ALTERNATIVE_SCORE_GAP = 0.10
-_AMBIGUOUS_DIAGNOSIS_SCORE_GAP = 0.05
-
 
 @dataclass(frozen=True, slots=True)
 class _CandidateEvaluation:
     order_summary: OrderTraceSummary
     spatial_summary: SpatialEvidenceSummary | None
-    confidence: ReportConfidenceFacts
-    support_factors: tuple[DiagnosisFactor, ...]
-    counterevidence_factors: tuple[DiagnosisFactor, ...]
+    assessment: DiagnosisAssessment
     alternative_source: str | None
-    confidence_gap_to_alternative: float | None
 
 
 def build_whole_run_diagnosis_summaries(
@@ -66,9 +61,9 @@ def build_whole_run_diagnosis_summaries(
     ranked = sorted(
         final,
         key=lambda candidate: (
-            -candidate.confidence.score_0_to_1,
-            -_factor_weight_sum(candidate.support_factors),
-            _factor_weight_sum(candidate.counterevidence_factors),
+            -candidate.assessment.score_0_to_1,
+            -_factor_weight_sum(candidate.assessment.support_factors),
+            _factor_weight_sum(candidate.assessment.counterevidence_factors),
             -candidate.order_summary.lock_score,
             -candidate.order_summary.support_ratio,
             candidate.order_summary.hypothesis_key,
@@ -81,12 +76,12 @@ def build_whole_run_diagnosis_summaries(
                 diagnosis_key=candidate.order_summary.hypothesis_key,
                 suspected_source=candidate.order_summary.suspected_source,
                 rank=rank,
-                data_basis=candidate.confidence.data_basis,  # type: ignore[arg-type]
-                support_score=round(_factor_weight_sum(candidate.support_factors), 2),
+                data_basis=candidate.assessment.data_basis,  # type: ignore[arg-type]
+                support_score=round(_factor_weight_sum(candidate.assessment.support_factors), 2),
                 counterevidence_score=round(
-                    _factor_weight_sum(candidate.counterevidence_factors), 2
+                    _factor_weight_sum(candidate.assessment.counterevidence_factors), 2
                 ),
-                total_score=round(candidate.confidence.score_0_to_1, 2),
+                total_score=round(candidate.assessment.score_0_to_1, 2),
                 order_hypothesis_key=candidate.order_summary.hypothesis_key,
                 spatial_candidate_key=(
                     candidate.spatial_summary.candidate_key
@@ -130,28 +125,31 @@ def build_whole_run_diagnosis_summaries(
                     else None
                 ),
                 alternative_source=candidate.alternative_source,
-                confidence_gap_to_alternative=candidate.confidence_gap_to_alternative,
-                ambiguous_diagnosis=bool(
-                    candidate.confidence_gap_to_alternative is not None
-                    and candidate.confidence_gap_to_alternative <= _AMBIGUOUS_DIAGNOSIS_SCORE_GAP
-                ),
+                confidence_gap_to_alternative=candidate.assessment.confidence_gap_to_alternative,
+                ambiguous_diagnosis=candidate.assessment.ambiguous_diagnosis,
                 ambiguous_location=(
                     candidate.spatial_summary.ambiguous_location
                     if candidate.spatial_summary is not None
                     else False
                 ),
-                suspicious=_is_suspicious(candidate),
+                suspicious=candidate.assessment.suspicious,
                 weak_spatial_separation=(
                     candidate.spatial_summary.weak_spatial_separation
                     if candidate.spatial_summary is not None
                     else False
                 ),
-                has_reference_gap=candidate.confidence.has_reference_gap,
-                uses_summary_fallback=candidate.confidence.uses_summary_fallback,
-                fallback_reason=candidate.confidence.fallback_reason,
+                has_reference_gap=candidate.assessment.has_reference_gap,
+                uses_summary_fallback=candidate.assessment.uses_summary_fallback,
+                fallback_reason=candidate.assessment.fallback_reason,
                 exemplar_references=_exemplar_references(candidate, context_intervals),
-                support_factors=candidate.support_factors,
-                counterevidence_factors=candidate.counterevidence_factors,
+                support_factors=tuple(
+                    _diagnosis_factor_from_assessment_factor(factor)
+                    for factor in candidate.assessment.support_factors
+                ),
+                counterevidence_factors=tuple(
+                    _diagnosis_factor_from_assessment_factor(factor)
+                    for factor in candidate.assessment.counterevidence_factors
+                ),
             )
         )
     return tuple(summaries)
@@ -165,8 +163,8 @@ def _reevaluate_with_alternative(
     alternative = _closest_alternative_candidate(candidate, initial)
     if alternative is None:
         return candidate
-    score_gap = abs(candidate.confidence.score_0_to_1 - alternative.confidence.score_0_to_1)
-    if score_gap > _CLOSE_ALTERNATIVE_SCORE_GAP:
+    score_gap = abs(candidate.assessment.score_0_to_1 - alternative.assessment.score_0_to_1)
+    if score_gap > DIAGNOSIS_CLOSE_ALTERNATIVE_REEVALUATION_GAP:
         return candidate
     return _evaluate_candidate(
         analysis_metadata=analysis_metadata,
@@ -192,8 +190,8 @@ def _closest_alternative_candidate(
     return min(
         alternatives,
         key=lambda other: (
-            abs(candidate.confidence.score_0_to_1 - other.confidence.score_0_to_1),
-            -other.confidence.score_0_to_1,
+            abs(candidate.assessment.score_0_to_1 - other.assessment.score_0_to_1),
+            -other.assessment.score_0_to_1,
             other.order_summary.hypothesis_key,
         ),
     )
@@ -207,45 +205,41 @@ def _evaluate_candidate(
     alternative_source: str | None,
     confidence_gap_to_alternative: float | None,
 ) -> _CandidateEvaluation:
-    scoring_inputs = ReportConfidenceScoringInputs(
-        base_confidence=_base_confidence(order_summary, spatial_summary),
-        data_basis=_data_basis(analysis_metadata, spatial_summary),
-        raw_backed_sample_count=_count(analysis_metadata.get("raw_backed_sample_count")),
-        supporting_window_count=order_summary.matched_window_count,
-        supporting_duration_s=_supporting_duration_s(order_summary),
-        stable_frequency_min_hz=order_summary.stable_frequency_min_hz,
-        stable_frequency_max_hz=order_summary.stable_frequency_max_hz,
-        supporting_location_count=_supporting_location_count(spatial_summary),
-        top_support_location=_top_support_location(spatial_summary),
-        top_support_share=_top_support_share(spatial_summary),
-        mean_relative_error=order_summary.mean_relative_error,
-        snr_db=_snr_db(order_summary),
-        alternative_source=alternative_source,
-        has_reference_gap=_has_reference_gap(order_summary),
-        weak_spatial=bool(spatial_summary and spatial_summary.weak_spatial_separation),
-        context_traceable=True,
-        context_source=_context_source(analysis_metadata),
-        speed_gap_window_count=_count(
-            analysis_metadata.get("whole_run_context_missing_speed_window_count")
+    assessment = score_diagnosis_assessment_inputs(
+        DiagnosisAssessmentInputs(
+            base_confidence=_base_confidence(order_summary, spatial_summary),
+            data_basis=_data_basis(analysis_metadata, spatial_summary),
+            raw_backed_sample_count=_count(analysis_metadata.get("raw_backed_sample_count")),
+            supporting_window_count=order_summary.matched_window_count,
+            supporting_duration_s=_supporting_duration_s(order_summary),
+            stable_frequency_min_hz=order_summary.stable_frequency_min_hz,
+            stable_frequency_max_hz=order_summary.stable_frequency_max_hz,
+            supporting_location_count=_supporting_location_count(spatial_summary),
+            top_support_location=_top_support_location(spatial_summary),
+            top_support_share=_top_support_share(spatial_summary),
+            mean_relative_error=order_summary.mean_relative_error,
+            snr_db=_snr_db(order_summary),
+            alternative_source=alternative_source,
+            has_reference_gap=_has_reference_gap(order_summary),
+            weak_spatial=bool(spatial_summary and spatial_summary.weak_spatial_separation),
+            context_traceable=True,
+            context_source=_context_source(analysis_metadata),
+            speed_gap_window_count=_count(
+                analysis_metadata.get("whole_run_context_missing_speed_window_count")
+            )
+            + _count(analysis_metadata.get("whole_run_context_stale_speed_window_count")),
+            rpm_gap_window_count=_count(
+                analysis_metadata.get("whole_run_context_missing_rpm_window_count")
+            )
+            + _count(analysis_metadata.get("whole_run_context_stale_rpm_window_count")),
+            confidence_gap_to_alternative=confidence_gap_to_alternative,
         )
-        + _count(analysis_metadata.get("whole_run_context_stale_speed_window_count")),
-        rpm_gap_window_count=_count(
-            analysis_metadata.get("whole_run_context_missing_rpm_window_count")
-        )
-        + _count(analysis_metadata.get("whole_run_context_stale_rpm_window_count")),
     )
-    confidence = score_report_confidence_inputs(scoring_inputs)
-    support_payloads, counter_payloads = project_whole_run_diagnosis_factors(confidence)
     return _CandidateEvaluation(
         order_summary=order_summary,
         spatial_summary=spatial_summary,
-        confidence=confidence,
-        support_factors=tuple(_diagnosis_factor_from_payload(row) for row in support_payloads),
-        counterevidence_factors=tuple(
-            _diagnosis_factor_from_payload(row) for row in counter_payloads
-        ),
+        assessment=assessment,
         alternative_source=alternative_source,
-        confidence_gap_to_alternative=confidence_gap_to_alternative,
     )
 
 
@@ -346,32 +340,28 @@ def _top_support_share(spatial_summary: SpatialEvidenceSummary | None) -> float 
     return spatial_summary.location_summaries[0].supporting_window_count / total
 
 
-def _diagnosis_factor_from_payload(payload: Mapping[str, object]) -> DiagnosisFactor:
-    details_payload = payload.get("details")
-    details_mapping = details_payload if isinstance(details_payload, Mapping) else {}
+def _diagnosis_factor_from_assessment_factor(factor: DiagnosisAssessmentFactor) -> DiagnosisFactor:
     return DiagnosisFactor(
-        factor_key=str(payload.get("factor_key")),  # type: ignore[arg-type]
-        polarity=str(payload.get("polarity")),  # type: ignore[arg-type]
-        severity=str(payload.get("severity")),  # type: ignore[arg-type]
-        weight=_optional_float(payload.get("weight")) or 0.0,
+        factor_key=factor.factor_key,  # type: ignore[arg-type]
+        polarity=factor.polarity,  # type: ignore[arg-type]
+        severity=factor.severity,  # type: ignore[arg-type]
+        weight=factor.weight,
         details=DiagnosisFactorDetails(
-            raw_backed_sample_count=_optional_count(details_mapping.get("raw_backed_sample_count")),
-            supporting_window_count=_optional_count(details_mapping.get("supporting_window_count")),
-            supporting_duration_s=_optional_float(details_mapping.get("supporting_duration_s")),
-            stable_frequency_min_hz=_optional_float(details_mapping.get("stable_frequency_min_hz")),
-            stable_frequency_max_hz=_optional_float(details_mapping.get("stable_frequency_max_hz")),
-            frequency_span_hz=_optional_float(details_mapping.get("frequency_span_hz")),
-            supporting_location_count=_optional_count(
-                details_mapping.get("supporting_location_count")
-            ),
-            top_support_location=_optional_text(details_mapping.get("top_support_location")),
-            top_support_share=_optional_float(details_mapping.get("top_support_share")),
-            mean_relative_error=_optional_float(details_mapping.get("mean_relative_error")),
-            snr_db=_optional_float(details_mapping.get("snr_db")),
-            alternative_source=_optional_text(details_mapping.get("alternative_source")),
-            speed_gap_window_count=_optional_count(details_mapping.get("speed_gap_window_count")),
-            rpm_gap_window_count=_optional_count(details_mapping.get("rpm_gap_window_count")),
-            fallback_reason=_optional_text(details_mapping.get("fallback_reason")),
+            raw_backed_sample_count=factor.details.raw_backed_sample_count,
+            supporting_window_count=factor.details.supporting_window_count,
+            supporting_duration_s=factor.details.supporting_duration_s,
+            stable_frequency_min_hz=factor.details.stable_frequency_min_hz,
+            stable_frequency_max_hz=factor.details.stable_frequency_max_hz,
+            frequency_span_hz=factor.details.frequency_span_hz,
+            supporting_location_count=factor.details.supporting_location_count,
+            top_support_location=factor.details.top_support_location,
+            top_support_share=factor.details.top_support_share,
+            mean_relative_error=factor.details.mean_relative_error,
+            snr_db=factor.details.snr_db,
+            alternative_source=factor.details.alternative_source,
+            speed_gap_window_count=factor.details.speed_gap_window_count,
+            rpm_gap_window_count=factor.details.rpm_gap_window_count,
+            fallback_reason=factor.details.fallback_reason,
         ),
     )
 
@@ -439,46 +429,12 @@ def _matching_context_interval(
     return context_intervals[0]
 
 
-def _is_suspicious(candidate: _CandidateEvaluation) -> bool:
-    suspicious_factor_keys = {
-        "drifting_frequency",
-        "mixed_support_locations",
-        "weak_spatial",
-        "close_alternative",
-    }
-    if (
-        candidate.confidence_gap_to_alternative is not None
-        and candidate.confidence_gap_to_alternative <= _AMBIGUOUS_DIAGNOSIS_SCORE_GAP
-    ):
-        return True
-    return any(
-        factor.factor_key in suspicious_factor_keys for factor in candidate.counterevidence_factors
-    )
-
-
-def _factor_weight_sum(factors: tuple[DiagnosisFactor, ...]) -> float:
-    return sum(factor.weight for factor in factors)
+def _factor_weight_sum(factors: tuple[object, ...]) -> float:
+    return sum(float(getattr(factor, "weight", 0.0)) for factor in factors)
 
 
 def _count(value: object) -> int:
     return int(value) if isinstance(value, int) and not isinstance(value, bool) else 0
-
-
-def _optional_count(value: object) -> int | None:
-    return int(value) if isinstance(value, int) and not isinstance(value, bool) else None
-
-
-def _optional_float(value: object) -> float | None:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return None
-    return float(value)
-
-
-def _optional_text(value: object) -> str | None:
-    if not isinstance(value, str):
-        return None
-    text = value.strip()
-    return text or None
 
 
 def _normalized_text(value: str | None) -> str:


### PR DESCRIPTION
## Summary
- add a canonical domain diagnosis assessment model for whole-run scoring, factor weights, ambiguity, and suspicious flags
- make whole-run diagnosis ranking persist that canonical assessment instead of relying on report-side scoring helpers
- make report confidence project persisted whole-run diagnosis summaries when present, with focused bridge tests for factor projection and report-surface selection

## Validation
- make typecheck-backend
- make lint
- make test-changed