### PR TITLE
Add adversarial WS and UDP ingress tests

### DIFF
--- a/apps/server/tests/adapters/http/test_ws_message_router.py
+++ b/apps/server/tests/adapters/http/test_ws_message_router.py
@@ -1,0 +1,47 @@
+"""Adversarial client-message coverage for WebSocket routing."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from vibesensor.adapters.http.ws_message_router import route_ws_message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "not-json",
+        json.dumps(["unexpected-list"]),
+        json.dumps({"unknown": "field"}),
+        json.dumps({"client_id": "x" * 4096}),
+        json.dumps({"client_id": ["bad-type"]}),
+    ],
+    ids=[
+        "malformed-json",
+        "non-dict-json",
+        "unknown-keys",
+        "oversized-client-id",
+        "wrong-client-id-type",
+    ],
+)
+async def test_route_ws_message_ignores_invalid_messages(message: str) -> None:
+    hub = AsyncMock()
+    ws = AsyncMock()
+
+    await route_ws_message(hub, ws, message)
+
+    hub.update_selected_client.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_route_ws_message_applies_valid_selection() -> None:
+    hub = AsyncMock()
+    ws = AsyncMock()
+
+    await route_ws_message(hub, ws, json.dumps({"client_id": "AA:BB:CC:DD:EE:FF"}))
+
+    hub.update_selected_client.assert_awaited_once_with(ws, "aabbccddeeff")

--- a/apps/server/tests/adapters/udp/test_udp_ingress_adversarial.py
+++ b/apps/server/tests/adapters/udp/test_udp_ingress_adversarial.py
@@ -1,0 +1,125 @@
+"""Focused adversarial coverage for UDP ingress packet handling."""
+
+from __future__ import annotations
+
+import logging
+import struct
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from vibesensor.adapters.udp.protocol import DATA_HEADER_BYTES, pack_data, parse_data_ack
+from vibesensor.adapters.udp.protocol_validator import MAX_SAMPLE_COUNT
+from vibesensor.adapters.udp.udp_data_rx import DataDatagramProtocol
+from vibesensor.infra.runtime.registry import DataUpdateResult
+
+
+def _valid_packet(*, seq: int) -> bytes:
+    return pack_data(
+        bytes.fromhex("010203040506"),
+        seq=seq,
+        t0_us=seq * 1_000,
+        samples=np.zeros((4, 3), dtype=np.int16),
+    )
+
+
+def _packet_with_oversized_sample_count() -> bytes:
+    packet = bytearray(_valid_packet(seq=7))
+    struct.pack_into("<H", packet, DATA_HEADER_BYTES - 2, MAX_SAMPLE_COUNT + 1)
+    return bytes(packet)
+
+
+class _FailFirstTransport:
+    def __init__(self) -> None:
+        self.sent: list[tuple[bytes, tuple[str, int]]] = []
+        self._failed = False
+
+    def sendto(self, data: bytes, addr: tuple[str, int]) -> None:
+        if not self._failed:
+            self._failed = True
+            raise OSError("boom")
+        self.sent.append((data, addr))
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.mark.parametrize(
+    "packet",
+    [
+        _valid_packet(seq=3)[:-1],
+        _packet_with_oversized_sample_count(),
+    ],
+    ids=["truncated-data", "oversized-sample-count"],
+)
+def test_process_datagram_rejects_malformed_or_oversized_packets(
+    packet: bytes,
+    fake_transport,
+) -> None:
+    registry = Mock()
+    processor = Mock()
+    proto = DataDatagramProtocol(registry=registry, processor=processor, queue_maxsize=8)
+    proto.connection_made(fake_transport)
+
+    proto._process_datagram(packet, ("127.0.0.1", 12345))
+
+    registry.note_parse_error.assert_called_once_with("010203040506")
+    registry.update_from_data.assert_not_called()
+    processor.ingest.assert_not_called()
+    assert fake_transport.sent == []
+
+
+@pytest.mark.asyncio
+async def test_out_of_order_duplicate_packet_is_acked_but_not_ingested(
+    fake_transport,
+    drain_queue,
+) -> None:
+    registry = Mock()
+    registry.update_from_data.side_effect = [
+        DataUpdateResult(),
+        DataUpdateResult(is_duplicate=True),
+    ]
+    registry.get.return_value = SimpleNamespace(sample_rate_hz=800)
+    processor = Mock()
+    proto = DataDatagramProtocol(registry=registry, processor=processor, queue_maxsize=8)
+    proto.connection_made(fake_transport)
+
+    newest = _valid_packet(seq=42)
+    older = _valid_packet(seq=41)
+    proto.datagram_received(newest, ("127.0.0.1", 12345))
+    proto.datagram_received(older, ("127.0.0.1", 12345))
+
+    await drain_queue(proto)
+
+    assert processor.ingest.call_count == 1
+    acked_sequences = [
+        parse_data_ack(data).last_seq_received for data, _addr in fake_transport.sent
+    ]
+    assert acked_sequences == [42, 41]
+    assert [call.args[0].seq for call in registry.update_from_data.call_args_list] == [42, 41]
+
+
+@pytest.mark.asyncio
+async def test_ack_send_failure_logs_and_continues_draining_queue(
+    caplog: pytest.LogCaptureFixture,
+    drain_queue,
+) -> None:
+    registry = Mock()
+    registry.update_from_data.side_effect = [DataUpdateResult(), DataUpdateResult()]
+    registry.get.return_value = SimpleNamespace(sample_rate_hz=800)
+    processor = Mock()
+    transport = _FailFirstTransport()
+    proto = DataDatagramProtocol(registry=registry, processor=processor, queue_maxsize=8)
+    proto.connection_made(transport)
+
+    proto.datagram_received(_valid_packet(seq=1), ("127.0.0.1", 12345))
+    proto.datagram_received(_valid_packet(seq=2), ("127.0.0.1", 12345))
+
+    with caplog.at_level(logging.WARNING, logger="vibesensor.adapters.udp.udp_data_rx"):
+        await drain_queue(proto)
+
+    assert processor.ingest.call_count == 2
+    assert [parse_data_ack(data).last_seq_received for data, _addr in transport.sent] == [2]
+    assert any("failed to send DATA_ACK" in record.message for record in caplog.records)

--- a/apps/server/tests/adapters/websocket/test_ws_ingress_adversarial.py
+++ b/apps/server/tests/adapters/websocket/test_ws_ingress_adversarial.py
@@ -1,0 +1,89 @@
+"""Focused adversarial coverage for WebSocket ingress and broadcast pressure."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock, patch
+
+import anyio
+import pytest
+from test_support.ws_hub import make_websocket as _make_ws
+
+from vibesensor.adapters.websocket.hub import WebSocketHub
+from vibesensor.adapters.websocket.tick_controller import BroadcastTickController
+
+
+@pytest.mark.asyncio
+async def test_broadcast_evicts_slow_consumer_without_blocking_fast_clients() -> None:
+    hub = WebSocketHub()
+    fast_ws = _make_ws()
+    slow_ws = _make_ws()
+
+    async def _hang_forever(_payload: str) -> None:
+        await anyio.sleep_forever()
+
+    slow_ws.send_text.side_effect = _hang_forever
+    await hub.add(fast_ws, None)
+    await hub.add(slow_ws, None)
+    hub._runner._send_timeout_s = 0.01
+
+    await hub.broadcast(lambda _selected: {"ok": True})
+
+    fast_ws.send_text.assert_awaited_once()
+    slow_ws.send_text.assert_awaited_once()
+    slow_ws.close.assert_awaited_once()
+    remaining = await hub._snapshot()
+    assert len(remaining) == 1
+    assert remaining[0].websocket is fast_ws
+
+
+@pytest.mark.asyncio
+async def test_broadcast_pressure_builds_one_payload_per_unique_selection() -> None:
+    hub = WebSocketHub()
+    websockets = []
+    selections = [None, "sensor-a", "sensor-b"]
+
+    for index in range(48):
+        ws = _make_ws()
+        await hub.add(ws, selections[index % len(selections)])
+        websockets.append(ws)
+
+    payload_builder = MagicMock(side_effect=lambda selected: {"selected": selected})
+
+    await hub.broadcast(payload_builder)
+
+    assert payload_builder.call_count == len(selections)
+    for ws in websockets:
+        ws.send_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_tick_controller_skips_negative_sleep_when_broadcast_lags() -> None:
+    controller = BroadcastTickController(
+        hz=100,
+        logger=logging.getLogger("vibesensor.adapters.websocket.hub"),
+    )
+    sleep_calls: list[float] = []
+
+    async def _broadcast_tick() -> None:
+        return None
+
+    async def _fake_sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+        raise asyncio.CancelledError
+
+    with (
+        patch(
+            "vibesensor.adapters.websocket.tick_controller.anyio.current_time",
+            side_effect=[0.0, 0.05],
+        ),
+        patch(
+            "vibesensor.adapters.websocket.tick_controller.anyio.sleep",
+            side_effect=_fake_sleep,
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await controller.run(broadcast_tick=_broadcast_tick)
+
+    assert sleep_calls == [0.0]


### PR DESCRIPTION
Closes #3144

## What changed
- add a focused websocket adversarial suite for slow-consumer eviction, bounded many-client payload reuse, and lagging tick scheduling
- add direct `route_ws_message()` coverage for malformed JSON, wrong-shape messages, oversized invalid client ids, and a valid selection path
- add a focused UDP adversarial suite for truncated and oversized DATA packets, out-of-order duplicate ACK behavior, and queue-drain recovery after a DATA_ACK send failure

## Why
- the repo already had happy-path and some narrow boundary tests, but it did not have one concentrated ingress suite proving bounded behavior under adversarial WS/UDP inputs
- these cases are the regression guard for slow consumers, malformed payloads, and burst/failure handling at live runtime boundaries

## Validation
- `/workspace/VibeSensor/.venv/bin/python -m pytest -q apps/server/tests/adapters/websocket/test_ws_ingress_adversarial.py apps/server/tests/adapters/http/test_ws_message_router.py apps/server/tests/adapters/udp/test_udp_ingress_adversarial.py apps/server/tests/adapters/websocket/test_ws_hub.py apps/server/tests/adapters/websocket/test_tick_controller.py apps/server/tests/adapters/udp/test_udp_data_rx.py apps/server/tests/adapters/udp/test_udp_data_rx_seams.py`
- `make typecheck-backend`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`

## Risks / tradeoffs
- test-only change; no production runtime behavior changed
- oversized WS coverage is route-level invalid-client-id handling, not a new transport size cap
- out-of-order UDP coverage documents the current duplicate-ack behavior; the stricter runtime policy work still belongs in #3156