### PR TITLE
Keep unusable FFT windows out of raw-backed replay

### DIFF
--- a/apps/server/tests/infra/processing/test_processing_fft.py
+++ b/apps/server/tests/infra/processing/test_processing_fft.py
@@ -428,7 +428,9 @@ class TestComputeFftSpectrum:
             "freq_slice",
             "spectrum_by_axis",
             "combined_amp",
+            "has_valid_analysis_bins",
             "strength_metrics",
+            "strength_metrics_analytically_valid",
             "axis_peaks",
         }
         assert freq_slice.dtype == np.float32
@@ -443,6 +445,8 @@ class TestComputeFftSpectrum:
         if expect_empty:
             assert freq_slice.size == 0
             assert result["combined_amp"].size == 0
+            assert result["has_valid_analysis_bins"] is False
+            assert result["strength_metrics_analytically_valid"] is False
             assert result["strength_metrics"]["vibration_strength_db"] == 0.0
             assert result["strength_metrics"]["top_peaks"] == []
             for axis in ("x", "y", "z"):
@@ -452,10 +456,38 @@ class TestComputeFftSpectrum:
 
         assert np.all(np.diff(freq_slice) >= 0.0)
         assert result["combined_amp"].shape == freq_slice.shape
+        assert result["has_valid_analysis_bins"] is True
+        assert result["strength_metrics_analytically_valid"] is True
         assert np.isfinite(result["strength_metrics"]["vibration_strength_db"])
         assert isinstance(result["strength_metrics"]["top_peaks"], list)
         for axis in ("x", "y", "z"):
             assert result["spectrum_by_axis"][axis]["amp"].shape == freq_slice.shape
+
+    def test_spectral_analysis_marks_no_valid_bin_slice_as_invalid(self) -> None:
+        sample_rate_hz = 8
+        fft_n = 64
+        t = np.arange(fft_n, dtype=np.float32) / sample_rate_hz
+        block = np.stack(
+            [
+                0.1 * np.sin(2 * np.pi * 2 * t),
+                np.zeros_like(t),
+                np.zeros_like(t),
+            ],
+            axis=0,
+        )
+        computer = SpectralAnalysisComputer(
+            fft_n=fft_n,
+            spectrum_min_hz=5.0,
+            spectrum_max_hz=200.0,
+        )
+
+        result = computer.compute_fft_spectrum(block, sample_rate_hz)
+
+        assert result["freq_slice"].size == 0
+        assert result["has_valid_analysis_bins"] is False
+        assert result["strength_metrics_analytically_valid"] is False
+        assert result["strength_metrics"]["vibration_strength_db"] == 0.0
+        assert result["strength_metrics"]["top_peaks"] == []
 
     def test_combined_spectrum_reports_multiple_axis_tones(self) -> None:
         sr = 512

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -289,6 +289,7 @@ def test_build_post_analysis_summary_adds_analysis_metadata(
         "raw_replay_write_error_chunk_count": 0,
         "raw_replay_timing_fallback_count": 0,
         "raw_replay_sample_rate_mismatch_count": 0,
+        "raw_replay_fft_unusable_window_count": 0,
         "raw_replay_sample_rate_unverified_sensor_count": 0,
         "raw_replay_unanchored_sensor_count": 0,
         "raw_replay_legacy_sensor_count": 0,

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary_fft_validity.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary_fft_validity.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.run_context_warning import WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureChunkIndex,
+    RawCaptureManifest,
+    RawCaptureSensorClockSync,
+    RawCaptureSensorData,
+    RawCaptureSensorManifest,
+    RawRunCapture,
+)
+from vibesensor.use_cases.run.post_analysis_input import build_post_analysis_input
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
+
+
+def _run_metadata(run_id: str):
+    return run_metadata_from_mapping(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": 8,
+            "sample_rate_hz": 8,
+            "feature_interval_s": 1.0,
+            "fft_window_size_samples": 64,
+            "accel_scale_g_per_lsb": 0.001,
+            "language": "en",
+        }
+    )
+
+
+def _verified_clock_sync() -> RawCaptureSensorClockSync:
+    return RawCaptureSensorClockSync(
+        clock_domain="server_monotonic",
+        proof_state="verified",
+        observed_monotonic_us=1_010_000,
+        last_sync_monotonic_us=1_009_000,
+        sync_offset_us=5_000,
+        sync_rtt_us=4_000,
+        max_sync_age_us=15_000_000,
+        max_sync_rtt_us=50_000,
+    )
+
+
+def _low_rate_raw_capture(run_id: str) -> RawRunCapture:
+    run_start_monotonic_us = 1_000_000
+    sample_rate_hz = 8
+    chunk_sample_count = 64
+    time_axis = np.arange(chunk_sample_count, dtype=np.float64) / float(sample_rate_hz)
+    wave = np.round(1000.0 * np.sin(2.0 * np.pi * 2.0 * time_axis)).astype(np.int16)
+    chunk = np.column_stack(
+        [
+            wave,
+            np.zeros(chunk_sample_count, dtype=np.int16),
+            np.zeros(chunk_sample_count, dtype=np.int16),
+        ]
+    )
+    chunk_rows = (
+        RawCaptureChunkIndex(
+            sample_start=0,
+            sample_count=chunk_sample_count,
+            t0_us=run_start_monotonic_us,
+            byte_offset=0,
+        ),
+    )
+    sensor_manifest = RawCaptureSensorManifest(
+        client_id="sensor-a",
+        sample_rate_hz=sample_rate_hz,
+        data_file="sensor-a.raw.i16le",
+        index_file="sensor-a.index.jsonl",
+        sample_count=chunk_sample_count,
+        chunk_count=1,
+        bytes_written=int(chunk.nbytes),
+        first_t0_us=chunk_rows[0].t0_us,
+        last_t0_us=chunk_rows[0].t0_us,
+        clock_sync=_verified_clock_sync(),
+        sample_rate_proof_state="observed_consistent",
+    )
+    manifest = RawCaptureManifest(
+        run_id=run_id,
+        relative_dir=f"raw-runs/{run_id}",
+        sensors=(sensor_manifest,),
+        total_samples=chunk_sample_count,
+        total_bytes=int(chunk.nbytes),
+        created_at="2025-01-01T00:00:01Z",
+        run_start_monotonic_us=run_start_monotonic_us,
+    )
+    return RawRunCapture(
+        manifest=manifest,
+        sensors=(
+            RawCaptureSensorData(
+                manifest=sensor_manifest,
+                samples_i16=chunk,
+                chunks=chunk_rows,
+            ),
+        ),
+    )
+
+
+def test_build_post_analysis_summary_persists_fft_unusable_warning_and_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRunAnalysis:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def summarize(self):
+            return SimpleNamespace(
+                diagnostic_case=SimpleNamespace(case_id="case-fft-unusable"),
+            )
+
+    monkeypatch.setattr(
+        "vibesensor.use_cases.diagnostics.run_analysis.RunAnalysis",
+        FakeRunAnalysis,
+    )
+    monkeypatch.setattr(
+        "vibesensor.use_cases.run.post_analysis_summary.analysis_result_to_summary",
+        lambda _result: {"warnings": [], "run_suitability": []},
+    )
+
+    run = build_post_analysis_input(
+        LoadedPostAnalysisRun(
+            run_id="run-fft-unusable",
+            metadata=_run_metadata("run-fft-unusable"),
+            language="en",
+            samples=sensor_frames_from_mappings(
+                [
+                    {
+                        "client_id": "sensor-a",
+                        "t_s": 8.0,
+                        "sample_rate_hz": 8,
+                        "vibration_strength_db": 0.0,
+                        "dominant_freq_hz": 0.0,
+                    }
+                ]
+            ),
+            raw_capture=_low_rate_raw_capture("run-fft-unusable"),
+            total_summary_row_count=1,
+            stride=1,
+        )
+    )
+
+    summary = build_post_analysis_summary(run)
+
+    assert summary["analysis_metadata"]["raw_replay_complete_window_count"] == 1
+    assert summary["analysis_metadata"]["raw_replay_fft_unusable_window_count"] == 1
+    assert summary["analysis_metadata"]["raw_capture_mode"] == "summary_only"
+    assert [warning["code"] for warning in summary["warnings"]] == [
+        WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE,
+    ]

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay.py
@@ -7,7 +7,10 @@ import numpy as np
 
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
-from vibesensor.shared.run_context_warning import WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS
+from vibesensor.shared.run_context_warning import (
+    WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS,
+    WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE,
+)
 from vibesensor.shared.types.raw_capture import (
     RawCaptureChunkIndex,
     RawCaptureLossStats,
@@ -22,14 +25,14 @@ from vibesensor.use_cases.run.post_analysis_input import build_post_analysis_inp
 from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
 
 
-def _metadata(run_id: str):
+def _metadata(run_id: str, *, sample_rate_hz: int = 800):
     return run_metadata_from_mapping(
         {
             "run_id": run_id,
             "start_time_utc": "2025-01-01T00:00:00Z",
             "sensor_model": "fixture-sensor",
-            "raw_sample_rate_hz": 800,
-            "sample_rate_hz": 800,
+            "raw_sample_rate_hz": sample_rate_hz,
+            "sample_rate_hz": sample_rate_hz,
             "feature_interval_s": 1.0,
             "fft_window_size_samples": 64,
             "accel_scale_g_per_lsb": 0.001,
@@ -38,11 +41,10 @@ def _metadata(run_id: str):
     )
 
 
-def _raw_capture(run_id: str) -> RawRunCapture:
-    sample_rate_hz = 800
+def _raw_capture(run_id: str, *, sample_rate_hz: int = 800, wave_hz: float = 50.0) -> RawRunCapture:
     fft_n = 64
     time_axis = np.arange(fft_n, dtype=np.float64) / sample_rate_hz
-    wave = np.round(1000.0 * np.sin(2.0 * math.pi * 50.0 * time_axis)).astype(np.int16)
+    wave = np.round(1000.0 * np.sin(2.0 * math.pi * wave_hz * time_axis)).astype(np.int16)
     samples_i16 = np.column_stack(
         [
             wave,
@@ -128,6 +130,49 @@ def test_build_post_analysis_input_replays_raw_backed_strength_metrics() -> None
     assert rebuilt.dominant_freq_hz is not None
     assert 30.0 <= rebuilt.dominant_freq_hz <= 70.0
     assert rebuilt.top_peaks
+
+
+def test_build_post_analysis_input_marks_no_valid_bin_fft_windows_unusable() -> None:
+    sample_rate_hz = 8
+    fft_n = 64
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-no-valid-bins",
+        metadata=_metadata("run-no-valid-bins", sample_rate_hz=sample_rate_hz),
+        language="en",
+        samples=sensor_frames_from_mappings(
+            [
+                {
+                    "client_id": "sensor-a",
+                    "t_s": fft_n / sample_rate_hz,
+                    "sample_rate_hz": sample_rate_hz,
+                    "vibration_strength_db": 0.0,
+                    "dominant_freq_hz": 0.0,
+                }
+            ]
+        ),
+        raw_capture=_raw_capture("run-no-valid-bins", sample_rate_hz=sample_rate_hz, wave_hz=2.0),
+        total_summary_row_count=1,
+        stride=1,
+    )
+
+    result = build_post_analysis_input(loaded)
+
+    rebuilt = result.diagnostics_run.samples[0]
+    assert result.raw_backed_summary_row_count == 0
+    assert result.raw_replay.complete_window_count == 1
+    assert result.raw_replay.fft_unusable_window_count == 1
+    assert result.raw_replay.replay_confidence == "fallback"
+    assert result.raw_replay.raw_capture_mode == "summary_only"
+    assert result.raw_replay_window_coverages[0].reason == "fft_no_valid_bins"
+    assert WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE in [
+        warning.code for warning in result.raw_replay.warnings
+    ]
+    assert rebuilt.vibration_strength_db is None
+    assert rebuilt.dominant_freq_hz is None
+    assert rebuilt.top_peaks == ()
+    assert rebuilt.strength_bucket is None
+    assert rebuilt.strength_peak_amp_g is None
+    assert rebuilt.strength_floor_amp_g is None
 
 
 def test_build_post_analysis_input_surfaces_persisted_dropped_chunk_counts() -> None:

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1739,6 +1739,14 @@
     "en": "Some persisted samples did not include explicit analysis-window timing metadata, so replay aligned {count} window(s) using legacy sample timestamps.",
     "nl": "Sommige persistente samples bevatten geen expliciete analysevenster-timingmetadata, dus replay lijnde {count} venster(s) uit met legacy-sampletijdstempels."
   },
+  "RUN_CONTEXT_WARNING_RAW_REPLAY_FFT_UNUSABLE_TITLE": {
+    "en": "Raw replay found windows with no analyzable FFT band",
+    "nl": "Raw replay vond vensters zonder analyseerbare FFT-band"
+  },
+  "RUN_CONTEXT_WARNING_RAW_REPLAY_FFT_UNUSABLE_DETAIL": {
+    "en": "Replay rebuilt {count} window(s) with complete raw coverage but no valid in-band FFT bins, so those windows stayed reduced-confidence instead of being marked raw-backed.",
+    "nl": "Replay herbouwde {count} venster(s) met volledige raw-dekking maar zonder geldige in-band FFT-bins, dus die vensters bleven verlaagde-confidence in plaats van raw-backed te worden gemarkeerd."
+  },
   "RUN_CONTEXT_WARNING_RAW_REPLAY_LEGACY_TITLE": {
     "en": "Raw replay fell back to persisted summary metrics",
     "nl": "Raw replay viel terug op persistente samenvattingsmetrieken"

--- a/apps/server/vibesensor/shared/fft_analysis.py
+++ b/apps/server/vibesensor/shared/fft_analysis.py
@@ -56,7 +56,9 @@ class FftSpectrumResult(TypedDict):
     freq_slice: FloatArray
     spectrum_by_axis: SpectrumByAxis
     combined_amp: FloatArray
+    has_valid_analysis_bins: bool
     strength_metrics: VibrationStrengthMetrics
+    strength_metrics_analytically_valid: bool
     axis_peaks: dict[Axis, list[AxisPeak]]
 
 
@@ -127,7 +129,9 @@ def _empty_fft_spectrum_result(freq_slice: FloatArray) -> FftSpectrumResult:
         "freq_slice": freq_slice,
         "spectrum_by_axis": spectrum_by_axis,
         "combined_amp": empty_amp,
+        "has_valid_analysis_bins": False,
         "strength_metrics": empty_vibration_strength_metrics(),
+        "strength_metrics_analytically_valid": False,
         "axis_peaks": axis_peaks,
     }
 
@@ -255,6 +259,7 @@ def compute_fft_spectrum(
 
     combined_amp: FloatArray = np.empty(0, dtype=np.float32)
     strength_metrics: VibrationStrengthMetrics = empty_vibration_strength_metrics()
+    has_valid_analysis_bins = freq_slice.size > 0
     if spectrum_by_axis:
         amp_slices = [spectrum_by_axis[axis]["amp"] for axis in spectrum_by_axis]
         combined_amp = _combined_spectrum_amp_g_array(
@@ -276,7 +281,9 @@ def compute_fft_spectrum(
         "freq_slice": freq_slice,
         "spectrum_by_axis": spectrum_by_axis,
         "combined_amp": combined_amp,
+        "has_valid_analysis_bins": has_valid_analysis_bins,
         "strength_metrics": strength_metrics,
+        "strength_metrics_analytically_valid": has_valid_analysis_bins,
         "axis_peaks": axis_peaks,
     }
 

--- a/apps/server/vibesensor/shared/run_context_warning.py
+++ b/apps/server/vibesensor/shared/run_context_warning.py
@@ -19,6 +19,7 @@ WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE = "raw_replay_coverage_incomplete"
 WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK = "raw_replay_legacy_fallback"
 WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS = "raw_replay_dropped_chunks"
 WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK = "raw_replay_timing_fallback"
+WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE = "raw_replay_fft_unusable"
 WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED = "raw_replay_sync_unverified"
 WarningSeverity = Literal["warn", "error"]
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -97,6 +97,7 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         "raw_replay_write_error_chunk_count": run.raw_replay.write_error_chunk_count,
         "raw_replay_timing_fallback_count": run.raw_replay.timing_fallback_count,
         "raw_replay_sample_rate_mismatch_count": run.raw_replay.sample_rate_mismatch_count,
+        "raw_replay_fft_unusable_window_count": run.raw_replay.fft_unusable_window_count,
         "raw_replay_sample_rate_unverified_sensor_count": (
             run.raw_replay.sample_rate_unverified_sensor_count
         ),

--- a/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
@@ -25,6 +25,7 @@ from vibesensor.shared.raw_capture_timeline import (
 from vibesensor.shared.run_context_warning import (
     WARNING_CODE_RAW_REPLAY_COVERAGE_INCOMPLETE,
     WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS,
+    WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE,
     WARNING_CODE_RAW_REPLAY_LEGACY_FALLBACK,
     WARNING_CODE_RAW_REPLAY_SYNC_UNVERIFIED,
     WARNING_CODE_RAW_REPLAY_TIMING_FALLBACK,
@@ -74,6 +75,7 @@ class RawReplaySummary:
     write_error_chunk_count: int
     timing_fallback_count: int
     sample_rate_mismatch_count: int
+    fft_unusable_window_count: int
     sample_rate_unverified_sensor_count: int
     unanchored_sensor_count: int
     legacy_sensor_count: int
@@ -103,6 +105,13 @@ class _ResolvedWindow:
     timing_source: str = "explicit_window"
 
 
+@dataclass(frozen=True, slots=True)
+class _ComputedStrengthMetrics:
+    metrics: StrengthMetrics
+    has_valid_analysis_bins: bool
+    analytically_valid: bool
+
+
 def build_raw_backed_samples(
     *,
     samples: tuple[SensorFrame, ...],
@@ -129,6 +138,7 @@ def build_raw_backed_samples(
                 write_error_chunk_count=0,
                 timing_fallback_count=0,
                 sample_rate_mismatch_count=0,
+                fft_unusable_window_count=0,
                 sample_rate_unverified_sensor_count=0,
                 unanchored_sensor_count=0,
                 legacy_sensor_count=0,
@@ -169,6 +179,7 @@ def build_raw_backed_samples(
                 write_error_chunk_count=0,
                 timing_fallback_count=0,
                 sample_rate_mismatch_count=0,
+                fft_unusable_window_count=0,
                 sample_rate_unverified_sensor_count=0,
                 unanchored_sensor_count=0,
                 legacy_sensor_count=0,
@@ -204,6 +215,7 @@ def build_raw_backed_samples(
     missing_window_count = 0
     sample_rate_mismatch_count = 0
     timing_fallback_count = 0
+    fft_unusable_window_count = 0
     raw_backed_count = 0
     scale = metadata.accel_scale_g_per_lsb
     for sample in samples:
@@ -227,6 +239,8 @@ def build_raw_backed_samples(
             sample_rate_mismatch_count += 1
         if coverage.reason == "timing_fallback":
             timing_fallback_count += 1
+        if coverage.reason == "fft_no_valid_bins":
+            fft_unusable_window_count += 1
         replayed.append(rebuilt)
         coverages.append(coverage)
     gap_count = sum(len(timeline.gap_intervals) for timeline in timelines.values())
@@ -263,6 +277,7 @@ def build_raw_backed_samples(
         overlap_count=overlap_count,
         dropped_chunk_count=dropped_chunk_count,
         sample_rate_mismatch_count=sample_rate_mismatch_count,
+        fft_unusable_window_count=fft_unusable_window_count,
         sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
         unanchored_sensor_count=unanchored_sensor_count,
         sync_unverified_sensor_count=sync_unverified_sensor_count,
@@ -289,6 +304,7 @@ def build_raw_backed_samples(
             write_error_chunk_count=write_error_chunk_count,
             timing_fallback_count=timing_fallback_count,
             sample_rate_mismatch_count=sample_rate_mismatch_count,
+            fft_unusable_window_count=fft_unusable_window_count,
             sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
             unanchored_sensor_count=unanchored_sensor_count,
             legacy_sensor_count=legacy_sensor_count,
@@ -311,6 +327,7 @@ def build_raw_backed_samples(
                 invalid_chunk_count=invalid_chunk_count,
                 write_error_chunk_count=write_error_chunk_count,
                 sample_rate_mismatch_count=sample_rate_mismatch_count,
+                fft_unusable_window_count=fft_unusable_window_count,
                 sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
                 legacy_sensor_count=legacy_sensor_count,
                 unanchored_sensor_count=unanchored_sensor_count,
@@ -424,13 +441,36 @@ def _rebuild_sample(
     window_f32 = window_i16.astype(np.float32, copy=True)
     if accel_scale_g_per_lsb is not None and accel_scale_g_per_lsb > 0:
         window_f32 *= np.float32(accel_scale_g_per_lsb)
-    domain_strength = _compute_strength_metrics(
+    computed_strength = _compute_strength_metrics(
         window_f32,
         sample_rate_hz,
         fft_computer=fft_computer,
     )
-    top_peaks = tuple(peak for peak in domain_strength.top_peaks if peak.is_valid)
     last_xyz = window_f32[-1]
+    if not computed_strength.analytically_valid:
+        return (
+            replace(
+                sample,
+                accel_x_g=float(last_xyz[0]),
+                accel_y_g=float(last_xyz[1]),
+                accel_z_g=float(last_xyz[2]),
+                dominant_freq_hz=None,
+                top_peaks=(),
+                vibration_strength_db=None,
+                strength_bucket=None,
+                strength_peak_amp_g=None,
+                strength_floor_amp_g=None,
+            ),
+            RawReplayWindowCoverage(
+                client_id=sample.client_id,
+                t_s=sample.t_s,
+                coverage_state="complete",
+                raw_backed=False,
+                reason="fft_no_valid_bins",
+            ),
+        )
+    domain_strength = computed_strength.metrics
+    top_peaks = tuple(peak for peak in domain_strength.top_peaks if peak.is_valid)
     return (
         replace(
             sample,
@@ -528,6 +568,7 @@ def _replay_confidence(
     overlap_count: int,
     dropped_chunk_count: int,
     sample_rate_mismatch_count: int,
+    fft_unusable_window_count: int,
     sample_rate_unverified_sensor_count: int,
     sync_unverified_sensor_count: int,
     unanchored_sensor_count: int,
@@ -544,6 +585,7 @@ def _replay_confidence(
         and overlap_count <= 0
         and dropped_chunk_count <= 0
         and sample_rate_mismatch_count <= 0
+        and fft_unusable_window_count <= 0
         and sample_rate_unverified_sensor_count <= 0
         and sync_unverified_sensor_count <= 0
         and unanchored_sensor_count <= 0
@@ -566,6 +608,7 @@ def _build_replay_warnings(
     invalid_chunk_count: int,
     write_error_chunk_count: int,
     sample_rate_mismatch_count: int,
+    fft_unusable_window_count: int,
     sample_rate_unverified_sensor_count: int,
     legacy_sensor_count: int,
     unanchored_sensor_count: int,
@@ -629,6 +672,19 @@ def _build_replay_warnings(
                 ),
             )
         )
+    if fft_unusable_window_count > 0:
+        warnings.append(
+            RunContextWarning(
+                code=WARNING_CODE_RAW_REPLAY_FFT_UNUSABLE,
+                severity="warn",
+                applies_to="raw_replay",
+                title=i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_FFT_UNUSABLE_TITLE"),
+                detail=i18n_ref(
+                    "RUN_CONTEXT_WARNING_RAW_REPLAY_FFT_UNUSABLE_DETAIL",
+                    count=str(max(0, fft_unusable_window_count)),
+                ),
+            )
+        )
     if dropped_chunk_count > 0:
         warnings.append(
             RunContextWarning(
@@ -688,12 +744,20 @@ def _compute_strength_metrics(
     sample_rate_hz: int,
     *,
     fft_computer: SpectralAnalysisComputer,
-) -> StrengthMetrics:
+) -> _ComputedStrengthMetrics:
     if window_f32.size <= 0:
-        return strength_metrics_from_mapping(None)
+        return _ComputedStrengthMetrics(
+            metrics=strength_metrics_from_mapping(None),
+            has_valid_analysis_bins=False,
+            analytically_valid=False,
+        )
     fft_result = fft_computer.compute_fft_spectrum(
         medfilt3(window_f32.T),
         sample_rate_hz,
         spike_filter_enabled=False,
     )
-    return strength_metrics_from_mapping(fft_result["strength_metrics"])
+    return _ComputedStrengthMetrics(
+        metrics=strength_metrics_from_mapping(fft_result["strength_metrics"]),
+        has_valid_analysis_bins=bool(fft_result["has_valid_analysis_bins"]),
+        analytically_valid=bool(fft_result["strength_metrics_analytically_valid"]),
+    )


### PR DESCRIPTION
## What changed
- add explicit FFT-result validity bits for whether the analysis band has any valid bins and whether strength metrics are analytically usable
- keep raw replay coverage honest but stop marking no-valid-bin windows as raw-backed; those rebuilt samples now clear replayed strength outputs and carry a dedicated `fft_no_valid_bins` reason
- surface a dedicated raw-replay FFT-unusable count/warning in post-analysis metadata and report i18n
- add focused regressions for FFT helper output, low-rate raw replay fallback, and post-analysis summary warning persistence

## Why
- complete raw coverage was being mistaken for analytically valid FFT output
- empty analysis-band slices could turn into clean-looking `0.0` raw-backed metrics instead of reduced-confidence fallback behavior

## Validation
- `pytest -q apps/server/tests/infra/processing/test_processing_fft.py apps/server/tests/use_cases/run/test_raw_capture_replay.py apps/server/tests/use_cases/run/test_post_analysis_summary.py apps/server/tests/use_cases/run/test_post_analysis_summary_fft_validity.py`
- `pytest -q apps/server/tests/use_cases/run/test_raw_capture_replay_alignment.py apps/server/tests/use_cases/run/test_post_analysis_executor.py`
- `make lint`
- `make typecheck-backend`

## Risks / tradeoffs
- raw replay now prefers explicit reduced-confidence fallback over preserving placeholder zero-strength values when the FFT band is unusable
- this adds new internal/report metadata and warning text instead of overloading the generic coverage-incomplete path

Closes #3166