### PR TITLE
Snapshot per-run sensor metadata

### DIFF
--- a/apps/server/tests/shared/boundaries/test_run_metadata_codec.py
+++ b/apps/server/tests/shared/boundaries/test_run_metadata_codec.py
@@ -84,3 +84,42 @@ def test_run_metadata_from_json_tolerates_legacy_non_string_record_type() -> Non
 
     assert decoded.record_type == "run_metadata"
     assert decoded.run_id == "legacy-run"
+
+
+def test_run_metadata_codec_roundtrip_preserves_sensor_snapshots() -> None:
+    metadata = run_metadata_from_mapping(
+        {
+            "run_id": "run-sensors",
+            "start_time_utc": "2026-01-01T00:00:00Z",
+            "sensor_model": "ADXL345",
+            "sensor_snapshots": [
+                {
+                    "sensor_id": "sensor-a",
+                    "display_name": "Front left",
+                    "location_code": "front_left_wheel",
+                    "sample_rate_hz": 800,
+                    "firmware_version": "1.2.3",
+                }
+            ],
+        }
+    )
+
+    payload = run_metadata_to_json_object(metadata)
+    decoded = run_metadata_from_json(run_metadata_to_json_bytes(metadata))
+
+    assert payload["sensor_snapshots"] == [
+        {
+            "sensor_id": "sensor-a",
+            "display_name": "Front left",
+            "location_code": "front_left_wheel",
+            "sample_rate_hz": 800,
+            "firmware_version": "1.2.3",
+        }
+    ]
+    assert len(decoded.sensor_snapshots) == 1
+    snapshot = decoded.sensor_snapshots[0]
+    assert snapshot.sensor_id == "sensor-a"
+    assert snapshot.display_name == "Front left"
+    assert snapshot.location_code == "front_left_wheel"
+    assert snapshot.sample_rate_hz == 800
+    assert snapshot.firmware_version == "1.2.3"

--- a/apps/server/tests/use_cases/diagnostics/test_sensor_location_snapshots.py
+++ b/apps/server/tests/use_cases/diagnostics/test_sensor_location_snapshots.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from vibesensor.domain import AnalysisSettingsSnapshot
+from vibesensor.shared.types.run_schema import RunMetadata, RunSensorMetadata
+from vibesensor.shared.types.sensor_frame import SensorFrame
+from vibesensor.use_cases.diagnostics.run_analysis_projection import build_sensor_analysis
+
+
+def test_build_sensor_analysis_prefers_run_sensor_snapshot_labels() -> None:
+    metadata = RunMetadata.create(
+        run_id="run-1",
+        start_time_utc="2026-01-01T00:00:00Z",
+        sensor_model="ADXL345",
+        raw_sample_rate_hz=800,
+        feature_interval_s=0.5,
+        fft_window_size_samples=1024,
+        accel_scale_g_per_lsb=None,
+        analysis_settings=AnalysisSettingsSnapshot(),
+        sensor_snapshots=(
+            RunSensorMetadata(
+                sensor_id="sensor-a",
+                display_name="Stable front left",
+                location_code="front_left_wheel",
+            ),
+        ),
+    )
+    samples = [
+        SensorFrame(
+            run_id="run-1",
+            timestamp_utc="2026-01-01T00:00:00Z",
+            t_s=0.0,
+            client_id="sensor-a",
+            client_name="Renamed live row",
+            location="rear_right_wheel",
+            sample_rate_hz=800,
+            speed_kmh=None,
+            gps_speed_kmh=None,
+            speed_source="none",
+            engine_rpm=None,
+            engine_rpm_source="missing",
+            gear=None,
+            final_drive_ratio=None,
+            accel_x_g=None,
+            accel_y_g=None,
+            accel_z_g=None,
+            dominant_freq_hz=None,
+            dominant_axis="combined",
+            top_peaks=tuple(),
+            vibration_strength_db=20.0,
+            strength_bucket="l2",
+            strength_peak_amp_g=0.1,
+            strength_floor_amp_g=0.01,
+            frames_dropped_total=0,
+            queue_overflow_drops=0,
+        )
+    ]
+
+    sensor_locations, connected_locations, sensor_intensity = build_sensor_analysis(
+        samples=samples,
+        language="en",
+        per_sample_phases=[],
+        metadata=metadata,
+    )
+
+    assert sensor_locations == ["Front Left Wheel"]
+    assert connected_locations == {"Front Left Wheel"}
+    assert sensor_intensity[0].location == "Front Left Wheel"
+
+
+def test_build_sensor_analysis_falls_back_for_legacy_runs_without_snapshot() -> None:
+    metadata = RunMetadata.create(
+        run_id="legacy-run",
+        start_time_utc="2026-01-01T00:00:00Z",
+        sensor_model="ADXL345",
+        raw_sample_rate_hz=800,
+        feature_interval_s=0.5,
+        fft_window_size_samples=1024,
+        accel_scale_g_per_lsb=None,
+        analysis_settings=AnalysisSettingsSnapshot(),
+    )
+    samples = [
+        SensorFrame(
+            run_id="legacy-run",
+            timestamp_utc="2026-01-01T00:00:00Z",
+            t_s=0.0,
+            client_id="sensor-a",
+            client_name="Legacy sample row",
+            location="",
+            sample_rate_hz=800,
+            speed_kmh=None,
+            gps_speed_kmh=None,
+            speed_source="none",
+            engine_rpm=None,
+            engine_rpm_source="missing",
+            gear=None,
+            final_drive_ratio=None,
+            accel_x_g=None,
+            accel_y_g=None,
+            accel_z_g=None,
+            dominant_freq_hz=None,
+            dominant_axis="combined",
+            top_peaks=tuple(),
+            vibration_strength_db=20.0,
+            strength_bucket="l2",
+            strength_peak_amp_g=0.1,
+            strength_floor_amp_g=0.01,
+            frames_dropped_total=0,
+            queue_overflow_drops=0,
+        )
+    ]
+
+    sensor_locations, connected_locations, sensor_intensity = build_sensor_analysis(
+        samples=samples,
+        language="en",
+        per_sample_phases=[],
+        metadata=metadata,
+    )
+
+    assert sensor_locations == ["Legacy sample row"]
+    assert connected_locations == {"Legacy sample row"}
+    assert sensor_intensity[0].location == "Legacy sample row"

--- a/apps/server/tests/use_cases/run/test_run_sensor_metadata_snapshot.py
+++ b/apps/server/tests/use_cases/run/test_run_sensor_metadata_snapshot.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from vibesensor.adapters.persistence.history_db import create_history_persistence_adapters
+from vibesensor.use_cases.run._recorder_types import _build_run_metadata_record
+
+
+def test_run_sensor_rows_stay_stable_when_live_metadata_changes(
+    make_logger,
+    fake_registry,
+) -> None:
+    sensor_id = "AA:BB:CC:DD:EE:01"
+    active_ids = [sensor_id]
+    fake_registry._records[sensor_id] = replace(
+        fake_registry._records.pop("active"),
+        client_id=sensor_id,
+        name="Front-left live name",
+        location_code="front_left_wheel",
+    )
+    fake_registry.active_client_ids = lambda: list(active_ids)
+    sensors_by_mac = {
+        "aabbccddee01": {
+            "name": "Configured front left",
+            "location_code": "front_left_wheel",
+        }
+    }
+    sensor_metadata_reader = MagicMock()
+    sensor_metadata_reader.get_sensors.side_effect = lambda: sensors_by_mac
+
+    logger = make_logger(
+        registry=fake_registry,
+        sensor_metadata_reader=sensor_metadata_reader,
+    )
+    logger.start_recording()
+    snapshot = logger._session_snapshot()
+    assert snapshot is not None
+
+    initial_rows = logger._sample_flush.build_sample_records(
+        run_id=snapshot.run_id,
+        t_s=1.0,
+        timestamp_utc="2026-02-16T12:00:00+00:00",
+    )
+    assert len(initial_rows) == 1
+    assert initial_rows[0].client_name == "Configured front left"
+    assert initial_rows[0].location == "front_left_wheel"
+
+    fake_registry._records[sensor_id].name = "Renamed live sensor"
+    fake_registry._records[sensor_id].location_code = "rear_right_wheel"
+    sensors_by_mac["aabbccddee01"] = {
+        "name": "Configured rear right",
+        "location_code": "rear_right_wheel",
+    }
+
+    later_rows = logger._sample_flush.build_sample_records(
+        run_id=snapshot.run_id,
+        t_s=2.0,
+        timestamp_utc="2026-02-16T12:00:01+00:00",
+    )
+    assert len(later_rows) == 1
+    assert later_rows[0].client_name == initial_rows[0].client_name
+    assert later_rows[0].location == initial_rows[0].location
+
+    metadata = _build_run_metadata_record(logger, snapshot.run_id, snapshot.start_time_utc)
+    assert len(metadata.sensor_snapshots) == 1
+    sensor_snapshot = metadata.sensor_snapshots[0]
+    assert sensor_snapshot.sensor_id == sensor_id
+    assert sensor_snapshot.display_name == "Configured front left"
+    assert sensor_snapshot.location_code == "front_left_wheel"
+
+
+def test_first_seen_sensor_gets_stable_snapshot_entry_during_run(
+    make_logger,
+    fake_registry,
+    tmp_path: Path,
+) -> None:
+    history_db = create_history_persistence_adapters(tmp_path / "history.db")
+    active_sensor_id = "AA:BB:CC:DD:EE:01"
+    late_sensor_id = "AA:BB:CC:DD:EE:02"
+    active_ids = [active_sensor_id]
+    fake_registry._records[active_sensor_id] = replace(
+        fake_registry._records.pop("active"),
+        client_id=active_sensor_id,
+        name="Front-left live name",
+        location_code="front_left_wheel",
+    )
+    sensors_by_mac = {
+        "aabbccddee01": {
+            "name": "Configured front left",
+            "location_code": "front_left_wheel",
+        }
+    }
+    sensor_metadata_reader = MagicMock()
+    sensor_metadata_reader.get_sensors.side_effect = lambda: sensors_by_mac
+    fake_registry.active_client_ids = lambda: list(active_ids)
+
+    logger = make_logger(
+        registry=fake_registry,
+        sensor_metadata_reader=sensor_metadata_reader,
+        history_db=history_db.run_repository,
+    )
+    logger.schedule_post_analysis = lambda _run_id: None
+    logger.start_recording()
+    snapshot = logger._session_snapshot()
+    assert snapshot is not None
+
+    logger._sample_flush.append_records(
+        snapshot.run_id,
+        snapshot.start_time_utc,
+        snapshot.start_mono_s,
+    )
+
+    late_record = replace(
+        fake_registry._records[active_sensor_id],
+        client_id=late_sensor_id,
+        name="Late joiner live",
+        location_code="rear_left_wheel",
+        firmware_version="2.0.0",
+    )
+    fake_registry._records[late_sensor_id] = late_record
+    active_ids.append(late_sensor_id)
+    sensors_by_mac["aabbccddee02"] = {
+        "name": "Configured rear left",
+        "location_code": "rear_left_wheel",
+    }
+
+    logger._sample_flush.append_records(
+        snapshot.run_id,
+        snapshot.start_time_utc,
+        snapshot.start_mono_s,
+    )
+
+    sensors_by_mac["aabbccddee02"] = {
+        "name": "Configured moved later",
+        "location_code": "front_right_wheel",
+    }
+    fake_registry._records[late_sensor_id].name = "Late joiner renamed live"
+    fake_registry._records[late_sensor_id].location_code = "front_right_wheel"
+
+    logger._sample_flush.append_records(
+        snapshot.run_id,
+        snapshot.start_time_utc,
+        snapshot.start_mono_s,
+    )
+    logger.stop_recording()
+
+    stored_metadata = history_db.run_repository.get_run(snapshot.run_id).metadata
+    late_snapshot = stored_metadata.sensor_snapshot_for(late_sensor_id)
+    assert late_snapshot is not None
+    assert late_snapshot.display_name == "Configured rear left"
+    assert late_snapshot.location_code == "rear_left_wheel"
+
+    stored_samples = history_db.run_repository.get_run_samples(snapshot.run_id)
+    late_rows = [sample for sample in stored_samples if sample.client_id == late_sensor_id]
+    assert late_rows
+    assert {sample.client_name for sample in late_rows} == {"Configured rear left"}
+    assert {sample.location for sample in late_rows} == {"rear_left_wheel"}

--- a/apps/server/vibesensor/shared/boundaries/runs/metadata.py
+++ b/apps/server/vibesensor/shared/boundaries/runs/metadata.py
@@ -25,6 +25,7 @@ from vibesensor.shared.types.run_schema import (
     RUN_METADATA_TYPE,
     RUN_SCHEMA_VERSION,
     RunMetadata,
+    RunSensorMetadata,
 )
 
 __all__ = [
@@ -57,6 +58,7 @@ class _RunMetadataRecord(msgspec.Struct, kw_only=True, frozen=True):
     incomplete_for_order_analysis: object = False
     analysis_settings_snapshot: object = None
     active_car_snapshot: object = None
+    sensor_snapshots: object = None
     case_id: object = ""
     sensor_mac: object = None
     symptom: object = None
@@ -104,6 +106,7 @@ def run_metadata_from_mapping(data: Mapping[str, object]) -> RunMetadata:
             data.get("analysis_settings_snapshot"),
         ),
         car=run_car_metadata_from_mapping(data.get("active_car_snapshot")),
+        sensor_snapshots=_run_sensor_snapshots_from_payload(data.get("sensor_snapshots")),
         case_id=text_or_none(data.get("case_id")) or "",
         sensor_mac=text_or_none(data.get("sensor_mac")),
         symptom=_symptom_from_payload(data.get("symptom")),
@@ -145,6 +148,10 @@ def run_metadata_to_json_object(metadata: RunMetadata) -> JsonObject:
     }
     if (car_metadata := run_car_metadata_to_json_object(metadata.car)) is not None:
         payload["active_car_snapshot"] = car_metadata
+    if metadata.sensor_snapshots:
+        payload["sensor_snapshots"] = [
+            _run_sensor_snapshot_to_json_object(snapshot) for snapshot in metadata.sensor_snapshots
+        ]
     if metadata.symptom is not None and not metadata.symptom.is_unspecified:
         payload["symptom"] = _symptom_to_json_object(metadata.symptom)
     if metadata.wheel_circumference_m is not None:
@@ -196,3 +203,61 @@ def _reference_tire_circumference(payload: object) -> float | None:
     if not isinstance(payload, Mapping):
         return None
     return as_float_or_none(payload.get("tire_circumference_m"))
+
+
+def _run_sensor_snapshots_from_payload(payload: object) -> tuple[RunSensorMetadata, ...]:
+    records: list[RunSensorMetadata] = []
+    if isinstance(payload, Mapping):
+        iterable: list[tuple[object, object]] = list(payload.items())
+        for sensor_id, entry in iterable:
+            if not isinstance(entry, Mapping):
+                continue
+            snapshot = _run_sensor_snapshot_from_mapping(entry, fallback_sensor_id=sensor_id)
+            if snapshot is not None:
+                records.append(snapshot)
+    elif isinstance(payload, list):
+        for entry in payload:
+            snapshot = _run_sensor_snapshot_from_mapping(entry)
+            if snapshot is not None:
+                records.append(snapshot)
+    records.sort(key=lambda snapshot: snapshot.sensor_id)
+    return tuple(records)
+
+
+def _run_sensor_snapshot_from_mapping(
+    payload: object,
+    *,
+    fallback_sensor_id: object = None,
+) -> RunSensorMetadata | None:
+    if not isinstance(payload, Mapping):
+        return None
+    sensor_id = (
+        text_or_none(payload.get("sensor_id"))
+        or text_or_none(payload.get("client_id"))
+        or text_or_none(fallback_sensor_id)
+        or ""
+    )
+    if not sensor_id:
+        return None
+    return RunSensorMetadata(
+        sensor_id=sensor_id,
+        display_name=text_or_none(payload.get("display_name"))
+        or text_or_none(payload.get("client_name"))
+        or "",
+        location_code=text_or_none(payload.get("location_code")) or "",
+        sample_rate_hz=as_int_or_none(payload.get("sample_rate_hz")),
+        firmware_version=text_or_none(payload.get("firmware_version")),
+    )
+
+
+def _run_sensor_snapshot_to_json_object(snapshot: RunSensorMetadata) -> JsonObject:
+    payload: JsonObject = {
+        "sensor_id": snapshot.sensor_id,
+        "display_name": snapshot.display_name,
+        "location_code": snapshot.location_code,
+    }
+    if snapshot.sample_rate_hz is not None:
+        payload["sample_rate_hz"] = snapshot.sample_rate_hz
+    if snapshot.firmware_version is not None:
+        payload["firmware_version"] = snapshot.firmware_version
+    return payload

--- a/apps/server/vibesensor/shared/types/run_schema.py
+++ b/apps/server/vibesensor/shared/types/run_schema.py
@@ -18,6 +18,7 @@ __all__ = [
     "RUN_SCHEMA_VERSION",
     "RunMetadata",
     "RunCarMetadata",
+    "RunSensorMetadata",
 ]
 
 RUN_SCHEMA_VERSION = "v2-jsonl"
@@ -36,6 +37,17 @@ class RunCarMetadata:
     name: str | None = None
     car_type: str | None = None
     variant: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RunSensorMetadata:
+    """Stable per-run snapshot of sensor identity and presentation metadata."""
+
+    sensor_id: str
+    display_name: str = ""
+    location_code: str = ""
+    sample_rate_hz: int | None = None
+    firmware_version: str | None = None
 
 
 @dataclass(slots=True)
@@ -59,6 +71,7 @@ class RunMetadata:
     incomplete_for_order_analysis: bool
     analysis_settings: AnalysisSettingsSnapshot = field(default_factory=AnalysisSettingsSnapshot)
     car: RunCarMetadata | None = None
+    sensor_snapshots: tuple[RunSensorMetadata, ...] = field(default_factory=tuple)
     case_id: str = ""
     sensor_mac: str | None = None
     symptom: Symptom | None = None
@@ -84,6 +97,7 @@ class RunMetadata:
         configured_raw_sample_rate_hz: int | None = None,
         analysis_settings: AnalysisSettingsSnapshot | None = None,
         car: RunCarMetadata | None = None,
+        sensor_snapshots: tuple[RunSensorMetadata, ...] = (),
         case_id: str = "",
         sensor_mac: str | None = None,
         symptom: Symptom | None = None,
@@ -113,6 +127,7 @@ class RunMetadata:
                 analysis_settings if analysis_settings is not None else AnalysisSettingsSnapshot()
             ),
             car=car,
+            sensor_snapshots=tuple(sensor_snapshots),
             case_id=case_id.strip(),
             sensor_mac=sensor_mac,
             symptom=symptom,
@@ -137,6 +152,15 @@ class RunMetadata:
     @property
     def active_car_id(self) -> str | None:
         return self.car.car_id if self.car is not None else None
+
+    def sensor_snapshot_for(self, sensor_id: str) -> RunSensorMetadata | None:
+        normalized_sensor_id = str(sensor_id).strip()
+        if not normalized_sensor_id:
+            return None
+        for snapshot in self.sensor_snapshots:
+            if snapshot.sensor_id == normalized_sensor_id:
+                return snapshot
+        return None
 
     @property
     def order_reference_spec(self) -> OrderReferenceSpec | None:

--- a/apps/server/vibesensor/use_cases/diagnostics/_sensor_locations.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/_sensor_locations.py
@@ -6,12 +6,37 @@ from collections import defaultdict
 from collections.abc import Sequence
 
 from vibesensor.shared.locations import label_for_code as _label_for_code
+from vibesensor.shared.types.run_schema import RunMetadata, RunSensorMetadata
 
 from ._types import Sample
 
 
-def _location_label(sample: Sample, *, lang: str = "en") -> str:
+def _sensor_snapshot_label(snapshot: RunSensorMetadata, *, lang: str = "en") -> str:
+    del lang
+    location_code = snapshot.location_code.strip()
+    if location_code:
+        translated = _label_for_code(location_code)
+        return str(translated) if translated else location_code
+    display_name = snapshot.display_name.strip()
+    if display_name:
+        return display_name
+    sensor_id = snapshot.sensor_id.strip()
+    if sensor_id:
+        return fallback_location_label(sensor_id)
+    return "Unknown sensor"
+
+
+def _location_label(
+    sample: Sample,
+    *,
+    metadata: RunMetadata | None = None,
+    lang: str = "en",
+) -> str:
     """Return a stable language-neutral location label for the sample."""
+    if metadata is not None:
+        snapshot = metadata.sensor_snapshot_for(sample.client_id)
+        if snapshot is not None:
+            return _sensor_snapshot_label(snapshot, lang=lang)
     del lang
     location_code = sample.location.strip()
     if location_code:
@@ -30,6 +55,7 @@ def _location_label(sample: Sample, *, lang: str = "en") -> str:
 def client_locations_by_sensor(
     samples: Sequence[Sample],
     *,
+    metadata: RunMetadata | None = None,
     lang: str = "en",
 ) -> dict[str, str]:
     """Return deterministic location labels keyed by client id."""
@@ -39,7 +65,7 @@ def client_locations_by_sensor(
         client_id = sample.client_id.strip()
         if not client_id or client_id in locations:
             continue
-        locations[client_id] = _location_label(sample, lang=lang)
+        locations[client_id] = _location_label(sample, metadata=metadata, lang=lang)
     return locations
 
 
@@ -53,6 +79,7 @@ def fallback_location_label(client_id: str) -> str:
 def _locations_connected_throughout_run(
     samples: Sequence[Sample],
     *,
+    metadata: RunMetadata | None = None,
     lang: str = "en",
 ) -> set[str]:
     """Return locations that remain present across the full run span."""
@@ -60,7 +87,7 @@ def _locations_connected_throughout_run(
     all_times: list[float] = []
 
     for sample in samples:
-        location = _location_label(sample, lang=lang)
+        location = _location_label(sample, metadata=metadata, lang=lang)
         if not location:
             continue
         t_s = sample.t_s

--- a/apps/server/vibesensor/use_cases/diagnostics/prepared_analysis_context.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/prepared_analysis_context.py
@@ -58,6 +58,7 @@ def prepare_analysis_context(
         samples=typed_samples,
         language=language,
         per_sample_phases=list(prepared.per_sample_phases),
+        metadata=context,
     )
     sensor_ids = {client_id for sample in typed_samples if (client_id := sample.client_id)}
     total_dropped, total_overflow = compute_frame_integrity_counts(typed_samples)

--- a/apps/server/vibesensor/use_cases/diagnostics/run_analysis_projection.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/run_analysis_projection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from vibesensor.domain import DrivingPhaseInterval, LocationIntensitySummary
 from vibesensor.domain import DrivingSegment as DomainDrivingSegment
@@ -15,6 +16,9 @@ from vibesensor.use_cases.diagnostics._sensor_locations import (
 from vibesensor.use_cases.diagnostics._types import Sample
 from vibesensor.use_cases.diagnostics.phase_segmentation import DrivingPhase, PhaseSegment
 from vibesensor.use_cases.diagnostics.signal_aggregation import _sensor_intensity_by_location
+
+if TYPE_CHECKING:
+    from vibesensor.shared.types.run_schema import RunMetadata
 
 
 def build_phase_timeline(
@@ -79,15 +83,25 @@ def build_sensor_analysis(
     samples: Sequence[Sample],
     language: str,
     per_sample_phases: Sequence[DrivingPhase],
+    metadata: RunMetadata | None = None,
 ) -> tuple[list[str], set[str], list[LocationIntensitySummary]]:
     """Build sensor location lists and intensity rows from analysed samples."""
     sensor_locations = sorted(
-        {label for sample in samples if (label := _location_label(sample, lang=language))},
+        {
+            label
+            for sample in samples
+            if (label := _location_label(sample, metadata=metadata, lang=language))
+        },
     )
-    connected_locations = _locations_connected_throughout_run(samples, lang=language)
+    connected_locations = _locations_connected_throughout_run(
+        samples,
+        metadata=metadata,
+        lang=language,
+    )
     sensor_intensity_by_location = _sensor_intensity_by_location(
         samples,
         include_locations=set(sensor_locations),
+        metadata=metadata,
         lang=language,
         connected_locations=connected_locations,
         per_sample_phases=per_sample_phases,

--- a/apps/server/vibesensor/use_cases/diagnostics/signal_aggregation.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/signal_aggregation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from vibesensor.domain import (
     LocationIntensitySummary,
@@ -28,6 +29,9 @@ from vibesensor.use_cases.diagnostics.math_utils import _mean
 from vibesensor.use_cases.diagnostics.phase_segmentation import DrivingPhase
 from vibesensor.use_cases.diagnostics.speed_profile_helpers import _phase_to_str
 from vibesensor.vibration_strength import percentile
+
+if TYPE_CHECKING:
+    from vibesensor.shared.types.run_schema import RunMetadata
 
 
 def _counter_delta(counter_values: Sequence[tuple[float | None, float]]) -> int:
@@ -126,6 +130,7 @@ def _sensor_intensity_by_location(
     samples: Sequence[Sample],
     include_locations: Sequence[str] | set[str] | None = None,
     *,
+    metadata: RunMetadata | None = None,
     lang: str = "en",
     connected_locations: Sequence[str] | set[str] | None = None,
     per_sample_phases: Sequence[DrivingPhase] | None = None,
@@ -144,7 +149,7 @@ def _sensor_intensity_by_location(
     _vib_db = _primary_vibration_strength_db
     _loc_label = _location_label
     for i, sample in enumerate(samples):
-        location = _loc_label(sample, lang=lang)
+        location = _loc_label(sample, metadata=metadata, lang=lang)
         if not location:
             continue
         if include_locations is not None and location not in include_locations:

--- a/apps/server/vibesensor/use_cases/run/_recorder_types.py
+++ b/apps/server/vibesensor/use_cases/run/_recorder_types.py
@@ -67,6 +67,7 @@ def _build_run_metadata_record(
         raw_capture_manifest=recorder._raw_capture_manifest_for_run(run_id),
         language_reader=recorder._language_reader,
         recorded_utc_offset_seconds=current_utc_offset_seconds(),
+        sensor_snapshots=recorder._run_sensor_snapshots_for_run(run_id),
     )
 
 

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Mapping
 from threading import RLock
 from typing import TYPE_CHECKING
 from uuid import uuid4
@@ -29,6 +30,8 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureManifest,
     RawCaptureSensorClockSync,
 )
+from vibesensor.shared.types.run_schema import RunSensorMetadata
+from vibesensor.shared.types.sensor_config import SensorConfigPayload
 from vibesensor.use_cases.run.capture_readiness import CaptureReadinessTracker
 from vibesensor.use_cases.run.capture_readiness_observation import observe_capture_readiness
 from vibesensor.use_cases.run.lifecycle_state import RunLifecycleState
@@ -43,6 +46,10 @@ from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
 from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
 from vibesensor.use_cases.run.raw_capture_writer import RunRawCaptureWriter
 from vibesensor.use_cases.run.run_context import build_run_context_snapshot
+from vibesensor.use_cases.run.run_sensor_snapshot import (
+    build_run_sensor_snapshot,
+    capture_run_sensor_snapshots,
+)
 from vibesensor.use_cases.run.sample_flush import SampleFlushOrchestrator
 from vibesensor.use_cases.run.status_reporting import (
     RunRecorderStatusSnapshot,
@@ -102,6 +109,7 @@ class RunRecorder:
         self._language_reader = language_reader
         self._live_start_mono_s = time.monotonic()
         self._active_run_context: RunContextSnapshot | None = None
+        self._run_sensor_snapshots: dict[str, RunSensorMetadata] = {}
         self._capture_readiness = CaptureReadinessTracker()
 
         self._lifecycle = RunLifecycleState(
@@ -147,6 +155,7 @@ class RunRecorder:
             analysis_settings_snapshot=self._recording_analysis_settings_snapshot,
             default_sample_rate_hz=self.default_sample_rate_hz,
             sensor_metadata_reader=sensor_metadata_reader,
+            run_sensor_presentation_resolver=self._resolve_run_sensor_presentation,
             lifecycle=self._lifecycle,
             persistence=self._persistence,
             active_frames_total=lambda: _recorder_runtime.active_frames_total(self.registry),
@@ -212,6 +221,40 @@ class RunRecorder:
     def _recording_analysis_settings_snapshot(self) -> AnalysisSettingsSnapshot:
         return self._run_context_snapshot().analysis_settings
 
+    def _run_sensor_snapshots_for_run(self, run_id: str) -> tuple[RunSensorMetadata, ...]:
+        with self._lock:
+            current_run = self._lifecycle.current_run
+            if current_run is None or current_run.run_id != run_id:
+                return tuple()
+            return tuple(
+                self._run_sensor_snapshots[client_id]
+                for client_id in sorted(self._run_sensor_snapshots)
+            )
+
+    def _resolve_run_sensor_presentation(
+        self,
+        *,
+        client_id: str,
+        fallback_name: str,
+        fallback_location_code: str,
+        sample_rate_hz: int | None,
+        firmware_version: str | None,
+        sensors_by_mac: Mapping[str, SensorConfigPayload],
+    ) -> tuple[str, str]:
+        with self._lock:
+            snapshot = self._run_sensor_snapshots.get(client_id)
+            if snapshot is None:
+                snapshot = build_run_sensor_snapshot(
+                    sensor_id=client_id,
+                    fallback_name=fallback_name,
+                    fallback_location_code=fallback_location_code,
+                    sample_rate_hz=sample_rate_hz,
+                    firmware_version=firmware_version,
+                    sensors_by_mac=sensors_by_mac,
+                )
+                self._run_sensor_snapshots[client_id] = snapshot
+            return snapshot.display_name, snapshot.location_code
+
     def _session_snapshot(self) -> ActiveRunSnapshot | None:
         with self._lock:
             return self._lifecycle.snapshot()
@@ -231,6 +274,11 @@ class RunRecorder:
             current_total=_recorder_runtime.active_frames_total(self.registry),
         )
         self._active_run_context = run_context
+        self._run_sensor_snapshots = capture_run_sensor_snapshots(
+            client_ids=self.registry.active_client_ids(),
+            registry=self.registry,
+            sensor_metadata_reader=self._sensor_metadata_reader,
+        )
         self._persistence.reset()
         self._live_start_mono_s = snapshot.start_mono_s
         self._raw_capture.start_run(
@@ -486,6 +534,7 @@ class RunRecorder:
                         )
                     self._lifecycle.stop()
                     self._active_run_context = None
+                    self._run_sensor_snapshots = {}
                     self._persistence.reset()
                     self._run_ingest_drop_baseline = None
                     result = self.status()

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -47,6 +47,7 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
             samples=run.samples,
             language=run.language,
             per_sample_phases=list(prepared.per_sample_phases),
+            metadata=run.context,
         )
         summary_payload["sensor_locations"] = sensor_locations
         summary_payload["sensor_locations_connected_throughout"] = sorted(connected_locations)

--- a/apps/server/vibesensor/use_cases/run/run_metadata_builder.py
+++ b/apps/server/vibesensor/use_cases/run/run_metadata_builder.py
@@ -7,7 +7,7 @@ from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 from vibesensor.shared.ports import ClientTracker, LanguageReader
 from vibesensor.shared.time_utils import coerce_utc_offset_seconds
 from vibesensor.shared.types.raw_capture import RawCaptureManifest
-from vibesensor.shared.types.run_schema import RunCarMetadata, RunMetadata
+from vibesensor.shared.types.run_schema import RunCarMetadata, RunMetadata, RunSensorMetadata
 
 from .run_context import order_reference_context_complete
 
@@ -46,6 +46,7 @@ def create_run_metadata(
     incomplete_for_order_analysis: bool = False,
     configured_raw_sample_rate_hz: int | None = None,
     recorded_utc_offset_seconds: int | None = None,
+    sensor_snapshots: tuple[RunSensorMetadata, ...] = (),
 ) -> RunMetadata:
     """Build and return typed run metadata from the supplied fields."""
     normalized_offset = coerce_utc_offset_seconds(recorded_utc_offset_seconds)
@@ -62,6 +63,7 @@ def create_run_metadata(
         end_time_utc=end_time_utc,
         incomplete_for_order_analysis=incomplete_for_order_analysis,
         recorded_utc_offset_seconds=normalized_offset,
+        sensor_snapshots=sensor_snapshots,
     )
 
 
@@ -80,6 +82,7 @@ def build_run_metadata(
     raw_capture_manifest: RawCaptureManifest | None = None,
     language_reader: LanguageReader | None = None,
     recorded_utc_offset_seconds: int | None = None,
+    sensor_snapshots: tuple[RunSensorMetadata, ...] = (),
 ) -> RunMetadata:
     """Assemble comprehensive typed run metadata."""
     feature_interval_s = 1.0 / max(1.0, float(metrics_log_hz))
@@ -105,6 +108,7 @@ def build_run_metadata(
         accel_scale_g_per_lsb=accel_scale_g_per_lsb,
         incomplete_for_order_analysis=incomplete,
         recorded_utc_offset_seconds=recorded_utc_offset_seconds,
+        sensor_snapshots=sensor_snapshots,
     )
     metadata.analysis_settings = analysis_settings_snapshot
     metadata.car = run_car_metadata

--- a/apps/server/vibesensor/use_cases/run/run_sensor_snapshot.py
+++ b/apps/server/vibesensor/use_cases/run/run_sensor_snapshot.py
@@ -1,0 +1,89 @@
+"""Helpers for stable per-run sensor metadata snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING
+
+from vibesensor.shared.sensor_metadata import resolve_sensor_presentation
+from vibesensor.shared.types.run_schema import RunSensorMetadata
+from vibesensor.shared.types.sensor_config import SensorConfigPayload
+
+if TYPE_CHECKING:
+    from vibesensor.shared.ports import ClientTracker, SensorMetadataReader
+
+
+def build_run_sensor_snapshot(
+    *,
+    sensor_id: str,
+    fallback_name: str,
+    fallback_location_code: str,
+    sample_rate_hz: int | None,
+    firmware_version: str | None,
+    sensors_by_mac: Mapping[str, SensorConfigPayload],
+) -> RunSensorMetadata:
+    """Build one stable run-scoped sensor snapshot from live metadata inputs."""
+
+    display_name, location_code = resolve_sensor_presentation(
+        sensor_id=sensor_id,
+        sensors_by_mac=sensors_by_mac,
+        fallback_name=fallback_name,
+        fallback_location_code=fallback_location_code,
+    )
+    return RunSensorMetadata(
+        sensor_id=sensor_id,
+        display_name=display_name,
+        location_code=location_code,
+        sample_rate_hz=sample_rate_hz,
+        firmware_version=firmware_version,
+    )
+
+
+def capture_run_sensor_snapshots(
+    *,
+    client_ids: Iterable[str],
+    registry: ClientTracker,
+    sensor_metadata_reader: SensorMetadataReader | None,
+) -> dict[str, RunSensorMetadata]:
+    """Capture deterministic run-start snapshots for the supplied client ids."""
+
+    sensors_by_mac = sensor_metadata_reader.get_sensors() if sensor_metadata_reader else {}
+    snapshots: dict[str, RunSensorMetadata] = {}
+    normalized_client_ids = {
+        str(client_id).strip() for client_id in client_ids if str(client_id).strip()
+    }
+    for client_id in sorted(normalized_client_ids):
+        record = registry.get(client_id)
+        if record is None:
+            continue
+        snapshots[client_id] = build_run_sensor_snapshot(
+            sensor_id=str(getattr(record, "client_id", client_id) or client_id),
+            fallback_name=str(getattr(record, "name", "") or ""),
+            fallback_location_code=str(getattr(record, "location_code", "") or ""),
+            sample_rate_hz=_sample_rate_hz_or_none(getattr(record, "sample_rate_hz", None)),
+            firmware_version=_text_or_none(getattr(record, "firmware_version", None)),
+            sensors_by_mac=sensors_by_mac,
+        )
+    return snapshots
+
+
+def _sample_rate_hz_or_none(value: object) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        sample_rate_hz = value
+    elif isinstance(value, float):
+        sample_rate_hz = int(value)
+    elif isinstance(value, str):
+        try:
+            sample_rate_hz = int(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    return sample_rate_hz if sample_rate_hz > 0 else None
+
+
+def _text_or_none(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None

--- a/apps/server/vibesensor/use_cases/run/sample_builder.py
+++ b/apps/server/vibesensor/use_cases/run/sample_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
@@ -38,6 +39,7 @@ def build_sample_records(
     analysis_settings_snapshot: AnalysisSettingsSnapshot,
     default_sample_rate_hz: int,
     sensor_metadata_reader: SensorMetadataReader | None = None,
+    run_sensor_presentation_resolver: Callable[..., tuple[str, str]] | None = None,
     live_sample_window_s: float | None = _LIVE_SAMPLE_WINDOW_S,
     run_start_mono_s: float | None = None,
 ) -> list[SensorFrame]:
@@ -95,12 +97,24 @@ def build_sample_records(
             or default_sample_rate_hz
             or None
         )
-        resolved_name, resolved_location = resolve_sensor_presentation(
-            sensor_id=record.client_id,
-            sensors_by_mac=sensors_by_mac,
-            fallback_name=str(record.name or ""),
-            fallback_location_code=str(getattr(record, "location_code", "") or ""),
-        )
+        fallback_name = str(record.name or "")
+        fallback_location_code = str(getattr(record, "location_code", "") or "")
+        if run_sensor_presentation_resolver is None:
+            resolved_name, resolved_location = resolve_sensor_presentation(
+                sensor_id=record.client_id,
+                sensors_by_mac=sensors_by_mac,
+                fallback_name=fallback_name,
+                fallback_location_code=fallback_location_code,
+            )
+        else:
+            resolved_name, resolved_location = run_sensor_presentation_resolver(
+                client_id=record.client_id,
+                fallback_name=fallback_name,
+                fallback_location_code=fallback_location_code,
+                sample_rate_hz=int(sample_rate_hz) if sample_rate_hz else None,
+                firmware_version=str(getattr(record, "firmware_version", "") or "") or None,
+                sensors_by_mac=sensors_by_mac,
+            )
         (
             analysis_window_start_us,
             analysis_window_end_us,

--- a/apps/server/vibesensor/use_cases/run/sample_flush.py
+++ b/apps/server/vibesensor/use_cases/run/sample_flush.py
@@ -36,6 +36,7 @@ class SampleFlushOrchestrator:
         analysis_settings_snapshot: AnalysisSettingsProvider,
         default_sample_rate_hz: int,
         sensor_metadata_reader: SensorMetadataReader | None = None,
+        run_sensor_presentation_resolver: Callable[..., tuple[str, str]] | None = None,
         lifecycle: RunLifecycleState,
         persistence: RunPersistenceWriter,
         active_frames_total: CurrentTotalProvider,
@@ -49,6 +50,7 @@ class SampleFlushOrchestrator:
         self._analysis_settings_snapshot = analysis_settings_snapshot
         self._default_sample_rate_hz = default_sample_rate_hz
         self._sensor_metadata_reader = sensor_metadata_reader
+        self._run_sensor_presentation_resolver = run_sensor_presentation_resolver
         self._lifecycle = lifecycle
         self._persistence = persistence
         self._active_frames_total = active_frames_total
@@ -117,6 +119,7 @@ class SampleFlushOrchestrator:
             analysis_settings_snapshot=analysis_settings_snapshot,
             default_sample_rate_hz=self._default_sample_rate_hz,
             sensor_metadata_reader=self._sensor_metadata_reader,
+            run_sensor_presentation_resolver=self._run_sensor_presentation_resolver,
             live_sample_window_s=live_sample_window_s,
             run_start_mono_s=run_start_mono_s,
         )


### PR DESCRIPTION
## What changed
- snapshot stable per-run sensor presentation metadata at recording start for known sensors
- add first-seen sensors to the run snapshot on first observation during the run
- persist that snapshot in `RunMetadata.sensor_snapshots`
- build sample rows from the run snapshot instead of re-reading mutable live sensor metadata on every flush
- make diagnostics/post-analysis/report location aggregation prefer the persisted run snapshot, with fallback for legacy runs that do not have one
- add focused regression coverage for rename/relocation during a run, late sensor appearance, sensor-snapshot codec round-trips, and legacy fallback behavior

## Why
Live sensor rename/location changes during recording could split one physical sensor across different names or locations inside the same run. That distorted location coverage, connected-throughout-run logic, intensity grouping, and report interpretation.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest -q apps/server/tests/shared/boundaries/test_run_metadata_codec.py apps/server/tests/use_cases/run/test_run_context_temporal_isolation.py apps/server/tests/use_cases/run/test_run_sensor_metadata_snapshot.py apps/server/tests/use_cases/diagnostics/test_sensor_location_snapshots.py apps/server/tests/infra/processing/test_sample_builder.py apps/server/tests/use_cases/run/test_post_analysis_summary.py`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest -q apps/server/tests/adapters/pdf/test_summary_view.py apps/server/tests/use_cases/diagnostics/test_findings_helpers.py apps/server/tests/use_cases/diagnostics/test_findings_subpackage.py`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
- `make typecheck-backend`

## Risks / tradeoffs / edges
- additive metadata field only; legacy runs without `sensor_snapshots` still fall back to persisted sample row labels
- late-joining sensors become durable through the run-owned snapshot and finalized run metadata path, not by reusing mutable live settings at report time

Closes #3160
