### PR TITLE
Keep first in-band bin in noise floor

### DIFF
--- a/apps/server/tests/infra/processing/test_processing_fft.py
+++ b/apps/server/tests/infra/processing/test_processing_fft.py
@@ -262,6 +262,41 @@ class TestComputeFftSpectrum:
         assert float(result["spectrum_by_axis"]["x"]["amp"][0]) > 0.0
         assert float(result["combined_amp"][0]) > 0.0
 
+    def test_strength_noise_floor_uses_first_analysis_bin_when_dc_is_absent(self) -> None:
+        sr = 512
+        fft_n = 512
+        t = np.arange(fft_n, dtype=np.float32) / sr
+        first_bin_tone = 0.05 * np.sin(2 * np.pi * 6 * t)
+        upper_tone = 0.25 * np.sin(2 * np.pi * 10 * t)
+        block = np.stack(
+            [
+                first_bin_tone + upper_tone,
+                first_bin_tone + upper_tone,
+                first_bin_tone + upper_tone,
+            ],
+            axis=0,
+        )
+        computer = SpectralAnalysisComputer(
+            fft_n=fft_n,
+            spectrum_min_hz=6.0,
+            spectrum_max_hz=100.0,
+        )
+        freq_slice, valid_idx = computer.fft_params(sr)
+
+        result = compute_fft_spectrum(
+            block,
+            sr,
+            fft_window=computer.fft_window,
+            fft_scale=computer.fft_scale,
+            freq_slice=freq_slice,
+            valid_idx=valid_idx,
+        )
+
+        assert result["freq_slice"][0] == pytest.approx(6.0)
+        assert result["strength_metrics"]["top_peaks"]
+        assert result["strength_metrics"]["top_peaks"][0]["hz"] == pytest.approx(10.0, abs=1.0)
+        assert float(result["strength_metrics"]["noise_floor_amp_g"]) > 0.0
+
     def test_dc_bias_does_not_mask_signal_peak(self) -> None:
         sr = 512
         fft_n = 512

--- a/apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py
+++ b/apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py
@@ -9,7 +9,9 @@ import pytest
 
 from vibesensor.vibration_strength import (
     _combined_spectrum_amp_g_array,
+    _noise_floor_amp_p20_g_aligned,
     combined_spectrum_amp_g,
+    compute_vibration_strength_db,
     median,
     noise_floor_amp_p20_g,
     percentile,
@@ -129,6 +131,36 @@ class TestNoiseFloorAmpP20G:
         result = noise_floor_amp_p20_g(combined_spectrum_amp_g=[-1.0, -2.0, 0.01, 0.02])
         # Only non-negative finite values are used
         assert result >= 0.0
+
+    def test_aligned_helper_skips_first_bin_only_when_dc_is_present(self) -> None:
+        with_dc = _noise_floor_amp_p20_g_aligned(
+            freq_hz=np.array([0.0, 5.0, 6.0, 7.0, 8.0], dtype=np.float64),
+            combined_spectrum_amp_g=np.array([100.0, 0.01, 0.02, 0.04, 0.08], dtype=np.float64),
+        )
+        without_dc = _noise_floor_amp_p20_g_aligned(
+            freq_hz=np.array([5.0, 6.0, 7.0, 8.0], dtype=np.float64),
+            combined_spectrum_amp_g=np.array([0.01, 0.02, 0.04, 0.08], dtype=np.float64),
+        )
+
+        expected = float(np.quantile(np.array([0.01, 0.02, 0.04, 0.08], dtype=np.float64), 0.20))
+        assert with_dc == pytest.approx(expected)
+        assert without_dc == pytest.approx(expected)
+
+    def test_compute_vibration_strength_preserves_first_in_band_noise_bin(self) -> None:
+        freq_hz = [5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        combined = [0.001, 0.05, 0.02, 0.02, 0.02, 0.30]
+
+        result = compute_vibration_strength_db(
+            freq_hz=freq_hz,
+            combined_spectrum_amp_g_values=combined,
+            peak_bandwidth_hz=0.5,
+            peak_separation_hz=0.5,
+            top_n=3,
+        )
+
+        assert result["top_peaks"]
+        assert result["top_peaks"][0]["hz"] == pytest.approx(10.0)
+        assert result["noise_floor_amp_g"] == pytest.approx(0.02)
 
 
 # -- relative_level_db_scalar --------------------------------------------------

--- a/apps/server/vibesensor/vibration_strength.py
+++ b/apps/server/vibesensor/vibration_strength.py
@@ -230,12 +230,25 @@ def noise_floor_amp_p20_g(*, combined_spectrum_amp_g: ArrayLike) -> float:
     return _noise_floor_amp_p20_g_aligned(combined_spectrum_amp_g=band)
 
 
-def _noise_floor_amp_p20_g_aligned(*, combined_spectrum_amp_g: npt.NDArray[np.float64]) -> float:
+def _spectrum_includes_dc_bin_aligned(*, freq_hz: npt.NDArray[np.float64] | None) -> bool:
+    if freq_hz is None or freq_hz.size == 0:
+        return True
+    first_hz = float(freq_hz[0])
+    return isfinite(first_hz) and abs(first_hz) <= 1e-12
+
+
+def _noise_floor_amp_p20_g_aligned(
+    *,
+    combined_spectrum_amp_g: npt.NDArray[np.float64],
+    freq_hz: npt.NDArray[np.float64] | None = None,
+) -> float:
     band = combined_spectrum_amp_g
-    if band.size <= 1:
-        # Empty spectrum or DC-only: no frequency content to estimate noise from.
+    noise_bins = band[1:] if _spectrum_includes_dc_bin_aligned(freq_hz=freq_hz) else band
+    if noise_bins.size == 0:
+        # Empty spectrum, DC-only, or DC removed before slicing: no usable
+        # frequency content remains to estimate the noise floor from.
         return 0.0
-    return _quantile_or_zero(band[1:], 0.20)
+    return _quantile_or_zero(noise_bins, 0.20)
 
 
 def strength_floor_amp_g(
@@ -528,7 +541,10 @@ def compute_vibration_strength_db(
 
     freq = freq_arr[:n]
     combined = np.where(np.isfinite(combined_arr[:n]), np.maximum(combined_arr[:n], 0.0), 0.0)
-    floor_p20 = _noise_floor_amp_p20_g_aligned(combined_spectrum_amp_g=combined)
+    floor_p20 = _noise_floor_amp_p20_g_aligned(
+        combined_spectrum_amp_g=combined,
+        freq_hz=freq,
+    )
     threshold = max(
         floor_p20 * PEAK_THRESHOLD_FLOOR_RATIO,
         floor_p20 + STRENGTH_EPSILON_MIN_G,


### PR DESCRIPTION
Fixes #3163

## What changed
- make the aligned P20 noise-floor helper frequency-aware
- skip index 0 only when the aligned spectrum actually contains DC
- keep the public full-spectrum helper semantics unchanged
- add focused strength and FFT regressions for DC-present and DC-absent slices

## Why
- after FFT band slicing, index 0 is often the first real analysis bin, not DC
- skipping that bin distorts thresholding and strength math near the lower analysis bound
- the canonical vibration-strength path should decide from `freq_hz`, not array position alone

## Validation
- `pytest -q apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py apps/server/tests/infra/processing/test_processing_fft.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py`
- `pytest -q apps/server/tests/infra/processing/test_processing_fft.py apps/server/tests/infra/processing/test_strength_and_spectrum_runtime_regressions.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_boundaries.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_core.py apps/server/tests/use_cases/diagnostics/test_vibration_strength_invariants.py apps/server/tests/use_cases/diagnostics/test_vibration_math_coverage.py apps/server/tests/use_cases/diagnostics/test_strength_scoring.py apps/server/tests/infra/processing/test_spectrum_and_peak_selection_regressions.py`
- `make lint`
- `make typecheck-backend`

## Risks / tradeoffs
- low-frequency strength outputs near the lower bound can change; that is the correction
- public `noise_floor_amp_p20_g()` stays DC-skipping for callers that still pass full spectra
- no API or contract changes

## Out of scope
- no broader peak-selection changes beyond the noise-floor fix
- no UI/report contract updates