### PR TITLE
Harden history HTTP route boundaries

### DIFF
--- a/apps/server/tests/adapters/http/test_api_history_export_endpoints.py
+++ b/apps/server/tests/adapters/http/test_api_history_export_endpoints.py
@@ -4,23 +4,14 @@ import csv
 import io
 import json
 import zipfile
-from dataclasses import dataclass, replace
 
 import pytest
 from _history_endpoint_helpers import (
-    FakeHistoryDB,
-    FakeState,
-    FakeWsHub,
-    make_metadata,
     make_router_and_state,
     read_streaming_body,
     route_endpoint,
-    sample,
 )
 from fastapi import HTTPException
-
-from vibesensor.adapters.analysis_summary import summarize_run_data
-from vibesensor.adapters.http import create_router
 
 
 @pytest.mark.asyncio
@@ -131,43 +122,6 @@ async def test_history_export_strips_internal_analysis_fields_from_json() -> Non
     with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
         metadata = json.loads(archive.read("run-1.json").decode("utf-8"))
     assert "_internal" not in metadata.get("analysis", {})
-
-
-@pytest.mark.asyncio
-async def test_history_export_sanitizes_filename_from_run_id() -> None:
-    run_id = "../bad:name*id"
-    metadata = make_metadata(run_id=run_id)
-    samples = [sample(i) for i in range(2)]
-    analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
-
-    @dataclass
-    class NamedRunDB(FakeHistoryDB):
-        accepted_run_id: str = run_id
-
-        async def aget_run(self, queried_run_id: str):
-            if queried_run_id != self.accepted_run_id:
-                return None
-            result = await super().aget_run("run-1")
-            assert result is not None
-            return replace(result, run_id=queried_run_id)
-
-        async def aiter_run_samples(
-            self, queried_run_id: str, batch_size: int = 1000, *, stride: int = 1
-        ):
-            if queried_run_id != self.accepted_run_id:
-                return
-            async for batch in super().aiter_run_samples(
-                "run-1", batch_size=batch_size, stride=stride
-            ):
-                yield batch
-
-    db = NamedRunDB(metadata, samples, analysis)
-    router = create_router(FakeState(db, FakeWsHub()))
-    endpoint = route_endpoint(router, "/api/history/{run_id}/export")
-    response = await endpoint(run_id)
-    body = await read_streaming_body(response)
-    with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
-        assert set(archive.namelist()) == {"_bad_name_id.json", "_bad_name_id_raw.csv"}
 
 
 @pytest.mark.asyncio

--- a/apps/server/tests/adapters/http/test_api_history_route_boundary_guards.py
+++ b/apps/server/tests/adapters/http/test_api_history_route_boundary_guards.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vibesensor.adapters.http.error_boundary import install_http_exception_handlers
+from vibesensor.adapters.http.history import create_history_routes
+from vibesensor.adapters.http.middleware import install_request_logging_middleware
+from vibesensor.shared.filenames import safe_filename
+from vibesensor.use_cases.history.reports import HistoryReportPdf
+
+
+@dataclass
+class _FakeExportDownload:
+    filename: str
+    file_size: int = 7
+    payload: bytes = b"payload"
+
+    def iter_bytes(self):
+        yield self.payload
+
+
+def _history_test_client() -> tuple[TestClient, MagicMock, MagicMock, MagicMock]:
+    run_service = MagicMock()
+    run_service.get_run = AsyncMock(return_value={"run_id": "run-1"})
+    run_service.get_insights = AsyncMock(return_value={"run_id": "run-1", "status": "complete"})
+    run_service.delete_run = AsyncMock(return_value={"run_id": "run-1", "deleted": True})
+
+    report_service = MagicMock()
+    report_service.build_pdf = AsyncMock(
+        return_value=HistoryReportPdf(content=b"%PDF-safe", filename="run-1_report.pdf")
+    )
+
+    export_service = MagicMock()
+    export_service.build_export = AsyncMock(return_value=_FakeExportDownload(filename="run-1.zip"))
+
+    app = FastAPI()
+    install_http_exception_handlers(app)
+    install_request_logging_middleware(app)
+    app.include_router(
+        create_history_routes(
+            run_service=run_service,
+            report_service=report_service,
+            export_service=export_service,
+        )
+    )
+    return (
+        TestClient(app, raise_server_exceptions=False),
+        run_service,
+        report_service,
+        export_service,
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "failing_attr"),
+    [
+        ("GET", "/api/history/run-1", "get_run"),
+        ("GET", "/api/history/run-1/insights", "get_insights"),
+        ("DELETE", "/api/history/run-1", "delete_run"),
+        ("GET", "/api/history/run-1/report.pdf", "build_pdf"),
+        ("GET", "/api/history/run-1/export", "build_export"),
+    ],
+)
+def test_history_routes_return_sanitized_json_for_unexpected_service_failures(
+    method: str,
+    path: str,
+    failing_attr: str,
+) -> None:
+    client, run_service, report_service, export_service = _history_test_client()
+    getattr(
+        {
+            "get_run": run_service,
+            "get_insights": run_service,
+            "delete_run": run_service,
+            "build_pdf": report_service,
+            "build_export": export_service,
+        }[failing_attr],
+        failing_attr,
+    ).side_effect = RuntimeError("sensitive failure detail")
+
+    response = client.request(method, path)
+
+    assert response.status_code == 500
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {"detail": "Internal Server Error"}
+    assert "sensitive failure detail" not in response.text
+
+
+@pytest.mark.parametrize(
+    ("path", "failing_attr", "malicious_filename", "expected_header"),
+    [
+        (
+            "/api/history/run-1/report.pdf",
+            "build_pdf",
+            "bad\r\nX-Injected: yes.pdf",
+            'attachment; filename="bad__X-Injected__yes.pdf"',
+        ),
+        (
+            "/api/history/run-1/export",
+            "build_export",
+            "bad\r\nX-Injected: yes.zip",
+            'attachment; filename="bad__X-Injected__yes.zip"',
+        ),
+    ],
+)
+def test_history_download_routes_sanitize_content_disposition_filenames(
+    path: str,
+    failing_attr: str,
+    malicious_filename: str,
+    expected_header: str,
+) -> None:
+    client, _run_service, report_service, export_service = _history_test_client()
+    if failing_attr == "build_pdf":
+        report_service.build_pdf = AsyncMock(
+            return_value=HistoryReportPdf(content=b"%PDF-safe", filename=malicious_filename)
+        )
+    else:
+        export_service.build_export = AsyncMock(
+            return_value=_FakeExportDownload(filename=malicious_filename)
+        )
+
+    response = client.get(path)
+
+    assert response.status_code == 200
+    assert response.headers["content-disposition"] == expected_header
+    assert safe_filename(malicious_filename) in response.headers["content-disposition"]
+    assert "\r" not in response.headers["content-disposition"]
+    assert "\n" not in response.headers["content-disposition"]

--- a/apps/server/tests/adapters/http/test_api_path_identifier_validation.py
+++ b/apps/server/tests/adapters/http/test_api_path_identifier_validation.py
@@ -88,21 +88,24 @@ def _settings_test_client() -> tuple[TestClient, MagicMock]:
     return TestClient(app), settings_store
 
 
+@pytest.mark.parametrize("invalid_run_id", ["bad%20id", "..%5csecret"])
 @pytest.mark.parametrize(
-    ("method", "path"),
+    ("method", "path_template"),
     [
-        ("GET", "/api/history/bad%20id"),
-        ("GET", "/api/history/bad%20id/insights"),
-        ("DELETE", "/api/history/bad%20id"),
-        ("GET", "/api/history/bad%20id/report.pdf"),
-        ("GET", "/api/history/bad%20id/export"),
+        ("GET", "/api/history/{run_id}"),
+        ("GET", "/api/history/{run_id}/insights"),
+        ("DELETE", "/api/history/{run_id}"),
+        ("GET", "/api/history/{run_id}/report.pdf"),
+        ("GET", "/api/history/{run_id}/export"),
     ],
 )
 def test_history_routes_reject_invalid_run_ids_before_reaching_services(
+    invalid_run_id: str,
     method: str,
-    path: str,
+    path_template: str,
 ) -> None:
     client, run_service, report_service, export_service = _history_test_client()
+    path = path_template.format(run_id=invalid_run_id)
 
     response = client.request(method, path)
 

--- a/apps/server/vibesensor/adapters/http/_helpers.py
+++ b/apps/server/vibesensor/adapters/http/_helpers.py
@@ -23,7 +23,7 @@ __all__ = [
 
 type OpenAPIResponses = dict[int | str, dict[str, Any]]
 _CAR_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
-_RUN_ID_RE = re.compile(r"^[!-~]{1,128}$")
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 
 
 def normalize_client_id_or_400(client_id: str) -> str:
@@ -36,7 +36,7 @@ def normalize_client_id_or_400(client_id: str) -> str:
 
 def normalize_run_id_or_400(run_id: str) -> str:
     """Validate a history run identifier or raise HTTP 400."""
-    if _RUN_ID_RE.fullmatch(run_id):
+    if _RUN_ID_RE.fullmatch(run_id) and ".." not in run_id:
         return run_id
     raise HTTPException(status_code=400, detail="Invalid run identifier")
 

--- a/apps/server/vibesensor/adapters/http/error_boundary.py
+++ b/apps/server/vibesensor/adapters/http/error_boundary.py
@@ -28,6 +28,8 @@ __all__ = [
     "route_errors_to_http",
 ]
 
+_UNEXPECTED_ROUTE_ERROR_DETAIL = "Internal Server Error"
+
 
 def http_status_for_operational_error(exc: OperationalError) -> int:
     """Return the HTTP status code for one operational failure."""
@@ -120,3 +122,9 @@ def route_errors_to_http() -> Iterator[None]:
         raise http_exception_for_vibesensor_error(exc) from exc
     except OperationalError as exc:
         raise http_exception_for_operational_error(exc) from exc
+    except HTTPException:
+        raise
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=_UNEXPECTED_ROUTE_ERROR_DETAIL) from exc

--- a/apps/server/vibesensor/adapters/http/history.py
+++ b/apps/server/vibesensor/adapters/http/history.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from vibesensor.adapters.http._helpers import (
     OpenAPIResponses,
     normalize_run_id_or_400,
+    safe_filename,
 )
 from vibesensor.adapters.http.error_boundary import route_errors_to_http
 from vibesensor.adapters.http.models import (
@@ -158,7 +159,7 @@ def create_history_routes(
         with route_errors_to_http():
             pdf = await report_service.build_pdf(run_id, lang)
         pdf_headers = {
-            "Content-Disposition": f'attachment; filename="{pdf.filename}"',
+            "Content-Disposition": f'attachment; filename="{safe_filename(pdf.filename)}"',
         }
         return Response(
             content=pdf.content,
@@ -182,7 +183,7 @@ def create_history_routes(
             content=export.iter_bytes(),
             media_type="application/zip",
             headers={
-                "Content-Disposition": f'attachment; filename="{export.filename}"',
+                "Content-Disposition": f'attachment; filename="{safe_filename(export.filename)}"',
                 "Content-Length": str(export.file_size),
             },
         )


### PR DESCRIPTION
Closes #3148

## What changed
- tighten history `run_id` path validation to safe identifier characters and reject traversal-like `..` segments
- sanitize report/export `Content-Disposition` filenames at the HTTP boundary instead of trusting the service return value
- map unexpected service exceptions inside history routes to sanitized JSON 500 responses
- expand invalid/traversal route coverage across get, insights, delete, report, and export endpoints
- add a focused history route-boundary regression module for sanitized 500s and header safety

## Why
- the audit found real trust-boundary gaps, not just missing tests
- traversal-like IDs such as `..\secret` still reached history services
- malicious service filenames were written straight into download headers
- unexpected service failures came back as plain-text 500s instead of the API JSON error contract

## Validation
- `./.venv/bin/python -m pytest -q apps/server/tests/adapters/http/test_api_path_identifier_validation.py apps/server/tests/adapters/http/test_api_history_route_boundary_guards.py apps/server/tests/adapters/http/test_api_history_export_endpoints.py apps/server/tests/adapters/http/test_api_history_report_endpoints.py apps/server/tests/adapters/http/test_helpers_exception_handling.py apps/server/tests/adapters/http/test_middleware_exception_discipline.py`
- `PATH=/workspace/VibeSensor/.venv/bin:$PATH make lint`
- `make typecheck-backend`

## Risks / tradeoffs
- this intentionally narrows accepted history route IDs to the safe path-identifier character set; odd legacy IDs with spaces, slashes, backslashes, or traversal-like `..` segments will now be rejected at the HTTP boundary
- unexpected route-owned service exceptions now surface as sanitized JSON 500s instead of bubbling out as plain-text framework errors
- filename sanitization now happens twice in the healthy path for exports/reports, once in service code and once at the HTTP boundary; that duplication is deliberate because the route is the final trust boundary for response headers
