### PR TITLE
Reject or quarantine late/out-of-order UDP DATA before live ring-buffer ingest

### DIFF
--- a/apps/server/tests/adapters/udp/test_udp_late_packet_quarantine.py
+++ b/apps/server/tests/adapters/udp/test_udp_late_packet_quarantine.py
@@ -1,0 +1,91 @@
+"""Late UDP DATA packets stay out of the live ring buffer."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import numpy as np
+
+from vibesensor.adapters.udp.protocol import HelloMessage, pack_data, parse_data_ack
+from vibesensor.adapters.udp.udp_data_rx import DataDatagramProtocol
+from vibesensor.infra.processing import SignalProcessor
+from vibesensor.infra.runtime.registry import ClientRegistry
+
+_CLIENT_ID = bytes.fromhex("aabbccddeeff")
+_ADDR = ("127.0.0.1", 12345)
+
+
+def _make_processor() -> SignalProcessor:
+    return SignalProcessor(
+        sample_rate_hz=800,
+        waveform_seconds=8,
+        waveform_display_hz=100,
+        fft_n=1024,
+        spectrum_max_hz=200,
+    )
+
+
+def _wave_chunk(freq_hz: float) -> np.ndarray:
+    time_axis = np.arange(1024, dtype=np.float64) / 800.0
+    wave = np.round(1200.0 * np.sin(2.0 * np.pi * freq_hz * time_axis)).astype(np.int16)
+    zeros = np.zeros(1024, dtype=np.int16)
+    return np.column_stack([wave, zeros, zeros])
+
+
+def test_late_packet_is_quarantined_to_raw_capture_only(fake_transport) -> None:
+    registry = ClientRegistry()
+    registry.update_from_hello(
+        HelloMessage(
+            client_id=_CLIENT_ID,
+            control_port=9010,
+            sample_rate_hz=800,
+            name="node-1",
+            firmware_version="fw",
+        ),
+        _ADDR,
+        now=1.0,
+    )
+    processor = _make_processor()
+    raw_capture_sink = Mock()
+    proto = DataDatagramProtocol(
+        registry=registry,
+        processor=processor,
+        raw_capture_sink=raw_capture_sink,
+        queue_maxsize=8,
+    )
+    proto.connection_made(fake_transport)
+
+    first = pack_data(_CLIENT_ID, seq=0, t0_us=1_000_000, samples=_wave_chunk(50.0))
+    newest = pack_data(_CLIENT_ID, seq=2, t0_us=2_280_000, samples=_wave_chunk(120.0))
+    late = pack_data(_CLIENT_ID, seq=1, t0_us=1_640_000, samples=_wave_chunk(30.0))
+
+    with patch.object(processor, "ingest", wraps=processor.ingest) as ingest_spy:
+        proto._process_datagram(first, _ADDR)
+        proto._process_datagram(newest, _ADDR)
+        metrics_before = processor.compute_metrics("aabbccddeeff", sample_rate_hz=800)
+        latest_before = processor.latest_sample_xyz("aabbccddeeff")
+
+        proto._process_datagram(late, _ADDR)
+        metrics_after = processor.compute_metrics("aabbccddeeff", sample_rate_hz=800)
+        latest_after = processor.latest_sample_xyz("aabbccddeeff")
+
+    peaks_before = metrics_before.get("combined", {}).get("peaks", [])
+    peaks_after = metrics_after.get("combined", {}).get("peaks", [])
+    assert any(abs(float(peak["hz"]) - 120.0) < 2.0 for peak in peaks_before)
+    assert any(abs(float(peak["hz"]) - 120.0) < 2.0 for peak in peaks_after)
+    assert not any(abs(float(peak["hz"]) - 30.0) < 2.0 for peak in peaks_after)
+    assert latest_before == latest_after
+    assert ingest_spy.call_count == 2
+    assert raw_capture_sink.capture_raw_samples.call_count == 3
+    assert [parse_data_ack(data).last_seq_received for data, _addr in fake_transport.sent] == [
+        0,
+        2,
+        1,
+    ]
+
+    record = registry.get("aabbccddeeff")
+    assert record is not None
+    assert record.frames_total == 2
+    assert record.frames_dropped == 1
+    assert record.last_seq == 2
+    assert record.last_t0_us == 2_280_000

--- a/apps/server/tests/infra/runtime/test_registry.py
+++ b/apps/server/tests/infra/runtime/test_registry.py
@@ -577,8 +577,10 @@ def test_duplicate_does_not_inflate_frames_total(tmp_path: Path) -> None:
     assert row["dropped_frames"] == 0
 
 
-def test_out_of_order_not_flagged_as_duplicate(tmp_path: Path) -> None:
-    """A frame arriving out of order (but not yet seen) should be ingested."""
+def test_out_of_order_packet_is_marked_late_without_rewinding_live_state(
+    tmp_path: Path,
+) -> None:
+    """A late non-duplicate frame should not mutate the live sequence state."""
     registry, client_id = _make_registry_with_hello(tmp_path)
 
     # Send seq 0, 2 (skip 1), then 1 arrives late
@@ -589,10 +591,14 @@ def test_out_of_order_not_flagged_as_duplicate(tmp_path: Path) -> None:
     msg1 = _data_msg(client_id, 1, 10000)
     r = registry.update_from_data(msg1, ("10.4.0.2", 50000), now=5.0)
     assert r.is_duplicate is False
+    assert r.is_late is True
 
     row = snapshot_for_api(registry, now=5.0)[0]
-    assert row["frames_total"] == 3
+    assert row["frames_total"] == 2
+    assert row["dropped_frames"] == 1
     assert registry.get(client_id.hex()).duplicates_received == 0
+    assert registry.get(client_id.hex()).last_seq == 2
+    assert registry.get(client_id.hex()).last_t0_us == 20_000
 
 
 def test_reset_clears_seen_seqs(tmp_path: Path) -> None:

--- a/apps/server/vibesensor/adapters/udp/udp_data_rx.py
+++ b/apps/server/vibesensor/adapters/udp/udp_data_rx.py
@@ -161,6 +161,7 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
                 mark_span_error(span, exc)
                 raise
             span.set_attribute("vibesensor.is_duplicate", result.is_duplicate)
+            span.set_attribute("vibesensor.is_late", result.is_late)
             span.set_attribute("vibesensor.reset_detected", result.reset_detected)
 
     def _parse_data_message(self, data: bytes, addr: tuple[str, int]) -> DataMessage | None:
@@ -192,12 +193,13 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
                 processor.flush_client_buffer(client_id)
             record = registry.get(client_id)
             sample_rate_hz = record.sample_rate_hz if record is not None else None
-            processor.ingest(
-                client_id,
-                msg.samples,
-                sample_rate_hz=sample_rate_hz,
-                t0_us=msg.t0_us,
-            )
+            if not result.is_late:
+                processor.ingest(
+                    client_id,
+                    msg.samples,
+                    sample_rate_hz=sample_rate_hz,
+                    t0_us=msg.t0_us,
+                )
             if self._raw_capture_sink is not None:
                 self._raw_capture_sink.capture_raw_samples(
                     client_id=client_id,

--- a/apps/server/vibesensor/infra/runtime/registry_updates.py
+++ b/apps/server/vibesensor/infra/runtime/registry_updates.py
@@ -22,6 +22,7 @@ class DataUpdateResult:
 
     reset_detected: bool = False
     is_duplicate: bool = False
+    is_late: bool = False
 
 
 def _is_short_session_restart(
@@ -38,6 +39,26 @@ def _is_short_session_restart(
         and seq <= last_seq
         and t0_us > last_t0_us
         and (last_seq - seq) < _RESTART_SEQ_GAP
+    )
+
+
+def _is_seq_behind(*, seq: int, last_seq: int) -> bool:
+    return seq != last_seq and ((last_seq - seq) & _SEQ_MASK) < _SEQ_HALF
+
+
+def _is_late_packet(
+    record: ClientRecord,
+    *,
+    seq: int,
+    t0_us: int,
+) -> bool:
+    last_seq = record.last_seq
+    last_t0_us = record.last_t0_us
+    return (
+        last_seq is not None
+        and last_t0_us is not None
+        and _is_seq_behind(seq=seq, last_seq=last_seq)
+        and t0_us <= last_t0_us
     )
 
 
@@ -69,6 +90,8 @@ def apply_data_message_update(
     if record.dedup_window.track(seq):
         record.duplicates_received += 1
         return DataUpdateResult(is_duplicate=True)
+    if _is_late_packet(record, seq=seq, t0_us=t0_us):
+        return DataUpdateResult(is_late=True)
 
     record.frames_total += 1
     reset_detected = False


### PR DESCRIPTION
## What changed
- mark older non-duplicate DATA packets as late in the registry instead of letting them look like normal live frames
- ACK late packets but keep them out of `processor.ingest()`; they only flow to raw capture
- lock the behavior with registry and live UDP regressions proving late packets do not change `latest_metrics()` or the latest live sample

## Why
A newer seq could arrive, advance live state, and then an older non-duplicate packet could still get appended to the tail of the ring buffer. That corrupts live ordering and makes current metrics lie.

## Validation
- focused UDP/runtime/system-health suites
- `make lint`
- `make typecheck-backend`
- `make test-changed`

## Risks / tradeoffs
- kept late-packet loss on the existing `frames_dropped` confidence path instead of adding new public report schema
- late packets are still ACKed and kept in raw capture, but they no longer affect live metrics

Closes #3156