### PR TITLE
Fix raw replay alignment in post-analysis

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
@@ -33,8 +33,13 @@ def _append_chunk(
     db.run_repository._run_sync(db.run_repository.aappend_raw_capture_chunk(run_id, chunk))
 
 
-def _finalize_raw_capture(db, run_id: str):
-    return db.run_repository._run_sync(db.run_repository.afinalize_raw_capture(run_id))
+def _finalize_raw_capture(db, run_id: str, *, run_start_monotonic_us: int | None = None):
+    return db.run_repository._run_sync(
+        db.run_repository.afinalize_raw_capture(
+            run_id,
+            run_start_monotonic_us=run_start_monotonic_us,
+        )
+    )
 
 
 def _load_raw_capture(db, run_id: str):
@@ -68,10 +73,15 @@ def test_raw_capture_round_trip_persists_manifest_and_samples(tmp_path: Path) ->
     _append_chunk(db, run_id="run-raw", client_id="sensor-a", t0_us=1000, samples=first)
     _append_chunk(db, run_id="run-raw", client_id="sensor-a", t0_us=2000, samples=second)
 
-    manifest = _finalize_raw_capture(db, "run-raw")
+    manifest = _finalize_raw_capture(
+        db,
+        "run-raw",
+        run_start_monotonic_us=1_234_567,
+    )
 
     assert manifest is not None
     assert manifest.total_samples == 3
+    assert manifest.run_start_monotonic_us == 1_234_567
     assert manifest.sensor_manifest("sensor-a") is not None
 
     stored = db.run_repository.get_run("run-raw")
@@ -80,6 +90,7 @@ def test_raw_capture_round_trip_persists_manifest_and_samples(tmp_path: Path) ->
 
     loaded = _load_raw_capture(db, "run-raw")
     assert loaded is not None
+    assert loaded.manifest.run_start_monotonic_us == 1_234_567
     sensor = loaded.sensor_data("sensor-a")
     assert sensor is not None
     assert sensor.manifest.chunk_count == 2

--- a/apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py
+++ b/apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from test_support.findings import make_finding_payload
+from test_support.report_helpers import minimal_summary
+
+from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
+from vibesensor.shared.json_utils import i18n_ref
+from vibesensor.shared.run_context_warning import WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE
+from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.use_cases.history.report_document import build_report_document
+
+
+def test_prepare_persisted_report_input_surfaces_partial_raw_replay_honestly() -> None:
+    primary = make_finding_payload(
+        finding_id="F_PARTIAL_RAW",
+        suspected_source="wheel/tire",
+        confidence=0.86,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+        matched_points=[
+            {
+                "t_s": 1.0,
+                "speed_kmh": 64.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.1,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.10,
+            },
+            {
+                "t_s": 1.5,
+                "speed_kmh": 66.0,
+                "predicted_hz": 15.0,
+                "matched_hz": 15.0,
+                "location": "Front Left",
+                "phase": "cruise",
+                "amp": 0.11,
+            },
+        ],
+        evidence_metrics={
+            "mean_relative_error": 0.03,
+            "snr_db": 7.5,
+            "matched_samples": 2,
+        },
+    )
+    prepared = prepare_persisted_report_input(
+        PersistedAnalysis.from_json_object(
+            minimal_summary(
+                run_id="partial-raw-report",
+                lang="en",
+                metadata={
+                    "run_id": "partial-raw-report",
+                    "record_type": "metadata",
+                    "schema_version": "v2-jsonl",
+                    "feature_interval_s": 0.5,
+                },
+                sensor_count_used=2,
+                sensor_locations=["Front Left", "Rear Left"],
+                sensor_locations_connected_throughout=["Front Left", "Rear Left"],
+                findings=[primary],
+                top_causes=[primary],
+                analysis_metadata={
+                    "raw_backed_sample_count": 6,
+                    "raw_capture_mode": "partial_raw_backed",
+                },
+                warnings=[
+                    {
+                        "code": WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
+                        "severity": "warn",
+                        "applies_to": "raw_replay",
+                        "title": i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_INCOMPLETE_TITLE"),
+                        "detail": i18n_ref(
+                            "RUN_CONTEXT_WARNING_RAW_REPLAY_INCOMPLETE_DETAIL",
+                            partial="1",
+                            missing="0",
+                            gaps="1",
+                            overlaps="0",
+                            mismatches="0",
+                        ),
+                    }
+                ],
+            )
+        )
+    )
+
+    document = build_report_document(prepared)
+
+    assert prepared.report_facts.evidence.data_basis == "partial_raw_backed"
+    assert "raw_replay_incomplete" in prepared.report_facts.confidence.caveat_keys
+    assert WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE in [
+        warning.code for warning in prepared.report_facts.decision.warnings
+    ]
+    assert any(
+        "Partially raw-backed replay" in row.value
+        for row in document.verdict_page.proof_snapshot_rows
+    )
+    assert "raw capture coverage was incomplete for some replay windows" in (
+        document.observed.certainty_reason
+    )

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -2,10 +2,19 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.run_context_warning import WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunkIndex,
+    RawCaptureManifest,
+    RawCaptureSensorData,
+    RawCaptureSensorManifest,
+    RawRunCapture,
+)
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.use_cases.run.post_analysis_input import (
     PostAnalysisRunInput,
@@ -29,6 +38,8 @@ def _run_metadata(
             "raw_sample_rate_hz": raw_sample_rate_hz,
             "sample_rate_hz": raw_sample_rate_hz,
             "feature_interval_s": 1.0,
+            "fft_window_size_samples": 64,
+            "accel_scale_g_per_lsb": 0.001,
             "language": language,
         }
     )
@@ -55,6 +66,69 @@ def _run_input(
             raw_capture=None,
             total_sample_count=total_sample_count,
             stride=stride,
+        ),
+    )
+
+
+def _wave(freq_hz: float, sample_count: int, *, sample_rate_hz: int = 800) -> np.ndarray:
+    time_axis = np.arange(sample_count, dtype=np.float64) / float(sample_rate_hz)
+    wave = np.round(1000.0 * np.sin(2.0 * np.pi * freq_hz * time_axis)).astype(np.int16)
+    return np.column_stack(
+        [
+            wave,
+            np.zeros(sample_count, dtype=np.int16),
+            np.zeros(sample_count, dtype=np.int16),
+        ]
+    )
+
+
+def _gap_raw_capture(run_id: str) -> RawRunCapture:
+    run_start_monotonic_us = 1_000_000
+    first_chunk = _wave(32.0, 64)
+    second_chunk = _wave(72.0, 64)
+    chunk_rows = (
+        RawCaptureChunkIndex(
+            sample_start=0,
+            sample_count=64,
+            t0_us=run_start_monotonic_us + 100_000,
+            byte_offset=0,
+        ),
+        RawCaptureChunkIndex(
+            sample_start=64,
+            sample_count=64,
+            t0_us=run_start_monotonic_us + 220_000,
+            byte_offset=int(first_chunk.nbytes),
+        ),
+    )
+    samples_i16 = np.vstack([first_chunk, second_chunk])
+    sensor_manifest = RawCaptureSensorManifest(
+        client_id="sensor-a",
+        sample_rate_hz=800,
+        data_file="sensor-a.raw.i16le",
+        index_file="sensor-a.index.jsonl",
+        sample_count=int(samples_i16.shape[0]),
+        chunk_count=2,
+        bytes_written=int(samples_i16.nbytes),
+        first_t0_us=chunk_rows[0].t0_us,
+        last_t0_us=chunk_rows[-1].t0_us,
+    )
+    manifest = RawCaptureManifest(
+        run_id=run_id,
+        relative_dir=f"raw-runs/{run_id}",
+        sensors=(sensor_manifest,),
+        total_samples=int(samples_i16.shape[0]),
+        total_bytes=int(samples_i16.nbytes),
+        created_at="2025-01-01T00:00:01Z",
+        run_start_monotonic_us=run_start_monotonic_us,
+    )
+    return RawRunCapture(
+        manifest=manifest,
+        sensors=(
+            RawCaptureSensorData(
+                manifest=sensor_manifest,
+                samples_i16=samples_i16,
+                chunks=chunk_rows,
+            ),
         ),
     )
 
@@ -101,6 +175,16 @@ def test_build_post_analysis_summary_adds_analysis_metadata(
         "raw_capture_available": False,
         "raw_backed_sample_count": 0,
         "raw_capture_mode": "summary_only",
+        "raw_replay_window_count": 1,
+        "raw_replay_complete_window_count": 0,
+        "raw_replay_partial_window_count": 0,
+        "raw_replay_missing_window_count": 1,
+        "raw_replay_gap_count": 0,
+        "raw_replay_overlap_count": 0,
+        "raw_replay_dropped_chunk_count": 0,
+        "raw_replay_sample_rate_mismatch_count": 0,
+        "raw_replay_unanchored_sensor_count": 0,
+        "raw_replay_confidence": "unavailable",
     }
 
 
@@ -231,3 +315,63 @@ def test_build_post_analysis_summary_enriches_missing_strength_db_from_peak_and_
     sample = captured["sample"]
     assert sample.vibration_strength_db is not None
     assert sample.strength_bucket
+
+
+def test_build_post_analysis_summary_persists_raw_replay_warning_and_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRunAnalysis:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def summarize(self):
+            return SimpleNamespace(
+                diagnostic_case=SimpleNamespace(case_id="case-raw-gap"),
+            )
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.diagnostics.run_analysis.RunAnalysis",
+        FakeRunAnalysis,
+    )
+    monkeypatch.setattr(
+        "vibesensor.use_cases.run.post_analysis_summary.analysis_result_to_summary",
+        lambda _result: {"warnings": [], "run_suitability": []},
+    )
+
+    run = build_post_analysis_input(
+        LoadedPostAnalysisRun(
+            run_id="run-raw-gap",
+            metadata=_run_metadata("run-raw-gap"),
+            language="en",
+            samples=sensor_frames_from_mappings(
+                [
+                    {
+                        "client_id": "sensor-a",
+                        "t_s": 0.18,
+                        "sample_rate_hz": 800,
+                        "vibration_strength_db": 0.0,
+                        "dominant_freq_hz": 0.0,
+                    },
+                    {
+                        "client_id": "sensor-a",
+                        "t_s": 0.24,
+                        "sample_rate_hz": 800,
+                        "vibration_strength_db": 12.0,
+                        "dominant_freq_hz": 14.0,
+                    },
+                ]
+            ),
+            raw_capture=_gap_raw_capture("run-raw-gap"),
+            total_sample_count=2,
+            stride=1,
+        )
+    )
+
+    summary = build_post_analysis_summary(run)
+
+    assert summary["analysis_metadata"]["raw_capture_mode"] == "partial_raw_backed"
+    assert summary["analysis_metadata"]["raw_replay_partial_window_count"] == 1
+    assert summary["analysis_metadata"]["raw_replay_gap_count"] == 1
+    assert [warning["code"] for warning in summary["warnings"]] == [
+        WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE
+    ]

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay.py
@@ -7,6 +7,7 @@ import numpy as np
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
 from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunkIndex,
     RawCaptureManifest,
     RawCaptureSensorData,
     RawCaptureSensorManifest,
@@ -62,6 +63,7 @@ def _raw_capture(run_id: str) -> RawRunCapture:
         total_samples=fft_n,
         total_bytes=int(samples_i16.nbytes),
         created_at="2025-01-01T00:00:01Z",
+        run_start_monotonic_us=1_000_000,
     )
     return RawRunCapture(
         manifest=manifest,
@@ -69,7 +71,14 @@ def _raw_capture(run_id: str) -> RawRunCapture:
             RawCaptureSensorData(
                 manifest=sensor_manifest,
                 samples_i16=samples_i16,
-                chunks=(),
+                chunks=(
+                    RawCaptureChunkIndex(
+                        sample_start=0,
+                        sample_count=fft_n,
+                        t0_us=1_000_000,
+                        byte_offset=0,
+                    ),
+                ),
             ),
         ),
     )

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay_alignment.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay_alignment.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.run_context_warning import (
+    WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
+    WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK,
+)
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunkIndex,
+    RawCaptureManifest,
+    RawCaptureSensorData,
+    RawCaptureSensorManifest,
+    RawRunCapture,
+)
+from vibesensor.use_cases.run.post_analysis_input import build_post_analysis_input
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+
+_SAMPLE_RATE_HZ = 800
+_FFT_N = 64
+_RUN_START_MONOTONIC_US = 1_000_000
+
+
+def _metadata(run_id: str):
+    return run_metadata_from_mapping(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": _SAMPLE_RATE_HZ,
+            "sample_rate_hz": _SAMPLE_RATE_HZ,
+            "feature_interval_s": 1.0,
+            "fft_window_size_samples": _FFT_N,
+            "accel_scale_g_per_lsb": 0.001,
+            "language": "en",
+        }
+    )
+
+
+def _wave(freq_hz: float, sample_count: int) -> np.ndarray:
+    time_axis = np.arange(sample_count, dtype=np.float64) / float(_SAMPLE_RATE_HZ)
+    wave = np.round(1000.0 * np.sin(2.0 * math.pi * freq_hz * time_axis)).astype(np.int16)
+    return np.column_stack(
+        [
+            wave,
+            np.zeros(sample_count, dtype=np.int16),
+            np.zeros(sample_count, dtype=np.int16),
+        ]
+    )
+
+
+def _sample_t_s(*, raw_start_offset_us: int, sample_end: int) -> float:
+    return (
+        float(raw_start_offset_us) + (float(sample_end) / float(_SAMPLE_RATE_HZ) * 1_000_000.0)
+    ) / 1_000_000.0
+
+
+def _raw_capture(
+    run_id: str,
+    *,
+    sensors: list[tuple[str, list[tuple[int, np.ndarray]]]],
+    run_start_monotonic_us: int | None = _RUN_START_MONOTONIC_US,
+) -> RawRunCapture:
+    sensor_rows: list[RawCaptureSensorData] = []
+    sensor_manifests: list[RawCaptureSensorManifest] = []
+    total_samples = 0
+    total_bytes = 0
+    for client_id, chunks in sensors:
+        sample_start = 0
+        byte_offset = 0
+        chunk_indexes: list[RawCaptureChunkIndex] = []
+        sample_arrays: list[np.ndarray] = []
+        for t0_us, samples in chunks:
+            normalized = np.ascontiguousarray(samples, dtype=np.int16)
+            sample_arrays.append(normalized)
+            chunk_indexes.append(
+                RawCaptureChunkIndex(
+                    sample_start=sample_start,
+                    sample_count=int(normalized.shape[0]),
+                    t0_us=t0_us,
+                    byte_offset=byte_offset,
+                )
+            )
+            sample_start += int(normalized.shape[0])
+            byte_offset += int(normalized.nbytes)
+        samples_i16 = (
+            np.vstack(sample_arrays) if sample_arrays else np.empty((0, 3), dtype=np.int16)
+        )
+        manifest = RawCaptureSensorManifest(
+            client_id=client_id,
+            sample_rate_hz=_SAMPLE_RATE_HZ,
+            data_file=f"{client_id}.raw.i16le",
+            index_file=f"{client_id}.index.jsonl",
+            sample_count=int(samples_i16.shape[0]),
+            chunk_count=len(chunk_indexes),
+            bytes_written=int(samples_i16.nbytes),
+            first_t0_us=chunks[0][0] if chunks else None,
+            last_t0_us=chunks[-1][0] if chunks else None,
+        )
+        sensor_rows.append(
+            RawCaptureSensorData(
+                manifest=manifest,
+                samples_i16=samples_i16,
+                chunks=tuple(chunk_indexes),
+            )
+        )
+        sensor_manifests.append(manifest)
+        total_samples += manifest.sample_count
+        total_bytes += manifest.bytes_written
+    manifest = RawCaptureManifest(
+        run_id=run_id,
+        relative_dir=f"raw-runs/{run_id}",
+        sensors=tuple(sensor_manifests),
+        total_samples=total_samples,
+        total_bytes=total_bytes,
+        created_at="2025-01-01T00:00:01Z",
+        run_start_monotonic_us=run_start_monotonic_us,
+    )
+    return RawRunCapture(manifest=manifest, sensors=tuple(sensor_rows))
+
+
+def test_build_post_analysis_input_aligns_raw_replay_from_run_start_anchor() -> None:
+    raw_start_offset_us = 100_000
+    raw_capture = _raw_capture(
+        "run-anchor",
+        sensors=[
+            (
+                "sensor-a",
+                [
+                    (
+                        _RUN_START_MONOTONIC_US + raw_start_offset_us,
+                        np.vstack([_wave(32.0, _FFT_N), _wave(88.0, 160)]),
+                    )
+                ],
+            )
+        ],
+    )
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-anchor",
+        metadata=_metadata("run-anchor"),
+        language="en",
+        samples=sensor_frames_from_mappings(
+            [
+                {
+                    "client_id": "sensor-a",
+                    "t_s": _sample_t_s(raw_start_offset_us=raw_start_offset_us, sample_end=_FFT_N),
+                    "sample_rate_hz": _SAMPLE_RATE_HZ,
+                    "vibration_strength_db": 0.0,
+                    "dominant_freq_hz": 0.0,
+                }
+            ]
+        ),
+        raw_capture=raw_capture,
+        total_sample_count=1,
+        stride=1,
+    )
+
+    result = build_post_analysis_input(loaded)
+
+    rebuilt = result.samples[0]
+    assert result.raw_backed_sample_count == 1
+    assert result.raw_replay.raw_capture_mode == "raw_backed"
+    assert result.raw_replay.complete_window_count == 1
+    assert rebuilt.dominant_freq_hz is not None
+    assert 25.0 <= rebuilt.dominant_freq_hz <= 40.0
+
+
+def test_build_post_analysis_input_replays_each_sensor_on_its_own_timeline() -> None:
+    sensor_a_offset_us = 100_000
+    sensor_b_offset_us = 140_000
+    raw_capture = _raw_capture(
+        "run-offsets",
+        sensors=[
+            (
+                "sensor-a",
+                [
+                    (
+                        _RUN_START_MONOTONIC_US + sensor_a_offset_us,
+                        np.vstack([_wave(28.0, 96), _wave(86.0, 160)]),
+                    )
+                ],
+            ),
+            (
+                "sensor-b",
+                [
+                    (
+                        _RUN_START_MONOTONIC_US + sensor_b_offset_us,
+                        np.vstack([_wave(52.0, _FFT_N), _wave(92.0, 192)]),
+                    )
+                ],
+            ),
+        ],
+    )
+    sample_t_s = 0.22
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-offsets",
+        metadata=_metadata("run-offsets"),
+        language="en",
+        samples=sensor_frames_from_mappings(
+            [
+                {
+                    "client_id": "sensor-a",
+                    "t_s": sample_t_s,
+                    "sample_rate_hz": _SAMPLE_RATE_HZ,
+                    "vibration_strength_db": 0.0,
+                    "dominant_freq_hz": 0.0,
+                },
+                {
+                    "client_id": "sensor-b",
+                    "t_s": sample_t_s,
+                    "sample_rate_hz": _SAMPLE_RATE_HZ,
+                    "vibration_strength_db": 0.0,
+                    "dominant_freq_hz": 0.0,
+                },
+            ]
+        ),
+        raw_capture=raw_capture,
+        total_sample_count=2,
+        stride=1,
+    )
+
+    result = build_post_analysis_input(loaded)
+
+    by_sensor = {sample.client_id: sample for sample in result.samples}
+    assert result.raw_backed_sample_count == 2
+    assert by_sensor["sensor-a"].dominant_freq_hz is not None
+    assert by_sensor["sensor-b"].dominant_freq_hz is not None
+    assert 20.0 <= float(by_sensor["sensor-a"].dominant_freq_hz) <= 35.0
+    assert 45.0 <= float(by_sensor["sensor-b"].dominant_freq_hz) <= 60.0
+
+
+def test_build_post_analysis_input_marks_gap_windows_partial_and_falls_back() -> None:
+    raw_start_offset_us = 100_000
+    first_chunk = _wave(34.0, _FFT_N)
+    second_chunk = _wave(74.0, _FFT_N)
+    raw_capture = _raw_capture(
+        "run-gap",
+        sensors=[
+            (
+                "sensor-a",
+                [
+                    (_RUN_START_MONOTONIC_US + raw_start_offset_us, first_chunk),
+                    (_RUN_START_MONOTONIC_US + 220_000, second_chunk),
+                ],
+            )
+        ],
+    )
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-gap",
+        metadata=_metadata("run-gap"),
+        language="en",
+        samples=sensor_frames_from_mappings(
+            [
+                {
+                    "client_id": "sensor-a",
+                    "t_s": _sample_t_s(raw_start_offset_us=raw_start_offset_us, sample_end=_FFT_N),
+                    "sample_rate_hz": _SAMPLE_RATE_HZ,
+                    "vibration_strength_db": 0.0,
+                    "dominant_freq_hz": 0.0,
+                },
+                {
+                    "client_id": "sensor-a",
+                    "t_s": 0.24,
+                    "sample_rate_hz": _SAMPLE_RATE_HZ,
+                    "vibration_strength_db": 12.0,
+                    "dominant_freq_hz": 14.0,
+                },
+            ]
+        ),
+        raw_capture=raw_capture,
+        total_sample_count=2,
+        stride=1,
+    )
+
+    result = build_post_analysis_input(loaded)
+
+    assert result.raw_backed_sample_count == 1
+    assert result.raw_replay.raw_capture_mode == "partial_raw_backed"
+    assert result.raw_replay.partial_window_count == 1
+    assert result.raw_replay.gap_count == 1
+    assert [warning.code for warning in result.raw_replay.warnings] == [
+        WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE
+    ]
+    assert [coverage.coverage_state for coverage in result.raw_replay_window_coverages] == [
+        "complete",
+        "partial",
+    ]
+    assert result.samples[1].vibration_strength_db == 12.0
+    assert result.samples[1].dominant_freq_hz == 14.0
+
+
+def test_build_post_analysis_input_falls_back_for_legacy_raw_capture_without_anchor() -> None:
+    raw_start_offset_us = 100_000
+    raw_capture = _raw_capture(
+        "run-legacy",
+        sensors=[
+            (
+                "sensor-a",
+                [
+                    (
+                        _RUN_START_MONOTONIC_US + raw_start_offset_us,
+                        np.vstack([_wave(36.0, _FFT_N), _wave(80.0, 96)]),
+                    )
+                ],
+            )
+        ],
+        run_start_monotonic_us=None,
+    )
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-legacy",
+        metadata=_metadata("run-legacy"),
+        language="en",
+        samples=sensor_frames_from_mappings(
+            [
+                {
+                    "client_id": "sensor-a",
+                    "t_s": _sample_t_s(raw_start_offset_us=raw_start_offset_us, sample_end=_FFT_N),
+                    "sample_rate_hz": _SAMPLE_RATE_HZ,
+                    "vibration_strength_db": 11.0,
+                    "dominant_freq_hz": 13.0,
+                }
+            ]
+        ),
+        raw_capture=raw_capture,
+        total_sample_count=1,
+        stride=1,
+    )
+
+    result = build_post_analysis_input(loaded)
+
+    assert result.raw_backed_sample_count == 0
+    assert result.raw_replay.raw_capture_mode == "summary_only"
+    assert result.raw_replay.replay_confidence == "fallback"
+    assert result.raw_replay.unanchored_sensor_count == 1
+    assert [warning.code for warning in result.raw_replay.warnings] == [
+        WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK
+    ]
+    assert result.samples[0].vibration_strength_db == 11.0
+    assert result.samples[0].dominant_freq_hz == 13.0

--- a/apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py
@@ -84,7 +84,12 @@ class HistoryRawCaptureStore:
             stream.first_t0_us = chunk.t0_us if stream.first_t0_us is None else stream.first_t0_us
             stream.last_t0_us = chunk.t0_us
 
-    def finalize_run(self, run_id: str) -> RawCaptureManifest | None:
+    def finalize_run(
+        self,
+        run_id: str,
+        *,
+        run_start_monotonic_us: int | None = None,
+    ) -> RawCaptureManifest | None:
         with self._lock:
             streams = self._open_runs.pop(run_id, None)
         if not streams:
@@ -118,6 +123,7 @@ class HistoryRawCaptureStore:
             total_samples=total_samples,
             total_bytes=total_bytes,
             created_at=utc_now_iso(),
+            run_start_monotonic_us=run_start_monotonic_us,
         )
         run_dir = self.run_dir(run_id)
         run_dir.mkdir(parents=True, exist_ok=True)

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
@@ -151,10 +151,19 @@ class _HistoryDBRunLifecycleMixin:
     async def aappend_raw_capture_chunk(self, run_id: str, chunk: RawCaptureChunk) -> None:
         await asyncio.to_thread(self._raw_capture_store.append_chunk, run_id, chunk)
 
-    async def afinalize_raw_capture(self, run_id: str) -> RawCaptureManifest | None:
+    async def afinalize_raw_capture(
+        self,
+        run_id: str,
+        *,
+        run_start_monotonic_us: int | None = None,
+    ) -> RawCaptureManifest | None:
         manifest = cast(
             RawCaptureManifest | None,
-            await asyncio.to_thread(self._raw_capture_store.finalize_run, run_id),
+            await asyncio.to_thread(
+                self._raw_capture_store.finalize_run,
+                run_id,
+                run_start_monotonic_us=run_start_monotonic_us,
+            ),
         )
         if manifest is None:
             return None

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -263,6 +263,10 @@
     "en": "only summary-level evidence was available",
     "nl": "alleen samenvattingsniveau-bewijs was beschikbaar"
   },
+  "REPORT_CONFIDENCE_CAVEAT_RAW_REPLAY_INCOMPLETE": {
+    "en": "raw capture coverage was incomplete for some replay windows",
+    "nl": "de raw-capturedekking was onvolledig voor sommige replayvensters"
+  },
   "REPORT_CONFIDENCE_CAVEAT_LEGACY_CONTEXT": {
     "en": "this run predates whole-run context coverage tracking",
     "nl": "deze run is ouder dan de whole-run contextdekkingsregistratie"
@@ -1683,6 +1687,22 @@
     "en": "Whole-run context coverage was not captured for this persisted run",
     "nl": "Whole-run contextdekking is niet vastgelegd voor deze bewaarde run"
   },
+  "RUN_CONTEXT_WARNING_RAW_REPLAY_INCOMPLETE_TITLE": {
+    "en": "Raw replay coverage was incomplete",
+    "nl": "De dekking van raw replay was onvolledig"
+  },
+  "RUN_CONTEXT_WARNING_RAW_REPLAY_INCOMPLETE_DETAIL": {
+    "en": "Raw capture coverage was incomplete for some replay windows; affected metrics used persisted summary samples. Partial windows: {partial}, missing windows: {missing}, timing gaps: {gaps}, overlaps: {overlaps}, sample-rate mismatches: {mismatches}.",
+    "nl": "De raw-capturedekking was onvolledig voor sommige replayvensters; getroffen metrieken gebruikten persistente samenvattingssamples. Gedeeltelijke vensters: {partial}, ontbrekende vensters: {missing}, timinggaten: {gaps}, overlappen: {overlaps}, samplefrequentiemismatches: {mismatches}."
+  },
+  "RUN_CONTEXT_WARNING_RAW_REPLAY_LEGACY_TITLE": {
+    "en": "Raw replay fell back to persisted summary metrics",
+    "nl": "Raw replay viel terug op persistente samenvattingsmetrieken"
+  },
+  "RUN_CONTEXT_WARNING_RAW_REPLAY_LEGACY_DETAIL": {
+    "en": "Raw capture timing metadata was unavailable for this run, so replay used persisted summary samples instead of guessing raw alignment.",
+    "nl": "Raw-capturetimingmetadata was niet beschikbaar voor deze run, dus replay gebruikte persistente samenvattingssamples in plaats van raw-uitlijning te raden."
+  },
   "WORKSHOP_SUMMARY": {
     "en": "Workshop Summary",
     "nl": "Werkplaatsoverzicht"
@@ -1994,6 +2014,10 @@
   "REPORT_EVIDENCE_BASIS_RAW": {
     "en": "Raw-backed replay ({samples} analyzed samples)",
     "nl": "Raw-ondersteunde replay ({samples} geanalyseerde samples)"
+  },
+  "REPORT_EVIDENCE_BASIS_PARTIAL_RAW": {
+    "en": "Partially raw-backed replay ({samples} raw-backed samples; summary fallback used where coverage was incomplete)",
+    "nl": "Gedeeltelijk raw-ondersteunde replay ({samples} raw-ondersteunde samples; samenvattingsfallback gebruikt waar de dekking onvolledig was)"
   },
   "REPORT_EVIDENCE_BASIS_SUMMARY": {
     "en": "Summary-only fallback",

--- a/apps/server/vibesensor/domain/diagnosis_assessment.py
+++ b/apps/server/vibesensor/domain/diagnosis_assessment.py
@@ -139,6 +139,10 @@ def score_diagnosis_assessment_inputs(inputs: DiagnosisAssessmentInputs) -> Diag
     if inputs.data_basis == "raw_backed":
         score += 0.10
         signal_keys.append("raw_backed")
+    elif inputs.data_basis == "partial_raw_backed":
+        score += 0.05
+        signal_keys.append("raw_backed")
+        caveat_keys.append("raw_replay_incomplete")
     else:
         score -= 0.05
         caveat_keys.append("summary_only")
@@ -259,6 +263,8 @@ def apply_diagnosis_assessment_fallback(
     caveat_keys = list(assessment.caveat_keys)
     if assessment.data_basis == "summary_only" and "summary_only" not in caveat_keys:
         caveat_keys.append("summary_only")
+    if assessment.data_basis == "partial_raw_backed" and "raw_replay_incomplete" not in caveat_keys:
+        caveat_keys.append("raw_replay_incomplete")
     return _assessment_from_keys(
         score_0_to_1=assessment.score_0_to_1,
         data_basis=assessment.data_basis,
@@ -485,6 +491,8 @@ def _factor_severity(weight: float) -> str:
 
 def _support_factor_weight(factor_key: str, assessment: DiagnosisAssessment) -> float:
     if factor_key == "raw_backed":
+        if assessment.data_basis == "partial_raw_backed":
+            return 0.05
         return 0.10
     if factor_key == "repeated_support":
         if (
@@ -515,7 +523,7 @@ def _support_factor_weight(factor_key: str, assessment: DiagnosisAssessment) -> 
 
 
 def _counter_factor_weight(factor_key: str) -> float:
-    if factor_key in {"summary_only", "legacy_context"}:
+    if factor_key in {"summary_only", "legacy_context", "raw_replay_incomplete"}:
         return 0.05
     if factor_key in {"speed_context_gaps", "rpm_context_gaps"}:
         return 0.04
@@ -601,6 +609,7 @@ def _tier_for_score(*, label_key: str, score_0_to_1: float, caveat_keys: tuple[s
     if set(caveat_keys).intersection(
         {
             "summary_only",
+            "raw_replay_incomplete",
             "drifting_frequency",
             "loose_order_lock",
             "mixed_support_locations",

--- a/apps/server/vibesensor/shared/boundaries/reporting/evidence_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/evidence_facts.py
@@ -75,7 +75,7 @@ def _resolve_data_basis(
     raw_backed_sample_count: int,
 ) -> str:
     raw_capture_mode = text_or_none(analysis_metadata.get("raw_capture_mode"))
-    if raw_capture_mode in {"raw_backed", "summary_only"}:
+    if raw_capture_mode in {"raw_backed", "partial_raw_backed", "summary_only"}:
         return raw_capture_mode
     return "raw_backed" if raw_backed_sample_count > 0 else "summary_only"
 

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -849,7 +849,7 @@ class ReportSummaryNormalizer:
 
     def _diagnosis_data_basis(self, raw_value: object) -> WholeRunDiagnosisDataBasis | None:
         value = text_or_none(raw_value)
-        if value not in {"raw_backed", "summary_only"}:
+        if value not in {"raw_backed", "partial_raw_backed", "summary_only"}:
             return None
         return cast(WholeRunDiagnosisDataBasis, value)
 
@@ -864,6 +864,7 @@ class ReportSummaryNormalizer:
             "localized_support",
             "clean_signal",
             "summary_only",
+            "raw_replay_incomplete",
             "legacy_context",
             "speed_context_gaps",
             "rpm_context_gaps",

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -113,7 +113,12 @@ class RunPersistence(Protocol):
 
     async def astore_analysis_error(self, run_id: str, error: str) -> bool: ...
 
-    async def afinalize_raw_capture(self, run_id: str) -> RawCaptureManifest | None: ...
+    async def afinalize_raw_capture(
+        self,
+        run_id: str,
+        *,
+        run_start_monotonic_us: int | None = None,
+    ) -> RawCaptureManifest | None: ...
 
     async def aget_raw_capture_manifest(self, run_id: str) -> RawCaptureManifest | None: ...
 

--- a/apps/server/vibesensor/shared/report_presentation.py
+++ b/apps/server/vibesensor/shared/report_presentation.py
@@ -414,6 +414,8 @@ def _confidence_caveat_texts(
     for key in confidence_facts.caveat_keys:
         if key == "summary_only":
             parts.append(tr("REPORT_CONFIDENCE_CAVEAT_SUMMARY_ONLY"))
+        elif key == "raw_replay_incomplete":
+            parts.append(tr("REPORT_CONFIDENCE_CAVEAT_RAW_REPLAY_INCOMPLETE"))
         elif key == "legacy_context":
             parts.append(tr("REPORT_CONFIDENCE_CAVEAT_LEGACY_CONTEXT"))
         elif key == "sparse_support":

--- a/apps/server/vibesensor/shared/run_context_warning.py
+++ b/apps/server/vibesensor/shared/run_context_warning.py
@@ -13,6 +13,8 @@ WARNING_CODE_REFERENCE_CONTEXT_INCOMPLETE = "reference_context_incomplete"
 WARNING_CODE_CAR_SETTINGS_CHANGED = "car_settings_changed"
 WARNING_CODE_WHOLE_RUN_CONTEXT_INCOMPLETE = "whole_run_context_incomplete"
 WARNING_CODE_WHOLE_RUN_CONTEXT_LEGACY_FALLBACK = "whole_run_context_legacy_fallback"
+WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE = "raw_replay_coverage_incomplete"
+WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK = "raw_replay_legacy_fallback"
 WarningSeverity = Literal["warn", "error"]
 
 

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -97,6 +97,7 @@ type DiagnosisFactorKey = Literal[
     "localized_support",
     "clean_signal",
     "summary_only",
+    "raw_replay_incomplete",
     "legacy_context",
     "speed_context_gaps",
     "rpm_context_gaps",
@@ -112,7 +113,7 @@ type DiagnosisFactorKey = Literal[
 ]
 type DiagnosisFactorPolarity = Literal["support", "counterevidence"]
 type DiagnosisFactorSeverity = Literal["low", "medium", "high"]
-type WholeRunDiagnosisDataBasis = Literal["raw_backed", "summary_only"]
+type WholeRunDiagnosisDataBasis = Literal["raw_backed", "partial_raw_backed", "summary_only"]
 type LocationProofBasis = Literal[
     "whole_run_summary",
     "supporting_windows_raw_backed",

--- a/apps/server/vibesensor/shared/types/raw_capture.py
+++ b/apps/server/vibesensor/shared/types/raw_capture.py
@@ -23,7 +23,7 @@ __all__ = [
 type Int16Array = npt.NDArray[np.int16]
 type RawCaptureCoverageState = Literal["missing", "empty", "partial", "full"]
 
-_RAW_CAPTURE_SCHEMA_VERSION = 1
+_RAW_CAPTURE_SCHEMA_VERSION = 2
 _RAW_CAPTURE_STORAGE_TYPE = "run-directory-v1"
 _RAW_CAPTURE_MODE = "full_run"
 
@@ -121,12 +121,13 @@ class RawCaptureManifest:
     total_samples: int
     total_bytes: int
     created_at: str
+    run_start_monotonic_us: int | None = None
     schema_version: int = _RAW_CAPTURE_SCHEMA_VERSION
     storage_type: str = _RAW_CAPTURE_STORAGE_TYPE
     capture_mode: str = _RAW_CAPTURE_MODE
 
     def to_json_object(self) -> JsonObject:
-        return {
+        payload: JsonObject = {
             "schema_version": self.schema_version,
             "storage_type": self.storage_type,
             "capture_mode": self.capture_mode,
@@ -137,6 +138,9 @@ class RawCaptureManifest:
             "created_at": self.created_at,
             "sensors": [sensor.to_json_object() for sensor in self.sensors],
         }
+        if self.run_start_monotonic_us is not None:
+            payload["run_start_monotonic_us"] = self.run_start_monotonic_us
+        return payload
 
     @classmethod
     def from_mapping(cls, data: JsonObject) -> RawCaptureManifest:
@@ -156,6 +160,7 @@ class RawCaptureManifest:
             total_samples=_int_from_json(data.get("total_samples")),
             total_bytes=_int_from_json(data.get("total_bytes")),
             created_at=_str_from_json(data.get("created_at")),
+            run_start_monotonic_us=_int_or_none(data.get("run_start_monotonic_us")),
         )
 
     def sensor_manifest(self, client_id: str) -> RawCaptureSensorManifest | None:

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
@@ -412,6 +412,7 @@ def _require_factor_key(value: DiagnosisFactorKey) -> None:
 def _required_factor_key(value: object) -> DiagnosisFactorKey:
     if value not in {
         "raw_backed",
+        "partial_raw_backed",
         "repeated_support",
         "sustained_support",
         "stable_frequency",
@@ -419,6 +420,7 @@ def _required_factor_key(value: object) -> DiagnosisFactorKey:
         "localized_support",
         "clean_signal",
         "summary_only",
+        "raw_replay_incomplete",
         "legacy_context",
         "speed_context_gaps",
         "rpm_context_gaps",
@@ -457,7 +459,7 @@ def _required_factor_severity(value: object) -> DiagnosisFactorSeverity:
 
 
 def _required_data_basis(value: object) -> WholeRunDiagnosisDataBasis:
-    if value not in {"raw_backed", "summary_only"}:
+    if value not in {"raw_backed", "partial_raw_backed", "summary_only"}:
         raise ValueError("data_basis must be a supported whole-run diagnosis data basis")
     return cast(WholeRunDiagnosisDataBasis, value)
 

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
@@ -276,7 +276,7 @@ def _data_basis(
     spatial_summary: SpatialEvidenceSummary | None,
 ) -> str:
     raw_capture_mode = str(analysis_metadata.get("raw_capture_mode") or "").strip().lower()
-    if raw_capture_mode in {"raw_backed", "summary_only"}:
+    if raw_capture_mode in {"raw_backed", "partial_raw_backed", "summary_only"}:
         return raw_capture_mode
     if (
         spatial_summary is not None

--- a/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
+++ b/apps/server/vibesensor/use_cases/history/report_document/evidence_snapshot.py
@@ -63,7 +63,7 @@ def build_evidence_snapshot_rows(
 
 def _data_basis_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str]) -> str:
     diagnosis = report_facts.primary_diagnosis
-    if diagnosis is not None and diagnosis.data_basis == "raw_backed":
+    if diagnosis is not None and diagnosis.data_basis in {"raw_backed", "partial_raw_backed"}:
         raw_backed_samples = 0
         for factor in diagnosis.support_factors:
             if (
@@ -72,13 +72,20 @@ def _data_basis_text(report_facts: PreparedReportFacts, *, tr: Callable[..., str
             ):
                 raw_backed_samples = factor.details.raw_backed_sample_count
                 break
-        return tr(
-            "REPORT_EVIDENCE_BASIS_RAW",
-            samples=str(max(0, raw_backed_samples)),
-        )
+        if diagnosis.data_basis == "partial_raw_backed":
+            return tr(
+                "REPORT_EVIDENCE_BASIS_PARTIAL_RAW",
+                samples=str(max(0, raw_backed_samples)),
+            )
+        return tr("REPORT_EVIDENCE_BASIS_RAW", samples=str(max(0, raw_backed_samples)))
     if diagnosis is not None and diagnosis.data_basis == "summary_only":
         return tr("REPORT_EVIDENCE_BASIS_SUMMARY")
     evidence = report_facts.evidence
+    if evidence.data_basis == "partial_raw_backed":
+        return tr(
+            "REPORT_EVIDENCE_BASIS_PARTIAL_RAW",
+            samples=str(max(0, evidence.raw_backed_sample_count)),
+        )
     if evidence.data_basis == "raw_backed":
         return tr(
             "REPORT_EVIDENCE_BASIS_RAW",

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -216,7 +216,10 @@ class RunRecorder:
         self._active_run_context = run_context
         self._persistence.reset()
         self._live_start_mono_s = snapshot.start_mono_s
-        self._raw_capture.start_run(snapshot.run_id)
+        self._raw_capture.start_run(
+            snapshot.run_id,
+            run_start_monotonic_us=int(round(snapshot.start_mono_s * 1_000_000.0)),
+        )
         return snapshot
 
     def capture_raw_samples(

--- a/apps/server/vibesensor/use_cases/run/post_analysis_input.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_input.py
@@ -14,7 +14,7 @@ from vibesensor.use_cases.diagnostics._types import Sample
 from vibesensor.vibration_strength import vibration_strength_db_scalar
 
 from .post_analysis_loader import LoadedPostAnalysisRun
-from .raw_capture_replay import build_raw_backed_samples
+from .raw_capture_replay import RawReplaySummary, RawReplayWindowCoverage, build_raw_backed_samples
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,6 +27,8 @@ class PostAnalysisRunInput:
     stride: int
     raw_capture_available: bool
     raw_backed_sample_count: int
+    raw_replay: RawReplaySummary
+    raw_replay_window_coverages: tuple[RawReplayWindowCoverage, ...] = field(default_factory=tuple)
     summary_samples: tuple[Sample, ...] = field(default_factory=tuple)
     context_samples: tuple[Sample, ...] = field(default_factory=tuple)
 
@@ -46,12 +48,12 @@ class PostAnalysisRunInput:
 def build_post_analysis_input(loaded: LoadedPostAnalysisRun) -> PostAnalysisRunInput:
     """Normalize one loaded persisted run into canonical diagnostics input."""
 
-    replayed_samples, raw_backed_sample_count = build_raw_backed_samples(
+    replay_result = build_raw_backed_samples(
         samples=tuple(loaded.samples),
         metadata=loaded.metadata,
         raw_capture=loaded.raw_capture,
     )
-    samples = tuple(_ensure_strength_metrics(sample) for sample in replayed_samples)
+    samples = tuple(_ensure_strength_metrics(sample) for sample in replay_result.samples)
     return PostAnalysisRunInput(
         diagnostics_run=build_diagnostics_run_input(
             loaded.metadata,
@@ -61,8 +63,10 @@ def build_post_analysis_input(loaded: LoadedPostAnalysisRun) -> PostAnalysisRunI
         language=loaded.language,
         total_sample_count=loaded.total_sample_count,
         stride=loaded.stride,
-        raw_capture_available=loaded.raw_capture is not None,
-        raw_backed_sample_count=raw_backed_sample_count,
+        raw_capture_available=replay_result.summary.raw_capture_available,
+        raw_backed_sample_count=replay_result.summary.raw_backed_sample_count,
+        raw_replay=replay_result.summary,
+        raw_replay_window_coverages=replay_result.window_coverages,
         summary_samples=tuple(loaded.samples),
         context_samples=(
             tuple(loaded.context_samples) if loaded.context_samples is not None else tuple()

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from vibesensor.shared.boundaries.analysis_payloads import analysis_result_to_summary
+from vibesensor.shared.boundaries.summary_fields.warnings import summary_warning_payloads
 from vibesensor.shared.boundaries.summary_serialization._location_intensity import (
     serialize_location_intensity_rows,
 )
@@ -66,11 +67,26 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         "analyzed_sample_count": len(run.samples),
         "total_sample_count": run.total_sample_count,
         "sampling_method": "full" if run.stride == 1 else f"stride_{run.stride}",
-        "raw_capture_available": run.raw_capture_available,
-        "raw_backed_sample_count": run.raw_backed_sample_count,
-        "raw_capture_mode": "raw_backed" if run.raw_backed_sample_count > 0 else "summary_only",
+        "raw_capture_available": run.raw_replay.raw_capture_available,
+        "raw_backed_sample_count": run.raw_replay.raw_backed_sample_count,
+        "raw_capture_mode": run.raw_replay.raw_capture_mode,
+        "raw_replay_window_count": run.raw_replay.replay_window_count,
+        "raw_replay_complete_window_count": run.raw_replay.complete_window_count,
+        "raw_replay_partial_window_count": run.raw_replay.partial_window_count,
+        "raw_replay_missing_window_count": run.raw_replay.missing_window_count,
+        "raw_replay_gap_count": run.raw_replay.gap_count,
+        "raw_replay_overlap_count": run.raw_replay.overlap_count,
+        "raw_replay_dropped_chunk_count": run.raw_replay.dropped_chunk_count,
+        "raw_replay_sample_rate_mismatch_count": run.raw_replay.sample_rate_mismatch_count,
+        "raw_replay_unanchored_sensor_count": run.raw_replay.unanchored_sensor_count,
+        "raw_replay_confidence": run.raw_replay.replay_confidence,
     }
     summary_payload["analysis_metadata"] = payload_object_from_json(analysis_metadata)
+    if run.raw_replay.warnings:
+        existing_warnings = summary_payload.get("warnings")
+        warnings_payload = list(existing_warnings) if isinstance(existing_warnings, list) else []
+        warnings_payload.extend(summary_warning_payloads(run.raw_replay.warnings))
+        summary_payload["warnings"] = warnings_payload
 
     sample_rate_hz = _post_analysis_sample_rate_hz(run)
     if sample_rate_hz is not None and run.total_sample_count < max(

--- a/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
@@ -2,19 +2,113 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
+from math import isfinite
+from typing import Literal
 
 import numpy as np
 
 from vibesensor.domain.strength_metrics import StrengthMetrics
 from vibesensor.shared.boundaries.codecs import strength_metrics_from_mapping
 from vibesensor.shared.constants.dsp import SPECTRUM_MAX_HZ, SPECTRUM_MIN_HZ
+from vibesensor.shared.json_utils import i18n_ref
+from vibesensor.shared.run_context_warning import (
+    WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
+    WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK,
+    RunContextWarning,
+)
 from vibesensor.shared.types.raw_capture import RawRunCapture
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.vibration_strength import combined_spectrum_amp_g, compute_vibration_strength_db
 
-__all__ = ["build_raw_backed_samples"]
+__all__ = [
+    "RawReplayResult",
+    "RawReplaySummary",
+    "RawReplayWindowCoverage",
+    "build_raw_backed_samples",
+]
+
+type RawReplayCoverageState = Literal["complete", "partial", "missing"]
+type RawReplayConfidence = Literal["full", "partial", "fallback", "unavailable"]
+_TIMING_TOLERANCE_SAMPLES = 0.75
+
+
+@dataclass(frozen=True, slots=True)
+class RawReplayWindowCoverage:
+    """Per-window replay coverage classification for one persisted summary sample."""
+
+    client_id: str
+    t_s: float | None
+    coverage_state: RawReplayCoverageState
+    raw_backed: bool
+    reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RawReplaySummary:
+    """Rolled-up replay coverage facts persisted into analysis metadata."""
+
+    raw_capture_available: bool
+    raw_backed_sample_count: int
+    replay_window_count: int
+    complete_window_count: int
+    partial_window_count: int
+    missing_window_count: int
+    gap_count: int
+    overlap_count: int
+    dropped_chunk_count: int
+    sample_rate_mismatch_count: int
+    unanchored_sensor_count: int
+    replay_confidence: RawReplayConfidence
+    raw_capture_mode: str
+    warnings: tuple[RunContextWarning, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class RawReplayResult:
+    """Replay result carrying rebuilt samples plus structured coverage metadata."""
+
+    samples: tuple[SensorFrame, ...]
+    summary: RawReplaySummary
+    window_coverages: tuple[RawReplayWindowCoverage, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class _TimelineInterval:
+    start_us: float
+    end_us: float
+
+
+@dataclass(frozen=True, slots=True)
+class _TimelineChunk:
+    sample_start: int
+    sample_end: int
+    start_us: float
+    end_us: float
+
+
+@dataclass(frozen=True, slots=True)
+class _SensorTimeline:
+    client_id: str
+    sample_rate_hz: int
+    sample_period_us: float
+    chunks: tuple[_TimelineChunk, ...]
+    gap_intervals: tuple[_TimelineInterval, ...]
+    overlap_intervals: tuple[_TimelineInterval, ...]
+    run_start_monotonic_us: int | None
+    anchored: bool
+
+    @property
+    def timing_tolerance_us(self) -> float:
+        return max(1.0, self.sample_period_us * _TIMING_TOLERANCE_SAMPLES)
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedWindow:
+    coverage_state: RawReplayCoverageState
+    reason: str | None
+    sample_end: int | None = None
 
 
 def build_raw_backed_samples(
@@ -22,87 +116,473 @@ def build_raw_backed_samples(
     samples: tuple[SensorFrame, ...],
     metadata: RunMetadata,
     raw_capture: RawRunCapture | None,
-) -> tuple[tuple[SensorFrame, ...], int]:
+) -> RawReplayResult:
     """Replace summary strength metrics with raw-backed metrics when possible."""
 
     if raw_capture is None:
-        return samples, 0
+        return RawReplayResult(
+            samples=samples,
+            summary=RawReplaySummary(
+                raw_capture_available=False,
+                raw_backed_sample_count=0,
+                replay_window_count=len(samples),
+                complete_window_count=0,
+                partial_window_count=0,
+                missing_window_count=len(samples),
+                gap_count=0,
+                overlap_count=0,
+                dropped_chunk_count=0,
+                sample_rate_mismatch_count=0,
+                unanchored_sensor_count=0,
+                replay_confidence="unavailable",
+                raw_capture_mode="summary_only",
+            ),
+            window_coverages=tuple(
+                RawReplayWindowCoverage(
+                    client_id=sample.client_id,
+                    t_s=sample.t_s,
+                    coverage_state="missing",
+                    raw_backed=False,
+                    reason="raw_capture_unavailable",
+                )
+                for sample in samples
+            ),
+        )
     fft_n = int(metadata.fft_window_size_samples or 0)
     if fft_n <= 0:
-        return samples, 0
+        return RawReplayResult(
+            samples=samples,
+            summary=RawReplaySummary(
+                raw_capture_available=True,
+                raw_backed_sample_count=0,
+                replay_window_count=len(samples),
+                complete_window_count=0,
+                partial_window_count=0,
+                missing_window_count=len(samples),
+                gap_count=0,
+                overlap_count=0,
+                dropped_chunk_count=0,
+                sample_rate_mismatch_count=0,
+                unanchored_sensor_count=0,
+                replay_confidence="fallback",
+                raw_capture_mode="summary_only",
+            ),
+            window_coverages=tuple(
+                RawReplayWindowCoverage(
+                    client_id=sample.client_id,
+                    t_s=sample.t_s,
+                    coverage_state="missing",
+                    raw_backed=False,
+                    reason="fft_window_missing",
+                )
+                for sample in samples
+            ),
+        )
+    timelines = {
+        sensor.manifest.client_id: _build_sensor_timeline(
+            raw_capture, sensor_id=sensor.manifest.client_id
+        )
+        for sensor in raw_capture.sensors
+    }
     replayed: list[SensorFrame] = []
+    coverages: list[RawReplayWindowCoverage] = []
+    complete_window_count = 0
+    partial_window_count = 0
+    missing_window_count = 0
+    sample_rate_mismatch_count = 0
     raw_backed_count = 0
     scale = metadata.accel_scale_g_per_lsb
     for sample in samples:
-        rebuilt = _rebuild_sample(
+        rebuilt, coverage = _rebuild_sample(
             sample=sample,
+            timeline=timelines.get(sample.client_id),
             raw_capture=raw_capture,
             fft_n=fft_n,
             accel_scale_g_per_lsb=scale,
         )
-        if rebuilt is not sample:
+        if coverage.raw_backed:
             raw_backed_count += 1
+        if coverage.coverage_state == "complete":
+            complete_window_count += 1
+        elif coverage.coverage_state == "partial":
+            partial_window_count += 1
+        else:
+            missing_window_count += 1
+        if coverage.reason == "sample_rate_mismatch":
+            sample_rate_mismatch_count += 1
         replayed.append(rebuilt)
-    return tuple(replayed), raw_backed_count
+        coverages.append(coverage)
+    gap_count = sum(len(timeline.gap_intervals) for timeline in timelines.values())
+    overlap_count = sum(len(timeline.overlap_intervals) for timeline in timelines.values())
+    unanchored_sensor_count = sum(1 for timeline in timelines.values() if not timeline.anchored)
+    replay_confidence = _replay_confidence(
+        raw_backed_sample_count=raw_backed_count,
+        replay_window_count=len(samples),
+        partial_window_count=partial_window_count,
+        missing_window_count=missing_window_count,
+        gap_count=gap_count,
+        overlap_count=overlap_count,
+        sample_rate_mismatch_count=sample_rate_mismatch_count,
+        unanchored_sensor_count=unanchored_sensor_count,
+    )
+    raw_capture_mode = (
+        "summary_only"
+        if raw_backed_count <= 0
+        else ("raw_backed" if replay_confidence == "full" else "partial_raw_backed")
+    )
+    return RawReplayResult(
+        samples=tuple(replayed),
+        summary=RawReplaySummary(
+            raw_capture_available=True,
+            raw_backed_sample_count=raw_backed_count,
+            replay_window_count=len(samples),
+            complete_window_count=complete_window_count,
+            partial_window_count=partial_window_count,
+            missing_window_count=missing_window_count,
+            gap_count=gap_count,
+            overlap_count=overlap_count,
+            dropped_chunk_count=0,
+            sample_rate_mismatch_count=sample_rate_mismatch_count,
+            unanchored_sensor_count=unanchored_sensor_count,
+            replay_confidence=replay_confidence,
+            raw_capture_mode=raw_capture_mode,
+            warnings=_build_replay_warnings(
+                raw_backed_sample_count=raw_backed_count,
+                partial_window_count=partial_window_count,
+                missing_window_count=missing_window_count,
+                gap_count=gap_count,
+                overlap_count=overlap_count,
+                sample_rate_mismatch_count=sample_rate_mismatch_count,
+                unanchored_sensor_count=unanchored_sensor_count,
+            ),
+        ),
+        window_coverages=tuple(coverages),
+    )
 
 
 def _rebuild_sample(
     *,
     sample: SensorFrame,
+    timeline: _SensorTimeline | None,
     raw_capture: RawRunCapture,
     fft_n: int,
     accel_scale_g_per_lsb: float | None,
-) -> SensorFrame:
+) -> tuple[SensorFrame, RawReplayWindowCoverage]:
+    if timeline is None:
+        return (
+            sample,
+            RawReplayWindowCoverage(
+                client_id=sample.client_id,
+                t_s=sample.t_s,
+                coverage_state="missing",
+                raw_backed=False,
+                reason="sensor_missing",
+            ),
+        )
     sensor_data = raw_capture.sensor_data(sample.client_id)
     if sensor_data is None:
-        return sample
-    sample_rate_hz = int(sample.sample_rate_hz or sensor_data.manifest.sample_rate_hz or 0)
+        return (
+            sample,
+            RawReplayWindowCoverage(
+                client_id=sample.client_id,
+                t_s=sample.t_s,
+                coverage_state="missing",
+                raw_backed=False,
+                reason="sensor_missing",
+            ),
+        )
+    sample_rate_hz = int(sample.sample_rate_hz or timeline.sample_rate_hz or 0)
     if sample_rate_hz <= 0:
-        return sample
-    target_end = _target_end_index(
-        t_s=sample.t_s,
-        sample_rate_hz=sample_rate_hz,
-        available_samples=sensor_data.samples_i16.shape[0],
-    )
-    if target_end is None or target_end < fft_n:
-        return sample
-    window_i16 = sensor_data.samples_i16[target_end - fft_n : target_end]
+        return (
+            sample,
+            RawReplayWindowCoverage(
+                client_id=sample.client_id,
+                t_s=sample.t_s,
+                coverage_state="missing",
+                raw_backed=False,
+                reason="sample_rate_missing",
+            ),
+        )
+    if sample_rate_hz != timeline.sample_rate_hz:
+        return (
+            sample,
+            RawReplayWindowCoverage(
+                client_id=sample.client_id,
+                t_s=sample.t_s,
+                coverage_state="missing",
+                raw_backed=False,
+                reason="sample_rate_mismatch",
+            ),
+        )
+    window = _resolve_window(timeline=timeline, sample=sample, fft_n=fft_n)
+    if window.coverage_state != "complete" or window.sample_end is None:
+        return (
+            sample,
+            RawReplayWindowCoverage(
+                client_id=sample.client_id,
+                t_s=sample.t_s,
+                coverage_state=window.coverage_state,
+                raw_backed=False,
+                reason=window.reason,
+            ),
+        )
+    window_i16 = sensor_data.samples_i16[window.sample_end - fft_n : window.sample_end]
     if window_i16.shape[0] != fft_n:
-        return sample
+        return (
+            sample,
+            RawReplayWindowCoverage(
+                client_id=sample.client_id,
+                t_s=sample.t_s,
+                coverage_state="partial",
+                raw_backed=False,
+                reason="window_truncated",
+            ),
+        )
     window_f32 = window_i16.astype(np.float32, copy=True)
     if accel_scale_g_per_lsb is not None and accel_scale_g_per_lsb > 0:
         window_f32 *= np.float32(accel_scale_g_per_lsb)
     domain_strength = _compute_strength_metrics(window_f32, sample_rate_hz)
     top_peaks = tuple(peak for peak in domain_strength.top_peaks if peak.is_valid)
     last_xyz = window_f32[-1]
-    return replace(
-        sample,
-        accel_x_g=float(last_xyz[0]),
-        accel_y_g=float(last_xyz[1]),
-        accel_z_g=float(last_xyz[2]),
-        dominant_freq_hz=domain_strength.dominant_hz,
-        top_peaks=top_peaks,
-        vibration_strength_db=domain_strength.vibration_strength_db,
-        strength_bucket=domain_strength.strength_bucket,
-        strength_peak_amp_g=domain_strength.peak_amp_g,
-        strength_floor_amp_g=domain_strength.noise_floor_amp_g,
+    return (
+        replace(
+            sample,
+            accel_x_g=float(last_xyz[0]),
+            accel_y_g=float(last_xyz[1]),
+            accel_z_g=float(last_xyz[2]),
+            dominant_freq_hz=domain_strength.dominant_hz,
+            top_peaks=top_peaks,
+            vibration_strength_db=domain_strength.vibration_strength_db,
+            strength_bucket=domain_strength.strength_bucket,
+            strength_peak_amp_g=domain_strength.peak_amp_g,
+            strength_floor_amp_g=domain_strength.noise_floor_amp_g,
+        ),
+        RawReplayWindowCoverage(
+            client_id=sample.client_id,
+            t_s=sample.t_s,
+            coverage_state="complete",
+            raw_backed=True,
+        ),
     )
 
 
-def _target_end_index(
+def _build_sensor_timeline(raw_capture: RawRunCapture, *, sensor_id: str) -> _SensorTimeline:
+    sensor_data = raw_capture.sensor_data(sensor_id)
+    if sensor_data is None:
+        return _SensorTimeline(
+            client_id=sensor_id,
+            sample_rate_hz=0,
+            sample_period_us=0.0,
+            chunks=(),
+            gap_intervals=(),
+            overlap_intervals=(),
+            run_start_monotonic_us=None,
+            anchored=False,
+        )
+    sample_rate_hz = int(sensor_data.manifest.sample_rate_hz or 0)
+    sample_period_us = 1_000_000.0 / float(sample_rate_hz) if sample_rate_hz > 0 else 0.0
+    chunk_spans = tuple(
+        _TimelineChunk(
+            sample_start=int(chunk.sample_start),
+            sample_end=int(chunk.sample_start + chunk.sample_count),
+            start_us=float(chunk.t0_us),
+            end_us=float(chunk.t0_us) + (float(chunk.sample_count) * sample_period_us),
+        )
+        for chunk in sorted(sensor_data.chunks, key=lambda chunk: (chunk.t0_us, chunk.sample_start))
+        if chunk.sample_count > 0
+    )
+    if sample_rate_hz <= 0 or not chunk_spans:
+        return _SensorTimeline(
+            client_id=sensor_id,
+            sample_rate_hz=sample_rate_hz,
+            sample_period_us=sample_period_us,
+            chunks=chunk_spans,
+            gap_intervals=(),
+            overlap_intervals=(),
+            run_start_monotonic_us=raw_capture.manifest.run_start_monotonic_us,
+            anchored=False,
+        )
+    gap_intervals: list[_TimelineInterval] = []
+    overlap_intervals: list[_TimelineInterval] = []
+    timing_tolerance_us = max(1.0, sample_period_us * _TIMING_TOLERANCE_SAMPLES)
+    previous: _TimelineChunk | None = None
+    for chunk in chunk_spans:
+        if previous is not None:
+            delta_us = chunk.start_us - previous.end_us
+            if delta_us > timing_tolerance_us:
+                gap_intervals.append(
+                    _TimelineInterval(start_us=previous.end_us, end_us=chunk.start_us)
+                )
+            elif delta_us < -timing_tolerance_us:
+                overlap_intervals.append(
+                    _TimelineInterval(
+                        start_us=chunk.start_us,
+                        end_us=min(previous.end_us, chunk.end_us),
+                    )
+                )
+        previous = chunk
+    return _SensorTimeline(
+        client_id=sensor_id,
+        sample_rate_hz=sample_rate_hz,
+        sample_period_us=sample_period_us,
+        chunks=chunk_spans,
+        gap_intervals=tuple(gap_intervals),
+        overlap_intervals=tuple(overlap_intervals),
+        run_start_monotonic_us=raw_capture.manifest.run_start_monotonic_us,
+        anchored=raw_capture.manifest.run_start_monotonic_us is not None,
+    )
+
+
+def _resolve_window(
     *,
-    t_s: float | None,
-    sample_rate_hz: int,
-    available_samples: int,
+    timeline: _SensorTimeline,
+    sample: SensorFrame,
+    fft_n: int,
+) -> _ResolvedWindow:
+    if not timeline.anchored:
+        return _ResolvedWindow(coverage_state="missing", reason="legacy_anchor_missing")
+    if not timeline.chunks or timeline.sample_period_us <= 0:
+        return _ResolvedWindow(coverage_state="missing", reason="raw_chunks_missing")
+    if sample.t_s is None or not isfinite(sample.t_s) or sample.t_s <= 0:
+        return _ResolvedWindow(coverage_state="missing", reason="sample_time_missing")
+    run_start_monotonic_us = float(timeline.run_start_monotonic_us or 0)
+    requested_end_us = run_start_monotonic_us + (float(sample.t_s) * 1_000_000.0)
+    requested_start_us = requested_end_us - (float(fft_n) * timeline.sample_period_us)
+    if requested_start_us < 0:
+        return _ResolvedWindow(coverage_state="missing", reason="window_before_capture")
+    if _intersects_intervals(
+        timeline.gap_intervals,
+        start_us=requested_start_us,
+        end_us=requested_end_us,
+        tolerance_us=timeline.timing_tolerance_us,
+    ):
+        return _ResolvedWindow(coverage_state="partial", reason="window_crosses_gap")
+    if _intersects_intervals(
+        timeline.overlap_intervals,
+        start_us=requested_start_us,
+        end_us=requested_end_us,
+        tolerance_us=timeline.timing_tolerance_us,
+    ):
+        return _ResolvedWindow(coverage_state="partial", reason="window_crosses_overlap")
+    first_chunk = timeline.chunks[0]
+    last_chunk = timeline.chunks[-1]
+    if requested_start_us < (first_chunk.start_us - timeline.timing_tolerance_us):
+        return _ResolvedWindow(coverage_state="missing", reason="window_before_capture")
+    if requested_end_us > (last_chunk.end_us + timeline.timing_tolerance_us):
+        return _ResolvedWindow(coverage_state="missing", reason="window_after_capture")
+    sample_end = _sample_end_for_time(
+        timeline=timeline,
+        requested_end_us=requested_end_us,
+    )
+    if sample_end is None or sample_end < fft_n:
+        return _ResolvedWindow(coverage_state="missing", reason="window_after_capture")
+    return _ResolvedWindow(coverage_state="complete", reason=None, sample_end=sample_end)
+
+
+def _sample_end_for_time(
+    *,
+    timeline: _SensorTimeline,
+    requested_end_us: float,
 ) -> int | None:
-    if available_samples <= 0:
-        return None
-    if t_s is None or t_s <= 0:
-        return None
-    target = int(round(float(t_s) * float(sample_rate_hz)))
-    if target <= 0:
-        return None
-    return min(target, available_samples)
+    tolerance_us = timeline.timing_tolerance_us
+    for chunk in timeline.chunks:
+        if requested_end_us < (chunk.start_us - tolerance_us):
+            break
+        if requested_end_us <= (chunk.end_us + tolerance_us):
+            relative_samples = int(
+                round((requested_end_us - chunk.start_us) / timeline.sample_period_us)
+            )
+            return max(
+                chunk.sample_start, min(chunk.sample_end, chunk.sample_start + relative_samples)
+            )
+    return None
+
+
+def _intersects_intervals(
+    intervals: tuple[_TimelineInterval, ...],
+    *,
+    start_us: float,
+    end_us: float,
+    tolerance_us: float,
+) -> bool:
+    return any(
+        interval.start_us < (end_us - tolerance_us) and interval.end_us > (start_us + tolerance_us)
+        for interval in intervals
+    )
+
+
+def _replay_confidence(
+    *,
+    raw_backed_sample_count: int,
+    replay_window_count: int,
+    partial_window_count: int,
+    missing_window_count: int,
+    gap_count: int,
+    overlap_count: int,
+    sample_rate_mismatch_count: int,
+    unanchored_sensor_count: int,
+) -> RawReplayConfidence:
+    if replay_window_count <= 0:
+        return "unavailable"
+    if raw_backed_sample_count <= 0:
+        return "fallback"
+    if (
+        raw_backed_sample_count == replay_window_count
+        and partial_window_count <= 0
+        and missing_window_count <= 0
+        and gap_count <= 0
+        and overlap_count <= 0
+        and sample_rate_mismatch_count <= 0
+        and unanchored_sensor_count <= 0
+    ):
+        return "full"
+    return "partial"
+
+
+def _build_replay_warnings(
+    *,
+    raw_backed_sample_count: int,
+    partial_window_count: int,
+    missing_window_count: int,
+    gap_count: int,
+    overlap_count: int,
+    sample_rate_mismatch_count: int,
+    unanchored_sensor_count: int,
+) -> tuple[RunContextWarning, ...]:
+    if unanchored_sensor_count > 0 and raw_backed_sample_count <= 0:
+        return (
+            RunContextWarning(
+                code=WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK,
+                severity="warn",
+                applies_to="raw_replay",
+                title=i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_LEGACY_TITLE"),
+                detail=i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_LEGACY_DETAIL"),
+            ),
+        )
+    if (
+        partial_window_count <= 0
+        and missing_window_count <= 0
+        and gap_count <= 0
+        and overlap_count <= 0
+        and sample_rate_mismatch_count <= 0
+    ):
+        return ()
+    return (
+        RunContextWarning(
+            code=WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
+            severity="warn",
+            applies_to="raw_replay",
+            title=i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_INCOMPLETE_TITLE"),
+            detail=i18n_ref(
+                "RUN_CONTEXT_WARNING_RAW_REPLAY_INCOMPLETE_DETAIL",
+                partial=str(max(0, partial_window_count)),
+                missing=str(max(0, missing_window_count)),
+                gaps=str(max(0, gap_count)),
+                overlaps=str(max(0, overlap_count)),
+                mismatches=str(max(0, sample_rate_mismatch_count)),
+            ),
+        ),
+    )
 
 
 def _compute_strength_metrics(window_f32: np.ndarray, sample_rate_hz: int) -> StrengthMetrics:

--- a/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
@@ -30,6 +30,7 @@ def _sync_call(db: Any, coro: Any) -> object:
 @dataclass(slots=True)
 class _FinalizeRequest:
     run_id: str
+    run_start_monotonic_us: int | None = None
     done: threading.Event = field(default_factory=threading.Event)
     manifest: RawCaptureManifest | None = None
     error: BaseException | None = None
@@ -50,6 +51,7 @@ class RunRawCaptureWriter:
         "_logger",
         "_queue",
         "_thread",
+        "_run_start_monotonic_us",
     )
 
     def __init__(
@@ -71,6 +73,7 @@ class RunRawCaptureWriter:
             tuple[str, RawCaptureChunk] | _FinalizeRequest | _ShutdownRequest
         ] = queue.Queue(maxsize=_QUEUE_MAXSIZE)
         self._active_run_id: str | None = None
+        self._run_start_monotonic_us: int | None = None
         self._thread: threading.Thread | None = None
         if self._history_db is not None:
             self._thread = threading.Thread(
@@ -80,9 +83,10 @@ class RunRawCaptureWriter:
             )
             self._thread.start()
 
-    def start_run(self, run_id: str) -> None:
+    def start_run(self, run_id: str, *, run_start_monotonic_us: int | None = None) -> None:
         with self._lock:
             self._active_run_id = run_id
+            self._run_start_monotonic_us = run_start_monotonic_us
 
     def capture_raw_samples(
         self,
@@ -131,7 +135,12 @@ class RunRawCaptureWriter:
         with self._lock:
             if self._active_run_id == run_id:
                 self._active_run_id = None
-        request = _FinalizeRequest(run_id=run_id)
+            run_start_monotonic_us = self._run_start_monotonic_us
+            self._run_start_monotonic_us = None
+        request = _FinalizeRequest(
+            run_id=run_id,
+            run_start_monotonic_us=run_start_monotonic_us,
+        )
         self._queue.put(request)
         request.done.wait()
         if request.error is not None:
@@ -164,7 +173,10 @@ class RunRawCaptureWriter:
                             RawCaptureManifest | None,
                             _sync_call(
                                 history_db,
-                                history_db.afinalize_raw_capture(item.run_id),
+                                history_db.afinalize_raw_capture(
+                                    item.run_id,
+                                    run_start_monotonic_us=item.run_start_monotonic_us,
+                                ),
                             ),
                         )
                     except BaseException as exc:  # noqa: BLE001

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -2009,6 +2009,7 @@
           "localized_support",
           "clean_signal",
           "summary_only",
+          "raw_replay_incomplete",
           "legacy_context",
           "speed_context_gaps",
           "rpm_context_gaps",
@@ -7932,6 +7933,7 @@
       "WholeRunDiagnosisDataBasis": {
         "enum": [
           "raw_backed",
+          "partial_raw_backed",
           "summary_only"
         ],
         "type": "string"

--- a/docs/time_alignment.md
+++ b/docs/time_alignment.md
@@ -97,6 +97,19 @@ The existing `_multi_sync_window_ms = 800 ms` recency check in
 alignment for real-time multi-sensor events.  No change was needed
 here.
 
+### 7. Persisted Raw Replay
+
+Post-stop raw replay now uses the persisted raw chunk timeline instead
+of assuming that summary-sample `t_s` starts at raw sample index zero.
+New raw-capture manifests store `run_start_monotonic_us`, and replay
+anchors each summary sample into the same monotonic time domain as the
+chunk `t0_us` timestamps before resolving the matching raw window.
+
+If a persisted run predates that anchor, or if replay detects gaps,
+overlaps, or other incomplete coverage inside a requested window, the
+system falls back to the persisted summary sample for that window and
+stores a deterministic warning instead of guessing.
+
 ## Fallback Behaviour
 
 | Scenario | Behaviour |


### PR DESCRIPTION
## Summary
- stop treating persisted summary `t_s` as a raw sample index and replay windows from per-sensor raw chunk timelines anchored by persisted `run_start_monotonic_us`
- classify replay windows as complete / partial / missing, fall back to persisted summary samples whenever alignment is not provable, and persist deterministic replay coverage metadata + warnings
- expose partial raw-backed evidence honestly in report/PDF preparation with `partial_raw_backed` data basis text and raw replay caveats

## What was wrong
Post-analysis rebuilt raw-backed samples with `round(sample.t_s * sample_rate_hz)`. That assumed the summary timeline started at raw index zero, that all sensors shared the same origin, and that raw chunks were contiguous with no gaps or overlaps. Persisted raw artifacts already contain chunk timing metadata (`t0_us`, chunk sample spans), but replay ignored it, so non-zero raw starts, per-sensor offsets, and missing chunks could map a summary window onto the wrong raw samples.

## What changed
- persist `run_start_monotonic_us` in raw capture manifests for new runs and load it back for replay
- build per-sensor replay timelines from chunk `t0_us` plus chunk sample spans, with gap / overlap detection before any raw slice is accepted
- anchor each summary sample into the raw time domain first, then derive the raw end index only after selecting a provable time-aligned window
- roll replay coverage into `analysis_metadata` (`raw_replay_*` counts, confidence, and `raw_capture_mode`) and append deterministic report-facing warnings
- keep report evidence honest with a `partial_raw_backed` basis and a raw replay incompleteness caveat instead of implying everything was fully raw-backed

## Incomplete raw coverage behavior
If replay cannot prove a window because timing metadata is missing, a window crosses a gap or overlap, or sample-rate expectations do not line up, post-analysis now falls back to the persisted summary sample for that window. The run is marked `summary_only` or `partial_raw_backed` as appropriate, and the warning says that affected metrics used persisted summary samples rather than guessing raw alignment.

## Older artifact behavior
Older raw capture artifacts that do not have the new run-start monotonic anchor do not crash and do not guess. Replay falls back to persisted summary metrics and emits a deterministic legacy raw replay warning.

## Tests
- added raw replay regressions for non-zero raw start alignment, per-sensor offsets, gap fallback, and legacy unanchored artifacts
- added post-analysis summary coverage/warning persistence coverage
- added raw capture manifest round-trip coverage for the new monotonic anchor
- added report preparation coverage proving partial raw replay warnings and evidence wording reach the report/PDF path
- reran focused report/whole-run diagnosis regressions plus backend typecheck/lint, contract sync, UI typecheck, and docs lint