### PR TITLE
Use canonical raw-backed post-analysis samples

### DIFF
--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -394,6 +394,64 @@ def test_build_post_analysis_summary_propagates_dropped_chunk_metadata_and_warni
     ]
 
 
+def test_build_post_analysis_summary_uses_raw_backed_samples_for_sensor_intensity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRunAnalysis:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def summarize(self):
+            return SimpleNamespace(
+                diagnostic_case=SimpleNamespace(case_id="case-raw-intensity"),
+                prepared=SimpleNamespace(per_sample_phases=["cruise"]),
+            )
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.diagnostics.run_analysis.RunAnalysis",
+        FakeRunAnalysis,
+    )
+    monkeypatch.setattr(
+        "vibesensor.use_cases.run.post_analysis_summary.analysis_result_to_summary",
+        lambda _result: {},
+    )
+
+    run = build_post_analysis_input(
+        LoadedPostAnalysisRun(
+            run_id="run-raw-intensity",
+            metadata=_run_metadata("run-raw-intensity"),
+            language="en",
+            samples=sensor_frames_from_mappings(
+                [
+                    {
+                        "client_id": "sensor-a",
+                        "location": "front_left",
+                        "t_s": 0.18,
+                        "sample_rate_hz": 800,
+                        "vibration_strength_db": 0.0,
+                        "strength_bucket": "l0",
+                        "dominant_freq_hz": 0.0,
+                    }
+                ]
+            ),
+            raw_capture=_full_raw_capture("run-raw-intensity"),
+            total_sample_count=1,
+            stride=1,
+        )
+    )
+
+    raw_backed_strength = run.samples[0].vibration_strength_db
+    assert raw_backed_strength is not None and raw_backed_strength > 0.0
+
+    summary = build_post_analysis_summary(run)
+    intensity_rows = summary["sensor_intensity_by_location"]
+
+    assert len(intensity_rows) == 1
+    assert intensity_rows[0]["p95_intensity_db"] == pytest.approx(raw_backed_strength)
+    assert intensity_rows[0]["strength_bucket_distribution"]["total"] == 1
+    assert intensity_rows[0]["strength_bucket_distribution"]["counts"]["l0"] == 0
+
+
 def test_build_post_analysis_summary_enriches_missing_strength_db_from_peak_and_floor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/server/vibesensor/use_cases/run/post_analysis_input.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_input.py
@@ -29,7 +29,6 @@ class PostAnalysisRunInput:
     raw_backed_sample_count: int
     raw_replay: RawReplaySummary
     raw_replay_window_coverages: tuple[RawReplayWindowCoverage, ...] = field(default_factory=tuple)
-    summary_samples: tuple[Sample, ...] = field(default_factory=tuple)
     context_samples: tuple[Sample, ...] = field(default_factory=tuple)
 
     @property
@@ -67,7 +66,6 @@ def build_post_analysis_input(loaded: LoadedPostAnalysisRun) -> PostAnalysisRunI
         raw_backed_sample_count=replay_result.summary.raw_backed_sample_count,
         raw_replay=replay_result.summary,
         raw_replay_window_coverages=replay_result.window_coverages,
-        summary_samples=tuple(loaded.samples),
         context_samples=(
             tuple(loaded.context_samples) if loaded.context_samples is not None else tuple()
         ),

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -32,9 +32,8 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
     summary_payload = analysis_result_to_summary(result)
     prepared = getattr(result, "prepared", None)
     if prepared is not None and hasattr(prepared, "per_sample_phases"):
-        source_samples = run.summary_samples if run.summary_samples else run.samples
         sensor_locations, connected_locations, sensor_intensity = build_sensor_analysis(
-            samples=source_samples,
+            samples=run.samples,
             language=run.language,
             per_sample_phases=list(prepared.per_sample_phases),
         )


### PR DESCRIPTION
## What changed
- remove the persisted `summary_samples` override from `PostAnalysisRunInput`
- make `build_post_analysis_summary()` project location/intensity summary fields from the canonical replayed samples used by diagnostics
- add a regression where raw replay changes the serialized intensity row and prove the summary follows the raw-backed value

## Why
- post-analysis could mix raw-backed diagnostic conclusions with location/intensity rows derived from older persisted summary samples
- that let the report/PDF path show subtle mixed-source inconsistencies without making them explicit

## Validation
- `pytest -q apps/server/tests/use_cases/run/test_post_analysis_summary.py apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py`
- `pytest -q apps/server/tests/use_cases/run/test_raw_capture_replay.py apps/server/tests/use_cases/run/test_post_analysis_summary.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs
- this is a narrow summary-path fix; it does not add new metadata because existing raw-replay warnings already describe partial fallback
- runs without raw capture artifacts keep the same persisted-summary behavior

Closes #3141