### PR TITLE
Fix #3201: bound raw capture finalize and shutdown

### DIFF
--- a/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
+++ b/apps/server/tests/use_cases/run/test_metrics_log_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 import time
 from pathlib import Path
@@ -591,6 +592,39 @@ def test_shutdown_report_exposes_timeout_state(
     assert report.analysis_queue_depth == 2
     assert report.analysis_active_run_id == "run-slow"
     assert report.final_status.enabled is False
+
+
+def test_stop_recording_continues_when_raw_capture_finalize_degrades(
+    make_logger,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from vibesensor.use_cases.run.raw_capture_writer import RawCaptureFinalizeResult
+
+    logger = make_logger()
+    logger.start_recording()
+    finalized_run_ids: list[str] = []
+    logger._raw_capture = SimpleNamespace(
+        finalize_run=lambda run_id, *, sensor_losses=None: RawCaptureFinalizeResult(
+            status="timeout",
+            error="raw capture finalize timed out",
+            queue_depth=3,
+        ),
+        shutdown=lambda timeout_s=5.0: True,
+    )
+    monkeypatch.setattr(
+        logger._persistence,
+        "finalize_run",
+        lambda run_id, start_time_utc, end_time_utc: finalized_run_ids.append(run_id) or True,
+    )
+    monkeypatch.setattr(logger, "schedule_post_analysis", lambda _run_id: None)
+
+    with caplog.at_level(logging.WARNING, logger="vibesensor.use_cases.run.logger"):
+        status = logger.stop_recording()
+
+    assert status.enabled is False
+    assert finalized_run_ids
+    assert "raw_capture_finalize_degraded" in caplog.text
 
 
 def test_post_analysis_uses_run_language_from_metadata(

--- a/apps/server/tests/use_cases/run/test_raw_capture_writer.py
+++ b/apps/server/tests/use_cases/run/test_raw_capture_writer.py
@@ -105,10 +105,12 @@ def test_raw_capture_writer_persists_queue_invalid_and_write_failures(
     writer.note_late_packet_loss(client_id="sensor-b")
 
     history_db.allow_first_write.set()
-    writer.finalize_run(
+    result = writer.finalize_run(
         "run-losses",
         sensor_losses={"sensor-d": RawCaptureLossStats(udp_ingest_queue_drop_count=2)},
     )
+    assert result.completed is True
+    assert result.manifest is None
 
     assert history_db.finalized_sensor_losses is not None
     assert history_db.finalized_sensor_losses["sensor-a"].queue_overflow_chunk_count == 1
@@ -122,3 +124,90 @@ def test_raw_capture_writer_persists_queue_invalid_and_write_failures(
     assert snapshot.write_error_chunks == 1
 
     assert writer.shutdown()
+
+
+def test_raw_capture_writer_finalize_timeout_returns_degraded_result() -> None:
+    class HangingHistoryDb:
+        def __init__(self) -> None:
+            self.block_finalize = threading.Event()
+
+        async def aappend_raw_capture_chunk(self, _run_id: str, _chunk) -> None:
+            return None
+
+        async def afinalize_raw_capture(
+            self,
+            _run_id: str,
+            *,
+            run_start_monotonic_us: int | None = None,
+            sensor_clock_sync=None,
+            sensor_losses=None,
+        ):
+            del run_start_monotonic_us, sensor_clock_sync, sensor_losses
+            await asyncio.to_thread(self.block_finalize.wait)
+
+    history_db = HangingHistoryDb()
+    writer = RunRawCaptureWriter(
+        history_db=history_db,
+        logger=logging.getLogger(__name__),
+    )
+    writer.start_run("run-timeout")
+
+    result = writer.finalize_run("run-timeout", timeout_s=0.1)
+
+    assert result.status == "timeout"
+    assert result.manifest is None
+    assert result.error is not None
+    history_db.block_finalize.set()
+    assert writer.shutdown(timeout_s=1.0) is True
+
+
+def test_raw_capture_writer_shutdown_returns_false_when_queue_offer_stays_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("vibesensor.use_cases.run.raw_capture_writer._QUEUE_MAXSIZE", 1)
+
+    class SlowHistoryDb:
+        def __init__(self) -> None:
+            self.block_append = threading.Event()
+
+        async def aappend_raw_capture_chunk(self, _run_id: str, _chunk) -> None:
+            await asyncio.to_thread(self.block_append.wait)
+
+        async def afinalize_raw_capture(
+            self,
+            _run_id: str,
+            *,
+            run_start_monotonic_us: int | None = None,
+            sensor_clock_sync=None,
+            sensor_losses=None,
+        ):
+            del run_start_monotonic_us, sensor_clock_sync, sensor_losses
+            return None
+
+    history_db = SlowHistoryDb()
+    writer = RunRawCaptureWriter(
+        history_db=history_db,
+        logger=logging.getLogger(__name__),
+    )
+    writer.start_run("run-shutdown-full")
+    writer.capture_raw_samples(
+        client_id="sensor-a",
+        sample_rate_hz=800,
+        t0_us=1000,
+        samples=_samples(),
+    )
+    writer.capture_raw_samples(
+        client_id="sensor-b",
+        sample_rate_hz=800,
+        t0_us=1100,
+        samples=_samples(),
+    )
+
+    assert writer.shutdown(timeout_s=0.1) is False
+
+    history_db.block_append.set()
+    thread = writer._thread
+    assert thread is not None
+    thread.join(timeout=1.0)
+    assert not thread.is_alive()
+    writer._thread = None

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -45,7 +45,10 @@ from vibesensor.use_cases.run.persistence_writer import (
 )
 from vibesensor.use_cases.run.post_analysis import PostAnalysisWorker
 from vibesensor.use_cases.run.post_analysis_summary import build_post_analysis_summary
-from vibesensor.use_cases.run.raw_capture_writer import RunRawCaptureWriter
+from vibesensor.use_cases.run.raw_capture_writer import (
+    RawCaptureFinalizeResult,
+    RunRawCaptureWriter,
+)
 from vibesensor.use_cases.run.run_context import build_run_context_snapshot
 from vibesensor.use_cases.run.run_sensor_snapshot import (
     build_run_sensor_snapshot,
@@ -406,12 +409,11 @@ class RunRecorder:
                             baseline=self._run_ingest_drop_baseline,
                         )
                         if run_id:
-                            manifest = self._raw_capture.finalize_run(
+                            finalize_result = self._raw_capture.finalize_run(
                                 run_id,
                                 sensor_losses=ingest_drop_losses,
                             )
-                            if manifest is not None:
-                                self._finalized_raw_capture_manifests[run_id] = manifest
+                            self._record_raw_capture_finalize_result(run_id, finalize_result)
                         if run_id and not self._persistence.finalize_run(
                             run_id,
                             start_time_utc,
@@ -513,12 +515,11 @@ class RunRecorder:
                         baseline=self._run_ingest_drop_baseline,
                     )
                     if run_id:
-                        manifest = self._raw_capture.finalize_run(
+                        finalize_result = self._raw_capture.finalize_run(
                             run_id,
                             sensor_losses=ingest_drop_losses,
                         )
-                        if manifest is not None:
-                            self._finalized_raw_capture_manifests[run_id] = manifest
+                        self._record_raw_capture_finalize_result(run_id, finalize_result)
                     if run_id and not self._persistence.finalize_run(
                         run_id,
                         start_time_utc,
@@ -589,6 +590,26 @@ class RunRecorder:
 
     def shutdown_raw_capture(self, timeout_s: float = 5.0) -> bool:
         return self._raw_capture.shutdown(timeout_s)
+
+    def _record_raw_capture_finalize_result(
+        self,
+        run_id: str,
+        result: RawCaptureFinalizeResult,
+    ) -> None:
+        if result.manifest is not None:
+            self._finalized_raw_capture_manifests[run_id] = result.manifest
+        if result.completed or result.status == "not_configured":
+            return
+        LOGGER.warning(
+            "raw_capture_finalize_degraded",
+            extra=log_extra(
+                event="raw_capture_finalize_degraded",
+                run_id=run_id,
+                raw_capture_finalize_status=result.status,
+                raw_capture_queue_depth=result.queue_depth,
+                raw_capture_error=result.error,
+            ),
+        )
 
     async def run(self) -> None:
         await _recorder_runtime.run_loop(self, logger=LOGGER)

--- a/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
+++ b/apps/server/vibesensor/use_cases/run/raw_capture_writer.py
@@ -7,7 +7,7 @@ import queue
 import threading
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 
@@ -20,9 +20,31 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureSensorClockSync,
 )
 
-__all__ = ["RunRawCaptureWriter"]
+__all__ = ["RawCaptureFinalizeResult", "RunRawCaptureWriter"]
 
 _QUEUE_MAXSIZE = 2048
+_FINALIZE_WAIT_TIMEOUT_S = 5.0
+_CONTROL_REQUEST_ENQUEUE_TIMEOUT_S = 1.0
+
+type RawCaptureFinalizeStatus = Literal[
+    "completed",
+    "not_configured",
+    "enqueue_timeout",
+    "timeout",
+    "failed",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class RawCaptureFinalizeResult:
+    status: RawCaptureFinalizeStatus
+    manifest: RawCaptureManifest | None = None
+    error: str | None = None
+    queue_depth: int | None = None
+
+    @property
+    def completed(self) -> bool:
+        return self.status == "completed"
 
 
 def _sync_call(db: Any, coro: Any) -> object:
@@ -224,9 +246,10 @@ class RunRawCaptureWriter:
         run_id: str,
         *,
         sensor_losses: Mapping[str, RawCaptureLossStats] | None = None,
-    ) -> RawCaptureManifest | None:
+        timeout_s: float = _FINALIZE_WAIT_TIMEOUT_S,
+    ) -> RawCaptureFinalizeResult:
         if self._history_db is None or self._thread is None:
-            return None
+            return RawCaptureFinalizeResult(status="not_configured")
         with self._lock:
             if self._active_run_id == run_id:
                 self._active_run_id = None
@@ -250,13 +273,50 @@ class RunRawCaptureWriter:
             sensor_losses=run_stats,
             extra_sensor_losses=sensor_losses,
         )
-        self._queue.put(request)
+        try:
+            self._queue.put(
+                request,
+                timeout=_bounded_wait_timeout(_CONTROL_REQUEST_ENQUEUE_TIMEOUT_S),
+            )
+        except queue.Full:
+            queue_depth = self._queue.qsize()
+            self._logger.error(
+                "Timed out queueing raw capture finalize for run %s; queue depth=%s",
+                run_id,
+                queue_depth,
+            )
+            return RawCaptureFinalizeResult(
+                status="enqueue_timeout",
+                error=f"raw capture finalize enqueue timed out for {run_id}",
+                queue_depth=queue_depth,
+            )
         if self._ingest_diagnostics is not None:
             self._ingest_diagnostics.note_raw_capture_queue_depth(self._queue.qsize())
-        request.done.wait()
+        finished = request.done.wait(timeout=_bounded_wait_timeout(timeout_s))
+        if not finished:
+            queue_depth = self._queue.qsize()
+            self._logger.error(
+                "Timed out waiting %.2fs for raw capture finalize for run %s; queue depth=%s",
+                max(0.0, float(timeout_s)),
+                run_id,
+                queue_depth,
+            )
+            return RawCaptureFinalizeResult(
+                status="timeout",
+                error=f"raw capture finalize timed out for {run_id}",
+                queue_depth=queue_depth,
+            )
         if request.error is not None:
-            raise RuntimeError(f"raw capture finalize failed for {run_id}") from request.error
-        return request.manifest
+            return RawCaptureFinalizeResult(
+                status="failed",
+                error=f"raw capture finalize failed for {run_id}: {request.error}",
+                queue_depth=self._queue.qsize(),
+            )
+        return RawCaptureFinalizeResult(
+            status="completed",
+            manifest=request.manifest,
+            queue_depth=self._queue.qsize(),
+        )
 
     def note_late_packet_loss(self, *, client_id: str) -> None:
         with self._lock:
@@ -271,13 +331,29 @@ class RunRawCaptureWriter:
         if thread is None:
             return True
         request = _ShutdownRequest()
-        self._queue.put(request)
+        try:
+            self._queue.put(
+                request,
+                timeout=_bounded_wait_timeout(min(timeout_s, _CONTROL_REQUEST_ENQUEUE_TIMEOUT_S)),
+            )
+        except queue.Full:
+            self._logger.error(
+                "Timed out queueing raw capture shutdown; queue depth=%s",
+                self._queue.qsize(),
+            )
+            return False
         if self._ingest_diagnostics is not None:
             self._ingest_diagnostics.note_raw_capture_queue_depth(self._queue.qsize())
-        finished = request.done.wait(timeout=max(0.1, timeout_s))
-        thread.join(timeout=max(0.1, timeout_s))
-        self._thread = None
-        return finished and not thread.is_alive()
+        finished = request.done.wait(timeout=_bounded_wait_timeout(timeout_s))
+        thread.join(timeout=_bounded_wait_timeout(timeout_s))
+        if not thread.is_alive():
+            self._thread = None
+            return finished
+        self._logger.error(
+            "Raw capture worker did not exit within %.2fs during shutdown",
+            max(0.0, float(timeout_s)),
+        )
+        return False
 
     def _worker_loop(self) -> None:
         history_db = self._history_db
@@ -355,3 +431,7 @@ def _merge_sensor_losses(
             continue
         merged[client_id] = losses
     return merged or None
+
+
+def _bounded_wait_timeout(timeout_s: float) -> float:
+    return max(0.1, float(timeout_s))


### PR DESCRIPTION
## What changed
- bound raw capture finalize to a typed result instead of an unbounded wait or raised stop-path failure
- bound finalize and shutdown queue waits so a full queue or stuck worker cannot block forever
- keep recorder stop and restart moving while logging degraded raw capture outcomes
- add focused tests for finalize timeout, shutdown queue pressure, and degraded recorder stop handling

## Why
- raw capture must not be able to hang run completion or process shutdown
- the old path could wait forever in finalize, block shutdown on queue insertion, and lose track of a still-live worker

## Validation
- python -m pytest -n 0 -q apps/server/tests/use_cases/run/test_raw_capture_writer.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py apps/server/tests/infra/runtime/test_lifecycle_shutdown_consistency.py
- make typecheck-backend
- make lint

## Risks / tradeoffs
- timed-out finalize can still complete later in the background; this change bounds caller wait, not filesystem latency
- degraded raw capture now logs and yields no immediate manifest instead of throwing through recorder stop paths

## Out of scope
- new UI or API fields for raw-capture degradation state