### PR TITLE
Fix stale PDF cache reuse when analysis changes

### DIFF
--- a/apps/server/tests/adapters/http/test_api_history_report_endpoints.py
+++ b/apps/server/tests/adapters/http/test_api_history_report_endpoints.py
@@ -18,9 +18,11 @@ from _history_endpoint_helpers import (
 )
 from fastapi import FastAPI, HTTPException
 from pypdf import PdfReader
+from test_support.persisted_analysis import make_persisted_analysis
 
 from vibesensor.adapters.analysis_summary import summarize_run_data
 from vibesensor.adapters.http import create_router
+from vibesensor.shared.types.history_analysis_contracts import AnalysisSummary
 
 
 def _pdf_text(body: bytes) -> str:
@@ -174,6 +176,54 @@ async def test_report_pdf_cache_invalidates_when_analysis_completed_at_changes()
 
     state = FakeState(
         TimestampFlipDB(metadata, samples, analysis), FakeWsHub(), pdf_renderer=fake_renderer
+    )
+    router = create_router(state)
+    endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")
+
+    await endpoint("run-1", "en")
+    await endpoint("run-1", "en")
+
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_report_pdf_cache_invalidates_when_analysis_content_changes() -> None:
+    metadata = make_metadata()
+    samples = [sample(i) for i in range(20)]
+    first_analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    first_analysis["_report_template_data"] = {"lang": "en", "title": "legacy"}
+    second_analysis = summarize_run_data(metadata, samples, lang="en", include_samples=False)
+    second_analysis["_report_template_data"] = {"lang": "en", "title": "updated"}
+
+    @dataclass
+    class AnalysisFlipDB(FakeHistoryDB):
+        analyses: list[AnalysisSummary] = field(default_factory=list)
+        idx: int = 0
+
+        async def aget_run(self, run_id: str):
+            result = await super().aget_run(run_id)
+            if result is None:
+                return None
+            analysis = self.analyses[min(self.idx, len(self.analyses) - 1)]
+            self.idx += 1
+            return replace(result, analysis=make_persisted_analysis(analysis))
+
+    call_count = 0
+
+    def fake_renderer(_prepared: object) -> bytes:
+        nonlocal call_count
+        call_count += 1
+        return b"%PDF-analysis-versioned"
+
+    state = FakeState(
+        AnalysisFlipDB(
+            metadata,
+            samples,
+            first_analysis,
+            analyses=[first_analysis, second_analysis],
+        ),
+        FakeWsHub(),
+        pdf_renderer=fake_renderer,
     )
     router = create_router(state)
     endpoint = route_endpoint(router, "/api/history/{run_id}/report.pdf")

--- a/apps/server/tests/use_cases/history/test_history_http_services.py
+++ b/apps/server/tests/use_cases/history/test_history_http_services.py
@@ -542,7 +542,7 @@ async def test_report_pdf_cache_builds_once_per_key() -> None:
         calls += 1
         return b"%PDF-cache"
 
-    cache_key = ("run-1", "nl", None, 0, "{}", "none")
+    cache_key = ("run-1", "nl", None, 0, "{}", "analysis", "none")
     first = await cache.get_or_build(cache_key, _build)
     second = await cache.get_or_build(cache_key, _build)
 

--- a/apps/server/tests/use_cases/history/test_history_service_edges.py
+++ b/apps/server/tests/use_cases/history/test_history_service_edges.py
@@ -169,7 +169,7 @@ async def test_report_loader_uses_requested_lang_when_persisted_lang_is_blank() 
 @pytest.mark.asyncio
 async def test_report_pdf_cache_retries_after_build_failure() -> None:
     cache = HistoryReportPdfCache()
-    cache_key = ("run-1", "en", None, 12, "{}", "none")
+    cache_key = ("run-1", "en", None, 12, "{}", "analysis", "none")
     calls = 0
 
     def _build() -> bytes:
@@ -193,7 +193,7 @@ async def test_report_pdf_cache_retries_after_build_failure() -> None:
 def test_report_pdf_cache_evicts_lru_entries_and_drops_evicted_locks() -> None:
     cache = HistoryReportPdfCache()
     keys = [
-        (f"run-{index}", "en", None, index, "{}", "none")
+        (f"run-{index}", "en", None, index, "{}", f"analysis-{index}", "none")
         for index in range(REPORT_PDF_CACHE_MAX_ENTRIES + 1)
     ]
 

--- a/apps/server/vibesensor/shared/types/report_cache.py
+++ b/apps/server/vibesensor/shared/types/report_cache.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["ReportPdfCacheKey"]
 
-ReportPdfCacheKey = tuple[str, str, str | None, int, str, str]
+ReportPdfCacheKey = tuple[str, str, str | None, int, str, str, str]

--- a/apps/server/vibesensor/use_cases/history/report_loader.py
+++ b/apps/server/vibesensor/use_cases/history/report_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from hashlib import sha256
 
 from opentelemetry.trace import SpanKind
 
@@ -120,6 +121,15 @@ class HistoryReportRequestLoader:
             sort_keys=True,
         )
 
+    @staticmethod
+    def _analysis_cache_token(analysis: object) -> str:
+        if hasattr(analysis, "to_json_object"):
+            analysis_payload = analysis.to_json_object()
+        else:
+            analysis_payload = analysis
+        encoded = json_text_dumps(analysis_payload, sort_keys=True).encode("utf-8")
+        return sha256(encoded).hexdigest()
+
     def _report_pdf_cache_key(
         self,
         run: StoredHistoryRun,
@@ -132,6 +142,7 @@ class HistoryReportRequestLoader:
             run.analysis_completed_at,
             run.sample_count,
             self._metadata_cache_token(run.metadata),
+            self._analysis_cache_token(run.analysis),
             _PERSISTED_REPORT_MODE_TOKEN,
         )
 


### PR DESCRIPTION
## What changed
- add a deterministic SHA-256 token of the persisted analysis payload to the PDF report cache key
- keep the existing run/language/metadata/mode cache partitioning intact
- add an endpoint regression where analysis content changes while analysis_completed_at stays fixed
- update the report cache utility tests for the expanded key shape

## Why
- the cache key trusted coarse metadata and could reuse a stale PDF if persisted analysis content changed without a timestamp bump
- report invalidation now follows real report-driving analysis content instead of timestamp luck

## Validation
- /tmp/vibesensor-313/bin/python -m pytest -q apps/server/tests/adapters/http/test_api_history_report_endpoints.py apps/server/tests/use_cases/history/test_history_service_edges.py apps/server/tests/use_cases/history/test_history_http_services.py
- PATH=/tmp/vibesensor-313/bin:/root/.local/bin make lint
- PATH=/tmp/vibesensor-313/bin:/root/.local/bin make typecheck-backend

## Risks / tradeoffs
- old cached PDFs miss once because the key shape is intentionally stricter
- this keeps analysis_completed_at in the key; it just stops treating that timestamp as the only version signal

Closes #3153