### PR TITLE
Adjust trimmed chunk timestamps

### DIFF
--- a/apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py
+++ b/apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py
@@ -35,6 +35,7 @@ def test_apply_overflow_policy_keeps_full_chunk_when_it_fits(caplog) -> None:
 
     assert prepared.overflow == OverflowResult(keep_count=4, drop_count=0, start_offset=0)
     np.testing.assert_array_equal(prepared.chunk, chunk)
+    assert prepared.adjusted_t0_us(t0_us=1_000_000, sample_rate_hz=200) == 1_000_000
     assert caplog.text == ""
 
 
@@ -51,5 +52,6 @@ def test_apply_overflow_policy_trims_oldest_samples_and_warns(caplog) -> None:
 
     assert prepared.overflow == OverflowResult(keep_count=4, drop_count=2, start_offset=2)
     np.testing.assert_array_equal(prepared.chunk, chunk[-4:])
+    assert prepared.adjusted_t0_us(t0_us=1_000_000, sample_rate_hz=4) == 1_500_000
     assert "exceeds buffer capacity 4" in caplog.text
     assert "discarding 2 oldest samples" in caplog.text

--- a/apps/server/tests/infra/processing/test_processing_components.py
+++ b/apps/server/tests/infra/processing/test_processing_components.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from vibesensor.infra.processing.buffer_store import SignalBufferStore
 from vibesensor.infra.processing.compute import SignalMetricsComputer
@@ -136,6 +137,24 @@ def test_buffer_store_warns_and_truncates_oversized_ingest(caplog) -> None:
         assert buf is not None
         latest = store._buffer_mutator.copy_latest(buf, 4).T
     np.testing.assert_array_equal(latest, samples[-4:])
+
+
+def test_buffer_store_adjusts_t0_us_for_oversized_ingest() -> None:
+    store = SignalBufferStore(_config(sample_rate_hz=4, waveform_seconds=1))
+    client_id = "client-oversized-t0"
+    samples = np.arange(18, dtype=np.float32).reshape(6, 3)
+
+    store.ingest(client_id, samples, sample_rate_hz=4, t0_us=1_000_000)
+
+    with store.locked_client_buffer(client_id) as buf:
+        assert buf is not None
+        assert buf.last_t0_us == 1_500_000
+        assert buf.samples_since_t0 == 4
+    plan = store.snapshot_for_compute(client_id, sample_rate_hz=4)
+    assert isinstance(plan, MetricsSnapshot)
+    assert plan.analysis_time_range is not None
+    assert plan.analysis_time_range.start_s == pytest.approx(1.5)
+    assert plan.analysis_time_range.end_s == pytest.approx(2.5)
 
 
 def test_fft_params_uses_lru_eviction(monkeypatch) -> None:

--- a/apps/server/vibesensor/infra/processing/buffer_store_ingest.py
+++ b/apps/server/vibesensor/infra/processing/buffer_store_ingest.py
@@ -78,8 +78,17 @@ class BufferStoreIngestCoordinator:
                 chunk,
                 capacity=buf.capacity,
             )
+            effective_sample_rate_hz = buf.sample_rate_hz or self._config.sample_rate_hz
             dropped_samples = prepared.overflow.drop_count
-            ingested_samples = apply_ring_buffer_ingest(buf, prepared.chunk, t0_us=t0_us)
+            adjusted_t0_us = prepared.adjusted_t0_us(
+                t0_us=t0_us,
+                sample_rate_hz=effective_sample_rate_hz,
+            )
+            ingested_samples = apply_ring_buffer_ingest(
+                buf,
+                prepared.chunk,
+                t0_us=adjusted_t0_us,
+            )
             self._buffer_mutator.invalidate_cached_payloads(buf)
         self._stats.record_ingest(
             ingested_samples=ingested_samples,

--- a/apps/server/vibesensor/infra/processing/ingest_preparation.py
+++ b/apps/server/vibesensor/infra/processing/ingest_preparation.py
@@ -18,6 +18,18 @@ class PreparedIngestChunk:
     chunk: FloatArray
     overflow: OverflowResult
 
+    def adjusted_t0_us(
+        self,
+        *,
+        t0_us: int | None,
+        sample_rate_hz: int,
+    ) -> int | None:
+        if t0_us is None or t0_us <= 0:
+            return t0_us
+        if self.overflow.start_offset <= 0 or sample_rate_hz <= 0:
+            return int(t0_us)
+        return int(t0_us) + (self.overflow.start_offset * 1_000_000) // sample_rate_hz
+
 
 class IngestChunkPreparer:
     """Own input normalization and overflow trimming for incoming sample chunks."""


### PR DESCRIPTION
Fixes #3164

## What changed
- keep overflow trimming metadata attached to the prepared ingest chunk
- shift `t0_us` forward by the dropped-sample duration before ring-buffer ingest
- leave non-trimmed chunks unchanged
- add focused overflow and retained-window timing regressions

## Why
- once the oldest samples are discarded, the retained block starts later in time
- keeping the original `t0_us` backdates the retained samples and shifts live timing backwards
- the right place to correct that is the trim seam, not downstream time-alignment math

## Validation
- `pytest -q apps/server/tests/infra/processing/test_buffer_store_overflow_policy.py apps/server/tests/infra/processing/test_processing_components.py apps/server/tests/infra/processing/test_time_alignment.py apps/server/tests/infra/processing/test_ring_buffer_ingest.py`
- `pytest -q apps/server/tests/infra/processing apps/server/tests/integration/test_runtime_queue_and_export_regressions.py`
- `make lint`
- `make typecheck-backend`

## Risks / tradeoffs
- oversized-chunk timing output shifts forward by design; that is the correction
- uses the effective sample rate already applied to the buffer, including clamp/override behavior
- no API or UI contract changes

## Out of scope
- no changes to raw capture persistence outside the live processing overflow path
- no changes to non-trimmed ingest behavior