### PR TITLE
Persist late UDP packet honesty metadata

### DIFF
--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py
@@ -141,6 +141,7 @@ def test_raw_capture_round_trip_persists_chunk_loss_counts_across_reload(tmp_pat
         sensor_losses={
             "sensor-a": RawCaptureLossStats(
                 udp_ingest_queue_drop_count=1,
+                late_packet_chunk_count=1,
                 queue_overflow_chunk_count=2,
             ),
             "sensor-b": RawCaptureLossStats(
@@ -152,12 +153,15 @@ def test_raw_capture_round_trip_persists_chunk_loss_counts_across_reload(tmp_pat
 
     assert manifest is not None
     assert manifest.total_dropped_chunk_count == 5
+    assert manifest.total_late_packet_chunk_count == 1
     assert manifest.losses.udp_ingest_queue_drop_count == 1
+    assert manifest.losses.late_packet_chunk_count == 1
     assert manifest.losses.queue_overflow_chunk_count == 2
     assert manifest.losses.invalid_chunk_count == 1
     assert manifest.losses.write_error_chunk_count == 1
     assert manifest.sensor_loss("sensor-a") is not None
     assert manifest.sensor_loss("sensor-a").losses.udp_ingest_queue_drop_count == 1
+    assert manifest.sensor_loss("sensor-a").losses.late_packet_chunk_count == 1
     assert manifest.sensor_loss("sensor-a").losses.queue_overflow_chunk_count == 2
     assert manifest.sensor_loss("sensor-b") is not None
     assert manifest.sensor_loss("sensor-b").losses.write_error_chunk_count == 1
@@ -169,7 +173,9 @@ def test_raw_capture_round_trip_persists_chunk_loss_counts_across_reload(tmp_pat
     assert stored is not None
     assert stored.raw_capture_manifest is not None
     assert stored.raw_capture_manifest.total_dropped_chunk_count == 5
+    assert stored.raw_capture_manifest.total_late_packet_chunk_count == 1
     assert stored.raw_capture_manifest.losses.udp_ingest_queue_drop_count == 1
+    assert stored.raw_capture_manifest.losses.late_packet_chunk_count == 1
     assert stored.raw_capture_manifest.losses.invalid_chunk_count == 1
     assert stored.raw_capture_manifest.sensor_loss("sensor-b") is not None
     assert stored.raw_capture_manifest.sensor_loss("sensor-b").losses.invalid_chunk_count == 1

--- a/apps/server/tests/adapters/udp/test_udp_late_packet_quarantine.py
+++ b/apps/server/tests/adapters/udp/test_udp_late_packet_quarantine.py
@@ -77,6 +77,7 @@ def test_late_packet_is_quarantined_to_raw_capture_only(fake_transport) -> None:
     assert latest_before == latest_after
     assert ingest_spy.call_count == 2
     assert raw_capture_sink.capture_raw_samples.call_count == 3
+    raw_capture_sink.note_late_packet_loss.assert_called_once_with(client_id="aabbccddeeff")
     assert [parse_data_ack(data).last_seq_received for data, _addr in fake_transport.sent] == [
         0,
         2,

--- a/apps/server/tests/integration/test_udp_late_packet_report_honesty.py
+++ b/apps/server/tests/integration/test_udp_late_packet_report_honesty.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+from test_support.findings import make_finding_payload
+from test_support.history_db_lifecycle import build_history_db
+from test_support.report_helpers import minimal_summary
+
+from vibesensor.adapters.gps.gps_speed import SpeedResolution
+from vibesensor.adapters.udp.protocol import HelloMessage, pack_data
+from vibesensor.adapters.udp.udp_data_rx import DataDatagramProtocol
+from vibesensor.infra.processing import SignalProcessor
+from vibesensor.infra.runtime.registry import ClientRegistry
+from vibesensor.shared.boundaries.reporting import prepare_persisted_report_input
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_to_json_object
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.run_context_warning import WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS
+from vibesensor.shared.types.aligned_speed_context import AlignedSpeedContextSnapshot
+from vibesensor.use_cases.history.report_document import build_report_document
+from vibesensor.use_cases.run import RunRecorder, RunRecorderConfig
+from vibesensor.use_cases.run.post_analysis_input import build_post_analysis_input
+from vibesensor.use_cases.run.post_analysis_loader import LoadedPostAnalysisRun
+from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
+
+_CLIENT_ID = bytes.fromhex("010203040506")
+_CLIENT_ID_HEX = _CLIENT_ID.hex()
+_ADDR = ("127.0.0.1", 12345)
+
+
+class _FakeTransport:
+    def sendto(self, _data: bytes, _addr: tuple[str, int]) -> None:
+        return None
+
+
+class _FakeSpeedProvider:
+    gps_speed_mps: float | None = None
+    engine_rpm: float | None = None
+    engine_rpm_source: str | None = None
+
+    def resolve_speed(self) -> SpeedResolution:
+        return SpeedResolution(speed_mps=None, fallback_active=False, source="none")
+
+    def resolve_speed_context_at(
+        self,
+        _target_mono_s: float | None,
+        *,
+        tolerance_s: float | None = None,
+    ) -> AlignedSpeedContextSnapshot:
+        del tolerance_s
+        return AlignedSpeedContextSnapshot(
+            selected_speed_source="gps",
+            resolved_speed_mps=None,
+            resolved_speed_source="none",
+            resolved_speed_aligned=False,
+            gps_speed_mps=None,
+            gps_speed_aligned=False,
+            measured_engine_rpm=None,
+            measured_engine_rpm_source=None,
+            measured_engine_rpm_aligned=False,
+        )
+
+
+def _processor() -> SignalProcessor:
+    return SignalProcessor(
+        sample_rate_hz=800,
+        waveform_seconds=4,
+        waveform_display_hz=100,
+        fft_n=256,
+        spectrum_max_hz=200,
+        accel_scale_g_per_lsb=0.0005,
+    )
+
+
+def _samples(freq_hz: float) -> np.ndarray:
+    time_axis = np.arange(256, dtype=np.float64) / 800.0
+    wave = np.round(1200.0 * np.sin(2.0 * np.pi * freq_hz * time_axis)).astype(np.int16)
+    zeros = np.zeros(256, dtype=np.int16)
+    return np.column_stack([wave, zeros, zeros])
+
+
+def test_late_udp_packet_reaches_persisted_report_honesty(tmp_path, monkeypatch) -> None:
+    history_db = build_history_db(tmp_path)
+    try:
+        registry = ClientRegistry(db=history_db.client_name_repository)
+        processor = _processor()
+        recorder = RunRecorder(
+            RunRecorderConfig(
+                metrics_log_hz=20,
+                sensor_model="ADXL345",
+                default_sample_rate_hz=800,
+                fft_window_size_samples=256,
+                persist_history_db=True,
+            ),
+            registry=registry,
+            gps_monitor=_FakeSpeedProvider(),
+            processor=processor,
+            history_db=history_db.run_repository,
+            language_reader=SimpleNamespace(language="en"),
+        )
+        proto = DataDatagramProtocol(
+            registry=registry,
+            processor=processor,
+            raw_capture_sink=recorder,
+            queue_maxsize=8,
+        )
+        proto.connection_made(_FakeTransport())
+        registry.update_from_hello(
+            HelloMessage(
+                client_id=_CLIENT_ID,
+                control_port=9010,
+                sample_rate_hz=800,
+                name="sensor-a",
+                firmware_version="fw",
+            ),
+            _ADDR,
+            now=1.0,
+        )
+        registry.set_location(_CLIENT_ID_HEX, "front-left")
+
+        recorder.start_recording()
+        snapshot = recorder._session_snapshot()
+        assert snapshot is not None
+        run_id = snapshot.run_id
+
+        first = pack_data(_CLIENT_ID, seq=0, t0_us=1_000_000, samples=_samples(40.0))
+        newest = pack_data(_CLIENT_ID, seq=2, t0_us=1_640_000, samples=_samples(55.0))
+        late = pack_data(_CLIENT_ID, seq=1, t0_us=1_320_000, samples=_samples(25.0))
+
+        proto._process_datagram(first, _ADDR)
+        proto._process_datagram(newest, _ADDR)
+        proto._process_datagram(late, _ADDR)
+
+        monkeypatch.setattr(recorder, "schedule_post_analysis", lambda _run_id: None)
+        recorder.stop_recording()
+        recorder.shutdown_raw_capture()
+
+        stored = history_db.run_repository.get_run(run_id)
+        assert stored is not None
+        assert stored.raw_capture_manifest is not None
+        manifest = stored.raw_capture_manifest
+        assert manifest.losses.late_packet_chunk_count == 1
+        assert manifest.total_late_packet_chunk_count == 1
+        sensor_loss = manifest.sensor_loss(_CLIENT_ID_HEX)
+        assert sensor_loss is not None
+        assert sensor_loss.losses.late_packet_chunk_count == 1
+
+        raw_capture = history_db.run_repository._run_sync(
+            history_db.run_repository.aload_raw_capture(run_id)
+        )
+        assert raw_capture is not None
+
+        finding = make_finding_payload(
+            finding_id="F_LATE_PACKET",
+            suspected_source="wheel/tire",
+            confidence=0.75,
+            strongest_location="Front Left",
+            strongest_speed_band="40-60 km/h",
+        )
+
+        class FakeRunAnalysis:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def summarize(self):
+                return SimpleNamespace(
+                    diagnostic_case=SimpleNamespace(case_id="case-late-packet"),
+                )
+
+        monkeypatch.setattr(
+            "vibesensor.use_cases.diagnostics.run_analysis.RunAnalysis",
+            FakeRunAnalysis,
+        )
+        monkeypatch.setattr(
+            "vibesensor.use_cases.run.post_analysis_summary.analysis_result_to_summary",
+            lambda _result: minimal_summary(
+                run_id=run_id,
+                lang="en",
+                metadata=run_metadata_to_json_object(stored.metadata),
+                findings=[finding],
+                top_causes=[finding],
+                sensor_count_used=1,
+                sensor_locations=["Front Left"],
+                sensor_locations_connected_throughout=["Front Left"],
+            ),
+        )
+
+        summary = build_post_analysis_summary(
+            build_post_analysis_input(
+                LoadedPostAnalysisRun(
+                    run_id=run_id,
+                    metadata=stored.metadata,
+                    language="en",
+                    samples=sensor_frames_from_mappings(
+                        [
+                            {
+                                "client_id": _CLIENT_ID_HEX,
+                                "client_name": "Front Left",
+                                "t_s": 0.32,
+                                "sample_rate_hz": 800,
+                                "vibration_strength_db": 12.0,
+                                "dominant_freq_hz": 40.0,
+                            }
+                        ]
+                    ),
+                    raw_capture=raw_capture,
+                    total_summary_row_count=1,
+                    stride=1,
+                )
+            )
+        )
+
+        assert summary["analysis_metadata"]["raw_replay_late_packet_chunk_count"] == 1
+        assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in [
+            warning["code"] for warning in summary["warnings"]
+        ]
+
+        prepared = prepare_persisted_report_input(summary)
+        document = build_report_document(prepared)
+
+        assert any(
+            "late or out-of-order packets quarantined from live processing" in (row.detail or "")
+            for row in document.data_trust
+        )
+    finally:
+        history_db.lifecycle.close()

--- a/apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py
+++ b/apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py
@@ -184,6 +184,7 @@ def test_prepare_persisted_report_input_surfaces_dropped_raw_chunk_warning() -> 
                     "raw_backed_sample_count": 4,
                     "raw_capture_mode": "partial_raw_backed",
                     "raw_replay_dropped_chunk_count": 4,
+                    "raw_replay_late_packet_chunk_count": 1,
                     "raw_replay_udp_ingest_queue_drop_count": 1,
                     "raw_replay_queue_overflow_chunk_count": 2,
                     "raw_replay_invalid_chunk_count": 1,
@@ -197,7 +198,8 @@ def test_prepare_persisted_report_input_surfaces_dropped_raw_chunk_warning() -> 
                         "title": i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_DROPPED_CHUNKS_TITLE"),
                         "detail": i18n_ref(
                             "RUN_CONTEXT_WARNING_RAW_REPLAY_DROPPED_CHUNKS_DETAIL",
-                            count="4",
+                            count="5",
+                            late="1",
                             udp_ingest="1",
                             queue_overflow="2",
                             invalid="1",
@@ -214,7 +216,10 @@ def test_prepare_persisted_report_input_surfaces_dropped_raw_chunk_warning() -> 
     assert WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS in [
         warning.code for warning in prepared.report_facts.decision.warnings
     ]
-    assert any("UDP ingest queue drops" in (row.detail or "") for row in document.data_trust)
+    assert any(
+        "late or out-of-order packets quarantined from live processing" in (row.detail or "")
+        for row in document.data_trust
+    )
 
 
 def test_prepare_persisted_report_input_surfaces_sync_unverified_warning() -> None:
@@ -322,6 +327,7 @@ def test_prepare_persisted_report_input_surfaces_whole_run_alignment_warning() -
                             gaps="1",
                             overlaps="0",
                             dropped="0",
+                            late="0",
                             udp_ingest="0",
                             queue_overflow="0",
                             invalid="0",

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor.py
@@ -73,6 +73,7 @@ def _spectral_result(bundle) -> WholeRunSpectralBuildResult:
             gap_count=0,
             overlap_count=0,
             dropped_chunk_count=0,
+            late_packet_chunk_count=0,
             queue_overflow_chunk_count=0,
             invalid_chunk_count=0,
             write_error_chunk_count=0,

--- a/apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py
@@ -81,6 +81,7 @@ def test_execute_post_analysis_appends_whole_run_alignment_warning_and_metadata(
                 gap_count=1,
                 overlap_count=0,
                 dropped_chunk_count=2,
+                late_packet_chunk_count=1,
                 queue_overflow_chunk_count=2,
                 invalid_chunk_count=0,
                 write_error_chunk_count=0,
@@ -105,6 +106,7 @@ def test_execute_post_analysis_appends_whole_run_alignment_warning_and_metadata(
                             gaps="1",
                             overlaps="0",
                             dropped="2",
+                            late="1",
                             udp_ingest="0",
                             queue_overflow="2",
                             invalid="0",
@@ -142,6 +144,7 @@ def test_execute_post_analysis_appends_whole_run_alignment_warning_and_metadata(
     assert analysis_metadata["whole_run_spectral_partial_sensor_window_count"] == 1
     assert analysis_metadata["whole_run_spectral_missing_sensor_window_count"] == 1
     assert analysis_metadata["whole_run_spectral_gap_count"] == 1
+    assert analysis_metadata["whole_run_spectral_late_packet_chunk_count"] == 1
     assert analysis_metadata["whole_run_spectral_sample_rate_mismatch_sensor_count"] == 1
     assert analysis_metadata["whole_run_spectral_sample_rate_unverified_sensor_count"] == 2
     assert analysis_metadata["whole_run_spectral_sync_unverified_sensor_count"] == 1

--- a/apps/server/tests/use_cases/run/test_post_analysis_summary.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_summary.py
@@ -199,7 +199,7 @@ def _full_raw_capture(
                 manifest,
                 sensor_losses=(
                     ()
-                    if losses is None or losses.total_dropped_chunk_count <= 0
+                    if losses is None or losses.total_loss_event_count <= 0
                     else (RawCaptureSensorLossStats(client_id="sensor-a", losses=losses),)
                 ),
                 losses=losses or RawCaptureLossStats(),
@@ -283,6 +283,7 @@ def test_build_post_analysis_summary_adds_analysis_metadata(
         "raw_replay_gap_count": 0,
         "raw_replay_overlap_count": 0,
         "raw_replay_dropped_chunk_count": 0,
+        "raw_replay_late_packet_chunk_count": 0,
         "raw_replay_udp_ingest_queue_drop_count": 0,
         "raw_replay_queue_overflow_chunk_count": 0,
         "raw_replay_invalid_chunk_count": 0,
@@ -393,6 +394,7 @@ def test_build_post_analysis_summary_propagates_dropped_chunk_metadata_and_warni
                 raw_capture=_full_raw_capture(
                     "run-drops",
                     losses=RawCaptureLossStats(
+                        late_packet_chunk_count=1,
                         udp_ingest_queue_drop_count=1,
                         queue_overflow_chunk_count=2,
                         write_error_chunk_count=1,
@@ -405,6 +407,7 @@ def test_build_post_analysis_summary_propagates_dropped_chunk_metadata_and_warni
     )
 
     assert summary["analysis_metadata"]["raw_replay_dropped_chunk_count"] == 4
+    assert summary["analysis_metadata"]["raw_replay_late_packet_chunk_count"] == 1
     assert summary["analysis_metadata"]["raw_replay_udp_ingest_queue_drop_count"] == 1
     assert summary["analysis_metadata"]["raw_replay_queue_overflow_chunk_count"] == 2
     assert summary["analysis_metadata"]["raw_replay_invalid_chunk_count"] == 0

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py
@@ -81,6 +81,7 @@ def _spectral_result(bundle) -> WholeRunSpectralBuildResult:
             gap_count=0,
             overlap_count=0,
             dropped_chunk_count=0,
+            late_packet_chunk_count=0,
             queue_overflow_chunk_count=0,
             invalid_chunk_count=0,
             write_error_chunk_count=0,

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py
@@ -66,6 +66,7 @@ def _spectral_result(bundle) -> WholeRunSpectralBuildResult:
             gap_count=0,
             overlap_count=0,
             dropped_chunk_count=0,
+            late_packet_chunk_count=0,
             queue_overflow_chunk_count=0,
             invalid_chunk_count=0,
             write_error_chunk_count=0,

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py
@@ -78,6 +78,7 @@ def _spectral_result(bundle) -> WholeRunSpectralBuildResult:
             gap_count=0,
             overlap_count=0,
             dropped_chunk_count=0,
+            late_packet_chunk_count=0,
             queue_overflow_chunk_count=0,
             invalid_chunk_count=0,
             write_error_chunk_count=0,

--- a/apps/server/tests/use_cases/run/test_raw_capture_replay.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_replay.py
@@ -178,6 +178,7 @@ def test_build_post_analysis_input_marks_no_valid_bin_fft_windows_unusable() -> 
 def test_build_post_analysis_input_surfaces_persisted_dropped_chunk_counts() -> None:
     raw_capture = _raw_capture("run-drops")
     loss_stats = RawCaptureLossStats(
+        late_packet_chunk_count=1,
         udp_ingest_queue_drop_count=1,
         queue_overflow_chunk_count=2,
         invalid_chunk_count=1,
@@ -214,6 +215,7 @@ def test_build_post_analysis_input_surfaces_persisted_dropped_chunk_counts() -> 
 
     assert result.raw_backed_summary_row_count == 1
     assert result.raw_replay.dropped_chunk_count == 4
+    assert result.raw_replay.late_packet_chunk_count == 1
     assert result.raw_replay.udp_ingest_queue_drop_count == 1
     assert result.raw_replay.queue_overflow_chunk_count == 2
     assert result.raw_replay.invalid_chunk_count == 1

--- a/apps/server/tests/use_cases/run/test_raw_capture_writer.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_writer.py
@@ -99,6 +99,7 @@ def test_raw_capture_writer_persists_queue_invalid_and_write_failures(
         t0_us=1300,
         samples=_samples(),
     )
+    writer.note_late_packet_loss(client_id="sensor-b")
 
     history_db.allow_first_write.set()
     writer.finalize_run(
@@ -109,6 +110,7 @@ def test_raw_capture_writer_persists_queue_invalid_and_write_failures(
     assert history_db.finalized_sensor_losses is not None
     assert history_db.finalized_sensor_losses["sensor-a"].queue_overflow_chunk_count == 1
     assert history_db.finalized_sensor_losses["sensor-b"].write_error_chunk_count == 1
+    assert history_db.finalized_sensor_losses["sensor-b"].late_packet_chunk_count == 1
     assert history_db.finalized_sensor_losses["sensor-c"].invalid_chunk_count == 1
     assert history_db.finalized_sensor_losses["sensor-d"].udp_ingest_queue_drop_count == 2
 

--- a/apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_raw_capture_store.py
@@ -139,7 +139,7 @@ class HistoryRawCaptureStore:
         if sensor_losses:
             for client_id in sorted(sensor_losses):
                 losses = sensor_losses[client_id]
-                if losses.total_dropped_chunk_count <= 0:
+                if losses.total_loss_event_count <= 0:
                     continue
                 sensor_loss_rows.append(
                     RawCaptureSensorLossStats(client_id=client_id, losses=losses)

--- a/apps/server/vibesensor/adapters/udp/udp_data_rx.py
+++ b/apps/server/vibesensor/adapters/udp/udp_data_rx.py
@@ -43,6 +43,8 @@ class RawCaptureSink(Protocol):
         samples: np.ndarray,
     ) -> None: ...
 
+    def note_late_packet_loss(self, *, client_id: str) -> None: ...
+
 
 class DatagramDispatchError(RuntimeError):
     """Operational failure while dispatching one parsed DATA message."""
@@ -201,6 +203,8 @@ class DataDatagramProtocol(asyncio.DatagramProtocol):
                     t0_us=msg.t0_us,
                 )
             if self._raw_capture_sink is not None:
+                if result.is_late:
+                    self._raw_capture_sink.note_late_packet_loss(client_id=client_id)
                 self._raw_capture_sink.capture_raw_samples(
                     client_id=client_id,
                     sample_rate_hz=sample_rate_hz,

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -1708,8 +1708,8 @@
     "nl": "De whole-run raw-uitlijning was onvolledig"
   },
   "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_INCOMPLETE_DETAIL": {
-    "en": "Whole-run raw coverage was incomplete for some time-aligned windows; affected order and spatial diagnostics used only fully covered windows. Partial windows: {partial}, missing windows: {missing}, timing gaps: {gaps}, overlaps: {overlaps}, dropped chunks: {dropped}, UDP ingest queue drops: {udp_ingest}, raw-capture queue overflows: {queue_overflow}, invalid chunks: {invalid}, write errors: {write_errors}, sample-rate mismatches: {mismatches}, sample-rate-unverified sensors: {unverified_rates}, unanchored sensors: {unanchored}, sync-unverified sensors: {sync_unverified}.",
-    "nl": "De whole-run raw-dekking was onvolledig voor sommige tijd-uitgelijnde vensters; getroffen orde- en ruimtelijke diagnostiek gebruikte alleen volledig gedekte vensters. Gedeeltelijke vensters: {partial}, ontbrekende vensters: {missing}, timinggaten: {gaps}, overlappen: {overlaps}, verloren chunks: {dropped}, UDP-ingestwachtrij-drops: {udp_ingest}, raw-capture-wachtrijoverlopen: {queue_overflow}, ongeldige chunks: {invalid}, schrijffouten: {write_errors}, samplefrequentiemismatches: {mismatches}, sensoren met onbewezen samplefrequentie: {unverified_rates}, niet-verankerde sensoren: {unanchored}, sensoren zonder bewezen sync: {sync_unverified}."
+    "en": "Whole-run raw coverage was incomplete for some time-aligned windows; affected order and spatial diagnostics used only fully covered windows. Partial windows: {partial}, missing windows: {missing}, timing gaps: {gaps}, overlaps: {overlaps}, dropped chunks: {dropped}, late or out-of-order packets quarantined from live processing: {late}, UDP ingest queue drops: {udp_ingest}, raw-capture queue overflows: {queue_overflow}, invalid chunks: {invalid}, write errors: {write_errors}, sample-rate mismatches: {mismatches}, sample-rate-unverified sensors: {unverified_rates}, unanchored sensors: {unanchored}, sync-unverified sensors: {sync_unverified}.",
+    "nl": "De whole-run raw-dekking was onvolledig voor sommige tijd-uitgelijnde vensters; getroffen orde- en ruimtelijke diagnostiek gebruikte alleen volledig gedekte vensters. Gedeeltelijke vensters: {partial}, ontbrekende vensters: {missing}, timinggaten: {gaps}, overlappen: {overlaps}, verloren chunks: {dropped}, late of niet-op-volgorde pakketten die uit live-verwerking zijn gehouden: {late}, UDP-ingestwachtrij-drops: {udp_ingest}, raw-capture-wachtrijoverlopen: {queue_overflow}, ongeldige chunks: {invalid}, schrijffouten: {write_errors}, samplefrequentiemismatches: {mismatches}, sensoren met onbewezen samplefrequentie: {unverified_rates}, niet-verankerde sensoren: {unanchored}, sensoren zonder bewezen sync: {sync_unverified}."
   },
   "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_UNAVAILABLE_DETAIL": {
     "en": "Whole-run raw timing could not be proven for the recorded sensors, so time-aligned order and spatial diagnostics were skipped. Legacy sensors: {legacy}, unanchored sensors: {unanchored}, sync-unverified sensors: {sync_unverified}, missing sync proof: {missing_sync}, stale sync snapshots: {stale}, high-RTT sync snapshots: {high_rtt}, sample-rate mismatches: {mismatches}.",
@@ -1724,12 +1724,12 @@
     "nl": "De raw-capturedekking was onvolledig voor sommige replayvensters; getroffen metrieken gebruikten persistente samenvattingssamples. Gedeeltelijke vensters: {partial}, ontbrekende vensters: {missing}, timinggaten: {gaps}, overlappen: {overlaps}, samplefrequentiemismatches: {mismatches}, sensoren met onbewezen samplefrequentie: {unverified_rates}."
   },
   "RUN_CONTEXT_WARNING_RAW_REPLAY_DROPPED_CHUNKS_TITLE": {
-    "en": "Raw capture dropped chunks before persistence",
-    "nl": "Raw capture verloor chunks voor persistente opslag"
+    "en": "UDP ingest or raw capture recorded chunk loss events",
+    "nl": "UDP-ingest of raw capture registreerde chunk-verliesgebeurtenissen"
   },
   "RUN_CONTEXT_WARNING_RAW_REPLAY_DROPPED_CHUNKS_DETAIL": {
-    "en": "Raw capture dropped {count} chunk(s) before persistence ({udp_ingest} UDP ingest queue drops, {queue_overflow} raw-capture queue overflows, {invalid} invalid chunks, {write_errors} write errors); affected metrics used persisted summary samples where needed.",
-    "nl": "Raw capture verloor {count} chunk(s) voor persistente opslag ({udp_ingest} UDP-ingestwachtrij-drops, {queue_overflow} raw-capture-wachtrijoverlopen, {invalid} ongeldige chunks, {write_errors} schrijffouten); getroffen metrieken gebruikten waar nodig persistente samenvattingssamples."
+    "en": "UDP ingest or raw capture recorded {count} chunk loss event(s) ({late} late or out-of-order packets quarantined from live processing, {udp_ingest} UDP ingest queue drops, {queue_overflow} raw-capture queue overflows, {invalid} invalid chunks, {write_errors} write errors); affected metrics used persisted summary samples where needed.",
+    "nl": "UDP-ingest of raw capture registreerde {count} chunk-verliesgebeurtenis(sen) ({late} late of niet-op-volgorde pakketten die uit live-verwerking zijn gehouden, {udp_ingest} UDP-ingestwachtrij-drops, {queue_overflow} raw-capture-wachtrijoverlopen, {invalid} ongeldige chunks, {write_errors} schrijffouten); getroffen metrieken gebruikten waar nodig persistente samenvattingssamples."
   },
   "RUN_CONTEXT_WARNING_RAW_REPLAY_TIMING_FALLBACK_TITLE": {
     "en": "Raw replay used persisted sample timing for some windows",

--- a/apps/server/vibesensor/shared/types/raw_capture.py
+++ b/apps/server/vibesensor/shared/types/raw_capture.py
@@ -42,7 +42,7 @@ type RawCaptureClockProofState = Literal[
     "missing_registry_record",
 ]
 
-_RAW_CAPTURE_SCHEMA_VERSION = 6
+_RAW_CAPTURE_SCHEMA_VERSION = 7
 _RAW_CAPTURE_STORAGE_TYPE = "run-directory-v1"
 _RAW_CAPTURE_MODE = "full_run"
 
@@ -87,9 +87,10 @@ class RawCaptureChunkIndex:
 
 @dataclass(frozen=True, slots=True)
 class RawCaptureLossStats:
-    """Structured counts for raw chunks lost before persistence."""
+    """Structured counts for raw chunk issues persisted alongside the run."""
 
     udp_ingest_queue_drop_count: int = 0
+    late_packet_chunk_count: int = 0
     queue_overflow_chunk_count: int = 0
     invalid_chunk_count: int = 0
     write_error_chunk_count: int = 0
@@ -103,9 +104,14 @@ class RawCaptureLossStats:
             + max(0, self.write_error_chunk_count)
         )
 
+    @property
+    def total_loss_event_count(self) -> int:
+        return self.total_dropped_chunk_count + max(0, self.late_packet_chunk_count)
+
     def to_json_object(self) -> JsonObject:
         return {
             "udp_ingest_queue_drop_count": self.udp_ingest_queue_drop_count,
+            "late_packet_chunk_count": self.late_packet_chunk_count,
             "queue_overflow_chunk_count": self.queue_overflow_chunk_count,
             "invalid_chunk_count": self.invalid_chunk_count,
             "write_error_chunk_count": self.write_error_chunk_count,
@@ -115,6 +121,7 @@ class RawCaptureLossStats:
     def from_mapping(cls, data: JsonObject) -> RawCaptureLossStats:
         return cls(
             udp_ingest_queue_drop_count=_int_from_json(data.get("udp_ingest_queue_drop_count")),
+            late_packet_chunk_count=_int_from_json(data.get("late_packet_chunk_count")),
             queue_overflow_chunk_count=_int_from_json(data.get("queue_overflow_chunk_count")),
             invalid_chunk_count=_int_from_json(data.get("invalid_chunk_count")),
             write_error_chunk_count=_int_from_json(data.get("write_error_chunk_count")),
@@ -125,6 +132,7 @@ class RawCaptureLossStats:
             udp_ingest_queue_drop_count=(
                 self.udp_ingest_queue_drop_count + other.udp_ingest_queue_drop_count
             ),
+            late_packet_chunk_count=self.late_packet_chunk_count + other.late_packet_chunk_count,
             queue_overflow_chunk_count=(
                 self.queue_overflow_chunk_count + other.queue_overflow_chunk_count
             ),
@@ -143,6 +151,14 @@ class RawCaptureSensorLossStats:
     @property
     def total_dropped_chunk_count(self) -> int:
         return self.losses.total_dropped_chunk_count
+
+    @property
+    def total_loss_event_count(self) -> int:
+        return self.losses.total_loss_event_count
+
+    @property
+    def late_packet_chunk_count(self) -> int:
+        return max(0, self.losses.late_packet_chunk_count)
 
     def to_json_object(self) -> JsonObject:
         return {
@@ -339,7 +355,7 @@ class RawCaptureManifest:
             payload["sensor_losses"] = [
                 sensor_loss.to_json_object() for sensor_loss in self.sensor_losses
             ]
-        if self.losses.total_dropped_chunk_count > 0:
+        if self.losses.total_loss_event_count > 0:
             payload["losses"] = self.losses.to_json_object()
         return payload
 
@@ -400,6 +416,20 @@ class RawCaptureManifest:
             max(0, sensor_loss.total_dropped_chunk_count) for sensor_loss in self.sensor_losses
         )
         return self.losses.total_dropped_chunk_count or sensor_total
+
+    @property
+    def total_late_packet_chunk_count(self) -> int:
+        sensor_total = sum(
+            max(0, sensor_loss.late_packet_chunk_count) for sensor_loss in self.sensor_losses
+        )
+        return max(0, self.losses.late_packet_chunk_count) or sensor_total
+
+    @property
+    def total_loss_event_count(self) -> int:
+        sensor_total = sum(
+            max(0, sensor_loss.total_loss_event_count) for sensor_loss in self.sensor_losses
+        )
+        return self.losses.total_loss_event_count or sensor_total
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
@@ -172,6 +172,7 @@ class WholeRunSpectralCoverageSummary:
     gap_count: int
     overlap_count: int
     dropped_chunk_count: int
+    late_packet_chunk_count: int
     queue_overflow_chunk_count: int
     invalid_chunk_count: int
     write_error_chunk_count: int
@@ -235,6 +236,7 @@ def build_whole_run_spectral_artifact_bundle(
             gap_count=0,
             overlap_count=0,
             dropped_chunk_count=0,
+            late_packet_chunk_count=0,
             queue_overflow_chunk_count=0,
             invalid_chunk_count=0,
             write_error_chunk_count=0,
@@ -872,6 +874,7 @@ def _build_coverage_summary(
         if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "high_rtt"
     )
     dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
+    late_packet_chunk_count = raw_capture.manifest.total_late_packet_chunk_count
     udp_ingest_queue_drop_count = raw_capture.manifest.losses.udp_ingest_queue_drop_count
     queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
     invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
@@ -884,6 +887,7 @@ def _build_coverage_summary(
         gap_count=gap_count,
         overlap_count=overlap_count,
         dropped_chunk_count=dropped_chunk_count,
+        late_packet_chunk_count=late_packet_chunk_count,
         sample_rate_mismatch_sensor_count=sample_rate_mismatch_sensor_count,
         sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
         unanchored_sensor_count=unanchored_sensor_count,
@@ -897,6 +901,7 @@ def _build_coverage_summary(
         gap_count=gap_count,
         overlap_count=overlap_count,
         dropped_chunk_count=dropped_chunk_count,
+        late_packet_chunk_count=late_packet_chunk_count,
         udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
         queue_overflow_chunk_count=queue_overflow_chunk_count,
         invalid_chunk_count=invalid_chunk_count,
@@ -918,6 +923,7 @@ def _build_coverage_summary(
         gap_count=gap_count,
         overlap_count=overlap_count,
         dropped_chunk_count=dropped_chunk_count,
+        late_packet_chunk_count=late_packet_chunk_count,
         udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
         queue_overflow_chunk_count=queue_overflow_chunk_count,
         invalid_chunk_count=invalid_chunk_count,
@@ -943,6 +949,7 @@ def _coverage_confidence(
     gap_count: int,
     overlap_count: int,
     dropped_chunk_count: int,
+    late_packet_chunk_count: int,
     sample_rate_mismatch_sensor_count: int,
     sample_rate_unverified_sensor_count: int,
     unanchored_sensor_count: int,
@@ -957,6 +964,7 @@ def _coverage_confidence(
         and gap_count <= 0
         and overlap_count <= 0
         and dropped_chunk_count <= 0
+        and late_packet_chunk_count <= 0
         and sample_rate_mismatch_sensor_count <= 0
         and sample_rate_unverified_sensor_count <= 0
         and unanchored_sensor_count <= 0
@@ -975,6 +983,7 @@ def _build_whole_run_warnings(
     gap_count: int,
     overlap_count: int,
     dropped_chunk_count: int,
+    late_packet_chunk_count: int,
     udp_ingest_queue_drop_count: int,
     queue_overflow_chunk_count: int,
     invalid_chunk_count: int,
@@ -994,6 +1003,7 @@ def _build_whole_run_warnings(
         and gap_count <= 0
         and overlap_count <= 0
         and dropped_chunk_count <= 0
+        and late_packet_chunk_count <= 0
         and sample_rate_mismatch_sensor_count <= 0
         and sample_rate_unverified_sensor_count <= 0
         and sync_unverified_sensor_count <= 0
@@ -1025,6 +1035,7 @@ def _build_whole_run_warnings(
                 gaps=str(max(0, gap_count)),
                 overlaps=str(max(0, overlap_count)),
                 dropped=str(max(0, dropped_chunk_count)),
+                late=str(max(0, late_packet_chunk_count)),
                 udp_ingest=str(max(0, udp_ingest_queue_drop_count)),
                 queue_overflow=str(max(0, queue_overflow_chunk_count)),
                 invalid=str(max(0, invalid_chunk_count)),

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -305,6 +305,9 @@ class RunRecorder:
             samples=samples,
         )
 
+    def note_late_packet_loss(self, *, client_id: str) -> None:
+        self._raw_capture.note_late_packet_loss(client_id=client_id)
+
     def status(self) -> RunRecorderStatusSnapshot:
         with self._lock:
             enabled = self._lifecycle.enabled

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -840,6 +840,9 @@ def _append_whole_run_spectral_metadata(
     analysis_metadata["whole_run_spectral_dropped_chunk_count"] = (
         coverage_summary.dropped_chunk_count
     )
+    analysis_metadata["whole_run_spectral_late_packet_chunk_count"] = getattr(
+        coverage_summary, "late_packet_chunk_count", 0
+    )
     analysis_metadata["whole_run_spectral_udp_ingest_queue_drop_count"] = getattr(
         coverage_summary, "udp_ingest_queue_drop_count", 0
     )

--- a/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_summary.py
@@ -91,6 +91,7 @@ def build_post_analysis_summary(run: PostAnalysisRunInput) -> PersistedAnalysis:
         "raw_replay_gap_count": run.raw_replay.gap_count,
         "raw_replay_overlap_count": run.raw_replay.overlap_count,
         "raw_replay_dropped_chunk_count": run.raw_replay.dropped_chunk_count,
+        "raw_replay_late_packet_chunk_count": run.raw_replay.late_packet_chunk_count,
         "raw_replay_udp_ingest_queue_drop_count": run.raw_replay.udp_ingest_queue_drop_count,
         "raw_replay_queue_overflow_chunk_count": run.raw_replay.queue_overflow_chunk_count,
         "raw_replay_invalid_chunk_count": run.raw_replay.invalid_chunk_count,

--- a/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_replay.py
@@ -70,6 +70,7 @@ class RawReplaySummary:
     gap_count: int
     overlap_count: int
     dropped_chunk_count: int
+    late_packet_chunk_count: int
     queue_overflow_chunk_count: int
     invalid_chunk_count: int
     write_error_chunk_count: int
@@ -133,6 +134,7 @@ def build_raw_backed_samples(
                 gap_count=0,
                 overlap_count=0,
                 dropped_chunk_count=0,
+                late_packet_chunk_count=0,
                 queue_overflow_chunk_count=0,
                 invalid_chunk_count=0,
                 write_error_chunk_count=0,
@@ -174,6 +176,7 @@ def build_raw_backed_samples(
                 gap_count=0,
                 overlap_count=0,
                 dropped_chunk_count=0,
+                late_packet_chunk_count=0,
                 queue_overflow_chunk_count=0,
                 invalid_chunk_count=0,
                 write_error_chunk_count=0,
@@ -264,6 +267,7 @@ def build_raw_backed_samples(
         if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "high_rtt"
     )
     dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
+    late_packet_chunk_count = raw_capture.manifest.total_late_packet_chunk_count
     udp_ingest_queue_drop_count = raw_capture.manifest.losses.udp_ingest_queue_drop_count
     queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
     invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
@@ -276,6 +280,7 @@ def build_raw_backed_samples(
         gap_count=gap_count,
         overlap_count=overlap_count,
         dropped_chunk_count=dropped_chunk_count,
+        late_packet_chunk_count=late_packet_chunk_count,
         sample_rate_mismatch_count=sample_rate_mismatch_count,
         fft_unusable_window_count=fft_unusable_window_count,
         sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
@@ -299,6 +304,7 @@ def build_raw_backed_samples(
             gap_count=gap_count,
             overlap_count=overlap_count,
             dropped_chunk_count=dropped_chunk_count,
+            late_packet_chunk_count=late_packet_chunk_count,
             queue_overflow_chunk_count=queue_overflow_chunk_count,
             invalid_chunk_count=invalid_chunk_count,
             write_error_chunk_count=write_error_chunk_count,
@@ -322,6 +328,7 @@ def build_raw_backed_samples(
                 gap_count=gap_count,
                 overlap_count=overlap_count,
                 dropped_chunk_count=dropped_chunk_count,
+                late_packet_chunk_count=late_packet_chunk_count,
                 udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
                 queue_overflow_chunk_count=queue_overflow_chunk_count,
                 invalid_chunk_count=invalid_chunk_count,
@@ -567,6 +574,7 @@ def _replay_confidence(
     gap_count: int,
     overlap_count: int,
     dropped_chunk_count: int,
+    late_packet_chunk_count: int,
     sample_rate_mismatch_count: int,
     fft_unusable_window_count: int,
     sample_rate_unverified_sensor_count: int,
@@ -584,6 +592,7 @@ def _replay_confidence(
         and gap_count <= 0
         and overlap_count <= 0
         and dropped_chunk_count <= 0
+        and late_packet_chunk_count <= 0
         and sample_rate_mismatch_count <= 0
         and fft_unusable_window_count <= 0
         and sample_rate_unverified_sensor_count <= 0
@@ -603,6 +612,7 @@ def _build_replay_warnings(
     gap_count: int,
     overlap_count: int,
     dropped_chunk_count: int,
+    late_packet_chunk_count: int,
     udp_ingest_queue_drop_count: int,
     queue_overflow_chunk_count: int,
     invalid_chunk_count: int,
@@ -685,7 +695,7 @@ def _build_replay_warnings(
                 ),
             )
         )
-    if dropped_chunk_count > 0:
+    if dropped_chunk_count > 0 or late_packet_chunk_count > 0:
         warnings.append(
             RunContextWarning(
                 code=WARNING_CODE_RAW_REPLAY_DROPPED_CHUNKS,
@@ -694,7 +704,8 @@ def _build_replay_warnings(
                 title=i18n_ref("RUN_CONTEXT_WARNING_RAW_REPLAY_DROPPED_CHUNKS_TITLE"),
                 detail=i18n_ref(
                     "RUN_CONTEXT_WARNING_RAW_REPLAY_DROPPED_CHUNKS_DETAIL",
-                    count=str(max(0, dropped_chunk_count)),
+                    count=str(max(0, dropped_chunk_count + late_packet_chunk_count)),
+                    late=str(max(0, late_packet_chunk_count)),
                     udp_ingest=str(max(0, udp_ingest_queue_drop_count)),
                     queue_overflow=str(max(0, queue_overflow_chunk_count)),
                     invalid=str(max(0, invalid_chunk_count)),

--- a/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
@@ -52,12 +52,14 @@ class _ShutdownRequest:
 
 @dataclass(slots=True)
 class _MutableLossStats:
+    late_packet_chunk_count: int = 0
     queue_overflow_chunk_count: int = 0
     invalid_chunk_count: int = 0
     write_error_chunk_count: int = 0
 
     def freeze(self) -> RawCaptureLossStats:
         return RawCaptureLossStats(
+            late_packet_chunk_count=self.late_packet_chunk_count,
             queue_overflow_chunk_count=self.queue_overflow_chunk_count,
             invalid_chunk_count=self.invalid_chunk_count,
             write_error_chunk_count=self.write_error_chunk_count,
@@ -76,6 +78,10 @@ class _RunCaptureStats:
         self.seen_client_ids.add(client_id)
         self._sensor(client_id).queue_overflow_chunk_count += 1
 
+    def record_late_packet(self, client_id: str) -> None:
+        self.seen_client_ids.add(client_id)
+        self._sensor(client_id).late_packet_chunk_count += 1
+
     def record_invalid_chunk(self, client_id: str) -> None:
         self.seen_client_ids.add(client_id)
         self._sensor(client_id).invalid_chunk_count += 1
@@ -91,7 +97,7 @@ class _RunCaptureStats:
         frozen: dict[str, RawCaptureLossStats] = {}
         for client_id, stats in self.by_client.items():
             loss_stats = stats.freeze()
-            if loss_stats.total_dropped_chunk_count <= 0:
+            if loss_stats.total_loss_event_count <= 0:
                 continue
             frozen[client_id] = loss_stats
         return frozen
@@ -242,6 +248,14 @@ class RunRawCaptureWriter:
             raise RuntimeError(f"raw capture finalize failed for {run_id}") from request.error
         return request.manifest
 
+    def note_late_packet_loss(self, *, client_id: str) -> None:
+        with self._lock:
+            run_stats = self._run_stats
+            run_id = self._active_run_id
+        if run_id is None or run_stats is None:
+            return
+        run_stats.record_late_packet(client_id)
+
     def shutdown(self, timeout_s: float = 5.0) -> bool:
         thread = self._thread
         if thread is None:
@@ -321,7 +335,7 @@ def _merge_sensor_losses(
             losses = losses.merged(primary.get(client_id, RawCaptureLossStats()))
         if secondary is not None:
             losses = losses.merged(secondary.get(client_id, RawCaptureLossStats()))
-        if losses.total_dropped_chunk_count <= 0:
+        if losses.total_loss_event_count <= 0:
             continue
         merged[client_id] = losses
     return merged or None


### PR DESCRIPTION
Closes #3198

Size: medium

## What changed
- add a dedicated `late_packet_chunk_count` field to raw-capture loss metadata
- record quarantined late/out-of-order UDP DATA packets at ingest and persist per-sensor plus rolled-up counts
- carry the late-packet counter through raw replay, whole-run coverage, post-analysis metadata, and report data-trust warnings
- add end-to-end and focused regression coverage for the full chain

## Why
- late packets already stayed out of the live ring buffer
- after recording, clean runs and late-packet runs still looked the same
- reusing UDP queue-drop counters would hide the real failure mode

## Validation
- `. .venv/bin/activate && python -m pytest -q apps/server/tests/adapters/udp/test_udp_late_packet_quarantine.py apps/server/tests/use_cases/run/test_raw_capture_writer.py apps/server/tests/adapters/persistence/history_db/test_history_db_raw_capture.py apps/server/tests/use_cases/run/test_raw_capture_replay.py apps/server/tests/use_cases/run/test_post_analysis_summary.py apps/server/tests/use_cases/history/test_report_raw_replay_coverage.py apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py apps/server/tests/use_cases/run/test_post_analysis_executor.py apps/server/tests/integration/test_udp_late_packet_report_honesty.py`
- `. .venv/bin/activate && make lint && make typecheck-backend`

## Risks / tradeoffs
- late packets now show up as reduced-trust metadata even when raw capture still persisted the waveform chunk
- dropped chunk totals stay drop-only; late packets keep a separate counter so the report does not lie about persistence loss
