### PR TITLE
Fix raw replay clock-domain sync proof gating

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
@@ -11,7 +11,11 @@ from test_support.history_db_lifecycle import (
     create_recording_run,
 )
 
-from vibesensor.shared.types.raw_capture import RawCaptureChunk, RawCaptureLossStats
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunk,
+    RawCaptureLossStats,
+    RawCaptureSensorClockSync,
+)
 
 
 def _append_chunk(
@@ -38,12 +42,14 @@ def _finalize_raw_capture(
     run_id: str,
     *,
     run_start_monotonic_us: int | None = None,
+    sensor_clock_sync: dict[str, RawCaptureSensorClockSync] | None = None,
     sensor_losses: dict[str, RawCaptureLossStats] | None = None,
 ):
     return db.run_repository._run_sync(
         db.run_repository.afinalize_raw_capture(
             run_id,
             run_start_monotonic_us=run_start_monotonic_us,
+            sensor_clock_sync=sensor_clock_sync,
             sensor_losses=sensor_losses,
         )
     )
@@ -84,12 +90,24 @@ def test_raw_capture_round_trip_persists_manifest_and_samples(tmp_path: Path) ->
         db,
         "run-raw",
         run_start_monotonic_us=1_234_567,
+        sensor_clock_sync={
+            "sensor-a": RawCaptureSensorClockSync(
+                clock_domain="server_monotonic",
+                proof_state="verified",
+                observed_monotonic_us=1_300_000,
+                last_sync_monotonic_us=1_299_000,
+                sync_offset_us=5_000,
+                sync_rtt_us=4_000,
+            )
+        },
     )
 
     assert manifest is not None
     assert manifest.total_samples == 3
     assert manifest.run_start_monotonic_us == 1_234_567
     assert manifest.sensor_manifest("sensor-a") is not None
+    assert manifest.sensor_manifest("sensor-a").clock_sync is not None
+    assert manifest.sensor_manifest("sensor-a").clock_sync.verified is True
 
     stored = db.run_repository.get_run("run-raw")
     assert stored is not None
@@ -100,6 +118,8 @@ def test_raw_capture_round_trip_persists_manifest_and_samples(tmp_path: Path) ->
     assert loaded.manifest.run_start_monotonic_us == 1_234_567
     sensor = loaded.sensor_data("sensor-a")
     assert sensor is not None
+    assert sensor.manifest.clock_sync is not None
+    assert sensor.manifest.clock_sync.sync_rtt_us == 4_000
     assert sensor.manifest.chunk_count == 2
     assert sensor.manifest.sample_count == 3
     assert len(sensor.chunks) == 2

--- a/apps/server/tests/adapters/udp/test_udp_control_tx.py
+++ b/apps/server/tests/adapters/udp/test_udp_control_tx.py
@@ -208,6 +208,7 @@ def test_broadcast_sync_clock_rolls_ack_timestamps_into_next_sync_payload(
     assert record is not None
     assert record.sync_offset_us == 5_000
     assert record.sync_rtt_us == 4_000
+    assert record.last_sync_monotonic_us == 1_004_500
 
     current_mono[0] = 2.0
     assert plane.broadcast_sync_clock() == 1

--- a/apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py
+++ b/apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py
@@ -8,6 +8,7 @@ from vibesensor.shared.json_utils import i18n_ref
 from vibesensor.shared.run_context_warning import (
     WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
     WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS,
+    WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED,
     WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK,
 )
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
@@ -211,5 +212,66 @@ def test_prepare_persisted_report_input_surfaces_dropped_raw_chunk_warning() -> 
     ]
     assert any(
         "Raw capture dropped 3 chunk(s) before persistence" in (row.detail or "")
+        for row in document.data_trust
+    )
+
+
+def test_prepare_persisted_report_input_surfaces_sync_unverified_warning() -> None:
+    primary = make_finding_payload(
+        finding_id="F_STALE_SYNC",
+        suspected_source="wheel/tire",
+        confidence=0.75,
+        strongest_location="Front Left",
+        strongest_speed_band="60-80 km/h",
+    )
+    prepared = prepare_persisted_report_input(
+        PersistedAnalysis.from_json_object(
+            minimal_summary(
+                run_id="stale-sync-report",
+                lang="en",
+                metadata={
+                    "run_id": "stale-sync-report",
+                    "record_type": "metadata",
+                    "schema_version": "v2-jsonl",
+                    "feature_interval_s": 0.5,
+                },
+                sensor_count_used=1,
+                sensor_locations=["Front Left"],
+                sensor_locations_connected_throughout=["Front Left"],
+                findings=[primary],
+                top_causes=[primary],
+                analysis_metadata={
+                    "raw_backed_sample_count": 0,
+                    "raw_capture_mode": "summary_only",
+                    "raw_replay_sync_unverified_sensor_count": 1,
+                    "raw_replay_stale_sync_sensor_count": 1,
+                },
+                warnings=[
+                    {
+                        "code": WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED,
+                        "severity": "warn",
+                        "applies_to": "raw_replay",
+                        "title": i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_SYNC_UNVERIFIED_TITLE"),
+                        "detail": i18n_ref(
+                            "RUN_CONTEXT_WARNING_RAW_REPLAY_SYNC_UNVERIFIED_DETAIL",
+                            sensors="1",
+                            missing_sync="0",
+                            stale="1",
+                            high_rtt="0",
+                        ),
+                    }
+                ],
+            )
+        )
+    )
+
+    document = build_report_document(prepared)
+
+    assert WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED in [
+        warning.code for warning in prepared.report_facts.decision.warnings
+    ]
+    assert "summary_only" in prepared.report_facts.confidence.caveat_keys
+    assert any(
+        "could not be proven against the recorder clock" in (row.detail or "")
         for row in document.data_trust
     )

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -17,6 +17,7 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureChunkIndex,
     RawCaptureLossStats,
     RawCaptureManifest,
+    RawCaptureSensorClockSync,
     RawCaptureSensorData,
     RawCaptureSensorLossStats,
     RawCaptureSensorManifest,
@@ -118,6 +119,7 @@ def _gap_raw_capture(run_id: str) -> RawRunCapture:
         bytes_written=int(samples_i16.nbytes),
         first_t0_us=chunk_rows[0].t0_us,
         last_t0_us=chunk_rows[-1].t0_us,
+        clock_sync=_verified_clock_sync(),
     )
     manifest = RawCaptureManifest(
         run_id=run_id,
@@ -144,6 +146,7 @@ def _full_raw_capture(
     run_id: str,
     *,
     losses: RawCaptureLossStats | None = None,
+    clock_sync: RawCaptureSensorClockSync | None = None,
 ) -> RawRunCapture:
     run_start_monotonic_us = 1_000_000
     chunk = _wave(32.0, 160)
@@ -165,6 +168,7 @@ def _full_raw_capture(
         bytes_written=int(chunk.nbytes),
         first_t0_us=chunk_rows[0].t0_us,
         last_t0_us=chunk_rows[-1].t0_us,
+        clock_sync=clock_sync or _verified_clock_sync(),
     )
     manifest = RawCaptureManifest(
         run_id=run_id,
@@ -194,6 +198,19 @@ def _full_raw_capture(
                 chunks=chunk_rows,
             ),
         ),
+    )
+
+
+def _verified_clock_sync() -> RawCaptureSensorClockSync:
+    return RawCaptureSensorClockSync(
+        clock_domain="server_monotonic",
+        proof_state="verified",
+        observed_monotonic_us=1_010_000,
+        last_sync_monotonic_us=1_009_000,
+        sync_offset_us=5_000,
+        sync_rtt_us=4_000,
+        max_sync_age_us=15_000_000,
+        max_sync_rtt_us=50_000,
     )
 
 
@@ -252,6 +269,10 @@ def test_build_post_analysis_summary_adds_analysis_metadata(
         "raw_replay_timing_fallback_count": 0,
         "raw_replay_sample_rate_mismatch_count": 0,
         "raw_replay_unanchored_sensor_count": 0,
+        "raw_replay_legacy_sensor_count": 0,
+        "raw_replay_sync_unverified_sensor_count": 0,
+        "raw_replay_stale_sync_sensor_count": 0,
+        "raw_replay_high_rtt_sensor_count": 0,
         "raw_replay_confidence": "unavailable",
     }
 

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary_raw_replay_sync.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary_raw_replay_sync.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from test_post_analysis_summary import _full_raw_capture
+
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.run_context_warning import (
+    WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
+    WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED,
+)
+from vibesensor.shared.types.raw_capture import RawCaptureSensorClockSync
+from vibesensor.use_cases.run.post_analysis_input import build_post_analysis_input
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
+
+
+def _run_metadata(run_id: str):
+    return run_metadata_from_mapping(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": 800,
+            "sample_rate_hz": 800,
+            "feature_interval_s": 1.0,
+            "fft_window_size_samples": 64,
+            "accel_scale_g_per_lsb": 0.001,
+            "language": "en",
+        }
+    )
+
+
+def test_build_post_analysis_summary_persists_sync_unverified_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRunAnalysis:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def summarize(self):
+            return SimpleNamespace(
+                diagnostic_case=SimpleNamespace(case_id="case-stale-sync"),
+            )
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.diagnostics.run_analysis.RunAnalysis",
+        FakeRunAnalysis,
+    )
+    monkeypatch.setattr(
+        "vibesensor.use_cases.run.post_analysis_summary.analysis_result_to_summary",
+        lambda _result: {"warnings": [], "run_suitability": []},
+    )
+
+    run = build_post_analysis_input(
+        LoadedPostAnalysisRun(
+            run_id="run-stale-sync",
+            metadata=_run_metadata("run-stale-sync"),
+            language="en",
+            samples=sensor_frames_from_mappings(
+                [
+                    {
+                        "client_id": "sensor-a",
+                        "t_s": 0.18,
+                        "sample_rate_hz": 800,
+                        "vibration_strength_db": 12.0,
+                        "dominant_freq_hz": 14.0,
+                    }
+                ]
+            ),
+            raw_capture=_full_raw_capture(
+                "run-stale-sync",
+                clock_sync=RawCaptureSensorClockSync(
+                    clock_domain="unverified",
+                    proof_state="stale_sync",
+                    observed_monotonic_us=2_000_000,
+                    last_sync_monotonic_us=1_000_000,
+                    sync_offset_us=5_000,
+                    sync_rtt_us=4_000,
+                    max_sync_age_us=15_000_000,
+                    max_sync_rtt_us=50_000,
+                ),
+            ),
+            total_sample_count=1,
+            stride=1,
+        )
+    )
+
+    summary = build_post_analysis_summary(run)
+
+    assert summary["analysis_metadata"]["raw_replay_sync_unverified_sensor_count"] == 1
+    assert summary["analysis_metadata"]["raw_replay_stale_sync_sensor_count"] == 1
+    assert [warning["code"] for warning in summary["warnings"]] == [
+        WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED,
+        WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
+    ]

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay.py
@@ -12,6 +12,7 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureChunkIndex,
     RawCaptureLossStats,
     RawCaptureManifest,
+    RawCaptureSensorClockSync,
     RawCaptureSensorData,
     RawCaptureSensorLossStats,
     RawCaptureSensorManifest,
@@ -59,6 +60,14 @@ def _raw_capture(run_id: str) -> RawRunCapture:
         bytes_written=int(samples_i16.nbytes),
         first_t0_us=1,
         last_t0_us=1,
+        clock_sync=RawCaptureSensorClockSync(
+            clock_domain="server_monotonic",
+            proof_state="verified",
+            observed_monotonic_us=1_010_000,
+            last_sync_monotonic_us=1_009_000,
+            sync_offset_us=5_000,
+            sync_rtt_us=4_000,
+        ),
     )
     manifest = RawCaptureManifest(
         run_id=run_id,

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay_alignment.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay_alignment.py
@@ -11,11 +11,13 @@ from vibesensor.shared.fft_analysis import SpectralAnalysisComputer, medfilt3
 from vibesensor.shared.run_context_warning import (
     WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
     WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK,
+    WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED,
     WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK,
 )
 from vibesensor.shared.types.raw_capture import (
     RawCaptureChunkIndex,
     RawCaptureManifest,
+    RawCaptureSensorClockSync,
     RawCaptureSensorData,
     RawCaptureSensorManifest,
     RawRunCapture,
@@ -74,6 +76,7 @@ def _raw_capture(
     *,
     sensors: list[tuple[str, list[tuple[int, np.ndarray]]]],
     run_start_monotonic_us: int | None = _RUN_START_MONOTONIC_US,
+    clock_sync_by_sensor: dict[str, RawCaptureSensorClockSync | None] | None = None,
 ) -> RawRunCapture:
     sensor_rows: list[RawCaptureSensorData] = []
     sensor_manifests: list[RawCaptureSensorManifest] = []
@@ -110,6 +113,9 @@ def _raw_capture(
             bytes_written=int(samples_i16.nbytes),
             first_t0_us=chunks[0][0] if chunks else None,
             last_t0_us=chunks[-1][0] if chunks else None,
+            clock_sync=(_verified_clock_sync() if run_start_monotonic_us is not None else None)
+            if clock_sync_by_sensor is None
+            else clock_sync_by_sensor.get(client_id),
         )
         sensor_rows.append(
             RawCaptureSensorData(
@@ -131,6 +137,19 @@ def _raw_capture(
         run_start_monotonic_us=run_start_monotonic_us,
     )
     return RawRunCapture(manifest=manifest, sensors=tuple(sensor_rows))
+
+
+def _verified_clock_sync() -> RawCaptureSensorClockSync:
+    return RawCaptureSensorClockSync(
+        clock_domain="server_monotonic",
+        proof_state="verified",
+        observed_monotonic_us=1_010_000,
+        last_sync_monotonic_us=1_009_000,
+        sync_offset_us=5_000,
+        sync_rtt_us=4_000,
+        max_sync_age_us=15_000_000,
+        max_sync_rtt_us=50_000,
+    )
 
 
 def _shared_strength_metrics(window_i16: np.ndarray) -> dict[str, object]:
@@ -547,5 +566,68 @@ def test_build_post_analysis_input_falls_back_for_legacy_raw_capture_without_anc
     assert [warning.code for warning in result.raw_replay.warnings] == [
         WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK
     ]
+    assert result.samples[0].vibration_strength_db == 11.0
+    assert result.samples[0].dominant_freq_hz == 13.0
+
+
+def test_build_post_analysis_input_falls_back_when_sync_proof_is_stale() -> None:
+    raw_start_offset_us = 100_000
+    raw_capture = _raw_capture(
+        "run-stale-sync",
+        sensors=[
+            (
+                "sensor-a",
+                [
+                    (
+                        _RUN_START_MONOTONIC_US + raw_start_offset_us,
+                        np.vstack([_wave(36.0, _FFT_N), _wave(80.0, 96)]),
+                    )
+                ],
+            )
+        ],
+        clock_sync_by_sensor={
+            "sensor-a": RawCaptureSensorClockSync(
+                clock_domain="unverified",
+                proof_state="stale_sync",
+                observed_monotonic_us=2_000_000,
+                last_sync_monotonic_us=1_000_000,
+                sync_offset_us=5_000,
+                sync_rtt_us=4_000,
+                max_sync_age_us=15_000_000,
+                max_sync_rtt_us=50_000,
+            )
+        },
+    )
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-stale-sync",
+        metadata=_metadata("run-stale-sync"),
+        language="en",
+        samples=sensor_frames_from_mappings(
+            [
+                {
+                    "client_id": "sensor-a",
+                    "t_s": _sample_t_s(raw_start_offset_us=raw_start_offset_us, sample_end=_FFT_N),
+                    "sample_rate_hz": _SAMPLE_RATE_HZ,
+                    "vibration_strength_db": 11.0,
+                    "dominant_freq_hz": 13.0,
+                }
+            ]
+        ),
+        raw_capture=raw_capture,
+        total_sample_count=1,
+        stride=1,
+    )
+
+    result = build_post_analysis_input(loaded)
+
+    assert result.raw_backed_sample_count == 0
+    assert result.raw_replay.raw_capture_mode == "summary_only"
+    assert result.raw_replay.sync_unverified_sensor_count == 1
+    assert result.raw_replay.stale_sync_sensor_count == 1
+    assert [warning.code for warning in result.raw_replay.warnings] == [
+        WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED,
+        WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
+    ]
+    assert result.raw_replay_window_coverages[0].reason == "clock_sync_stale_sync"
     assert result.samples[0].vibration_strength_db == 11.0
     assert result.samples[0].dominant_freq_hz == 13.0

--- a/apps/server/tests/use_cases/run/test_raw_capture_writer.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_writer.py
@@ -7,6 +7,7 @@ import threading
 import numpy as np
 import pytest
 
+from vibesensor.shared.types.raw_capture import RawCaptureSensorClockSync
 from vibesensor.use_cases.run.raw_capture_writer import RunRawCaptureWriter
 
 
@@ -37,14 +38,39 @@ def test_raw_capture_writer_persists_queue_invalid_and_write_failures(
             _run_id: str,
             *,
             run_start_monotonic_us: int | None = None,
+            sensor_clock_sync=None,
             sensor_losses=None,
         ):
             assert run_start_monotonic_us == 1234
+            assert sensor_clock_sync == {
+                "sensor-a": RawCaptureSensorClockSync(
+                    clock_domain="server_monotonic",
+                    proof_state="verified",
+                ),
+                "sensor-b": RawCaptureSensorClockSync(
+                    clock_domain="unverified",
+                    proof_state="missing_sync",
+                ),
+                "sensor-c": RawCaptureSensorClockSync(
+                    clock_domain="unverified",
+                    proof_state="missing_sync",
+                ),
+            }
             self.finalized_sensor_losses = sensor_losses
             return None
 
     history_db = FakeHistoryDb()
-    writer = RunRawCaptureWriter(history_db=history_db, logger=logging.getLogger(__name__))
+    writer = RunRawCaptureWriter(
+        history_db=history_db,
+        logger=logging.getLogger(__name__),
+        sensor_sync_snapshotter=lambda client_ids: {
+            client_id: RawCaptureSensorClockSync(
+                clock_domain="server_monotonic" if client_id == "sensor-a" else "unverified",
+                proof_state="verified" if client_id == "sensor-a" else "missing_sync",
+            )
+            for client_id in client_ids
+        },
+    )
     writer.start_run("run-losses", run_start_monotonic_us=1234)
 
     writer.capture_raw_samples(

--- a/apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py
@@ -20,6 +20,7 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureCoverageState,
     RawCaptureLossStats,
     RawCaptureManifest,
+    RawCaptureSensorClockSync,
     RawCaptureSensorData,
     RawCaptureSensorLossStats,
     RawCaptureSensorManifest,
@@ -92,6 +93,7 @@ class HistoryRawCaptureStore:
         run_id: str,
         *,
         run_start_monotonic_us: int | None = None,
+        sensor_clock_sync: Mapping[str, RawCaptureSensorClockSync] | None = None,
         sensor_losses: Mapping[str, RawCaptureLossStats] | None = None,
     ) -> RawCaptureManifest | None:
         with self._lock:
@@ -118,6 +120,7 @@ class HistoryRawCaptureStore:
                 bytes_written=stream.bytes_written,
                 first_t0_us=stream.first_t0_us,
                 last_t0_us=stream.last_t0_us,
+                clock_sync=(sensor_clock_sync or {}).get(client_id),
             )
             sensor_manifests.append(sensor_manifest)
             total_samples += sensor_manifest.sample_count

--- a/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_run_lifecycle.py
@@ -30,6 +30,7 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureChunk,
     RawCaptureLossStats,
     RawCaptureManifest,
+    RawCaptureSensorClockSync,
 )
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
@@ -160,6 +161,7 @@ class _HistoryDBRunLifecycleMixin:
         run_id: str,
         *,
         run_start_monotonic_us: int | None = None,
+        sensor_clock_sync: Mapping[str, RawCaptureSensorClockSync] | None = None,
         sensor_losses: Mapping[str, RawCaptureLossStats] | None = None,
     ) -> RawCaptureManifest | None:
         manifest = cast(
@@ -168,6 +170,7 @@ class _HistoryDBRunLifecycleMixin:
                 self._raw_capture_store.finalize_run,
                 run_id,
                 run_start_monotonic_us=run_start_monotonic_us,
+                sensor_clock_sync=sensor_clock_sync,
                 sensor_losses=sensor_losses,
             ),
         )

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1719,6 +1719,14 @@
     "en": "Raw capture timing metadata was unavailable for this run, so replay used persisted summary samples instead of guessing raw alignment.",
     "nl": "Raw-capturetimingmetadata was niet beschikbaar voor deze run, dus replay gebruikte persistente samenvattingssamples in plaats van raw-uitlijning te raden."
   },
+  "RUN_CONTEXT_WARNING_RAW_REPLAY_SYNC_UNVERIFIED_TITLE": {
+    "en": "Raw replay could not prove clock alignment for some sensors",
+    "nl": "Raw replay kon voor sommige sensoren de klokuitlijning niet bewijzen"
+  },
+  "RUN_CONTEXT_WARNING_RAW_REPLAY_SYNC_UNVERIFIED_DETAIL": {
+    "en": "Raw capture timing could not be proven against the recorder clock for {sensors} sensor(s), so affected metrics used persisted summary samples. Missing sync proof: {missing_sync}, stale sync snapshots: {stale}, high-RTT sync snapshots: {high_rtt}.",
+    "nl": "Raw-capturetiming kon voor {sensors} sensor(en) niet tegen de recorderklok worden bewezen, dus getroffen metrieken gebruikten persistente samenvattingssamples. Ontbrekend sync-bewijs: {missing_sync}, verouderde sync-snapshots: {stale}, sync-snapshots met hoge RTT: {high_rtt}."
+  },
   "WORKSHOP_SUMMARY": {
     "en": "Workshop Summary",
     "nl": "Werkplaatsoverzicht"

--- a/apps/server/vibesensor/infra/runtime/registry.py
+++ b/apps/server/vibesensor/infra/runtime/registry.py
@@ -84,6 +84,7 @@ class ClientRecord:
     pending_sync_send_us: int | None = None
     sync_offset_us: int | None = None
     sync_rtt_us: int | None = None
+    last_sync_monotonic_us: int | None = None
     reset_count: int = 0
     last_reset_time: float | None = None
     last_t0_us: int | None = None
@@ -117,6 +118,7 @@ class ClientRecordSnapshot:
     last_ack_status: int | None = None
     sync_offset_us: int | None = None
     sync_rtt_us: int | None = None
+    last_sync_monotonic_us: int | None = None
     reset_count: int = 0
     last_reset_time: float | None = None
     last_t0_us: int | None = None
@@ -147,6 +149,7 @@ def _snapshot_record(record: ClientRecord) -> ClientRecordSnapshot:
         last_ack_status=record.last_ack_status,
         sync_offset_us=record.sync_offset_us,
         sync_rtt_us=record.sync_rtt_us,
+        last_sync_monotonic_us=record.last_sync_monotonic_us,
         reset_count=record.reset_count,
         last_reset_time=record.last_reset_time,
         last_t0_us=record.last_t0_us,
@@ -304,6 +307,7 @@ class ClientRegistry:
                         + (server_receive_us - ack.device_send_us)
                     ) // 2
                     record.sync_rtt_us = round_trip_us
+                    record.last_sync_monotonic_us = server_receive_us
                 record.pending_sync_cmd_seq = None
                 record.pending_sync_send_us = None
 

--- a/apps/server/vibesensor/shared/ports.py
+++ b/apps/server/vibesensor/shared/ports.py
@@ -19,6 +19,7 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureChunk,
     RawCaptureLossStats,
     RawCaptureManifest,
+    RawCaptureSensorClockSync,
     RawCaptureSensorRange,
     RawRunCapture,
 )
@@ -120,6 +121,7 @@ class RunPersistence(Protocol):
         run_id: str,
         *,
         run_start_monotonic_us: int | None = None,
+        sensor_clock_sync: Mapping[str, RawCaptureSensorClockSync] | None = None,
         sensor_losses: Mapping[str, RawCaptureLossStats] | None = None,
     ) -> RawCaptureManifest | None: ...
 

--- a/apps/server/vibesensor/shared/run_context_warning.py
+++ b/apps/server/vibesensor/shared/run_context_warning.py
@@ -17,6 +17,7 @@ WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE = "raw_replay_coverage_incomplete"
 WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK = "raw_replay_legacy_fallback"
 WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS = "raw_replay_dropped_chunks"
 WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK = "raw_replay_timing_fallback"
+WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED = "raw_replay_sync_unverified"
 WarningSeverity = Literal["warn", "error"]
 
 

--- a/apps/server/vibesensor/shared/types/raw_capture.py
+++ b/apps/server/vibesensor/shared/types/raw_capture.py
@@ -13,8 +13,10 @@ from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_ob
 __all__ = [
     "RawCaptureChunk",
     "RawCaptureChunkIndex",
+    "RawCaptureClockDomain",
     "RawCaptureLossStats",
     "RawCaptureManifest",
+    "RawCaptureSensorClockSync",
     "RawCaptureSensorLossStats",
     "RawCaptureSensorData",
     "RawCaptureSensorManifest",
@@ -24,8 +26,16 @@ __all__ = [
 
 type Int16Array = npt.NDArray[np.int16]
 type RawCaptureCoverageState = Literal["missing", "empty", "partial", "full"]
+type RawCaptureClockDomain = Literal["server_monotonic", "unverified"]
+type RawCaptureClockProofState = Literal[
+    "verified",
+    "missing_sync",
+    "stale_sync",
+    "high_rtt",
+    "missing_registry_record",
+]
 
-_RAW_CAPTURE_SCHEMA_VERSION = 3
+_RAW_CAPTURE_SCHEMA_VERSION = 4
 _RAW_CAPTURE_STORAGE_TYPE = "run-directory-v1"
 _RAW_CAPTURE_MODE = "full_run"
 
@@ -141,6 +151,62 @@ class RawCaptureSensorLossStats:
 
 
 @dataclass(frozen=True, slots=True)
+class RawCaptureSensorClockSync:
+    """Persisted proof about whether one sensor's ``t0_us`` uses server monotonic time."""
+
+    clock_domain: RawCaptureClockDomain = "unverified"
+    proof_state: RawCaptureClockProofState = "missing_sync"
+    observed_monotonic_us: int | None = None
+    last_sync_monotonic_us: int | None = None
+    sync_offset_us: int | None = None
+    sync_rtt_us: int | None = None
+    max_sync_age_us: int | None = None
+    max_sync_rtt_us: int | None = None
+
+    @property
+    def verified(self) -> bool:
+        return self.clock_domain == "server_monotonic" and self.proof_state == "verified"
+
+    @property
+    def sync_age_us(self) -> int | None:
+        if self.observed_monotonic_us is None or self.last_sync_monotonic_us is None:
+            return None
+        return max(0, self.observed_monotonic_us - self.last_sync_monotonic_us)
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "clock_domain": self.clock_domain,
+            "proof_state": self.proof_state,
+        }
+        if self.observed_monotonic_us is not None:
+            payload["observed_monotonic_us"] = self.observed_monotonic_us
+        if self.last_sync_monotonic_us is not None:
+            payload["last_sync_monotonic_us"] = self.last_sync_monotonic_us
+        if self.sync_offset_us is not None:
+            payload["sync_offset_us"] = self.sync_offset_us
+        if self.sync_rtt_us is not None:
+            payload["sync_rtt_us"] = self.sync_rtt_us
+        if self.max_sync_age_us is not None:
+            payload["max_sync_age_us"] = self.max_sync_age_us
+        if self.max_sync_rtt_us is not None:
+            payload["max_sync_rtt_us"] = self.max_sync_rtt_us
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> RawCaptureSensorClockSync:
+        return cls(
+            clock_domain=_str_from_json(data.get("clock_domain"), "unverified"),  # type: ignore[arg-type]
+            proof_state=_str_from_json(data.get("proof_state"), "missing_sync"),  # type: ignore[arg-type]
+            observed_monotonic_us=_int_or_none(data.get("observed_monotonic_us")),
+            last_sync_monotonic_us=_int_or_none(data.get("last_sync_monotonic_us")),
+            sync_offset_us=_int_or_none(data.get("sync_offset_us")),
+            sync_rtt_us=_int_or_none(data.get("sync_rtt_us")),
+            max_sync_age_us=_int_or_none(data.get("max_sync_age_us")),
+            max_sync_rtt_us=_int_or_none(data.get("max_sync_rtt_us")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class RawCaptureSensorManifest:
     """One sensor stream persisted inside a raw run-artifact bundle."""
 
@@ -153,6 +219,7 @@ class RawCaptureSensorManifest:
     bytes_written: int
     first_t0_us: int | None = None
     last_t0_us: int | None = None
+    clock_sync: RawCaptureSensorClockSync | None = None
 
     def to_json_object(self) -> JsonObject:
         payload: JsonObject = {
@@ -168,6 +235,8 @@ class RawCaptureSensorManifest:
             payload["first_t0_us"] = self.first_t0_us
         if self.last_t0_us is not None:
             payload["last_t0_us"] = self.last_t0_us
+        if self.clock_sync is not None:
+            payload["clock_sync"] = self.clock_sync.to_json_object()
         return payload
 
     @classmethod
@@ -182,6 +251,11 @@ class RawCaptureSensorManifest:
             bytes_written=_int_from_json(data.get("bytes_written")),
             first_t0_us=_int_or_none(data.get("first_t0_us")),
             last_t0_us=_int_or_none(data.get("last_t0_us")),
+            clock_sync=(
+                RawCaptureSensorClockSync.from_mapping(clock_sync_raw)
+                if is_json_object(clock_sync_raw := data.get("clock_sync"))
+                else None
+            ),
         )
 
 

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -23,6 +23,7 @@ from vibesensor.shared.ports import (
 from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.tracing import mark_span_error, start_span
+from vibesensor.shared.types.raw_capture import RawCaptureClockProofState, RawCaptureSensorClockSync
 from vibesensor.use_cases.run.capture_readiness import CaptureReadinessTracker
 from vibesensor.use_cases.run.capture_readiness_observation import observe_capture_readiness
 from vibesensor.use_cases.run.lifecycle_state import RunLifecycleState
@@ -53,6 +54,8 @@ if TYPE_CHECKING:
     from vibesensor.use_cases.run.lifecycle_state import ActiveRunSnapshot
 
 LOGGER = logging.getLogger(__name__)
+_RAW_CAPTURE_MAX_SYNC_AGE_US = 15_000_000
+_RAW_CAPTURE_MAX_SYNC_RTT_US = 50_000
 
 __all__ = [
     "RunRecorder",
@@ -126,6 +129,10 @@ class RunRecorder:
         self._raw_capture = RunRawCaptureWriter(
             history_db=history_db if config.persist_history_db else None,
             logger=LOGGER,
+            sensor_sync_snapshotter=lambda client_ids: _snapshot_raw_capture_sensor_sync(
+                self.registry,
+                client_ids,
+            ),
         )
 
         self._sample_flush = SampleFlushOrchestrator(
@@ -500,3 +507,65 @@ class RunRecorder:
 
     async def run(self) -> None:
         await _recorder_runtime.run_loop(self, logger=LOGGER)
+
+
+def _snapshot_raw_capture_sensor_sync(
+    registry: ClientTracker,
+    client_ids: tuple[str, ...],
+) -> dict[str, RawCaptureSensorClockSync]:
+    observed_monotonic_us = int(round(time.monotonic() * 1_000_000.0))
+    snapshot: dict[str, RawCaptureSensorClockSync] = {}
+    for client_id in client_ids:
+        record = registry.get(client_id)
+        if record is None:
+            snapshot[client_id] = RawCaptureSensorClockSync(
+                clock_domain="unverified",
+                proof_state="missing_registry_record",
+                observed_monotonic_us=observed_monotonic_us,
+                max_sync_age_us=_RAW_CAPTURE_MAX_SYNC_AGE_US,
+                max_sync_rtt_us=_RAW_CAPTURE_MAX_SYNC_RTT_US,
+            )
+            continue
+        sync_offset_us = _int_attr(record, "sync_offset_us")
+        sync_rtt_us = _int_attr(record, "sync_rtt_us")
+        last_sync_monotonic_us = _int_attr(record, "last_sync_monotonic_us")
+        proof_state = _raw_capture_clock_proof_state(
+            observed_monotonic_us=observed_monotonic_us,
+            last_sync_monotonic_us=last_sync_monotonic_us,
+            sync_offset_us=sync_offset_us,
+            sync_rtt_us=sync_rtt_us,
+        )
+        snapshot[client_id] = RawCaptureSensorClockSync(
+            clock_domain="server_monotonic" if proof_state == "verified" else "unverified",
+            proof_state=proof_state,
+            observed_monotonic_us=observed_monotonic_us,
+            last_sync_monotonic_us=last_sync_monotonic_us,
+            sync_offset_us=sync_offset_us,
+            sync_rtt_us=sync_rtt_us,
+            max_sync_age_us=_RAW_CAPTURE_MAX_SYNC_AGE_US,
+            max_sync_rtt_us=_RAW_CAPTURE_MAX_SYNC_RTT_US,
+        )
+    return snapshot
+
+
+def _raw_capture_clock_proof_state(
+    *,
+    observed_monotonic_us: int,
+    last_sync_monotonic_us: int | None,
+    sync_offset_us: int | None,
+    sync_rtt_us: int | None,
+) -> RawCaptureClockProofState:
+    if sync_offset_us is None or sync_rtt_us is None or last_sync_monotonic_us is None:
+        return "missing_sync"
+    if observed_monotonic_us < last_sync_monotonic_us:
+        return "stale_sync"
+    if (observed_monotonic_us - last_sync_monotonic_us) > _RAW_CAPTURE_MAX_SYNC_AGE_US:
+        return "stale_sync"
+    if sync_rtt_us > _RAW_CAPTURE_MAX_SYNC_RTT_US:
+        return "high_rtt"
+    return "verified"
+
+
+def _int_attr(value: object, name: str) -> int | None:
+    raw_value = getattr(value, name, None)
+    return int(raw_value) if isinstance(raw_value, int) else None

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -82,6 +82,10 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         "raw_replay_timing_fallback_count": run.raw_replay.timing_fallback_count,
         "raw_replay_sample_rate_mismatch_count": run.raw_replay.sample_rate_mismatch_count,
         "raw_replay_unanchored_sensor_count": run.raw_replay.unanchored_sensor_count,
+        "raw_replay_legacy_sensor_count": run.raw_replay.legacy_sensor_count,
+        "raw_replay_sync_unverified_sensor_count": run.raw_replay.sync_unverified_sensor_count,
+        "raw_replay_stale_sync_sensor_count": run.raw_replay.stale_sync_sensor_count,
+        "raw_replay_high_rtt_sensor_count": run.raw_replay.high_rtt_sensor_count,
         "raw_replay_confidence": run.raw_replay.replay_confidence,
     }
     summary_payload["analysis_metadata"] = payload_object_from_json(analysis_metadata)

--- a/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
@@ -17,10 +17,15 @@ from vibesensor.shared.run_context_warning import (
     WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
     WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS,
     WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK,
+    WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED,
     WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK,
     RunContextWarning,
 )
-from vibesensor.shared.types.raw_capture import RawCaptureSensorData, RawRunCapture
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureSensorClockSync,
+    RawCaptureSensorData,
+    RawRunCapture,
+)
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 
@@ -66,6 +71,10 @@ class RawReplaySummary:
     timing_fallback_count: int
     sample_rate_mismatch_count: int
     unanchored_sensor_count: int
+    legacy_sensor_count: int
+    sync_unverified_sensor_count: int
+    stale_sync_sensor_count: int
+    high_rtt_sensor_count: int
     replay_confidence: RawReplayConfidence
     raw_capture_mode: str
     warnings: tuple[RunContextWarning, ...] = ()
@@ -106,6 +115,8 @@ class _SensorTimeline:
     overlap_intervals: tuple[_TimelineInterval, ...]
     run_start_monotonic_us: int | None
     anchored: bool
+    anchor_reason: str | None
+    clock_sync: RawCaptureSensorClockSync | None = None
 
     @property
     def timing_tolerance_us(self) -> float:
@@ -153,6 +164,10 @@ def build_raw_backed_samples(
                 timing_fallback_count=0,
                 sample_rate_mismatch_count=0,
                 unanchored_sensor_count=0,
+                legacy_sensor_count=0,
+                sync_unverified_sensor_count=0,
+                stale_sync_sensor_count=0,
+                high_rtt_sensor_count=0,
                 replay_confidence="unavailable",
                 raw_capture_mode="summary_only",
             ),
@@ -187,6 +202,10 @@ def build_raw_backed_samples(
                 timing_fallback_count=0,
                 sample_rate_mismatch_count=0,
                 unanchored_sensor_count=0,
+                legacy_sensor_count=0,
+                sync_unverified_sensor_count=0,
+                stale_sync_sensor_count=0,
+                high_rtt_sensor_count=0,
                 replay_confidence="fallback",
                 raw_capture_mode="summary_only",
             ),
@@ -243,6 +262,20 @@ def build_raw_backed_samples(
     gap_count = sum(len(timeline.gap_intervals) for timeline in timelines.values())
     overlap_count = sum(len(timeline.overlap_intervals) for timeline in timelines.values())
     unanchored_sensor_count = sum(1 for timeline in timelines.values() if not timeline.anchored)
+    legacy_sensor_count = sum(1 for timeline in timelines.values() if _timeline_is_legacy(timeline))
+    sync_unverified_sensor_count = sum(
+        1 for timeline in timelines.values() if _timeline_has_unverified_sync(timeline)
+    )
+    stale_sync_sensor_count = sum(
+        1
+        for timeline in timelines.values()
+        if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "stale_sync"
+    )
+    high_rtt_sensor_count = sum(
+        1
+        for timeline in timelines.values()
+        if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "high_rtt"
+    )
     dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
     queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
     invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
@@ -257,6 +290,7 @@ def build_raw_backed_samples(
         dropped_chunk_count=dropped_chunk_count,
         sample_rate_mismatch_count=sample_rate_mismatch_count,
         unanchored_sensor_count=unanchored_sensor_count,
+        sync_unverified_sensor_count=sync_unverified_sensor_count,
     )
     raw_capture_mode = (
         "summary_only"
@@ -281,6 +315,10 @@ def build_raw_backed_samples(
             timing_fallback_count=timing_fallback_count,
             sample_rate_mismatch_count=sample_rate_mismatch_count,
             unanchored_sensor_count=unanchored_sensor_count,
+            legacy_sensor_count=legacy_sensor_count,
+            sync_unverified_sensor_count=sync_unverified_sensor_count,
+            stale_sync_sensor_count=stale_sync_sensor_count,
+            high_rtt_sensor_count=high_rtt_sensor_count,
             replay_confidence=replay_confidence,
             raw_capture_mode=raw_capture_mode,
             warnings=_build_replay_warnings(
@@ -295,7 +333,11 @@ def build_raw_backed_samples(
                 invalid_chunk_count=invalid_chunk_count,
                 write_error_chunk_count=write_error_chunk_count,
                 sample_rate_mismatch_count=sample_rate_mismatch_count,
+                legacy_sensor_count=legacy_sensor_count,
                 unanchored_sensor_count=unanchored_sensor_count,
+                sync_unverified_sensor_count=sync_unverified_sensor_count,
+                stale_sync_sensor_count=stale_sync_sensor_count,
+                high_rtt_sensor_count=high_rtt_sensor_count,
             ),
         ),
         window_coverages=tuple(coverages),
@@ -437,6 +479,7 @@ def _build_sensor_timeline(raw_capture: RawRunCapture, *, sensor_id: str) -> _Se
             overlap_intervals=(),
             run_start_monotonic_us=None,
             anchored=False,
+            anchor_reason="sensor_missing",
         )
     sample_rate_hz = int(sensor_data.manifest.sample_rate_hz or 0)
     sample_period_us = 1_000_000.0 / float(sample_rate_hz) if sample_rate_hz > 0 else 0.0
@@ -460,6 +503,8 @@ def _build_sensor_timeline(raw_capture: RawRunCapture, *, sensor_id: str) -> _Se
             overlap_intervals=(),
             run_start_monotonic_us=raw_capture.manifest.run_start_monotonic_us,
             anchored=False,
+            anchor_reason="raw_chunks_missing",
+            clock_sync=sensor_data.manifest.clock_sync,
         )
     gap_intervals: list[_TimelineInterval] = []
     overlap_intervals: list[_TimelineInterval] = []
@@ -488,7 +533,16 @@ def _build_sensor_timeline(raw_capture: RawRunCapture, *, sensor_id: str) -> _Se
         gap_intervals=tuple(gap_intervals),
         overlap_intervals=tuple(overlap_intervals),
         run_start_monotonic_us=raw_capture.manifest.run_start_monotonic_us,
-        anchored=raw_capture.manifest.run_start_monotonic_us is not None,
+        anchored=(
+            raw_capture.manifest.run_start_monotonic_us is not None
+            and sensor_data.manifest.clock_sync is not None
+            and sensor_data.manifest.clock_sync.verified
+        ),
+        anchor_reason=_anchor_reason(
+            run_start_monotonic_us=raw_capture.manifest.run_start_monotonic_us,
+            clock_sync=sensor_data.manifest.clock_sync,
+        ),
+        clock_sync=sensor_data.manifest.clock_sync,
     )
 
 
@@ -499,7 +553,10 @@ def _resolve_window(
     fft_n: int,
 ) -> _ResolvedWindow:
     if not timeline.anchored:
-        return _ResolvedWindow(coverage_state="missing", reason="legacy_anchor_missing")
+        return _ResolvedWindow(
+            coverage_state="missing",
+            reason=timeline.anchor_reason or "legacy_anchor_missing",
+        )
     if not timeline.chunks or timeline.sample_period_us <= 0:
         return _ResolvedWindow(coverage_state="missing", reason="raw_chunks_missing")
     requested_end_us, timing_source = _requested_end_us(timeline=timeline, sample=sample)
@@ -650,6 +707,7 @@ def _replay_confidence(
     overlap_count: int,
     dropped_chunk_count: int,
     sample_rate_mismatch_count: int,
+    sync_unverified_sensor_count: int,
     unanchored_sensor_count: int,
 ) -> RawReplayConfidence:
     if replay_window_count <= 0:
@@ -664,6 +722,7 @@ def _replay_confidence(
         and overlap_count <= 0
         and dropped_chunk_count <= 0
         and sample_rate_mismatch_count <= 0
+        and sync_unverified_sensor_count <= 0
         and unanchored_sensor_count <= 0
     ):
         return "full"
@@ -683,9 +742,13 @@ def _build_replay_warnings(
     invalid_chunk_count: int,
     write_error_chunk_count: int,
     sample_rate_mismatch_count: int,
+    legacy_sensor_count: int,
     unanchored_sensor_count: int,
+    sync_unverified_sensor_count: int,
+    stale_sync_sensor_count: int,
+    high_rtt_sensor_count: int,
 ) -> tuple[RunContextWarning, ...]:
-    if unanchored_sensor_count > 0 and raw_backed_sample_count <= 0:
+    if legacy_sensor_count > 0 and raw_backed_sample_count <= 0:
         return (
             RunContextWarning(
                 code=WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK,
@@ -696,6 +759,38 @@ def _build_replay_warnings(
             ),
         )
     warnings: list[RunContextWarning] = []
+    if legacy_sensor_count > 0:
+        warnings.append(
+            RunContextWarning(
+                code=WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK,
+                severity="warn",
+                applies_to="raw_replay",
+                title=i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_LEGACY_TITLE"),
+                detail=i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_LEGACY_DETAIL"),
+            )
+        )
+    if sync_unverified_sensor_count > 0:
+        missing_sync_sensor_count = max(
+            0,
+            sync_unverified_sensor_count
+            - max(0, stale_sync_sensor_count)
+            - max(0, high_rtt_sensor_count),
+        )
+        warnings.append(
+            RunContextWarning(
+                code=WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED,
+                severity="warn",
+                applies_to="raw_replay",
+                title=i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_SYNC_UNVERIFIED_TITLE"),
+                detail=i18n_ref(
+                    "RUN_CONTEXT_WARNING_RAW_REPLAY_SYNC_UNVERIFIED_DETAIL",
+                    sensors=str(max(0, sync_unverified_sensor_count)),
+                    missing_sync=str(missing_sync_sensor_count),
+                    stale=str(max(0, stale_sync_sensor_count)),
+                    high_rtt=str(max(0, high_rtt_sensor_count)),
+                ),
+            )
+        )
     if timing_fallback_count > 0:
         warnings.append(
             RunContextWarning(
@@ -750,6 +845,30 @@ def _build_replay_warnings(
         )
     )
     return tuple(warnings)
+
+
+def _anchor_reason(
+    *,
+    run_start_monotonic_us: int | None,
+    clock_sync: RawCaptureSensorClockSync | None,
+) -> str:
+    if run_start_monotonic_us is None or clock_sync is None:
+        return "legacy_anchor_missing"
+    if clock_sync.proof_state == "verified":
+        return "anchor_verified"
+    return f"clock_sync_{clock_sync.proof_state}"
+
+
+def _timeline_is_legacy(timeline: _SensorTimeline) -> bool:
+    return timeline.run_start_monotonic_us is None or timeline.clock_sync is None
+
+
+def _timeline_has_unverified_sync(timeline: _SensorTimeline) -> bool:
+    return (
+        timeline.clock_sync is not None
+        and not timeline.clock_sync.verified
+        and timeline.run_start_monotonic_us is not None
+    )
 
 
 def _compute_strength_metrics(

--- a/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import queue
 import threading
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -15,6 +16,7 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureChunk,
     RawCaptureLossStats,
     RawCaptureManifest,
+    RawCaptureSensorClockSync,
 )
 
 __all__ = ["RunRawCaptureWriter"]
@@ -35,6 +37,7 @@ def _sync_call(db: Any, coro: Any) -> object:
 class _FinalizeRequest:
     run_id: str
     run_start_monotonic_us: int | None = None
+    sensor_clock_sync: Mapping[str, RawCaptureSensorClockSync] | None = None
     sensor_losses: _RunCaptureStats | None = None
     done: threading.Event = field(default_factory=threading.Event)
     manifest: RawCaptureManifest | None = None
@@ -63,18 +66,25 @@ class _MutableLossStats:
 @dataclass(slots=True)
 class _RunCaptureStats:
     by_client: dict[str, _MutableLossStats] = field(default_factory=dict)
+    seen_client_ids: set[str] = field(default_factory=set)
 
     def _sensor(self, client_id: str) -> _MutableLossStats:
         return self.by_client.setdefault(client_id, _MutableLossStats())
 
     def record_queue_overflow(self, client_id: str) -> None:
+        self.seen_client_ids.add(client_id)
         self._sensor(client_id).queue_overflow_chunk_count += 1
 
     def record_invalid_chunk(self, client_id: str) -> None:
+        self.seen_client_ids.add(client_id)
         self._sensor(client_id).invalid_chunk_count += 1
 
     def record_write_error(self, client_id: str) -> None:
+        self.seen_client_ids.add(client_id)
         self._sensor(client_id).write_error_chunk_count += 1
+
+    def record_seen(self, client_id: str) -> None:
+        self.seen_client_ids.add(client_id)
 
     def freeze(self) -> dict[str, RawCaptureLossStats]:
         frozen: dict[str, RawCaptureLossStats] = {}
@@ -96,6 +106,7 @@ class RunRawCaptureWriter:
         "_logger",
         "_queue",
         "_run_stats",
+        "_sensor_sync_snapshotter",
         "_thread",
         "_run_start_monotonic_us",
     )
@@ -105,6 +116,9 @@ class RunRawCaptureWriter:
         *,
         history_db: RunPersistence | None,
         logger: logging.Logger,
+        sensor_sync_snapshotter: (
+            Callable[[tuple[str, ...]], Mapping[str, RawCaptureSensorClockSync] | None] | None
+        ) = None,
     ) -> None:
         self._history_db = (
             history_db
@@ -115,6 +129,7 @@ class RunRawCaptureWriter:
         )
         self._logger = logger
         self._lock = threading.RLock()
+        self._sensor_sync_snapshotter = sensor_sync_snapshotter
         self._queue: queue.Queue[
             tuple[str, RawCaptureChunk, _RunCaptureStats | None]
             | _FinalizeRequest
@@ -164,6 +179,8 @@ class RunRawCaptureWriter:
             if run_stats is not None:
                 run_stats.record_invalid_chunk(client_id)
             return
+        if run_stats is not None:
+            run_stats.record_seen(client_id)
         try:
             self._queue.put_nowait(
                 (
@@ -197,9 +214,19 @@ class RunRawCaptureWriter:
             self._run_start_monotonic_us = None
             run_stats = self._run_stats
             self._run_stats = None
+        sensor_clock_sync = None
+        if (
+            self._sensor_sync_snapshotter is not None
+            and run_stats is not None
+            and run_stats.seen_client_ids
+        ):
+            sensor_clock_sync = self._sensor_sync_snapshotter(
+                tuple(sorted(run_stats.seen_client_ids)),
+            )
         request = _FinalizeRequest(
             run_id=run_id,
             run_start_monotonic_us=run_start_monotonic_us,
+            sensor_clock_sync=sensor_clock_sync,
             sensor_losses=run_stats,
         )
         self._queue.put(request)
@@ -237,6 +264,7 @@ class RunRawCaptureWriter:
                                 history_db.afinalize_raw_capture(
                                     item.run_id,
                                     run_start_monotonic_us=item.run_start_monotonic_us,
+                                    sensor_clock_sync=item.sensor_clock_sync,
                                     sensor_losses=(
                                         item.sensor_losses.freeze()
                                         if item.sensor_losses is not None

--- a/docs/time_alignment.md
+++ b/docs/time_alignment.md
@@ -101,14 +101,22 @@ here.
 
 Post-stop raw replay now uses the persisted raw chunk timeline instead
 of assuming that summary-sample `t_s` starts at raw sample index zero.
-New raw-capture manifests store `run_start_monotonic_us`, and replay
-anchors each summary sample into the same monotonic time domain as the
-chunk `t0_us` timestamps before resolving the matching raw window.
+Raw-capture manifests store the run anchor plus **per-sensor clock-sync
+proof** captured at finalize time:
 
-If a persisted run predates that anchor, or if replay detects gaps,
-overlaps, or other incomplete coverage inside a requested window, the
-system falls back to the persisted summary sample for that window and
-stores a deterministic warning instead of guessing.
+- whether the sensor `t0_us` was proven to be in the server monotonic
+  clock domain,
+- the last successful sync-ack monotonic timestamp,
+- the applied offset and measured RTT,
+- the proof status (`verified`, `stale_sync`, `high_rtt`,
+  `missing_sync`, or `missing_registry_record`).
+
+Replay only treats `t0_us` as server-monotonic when that proof is
+explicitly `verified`. Older artifacts without the per-sensor proof, or
+newer artifacts whose proof is stale/missing/high-RTT, fall back to the
+persisted summary sample instead of guessing raw alignment. Gaps,
+overlaps, dropped chunks, and other incomplete raw coverage still fall
+back per window and emit deterministic warnings.
 
 ## Fallback Behaviour
 


### PR DESCRIPTION
Closes #3149

## What changed
- persist per-sensor raw clock-sync proof in raw capture manifests, including proof state, last successful sync time, offset, RTT, and validation thresholds
- snapshot that proof at raw-capture finalize time from the live registry, including the last successful sync ACK monotonic timestamp
- gate raw replay anchoring on explicit verified server-monotonic proof instead of trusting `run_start_monotonic_us` alone
- fall back to persisted summary samples with deterministic warnings when sync proof is missing, stale, high-RTT, or legacy metadata is absent
- propagate the new sync-proof counts and warnings through post-analysis metadata and report preparation
- document the new proof-based replay model in `docs/time_alignment.md`

## Why
- replay was treating raw `t0_us` as recorder-monotonic whenever the run had a start anchor
- that was not enough to prove the raw chunks were still in the same clock domain as the persisted summary windows
- a stale or missing sync state could make post-analysis compute raw-backed metrics from the wrong raw window and then carry that confidence into the report/PDF path

## Validation
- focused raw-capture writer/history/replay/post-analysis/report/UDP sync pytest suites
- broader adjacent post-analysis loader/executor/replay/report/history suites
- `make lint`
- `make typecheck-backend`

## Risks / limits
- older raw artifacts without the new per-sensor proof now fail safe to summary-backed replay instead of guessing alignment
- sync proof is evaluated from the persisted finalize snapshot, so replay trusts only sensors whose proof was explicitly verified for that run
- stale/high-RTT proof reduces raw-backed coverage on purpose; that is the honest outcome for report confidence

## Tests added
- raw manifest round-trip persistence for per-sensor sync proof
- recorder raw-capture writer finalize handoff of sync proof
- replay fallback when per-sensor sync proof is stale
- post-analysis summary propagation of sync-unverified metadata/warnings
- report preparation propagation of the new warning
- UDP control ACK regression for persisted last successful sync monotonic time