### PR TITLE
Preserve transient events in capped post-analysis

### DIFF
--- a/apps/server/tests/use_cases/run/test_post_analysis_loader.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_loader.py
@@ -149,7 +149,7 @@ def test_load_post_analysis_run_handles_no_samples() -> None:
     assert "samples" in result.error_message.lower()
 
 
-def test_load_post_analysis_run_applies_upfront_stride(
+def test_load_post_analysis_run_preserves_transient_events_when_capped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -167,7 +167,9 @@ def test_load_post_analysis_run_applies_upfront_stride(
             yield sensor_frames_from_mappings(
                 [
                     {"t_s": 1.0, "vibration_strength_db": 10.0},
-                    {"t_s": 3.0, "vibration_strength_db": 12.0},
+                    {"t_s": 2.0, "vibration_strength_db": 11.0},
+                    {"t_s": 3.0, "vibration_strength_db": 48.0},
+                    {"t_s": 4.0, "vibration_strength_db": 12.0},
                 ]
             )
 
@@ -194,7 +196,64 @@ def test_load_post_analysis_run_applies_upfront_stride(
     assert len(result.samples) == 2
     assert result.total_sample_count == 4
     assert result.stride == 2
-    assert iter_calls == [(1024, 2)]
+    assert result.sampling_method == "event_preserving"
+    assert result.event_sample_count == 1
+    assert [sample.t_s for sample in result.samples] == [1.0, 3.0]
+    assert iter_calls == [(1024, 1)]
+
+
+def test_load_post_analysis_run_keeps_event_preserving_selection_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "vibesensor.use_cases.run.post_analysis_loader._MAX_POST_ANALYSIS_SAMPLES",
+        3,
+    )
+
+    class FakeDB:
+        async def aget_run(self, run_id):
+            return _StoredRun(metadata=_run_metadata(run_id), sample_count=6)
+
+        async def aiter_run_samples(self, _run_id, batch_size=1024, *, stride=1):
+            assert batch_size == 1024
+            assert stride == 1
+            yield sensor_frames_from_mappings(
+                [
+                    {"t_s": 1.0, "vibration_strength_db": 10.0},
+                    {"t_s": 2.0, "vibration_strength_db": 11.0},
+                    {"t_s": 3.0, "vibration_strength_db": 12.0},
+                    {"t_s": 4.0, "vibration_strength_db": 13.0},
+                    {"t_s": 5.0, "vibration_strength_db": 14.0},
+                    {"t_s": 6.0, "vibration_strength_db": 15.0},
+                ]
+            )
+
+        async def aload_raw_capture(self, _run_id):
+            return None
+
+        async def aload_raw_capture_sensor_range(
+            self,
+            _run_id,
+            client_id,
+            *,
+            sample_start,
+            sample_count,
+        ):
+            return RawCaptureSensorRange.missing(
+                client_id=client_id,
+                requested_sample_start=sample_start,
+                requested_sample_count=sample_count,
+            )
+
+    first = load_post_analysis_run(run_id="run-deterministic", db=FakeDB())
+    second = load_post_analysis_run(run_id="run-deterministic", db=FakeDB())
+
+    assert isinstance(first, LoadedPostAnalysisRun)
+    assert isinstance(second, LoadedPostAnalysisRun)
+    assert len(first.samples) == 3
+    assert len(second.samples) == 3
+    assert first.sampling_method == "event_preserving"
+    assert [sample.t_s for sample in first.samples] == [sample.t_s for sample in second.samples]
 
 
 def test_load_post_analysis_run_loads_full_context_samples_when_whole_run_artifacts_exist(
@@ -223,15 +282,15 @@ def test_load_post_analysis_run_loads_full_context_samples_when_whole_run_artifa
 
         async def aiter_run_samples(self, _run_id, batch_size=1024, *, stride=1):
             assert batch_size == 1024
-            if stride == 2:
-                yield sensor_frames_from_mappings(
-                    [
-                        {"t_s": 1.0, "vibration_strength_db": 10.0},
-                        {"t_s": 3.0, "vibration_strength_db": 12.0},
-                    ]
-                )
-                return
-            raise AssertionError(f"unexpected iter stride {stride}")
+            assert stride == 1
+            yield sensor_frames_from_mappings(
+                [
+                    {"t_s": 1.0, "vibration_strength_db": 10.0},
+                    {"t_s": 2.0, "vibration_strength_db": 11.0},
+                    {"t_s": 3.0, "vibration_strength_db": 12.0},
+                    {"t_s": 4.0, "vibration_strength_db": 13.0},
+                ]
+            )
 
         async def aget_run_samples(self, _run_id):
             return sensor_frames_from_mappings(
@@ -267,6 +326,7 @@ def test_load_post_analysis_run_loads_full_context_samples_when_whole_run_artifa
     assert result.context_samples is not None
     assert len(result.context_samples) == 4
     assert result.stride == 2
+    assert result.sampling_method == "event_preserving"
 
 
 def test_load_post_analysis_run_defaults_language_to_en() -> None:

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -60,6 +60,9 @@ def _run_input(
     raw_sample_rate_hz: int = 800,
     total_sample_count: int = 1,
     stride: int = 1,
+    sampling_method: str = "full",
+    evenly_spaced_sample_count: int = 0,
+    event_sample_count: int = 0,
 ) -> PostAnalysisRunInput:
     return build_post_analysis_input(
         LoadedPostAnalysisRun(
@@ -74,6 +77,9 @@ def _run_input(
             raw_capture=None,
             total_sample_count=total_sample_count,
             stride=stride,
+            sampling_method=sampling_method,
+            evenly_spaced_sample_count=evenly_spaced_sample_count,
+            event_sample_count=event_sample_count,
         ),
     )
 
@@ -303,9 +309,21 @@ def test_build_post_analysis_summary_adds_stride_warning(
     )
 
     summary = build_post_analysis_summary(
-        _run_input("run-stride", raw_sample_rate_hz=1, total_sample_count=5, stride=3),
+        _run_input(
+            "run-stride",
+            raw_sample_rate_hz=1,
+            total_sample_count=5,
+            stride=3,
+            sampling_method="event_preserving",
+            evenly_spaced_sample_count=2,
+            event_sample_count=1,
+        ),
     )
 
+    assert summary["analysis_metadata"]["sampling_method"] == "event_preserving"
+    assert summary["analysis_metadata"]["sampling_base_stride"] == 3
+    assert summary["analysis_metadata"]["sampling_evenly_spaced_sample_count"] == 2
+    assert summary["analysis_metadata"]["sampling_event_sample_count"] == 1
     run_suitability = summary["run_suitability"]
     assert isinstance(run_suitability, list)
     assert run_suitability == [

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1364,8 +1364,8 @@
     "nl": "Sterkste snelheidsband"
   },
   "SUITABILITY_ANALYSIS_SAMPLING_STRIDE_WARNING": {
-    "en": "Long run analyzed with stride {stride}. Brief intermittent events may be underrepresented.",
-    "nl": "Lange run geanalyseerd met stride {stride}. Korte, intermitterende events kunnen ondervertegenwoordigd zijn."
+    "en": "Long run analyzed with event-preserving reduction using base stride {stride}. High-energy brief events were retained where possible.",
+    "nl": "Lange run geanalyseerd met event-behoudende reductie met basis-stride {stride}. Korte events met hoge energie zijn waar mogelijk behouden."
   },
   "SUITABILITY_CHECK_ANALYSIS_SAMPLING": {
     "en": "Analysis sampling",

--- a/apps/server/vibesensor/use_cases/run/post_analysis_input.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_input.py
@@ -25,6 +25,9 @@ class PostAnalysisRunInput:
     language: str
     total_sample_count: int
     stride: int
+    sampling_method: str
+    evenly_spaced_sample_count: int
+    event_sample_count: int
     raw_capture_available: bool
     raw_backed_sample_count: int
     raw_replay: RawReplaySummary
@@ -62,6 +65,9 @@ def build_post_analysis_input(loaded: LoadedPostAnalysisRun) -> PostAnalysisRunI
         language=loaded.language,
         total_sample_count=loaded.total_sample_count,
         stride=loaded.stride,
+        sampling_method=loaded.sampling_method,
+        evenly_spaced_sample_count=loaded.evenly_spaced_sample_count,
+        event_sample_count=loaded.event_sample_count,
         raw_capture_available=replay_result.summary.raw_capture_available,
         raw_backed_sample_count=replay_result.summary.raw_backed_sample_count,
         raw_replay=replay_result.summary,

--- a/apps/server/vibesensor/use_cases/run/post_analysis_loader.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from math import ceil
 
@@ -11,6 +12,7 @@ from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 
 _MAX_POST_ANALYSIS_SAMPLES = 12_000
+_EVENT_PRESERVING_SAMPLING_METHOD = "event_preserving"
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,6 +23,9 @@ class LoadedPostAnalysisRun:
     samples: list[SensorFrame]
     total_sample_count: int
     stride: int
+    sampling_method: str = "full"
+    evenly_spaced_sample_count: int = 0
+    event_sample_count: int = 0
     context_samples: list[SensorFrame] | None = None
     raw_capture: RawRunCapture | None = None
     raw_capture_manifest: RawCaptureManifest | None = None
@@ -41,6 +46,15 @@ class EmptyPostAnalysisSamples:
 PostAnalysisLoadResult = (
     LoadedPostAnalysisRun | MissingPostAnalysisMetadata | EmptyPostAnalysisSamples
 )
+
+
+@dataclass(frozen=True, slots=True)
+class _PostAnalysisSampleSelection:
+    samples: list[SensorFrame]
+    stride: int
+    sampling_method: str = "full"
+    evenly_spaced_sample_count: int = 0
+    event_sample_count: int = 0
 
 
 def _sample_stride(total_sample_count: int) -> int:
@@ -75,33 +89,21 @@ def load_post_analysis_run(
             if callable(get_raw_capture_manifest):
                 raw_capture_manifest = await get_raw_capture_manifest(run_id)
 
-        stride = _sample_stride(total_sample_count)
-        samples: list[SensorFrame] = []
-        if stored_run is not None:
-            async for batch in db.aiter_run_samples(run_id, batch_size=1024, stride=stride):
-                samples.extend(batch)
-        else:
-            async for batch in db.aiter_run_samples(run_id, batch_size=1024):
-                samples.extend(batch)
+        full_samples: list[SensorFrame] = []
+        async for batch in db.aiter_run_samples(run_id, batch_size=1024):
+            full_samples.extend(batch)
+        samples = full_samples
         if total_sample_count <= 0:
-            total_sample_count = len(samples)
+            total_sample_count = len(full_samples)
         if not samples:
             return EmptyPostAnalysisSamples(
                 run_id=run_id,
                 error_message="No samples collected during run",
             )
+        sample_selection = _select_post_analysis_samples(full_samples)
         context_samples: list[SensorFrame] | None = None
         if raw_capture_manifest is not None:
-            if stride == 1:
-                context_samples = list(samples)
-            else:
-                get_run_samples = getattr(db, "aget_run_samples", None)
-                if callable(get_run_samples):
-                    context_samples = list(await get_run_samples(run_id))
-                else:
-                    context_samples = []
-                    async for batch in db.aiter_run_samples(run_id, batch_size=1024):
-                        context_samples.extend(batch)
+            context_samples = list(full_samples)
         load_raw_capture = getattr(db, "aload_raw_capture", None)
         raw_capture = await load_raw_capture(run_id) if callable(load_raw_capture) else None
 
@@ -109,10 +111,13 @@ def load_post_analysis_run(
             run_id=run_id,
             metadata=metadata,
             language=metadata.language or "en",
-            samples=samples,
+            samples=sample_selection.samples,
             context_samples=context_samples,
             total_sample_count=total_sample_count,
-            stride=stride,
+            stride=sample_selection.stride,
+            sampling_method=sample_selection.sampling_method,
+            evenly_spaced_sample_count=sample_selection.evenly_spaced_sample_count,
+            event_sample_count=sample_selection.event_sample_count,
             raw_capture=raw_capture,
             raw_capture_manifest=raw_capture_manifest,
         )
@@ -123,3 +128,99 @@ def load_post_analysis_run(
     import asyncio as _asyncio
 
     return _asyncio.run(_aload())
+
+
+def _select_post_analysis_samples(
+    samples: Sequence[SensorFrame],
+) -> _PostAnalysisSampleSelection:
+    total_sample_count = len(samples)
+    stride = _sample_stride(total_sample_count)
+    if stride <= 1 or total_sample_count <= _MAX_POST_ANALYSIS_SAMPLES:
+        return _PostAnalysisSampleSelection(samples=list(samples), stride=1)
+    event_budget = max(1, _MAX_POST_ANALYSIS_SAMPLES // 3)
+    evenly_spaced_budget = max(1, _MAX_POST_ANALYSIS_SAMPLES - event_budget)
+    evenly_spaced_indices = set(
+        _evenly_spaced_indices(total_sample_count, selection_count=evenly_spaced_budget)
+    )
+    event_indices = _event_preserving_indices(
+        samples,
+        bucket_count=event_budget,
+        exclude=evenly_spaced_indices,
+    )
+    selected_indices = sorted(evenly_spaced_indices | set(event_indices))
+    if len(selected_indices) < _MAX_POST_ANALYSIS_SAMPLES:
+        for index in _evenly_spaced_indices(
+            total_sample_count,
+            selection_count=min(total_sample_count, _MAX_POST_ANALYSIS_SAMPLES * 3),
+        ):
+            if index in evenly_spaced_indices or index in event_indices:
+                continue
+            selected_indices.append(index)
+            if len(selected_indices) >= _MAX_POST_ANALYSIS_SAMPLES:
+                break
+        selected_indices.sort()
+    return _PostAnalysisSampleSelection(
+        samples=[samples[index] for index in selected_indices[:_MAX_POST_ANALYSIS_SAMPLES]],
+        stride=stride,
+        sampling_method=_EVENT_PRESERVING_SAMPLING_METHOD,
+        evenly_spaced_sample_count=len(evenly_spaced_indices),
+        event_sample_count=len(set(event_indices) - evenly_spaced_indices),
+    )
+
+
+def _evenly_spaced_indices(total_sample_count: int, *, selection_count: int) -> list[int]:
+    if total_sample_count <= 0 or selection_count <= 0:
+        return []
+    if selection_count >= total_sample_count:
+        return list(range(total_sample_count))
+    if selection_count == 1:
+        return [0]
+    last_index = total_sample_count - 1
+    return sorted(
+        {
+            min(last_index, round((last_index * step) / float(selection_count - 1)))
+            for step in range(selection_count)
+        }
+    )
+
+
+def _event_preserving_indices(
+    samples: Sequence[SensorFrame],
+    *,
+    bucket_count: int,
+    exclude: set[int],
+) -> list[int]:
+    if bucket_count <= 0:
+        return []
+    total_sample_count = len(samples)
+    selected: list[int] = []
+    for bucket_index in range(bucket_count):
+        start = (bucket_index * total_sample_count) // bucket_count
+        end = ((bucket_index + 1) * total_sample_count) // bucket_count
+        best_index: int | None = None
+        best_score: tuple[float, float, float] | None = None
+        for sample_index in range(start, end):
+            if sample_index in exclude:
+                continue
+            score = _sample_event_score(samples[sample_index])
+            if best_score is None or score > best_score:
+                best_index = sample_index
+                best_score = score
+        if best_index is not None:
+            selected.append(best_index)
+    return selected
+
+
+def _sample_event_score(sample: SensorFrame) -> tuple[float, float, float]:
+    strength_db = (
+        float(sample.vibration_strength_db)
+        if sample.vibration_strength_db is not None
+        else float("-inf")
+    )
+    peak_amp_g = (
+        float(sample.strength_peak_amp_g)
+        if sample.strength_peak_amp_g is not None
+        else float("-inf")
+    )
+    top_peak_amp_g = max((peak.amp for peak in sample.top_peaks), default=float("-inf"))
+    return (strength_db, peak_amp_g, top_peak_amp_g)

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -65,7 +65,7 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
     analysis_metadata: JsonObject = {
         "analyzed_sample_count": len(run.samples),
         "total_sample_count": run.total_sample_count,
-        "sampling_method": "full" if run.stride == 1 else f"stride_{run.stride}",
+        "sampling_method": run.sampling_method,
         "raw_capture_available": run.raw_replay.raw_capture_available,
         "raw_backed_sample_count": run.raw_replay.raw_backed_sample_count,
         "raw_capture_mode": run.raw_replay.raw_capture_mode,
@@ -88,6 +88,10 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         "raw_replay_high_rtt_sensor_count": run.raw_replay.high_rtt_sensor_count,
         "raw_replay_confidence": run.raw_replay.replay_confidence,
     }
+    if run.sampling_method != "full":
+        analysis_metadata["sampling_base_stride"] = run.stride
+        analysis_metadata["sampling_evenly_spaced_sample_count"] = run.evenly_spaced_sample_count
+        analysis_metadata["sampling_event_sample_count"] = run.event_sample_count
     summary_payload["analysis_metadata"] = payload_object_from_json(analysis_metadata)
     if run.raw_replay.warnings:
         existing_warnings = summary_payload.get("warnings")
@@ -111,7 +115,7 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
             explanation=explanation,
         )
 
-    if run.stride > 1:
+    if run.sampling_method != "full":
         stride_check = SuitabilityCheck(
             check_key="SUITABILITY_CHECK_ANALYSIS_SAMPLING",
             state="warn",


### PR DESCRIPTION
## What changed
- replaced pure stride-only long-run post-analysis reduction with a deterministic event-preserving selector in `post_analysis_loader.py`
- the selector now keeps evenly spaced chronological context plus high-energy representative samples, then returns the merged set in time order
- persisted analysis metadata now records the real reduction method (`event_preserving`), the base stride, and the evenly-spaced vs event-picked counts
- updated the long-run suitability warning text so it describes event-preserving reduction instead of naive stride-only sampling
- added loader + summary regressions for transient retention, bounded deterministic selection, and the new metadata/warning shape

## Why
Old behavior only kept every Nth sample once a run crossed the post-analysis cap.
That was cheap, but it could miss a short high-energy event completely if the event landed between retained rows.

This fix keeps the run bounded without pretending evenly spaced stride samples are enough.
It still preserves chronological context, but now each coarse bucket also gets a best-energy candidate so narrow transients survive the reduction.

## Tradeoffs
- the loader now inspects the full persisted sample stream before reducing capped runs
- output size stays bounded at the existing cap
- the analysis warning stays explicit so reports say event-preserving reduction happened and what base stride was used

## Validation
- `pytest -q apps/server/tests/use_cases/run/test_post_analysis_loader.py apps/server/tests/use_cases/run/test_post_analysis_summary.py apps/server/tests/use_cases/run/test_post_analysis_worker.py apps/server/tests/use_cases/run/test_post_analysis_executor.py`
- `pytest -q apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/integration/test_multi_domain_regressions.py apps/server/tests/domain/test_speed_profile_and_run_suitability.py`
- `make lint`
- `make typecheck-backend`

Closes #3152
