### PR TITLE
Add native firmware runtime tests

### DIFF
--- a/firmware/esp/test/native_support/Adafruit_NeoPixel.h
+++ b/firmware/esp/test/native_support/Adafruit_NeoPixel.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+using neoPixelType = uint16_t;
+
+constexpr neoPixelType NEO_GRB = 0x01;
+constexpr neoPixelType NEO_KHZ800 = 0x02;
+
+class Adafruit_NeoPixel {
+ public:
+  Adafruit_NeoPixel(uint16_t n, int16_t, neoPixelType)
+      : pixels_(n, 0) {}
+
+  Adafruit_NeoPixel() = default;
+
+  bool begin() {
+    begun_ = true;
+    return true;
+  }
+
+  void clear() {
+    for (size_t i = 0; i < pixels_.size(); ++i) {
+      pixels_[i] = 0;
+    }
+  }
+
+  void show() { show_count_++; }
+
+  void setPixelColor(uint16_t index, uint32_t color) {
+    if (index < pixels_.size()) {
+      pixels_[index] = color;
+    }
+  }
+
+  uint32_t getPixelColor(uint16_t index) const {
+    return index < pixels_.size() ? pixels_[index] : 0;
+  }
+
+  uint32_t Color(uint8_t r, uint8_t g, uint8_t b) const {
+    return (static_cast<uint32_t>(r) << 16) | (static_cast<uint32_t>(g) << 8) |
+           static_cast<uint32_t>(b);
+  }
+
+  bool begun() const { return begun_; }
+
+  uint32_t show_count() const { return show_count_; }
+
+ private:
+  std::vector<uint32_t> pixels_;
+  bool begun_ = false;
+  uint32_t show_count_ = 0;
+};

--- a/firmware/esp/test/native_support/Arduino.h
+++ b/firmware/esp/test/native_support/Arduino.h
@@ -5,4 +5,85 @@
 #include <string>
 
 using String = std::string;
-// Native tests only need Arduino's String name, not the full framework API.
+using byte = uint8_t;
+
+class IPAddress {
+ public:
+  IPAddress(uint8_t a = 0, uint8_t b = 0, uint8_t c = 0, uint8_t d = 0)
+      : octets_{a, b, c, d} {}
+
+  uint8_t operator[](size_t index) const { return octets_[index]; }
+
+  bool operator==(const IPAddress& other) const {
+    return octets_[0] == other.octets_[0] && octets_[1] == other.octets_[1] &&
+           octets_[2] == other.octets_[2] && octets_[3] == other.octets_[3];
+  }
+
+ private:
+  uint8_t octets_[4];
+};
+
+namespace arduino_test {
+
+inline uint32_t& millis_ref() {
+  static uint32_t value = 0;
+  return value;
+}
+
+inline uint64_t& esp_time_ref() {
+  static uint64_t value = 0;
+  return value;
+}
+
+inline uint64_t& esp_time_step_ref() {
+  static uint64_t value = 0;
+  return value;
+}
+
+inline uint32_t& random_value_ref() {
+  static uint32_t value = 0;
+  return value;
+}
+
+inline void reset_time() {
+  millis_ref() = 0;
+  esp_time_ref() = 0;
+  esp_time_step_ref() = 0;
+}
+
+inline void set_millis(uint32_t value) { millis_ref() = value; }
+
+inline void advance_millis(uint32_t delta_ms) { millis_ref() += delta_ms; }
+
+inline void set_esp_time(uint64_t value) { esp_time_ref() = value; }
+
+inline void set_esp_time_step(uint64_t value) { esp_time_step_ref() = value; }
+
+inline uint64_t next_esp_time() {
+  const uint64_t current = esp_time_ref();
+  esp_time_ref() += esp_time_step_ref();
+  return current;
+}
+
+inline void set_random_value(uint32_t value) { random_value_ref() = value; }
+
+}  // namespace arduino_test
+
+inline uint32_t millis() { return arduino_test::millis_ref(); }
+
+inline void delay(uint32_t ms) { arduino_test::advance_millis(ms); }
+
+inline uint32_t esp_random() { return arduino_test::random_value_ref(); }
+
+struct HardwareSerial {
+  void begin(unsigned long) {}
+
+  template <typename... Args>
+  void printf(const char*, Args...) {}
+};
+
+static HardwareSerial Serial;
+
+#ifndef PI
+#define PI 3.14159265358979323846
+#endif

--- a/firmware/esp/test/native_support/WiFi.h
+++ b/firmware/esp/test/native_support/WiFi.h
@@ -1,0 +1,188 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <deque>
+#include <vector>
+
+#include "Arduino.h"
+
+using wl_status_t = int;
+
+constexpr wl_status_t WL_CONNECTED = 3;
+constexpr wl_status_t WL_DISCONNECTED = 6;
+constexpr int WIFI_STA = 1;
+constexpr int WIFI_SCAN_RUNNING = -1;
+#ifndef WIFI_AUTH_WPA_PSK
+#define WIFI_AUTH_WPA_PSK 1
+#endif
+
+class WiFiClass {
+ public:
+  struct ScanResult {
+    String ssid;
+    std::array<uint8_t, 6> bssid = {};
+    int32_t channel = 0;
+    bool has_bssid = true;
+  };
+
+  struct BeginCall {
+    String ssid;
+    String psk;
+    int32_t channel = 0;
+    std::array<uint8_t, 6> bssid = {};
+    bool used_bssid = false;
+    bool connect = false;
+  };
+
+  struct DisconnectCall {
+    bool wifioff = false;
+    bool eraseap = false;
+  };
+
+  void reset() {
+    begin_calls.clear();
+    disconnect_calls.clear();
+    scan_results_.clear();
+    begin_outcomes_.clear();
+    scan_delete_count = 0;
+    mode_value = 0;
+    min_security = -1;
+    sleep_enabled = true;
+    mac_address = "D0:5A:00:00:00:01";
+    async_scan_response = WIFI_SCAN_RUNNING;
+    scan_complete_response = WIFI_SCAN_RUNNING;
+    connected_ = false;
+    begin_status_polls_remaining_ = -1;
+    status_value = WL_DISCONNECTED;
+  }
+
+  void setStatus(wl_status_t value) {
+    status_value = value;
+    connected_ = (value == WL_CONNECTED);
+  }
+
+  void setScanResults(const std::vector<ScanResult>& results) { scan_results_ = results; }
+
+  void setAsyncScanResponse(int16_t value) { async_scan_response = value; }
+
+  void setScanCompleteResponse(int16_t value) { scan_complete_response = value; }
+
+  void queueBeginOutcome(int status_polls_until_connected) {
+    begin_outcomes_.push_back(status_polls_until_connected);
+  }
+
+  void setMacAddress(const String& value) { mac_address = value; }
+
+  void mode(int value) { mode_value = value; }
+
+  void setMinSecurity(int value) { min_security = value; }
+
+  void setSleep(bool value) { sleep_enabled = value; }
+
+  int scanNetworks(bool async = false, bool = true) {
+    return async ? async_scan_response : static_cast<int>(scan_results_.size());
+  }
+
+  int scanComplete() { return scan_complete_response; }
+
+  void scanDelete() {
+    scan_delete_count++;
+    scan_complete_response = 0;
+  }
+
+  String SSID(int index) const { return scan_results_[static_cast<size_t>(index)].ssid; }
+
+  const uint8_t* BSSID(int index) const {
+    const ScanResult& result = scan_results_[static_cast<size_t>(index)];
+    return result.has_bssid ? result.bssid.data() : nullptr;
+  }
+
+  int32_t channel(int index) const {
+    return scan_results_[static_cast<size_t>(index)].channel;
+  }
+
+  void begin(const char* ssid) { record_begin(ssid, nullptr, 0, nullptr, false); }
+
+  void begin(const char* ssid, const char* psk) { record_begin(ssid, psk, 0, nullptr, false); }
+
+  void begin(const char* ssid,
+             const char* psk,
+             int32_t channel,
+             const uint8_t* bssid,
+             bool connect) {
+    record_begin(ssid, psk, channel, bssid, connect);
+  }
+
+  wl_status_t status() {
+    if (connected_) {
+      return WL_CONNECTED;
+    }
+    if (begin_status_polls_remaining_ == 0) {
+      connected_ = true;
+      status_value = WL_CONNECTED;
+      return WL_CONNECTED;
+    }
+    if (begin_status_polls_remaining_ > 0) {
+      begin_status_polls_remaining_--;
+    }
+    return status_value;
+  }
+
+  void disconnect(bool wifioff, bool eraseap) {
+    DisconnectCall call;
+    call.wifioff = wifioff;
+    call.eraseap = eraseap;
+    disconnect_calls.push_back(call);
+    connected_ = false;
+    status_value = WL_DISCONNECTED;
+  }
+
+  String macAddress() const { return mac_address; }
+
+  std::vector<BeginCall> begin_calls;
+  std::vector<DisconnectCall> disconnect_calls;
+  int scan_delete_count = 0;
+  int mode_value = 0;
+  int min_security = -1;
+  bool sleep_enabled = true;
+  String mac_address = "D0:5A:00:00:00:01";
+  int16_t async_scan_response = WIFI_SCAN_RUNNING;
+  int16_t scan_complete_response = WIFI_SCAN_RUNNING;
+
+ private:
+  void record_begin(const char* ssid,
+                    const char* psk,
+                    int32_t channel,
+                    const uint8_t* bssid,
+                    bool connect) {
+    BeginCall call{};
+    call.ssid = ssid == nullptr ? "" : String(ssid);
+    call.psk = psk == nullptr ? "" : String(psk);
+    call.channel = channel;
+    call.used_bssid = bssid != nullptr;
+    call.connect = connect;
+    if (bssid != nullptr) {
+      for (size_t i = 0; i < call.bssid.size(); ++i) {
+        call.bssid[i] = bssid[i];
+      }
+    }
+    begin_calls.push_back(call);
+    connected_ = false;
+    status_value = WL_DISCONNECTED;
+    if (begin_outcomes_.empty()) {
+      begin_status_polls_remaining_ = -1;
+      return;
+    }
+    begin_status_polls_remaining_ = begin_outcomes_.front();
+    begin_outcomes_.pop_front();
+  }
+
+  std::vector<ScanResult> scan_results_;
+  std::deque<int> begin_outcomes_;
+  bool connected_ = false;
+  int begin_status_polls_remaining_ = -1;
+  wl_status_t status_value = WL_DISCONNECTED;
+};
+
+static WiFiClass WiFi;

--- a/firmware/esp/test/native_support/WiFiUdp.h
+++ b/firmware/esp/test/native_support/WiFiUdp.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <initializer_list>
+#include <vector>
+
+#include "Arduino.h"
+
+class WiFiUDP {
+ public:
+  struct SentPacket {
+    IPAddress ip;
+    uint16_t port = 0;
+    std::vector<uint8_t> payload;
+  };
+
+  int begin(uint16_t port) {
+    begin_port = port;
+    return 1;
+  }
+
+  void reset() {
+    begin_port = 0;
+    sent_packets.clear();
+    incoming_packets_.clear();
+    begin_packet_results_.clear();
+    end_packet_results_.clear();
+    active_payload_.clear();
+    packet_open_ = false;
+  }
+
+  void setBeginPacketResults(std::initializer_list<int> results) {
+    begin_packet_results_ = std::deque<int>(results.begin(), results.end());
+  }
+
+  void setEndPacketResults(std::initializer_list<int> results) {
+    end_packet_results_ = std::deque<int>(results.begin(), results.end());
+  }
+
+  int beginPacket(const IPAddress& ip, uint16_t port) {
+    active_ip_ = ip;
+    active_port_ = port;
+    active_payload_.clear();
+    const int result = begin_packet_results_.empty() ? 1 : begin_packet_results_.front();
+    if (!begin_packet_results_.empty()) {
+      begin_packet_results_.pop_front();
+    }
+    packet_open_ = (result == 1);
+    return result;
+  }
+
+  size_t write(const uint8_t* data, size_t len) {
+    if (!packet_open_) {
+      return 0;
+    }
+    active_payload_.insert(active_payload_.end(), data, data + len);
+    return len;
+  }
+
+  int endPacket() {
+    const int result = end_packet_results_.empty() ? 1 : end_packet_results_.front();
+    if (!end_packet_results_.empty()) {
+      end_packet_results_.pop_front();
+    }
+    if (packet_open_ && result == 1) {
+      SentPacket packet;
+      packet.ip = active_ip_;
+      packet.port = active_port_;
+      packet.payload = active_payload_;
+      sent_packets.push_back(packet);
+    }
+    packet_open_ = false;
+    active_payload_.clear();
+    return result;
+  }
+
+  void queueIncoming(const uint8_t* data, size_t len) {
+    incoming_packets_.push_back(std::vector<uint8_t>(data, data + len));
+  }
+
+  int parsePacket() { return incoming_packets_.empty() ? 0 : incoming_packets_.front().size(); }
+
+  int read(uint8_t* buffer, size_t len) {
+    if (incoming_packets_.empty()) {
+      return 0;
+    }
+    const std::vector<uint8_t>& packet = incoming_packets_.front();
+    const size_t to_copy = packet.size() < len ? packet.size() : len;
+    for (size_t i = 0; i < to_copy; ++i) {
+      buffer[i] = packet[i];
+    }
+    incoming_packets_.pop_front();
+    return static_cast<int>(to_copy);
+  }
+
+  uint16_t begin_port = 0;
+  std::vector<SentPacket> sent_packets;
+
+ private:
+  std::deque<std::vector<uint8_t>> incoming_packets_;
+  std::deque<int> begin_packet_results_;
+  std::deque<int> end_packet_results_;
+  IPAddress active_ip_;
+  uint16_t active_port_ = 0;
+  std::vector<uint8_t> active_payload_;
+  bool packet_open_ = false;
+};

--- a/firmware/esp/test/native_support/Wire.h
+++ b/firmware/esp/test/native_support/Wire.h
@@ -1,0 +1,9 @@
+#pragma once
+
+class TwoWire {
+ public:
+  void begin(int = 0, int = 0) {}
+  void setClock(unsigned long) {}
+};
+
+static TwoWire Wire;

--- a/firmware/esp/test/native_support/adxl345.h
+++ b/firmware/esp/test/native_support/adxl345.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "../../lib/adxl345/adxl345.h"

--- a/firmware/esp/test/native_support/esp_err.h
+++ b/firmware/esp/test/native_support/esp_err.h
@@ -1,0 +1,6 @@
+#pragma once
+
+using esp_err_t = int;
+
+constexpr esp_err_t ESP_OK = 0;
+constexpr esp_err_t ESP_ERR_INVALID_STATE = 0x103;

--- a/firmware/esp/test/native_support/esp_timer.h
+++ b/firmware/esp/test/native_support/esp_timer.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+
+#include "Arduino.h"
+#include "esp_err.h"
+
+using esp_timer_handle_t = void*;
+
+struct esp_timer_create_args_t {
+  void (*callback)(void*) = nullptr;
+  void* arg = nullptr;
+  int dispatch_method = 0;
+  const char* name = nullptr;
+};
+
+constexpr int ESP_TIMER_TASK = 0;
+
+inline int64_t esp_timer_get_time() {
+  return static_cast<int64_t>(arduino_test::next_esp_time());
+}
+
+inline esp_err_t esp_timer_create(const esp_timer_create_args_t*, esp_timer_handle_t* out_handle) {
+  if (out_handle != nullptr) {
+    *out_handle = reinterpret_cast<void*>(0x1);
+  }
+  return ESP_OK;
+}
+
+inline esp_err_t esp_timer_start_periodic(esp_timer_handle_t, uint64_t) { return ESP_OK; }
+
+inline esp_err_t esp_timer_delete(esp_timer_handle_t) { return ESP_OK; }

--- a/firmware/esp/test/native_support/freertos/FreeRTOS.h
+++ b/firmware/esp/test/native_support/freertos/FreeRTOS.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+using BaseType_t = int;
+using UBaseType_t = unsigned int;
+using portMUX_TYPE = int;
+
+constexpr BaseType_t pdTRUE = 1;
+constexpr BaseType_t pdPASS = 1;
+constexpr uint32_t portMAX_DELAY = 0xffffffffU;
+constexpr UBaseType_t configMAX_PRIORITIES = 25;
+
+#define portMUX_INITIALIZER_UNLOCKED 0
+#define portENTER_CRITICAL(lock) (void)(lock)
+#define portEXIT_CRITICAL(lock) (void)(lock)

--- a/firmware/esp/test/native_support/freertos/task.h
+++ b/firmware/esp/test/native_support/freertos/task.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "freertos/FreeRTOS.h"
+
+using TaskHandle_t = void*;
+
+inline BaseType_t xTaskCreatePinnedToCore(void (*)(void*),
+                                          const char*,
+                                          uint32_t,
+                                          void*,
+                                          UBaseType_t,
+                                          TaskHandle_t* out_handle,
+                                          BaseType_t) {
+  if (out_handle != nullptr) {
+    *out_handle = reinterpret_cast<void*>(0x1);
+  }
+  return pdPASS;
+}
+
+inline void vTaskDelete(TaskHandle_t) {}
+
+inline UBaseType_t uxTaskPriorityGet(void*) { return 1; }
+
+inline uint32_t ulTaskNotifyTake(BaseType_t, uint32_t) { return 0; }
+
+inline BaseType_t xTaskNotifyGive(TaskHandle_t) { return pdPASS; }
+
+inline BaseType_t xPortGetCoreID() { return 0; }

--- a/firmware/esp/test/test_runtime_led/test_main.cpp
+++ b/firmware/esp/test/test_runtime_led/test_main.cpp
@@ -1,0 +1,41 @@
+#include <unity.h>
+
+#include "../../src/runtime_led.cpp"
+
+using vibesensor::runtime::LedState;
+
+void test_begin_leds_clears_boot_state() {
+  LedState state;
+
+  vibesensor::runtime::begin_leds(state);
+
+  TEST_ASSERT_TRUE(state.led_strip.begun());
+  TEST_ASSERT_EQUAL_UINT32(1, state.led_strip.show_count());
+  TEST_ASSERT_EQUAL_UINT32(0, state.led_strip.getPixelColor(0));
+}
+
+void test_service_blink_toggles_identify_and_clears_after_expiry() {
+  LedState state;
+  vibesensor::runtime::begin_leds(state);
+  vibesensor::runtime::start_identify(state, 600, 1350);
+
+  vibesensor::runtime::service_blink(state, 1350);
+  TEST_ASSERT_TRUE(state.identify_leds_active);
+  TEST_ASSERT_EQUAL_UINT32(
+      state.led_strip.Color(0, vibesensor::runtime::kIdentifyBrightness, vibesensor::runtime::kIdentifyBrightness),
+      state.led_strip.getPixelColor(0));
+
+  vibesensor::runtime::service_blink(state, 1500);
+  TEST_ASSERT_EQUAL_UINT32(0, state.led_strip.getPixelColor(0));
+
+  vibesensor::runtime::service_blink(state, 1950);
+  TEST_ASSERT_FALSE(state.identify_leds_active);
+  TEST_ASSERT_EQUAL_UINT32(0, state.led_strip.getPixelColor(0));
+}
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_begin_leds_clears_boot_state);
+  RUN_TEST(test_service_blink_toggles_identify_and_clears_after_expiry);
+  return UNITY_END();
+}

--- a/firmware/esp/test/test_runtime_sampling/test_main.cpp
+++ b/firmware/esp/test/test_runtime_sampling/test_main.cpp
@@ -1,0 +1,156 @@
+#include <unity.h>
+
+#include "../../src/runtime_queue.cpp"
+#include "../../src/runtime_sample_handoff.cpp"
+#include "../../src/runtime_sampling.cpp"
+
+ADXL345::ADXL345(TwoWire& wire, uint8_t i2c_addr, int sda_pin, int scl_pin, uint8_t fifo_watermark)
+    : wire_(wire),
+      i2c_addr_(i2c_addr),
+      sda_pin_(sda_pin),
+      scl_pin_(scl_pin),
+      fifo_watermark_(fifo_watermark),
+      available_(false) {}
+
+bool ADXL345::begin(FailureKind* failure_kind) {
+  available_ = true;
+  if (failure_kind != nullptr) {
+    *failure_kind = FailureKind::kNone;
+  }
+  return true;
+}
+
+bool ADXL345::recover_bus(FailureKind* failure_kind) {
+  if (failure_kind != nullptr) {
+    *failure_kind = FailureKind::kNone;
+  }
+  return true;
+}
+
+bool ADXL345::available() const { return available_; }
+
+size_t ADXL345::read_samples(
+    int16_t*, size_t, FailureKind* failure_kind, bool* fifo_truncated) {
+  if (failure_kind != nullptr) {
+    *failure_kind = FailureKind::kNone;
+  }
+  if (fifo_truncated != nullptr) {
+    *fifo_truncated = false;
+  }
+  return 0;
+}
+
+bool ADXL345::read_reg(uint8_t, uint8_t*) { return false; }
+
+bool ADXL345::write_reg(uint8_t, uint8_t) { return false; }
+
+bool ADXL345::read_multi(uint8_t, uint8_t*, size_t) { return false; }
+
+namespace {
+
+using vibesensor::runtime::DataFrame;
+using vibesensor::runtime::FrameQueueState;
+using vibesensor::runtime::PendingSample;
+using vibesensor::runtime::RuntimeStatus;
+using vibesensor::runtime::SamplingState;
+
+FrameQueueState make_queue_state(DataFrame* frames, size_t capacity) {
+  FrameQueueState state{};
+  state.queue = frames;
+  state.capacity = capacity;
+  return state;
+}
+
+void expect_xyz_sample(const DataFrame& frame,
+                       uint16_t sample_index,
+                       int16_t expected_x,
+                       int16_t expected_y,
+                       int16_t expected_z) {
+  const size_t offset = static_cast<size_t>(sample_index) * vibesensor::runtime::kAxesPerSample;
+  TEST_ASSERT_EQUAL_INT16(expected_x, frame.xyz[offset + 0]);
+  TEST_ASSERT_EQUAL_INT16(expected_y, frame.xyz[offset + 1]);
+  TEST_ASSERT_EQUAL_INT16(expected_z, frame.xyz[offset + 2]);
+}
+
+void enqueue_sample(SamplingState& state, uint64_t due_us, int16_t base) {
+  PendingSample sample{};
+  sample.due_us = due_us;
+  sample.x = base;
+  sample.y = static_cast<int16_t>(base + 1);
+  sample.z = static_cast<int16_t>(base + 2);
+  TEST_ASSERT_TRUE(vibesensor::runtime::enqueue_pending_sample(state.handoff, sample));
+}
+
+}  // namespace
+
+void setUp() { arduino_test::reset_time(); }
+
+void test_service_sample_handoff_builds_frame_and_updates_snapshot() {
+  SamplingState sampling_state;
+  vibesensor::runtime::initialize_sample_handoff(
+      sampling_state.handoff, sampling_state.handoff_storage, vibesensor::runtime::kSampleHandoffQueueSamples);
+  DataFrame frames[2] = {};
+  FrameQueueState queue_state = make_queue_state(frames, 2);
+  RuntimeStatus status{};
+
+  for (uint16_t i = 0; i < vibesensor::runtime::kFrameSamples; ++i) {
+    enqueue_sample(sampling_state, 1000 + i, static_cast<int16_t>(10 + i));
+  }
+
+  vibesensor::runtime::service_sample_handoff(sampling_state, queue_state, status, 25);
+
+  const DataFrame* frame = vibesensor::runtime::peek_frame(queue_state);
+  TEST_ASSERT_NOT_NULL(frame);
+  TEST_ASSERT_EQUAL_UINT64(1025, frame->t0_us);
+  TEST_ASSERT_EQUAL_UINT16(vibesensor::runtime::kFrameSamples, frame->sample_count);
+  expect_xyz_sample(*frame, 0, 10, 11, 12);
+  const int16_t last_sample =
+      static_cast<int16_t>(10 + vibesensor::runtime::kFrameSamples - 1);
+  expect_xyz_sample(*frame,
+                    vibesensor::runtime::kFrameSamples - 1,
+                    last_sample,
+                    static_cast<int16_t>(last_sample + 1),
+                    static_cast<int16_t>(last_sample + 2));
+
+  const vibesensor::runtime::SamplingStatusSnapshot snapshot =
+      vibesensor::runtime::snapshot_sampling_status(sampling_state);
+  TEST_ASSERT_EQUAL_UINT16(0, snapshot.sample_handoff_size);
+  TEST_ASSERT_EQUAL_UINT16(
+      vibesensor::runtime::kSampleHandoffQueueSamples, snapshot.sample_handoff_capacity);
+}
+
+void test_service_sample_handoff_drops_oldest_frame_when_queue_saturates() {
+  SamplingState sampling_state;
+  vibesensor::runtime::initialize_sample_handoff(
+      sampling_state.handoff, sampling_state.handoff_storage, vibesensor::runtime::kSampleHandoffQueueSamples);
+  DataFrame frames[1] = {};
+  FrameQueueState queue_state = make_queue_state(frames, 1);
+  RuntimeStatus status{};
+
+  for (uint16_t i = 0; i < vibesensor::runtime::kFrameSamples; ++i) {
+    enqueue_sample(sampling_state, 1000 + i, static_cast<int16_t>(100 + i));
+  }
+  for (uint16_t i = 0; i < vibesensor::runtime::kFrameSamples; ++i) {
+    enqueue_sample(sampling_state, 2000 + i, static_cast<int16_t>(500 + i));
+  }
+
+  vibesensor::runtime::service_sample_handoff(sampling_state, queue_state, status, 0);
+
+  const DataFrame* frame = vibesensor::runtime::peek_frame(queue_state);
+  TEST_ASSERT_NOT_NULL(frame);
+  TEST_ASSERT_EQUAL_UINT32(1, status.queue_overflow_drops);
+  TEST_ASSERT_EQUAL_UINT32(1, frame->seq);
+  TEST_ASSERT_EQUAL_UINT64(2000, frame->t0_us);
+  expect_xyz_sample(*frame, 0, 500, 501, 502);
+
+  const vibesensor::runtime::SamplingStatusSnapshot snapshot =
+      vibesensor::runtime::snapshot_sampling_status(sampling_state);
+  TEST_ASSERT_EQUAL_UINT16(0, snapshot.sample_handoff_size);
+}
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_service_sample_handoff_builds_frame_and_updates_snapshot);
+  RUN_TEST(test_service_sample_handoff_drops_oldest_frame_when_queue_saturates);
+  return UNITY_END();
+}

--- a/firmware/esp/test/test_runtime_transport/test_main.cpp
+++ b/firmware/esp/test/test_runtime_transport/test_main.cpp
@@ -1,0 +1,143 @@
+#include <unity.h>
+
+#include <array>
+
+#include "../native_support/generated_protocol_contract_fixtures.h"
+
+#include "../../lib/vibesensor_proto/vibesensor_proto.cpp"
+#include "../../src/runtime_led.cpp"
+#include "../../src/runtime_queue.cpp"
+#include "../../src/runtime_status.cpp"
+#include "../../src/runtime_transport.cpp"
+
+namespace {
+
+namespace fixture = vibesensor::test_support;
+
+using vibesensor::runtime::DataFrame;
+using vibesensor::runtime::FrameQueueState;
+using vibesensor::runtime::LedState;
+using vibesensor::runtime::RuntimeStatus;
+using vibesensor::runtime::TransportState;
+
+FrameQueueState make_queue_state(DataFrame* frames, size_t capacity) {
+  FrameQueueState state{};
+  state.queue = frames;
+  state.capacity = capacity;
+  return state;
+}
+
+void append_full_frame(FrameQueueState& state,
+                       RuntimeStatus& status,
+                       int16_t sample_base,
+                       uint64_t first_due_us,
+                       int64_t clock_offset_us) {
+  for (uint16_t i = 0; i < vibesensor::runtime::kFrameSamples; ++i) {
+    const int16_t value = static_cast<int16_t>(sample_base + static_cast<int16_t>(i));
+    vibesensor::runtime::append_sample(state,
+                                       status,
+                                       value,
+                                       static_cast<int16_t>(value + 1),
+                                       static_cast<int16_t>(value + 2),
+                                       first_due_us + i,
+                                       clock_offset_us);
+  }
+}
+
+void copy_client_id(uint8_t out[vibesensor::kClientIdBytes],
+                    const std::array<uint8_t, vibesensor::kClientIdBytes>& value) {
+  for (size_t i = 0; i < value.size(); ++i) {
+    out[i] = value[i];
+  }
+}
+
+}  // namespace
+
+void setUp() {
+  arduino_test::reset_time();
+  WiFi.reset();
+}
+
+void test_service_tx_tracks_send_failures_and_retries_after_backoff() {
+  DataFrame frames[1] = {};
+  FrameQueueState queue_state = make_queue_state(frames, 1);
+  RuntimeStatus status{};
+  TransportState transport{};
+  copy_client_id(transport.client_id, fixture::kCommandClientId);
+  transport.handshake_complete = true;
+  WiFi.setStatus(WL_CONNECTED);
+  arduino_test::set_millis(1000);
+  append_full_frame(queue_state, status, 10, 1000, 0);
+
+  transport.data_udp.setBeginPacketResults({0});
+  vibesensor::runtime::service_tx(transport, queue_state, status);
+  TEST_ASSERT_EQUAL_UINT32(1, status.tx_begin_failures);
+  TEST_ASSERT_EQUAL_UINT8(6, status.last_error_code);
+  TEST_ASSERT_EQUAL_UINT32(0, transport.data_udp.sent_packets.size());
+  TEST_ASSERT_FALSE(vibesensor::runtime::peek_frame(queue_state)->transmitted);
+
+  transport.data_udp.setBeginPacketResults({1, 1});
+  transport.data_udp.setEndPacketResults({1, 1});
+  vibesensor::runtime::service_tx(transport, queue_state, status);
+  TEST_ASSERT_EQUAL_UINT32(1, transport.data_udp.sent_packets.size());
+  TEST_ASSERT_TRUE(vibesensor::runtime::peek_frame(queue_state)->transmitted);
+  TEST_ASSERT_EQUAL_UINT32(1000, vibesensor::runtime::peek_frame(queue_state)->last_tx_ms);
+
+  vibesensor::runtime::service_tx(transport, queue_state, status);
+  TEST_ASSERT_EQUAL_UINT32(1, transport.data_udp.sent_packets.size());
+
+  arduino_test::advance_millis(vibesensor::runtime::kDataRetransmitIntervalMs);
+  vibesensor::runtime::service_tx(transport, queue_state, status);
+  TEST_ASSERT_EQUAL_UINT32(2, transport.data_udp.sent_packets.size());
+}
+
+void test_service_control_rx_handles_handshake_identify_and_sync_clock() {
+  DataFrame frames[1] = {};
+  FrameQueueState queue_state = make_queue_state(frames, 1);
+  RuntimeStatus status{};
+  TransportState transport{};
+  LedState led_state;
+  vibesensor::runtime::begin_leds(led_state);
+  copy_client_id(transport.client_id, fixture::kCommandClientId);
+
+  uint8_t hello_ack[vibesensor::kHelloAckBytes] = {};
+  const size_t hello_ack_len =
+      vibesensor::pack_hello_ack(hello_ack, sizeof(hello_ack), transport.client_id);
+  transport.control_udp.queueIncoming(hello_ack, hello_ack_len);
+  vibesensor::runtime::service_control_rx(transport, queue_state, led_state, status);
+  TEST_ASSERT_TRUE(transport.handshake_complete);
+
+  arduino_test::set_millis(5000);
+  transport.control_udp.queueIncoming(
+      fixture::kIdentifyPacket.data(), fixture::kIdentifyPacket.size());
+  vibesensor::runtime::service_control_rx(transport, queue_state, led_state, status);
+  TEST_ASSERT_EQUAL_UINT32(6500, led_state.blink_until_ms);
+  TEST_ASSERT_EQUAL_UINT32(1, transport.control_udp.sent_packets.size());
+  uint8_t expected_ack[vibesensor::kAckBytes] = {};
+  const size_t expected_ack_len = vibesensor::pack_ack(
+      expected_ack, sizeof(expected_ack), transport.client_id, fixture::kIdentifyCmdSeq, 0);
+  TEST_ASSERT_EQUAL_UINT32(expected_ack_len, transport.control_udp.sent_packets[0].payload.size());
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(
+      expected_ack, transport.control_udp.sent_packets[0].payload.data(), expected_ack_len);
+
+  arduino_test::set_esp_time(fixture::kSyncClockAckReceiveUs);
+  arduino_test::set_esp_time_step(
+      fixture::kSyncClockAckSendUs - fixture::kSyncClockAckReceiveUs);
+  transport.control_udp.queueIncoming(
+      fixture::kSyncClockPacket.data(), fixture::kSyncClockPacket.size());
+  vibesensor::runtime::service_control_rx(transport, queue_state, led_state, status);
+  TEST_ASSERT_EQUAL_INT64(fixture::kSyncClockAppliedOffsetUs, transport.clock_offset_us);
+  TEST_ASSERT_EQUAL_INT64(fixture::kSyncClockAppliedOffsetUs, status.sync_offset_us);
+  TEST_ASSERT_EQUAL_UINT32(fixture::kSyncClockRoundTripUs, status.sync_round_trip_us);
+  TEST_ASSERT_EQUAL_UINT32(2, transport.control_udp.sent_packets.size());
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(fixture::kSyncClockAckPacket.data(),
+                                transport.control_udp.sent_packets[1].payload.data(),
+                                fixture::kSyncClockAckPacket.size());
+}
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_service_tx_tracks_send_failures_and_retries_after_backoff);
+  RUN_TEST(test_service_control_rx_handles_handshake_identify_and_sync_clock);
+  return UNITY_END();
+}

--- a/firmware/esp/test/test_runtime_wifi/test_main.cpp
+++ b/firmware/esp/test/test_runtime_wifi/test_main.cpp
@@ -1,0 +1,106 @@
+#include <unity.h>
+
+#include <vector>
+
+#include "../../src/runtime_status.cpp"
+#include "../../src/runtime_wifi.cpp"
+
+namespace {
+
+using vibesensor::runtime::RuntimeStatus;
+using vibesensor::runtime::WifiState;
+
+std::vector<WiFiClass::ScanResult> target_scan_results() {
+  WiFiClass::ScanResult other;
+  other.ssid = "OtherNetwork";
+  other.bssid = {{0, 1, 2, 3, 4, 5}};
+  other.channel = 1;
+  other.has_bssid = true;
+
+  WiFiClass::ScanResult target;
+  target.ssid = vibesensor_network::wifi_ssid;
+  target.bssid = {{6, 7, 8, 9, 10, 11}};
+  target.channel = 6;
+  target.has_bssid = true;
+
+  std::vector<WiFiClass::ScanResult> results;
+  results.push_back(other);
+  results.push_back(target);
+  return results;
+}
+
+}  // namespace
+
+void setUp() {
+  arduino_test::reset_time();
+  WiFi.reset();
+}
+
+void test_connect_wifi_retries_until_connected_and_uses_scanned_bssid() {
+  WifiState state{};
+  RuntimeStatus status{};
+  const std::vector<WiFiClass::ScanResult> scan_results = target_scan_results();
+  WiFi.setScanResults(scan_results);
+  WiFi.queueBeginOutcome(-1);
+  WiFi.queueBeginOutcome(-1);
+  WiFi.queueBeginOutcome(2);
+
+  const bool ok = vibesensor::runtime::connect_wifi(state, status);
+
+  TEST_ASSERT_TRUE(ok);
+  TEST_ASSERT_TRUE(state.has_target_bssid);
+  TEST_ASSERT_EQUAL_INT32(6, state.target_channel);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(scan_results[1].bssid.data(), state.target_bssid, 6);
+  TEST_ASSERT_EQUAL_UINT32(2, status.wifi_connect_failures);
+  TEST_ASSERT_EQUAL_UINT8(11, status.last_error_code);
+  TEST_ASSERT_EQUAL_INT(WIFI_STA, WiFi.mode_value);
+  TEST_ASSERT_FALSE(WiFi.sleep_enabled);
+  TEST_ASSERT_EQUAL_INT(WIFI_AUTH_WPA_PSK, WiFi.min_security);
+  TEST_ASSERT_EQUAL_UINT32(3, WiFi.begin_calls.size());
+  TEST_ASSERT_TRUE(WiFi.begin_calls[0].used_bssid);
+  TEST_ASSERT_EQUAL_INT32(6, WiFi.begin_calls[0].channel);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(scan_results[1].bssid.data(), WiFi.begin_calls[0].bssid.data(), 6);
+  TEST_ASSERT_EQUAL_UINT32(2, WiFi.disconnect_calls.size());
+  TEST_ASSERT_TRUE(WiFi.disconnect_calls[0].wifioff);
+  TEST_ASSERT_TRUE(WiFi.disconnect_calls[0].eraseap);
+}
+
+void test_service_wifi_starts_async_scan_and_schedules_backoff_retry() {
+  WifiState state{};
+  RuntimeStatus status{};
+  WiFi.setStatus(WL_DISCONNECTED);
+  WiFi.setScanResults(target_scan_results());
+  WiFi.setAsyncScanResponse(WIFI_SCAN_RUNNING);
+  WiFi.setScanCompleteResponse(2);
+  WiFi.queueBeginOutcome(-1);
+  arduino_test::set_random_value(0);
+  arduino_test::set_millis(25000);
+
+  vibesensor::runtime::service_wifi(state, status);
+
+  TEST_ASSERT_TRUE(state.scan_in_progress);
+  TEST_ASSERT_EQUAL_UINT32(25000, state.last_wifi_scan_ms);
+  TEST_ASSERT_EQUAL_UINT32(1, status.wifi_reconnect_attempts);
+  TEST_ASSERT_EQUAL_UINT32(25000, state.last_wifi_retry_ms);
+  TEST_ASSERT_EQUAL_UINT32(32000, state.wifi_next_retry_ms);
+  TEST_ASSERT_EQUAL_UINT8(1, state.wifi_retry_failures);
+  TEST_ASSERT_EQUAL_UINT8(12, status.last_error_code);
+  TEST_ASSERT_EQUAL_UINT32(1, WiFi.disconnect_calls.size());
+  TEST_ASSERT_TRUE(WiFi.disconnect_calls[0].wifioff);
+  TEST_ASSERT_FALSE(WiFi.disconnect_calls[0].eraseap);
+
+  arduino_test::set_millis(26000);
+  vibesensor::runtime::service_wifi(state, status);
+
+  TEST_ASSERT_FALSE(state.scan_in_progress);
+  TEST_ASSERT_TRUE(state.has_target_bssid);
+  TEST_ASSERT_EQUAL_INT32(6, state.target_channel);
+  TEST_ASSERT_EQUAL_UINT32(1, status.wifi_reconnect_attempts);
+}
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_connect_wifi_retries_until_connected_and_uses_scanned_bssid);
+  RUN_TEST(test_service_wifi_starts_async_scan_and_schedules_backoff_retry);
+  return UNITY_END();
+}


### PR DESCRIPTION
Closes #3143

## What changed
- added native-support stubs for Arduino time/random, WiFi, UDP, NeoPixel, timers, Wire, and FreeRTOS so the firmware runtime modules can run under `pio test -e native`
- added focused native runtime tests for `runtime_wifi`, `runtime_transport`, `runtime_led`, and `runtime_sampling`
- new tests cover reconnect/backoff, HELLO/DATA/control behavior, identify blinking, and sampling-to-queue handoff saturation

## Why
- the existing native suite covered queue/protocol helpers, but real runtime owners still had almost no deterministic coverage
- WiFi retry logic, UDP retry/failure handling, LED identify behavior, and handoff pressure are all shipped product behavior and easy to regress
- this keeps the firmware runtime honest without needing hardware for every check

## Validation
- `cd firmware/esp && PATH=/workspace/VibeSensor/.venv/bin:$PATH pio test -e native`
- `cd firmware/esp && PATH=/workspace/VibeSensor/.venv/bin:$PATH pio run -e m5stack_atom`

## Risks / tradeoffs
- this adds a native host harness, so the stubs need to stay thin and behavior-focused
- no production firmware logic changed in this PR; if a future runtime fix is needed, these tests should catch it instead of re-adding smoke-only coverage

## Notes
- the new runtime tests reuse the real module implementations; only hardware/platform APIs are substituted in the native environment
