### PR TITLE
Preserve fallback speed provenance

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_context.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_context.py
@@ -121,6 +121,39 @@ def test_normalize_whole_run_context_labels_marks_stale_context_explicitly() -> 
     assert label.load_state == "unknown"
 
 
+def test_normalize_whole_run_context_labels_marks_fallback_manual_as_stale_provenance() -> None:
+    metadata = _metadata()
+    window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=2048)
+    samples = sensor_frames_from_mappings(
+        [
+            {
+                "t_s": 1.28,
+                "client_id": "sensor-a",
+                "speed_kmh": 30.0,
+                "speed_source": "fallback_manual",
+                "gear": 0.64,
+                "final_drive_ratio": 3.08,
+            }
+        ]
+    )
+
+    label = normalize_whole_run_context_labels(
+        metadata=metadata,
+        samples=samples,
+        window_plan=window_plan,
+    )[0]
+
+    assert label.context_coverage == "partial"
+    assert label.speed_validity == "assumed"
+    assert label.rpm_validity == "estimated"
+    assert label.speed_source == "fallback_manual"
+    assert label.speed_is_stale is True
+    assert label.rpm_is_stale is True
+    assert label.speed_band is None
+    assert label.phase == DrivingPhase.SPEED_UNKNOWN
+    assert label.load_state == "unknown"
+
+
 def test_normalize_whole_run_context_labels_keeps_missing_windows_explicit() -> None:
     metadata = _metadata()
     window_plan = plan_whole_run_windows(metadata=metadata, total_sample_count=2048)

--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -77,11 +77,18 @@ def test_build_sample_records_caps_combined_and_axis_peak_lists(make_logger, fak
 
 
 @pytest.mark.parametrize(
-    ("gps_speed_mps", "override_speed_mps", "expected_source", "expected_speed_kmh"),
+    (
+        "gps_speed_mps",
+        "override_speed_mps",
+        "resolved_source",
+        "expected_source",
+        "expected_speed_kmh",
+    ),
     [
-        (10.0, 20.0, "manual", 20.0 * 3.6),
-        (10.0, None, "gps", 10.0 * 3.6),
-        (None, None, "none", None),
+        (10.0, 20.0, None, "manual", 20.0 * 3.6),
+        (10.0, None, "gps", "gps", 10.0 * 3.6),
+        (10.0, None, "fallback_manual", "fallback_manual", 10.0 * 3.6),
+        (None, None, None, "none", None),
     ],
 )
 def test_speed_source_reports(
@@ -89,12 +96,14 @@ def test_speed_source_reports(
     fake_gps_monitor,
     gps_speed_mps: float | None,
     override_speed_mps: float | None,
+    resolved_source: str | None,
     expected_source: str,
     expected_speed_kmh: float | None,
 ) -> None:
     """speed_source should reflect manual override, GPS, or missing speed state."""
     fake_gps_monitor.speed_mps = gps_speed_mps
     fake_gps_monitor.override_speed_mps = override_speed_mps
+    fake_gps_monitor.resolved_source = resolved_source
     fake_gps_monitor.effective_speed_mps = (
         override_speed_mps if override_speed_mps is not None else gps_speed_mps
     )

--- a/apps/server/tests/use_cases/run/test_speed_context.py
+++ b/apps/server/tests/use_cases/run/test_speed_context.py
@@ -7,8 +7,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from vibesensor.domain import AnalysisSettingsSnapshot
+from vibesensor.shared.types.aligned_speed_context import AlignedSpeedContextSnapshot
 from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
-from vibesensor.use_cases.run.sample_speed_context import resolve_speed_context
+from vibesensor.use_cases.run.sample_speed_context import (
+    resolve_speed_context,
+    resolve_speed_context_snapshot,
+)
 
 
 def _make_run_recorder() -> tuple[RunRecorder, MagicMock]:
@@ -89,6 +93,14 @@ class TestResolveSpeedContext:
         assert speed_kmh == pytest.approx(72.0, rel=0.01)
         assert source == "manual"
 
+    def test_fallback_manual_override_preserves_distinct_source(self) -> None:
+        logger, gps_mock = _make_run_recorder()
+        gps_mock.override_speed_mps = 20.0
+        gps_mock.resolve_speed.return_value = MagicMock(source="fallback_manual", speed_mps=20.0)
+        speed_kmh, _, source, _, _ = self._resolve_from_logger(logger)
+        assert speed_kmh == pytest.approx(72.0, rel=0.01)
+        assert source == "fallback_manual"
+
     def test_no_gear_ratio_skips_rpm(self) -> None:
         logger, gps_mock = _make_run_recorder()
         gps_mock.resolve_speed.return_value = MagicMock(source="gps", speed_mps=15.0)
@@ -124,3 +136,33 @@ class TestResolveSpeedContext:
         assert speed == pytest.approx(36.0, rel=0.01)
         assert rpm == 1234.5
         assert rpm_source == "estimated_from_speed_and_ratios"
+
+
+def test_resolve_speed_context_snapshot_preserves_fallback_manual_source() -> None:
+    snapshot = AlignedSpeedContextSnapshot(
+        selected_speed_source="gps",
+        resolved_speed_mps=20.0,
+        resolved_speed_source="fallback_manual",
+        resolved_speed_aligned=True,
+        gps_speed_mps=None,
+        gps_speed_aligned=False,
+        measured_engine_rpm=None,
+        measured_engine_rpm_source=None,
+        measured_engine_rpm_aligned=False,
+    )
+
+    context = resolve_speed_context_snapshot(
+        snapshot=snapshot,
+        analysis_settings_snapshot=AnalysisSettingsSnapshot(
+            tire_width_mm=205,
+            tire_aspect_pct=55,
+            rim_in=16,
+            final_drive_ratio=3.73,
+            current_gear_ratio=1.0,
+        ),
+    )
+
+    assert context.speed_kmh == pytest.approx(72.0, rel=0.01)
+    assert context.speed_source == "fallback_manual"
+    assert context.engine_rpm is not None and context.engine_rpm > 0.0
+    assert context.engine_rpm_source == "estimated_from_speed_and_ratios"

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_context.py
@@ -198,8 +198,16 @@ def normalize_whole_run_context_labels(
         rpm_age_s = (
             abs(rpm_observation.t_s - window.center_t_s) if rpm_observation is not None else None
         )
-        speed_is_stale = speed_age_s is not None and speed_age_s > freshness_limit_s
-        rpm_is_stale = rpm_age_s is not None and rpm_age_s > freshness_limit_s
+        speed_source = speed_observation.speed_source if speed_observation is not None else None
+        engine_rpm_source = (
+            rpm_observation.engine_rpm_source if rpm_observation is not None else None
+        )
+        speed_is_stale = (
+            speed_age_s is not None and speed_age_s > freshness_limit_s
+        ) or _speed_source_requires_stale_context(speed_source)
+        rpm_is_stale = (rpm_age_s is not None and rpm_age_s > freshness_limit_s) or (
+            speed_is_stale and engine_rpm_source == "estimated_from_speed_and_ratios"
+        )
         speed_kmh = speed_observation.speed_kmh if speed_observation is not None else None
         speed_validity = (
             speed_observation.speed_validity if speed_observation is not None else "missing"
@@ -230,14 +238,10 @@ def normalize_whole_run_context_labels(
                     if speed_kmh is not None and not speed_is_stale
                     else None
                 ),
-                speed_source=(
-                    speed_observation.speed_source if speed_observation is not None else None
-                ),
+                speed_source=speed_source,
                 speed_is_stale=speed_is_stale,
                 engine_rpm=(rpm_observation.engine_rpm if rpm_observation is not None else None),
-                engine_rpm_source=(
-                    rpm_observation.engine_rpm_source if rpm_observation is not None else None
-                ),
+                engine_rpm_source=engine_rpm_source,
                 rpm_is_stale=rpm_is_stale,
             )
         )
@@ -402,7 +406,7 @@ def _speed_validity_for_source(source: str) -> WholeRunSpeedValidity:
         return "missing"
     if source in {"gps", "obd2"}:
         return "measured"
-    if source == "manual":
+    if source in {"manual", "fallback_manual"}:
         return "assumed"
     return "missing"
 
@@ -422,4 +426,10 @@ def _speed_source_rank(source: str) -> int:
         return 2
     if source == "manual":
         return 1
+    if source == "fallback_manual":
+        return 0
     return 0
+
+
+def _speed_source_requires_stale_context(source: str | None) -> bool:
+    return source == "fallback_manual"

--- a/apps/server/vibesensor/use_cases/run/sample_speed_context.py
+++ b/apps/server/vibesensor/use_cases/run/sample_speed_context.py
@@ -17,7 +17,7 @@ _SPEED_SOURCE_MAP = {
     "manual": "manual",
     "gps": "gps",
     "obd2": "obd2",
-    "fallback_manual": "manual",
+    "fallback_manual": "fallback_manual",
     "none": "none",
 }
 


### PR DESCRIPTION
## What changed
- keep `fallback_manual` intact in run sample speed context for both live and aligned sample paths
- mark fallback-derived whole-run speed context as assumed + stale, and carry that staleness into RPM estimated from speed
- add regressions for helper mapping, persisted sample rows, and whole-run context labels

## Why
- stale or disconnected GPS fallback was getting flattened into plain manual speed
- that hid lower-confidence provenance from persisted rows and whole-run/report confidence logic

## Validation
- `pytest -q apps/server/tests/use_cases/run/test_speed_context.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/diagnostics/test_whole_run_context.py`
- `pytest -q apps/server/tests/use_cases/run/test_post_analysis_executor.py apps/server/tests/use_cases/run/test_post_analysis_summary_vehicle_context.py`
- `make lint`
- `make typecheck-backend`

## Risks / tradeoffs
- fallback-manual windows now downgrade to stale assumed context instead of looking like intentional manual input
- no additive flag was needed because `speed_source` already carries the distinct provenance value

Closes #3165