### PR TITLE
[codex] Fix sensor-to-PDF E2E location setup

### DIFF
--- a/apps/server/tests_e2e/_docker_edge_helpers.py
+++ b/apps/server/tests_e2e/_docker_edge_helpers.py
@@ -2,14 +2,31 @@
 
 from __future__ import annotations
 
+import time
+from typing import Final
+
 from tests_e2e.e2e_helpers import (
     api_json,
     run_simulator,
+    wait_for,
     wait_run_status,
 )
+from vibesensor.adapters.simulator.sim_client import make_client_id
 
 SHORT_RUN_DURATION_S = 0.8
 FORBIDDEN_PLACEHOLDERS = (" null ", " none ", " nan ", " undefined ", "{{", "}}")
+DEFAULT_SIMULATOR_NAMES: Final[tuple[str, ...]] = (
+    "front-left",
+    "front-right",
+    "rear-left",
+    "rear-right",
+)
+SIMULATOR_LOCATION_BY_NAME: Final[dict[str, str]] = {
+    "front-left": "front_left_wheel",
+    "front-right": "front_right_wheel",
+    "rear-left": "rear_left_wheel",
+    "rear-right": "rear_right_wheel",
+}
 
 
 def _simulate(
@@ -30,11 +47,96 @@ def _cleanup_run(base_url: str, run_id: str) -> None:
     api_json(base_url, f"/api/history/{run_id}", method="DELETE", expected_status=(200, 404, 409))
 
 
-def _cleanup_clients(base_url: str) -> None:
+def _delete_clients_preserving_sensor_settings(base_url: str) -> None:
     for client in api_json(base_url, "/api/clients").get("clients", []):
         api_json(
             base_url, f"/api/clients/{client['id']}", method="DELETE", expected_status=(200, 404)
         )
+
+
+def _cleanup_clients(base_url: str) -> None:
+    for client in api_json(base_url, "/api/clients").get("clients", []):
+        api_json(
+            base_url,
+            f"/api/clients/{client['id']}/location",
+            method="POST",
+            body={"location_code": ""},
+            expected_status=(200, 404),
+        )
+        api_json(
+            base_url, f"/api/clients/{client['id']}", method="DELETE", expected_status=(200, 404)
+        )
+
+
+def _prepare_simulator_locations(
+    e: dict[str, str],
+    *,
+    count: int = 4,
+    names: str | None = None,
+    preflight_duration_s: float = 2.0,
+) -> None:
+    """Persist canonical location settings for deterministic simulator clients.
+
+    The simulator client ids are deterministic by index.  Run a short preflight
+    so the public client-location endpoint can assign settings, then delete the
+    runtime records so the real capture starts with fresh sequence/dedup state.
+    """
+
+    name_list = _simulator_names(names, count=count)
+    assignments = [
+        (make_client_id(index + 1).hex(), SIMULATOR_LOCATION_BY_NAME[name])
+        for index, name in enumerate(name_list)
+        if name in SIMULATOR_LOCATION_BY_NAME
+    ]
+    if not assignments:
+        return
+
+    base_url = e["base_url"]
+    run_simulator(
+        base_url=base_url,
+        sim_host=e["sim_host"],
+        sim_data_port=e["sim_data_port"],
+        sim_control_port=e["sim_control_port"],
+        duration_s=preflight_duration_s,
+        count=count,
+        names=",".join(name_list),
+        scenario="road-fixed",
+    )
+    expected_ids = {client_id for client_id, _ in assignments}
+    wait_for(
+        lambda: expected_ids
+        if expected_ids
+        <= {str(client["id"]) for client in api_json(base_url, "/api/clients").get("clients", [])}
+        else None,
+        timeout_s=5.0,
+        interval_s=0.25,
+        message="simulator clients did not register before location assignment",
+    )
+
+    for client_id, _location_code in assignments:
+        api_json(
+            base_url,
+            f"/api/clients/{client_id}/location",
+            method="POST",
+            body={"location_code": ""},
+        )
+    for client_id, location_code in assignments:
+        api_json(
+            base_url,
+            f"/api/clients/{client_id}/location",
+            method="POST",
+            body={"location_code": location_code},
+        )
+
+    _delete_clients_preserving_sensor_settings(base_url)
+    time.sleep(0.5)
+    _delete_clients_preserving_sensor_settings(base_url)
+    wait_for(
+        lambda: not api_json(base_url, "/api/clients").get("clients"),
+        timeout_s=3.0,
+        interval_s=0.25,
+        message="preflight simulator clients did not clear before capture",
+    )
 
 
 def _wait_complete(base_url: str, run_id: str) -> dict:
@@ -91,3 +193,12 @@ def _pdf_mentions_frequency(text: str, hz: float) -> bool:
     # Only match period-decimal tokens (from the original tokens set, not comma
     # variants) to stay locale-neutral and avoid colliding with "13%".
     return any(token in lowered for token in tokens if "." in token)
+
+
+def _simulator_names(names: str | None, *, count: int) -> list[str]:
+    raw = [name.strip() for name in names.split(",") if name.strip()] if names else []
+    if not raw:
+        raw = list(DEFAULT_SIMULATOR_NAMES)
+    while len(raw) < count:
+        raw.append(f"sim-{len(raw) + 1}")
+    return raw[:count]

--- a/apps/server/tests_e2e/_docker_wheel_fault_helpers.py
+++ b/apps/server/tests_e2e/_docker_wheel_fault_helpers.py
@@ -8,7 +8,11 @@ import time
 from dataclasses import dataclass
 from math import floor
 
-from tests_e2e._docker_edge_helpers import _cleanup_clients, _cleanup_run
+from tests_e2e._docker_edge_helpers import (
+    _cleanup_clients,
+    _cleanup_run,
+    _prepare_simulator_locations,
+)
 from tests_e2e.e2e_helpers import (
     api_bytes,
     api_json,
@@ -48,6 +52,7 @@ def run_localized_wheel_fault_capture(
         message="simulator clients did not quiesce before wheel-fault E2E run",
     )
     time.sleep(2.5)
+    _prepare_simulator_locations(e2e_env)
 
     api_json(
         base_url,
@@ -134,10 +139,10 @@ def assert_localized_wheel_fault_report(
     report_text = pdf_text(artifacts.pdf_bytes)
     report_text_normalized = normalize_location(report_text)
     assert "what to do next" in report_text
-    assert re.search(r"most likely source\s+wheel / tire", report_text)
+    assert re.search(r"(?:most\s+)?likely source\s+wheel / tire", report_text)
     assert expected_location in report_text_normalized
-    assert not re.search(r"most likely source\s+driveline", report_text)
-    assert not re.search(r"most likely source\s+engine", report_text)
+    assert not re.search(r"(?:most\s+)?likely source\s+driveline", report_text)
+    assert not re.search(r"(?:most\s+)?likely source\s+engine", report_text)
     _validate_pdf_report(artifacts.pdf_bytes, primary_finding)
 
 

--- a/apps/server/tests_e2e/test_e2e_docker_engine_order_fault.py
+++ b/apps/server/tests_e2e/test_e2e_docker_engine_order_fault.py
@@ -8,7 +8,11 @@ import time
 
 import pytest
 
-from tests_e2e._docker_edge_helpers import _cleanup_clients, _cleanup_run
+from tests_e2e._docker_edge_helpers import (
+    _cleanup_clients,
+    _cleanup_run,
+    _prepare_simulator_locations,
+)
 from tests_e2e.e2e_helpers import (
     api_bytes,
     api_json,
@@ -31,6 +35,13 @@ def test_e2e_docker_engine_order_fault() -> None:
     sim_data_port = os.environ["VIBESENSOR_SIM_DATA_PORT"]
     sim_control_port = os.environ["VIBESENSOR_SIM_CONTROL_PORT"]
     sim_duration = os.environ["VIBESENSOR_SIM_DURATION"]
+    e2e_env = {
+        "base_url": base_url,
+        "sim_host": sim_host,
+        "sim_data_port": sim_data_port,
+        "sim_control_port": sim_control_port,
+        "sim_duration": sim_duration,
+    }
     run_id: str | None = None
     _cleanup_clients(base_url)
     wait_for(
@@ -40,6 +51,7 @@ def test_e2e_docker_engine_order_fault() -> None:
         message="simulator clients did not quiesce before engine-order E2E run",
     )
     time.sleep(2.5)
+    _prepare_simulator_locations(e2e_env)
     try:
         api_json(
             base_url,
@@ -100,8 +112,8 @@ def test_e2e_docker_engine_order_fault() -> None:
         report_text = pdf_text(pdf_resp.body)
         assert "what to do next" in report_text
         assert "recapture before acting" in report_text
-        assert re.search(r"most likely source\s+insufficient evidence", report_text)
-        assert not re.search(r"most likely source\s+wheel / tire", report_text)
+        assert re.search(r"(?:most\s+)?likely source\s+insufficient evidence", report_text)
+        assert not re.search(r"(?:most\s+)?likely source\s+wheel / tire", report_text)
     finally:
         cleanup_steps = [
             ("stop recording", lambda: api_json(base_url, "/api/recording/stop", method="POST")),

--- a/apps/server/tests_e2e/test_e2e_docker_pdf_accuracy.py
+++ b/apps/server/tests_e2e/test_e2e_docker_pdf_accuracy.py
@@ -6,8 +6,10 @@ import pytest
 
 from tests_e2e._docker_edge_helpers import (
     _assert_no_placeholders,
+    _cleanup_clients,
     _cleanup_run,
     _pdf_mentions_frequency,
+    _prepare_simulator_locations,
     _simulate,
     _wait_complete,
 )
@@ -25,6 +27,8 @@ pytestmark = pytest.mark.e2e
 def test_full_pdf_report_20s_accuracy_e2e(e2e_env: dict[str, str]) -> None:
     base = e2e_env["base_url"]
     duration_long = float(e2e_env["sim_duration_long"])
+    _cleanup_clients(base)
+    _prepare_simulator_locations(e2e_env)
     run_id = str(api_json(base, "/api/recording/start", method="POST")["run_id"])
     try:
         _simulate(e2e_env, duration=duration_long, count=4)
@@ -41,10 +45,12 @@ def test_full_pdf_report_20s_accuracy_e2e(e2e_env: dict[str, str]) -> None:
 
         for required in (
             "vibesensor diagnostic report",
-            "observed signature",
-            "systems with findings",
-            "next steps",
-            "data trust",
+            "likely source",
+            "what to do next",
+            "sensor model",
+            "firmware version",
+            "analysis rows",
+            "raw sample rate",
         ):
             assert required in text, f"missing PDF section: {required}"
 
@@ -105,7 +111,11 @@ def test_full_pdf_report_20s_accuracy_e2e(e2e_env: dict[str, str]) -> None:
         # The PDF renders frequencies from the persistence-ranked peaks_table, not
         # from the raw fft_spectrum top amplitude (which may be a transient spike).
         peaks_table = analysis.get("plots", {}).get("peaks_table", [])
-        if peaks_table and isinstance(peaks_table[0], dict):
+        if (
+            peaks_table
+            and isinstance(peaks_table[0], dict)
+            and "recapture before acting" not in text
+        ):
             peak_hz = float(peaks_table[0].get("frequency_hz") or 0)
             assert _pdf_mentions_frequency(text, peak_hz), (
                 f"PDF missing expected peaks-table top frequency {peak_hz:.2f} Hz"
@@ -115,3 +125,4 @@ def test_full_pdf_report_20s_accuracy_e2e(e2e_env: dict[str, str]) -> None:
     finally:
         api_json(base, "/api/recording/stop", method="POST")
         _cleanup_run(base, run_id)
+        _cleanup_clients(base)


### PR DESCRIPTION
## Summary
- Add a simulator preflight helper that assigns deterministic simulator clients to canonical wheel locations through the real HTTP client-location endpoint.
- Use that setup for wheel-fault, engine-order, and long PDF E2E coverage so recordings start with accurate persisted sensor metadata.
- Refresh PDF text assertions to match the current report surfaces and recapture-vs-measurement-page behavior.

## Root Cause
Docker E2E simulator clients advertise names such as `front-left`, but production analysis and reporting use persisted logical `location_code` values. Without the operator-style location assignment step, process-backed E2E could record with empty `location_code`s and misrepresent the real sensor-to-report workflow.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`
- `.venv/bin/python tools/tests/run_e2e_parallel.py --shards 1`