### PR TITLE
[codex] Improve AI agent guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,11 +9,12 @@ Guidance stack
 - Paths below are repo-relative unless a bullet is explicitly talking about a Python import namespace such as `vibesensor.domain` or `vibesensor.shared.*`.
 
 Execution philosophy
-- Be decisive, direct, and completion-oriented. Attack large tasks aggressively; do not narrow scope because the work is broad or invasive.
-- Large scope is not itself a blocker. Decompose and execute in waves until the work is done. Do not stop at analysis, planning, or partial implementation.
+- Be decisive, direct, and completion-oriented. Default to completing the user's requested change end to end.
+- Expand scope only to fix the root cause, update direct callers, or handle clearly adjacent regressions found during validation. Do not broaden into unrelated cleanup.
+- Decompose large tasks into execution waves and keep going until the in-scope work is done, validated, or blocked by credentials, hardware, external services, or an explicit user pause.
 - Breaking internal-only interfaces is acceptable and preferred when the result is cleaner. The repo controls both producers and consumers; coordinated breaking refactors are the right default, not the exception.
 - Do not preserve deprecated aliases, old DTO shapes, fallback branches, or legacy config forms unless a real external consumer is confirmed. The cleaner architecture wins.
-- Full execution-completion rules and anti-hedging guidance live in `.github/instructions/general.instructions.md`.
+- Full workflow and validation rules live in `.github/instructions/general.instructions.md`.
 
 Repository overview
 - VibeSensor: Python backend (`apps/server/`), TypeScript/Vite dashboard (`apps/ui/`), ESP32 firmware (`firmware/esp/`), Pi image build (`infra/pi-image/`).
@@ -65,6 +66,24 @@ Commands
 - `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh`
 - `./infra/pi-image/pi-gen/validate-image.sh`
 - `docker compose build --pull && docker compose up -d`
+
+Validation chooser
+- Backend source: `make lint`, `make typecheck-backend`, and targeted `pytest -q apps/server/tests/<module>/`.
+- Backend contracts/API payloads: add `make sync-contracts` and `make ui-typecheck`.
+- Frontend logic, contracts, or composition: `make ui-typecheck`; for bundle behavior also run `cd apps/ui && npm ci && npm run build`.
+- Rendered UI or snapshots: add `cd apps/ui && npm run test:visual`.
+- Firmware code: `cd firmware/esp && pio run`.
+- Pi app artifact changes: `BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh`.
+- Pi image-stage logic: `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh`, then `./infra/pi-image/pi-gen/validate-image.sh [artifact]` when an artifact is available.
+- Docs or AI-instruction-only changes: `make docs-lint`.
+
+Command gotchas
+- `make ui-typecheck` is the default frontend gate because it materializes generated UI contract artifacts before linting and TypeScript checks.
+- Raw `cd apps/ui && npm run typecheck` or `npm run build` can fail when generated UI contract files are stale; run `make sync-contracts` or `make ui-typecheck` first when backend contracts changed.
+- `act` requires Docker and is best for targeted GitHub workflow parity, not docs-only changes.
+- PlatformIO must be installed before `cd firmware/esp && pio run`.
+- Pi image builds are expensive; use the narrow `BUILD_MODE=app` or `BUILD_MODE=image` path unless both layers changed.
+- The local Docker stack is for runtime integration behavior, not docs-only, instruction-only, or pure unit-test changes.
 
 Pi access defaults (prebuilt image)
 - Narrow owner: `infra/pi-image/pi-gen/README.md` and `docs/operational-runbooks.md`

--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -10,20 +10,20 @@ Agent workflow
 - Scan the blast radius for similar in-scope issues and fix them in the same run.
 - Prefer extending and hardening existing logic over adding parallel implementations.
 - When a larger refactor or other major in-scope change is the clearest path to better long-term maintainability, prefer that over a narrowly local patch that preserves poor structure.
-- Analysis-first default: examine the issue from multiple angles, choose the strongest approach, and deliver the most direct, validated, **complete** in-scope fix that addresses root cause and nearby in-scope blast radius.
+- Analysis-first default: examine the issue from multiple angles, choose the strongest approach, and deliver the most direct, validated, complete in-scope fix that addresses root cause and nearby in-scope blast radius.
 - Avoid symptom-only patches. Prefer fixes that make sense to a human maintainer and reduce future maintenance burden in the touched area.
 - Avoid over-conservative blocking behavior: do not hold a clear fix for exhaustive hypothetical analysis.
 - Use bounded risk rather than risk avoidance: keep changes reversible, validate early, and recover quickly on failures.
-- Continue autonomously on clearly adjacent in-scope issues without waiting for another prompt.
+- Continue autonomously on clearly adjacent in-scope issues without waiting for another prompt, but do not turn incidental cleanup into a new project.
 - Stop only when one of these conditions is true:
   1. all plan items are complete and validated,
   2. no similar in-scope issues remain,
   3. a real blocker exists (credentials/hardware/external dependency),
   4. the user explicitly asks to pause.
-- Long, thorough runs are allowed and preferred for deeper tasks; multi-hour runs are acceptable when needed to complete in-scope work well.
-- Execution-completion bias: the default mode is to finish the requested work entirely, not to make progress toward it. Do not stop at analysis, planning, or partial implementation. Do not treat "first green test pass" as completion if architectural residue remains.
-- Task size is not a blocker. Large tasks must be decomposed and executed in full, not narrowed or deferred. When a task is large, split it into strong execution buckets and work through all of them in the same run.
-- Anti-hedging rule: do not write or think with language like "this is probably too large for one session", "I'll do as much as possible", "maybe just inspect first and continue later", "I should keep the first pass small", "this is huge so I'll narrow scope", or "I should avoid coordinated breaking changes unless absolutely necessary". Replace those defaults with: decompose → execute → continue until done.
+- Long, thorough runs are allowed for deeper tasks when the requested scope and validation needs justify them.
+- Execution-completion bias: finish the requested work, not merely a first pass. Do not stop at analysis, planning, or partial implementation. Do not treat "first green test pass" as completion if architectural residue remains.
+- Task size is not a blocker by itself. For large tasks, decompose into execution buckets and work through the in-scope buckets in order.
+- Avoid hedging language such as "this is probably too large for one session" or "I'll do as much as possible." Instead, state the execution buckets, current validation target, and any real blocker.
 - Context/noise control:
   - avoid scanning generated/build/cache/vendor artifacts unless debugging them (`artifacts/`, `.cache/`, `node_modules/`, `dist/`, `.venv/`, `.pytest_cache/`, `.ruff_cache/`),
   - use focused file reads and scoped searches,
@@ -32,6 +32,13 @@ Agent workflow
   - put executable logic in proper code files, not hidden in docs/json/txt wrappers,
   - when adding large inline data definitions, move them into appropriate data files (`.json`, `.yaml`, etc.),
   - do not create duplicate parallel implementations when extending existing logic is cleaner.
+
+Deliberate reasoning gates
+- Medium/large code changes need an architecture pass before edits: owner module, data flow, invariants, root cause, and validation target.
+- Compare at least two viable approaches before non-trivial implementation, then choose the one that best preserves correctness, simplicity, and existing architecture.
+- Gather current-behavior evidence before refactoring: read owner code, direct callers, and nearest tests; run or inspect the closest relevant test when practical.
+- When an AI mistake repeats, prefer a lint/static guard/hygiene test or tighter path-scoped instruction over more prose.
+- Keep instructions short and scoped: repo-wide rules must affect most tasks; area rules belong near their paths; add a rule only when removing it would cause real mistakes.
 
 Complexity hygiene
 - Remove config fields that are not read by any code path. Do not add speculative config knobs.
@@ -66,6 +73,7 @@ Validation (always required)
 - Use proportionate validation instead of the local Docker stack for docs-only changes, AI-instruction-only changes, README/repo-map/docs-lint edits, pure test-only changes that do not alter runtime behavior, and CI/workflow-only changes unless they also change local stack behavior.
 - Breaking changes are allowed when intentional.
 - No-backward-compatibility policy: we own the full codebase end to end. Do not add or preserve backward-compatibility layers (deprecated paths, adapters, fallbacks, shims, version-bridging logic, or legacy schema support) unless explicitly asked. Remove them when encountered. Standardize on the current contract, schema, config, and runtime path. Do not add new compatibility code "just in case". If compatibility seems necessary, flag it explicitly rather than implementing it silently. Internal-only backward compatibility is never the default: when the repo controls both producers and consumers, coordinated breaking changes are preferred over preserving old shapes. The cleaner architecture always wins over old migration scaffolding.
+- Completion reports should state files changed, validation commands run, any validation skipped with the reason, and whether docs or AI guidance were updated or confirmed unnecessary.
 
 Docs (`docs/`)
 - Keep `docs/` short and focused. Add design changes (e.g. report layout) to `docs/design_language.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,11 @@
 # Agent guidance
 
-See [.github/copilot-instructions.md](.github/copilot-instructions.md) for the canonical AI guidance entrypoint.
+VibeSensor is a mixed Python backend, TypeScript/Vite dashboard, ESP32 firmware, and Raspberry Pi image repository.
+
+Read [.github/copilot-instructions.md](.github/copilot-instructions.md) for the canonical architecture, command, and validation guidance. Use `.github/instructions/` for Copilot path-scoped rules, and use `docs/ai/repo-map.md` for navigation only.
+
+Before changing code:
+- Identify the touched area: backend, frontend, firmware, Pi image, tests, docs, or instructions.
+- Follow the matching validation path from `.github/copilot-instructions.md`.
+- Update docs or AI guidance when the touched behavior changes their facts.
+- Keep changes scoped to the request plus direct root-cause fixes and clearly adjacent regressions found during validation.

--- a/apps/server/AGENTS.md
+++ b/apps/server/AGENTS.md
@@ -1,0 +1,15 @@
+# Backend agent guidance
+
+Backend-specific rules live in `../../.github/instructions/backend.instructions.md`; test-specific rules live in `tests/AGENTS.md` and `../../.github/instructions/tests.instructions.md`.
+
+Key anchors:
+- Package entry points and ownership boundaries: `../../docs/ai/repo-map.md`.
+- Domain object rules: `../../docs/domain-model.md`.
+- Layering guard: `../../tools/dev/verify_backend_static_guards.py`.
+
+Default validation for backend source changes:
+- `make lint`
+- `make typecheck-backend`
+- `pytest -q apps/server/tests/<module>/`
+
+Add `make sync-contracts` and `make ui-typecheck` when API payloads, generated contracts, or shared backend/frontend constants change.

--- a/apps/server/tests/AGENTS.md
+++ b/apps/server/tests/AGENTS.md
@@ -1,0 +1,11 @@
+# Backend test agent guidance
+
+Backend test rules live in `../../../.github/instructions/tests.instructions.md`; the full test map lives in `../../../docs/testing.md`.
+
+Use the matching `apps/server/tests/<module>/` directory for new tests. Reserve `integration/` for cross-cutting regressions and `hygiene/` for guards.
+
+Prefer focused test modules over adding to large omnibus regression files. Test observable behavior instead of source text.
+
+Default focused validation:
+- `pytest -q apps/server/tests/<module>/`
+- `python3 tools/tests/pytest_progress.py --show-test-names apps/server/tests` when broader backend test visibility is useful.

--- a/apps/ui/AGENTS.md
+++ b/apps/ui/AGENTS.md
@@ -1,0 +1,15 @@
+# Frontend agent guidance
+
+Frontend-specific rules live in `../../.github/instructions/frontend.instructions.md`.
+
+Key anchors:
+- Contract sync: `README.md` section "Contract sync".
+- Runtime composition: `src/app/runtime/`.
+- Feature workflows and API/polling state: `src/app/features/`.
+- DOM rendering and event decoding: `src/app/views/`.
+
+Default validation for frontend logic, contracts, or composition:
+- `make ui-typecheck`
+- `cd apps/ui && npm ci && npm run build` when bundle behavior matters.
+
+Add `cd apps/ui && npm run test:visual` when rendered UI states or snapshots change.

--- a/firmware/esp/AGENTS.md
+++ b/firmware/esp/AGENTS.md
@@ -1,0 +1,10 @@
+# Firmware agent guidance
+
+Firmware-specific rules live in `../../.github/instructions/firmware.instructions.md`.
+
+Keep `src/main.cpp` as a thin orchestrator. Put queue, sampling, transport, Wi-Fi, LED, config, and status behavior in the matching `src/runtime_*.{h,cpp}` owner.
+
+Keep firmware aligned with `../../docs/protocol.md` and `../../infra/pi-image/pi-gen/README.md`; do not add internet-dependent hotspot boot assumptions.
+
+Default validation:
+- `cd firmware/esp && pio run`

--- a/infra/pi-image/AGENTS.md
+++ b/infra/pi-image/AGENTS.md
@@ -1,0 +1,12 @@
+# Pi image agent guidance
+
+Pi image-specific rules live in `../../.github/instructions/pi-image.instructions.md`.
+
+Keep `pi-gen/build.sh` as a thin coordinator. Host-side helpers belong in `pi-gen/lib/`, tracked stage/config sources belong in `pi-gen/templates/`, and post-build validation belongs in `pi-gen/validate-image.sh`.
+
+Preserve the wheel-first, offline-first image flow.
+
+Default validation:
+- `BUILD_MODE=app ./infra/pi-image/pi-gen/build.sh` for packaged app artifact changes.
+- `BUILD_MODE=image ./infra/pi-image/pi-gen/build.sh` for image-stage logic.
+- `./infra/pi-image/pi-gen/validate-image.sh [artifact]` to rerun validation against an existing image artifact.


### PR DESCRIPTION
## Summary
- Expand the root AGENTS.md into a useful cross-agent entrypoint.
- Add validation chooser and command gotchas to the canonical Copilot guidance.
- Add deliberate reasoning gates for architecture-first agent work.
- Add small nested AGENTS.md shims for backend, tests, UI, firmware, and Pi image areas.

## Validation
- `make docs-lint`
- `git diff --check`

## Notes
- Runtime/Docker validation was skipped because this is AI-instruction-only.