### PR TITLE
Reject stale metrics after buffer reset

### DIFF
--- a/apps/server/tests/infra/processing/test_buffer_mutations.py
+++ b/apps/server/tests/infra/processing/test_buffer_mutations.py
@@ -28,7 +28,10 @@ def test_reset_clears_cached_payloads_and_bumps_generation() -> None:
         buf = registry._get_or_create_unlocked("sensor-reset")
     buf.data[:] = 1.0
     buf.count = 8
+    buf.reset_generation = 2
     buf.ingest_generation = 4
+    buf.compute_generation = 3
+    buf.compute_sample_rate_hz = 200
     buf.cached_spectrum_payload = {"freq": [1.0, 2.0]}
     buf.cached_spectrum_payload_generation = 9
 
@@ -36,7 +39,10 @@ def test_reset_clears_cached_payloads_and_bumps_generation() -> None:
 
     assert buf.count == 0
     assert buf.write_idx == 0
+    assert buf.reset_generation == 3
     assert buf.ingest_generation == 5
+    assert buf.compute_generation == -1
+    assert buf.compute_sample_rate_hz == 0
     assert buf.cached_spectrum_payload is None
     assert buf.cached_spectrum_payload_generation == -1
     np.testing.assert_array_equal(buf.data, np.zeros_like(buf.data))
@@ -61,6 +67,35 @@ def test_commit_metrics_result_rejects_stale_buffer_epoch() -> None:
             has_fft_data=False,
             duration_s=0.01,
             buffer_epoch=buf.buffer_epoch + 1,
+        ),
+    )
+
+    assert not accepted
+    assert buf.latest_metrics["combined"]["vib_mag_rms"] == 0.5
+    assert buf.compute_generation == -1
+
+
+def test_commit_metrics_result_rejects_stale_reset_generation() -> None:
+    registry = ClientBufferRegistry(_config())
+    mutator = ClientBufferMutator(_config())
+    with registry.lock:
+        buf = registry._get_or_create_unlocked("sensor-reset-stale")
+    buf.latest_metrics = {"combined": {"vib_mag_rms": 0.5, "vib_mag_p2p": 1.0, "peaks": []}}
+    buf.reset_generation = 4
+
+    accepted = mutator.commit_metrics_result(
+        buf,
+        MetricsComputationResult(
+            client_id="sensor-reset-stale",
+            sample_rate_hz=200,
+            ingest_generation=3,
+            metrics={"combined": {"vib_mag_rms": 2.0, "vib_mag_p2p": 4.0, "peaks": []}},
+            spectrum_by_axis={},
+            strength_metrics={},
+            has_fft_data=False,
+            duration_s=0.01,
+            buffer_epoch=buf.buffer_epoch,
+            reset_generation=buf.reset_generation - 1,
         ),
     )
 

--- a/apps/server/tests/infra/processing/test_buffer_store_reset_generation.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_reset_generation.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import numpy as np
+
+from vibesensor.infra.processing.buffer_store import SignalBufferStore
+from vibesensor.infra.processing.compute import SignalMetricsComputer
+from vibesensor.infra.processing.models import MetricsSnapshot, ProcessorConfig
+
+
+def _config(**overrides: object) -> ProcessorConfig:
+    base = {
+        "sample_rate_hz": 200,
+        "waveform_seconds": 2,
+        "waveform_display_hz": 50,
+        "fft_n": 128,
+        "spectrum_min_hz": 0.0,
+        "spectrum_max_hz": 100.0,
+        "accel_scale_g_per_lsb": None,
+    }
+    base.update(overrides)
+    return ProcessorConfig(**base)
+
+
+def test_flush_rejects_pre_reset_inflight_result() -> None:
+    config = _config()
+    store = SignalBufferStore(config)
+    computer = SignalMetricsComputer(config)
+    client_id = "sensor-reset-stale"
+
+    samples = np.random.default_rng(0).standard_normal((256, 3)).astype(np.float32)
+    store.ingest(client_id, samples, sample_rate_hz=200)
+    stale_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
+
+    assert isinstance(stale_plan, MetricsSnapshot)
+    stale_result = computer.compute(stale_plan)
+
+    store.flush_client_buffer(client_id)
+    store.store_metrics_result(stale_result)
+
+    with store.locked_client_buffer(client_id) as buf:
+        assert buf is not None
+        assert buf.count == 0
+        assert buf.latest_metrics == {}
+        assert buf.compute_generation == -1
+        assert buf.reset_generation == stale_plan.reset_generation + 1
+
+
+def test_post_reset_result_commits_after_new_ingest() -> None:
+    config = _config()
+    store = SignalBufferStore(config)
+    computer = SignalMetricsComputer(config)
+    client_id = "sensor-reset-fresh"
+
+    old_samples = np.random.default_rng(1).standard_normal((256, 3)).astype(np.float32)
+    new_samples = (np.random.default_rng(2).standard_normal((256, 3)) * 5.0).astype(np.float32)
+
+    store.ingest(client_id, old_samples, sample_rate_hz=200)
+    stale_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
+    assert isinstance(stale_plan, MetricsSnapshot)
+    stale_result = computer.compute(stale_plan)
+
+    store.flush_client_buffer(client_id)
+    store.ingest(client_id, new_samples, sample_rate_hz=200)
+    fresh_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
+    assert isinstance(fresh_plan, MetricsSnapshot)
+    fresh_result = computer.compute(fresh_plan)
+
+    store.store_metrics_result(stale_result)
+    store.store_metrics_result(fresh_result)
+
+    with store.locked_client_buffer(client_id) as buf:
+        assert buf is not None
+        assert buf.reset_generation == fresh_plan.reset_generation
+        assert buf.compute_generation == fresh_result.ingest_generation
+        assert buf.latest_metrics == fresh_result.metrics
+
+
+def test_repeated_resets_keep_older_results_rejected() -> None:
+    config = _config()
+    store = SignalBufferStore(config)
+    computer = SignalMetricsComputer(config)
+    client_id = "sensor-reset-repeat"
+
+    first_samples = np.random.default_rng(3).standard_normal((256, 3)).astype(np.float32)
+    second_samples = np.random.default_rng(4).standard_normal((256, 3)).astype(np.float32)
+
+    store.ingest(client_id, first_samples, sample_rate_hz=200)
+    first_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
+    assert isinstance(first_plan, MetricsSnapshot)
+    first_result = computer.compute(first_plan)
+
+    store.flush_client_buffer(client_id)
+    store.ingest(client_id, second_samples, sample_rate_hz=200)
+    second_plan = store.snapshot_for_compute(client_id, sample_rate_hz=200)
+    assert isinstance(second_plan, MetricsSnapshot)
+    second_result = computer.compute(second_plan)
+
+    store.flush_client_buffer(client_id)
+    store.store_metrics_result(first_result)
+    store.store_metrics_result(second_result)
+
+    with store.locked_client_buffer(client_id) as buf:
+        assert buf is not None
+        assert buf.count == 0
+        assert buf.reset_generation == second_plan.reset_generation + 1
+        assert buf.latest_metrics == {}
+        assert buf.compute_generation == -1

--- a/apps/server/vibesensor/infra/processing/buffer_mutations.py
+++ b/apps/server/vibesensor/infra/processing/buffer_mutations.py
@@ -23,6 +23,7 @@ class ClientBufferMutator:
 
     def reset(self, buf: ClientBuffer) -> None:
         buf.data[:] = 0.0
+        buf.reset_generation += 1
         buf.write_idx = 0
         buf.count = 0
         buf.last_t0_us = 0
@@ -31,6 +32,8 @@ class ClientBufferMutator:
         buf.latest_analysis_time_range = None
         buf.latest_spectrum = {}
         buf.latest_strength_metrics = empty_vibration_strength_metrics()
+        buf.compute_generation = -1
+        buf.compute_sample_rate_hz = 0
         self.invalidate_cached_payloads(buf)
         buf.ingest_generation += 1
 
@@ -41,6 +44,7 @@ class ClientBufferMutator:
     ) -> bool:
         if (
             result.buffer_epoch != buf.buffer_epoch
+            or result.reset_generation != buf.reset_generation
             or result.ingest_generation < buf.compute_generation
         ):
             return False

--- a/apps/server/vibesensor/infra/processing/buffer_store_snapshot.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store_snapshot.py
@@ -82,6 +82,7 @@ class BufferStoreSnapshotReader:
                 sample_rate_hz=sr,
                 ingest_generation=buf.ingest_generation,
                 buffer_epoch=buf.buffer_epoch,
+                reset_generation=buf.reset_generation,
                 time_window=time_window,
                 fft_block=fft_block,
                 analysis_time_range=self._analysis_time_range(buf, sample_rate_hz=sr),

--- a/apps/server/vibesensor/infra/processing/buffers.py
+++ b/apps/server/vibesensor/infra/processing/buffers.py
@@ -24,6 +24,7 @@ class ClientBuffer:
     data: np.ndarray
     capacity: int
     buffer_epoch: int = 0
+    reset_generation: int = 0
     write_idx: int = 0
     count: int = 0
     sample_rate_hz: int = 0
@@ -40,7 +41,8 @@ class ClientBuffer:
     # Number of samples ingested since last_t0_us was recorded.  Used to
     # back-compute the timestamp of the oldest sample in the analysis window.
     samples_since_t0: int = 0
-    # Generation counters: ingest_generation increments on new samples,
+    # Generation counters: reset_generation invalidates in-flight compute work
+    # across buffer flushes, ingest_generation increments on new samples,
     # compute_generation marks which ingest generation metrics reflect, and
     # spectrum_generation marks spectrum snapshot updates for payload caching.
     ingest_generation: int = 0

--- a/apps/server/vibesensor/infra/processing/compute.py
+++ b/apps/server/vibesensor/infra/processing/compute.py
@@ -112,6 +112,7 @@ class SignalMetricsComputer(SpectralAnalysisComputer):
             sample_rate_hz=snapshot.sample_rate_hz,
             ingest_generation=snapshot.ingest_generation,
             buffer_epoch=snapshot.buffer_epoch,
+            reset_generation=snapshot.reset_generation,
             metrics=metrics,
             spectrum_by_axis=spectrum_by_axis,
             strength_metrics=strength_metrics_dict,

--- a/apps/server/vibesensor/infra/processing/models.py
+++ b/apps/server/vibesensor/infra/processing/models.py
@@ -80,6 +80,7 @@ class MetricsSnapshot:
     fft_block: FloatArray | None
     analysis_time_range: AnalysisTimeRange | None = None
     buffer_epoch: int = 0
+    reset_generation: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,3 +97,4 @@ class MetricsComputationResult:
     duration_s: float
     analysis_time_range: AnalysisTimeRange | None = None
     buffer_epoch: int = 0
+    reset_generation: int = 0


### PR DESCRIPTION
Fixes #3162

## What changed
- add reset-only invalidation state to live processing buffers
- carry that token through compute snapshots and async result commits
- reject results that were computed before a buffer reset
- clear compute state on reset and add focused stale/fresh/repeated-reset regressions

## Why
- reset should mean old analysis work is dead
- ingest generation alone is not enough because new samples between snapshot and commit are valid
- buffer eviction identity and buffer reset invalidation are different things

## Validation
- `pytest -q apps/server/tests/infra/processing/test_buffer_mutations.py apps/server/tests/infra/processing/test_buffer_store_reset_generation.py apps/server/tests/infra/processing/test_buffer_store_identity_and_rate_guards.py apps/server/tests/infra/processing/test_buffer_store_cache_invalidation.py apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/infra/processing/test_compute_filtering.py`
- `pytest -q apps/server/tests/infra/processing apps/server/tests/integration/test_runtime_queue_and_export_regressions.py`
- `make lint`
- `make typecheck-backend`

## Risks / tradeoffs
- adds one more lifecycle token to the processing path, but keeps reset invalidation explicit instead of overloading ingest generation
- keeps existing buffer-epoch eviction protection unchanged
- no contract or UI changes

## Out of scope
- no changes to higher-level diagnostics or report logic
- no changes to ingestion ordering beyond reset invalidation