### PR TITLE
Derive real axis peaks and dominant axis

### DIFF
--- a/apps/server/tests/infra/processing/test_processing_fft.py
+++ b/apps/server/tests/infra/processing/test_processing_fft.py
@@ -208,7 +208,8 @@ class TestComputeFftSpectrum:
             assert float(result["spectrum_by_axis"][axis]["amp"][dominant_idx]) == pytest.approx(
                 float(result["combined_amp"][dominant_idx]),
             )
-            assert result["axis_peaks"][axis] == []
+            assert float(result["axis_peaks"][axis][0]["hz"]) == pytest.approx(50.0, abs=1.0)
+            assert float(result["axis_peaks"][axis][0]["amp"]) > 0.0
 
     def test_spike_filter_toggle(self) -> None:
         """Verify spike filter can be disabled."""
@@ -508,10 +509,14 @@ class TestComputeFftSpectrum:
             **_make_fft_params(sr=sr, fft_n=fft_n, max_hz=200.0),
         )
         peak_freqs = [float(peak["hz"]) for peak in result["strength_metrics"]["top_peaks"][:2]]
+        x_axis_peak_freqs = [float(peak["hz"]) for peak in result["axis_peaks"]["x"][:1]]
+        y_axis_peak_freqs = [float(peak["hz"]) for peak in result["axis_peaks"]["y"][:1]]
         idx_50 = int(np.argmin(np.abs(result["freq_slice"] - 50.0)))
         idx_80 = int(np.argmin(np.abs(result["freq_slice"] - 80.0)))
 
         assert peak_freqs == pytest.approx([50.0, 80.0], abs=1.0)
+        assert x_axis_peak_freqs == pytest.approx([50.0], abs=1.0)
+        assert y_axis_peak_freqs == pytest.approx([80.0], abs=1.0)
         assert float(result["combined_amp"][idx_50]) > float(
             result["spectrum_by_axis"]["y"]["amp"][idx_50],
         )

--- a/apps/server/tests/infra/processing/test_sample_builder.py
+++ b/apps/server/tests/infra/processing/test_sample_builder.py
@@ -29,6 +29,7 @@ from vibesensor.use_cases.run.run_metadata_builder import (
 from vibesensor.use_cases.run.sample_builder import build_sample_records
 from vibesensor.use_cases.run.sample_speed_context import SpeedContext
 from vibesensor.use_cases.run.sample_strength_metrics import (
+    dominant_axis_from_metrics,
     dominant_hz_from_strength,
     extract_strength_data,
 )
@@ -92,6 +93,35 @@ class TestDominantHzFromStrength:
             },
         )
         assert dominant_hz_from_strength(sm) is None
+
+
+class TestDominantAxisFromMetrics:
+    def test_returns_empty_when_no_dominant_frequency(self) -> None:
+        assert dominant_axis_from_metrics(ClientMetrics(), dominant_hz=None) == ""
+
+    def test_returns_axis_when_peak_match_is_clear(self) -> None:
+        metrics: ClientMetrics = {
+            "x": {"rms": 0.0, "p2p": 0.0, "peaks": [{"hz": 42.0, "amp": 0.3}]},
+            "y": {"rms": 0.0, "p2p": 0.0, "peaks": [{"hz": 42.0, "amp": 0.1}]},
+            "z": {"rms": 0.0, "p2p": 0.0, "peaks": []},
+        }
+        assert dominant_axis_from_metrics(metrics, dominant_hz=42.0) == "x"
+
+    def test_returns_combined_when_multiple_axes_match_without_clear_winner(self) -> None:
+        metrics: ClientMetrics = {
+            "x": {"rms": 0.0, "p2p": 0.0, "peaks": [{"hz": 42.0, "amp": 0.2}]},
+            "y": {"rms": 0.0, "p2p": 0.0, "peaks": [{"hz": 42.0, "amp": 0.2}]},
+            "z": {"rms": 0.0, "p2p": 0.0, "peaks": []},
+        }
+        assert dominant_axis_from_metrics(metrics, dominant_hz=42.0) == "combined"
+
+    def test_returns_empty_when_dominant_peak_has_no_axis_evidence(self) -> None:
+        metrics: ClientMetrics = {
+            "x": {"rms": 0.0, "p2p": 0.0, "peaks": [{"hz": 20.0, "amp": 0.1}]},
+            "y": {"rms": 0.0, "p2p": 0.0, "peaks": []},
+            "z": {"rms": 0.0, "p2p": 0.0, "peaks": []},
+        }
+        assert dominant_axis_from_metrics(metrics, dominant_hz=42.0) == ""
 
 
 # ---------------------------------------------------------------------------
@@ -319,6 +349,7 @@ class TestBuildSampleRecords:
         frame = records[0]
         assert isinstance(frame, SensorFrame)
         assert frame.dominant_freq_hz == 15.0
+        assert frame.dominant_axis == ""
         assert frame.vibration_strength_db == 22.0
         assert frame.strength_peak_amp_g == 0.15
         assert frame.strength_floor_amp_g == 0.003
@@ -334,6 +365,114 @@ class TestBuildSampleRecords:
                 "strength_bucket": "l2",
             },
         ]
+
+    def test_derives_dominant_axis_from_real_axis_peak_evidence(self) -> None:
+        record = MagicMock()
+        record.client_id = "client-1"
+        record.name = "Front Left"
+        record.location_code = "fl"
+        record.sample_rate_hz = 400
+        record.frames_dropped = 0
+        record.queue_overflow_drops = 0
+
+        reg = MagicMock()
+        reg.active_client_ids.return_value = ["client-1"]
+        reg.get.return_value = record
+
+        proc = MagicMock()
+        proc.clients_with_recent_data.return_value = ["client-1"]
+        proc.latest_metrics.return_value = {
+            "x": {"rms": 0.0, "p2p": 0.0, "peaks": [{"hz": 15.0, "amp": 0.12}]},
+            "y": {"rms": 0.0, "p2p": 0.0, "peaks": [{"hz": 15.0, "amp": 0.05}]},
+            "z": {"rms": 0.0, "p2p": 0.0, "peaks": []},
+            "combined": {
+                "strength_metrics": {
+                    "vibration_strength_db": 22.0,
+                    "strength_bucket": "l2",
+                    "peak_amp_g": 0.15,
+                    "noise_floor_amp_g": 0.003,
+                    "top_peaks": [
+                        {
+                            "hz": 15.0,
+                            "amp": 0.12,
+                            "vibration_strength_db": 22.0,
+                            "strength_bucket": "l2",
+                        },
+                    ],
+                },
+            },
+        }
+        proc.latest_sample_xyz.return_value = (0.1, 0.2, 0.3)
+        proc.latest_sample_rate_hz.return_value = 400
+        proc.latest_analysis_time_range.return_value = None
+
+        records = build_sample_records(
+            run_id="r1",
+            t_s=1.25,
+            timestamp_utc="2026-01-01T00:00:00Z",
+            registry=reg,
+            processor=proc,
+            speed_context=SpeedContext(None, None, "none", None, "missing"),
+            analysis_settings_snapshot=AnalysisSettingsSnapshot(),
+            default_sample_rate_hz=800,
+        )
+
+        assert len(records) == 1
+        assert records[0].dominant_axis == "x"
+
+    def test_marks_dominant_axis_combined_when_axis_evidence_is_ambiguous(self) -> None:
+        record = MagicMock()
+        record.client_id = "client-1"
+        record.name = "Front Left"
+        record.location_code = "fl"
+        record.sample_rate_hz = 400
+        record.frames_dropped = 0
+        record.queue_overflow_drops = 0
+
+        reg = MagicMock()
+        reg.active_client_ids.return_value = ["client-1"]
+        reg.get.return_value = record
+
+        proc = MagicMock()
+        proc.clients_with_recent_data.return_value = ["client-1"]
+        proc.latest_metrics.return_value = {
+            "x": {"rms": 0.0, "p2p": 0.0, "peaks": [{"hz": 15.0, "amp": 0.12}]},
+            "y": {"rms": 0.0, "p2p": 0.0, "peaks": [{"hz": 15.0, "amp": 0.12}]},
+            "z": {"rms": 0.0, "p2p": 0.0, "peaks": []},
+            "combined": {
+                "strength_metrics": {
+                    "vibration_strength_db": 22.0,
+                    "strength_bucket": "l2",
+                    "peak_amp_g": 0.15,
+                    "noise_floor_amp_g": 0.003,
+                    "top_peaks": [
+                        {
+                            "hz": 15.0,
+                            "amp": 0.12,
+                            "vibration_strength_db": 22.0,
+                            "strength_bucket": "l2",
+                        },
+                    ],
+                },
+            },
+        }
+        proc.latest_sample_xyz.return_value = (0.1, 0.2, 0.3)
+        proc.latest_sample_rate_hz.return_value = 400
+        proc.latest_analysis_time_range.return_value = None
+
+        records = build_sample_records(
+            run_id="r1",
+            t_s=1.25,
+            timestamp_utc="2026-01-01T00:00:00Z",
+            registry=reg,
+            processor=proc,
+            speed_context=SpeedContext(None, None, "none", None, "missing"),
+            analysis_settings_snapshot=AnalysisSettingsSnapshot(),
+            default_sample_rate_hz=800,
+        )
+
+        assert len(records) == 1
+        assert records[0].dominant_axis == "combined"
 
     def test_uses_canonical_sensor_metadata_when_runtime_fields_are_stale(self) -> None:
         record = MagicMock()

--- a/apps/server/vibesensor/shared/fft_analysis.py
+++ b/apps/server/vibesensor/shared/fft_analysis.py
@@ -136,6 +136,39 @@ def _empty_fft_spectrum_result(freq_slice: FloatArray) -> FftSpectrumResult:
     }
 
 
+def _axis_peaks_from_spectrum(
+    *,
+    freq_slice: FloatArray,
+    amp_slice: FloatArray,
+    strength_range_mask: BoolArray | None,
+) -> list[AxisPeak]:
+    if freq_slice.size == 0 or amp_slice.size == 0:
+        return []
+    strength_metrics = compute_vibration_strength_db(
+        freq_hz=freq_slice,
+        combined_spectrum_amp_g_values=amp_slice,
+        peak_bandwidth_hz=PEAK_BANDWIDTH_HZ,
+        peak_separation_hz=PEAK_SEPARATION_HZ,
+        top_n=8,
+        strength_range_mask=strength_range_mask,
+    )
+    floor_amp_g = float(strength_metrics["noise_floor_amp_g"])
+    peaks: list[AxisPeak] = []
+    for peak in strength_metrics["top_peaks"]:
+        hz = float(peak["hz"])
+        amp = float(peak["amp"])
+        if hz <= 0.0 or amp <= 0.0:
+            continue
+        axis_peak: AxisPeak = {
+            "hz": hz,
+            "amp": amp,
+        }
+        if floor_amp_g > 0.0:
+            axis_peak["snr_ratio"] = amp / floor_amp_g
+        peaks.append(axis_peak)
+    return peaks
+
+
 def medfilt3(block: FloatArray) -> FloatArray:
     """Apply a 3-point median filter per-row (per-axis)."""
     if block.ndim != 2:
@@ -251,11 +284,15 @@ def compute_fft_spectrum(
 
     for axis_idx, axis in enumerate(AXES):
         amp_slice = specs_all[axis_idx, valid_idx]
-        axis_peaks[axis] = []
         spectrum_by_axis[axis] = {
             "freq": freq_slice,
             "amp": amp_slice,
         }
+        axis_peaks[axis] = _axis_peaks_from_spectrum(
+            freq_slice=freq_slice,
+            amp_slice=amp_slice,
+            strength_range_mask=strength_range_mask,
+        )
 
     combined_amp: FloatArray = np.empty(0, dtype=np.float32)
     strength_metrics: VibrationStrengthMetrics = empty_vibration_strength_metrics()

--- a/apps/server/vibesensor/use_cases/run/sample_builder.py
+++ b/apps/server/vibesensor/use_cases/run/sample_builder.py
@@ -13,7 +13,11 @@ from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.strength_bands import bucket_for_strength
 
 from .sample_speed_context import SpeedContext, resolve_speed_context_snapshot
-from .sample_strength_metrics import dominant_hz_from_strength, extract_strength_data
+from .sample_strength_metrics import (
+    dominant_axis_from_metrics,
+    dominant_hz_from_strength,
+    extract_strength_data,
+)
 
 if TYPE_CHECKING:
     from vibesensor.shared.ports import (
@@ -82,6 +86,7 @@ def build_sample_records(
 
         strength_metrics = extract_strength_data(metrics)
         dominant_hz = dominant_hz_from_strength(strength_metrics)
+        dominant_axis = dominant_axis_from_metrics(metrics, dominant_hz=dominant_hz)
         vibration_strength_db = strength_metrics.vibration_strength_db
         strength_peak_amp_g = strength_metrics.peak_amp_g
         strength_floor_amp_g = strength_metrics.noise_floor_amp_g
@@ -160,7 +165,7 @@ def build_sample_records(
                 accel_y_g=accel_y_g,
                 accel_z_g=accel_z_g,
                 dominant_freq_hz=dominant_hz,
-                dominant_axis="combined",
+                dominant_axis=dominant_axis,
                 top_peaks=tuple(peak for peak in strength_metrics.top_peaks[:8] if peak.is_valid),
                 vibration_strength_db=vibration_strength_db,
                 strength_bucket=strength_bucket,

--- a/apps/server/vibesensor/use_cases/run/sample_strength_metrics.py
+++ b/apps/server/vibesensor/use_cases/run/sample_strength_metrics.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import math
+from collections.abc import Mapping
+
 from vibesensor.domain.strength_metrics import StrengthMetrics
 from vibesensor.shared.boundaries.codecs import strength_metrics_from_mapping
+from vibesensor.shared.constants.dsp import PEAK_SEPARATION_HZ
 from vibesensor.shared.types.payload_types import ClientMetrics
 
-__all__ = ["dominant_hz_from_strength", "extract_strength_data"]
+__all__ = ["dominant_axis_from_metrics", "dominant_hz_from_strength", "extract_strength_data"]
+
+_AXES: tuple[str, str, str] = ("x", "y", "z")
+_AXIS_DOMINANCE_REL_TOL = 0.05
 
 
 def extract_strength_data(metrics: ClientMetrics) -> StrengthMetrics:
@@ -23,3 +30,71 @@ def dominant_hz_from_strength(strength_metrics: StrengthMetrics) -> float | None
     """Return the frequency of the strongest peak, or ``None``."""
 
     return strength_metrics.dominant_hz
+
+
+def dominant_axis_from_metrics(
+    metrics: ClientMetrics,
+    *,
+    dominant_hz: float | None,
+) -> str:
+    """Return the real dominant axis, or non-directional/unavailable semantics.
+
+    ``""`` means the input carries no usable per-axis evidence.
+    ``"combined"`` means the dominant combined peak is real, but no single axis
+    clearly dominates it.
+    """
+
+    if dominant_hz is None or not math.isfinite(dominant_hz):
+        return ""
+    matches: list[tuple[float, float, str]] = []
+    for axis in _AXES:
+        axis_metrics = metrics.get(axis)
+        if not isinstance(axis_metrics, Mapping):
+            continue
+        best_match = _best_axis_peak_match(axis_metrics.get("peaks"), dominant_hz)
+        if best_match is None:
+            continue
+        matches.append((best_match[0], best_match[1], axis))
+    if not matches:
+        return ""
+
+    matches.sort(key=lambda item: (-item[0], item[1], item[2]))
+    if len(matches) == 1:
+        return matches[0][2]
+
+    best_amp, _best_delta, best_axis = matches[0]
+    second_amp = matches[1][0]
+    if math.isclose(best_amp, second_amp, rel_tol=_AXIS_DOMINANCE_REL_TOL, abs_tol=1e-9):
+        return "combined"
+    return best_axis
+
+
+def _best_axis_peak_match(peaks: object, dominant_hz: float) -> tuple[float, float] | None:
+    if not isinstance(peaks, list):
+        return None
+    best: tuple[float, float] | None = None
+    for peak in peaks:
+        if not isinstance(peak, Mapping):
+            continue
+        raw_hz = peak.get("hz")
+        raw_amp = peak.get("amp")
+        if not isinstance(raw_hz, int | float) or not isinstance(raw_amp, int | float):
+            continue
+        hz = float(raw_hz)
+        amp = float(raw_amp)
+        if not math.isfinite(hz) or not math.isfinite(amp) or amp <= 0.0:
+            continue
+        delta_hz = abs(hz - dominant_hz)
+        if delta_hz > PEAK_SEPARATION_HZ:
+            continue
+        candidate = (amp, delta_hz)
+        if (
+            best is None
+            or candidate[0] > best[0]
+            or (
+                math.isclose(candidate[0], best[0], rel_tol=1e-9, abs_tol=1e-12)
+                and candidate[1] < best[1]
+            )
+        ):
+            best = candidate
+    return best

--- a/docs/history_db_schema.md
+++ b/docs/history_db_schema.md
@@ -82,7 +82,7 @@ are rehydrated back into typed `SensorFrame.top_peaks` data on read.
 | `accel_y_g` | REAL | Y-axis acceleration (g) |
 | `accel_z_g` | REAL | Z-axis acceleration (g) |
 | `dominant_freq_hz` | REAL | Dominant vibration frequency |
-| `dominant_axis` | TEXT | Axis with dominant vibration |
+| `dominant_axis` | TEXT | Real dominant axis (`x`/`y`/`z`) when one axis clearly owns the strongest peak, `combined` when the strongest peak is non-directional across axes, empty when unavailable |
 | `vibration_strength_db` | REAL | Vibration strength in dB |
 | `strength_bucket` | TEXT | Strength classification label |
 | `strength_peak_amp_g` | REAL | Peak amplitude (g) |


### PR DESCRIPTION
## What changed
- compute real per-axis FFT peak lists from the existing per-axis spectra instead of returning placeholder empty `axis_peaks`
- derive persisted sample `dominant_axis` from real axis peak evidence near the combined dominant peak
- keep `dominant_axis` honest: clear winner -> `x`/`y`/`z`, ambiguous multi-axis match -> `combined`, no usable axis evidence -> empty string
- update focused FFT/sample-builder regressions and document the stored `dominant_axis` semantics in the history DB schema doc

## Why
- the repo already exposed per-axis/report-facing fields, but they were not backed by real per-axis analysis
- hard-coded `combined` and placeholder empty axis peaks could imply directional confidence that was never computed

## Validation
- `pytest -q apps/server/tests/infra/processing/test_processing_fft.py apps/server/tests/infra/processing/test_sample_builder.py`
- `pytest -q apps/server/tests/infra/processing/test_processing.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py`
- `make lint`
- `make typecheck-backend`

## Risks / tradeoffs
- some rows that previously said `combined` now become empty when there is no usable axis evidence at all
- ambiguous equal-strength multi-axis peaks still stay non-directional as `combined` instead of forcing a fake winner
- this keeps the public field shape but changes the meaning from placeholder to computed semantics

Closes #3167