### PR TITLE
Propagate UDP ingest queue drops into run/report confidence metadata

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
@@ -136,7 +136,10 @@ def test_raw_capture_round_trip_persists_chunk_loss_counts_across_reload(tmp_pat
         db,
         "run-losses",
         sensor_losses={
-            "sensor-a": RawCaptureLossStats(queue_overflow_chunk_count=2),
+            "sensor-a": RawCaptureLossStats(
+                udp_ingest_queue_drop_count=1,
+                queue_overflow_chunk_count=2,
+            ),
             "sensor-b": RawCaptureLossStats(
                 invalid_chunk_count=1,
                 write_error_chunk_count=1,
@@ -145,11 +148,13 @@ def test_raw_capture_round_trip_persists_chunk_loss_counts_across_reload(tmp_pat
     )
 
     assert manifest is not None
-    assert manifest.total_dropped_chunk_count == 4
+    assert manifest.total_dropped_chunk_count == 5
+    assert manifest.losses.udp_ingest_queue_drop_count == 1
     assert manifest.losses.queue_overflow_chunk_count == 2
     assert manifest.losses.invalid_chunk_count == 1
     assert manifest.losses.write_error_chunk_count == 1
     assert manifest.sensor_loss("sensor-a") is not None
+    assert manifest.sensor_loss("sensor-a").losses.udp_ingest_queue_drop_count == 1
     assert manifest.sensor_loss("sensor-a").losses.queue_overflow_chunk_count == 2
     assert manifest.sensor_loss("sensor-b") is not None
     assert manifest.sensor_loss("sensor-b").losses.write_error_chunk_count == 1
@@ -160,7 +165,8 @@ def test_raw_capture_round_trip_persists_chunk_loss_counts_across_reload(tmp_pat
 
     assert stored is not None
     assert stored.raw_capture_manifest is not None
-    assert stored.raw_capture_manifest.total_dropped_chunk_count == 4
+    assert stored.raw_capture_manifest.total_dropped_chunk_count == 5
+    assert stored.raw_capture_manifest.losses.udp_ingest_queue_drop_count == 1
     assert stored.raw_capture_manifest.losses.invalid_chunk_count == 1
     assert stored.raw_capture_manifest.sensor_loss("sensor-b") is not None
     assert stored.raw_capture_manifest.sensor_loss("sensor-b").losses.invalid_chunk_count == 1

--- a/apps/server/tests/integration/test_udp_ingest_drop_report_honesty.py
+++ b/apps/server/tests/integration/test_udp_ingest_drop_report_honesty.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from test_support.findings import make_finding_payload
+from test_support.history_db_lifecycle import build_history_db
+from test_support.report_helpers import minimal_summary
+
+from vibesensor.adapters.gps.gps_speed import SpeedResolution
+from vibesensor.adapters.udp.protocol import HelloMessage, pack_data
+from vibesensor.adapters.udp.udp_data_rx import DataDatagramProtocol
+from vibesensor.infra.processing import SignalProcessor
+from vibesensor.infra.runtime.registry import ClientRegistry
+from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_to_json_object
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.run_context_warning import WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS
+from vibesensor.shared.types.aligned_speed_context import AlignedSpeedContextSnapshot
+from vibesensor.use_cases.history.report_document import build_report_document
+from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
+from vibesensor.use_cases.run.post_analysis_input import build_post_analysis_input
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
+
+_CLIENT_ID = bytes.fromhex("010203040506")
+_CLIENT_ID_HEX = _CLIENT_ID.hex()
+_ADDR = ("127.0.0.1", 12345)
+
+
+class _FakeTransport:
+    def sendto(self, _data: bytes, _addr: tuple[str, int]) -> None:
+        return None
+
+
+class _FakeSpeedProvider:
+    gps_speed_mps: float | None = None
+    engine_rpm: float | None = None
+    engine_rpm_source: str | None = None
+
+    def resolve_speed(self) -> SpeedResolution:
+        return SpeedResolution(speed_mps=None, fallback_active=False, source="none")
+
+    def resolve_speed_context_at(
+        self,
+        _target_mono_s: float | None,
+        *,
+        tolerance_s: float | None = None,
+    ) -> AlignedSpeedContextSnapshot:
+        del tolerance_s
+        return AlignedSpeedContextSnapshot(
+            selected_speed_source="gps",
+            resolved_speed_mps=None,
+            resolved_speed_source="none",
+            resolved_speed_aligned=False,
+            gps_speed_mps=None,
+            gps_speed_aligned=False,
+            measured_engine_rpm=None,
+            measured_engine_rpm_source=None,
+            measured_engine_rpm_aligned=False,
+        )
+
+
+def _processor() -> SignalProcessor:
+    return SignalProcessor(
+        sample_rate_hz=800,
+        waveform_seconds=4,
+        waveform_display_hz=100,
+        fft_n=256,
+        spectrum_max_hz=200,
+        accel_scale_g_per_lsb=0.0005,
+    )
+
+
+def _samples() -> np.ndarray:
+    time_axis = np.arange(256, dtype=np.float64) / 800.0
+    wave = np.round(1200.0 * np.sin(2.0 * np.pi * 40.0 * time_axis)).astype(np.int16)
+    zeros = np.zeros(256, dtype=np.int16)
+    return np.column_stack([wave, zeros, zeros])
+
+
+def test_udp_ingest_queue_drop_reaches_persisted_report_honesty(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history_db = build_history_db(tmp_path)
+    try:
+        registry = ClientRegistry(db=history_db.client_name_repository)
+        processor = _processor()
+        recorder = RunRecorder(
+            RunRecorderConfig(
+                metrics_log_hz=20,
+                sensor_model="ADXL345",
+                default_sample_rate_hz=800,
+                fft_window_size_samples=256,
+                persist_history_db=True,
+            ),
+            registry=registry,
+            gps_monitor=_FakeSpeedProvider(),
+            processor=processor,
+            history_db=history_db.run_repository,
+            language_reader=SimpleNamespace(language="en"),
+        )
+        proto = DataDatagramProtocol(
+            registry=registry,
+            processor=processor,
+            raw_capture_sink=recorder,
+            queue_maxsize=1,
+        )
+        proto.connection_made(_FakeTransport())
+        registry.update_from_hello(
+            HelloMessage(
+                client_id=_CLIENT_ID,
+                control_port=9010,
+                sample_rate_hz=800,
+                name="sensor-a",
+                firmware_version="fw",
+            ),
+            _ADDR,
+            now=1.0,
+        )
+        registry.set_location(_CLIENT_ID_HEX, "front-left")
+
+        recorder.start_recording()
+        snapshot = recorder._session_snapshot()
+        assert snapshot is not None
+        run_id = snapshot.run_id
+
+        first = pack_data(_CLIENT_ID, seq=1, t0_us=0, samples=_samples())
+        dropped = pack_data(_CLIENT_ID, seq=2, t0_us=320_000, samples=_samples())
+        proto.datagram_received(first, _ADDR)
+        proto.datagram_received(dropped, _ADDR)
+
+        queued_data, queued_addr = proto._queue.get_nowait()
+        try:
+            proto._process_datagram(queued_data, queued_addr)
+        finally:
+            proto._queue.task_done()
+
+        monkeypatch.setattr(recorder, "schedule_post_analysis", lambda _run_id: None)
+        recorder.stop_recording()
+        recorder.shutdown_raw_capture()
+
+        stored = history_db.run_repository.get_run(run_id)
+        assert stored is not None
+        assert stored.raw_capture_manifest is not None
+        manifest = stored.raw_capture_manifest
+        assert manifest.losses.udp_ingest_queue_drop_count == 1
+        assert manifest.total_dropped_chunk_count == 1
+        sensor_loss = manifest.sensor_loss(_CLIENT_ID_HEX)
+        assert sensor_loss is not None
+        assert sensor_loss.losses.udp_ingest_queue_drop_count == 1
+
+        raw_capture = history_db.run_repository._run_sync(
+            history_db.run_repository.aload_raw_capture(run_id)
+        )
+        assert raw_capture is not None
+
+        finding = make_finding_payload(
+            finding_id="F_INGEST_DROP",
+            suspected_source="wheel/tire",
+            confidence=0.75,
+            strongest_location="Front Left",
+            strongest_speed_band="40-60 km/h",
+        )
+
+        class FakeRunAnalysis:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def summarize(self):
+                return SimpleNamespace(
+                    diagnostic_case=SimpleNamespace(case_id="case-ingest-drop"),
+                )
+
+        monkeypatch.setattr(
+            "vibesensor.use_cases.diagnostics.run_analysis.RunAnalysis",
+            FakeRunAnalysis,
+        )
+        monkeypatch.setattr(
+            "vibesensor.use_cases.run.post_analysis_summary.analysis_result_to_summary",
+            lambda _result: minimal_summary(
+                run_id=run_id,
+                lang="en",
+                metadata=run_metadata_to_json_object(stored.metadata),
+                findings=[finding],
+                top_causes=[finding],
+                sensor_count_used=1,
+                sensor_locations=["Front Left"],
+                sensor_locations_connected_throughout=["Front Left"],
+            ),
+        )
+
+        summary = build_post_analysis_summary(
+            build_post_analysis_input(
+                LoadedPostAnalysisRun(
+                    run_id=run_id,
+                    metadata=stored.metadata,
+                    language="en",
+                    samples=sensor_frames_from_mappings(
+                        [
+                            {
+                                "client_id": _CLIENT_ID_HEX,
+                                "client_name": "Front Left",
+                                "t_s": 0.32,
+                                "sample_rate_hz": 800,
+                                "vibration_strength_db": 12.0,
+                                "dominant_freq_hz": 40.0,
+                            }
+                        ]
+                    ),
+                    raw_capture=raw_capture,
+                    total_sample_count=1,
+                    stride=1,
+                )
+            )
+        )
+
+        assert summary["analysis_metadata"]["raw_replay_udp_ingest_queue_drop_count"] == 1
+        assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in [
+            warning["code"] for warning in summary["warnings"]
+        ]
+
+        prepared = prepare_persisted_report_input(summary)
+        document = build_report_document(prepared)
+
+        assert any("UDP ingest queue drops" in (row.detail or "") for row in document.data_trust)
+    finally:
+        history_db.lifecycle.close()
+
+
+def test_clean_udp_run_keeps_report_free_of_ingest_drop_warning(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history_db = build_history_db(tmp_path)
+    try:
+        registry = ClientRegistry(db=history_db.client_name_repository)
+        processor = _processor()
+        recorder = RunRecorder(
+            RunRecorderConfig(
+                metrics_log_hz=20,
+                sensor_model="ADXL345",
+                default_sample_rate_hz=800,
+                fft_window_size_samples=256,
+                persist_history_db=True,
+            ),
+            registry=registry,
+            gps_monitor=_FakeSpeedProvider(),
+            processor=processor,
+            history_db=history_db.run_repository,
+            language_reader=SimpleNamespace(language="en"),
+        )
+        proto = DataDatagramProtocol(
+            registry=registry,
+            processor=processor,
+            raw_capture_sink=recorder,
+            queue_maxsize=4,
+        )
+        proto.connection_made(_FakeTransport())
+        registry.update_from_hello(
+            HelloMessage(
+                client_id=_CLIENT_ID,
+                control_port=9010,
+                sample_rate_hz=800,
+                name="sensor-a",
+                firmware_version="fw",
+            ),
+            _ADDR,
+            now=1.0,
+        )
+        registry.set_location(_CLIENT_ID_HEX, "front-left")
+
+        recorder.start_recording()
+        snapshot = recorder._session_snapshot()
+        assert snapshot is not None
+        run_id = snapshot.run_id
+
+        packet = pack_data(_CLIENT_ID, seq=1, t0_us=0, samples=_samples())
+        proto.datagram_received(packet, _ADDR)
+        queued_data, queued_addr = proto._queue.get_nowait()
+        try:
+            proto._process_datagram(queued_data, queued_addr)
+        finally:
+            proto._queue.task_done()
+
+        monkeypatch.setattr(recorder, "schedule_post_analysis", lambda _run_id: None)
+        recorder.stop_recording()
+        recorder.shutdown_raw_capture()
+
+        stored = history_db.run_repository.get_run(run_id)
+        assert stored is not None
+        assert stored.raw_capture_manifest is not None
+        manifest = stored.raw_capture_manifest
+        assert manifest.losses.udp_ingest_queue_drop_count == 0
+        assert manifest.total_dropped_chunk_count == 0
+        assert manifest.sensor_loss(_CLIENT_ID_HEX) is None
+
+        raw_capture = history_db.run_repository._run_sync(
+            history_db.run_repository.aload_raw_capture(run_id)
+        )
+        assert raw_capture is not None
+
+        finding = make_finding_payload(
+            finding_id="F_CLEAN_RUN",
+            suspected_source="wheel/tire",
+            confidence=0.75,
+            strongest_location="Front Left",
+            strongest_speed_band="40-60 km/h",
+        )
+
+        class FakeRunAnalysis:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def summarize(self):
+                return SimpleNamespace(
+                    diagnostic_case=SimpleNamespace(case_id="case-clean-run"),
+                )
+
+        monkeypatch.setattr(
+            "vibesensor.use_cases.diagnostics.run_analysis.RunAnalysis",
+            FakeRunAnalysis,
+        )
+        monkeypatch.setattr(
+            "vibesensor.use_cases.run.post_analysis_summary.analysis_result_to_summary",
+            lambda _result: minimal_summary(
+                run_id=run_id,
+                lang="en",
+                metadata=run_metadata_to_json_object(stored.metadata),
+                findings=[finding],
+                top_causes=[finding],
+                sensor_count_used=1,
+                sensor_locations=["Front Left"],
+                sensor_locations_connected_throughout=["Front Left"],
+            ),
+        )
+
+        summary = build_post_analysis_summary(
+            build_post_analysis_input(
+                LoadedPostAnalysisRun(
+                    run_id=run_id,
+                    metadata=stored.metadata,
+                    language="en",
+                    samples=sensor_frames_from_mappings(
+                        [
+                            {
+                                "client_id": _CLIENT_ID_HEX,
+                                "client_name": "Front Left",
+                                "t_s": 0.0,
+                                "sample_rate_hz": 800,
+                                "vibration_strength_db": 12.0,
+                                "dominant_freq_hz": 40.0,
+                            }
+                        ]
+                    ),
+                    raw_capture=raw_capture,
+                    total_sample_count=1,
+                    stride=1,
+                )
+            )
+        )
+
+        assert summary["analysis_metadata"]["raw_replay_udp_ingest_queue_drop_count"] == 0
+        assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS not in [
+            warning["code"] for warning in summary.get("warnings", [])
+        ]
+
+        prepared = prepare_persisted_report_input(summary)
+        document = build_report_document(prepared)
+
+        assert not any(
+            "UDP ingest queue drops" in (row.detail or "") for row in document.data_trust
+        )
+    finally:
+        history_db.lifecycle.close()

--- a/apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py
+++ b/apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py
@@ -182,7 +182,8 @@ def test_prepare_persisted_report_input_surfaces_dropped_raw_chunk_warning() -> 
                 analysis_metadata={
                     "raw_backed_sample_count": 4,
                     "raw_capture_mode": "partial_raw_backed",
-                    "raw_replay_dropped_chunk_count": 3,
+                    "raw_replay_dropped_chunk_count": 4,
+                    "raw_replay_udp_ingest_queue_drop_count": 1,
                     "raw_replay_queue_overflow_chunk_count": 2,
                     "raw_replay_invalid_chunk_count": 1,
                     "raw_replay_write_error_chunk_count": 0,
@@ -195,7 +196,8 @@ def test_prepare_persisted_report_input_surfaces_dropped_raw_chunk_warning() -> 
                         "title": i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_DROPPED_CHUNKS_TITLE"),
                         "detail": i18n_ref(
                             "RUN_CONTEXT_WARNING_RAW_REPLAY_DROPPED_CHUNKS_DETAIL",
-                            count="3",
+                            count="4",
+                            udp_ingest="1",
                             queue_overflow="2",
                             invalid="1",
                             write_errors="0",
@@ -211,10 +213,7 @@ def test_prepare_persisted_report_input_surfaces_dropped_raw_chunk_warning() -> 
     assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in [
         warning.code for warning in prepared.report_facts.decision.warnings
     ]
-    assert any(
-        "Raw capture dropped 3 chunk(s) before persistence" in (row.detail or "")
-        for row in document.data_trust
-    )
+    assert any("UDP ingest queue drops" in (row.detail or "") for row in document.data_trust)
 
 
 def test_prepare_persisted_report_input_surfaces_sync_unverified_warning() -> None:
@@ -321,6 +320,7 @@ def test_prepare_persisted_report_input_surfaces_whole_run_alignment_warning() -
                             gaps="1",
                             overlaps="0",
                             dropped="0",
+                            udp_ingest="0",
                             queue_overflow="0",
                             invalid="0",
                             write_errors="0",

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py
@@ -104,6 +104,7 @@ def test_execute_post_analysis_appends_whole_run_alignment_warning_and_metadata(
                             gaps="1",
                             overlaps="0",
                             dropped="2",
+                            udp_ingest="0",
                             queue_overflow="2",
                             invalid="0",
                             write_errors="0",

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -271,6 +271,7 @@ def test_build_post_analysis_summary_adds_analysis_metadata(
         "raw_replay_gap_count": 0,
         "raw_replay_overlap_count": 0,
         "raw_replay_dropped_chunk_count": 0,
+        "raw_replay_udp_ingest_queue_drop_count": 0,
         "raw_replay_queue_overflow_chunk_count": 0,
         "raw_replay_invalid_chunk_count": 0,
         "raw_replay_write_error_chunk_count": 0,
@@ -416,6 +417,7 @@ def test_build_post_analysis_summary_propagates_dropped_chunk_metadata_and_warni
                 raw_capture=_full_raw_capture(
                     "run-drops",
                     losses=RawCaptureLossStats(
+                        udp_ingest_queue_drop_count=1,
                         queue_overflow_chunk_count=2,
                         write_error_chunk_count=1,
                     ),
@@ -426,7 +428,8 @@ def test_build_post_analysis_summary_propagates_dropped_chunk_metadata_and_warni
         )
     )
 
-    assert summary["analysis_metadata"]["raw_replay_dropped_chunk_count"] == 3
+    assert summary["analysis_metadata"]["raw_replay_dropped_chunk_count"] == 4
+    assert summary["analysis_metadata"]["raw_replay_udp_ingest_queue_drop_count"] == 1
     assert summary["analysis_metadata"]["raw_replay_queue_overflow_chunk_count"] == 2
     assert summary["analysis_metadata"]["raw_replay_invalid_chunk_count"] == 0
     assert summary["analysis_metadata"]["raw_replay_write_error_chunk_count"] == 1

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay.py
@@ -133,6 +133,7 @@ def test_build_post_analysis_input_replays_raw_backed_strength_metrics() -> None
 def test_build_post_analysis_input_surfaces_persisted_dropped_chunk_counts() -> None:
     raw_capture = _raw_capture("run-drops")
     loss_stats = RawCaptureLossStats(
+        udp_ingest_queue_drop_count=1,
         queue_overflow_chunk_count=2,
         invalid_chunk_count=1,
     )
@@ -167,7 +168,8 @@ def test_build_post_analysis_input_surfaces_persisted_dropped_chunk_counts() -> 
     result = build_post_analysis_input(loaded)
 
     assert result.raw_backed_sample_count == 1
-    assert result.raw_replay.dropped_chunk_count == 3
+    assert result.raw_replay.dropped_chunk_count == 4
+    assert result.raw_replay.udp_ingest_queue_drop_count == 1
     assert result.raw_replay.queue_overflow_chunk_count == 2
     assert result.raw_replay.invalid_chunk_count == 1
     assert result.raw_replay.write_error_chunk_count == 0

--- a/apps/server/tests/use_cases/run/test_raw_capture_writer.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_writer.py
@@ -7,7 +7,7 @@ import threading
 import numpy as np
 import pytest
 
-from vibesensor.shared.types.raw_capture import RawCaptureSensorClockSync
+from vibesensor.shared.types.raw_capture import RawCaptureLossStats, RawCaptureSensorClockSync
 from vibesensor.use_cases.run.raw_capture_writer import RunRawCaptureWriter
 
 
@@ -101,11 +101,15 @@ def test_raw_capture_writer_persists_queue_invalid_and_write_failures(
     )
 
     history_db.allow_first_write.set()
-    writer.finalize_run("run-losses")
+    writer.finalize_run(
+        "run-losses",
+        sensor_losses={"sensor-d": RawCaptureLossStats(udp_ingest_queue_drop_count=2)},
+    )
 
     assert history_db.finalized_sensor_losses is not None
     assert history_db.finalized_sensor_losses["sensor-a"].queue_overflow_chunk_count == 1
     assert history_db.finalized_sensor_losses["sensor-b"].write_error_chunk_count == 1
     assert history_db.finalized_sensor_losses["sensor-c"].invalid_chunk_count == 1
+    assert history_db.finalized_sensor_losses["sensor-d"].udp_ingest_queue_drop_count == 2
 
     assert writer.shutdown()

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1700,8 +1700,8 @@
     "nl": "De whole-run raw-uitlijning was onvolledig"
   },
   "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_INCOMPLETE_DETAIL": {
-    "en": "Whole-run raw coverage was incomplete for some time-aligned windows; affected order and spatial diagnostics used only fully covered windows. Partial windows: {partial}, missing windows: {missing}, timing gaps: {gaps}, overlaps: {overlaps}, dropped chunks: {dropped}, sample-rate mismatches: {mismatches}, unanchored sensors: {unanchored}, sync-unverified sensors: {sync_unverified}.",
-    "nl": "De whole-run raw-dekking was onvolledig voor sommige tijd-uitgelijnde vensters; getroffen orde- en ruimtelijke diagnostiek gebruikte alleen volledig gedekte vensters. Gedeeltelijke vensters: {partial}, ontbrekende vensters: {missing}, timinggaten: {gaps}, overlappen: {overlaps}, verloren chunks: {dropped}, samplefrequentiemismatches: {mismatches}, niet-verankerde sensoren: {unanchored}, sensoren zonder bewezen sync: {sync_unverified}."
+    "en": "Whole-run raw coverage was incomplete for some time-aligned windows; affected order and spatial diagnostics used only fully covered windows. Partial windows: {partial}, missing windows: {missing}, timing gaps: {gaps}, overlaps: {overlaps}, dropped chunks: {dropped}, UDP ingest queue drops: {udp_ingest}, raw-capture queue overflows: {queue_overflow}, invalid chunks: {invalid}, write errors: {write_errors}, sample-rate mismatches: {mismatches}, unanchored sensors: {unanchored}, sync-unverified sensors: {sync_unverified}.",
+    "nl": "De whole-run raw-dekking was onvolledig voor sommige tijd-uitgelijnde vensters; getroffen orde- en ruimtelijke diagnostiek gebruikte alleen volledig gedekte vensters. Gedeeltelijke vensters: {partial}, ontbrekende vensters: {missing}, timinggaten: {gaps}, overlappen: {overlaps}, verloren chunks: {dropped}, UDP-ingestwachtrij-drops: {udp_ingest}, raw-capture-wachtrijoverlopen: {queue_overflow}, ongeldige chunks: {invalid}, schrijffouten: {write_errors}, samplefrequentiemismatches: {mismatches}, niet-verankerde sensoren: {unanchored}, sensoren zonder bewezen sync: {sync_unverified}."
   },
   "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_UNAVAILABLE_DETAIL": {
     "en": "Whole-run raw timing could not be proven for the recorded sensors, so time-aligned order and spatial diagnostics were skipped. Legacy sensors: {legacy}, unanchored sensors: {unanchored}, sync-unverified sensors: {sync_unverified}, missing sync proof: {missing_sync}, stale sync snapshots: {stale}, high-RTT sync snapshots: {high_rtt}, sample-rate mismatches: {mismatches}.",
@@ -1720,8 +1720,8 @@
     "nl": "Raw capture verloor chunks voor persistente opslag"
   },
   "RUN_CONTEXT_WARNING_RAW_REPLAY_DROPPED_CHUNKS_DETAIL": {
-    "en": "Raw capture dropped {count} chunk(s) before persistence ({queue_overflow} queue overflows, {invalid} invalid chunks, {write_errors} write errors); affected metrics used persisted summary samples where needed.",
-    "nl": "Raw capture verloor {count} chunk(s) voor persistente opslag ({queue_overflow} wachtrijoverlopen, {invalid} ongeldige chunks, {write_errors} schrijffouten); getroffen metrieken gebruikten waar nodig persistente samenvattingssamples."
+    "en": "Raw capture dropped {count} chunk(s) before persistence ({udp_ingest} UDP ingest queue drops, {queue_overflow} raw-capture queue overflows, {invalid} invalid chunks, {write_errors} write errors); affected metrics used persisted summary samples where needed.",
+    "nl": "Raw capture verloor {count} chunk(s) voor persistente opslag ({udp_ingest} UDP-ingestwachtrij-drops, {queue_overflow} raw-capture-wachtrijoverlopen, {invalid} ongeldige chunks, {write_errors} schrijffouten); getroffen metrieken gebruikten waar nodig persistente samenvattingssamples."
   },
   "RUN_CONTEXT_WARNING_RAW_REPLAY_TIMING_FALLBACK_TITLE": {
     "en": "Raw replay used persisted sample timing for some windows",

--- a/apps/server/vibesensor/shared/types/raw_capture.py
+++ b/apps/server/vibesensor/shared/types/raw_capture.py
@@ -35,7 +35,7 @@ type RawCaptureClockProofState = Literal[
     "missing_registry_record",
 ]
 
-_RAW_CAPTURE_SCHEMA_VERSION = 4
+_RAW_CAPTURE_SCHEMA_VERSION = 5
 _RAW_CAPTURE_STORAGE_TYPE = "run-directory-v1"
 _RAW_CAPTURE_MODE = "full_run"
 
@@ -82,6 +82,7 @@ class RawCaptureChunkIndex:
 class RawCaptureLossStats:
     """Structured counts for raw chunks lost before persistence."""
 
+    udp_ingest_queue_drop_count: int = 0
     queue_overflow_chunk_count: int = 0
     invalid_chunk_count: int = 0
     write_error_chunk_count: int = 0
@@ -89,13 +90,15 @@ class RawCaptureLossStats:
     @property
     def total_dropped_chunk_count(self) -> int:
         return (
-            max(0, self.queue_overflow_chunk_count)
+            max(0, self.udp_ingest_queue_drop_count)
+            + max(0, self.queue_overflow_chunk_count)
             + max(0, self.invalid_chunk_count)
             + max(0, self.write_error_chunk_count)
         )
 
     def to_json_object(self) -> JsonObject:
         return {
+            "udp_ingest_queue_drop_count": self.udp_ingest_queue_drop_count,
             "queue_overflow_chunk_count": self.queue_overflow_chunk_count,
             "invalid_chunk_count": self.invalid_chunk_count,
             "write_error_chunk_count": self.write_error_chunk_count,
@@ -104,6 +107,7 @@ class RawCaptureLossStats:
     @classmethod
     def from_mapping(cls, data: JsonObject) -> RawCaptureLossStats:
         return cls(
+            udp_ingest_queue_drop_count=_int_from_json(data.get("udp_ingest_queue_drop_count")),
             queue_overflow_chunk_count=_int_from_json(data.get("queue_overflow_chunk_count")),
             invalid_chunk_count=_int_from_json(data.get("invalid_chunk_count")),
             write_error_chunk_count=_int_from_json(data.get("write_error_chunk_count")),
@@ -111,6 +115,9 @@ class RawCaptureLossStats:
 
     def merged(self, other: RawCaptureLossStats) -> RawCaptureLossStats:
         return RawCaptureLossStats(
+            udp_ingest_queue_drop_count=(
+                self.udp_ingest_queue_drop_count + other.udp_ingest_queue_drop_count
+            ),
             queue_overflow_chunk_count=(
                 self.queue_overflow_chunk_count + other.queue_overflow_chunk_count
             ),

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
@@ -186,6 +186,7 @@ class WholeRunSpectralCoverageSummary:
     stale_sync_sensor_count: int
     high_rtt_sensor_count: int
     coverage_confidence: WholeRunCoverageConfidence
+    udp_ingest_queue_drop_count: int = 0
     warnings: tuple[RunContextWarning, ...] = ()
 
 
@@ -247,6 +248,7 @@ def build_whole_run_spectral_artifact_bundle(
             stale_sync_sensor_count=0,
             high_rtt_sensor_count=0,
             coverage_confidence="unavailable",
+            udp_ingest_queue_drop_count=0,
         )
         return WholeRunSpectralBuildResult(bundle=None, coverage_summary=coverage_summary)
     timelines = {
@@ -802,6 +804,7 @@ def _build_coverage_summary(
         if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "high_rtt"
     )
     dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
+    udp_ingest_queue_drop_count = raw_capture.manifest.losses.udp_ingest_queue_drop_count
     queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
     invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
     write_error_chunk_count = raw_capture.manifest.losses.write_error_chunk_count
@@ -825,6 +828,7 @@ def _build_coverage_summary(
         gap_count=gap_count,
         overlap_count=overlap_count,
         dropped_chunk_count=dropped_chunk_count,
+        udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
         queue_overflow_chunk_count=queue_overflow_chunk_count,
         invalid_chunk_count=invalid_chunk_count,
         write_error_chunk_count=write_error_chunk_count,
@@ -844,6 +848,7 @@ def _build_coverage_summary(
         gap_count=gap_count,
         overlap_count=overlap_count,
         dropped_chunk_count=dropped_chunk_count,
+        udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
         queue_overflow_chunk_count=queue_overflow_chunk_count,
         invalid_chunk_count=invalid_chunk_count,
         write_error_chunk_count=write_error_chunk_count,
@@ -897,6 +902,7 @@ def _build_whole_run_warnings(
     gap_count: int,
     overlap_count: int,
     dropped_chunk_count: int,
+    udp_ingest_queue_drop_count: int,
     queue_overflow_chunk_count: int,
     invalid_chunk_count: int,
     write_error_chunk_count: int,
@@ -944,6 +950,7 @@ def _build_whole_run_warnings(
                 gaps=str(max(0, gap_count)),
                 overlaps=str(max(0, overlap_count)),
                 dropped=str(max(0, dropped_chunk_count)),
+                udp_ingest=str(max(0, udp_ingest_queue_drop_count)),
                 queue_overflow=str(max(0, queue_overflow_chunk_count)),
                 invalid=str(max(0, invalid_chunk_count)),
                 write_errors=str(max(0, write_error_chunk_count)),

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -23,7 +23,11 @@ from vibesensor.shared.ports import (
 from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.tracing import mark_span_error, start_span
-from vibesensor.shared.types.raw_capture import RawCaptureClockProofState, RawCaptureSensorClockSync
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureClockProofState,
+    RawCaptureLossStats,
+    RawCaptureSensorClockSync,
+)
 from vibesensor.use_cases.run.capture_readiness import CaptureReadinessTracker
 from vibesensor.use_cases.run.capture_readiness_observation import observe_capture_readiness
 from vibesensor.use_cases.run.lifecycle_state import RunLifecycleState
@@ -151,6 +155,7 @@ class RunRecorder:
 
         with self._lock:
             self._persistence.reset()
+        self._run_ingest_drop_baseline: dict[str, int] | None = None
 
     @property
     def enabled(self) -> bool:
@@ -227,6 +232,7 @@ class RunRecorder:
             snapshot.run_id,
             run_start_monotonic_us=int(round(snapshot.start_mono_s * 1_000_000.0)),
         )
+        self._run_ingest_drop_baseline = _snapshot_server_queue_drops(self.registry)
         return snapshot
 
     def capture_raw_samples(
@@ -336,8 +342,15 @@ class RunRecorder:
                         start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
                         end_time_utc = utc_now_iso()
                         persistence_snapshot = self._persistence.status_snapshot()
+                        ingest_drop_losses = _udp_ingest_drop_sensor_losses(
+                            self.registry,
+                            baseline=self._run_ingest_drop_baseline,
+                        )
                         if run_id:
-                            self._raw_capture.finalize_run(run_id)
+                            self._raw_capture.finalize_run(
+                                run_id,
+                                sensor_losses=ingest_drop_losses,
+                            )
                         if run_id and not self._persistence.finalize_run(
                             run_id,
                             start_time_utc,
@@ -434,8 +447,15 @@ class RunRecorder:
                     start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
                     end_time_utc = utc_now_iso()
                     persistence_snapshot = self._persistence.status_snapshot()
+                    ingest_drop_losses = _udp_ingest_drop_sensor_losses(
+                        self.registry,
+                        baseline=self._run_ingest_drop_baseline,
+                    )
                     if run_id:
-                        self._raw_capture.finalize_run(run_id)
+                        self._raw_capture.finalize_run(
+                            run_id,
+                            sensor_losses=ingest_drop_losses,
+                        )
                     if run_id and not self._persistence.finalize_run(
                         run_id,
                         start_time_utc,
@@ -458,6 +478,7 @@ class RunRecorder:
                     self._lifecycle.stop()
                     self._active_run_context = None
                     self._persistence.reset()
+                    self._run_ingest_drop_baseline = None
                     result = self.status()
             except Exception as exc:
                 mark_span_error(span, exc)
@@ -569,3 +590,40 @@ def _raw_capture_clock_proof_state(
 def _int_attr(value: object, name: str) -> int | None:
     raw_value = getattr(value, name, None)
     return int(raw_value) if isinstance(raw_value, int) else None
+
+
+def _snapshot_server_queue_drops(registry: ClientTracker) -> dict[str, int]:
+    client_ids: set[str] = set()
+    client_snapshots = getattr(registry, "client_snapshots", None)
+    if callable(client_snapshots):
+        for client_snapshot in client_snapshots():
+            client_id = str(getattr(client_snapshot, "client_id", "") or "").strip()
+            if client_id:
+                client_ids.add(client_id)
+    else:
+        client_ids.update(str(client_id) for client_id in registry.active_client_ids())
+    queue_drop_snapshot: dict[str, int] = {}
+    for client_id in sorted(client_ids):
+        record = registry.get(client_id)
+        if record is None:
+            continue
+        queue_drop_snapshot[client_id] = _int_attr(record, "server_queue_drops") or 0
+    return queue_drop_snapshot
+
+
+def _udp_ingest_drop_sensor_losses(
+    registry: ClientTracker,
+    *,
+    baseline: dict[str, int] | None,
+) -> dict[str, RawCaptureLossStats] | None:
+    current = _snapshot_server_queue_drops(registry)
+    client_ids = set(current) | set(baseline or {})
+    if not client_ids:
+        return None
+    losses: dict[str, RawCaptureLossStats] = {}
+    for client_id in sorted(client_ids):
+        delta = max(0, current.get(client_id, 0) - (baseline or {}).get(client_id, 0))
+        if delta <= 0:
+            continue
+        losses[client_id] = RawCaptureLossStats(udp_ingest_queue_drop_count=delta)
+    return losses or None

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -840,6 +840,9 @@ def _append_whole_run_spectral_metadata(
     analysis_metadata["whole_run_spectral_dropped_chunk_count"] = (
         coverage_summary.dropped_chunk_count
     )
+    analysis_metadata["whole_run_spectral_udp_ingest_queue_drop_count"] = getattr(
+        coverage_summary, "udp_ingest_queue_drop_count", 0
+    )
     analysis_metadata["whole_run_spectral_queue_overflow_chunk_count"] = (
         coverage_summary.queue_overflow_chunk_count
     )

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -80,6 +80,7 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         "raw_replay_gap_count": run.raw_replay.gap_count,
         "raw_replay_overlap_count": run.raw_replay.overlap_count,
         "raw_replay_dropped_chunk_count": run.raw_replay.dropped_chunk_count,
+        "raw_replay_udp_ingest_queue_drop_count": run.raw_replay.udp_ingest_queue_drop_count,
         "raw_replay_queue_overflow_chunk_count": run.raw_replay.queue_overflow_chunk_count,
         "raw_replay_invalid_chunk_count": run.raw_replay.invalid_chunk_count,
         "raw_replay_write_error_chunk_count": run.raw_replay.write_error_chunk_count,

--- a/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
@@ -81,6 +81,7 @@ class RawReplaySummary:
     high_rtt_sensor_count: int
     replay_confidence: RawReplayConfidence
     raw_capture_mode: str
+    udp_ingest_queue_drop_count: int = 0
     warnings: tuple[RunContextWarning, ...] = ()
 
 
@@ -134,6 +135,7 @@ def build_raw_backed_samples(
                 high_rtt_sensor_count=0,
                 replay_confidence="unavailable",
                 raw_capture_mode="summary_only",
+                udp_ingest_queue_drop_count=0,
             ),
             window_coverages=tuple(
                 RawReplayWindowCoverage(
@@ -172,6 +174,7 @@ def build_raw_backed_samples(
                 high_rtt_sensor_count=0,
                 replay_confidence="fallback",
                 raw_capture_mode="summary_only",
+                udp_ingest_queue_drop_count=0,
             ),
             window_coverages=tuple(
                 RawReplayWindowCoverage(
@@ -241,6 +244,7 @@ def build_raw_backed_samples(
         if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "high_rtt"
     )
     dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
+    udp_ingest_queue_drop_count = raw_capture.manifest.losses.udp_ingest_queue_drop_count
     queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
     invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
     write_error_chunk_count = raw_capture.manifest.losses.write_error_chunk_count
@@ -285,6 +289,7 @@ def build_raw_backed_samples(
             high_rtt_sensor_count=high_rtt_sensor_count,
             replay_confidence=replay_confidence,
             raw_capture_mode=raw_capture_mode,
+            udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
             warnings=_build_replay_warnings(
                 raw_backed_sample_count=raw_backed_count,
                 timing_fallback_count=timing_fallback_count,
@@ -293,6 +298,7 @@ def build_raw_backed_samples(
                 gap_count=gap_count,
                 overlap_count=overlap_count,
                 dropped_chunk_count=dropped_chunk_count,
+                udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
                 queue_overflow_chunk_count=queue_overflow_chunk_count,
                 invalid_chunk_count=invalid_chunk_count,
                 write_error_chunk_count=write_error_chunk_count,
@@ -524,6 +530,7 @@ def _build_replay_warnings(
     gap_count: int,
     overlap_count: int,
     dropped_chunk_count: int,
+    udp_ingest_queue_drop_count: int,
     queue_overflow_chunk_count: int,
     invalid_chunk_count: int,
     write_error_chunk_count: int,
@@ -600,6 +607,7 @@ def _build_replay_warnings(
                 detail=i18n_ref(
                     "RUN_CONTEXT_WARNING_RAW_REPLAY_DROPPED_CHUNKS_DETAIL",
                     count=str(max(0, dropped_chunk_count)),
+                    udp_ingest=str(max(0, udp_ingest_queue_drop_count)),
                     queue_overflow=str(max(0, queue_overflow_chunk_count)),
                     invalid=str(max(0, invalid_chunk_count)),
                     write_errors=str(max(0, write_error_chunk_count)),

--- a/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
@@ -39,6 +39,7 @@ class _FinalizeRequest:
     run_start_monotonic_us: int | None = None
     sensor_clock_sync: Mapping[str, RawCaptureSensorClockSync] | None = None
     sensor_losses: _RunCaptureStats | None = None
+    extra_sensor_losses: Mapping[str, RawCaptureLossStats] | None = None
     done: threading.Event = field(default_factory=threading.Event)
     manifest: RawCaptureManifest | None = None
     error: BaseException | None = None
@@ -204,7 +205,12 @@ class RunRawCaptureWriter:
                 client_id,
             )
 
-    def finalize_run(self, run_id: str) -> RawCaptureManifest | None:
+    def finalize_run(
+        self,
+        run_id: str,
+        *,
+        sensor_losses: Mapping[str, RawCaptureLossStats] | None = None,
+    ) -> RawCaptureManifest | None:
         if self._history_db is None or self._thread is None:
             return None
         with self._lock:
@@ -228,6 +234,7 @@ class RunRawCaptureWriter:
             run_start_monotonic_us=run_start_monotonic_us,
             sensor_clock_sync=sensor_clock_sync,
             sensor_losses=run_stats,
+            extra_sensor_losses=sensor_losses,
         )
         self._queue.put(request)
         request.done.wait()
@@ -265,10 +272,11 @@ class RunRawCaptureWriter:
                                     item.run_id,
                                     run_start_monotonic_us=item.run_start_monotonic_us,
                                     sensor_clock_sync=item.sensor_clock_sync,
-                                    sensor_losses=(
+                                    sensor_losses=_merge_sensor_losses(
                                         item.sensor_losses.freeze()
                                         if item.sensor_losses is not None
-                                        else None
+                                        else None,
+                                        item.extra_sensor_losses,
                                     ),
                                 ),
                             ),
@@ -297,3 +305,23 @@ class RunRawCaptureWriter:
                     )
             finally:
                 self._queue.task_done()
+
+
+def _merge_sensor_losses(
+    primary: Mapping[str, RawCaptureLossStats] | None,
+    secondary: Mapping[str, RawCaptureLossStats] | None,
+) -> dict[str, RawCaptureLossStats] | None:
+    if not primary and not secondary:
+        return None
+    merged: dict[str, RawCaptureLossStats] = {}
+    client_ids = set(primary or ()) | set(secondary or ())
+    for client_id in sorted(client_ids):
+        losses = RawCaptureLossStats()
+        if primary is not None:
+            losses = losses.merged(primary.get(client_id, RawCaptureLossStats()))
+        if secondary is not None:
+            losses = losses.merged(secondary.get(client_id, RawCaptureLossStats()))
+        if losses.total_dropped_chunk_count <= 0:
+            continue
+        merged[client_id] = losses
+    return merged or None


### PR DESCRIPTION
## What changed
- add a distinct `udp_ingest_queue_drop_count` raw-capture loss bucket and bump the persisted raw-capture schema
- snapshot per-sensor `server_queue_drops` at run start/stop and persist only the in-run delta into finalized raw-capture metadata
- thread the new loss count through raw replay, post-analysis, whole-run spectral metadata, warning text, and report data-trust output
- add focused coverage for persistence/reload, replay/summary/report warnings, and a clean-run integration path that proves zero-drop runs stay warning-free

## Why
Packets dropped before raw capture never reach replay. Reports were honest about raw-capture queue loss, but not earlier UDP ingest loss.

## Validation
- `.venv/bin/python -m pytest -q apps/server/tests/integration/test_udp_ingest_drop_report_honesty.py apps/server/tests/use_cases/run/test_raw_capture_writer.py apps/server/tests/use_cases/run/test_raw_capture_replay.py apps/server/tests/use_cases/run/test_post_analysis_summary.py apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`

## Risks / tradeoffs
- raw-capture manifests move to schema v5; older manifests still decode with the new field defaulting to zero
- counting depends on per-sensor registry `server_queue_drops` deltas across the run, so removing a client record mid-run would discard that sensor's later counter history
- out of scope: recovery for packets already dropped before ingress

Closes #3157
