### PR TITLE
Refactor post-analysis executor into explicit pipeline stages

### DIFF
--- a/apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from test_support.persisted_analysis import make_persisted_analysis
+
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.boundaries.sensor_frames import sensor_frames_from_mappings
+from vibesensor.shared.types.raw_capture import RawCaptureManifest
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.whole_run_context import (
+    WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
+    WholeRunContextArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    WholeRunSpectralBuildResult,
+    WholeRunSpectralCoverageSummary,
+)
+from vibesensor.use_cases.run.post_analysis_executor import (
+    resolve_whole_run_builders,
+    run_build_post_analysis_input_stage,
+    run_load_run_stage,
+    run_persist_analysis_summary_stage,
+    run_whole_run_pipeline_stages,
+)
+from vibesensor.use_cases.run.post_analysis_loader import (
+    LoadedPostAnalysisRun,
+    MissingPostAnalysisMetadata,
+)
+from vibesensor.use_cases.run.post_analysis_outcomes import PostAnalysisExecutionMissingMetadata
+
+
+def _run_metadata(run_id: str) -> RunMetadata:
+    return run_metadata_from_mapping(
+        {
+            "run_id": run_id,
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": 800,
+            "sample_rate_hz": 800,
+            "feature_interval_s": 1.0,
+            "language": "en",
+        }
+    )
+
+
+def _samples() -> list:
+    return sensor_frames_from_mappings([{"t_s": 1.0, "vibration_strength_db": 10.0}])
+
+
+def _spectral_result(bundle) -> WholeRunSpectralBuildResult:
+    return WholeRunSpectralBuildResult(
+        bundle=bundle,
+        coverage_summary=WholeRunSpectralCoverageSummary(
+            total_sensor_window_count=0,
+            full_sensor_window_count=0,
+            partial_sensor_window_count=0,
+            missing_sensor_window_count=0,
+            empty_sensor_window_count=0,
+            gap_count=0,
+            overlap_count=0,
+            dropped_chunk_count=0,
+            late_packet_chunk_count=0,
+            queue_overflow_chunk_count=0,
+            invalid_chunk_count=0,
+            write_error_chunk_count=0,
+            sample_rate_mismatch_sensor_count=0,
+            sample_rate_unverified_sensor_count=0,
+            unanchored_sensor_count=0,
+            legacy_sensor_count=0,
+            sync_unverified_sensor_count=0,
+            stale_sync_sensor_count=0,
+            high_rtt_sensor_count=0,
+            coverage_confidence="unavailable",
+        ),
+    )
+
+
+def test_run_load_run_stage_returns_terminal_missing_metadata_result() -> None:
+    stored_errors: list[tuple[str, str]] = []
+
+    class FakeDB:
+        async def astore_analysis_error(self, run_id, error):
+            stored_errors.append((run_id, error))
+
+    stage = run_load_run_stage(
+        run_id="run-missing-stage",
+        db=FakeDB(),
+        load_run=lambda *, run_id, db: MissingPostAnalysisMetadata(
+            run_id=run_id,
+            error_message="Metadata not found or corrupt; cannot analyse",
+        ),
+        analysis_start=0.0,
+        defer_retryable_error_storage=False,
+    )
+
+    assert stage.loaded is None
+    assert isinstance(stage.terminal_result, PostAnalysisExecutionMissingMetadata)
+    assert stage.stage_result.stage_name == "LoadRunStage"
+    assert stage.stage_result.status == "failed"
+    assert stored_errors == [("run-missing-stage", "Metadata not found or corrupt; cannot analyse")]
+
+
+def test_run_whole_run_pipeline_stages_reports_degraded_context_fallback() -> None:
+    stored: dict[str, object] = {}
+    raw_capture_manifest = RawCaptureManifest(
+        run_id="run-stage-pipeline",
+        relative_dir="raw-runs/run-stage-pipeline",
+        sensors=(),
+        total_samples=0,
+        total_bytes=0,
+        created_at="2025-01-01T00:00:00Z",
+    )
+    context_bundle = WholeRunContextArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id="run-stage-pipeline",
+            relative_dir="whole-run-artifacts/run-stage-pipeline",
+            window_policy=WholeRunWindowPolicy(
+                sample_rate_hz=800,
+                window_size_samples=2048,
+                stride_samples=200,
+                overlap_samples=1848,
+                feature_interval_s=0.25,
+            ),
+            total_window_count=1,
+            artifacts=(
+                WholeRunArtifactFile(
+                    artifact_key=WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
+                    relative_path="context/window-labels.jsonl",
+                    file_format="jsonl",
+                    record_count=1,
+                ),
+            ),
+            created_at="2025-01-01T00:00:00Z",
+        ),
+        artifact_contents={WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY: b'{"window_index":0}\n'},
+        labels=(),
+        intervals=(),
+    )
+
+    class FakeDB:
+        async def astore_whole_run_artifacts(self, run_id, manifest, *, artifact_contents):
+            stored["run_id"] = run_id
+            stored["manifest"] = manifest
+            stored["artifact_contents"] = artifact_contents
+            return manifest
+
+    loaded = LoadedPostAnalysisRun(
+        run_id="run-stage-pipeline",
+        metadata=_run_metadata("run-stage-pipeline"),
+        language="en",
+        samples=_samples(),
+        total_summary_row_count=1,
+        stride=1,
+        raw_capture_manifest=raw_capture_manifest,
+    )
+    run_input = run_build_post_analysis_input_stage(loaded).run_input
+    builders = resolve_whole_run_builders(
+        whole_run_artifact_builder=lambda **_kwargs: _spectral_result(None),
+        whole_run_context_builder=lambda **_kwargs: context_bundle,
+        whole_run_order_trace_builder=lambda **_kwargs: None,
+        whole_run_order_trace_summary_builder=lambda **_kwargs: None,
+        whole_run_order_family_summary_builder=lambda **_kwargs: None,
+        whole_run_spatial_coherence_builder=lambda **_kwargs: None,
+        whole_run_diagnosis_summary_builder=lambda **_kwargs: (),
+    )
+
+    result = run_whole_run_pipeline_stages(
+        db=FakeDB(),
+        loaded=loaded,
+        run_input=run_input,
+        builders=builders,
+    )
+
+    statuses = {stage.stage_name: stage.status for stage in result.stage_results}
+    assert statuses["BuildWholeRunSpectraStage"] == "skipped"
+    assert statuses["BuildWholeRunContextStage"] == "degraded"
+    assert statuses["BuildOrderTraceStage"] == "skipped"
+    assert statuses["PersistArtifactsStage"] == "ok"
+    assert stored["run_id"] == "run-stage-pipeline"
+    assert result.stored_artifact_manifest is not None
+
+
+def test_run_persist_analysis_summary_stage_stores_summary() -> None:
+    stored: list[tuple[str, object]] = []
+
+    class FakeDB:
+        async def astore_analysis(self, run_id, analysis):
+            stored.append((run_id, analysis))
+
+    summary = make_persisted_analysis({"run_suitability": []})
+    stage = run_persist_analysis_summary_stage(
+        db=FakeDB(),
+        run_id="run-persist-stage",
+        summary=summary,
+    )
+
+    assert stage.stage_name == "PersistAnalysisSummaryStage"
+    assert stage.status == "ok"
+    assert stored == [("run-persist-stage", summary)]

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -6,8 +6,8 @@ import asyncio
 import logging
 import time
 from collections.abc import Mapping
-from dataclasses import dataclass
-from typing import Any, Protocol
+from dataclasses import dataclass, field
+from typing import Any, Literal, NoReturn, Protocol
 
 import aiosqlite
 from opentelemetry.trace import SpanKind
@@ -72,6 +72,7 @@ from vibesensor.use_cases.run.post_analysis_input import (
 )
 from vibesensor.use_cases.run.post_analysis_loader import (
     EmptyPostAnalysisSamples,
+    LoadedPostAnalysisRun,
     MissingPostAnalysisMetadata,
     PostAnalysisLoadResult,
     load_post_analysis_run,
@@ -226,6 +227,792 @@ class _StoredWholeRunArtifactBundle:
     artifact_contents: dict[str, bytes]
 
 
+type PostAnalysisStageStatus = Literal["ok", "skipped", "degraded", "failed"]
+
+
+@dataclass(frozen=True, slots=True)
+class PostAnalysisStageResult:
+    """Structured result for one executor pipeline stage."""
+
+    stage_name: str
+    status: PostAnalysisStageStatus
+    duration_ms: int
+    artifacts_created: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    diagnostic_context: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class PostAnalysisLoadStageOutput:
+    """Output of the load stage before input shaping begins."""
+
+    stage_result: PostAnalysisStageResult
+    loaded: LoadedPostAnalysisRun | None = None
+    terminal_result: PostAnalysisAttemptResult | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PostAnalysisInputStageOutput:
+    """Output of canonical post-analysis input shaping."""
+
+    run_input: PostAnalysisRunInput
+    stage_result: PostAnalysisStageResult
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunPipelineStageOutput:
+    """Artifacts and stage reports from the whole-run sidecar pipeline."""
+
+    stage_results: tuple[PostAnalysisStageResult, ...]
+    stored_artifact_manifest: WholeRunArtifactManifest | None = None
+    spectral_result: WholeRunSpectralBuildResult | None = None
+    spectral_bundle: WholeRunSpectralArtifactBundle | None = None
+    context_bundle: WholeRunContextArtifactBundle | None = None
+    order_trace_bundle: WholeRunOrderTraceArtifactBundle | None = None
+    order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle | None = None
+    order_family_summary_bundle: WholeRunOrderFamilySummaryArtifactBundle | None = None
+    spatial_coherence_bundle: WholeRunSpatialCoherenceArtifactBundle | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedWholeRunBuilders:
+    """Resolved builder callables used by the explicit whole-run pipeline stages."""
+
+    artifact_builder: WholeRunArtifactBuilder
+    context_builder: WholeRunContextBuilder
+    order_trace_builder: WholeRunOrderTraceBuilder
+    order_trace_summary_builder: WholeRunOrderTraceSummaryBuilder
+    order_family_summary_builder: WholeRunOrderFamilySummaryBuilder
+    spatial_coherence_builder: WholeRunSpatialCoherenceBuilder
+    diagnosis_summary_builder: WholeRunDiagnosisSummaryBuilder
+
+
+class PostAnalysisStageFailure(Exception):
+    """Retryable or persistence-bound stage failure with explicit stage metadata."""
+
+    def __init__(self, stage_result: PostAnalysisStageResult, cause: BaseException) -> None:
+        super().__init__(str(cause))
+        self.stage_result = stage_result
+        self.cause = cause
+
+
+def _duration_ms(stage_start: float) -> int:
+    return max(0, int(round((time.monotonic() - stage_start) * 1000)))
+
+
+def _make_stage_result(
+    *,
+    stage_name: str,
+    status: PostAnalysisStageStatus,
+    stage_start: float,
+    artifacts_created: tuple[str, ...] = (),
+    warnings: tuple[str, ...] = (),
+    diagnostic_context: JsonObject | None = None,
+) -> PostAnalysisStageResult:
+    return PostAnalysisStageResult(
+        stage_name=stage_name,
+        status=status,
+        duration_ms=_duration_ms(stage_start),
+        artifacts_created=artifacts_created,
+        warnings=warnings,
+        diagnostic_context={} if diagnostic_context is None else diagnostic_context,
+    )
+
+
+def _artifact_keys(manifest: WholeRunArtifactManifest | None) -> tuple[str, ...]:
+    if manifest is None:
+        return ()
+    return tuple(artifact.artifact_key for artifact in manifest.artifacts)
+
+
+def _warning_codes(warnings: tuple[object, ...]) -> tuple[str, ...]:
+    codes: list[str] = []
+    for warning in warnings:
+        code = getattr(warning, "code", None)
+        if isinstance(code, str) and code:
+            codes.append(code)
+    return tuple(codes)
+
+
+def _log_stage_result(run_id: str, stage_result: PostAnalysisStageResult) -> None:
+    if stage_result.status == "ok":
+        return
+    log_fn = LOGGER.warning if stage_result.status in {"degraded", "failed"} else LOGGER.info
+    log_fn(
+        "Post-analysis stage %s for run %s is %s",
+        stage_result.stage_name,
+        run_id,
+        stage_result.status,
+        extra=log_extra(
+            event="post_analysis_stage_result",
+            run_id=run_id,
+            stage_name=stage_result.stage_name,
+            stage_status=stage_result.status,
+            duration_ms=stage_result.duration_ms,
+            artifacts_created=list(stage_result.artifacts_created),
+            warnings=list(stage_result.warnings),
+            diagnostic_context=stage_result.diagnostic_context,
+        ),
+    )
+
+
+def _raise_stage_failure(
+    *,
+    stage_name: str,
+    stage_start: float,
+    exc: BaseException,
+    diagnostic_context: JsonObject | None = None,
+) -> NoReturn:
+    raise PostAnalysisStageFailure(
+        _make_stage_result(
+            stage_name=stage_name,
+            status="failed",
+            stage_start=stage_start,
+            diagnostic_context=(
+                {"error_message": str(exc)}
+                if diagnostic_context is None
+                else {**diagnostic_context, "error_message": str(exc)}
+            ),
+        ),
+        exc,
+    ) from exc
+
+
+def resolve_whole_run_builders(
+    *,
+    whole_run_artifact_builder: WholeRunArtifactBuilder | None,
+    whole_run_context_builder: WholeRunContextBuilder | None,
+    whole_run_order_trace_builder: WholeRunOrderTraceBuilder | None,
+    whole_run_order_trace_summary_builder: WholeRunOrderTraceSummaryBuilder | None,
+    whole_run_order_family_summary_builder: WholeRunOrderFamilySummaryBuilder | None,
+    whole_run_spatial_coherence_builder: WholeRunSpatialCoherenceBuilder | None,
+    whole_run_diagnosis_summary_builder: WholeRunDiagnosisSummaryBuilder | None,
+) -> ResolvedWholeRunBuilders:
+    return ResolvedWholeRunBuilders(
+        artifact_builder=(
+            _build_whole_run_artifacts
+            if whole_run_artifact_builder is None
+            else whole_run_artifact_builder
+        ),
+        context_builder=(
+            _build_whole_run_context_artifacts
+            if whole_run_context_builder is None
+            else whole_run_context_builder
+        ),
+        order_trace_builder=(
+            _build_whole_run_order_trace_artifacts
+            if whole_run_order_trace_builder is None
+            else whole_run_order_trace_builder
+        ),
+        order_trace_summary_builder=(
+            _build_whole_run_order_trace_summary_artifacts
+            if whole_run_order_trace_summary_builder is None
+            else whole_run_order_trace_summary_builder
+        ),
+        order_family_summary_builder=(
+            _build_whole_run_order_family_summary_artifacts
+            if whole_run_order_family_summary_builder is None
+            else whole_run_order_family_summary_builder
+        ),
+        spatial_coherence_builder=(
+            _build_whole_run_spatial_coherence_artifacts
+            if whole_run_spatial_coherence_builder is None
+            else whole_run_spatial_coherence_builder
+        ),
+        diagnosis_summary_builder=(
+            _build_whole_run_diagnosis_summaries
+            if whole_run_diagnosis_summary_builder is None
+            else whole_run_diagnosis_summary_builder
+        ),
+    )
+
+
+def run_load_run_stage(
+    *,
+    run_id: str,
+    db: RunPersistence,
+    load_run: PostAnalysisLoader,
+    analysis_start: float,
+    defer_retryable_error_storage: bool,
+) -> PostAnalysisLoadStageOutput:
+    stage_name = "LoadRunStage"
+    stage_start = time.monotonic()
+    try:
+        load_result = load_run(run_id=run_id, db=db)
+    except (aiosqlite.Error, OSError, MemoryError) as exc:
+        terminal_result: PostAnalysisAttemptResult
+        if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
+            terminal_result = _retryable_failure_result(
+                run_id=run_id,
+                analysis_start=analysis_start,
+                exc=exc,
+                stage_name=stage_name,
+            )
+        else:
+            terminal_result = _persistence_failure_result(
+                run_id=run_id,
+                analysis_start=analysis_start,
+                exc=exc,
+                db=db,
+                stage_name=stage_name,
+            )
+        return PostAnalysisLoadStageOutput(
+            stage_result=_make_stage_result(
+                stage_name=stage_name,
+                status="failed",
+                stage_start=stage_start,
+                diagnostic_context={"error_message": str(exc)},
+            ),
+            terminal_result=terminal_result,
+        )
+
+    if isinstance(load_result, MissingPostAnalysisMetadata):
+        LOGGER.warning(
+            "Cannot analyse run %s: metadata not found",
+            run_id,
+            extra=log_extra(
+                event="post_analysis_skipped",
+                run_id=run_id,
+                failure_kind="missing_metadata",
+            ),
+        )
+        return PostAnalysisLoadStageOutput(
+            stage_result=_make_stage_result(
+                stage_name=stage_name,
+                status="failed",
+                stage_start=stage_start,
+                diagnostic_context={"failure_kind": "missing_metadata"},
+            ),
+            terminal_result=_store_load_error(
+                db=db,
+                run_id=run_id,
+                completed_error=load_result.error_message,
+                kind="missing_metadata",
+            ),
+        )
+
+    if isinstance(load_result, EmptyPostAnalysisSamples):
+        LOGGER.warning(
+            "Skipping post-analysis for run %s: no samples collected",
+            run_id,
+            extra=log_extra(
+                event="post_analysis_skipped",
+                run_id=run_id,
+                failure_kind="no_samples",
+            ),
+        )
+        return PostAnalysisLoadStageOutput(
+            stage_result=_make_stage_result(
+                stage_name=stage_name,
+                status="failed",
+                stage_start=stage_start,
+                diagnostic_context={"failure_kind": "no_samples"},
+            ),
+            terminal_result=_store_load_error(
+                db=db,
+                run_id=run_id,
+                completed_error=load_result.error_message,
+                kind="no_samples",
+            ),
+        )
+
+    return PostAnalysisLoadStageOutput(
+        stage_result=_make_stage_result(
+            stage_name=stage_name,
+            status="ok",
+            stage_start=stage_start,
+            diagnostic_context={
+                "sample_count": len(load_result.samples),
+                "raw_capture_available": load_result.raw_capture is not None,
+                "raw_capture_manifest_available": load_result.raw_capture_manifest is not None,
+            },
+        ),
+        loaded=load_result,
+    )
+
+
+def run_build_post_analysis_input_stage(
+    loaded: LoadedPostAnalysisRun,
+) -> PostAnalysisInputStageOutput:
+    stage_name = "BuildPostAnalysisInputStage"
+    stage_start = time.monotonic()
+    try:
+        run_input = build_post_analysis_input(loaded)
+    except (aiosqlite.Error, OSError, MemoryError) as exc:
+        _raise_stage_failure(
+            stage_name=stage_name,
+            stage_start=stage_start,
+            exc=exc,
+            diagnostic_context={"run_id": loaded.run_id},
+        )
+    return PostAnalysisInputStageOutput(
+        run_input=run_input,
+        stage_result=_make_stage_result(
+            stage_name=stage_name,
+            status="ok",
+            stage_start=stage_start,
+            diagnostic_context={
+                "summary_row_count": len(run_input.samples),
+                "raw_capture_available": run_input.raw_capture_available,
+                "sampling_method": run_input.sampling_method,
+            },
+        ),
+    )
+
+
+def run_whole_run_pipeline_stages(
+    *,
+    db: RunPersistence,
+    loaded: LoadedPostAnalysisRun,
+    run_input: PostAnalysisRunInput,
+    builders: ResolvedWholeRunBuilders,
+) -> WholeRunPipelineStageOutput:
+    stage_results: list[PostAnalysisStageResult] = []
+    spectral_result: WholeRunSpectralBuildResult | None = None
+    spectral_bundle: WholeRunSpectralArtifactBundle | None = None
+    context_bundle: WholeRunContextArtifactBundle | None = None
+    order_trace_bundle: WholeRunOrderTraceArtifactBundle | None = None
+    order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle | None = None
+    order_family_summary_bundle: WholeRunOrderFamilySummaryArtifactBundle | None = None
+    spatial_coherence_bundle: WholeRunSpatialCoherenceArtifactBundle | None = None
+    stored_artifact_manifest: WholeRunArtifactManifest | None = None
+
+    spectral_stage_start = time.monotonic()
+    if loaded.raw_capture is None:
+        stage_results.append(
+            _make_stage_result(
+                stage_name="BuildWholeRunSpectraStage",
+                status="skipped",
+                stage_start=spectral_stage_start,
+                diagnostic_context={"reason": "raw_capture_missing"},
+            )
+        )
+    else:
+        try:
+            spectral_result = builders.artifact_builder(
+                run_id=loaded.run_id,
+                metadata=loaded.metadata,
+                raw_capture=loaded.raw_capture,
+            )
+        except (aiosqlite.Error, OSError, MemoryError) as exc:
+            _raise_stage_failure(
+                stage_name="BuildWholeRunSpectraStage",
+                stage_start=spectral_stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": loaded.run_id},
+            )
+        spectral_bundle = spectral_result.bundle
+        stage_results.append(
+            _make_stage_result(
+                stage_name="BuildWholeRunSpectraStage",
+                status="ok",
+                stage_start=spectral_stage_start,
+                artifacts_created=_artifact_keys(
+                    spectral_bundle.manifest if spectral_bundle is not None else None
+                ),
+                warnings=_warning_codes(tuple(spectral_result.coverage_summary.warnings)),
+                diagnostic_context={
+                    "bundle_available": spectral_bundle is not None,
+                    "coverage_confidence": spectral_result.coverage_summary.coverage_confidence,
+                },
+            )
+        )
+
+    context_stage_start = time.monotonic()
+    context_status: PostAnalysisStageStatus = "skipped"
+    context_diagnostic: JsonObject = {"reason": "raw_capture_manifest_missing"}
+    if loaded.raw_capture_manifest is not None:
+        try:
+            if spectral_result is not None and spectral_result.window_plan is not None:
+                context_bundle = builders.context_builder(
+                    run=run_input,
+                    window_plan=spectral_result.window_plan,
+                )
+                context_status = "ok"
+                context_diagnostic = {"build_mode": "window_plan"}
+            else:
+                context_bundle = builders.context_builder(
+                    run=run_input,
+                    total_sample_count=_whole_run_total_sample_count(loaded.raw_capture_manifest),
+                )
+                context_status = "degraded"
+                context_diagnostic = {"build_mode": "total_sample_count_fallback"}
+        except (aiosqlite.Error, OSError, MemoryError) as exc:
+            _raise_stage_failure(
+                stage_name="BuildWholeRunContextStage",
+                stage_start=context_stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": loaded.run_id},
+            )
+        if context_bundle is None:
+            context_status = "skipped"
+            context_diagnostic = {**context_diagnostic, "reason": "builder_returned_none"}
+    stage_results.append(
+        _make_stage_result(
+            stage_name="BuildWholeRunContextStage",
+            status=context_status,
+            stage_start=context_stage_start,
+            artifacts_created=_artifact_keys(
+                context_bundle.manifest if context_bundle is not None else None
+            ),
+            diagnostic_context=context_diagnostic,
+        )
+    )
+
+    order_trace_stage_start = time.monotonic()
+    if spectral_bundle is None or context_bundle is None:
+        stage_results.append(
+            _make_stage_result(
+                stage_name="BuildOrderTraceStage",
+                status="skipped",
+                stage_start=order_trace_stage_start,
+                diagnostic_context={"reason": "missing_prerequisites"},
+            )
+        )
+    else:
+        try:
+            order_trace_bundle = builders.order_trace_builder(
+                run=run_input,
+                spectral_bundle=spectral_bundle,
+                context_bundle=context_bundle,
+            )
+        except (aiosqlite.Error, OSError, MemoryError) as exc:
+            _raise_stage_failure(
+                stage_name="BuildOrderTraceStage",
+                stage_start=order_trace_stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": loaded.run_id},
+            )
+        stage_results.append(
+            _make_stage_result(
+                stage_name="BuildOrderTraceStage",
+                status="ok" if order_trace_bundle is not None else "skipped",
+                stage_start=order_trace_stage_start,
+                artifacts_created=_artifact_keys(
+                    order_trace_bundle.manifest if order_trace_bundle is not None else None
+                ),
+                diagnostic_context=(
+                    {"reason": "builder_returned_none"} if order_trace_bundle is None else {}
+                ),
+            )
+        )
+
+    order_trace_summary_stage_start = time.monotonic()
+    if order_trace_bundle is None or context_bundle is None:
+        stage_results.append(
+            _make_stage_result(
+                stage_name="BuildOrderTraceSummaryStage",
+                status="skipped",
+                stage_start=order_trace_summary_stage_start,
+                diagnostic_context={"reason": "missing_prerequisites"},
+            )
+        )
+    else:
+        try:
+            order_trace_summary_bundle = builders.order_trace_summary_builder(
+                order_trace_bundle=order_trace_bundle,
+                context_bundle=context_bundle,
+            )
+        except (aiosqlite.Error, OSError, MemoryError) as exc:
+            _raise_stage_failure(
+                stage_name="BuildOrderTraceSummaryStage",
+                stage_start=order_trace_summary_stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": loaded.run_id},
+            )
+        stage_results.append(
+            _make_stage_result(
+                stage_name="BuildOrderTraceSummaryStage",
+                status="ok" if order_trace_summary_bundle is not None else "skipped",
+                stage_start=order_trace_summary_stage_start,
+                artifacts_created=_artifact_keys(
+                    order_trace_summary_bundle.manifest
+                    if order_trace_summary_bundle is not None
+                    else None
+                ),
+                diagnostic_context=(
+                    {"reason": "builder_returned_none"}
+                    if order_trace_summary_bundle is None
+                    else {}
+                ),
+            )
+        )
+
+    order_family_stage_start = time.monotonic()
+    if order_trace_bundle is None or order_trace_summary_bundle is None or context_bundle is None:
+        stage_results.append(
+            _make_stage_result(
+                stage_name="BuildOrderFamilySummaryStage",
+                status="skipped",
+                stage_start=order_family_stage_start,
+                diagnostic_context={"reason": "missing_prerequisites"},
+            )
+        )
+    else:
+        try:
+            order_family_summary_bundle = builders.order_family_summary_builder(
+                order_trace_bundle=order_trace_bundle,
+                order_trace_summary_bundle=order_trace_summary_bundle,
+                context_bundle=context_bundle,
+            )
+        except (aiosqlite.Error, OSError, MemoryError) as exc:
+            _raise_stage_failure(
+                stage_name="BuildOrderFamilySummaryStage",
+                stage_start=order_family_stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": loaded.run_id},
+            )
+        stage_results.append(
+            _make_stage_result(
+                stage_name="BuildOrderFamilySummaryStage",
+                status="ok" if order_family_summary_bundle is not None else "skipped",
+                stage_start=order_family_stage_start,
+                artifacts_created=_artifact_keys(
+                    order_family_summary_bundle.manifest
+                    if order_family_summary_bundle is not None
+                    else None
+                ),
+                diagnostic_context=(
+                    {"reason": "builder_returned_none"}
+                    if order_family_summary_bundle is None
+                    else {}
+                ),
+            )
+        )
+
+    spatial_stage_start = time.monotonic()
+    if spectral_bundle is None or context_bundle is None or order_trace_bundle is None:
+        stage_results.append(
+            _make_stage_result(
+                stage_name="BuildSpatialSummaryStage",
+                status="skipped",
+                stage_start=spatial_stage_start,
+                diagnostic_context={"reason": "missing_prerequisites"},
+            )
+        )
+    else:
+        try:
+            spatial_coherence_bundle = builders.spatial_coherence_builder(
+                run=run_input,
+                spectral_bundle=spectral_bundle,
+                context_bundle=context_bundle,
+                order_trace_bundle=order_trace_bundle,
+            )
+        except (aiosqlite.Error, OSError, MemoryError) as exc:
+            _raise_stage_failure(
+                stage_name="BuildSpatialSummaryStage",
+                stage_start=spatial_stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": loaded.run_id},
+            )
+        stage_results.append(
+            _make_stage_result(
+                stage_name="BuildSpatialSummaryStage",
+                status="ok" if spatial_coherence_bundle is not None else "skipped",
+                stage_start=spatial_stage_start,
+                artifacts_created=_artifact_keys(
+                    spatial_coherence_bundle.manifest
+                    if spatial_coherence_bundle is not None
+                    else None
+                ),
+                diagnostic_context=(
+                    {"reason": "builder_returned_none"} if spatial_coherence_bundle is None else {}
+                ),
+            )
+        )
+
+    persist_artifacts_stage_start = time.monotonic()
+    merged_bundle = _merge_whole_run_artifact_bundles(
+        spectral_bundle,
+        context_bundle,
+        order_trace_bundle,
+        order_trace_summary_bundle,
+        order_family_summary_bundle,
+        spatial_coherence_bundle,
+    )
+    if merged_bundle is None:
+        stage_results.append(
+            _make_stage_result(
+                stage_name="PersistArtifactsStage",
+                status="skipped",
+                stage_start=persist_artifacts_stage_start,
+                diagnostic_context={"reason": "no_artifacts_to_persist"},
+            )
+        )
+    else:
+        try:
+            stored_artifact_manifest = _sync_call(
+                db,
+                "astore_whole_run_artifacts",
+                loaded.run_id,
+                merged_bundle.manifest,
+                artifact_contents=merged_bundle.artifact_contents,
+            )
+        except (aiosqlite.Error, OSError, MemoryError) as exc:
+            _raise_stage_failure(
+                stage_name="PersistArtifactsStage",
+                stage_start=persist_artifacts_stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": loaded.run_id},
+            )
+        if stored_artifact_manifest is None:
+            _raise_stage_failure(
+                stage_name="PersistArtifactsStage",
+                stage_start=persist_artifacts_stage_start,
+                exc=OSError(f"Failed to persist whole-run artifacts for run {loaded.run_id}"),
+                diagnostic_context={"run_id": loaded.run_id},
+            )
+        stage_results.append(
+            _make_stage_result(
+                stage_name="PersistArtifactsStage",
+                status="ok",
+                stage_start=persist_artifacts_stage_start,
+                artifacts_created=_artifact_keys(stored_artifact_manifest),
+                diagnostic_context={"artifact_count": len(stored_artifact_manifest.artifacts)},
+            )
+        )
+
+    return WholeRunPipelineStageOutput(
+        stage_results=tuple(stage_results),
+        stored_artifact_manifest=stored_artifact_manifest,
+        spectral_result=spectral_result,
+        spectral_bundle=spectral_bundle,
+        context_bundle=context_bundle,
+        order_trace_bundle=order_trace_bundle,
+        order_trace_summary_bundle=order_trace_summary_bundle,
+        order_family_summary_bundle=order_family_summary_bundle,
+        spatial_coherence_bundle=spatial_coherence_bundle,
+    )
+
+
+def run_build_report_facts_stage(
+    *,
+    run_input: PostAnalysisRunInput,
+    analysis_runner: PostAnalysisRunner,
+    whole_run_output: WholeRunPipelineStageOutput,
+    diagnosis_summary_builder: WholeRunDiagnosisSummaryBuilder,
+) -> tuple[PersistedAnalysis, PostAnalysisStageResult]:
+    stage_name = "BuildReportFactsStage"
+    stage_start = time.monotonic()
+    try:
+        summary = _coerce_persisted_analysis(analysis_runner(run_input))
+    except (aiosqlite.Error, OSError, MemoryError) as exc:
+        _raise_stage_failure(
+            stage_name=stage_name,
+            stage_start=stage_start,
+            exc=exc,
+            diagnostic_context={"run_id": run_input.run_id},
+        )
+
+    spectral_result = whole_run_output.spectral_result
+    spectral_bundle = whole_run_output.spectral_bundle
+    context_bundle = whole_run_output.context_bundle
+    order_trace_bundle = whole_run_output.order_trace_bundle
+    order_trace_summary_bundle = whole_run_output.order_trace_summary_bundle
+    order_family_summary_bundle = whole_run_output.order_family_summary_bundle
+    spatial_coherence_bundle = whole_run_output.spatial_coherence_bundle
+    stored_artifact_manifest = whole_run_output.stored_artifact_manifest
+
+    if spectral_result is not None:
+        summary = _append_whole_run_spectral_metadata(
+            summary,
+            spectral_result.coverage_summary,
+            spectral_bundle=spectral_bundle,
+        )
+        summary = _append_run_context_warnings(summary, spectral_result.coverage_summary.warnings)
+    if context_bundle is not None:
+        summary = _append_whole_run_context(summary, context_bundle)
+
+    analysis_payload = summary.to_json_object()
+    analysis_metadata_payload = analysis_payload.get("analysis_metadata")
+    analysis_metadata = (
+        dict(analysis_metadata_payload) if isinstance(analysis_metadata_payload, dict) else {}
+    )
+
+    if order_trace_bundle is not None:
+        summary = _append_whole_run_order_trace_metadata(summary, order_trace_bundle)
+    if order_trace_summary_bundle is not None:
+        summary = _append_whole_run_order_trace_summary_metadata(
+            summary,
+            order_trace_summary_bundle,
+        )
+    if order_family_summary_bundle is not None:
+        summary = _append_whole_run_order_summaries(summary, order_family_summary_bundle)
+        summary = _append_whole_run_order_family_summary_metadata(
+            summary,
+            order_family_summary_bundle,
+        )
+    if spatial_coherence_bundle is not None:
+        summary = _append_whole_run_spatial_summaries(summary, spatial_coherence_bundle)
+        summary = _append_whole_run_spatial_coherence_metadata(
+            summary,
+            spatial_coherence_bundle,
+        )
+    if context_bundle is not None and order_family_summary_bundle is not None:
+        diagnosis_summaries = diagnosis_summary_builder(
+            analysis_metadata=analysis_metadata,
+            context_bundle=context_bundle,
+            order_summaries=_ranked_whole_run_order_summaries(
+                order_family_summary_bundle.summaries
+            ),
+            spatial_summaries=(
+                _ranked_whole_run_spatial_summaries(spatial_coherence_bundle.summaries)
+                if spatial_coherence_bundle is not None
+                else ()
+            ),
+        )
+        if diagnosis_summaries:
+            summary = _append_whole_run_diagnosis_summaries(summary, diagnosis_summaries)
+            summary = _append_whole_run_diagnosis_summary_metadata(
+                summary,
+                diagnosis_summaries,
+            )
+    if stored_artifact_manifest is not None:
+        summary = _append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
+
+    return summary, _make_stage_result(
+        stage_name=stage_name,
+        status="ok",
+        stage_start=stage_start,
+        warnings=(
+            _warning_codes(tuple(spectral_result.coverage_summary.warnings))
+            if spectral_result is not None
+            else ()
+        ),
+        diagnostic_context={
+            "whole_run_artifacts_available": stored_artifact_manifest is not None,
+            "whole_run_context_available": context_bundle is not None,
+            "whole_run_order_family_available": order_family_summary_bundle is not None,
+            "whole_run_spatial_available": spatial_coherence_bundle is not None,
+        },
+    )
+
+
+def run_persist_analysis_summary_stage(
+    *,
+    db: RunPersistence,
+    run_id: str,
+    summary: PersistedAnalysis,
+) -> PostAnalysisStageResult:
+    stage_name = "PersistAnalysisSummaryStage"
+    stage_start = time.monotonic()
+    try:
+        _sync_call(db, "astore_analysis", run_id, summary)
+    except (aiosqlite.Error, OSError, MemoryError) as exc:
+        _raise_stage_failure(
+            stage_name=stage_name,
+            stage_start=stage_start,
+            exc=exc,
+            diagnostic_context={"run_id": run_id},
+        )
+    return _make_stage_result(
+        stage_name=stage_name,
+        status="ok",
+        stage_start=stage_start,
+        diagnostic_context={"run_id": run_id},
+    )
+
+
 def execute_post_analysis(
     *,
     run_id: str,
@@ -242,40 +1029,14 @@ def execute_post_analysis(
     defer_retryable_error_storage: bool = False,
 ) -> PostAnalysisAttemptResult:
     analysis_start = time.monotonic()
-    resolved_whole_run_artifact_builder = (
-        _build_whole_run_artifacts
-        if whole_run_artifact_builder is None
-        else whole_run_artifact_builder
-    )
-    resolved_whole_run_context_builder = (
-        _build_whole_run_context_artifacts
-        if whole_run_context_builder is None
-        else whole_run_context_builder
-    )
-    resolved_whole_run_order_trace_builder = (
-        _build_whole_run_order_trace_artifacts
-        if whole_run_order_trace_builder is None
-        else whole_run_order_trace_builder
-    )
-    resolved_whole_run_order_trace_summary_builder = (
-        _build_whole_run_order_trace_summary_artifacts
-        if whole_run_order_trace_summary_builder is None
-        else whole_run_order_trace_summary_builder
-    )
-    resolved_whole_run_order_family_summary_builder = (
-        _build_whole_run_order_family_summary_artifacts
-        if whole_run_order_family_summary_builder is None
-        else whole_run_order_family_summary_builder
-    )
-    resolved_whole_run_spatial_coherence_builder = (
-        _build_whole_run_spatial_coherence_artifacts
-        if whole_run_spatial_coherence_builder is None
-        else whole_run_spatial_coherence_builder
-    )
-    resolved_whole_run_diagnosis_summary_builder = (
-        _build_whole_run_diagnosis_summaries
-        if whole_run_diagnosis_summary_builder is None
-        else whole_run_diagnosis_summary_builder
+    resolved_builders = resolve_whole_run_builders(
+        whole_run_artifact_builder=whole_run_artifact_builder,
+        whole_run_context_builder=whole_run_context_builder,
+        whole_run_order_trace_builder=whole_run_order_trace_builder,
+        whole_run_order_trace_summary_builder=whole_run_order_trace_summary_builder,
+        whole_run_order_family_summary_builder=whole_run_order_family_summary_builder,
+        whole_run_spatial_coherence_builder=whole_run_spatial_coherence_builder,
+        whole_run_diagnosis_summary_builder=whole_run_diagnosis_summary_builder,
     )
     with start_span(
         __name__,
@@ -288,222 +1049,70 @@ def execute_post_analysis(
             run_id,
             extra=log_extra(event="post_analysis_started", run_id=run_id),
         )
+        load_stage = run_load_run_stage(
+            run_id=run_id,
+            db=db,
+            load_run=load_run,
+            analysis_start=analysis_start,
+            defer_retryable_error_storage=defer_retryable_error_storage,
+        )
+        _log_stage_result(run_id, load_stage.stage_result)
+        if load_stage.terminal_result is not None:
+            if load_stage.stage_result.diagnostic_context.get("failure_kind") == "missing_metadata":
+                span.set_attribute("vibesensor.failure_kind", "missing_metadata")
+            if load_stage.stage_result.diagnostic_context.get("failure_kind") == "no_samples":
+                span.set_attribute("vibesensor.failure_kind", "no_samples")
+            return load_stage.terminal_result
+
+        loaded = load_stage.loaded
+        assert loaded is not None
         try:
-            load_result = load_run(run_id=run_id, db=db)
-        except (aiosqlite.Error, OSError, MemoryError) as exc:
-            mark_span_error(span, exc)
-            if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
-                return _retryable_failure_result(
-                    run_id=run_id,
-                    analysis_start=analysis_start,
-                    exc=exc,
-                )
-            return _persistence_failure_result(
-                run_id=run_id,
-                analysis_start=analysis_start,
-                exc=exc,
-                db=db,
-            )
+            input_stage = run_build_post_analysis_input_stage(loaded)
+            _log_stage_result(loaded.run_id, input_stage.stage_result)
 
-        if isinstance(load_result, MissingPostAnalysisMetadata):
-            span.set_attribute("vibesensor.failure_kind", "missing_metadata")
-            LOGGER.warning(
-                "Cannot analyse run %s: metadata not found",
-                run_id,
-                extra=log_extra(
-                    event="post_analysis_skipped",
-                    run_id=run_id,
-                    failure_kind="missing_metadata",
-                ),
-            )
-            return _store_load_error(
+            whole_run_stage = run_whole_run_pipeline_stages(
                 db=db,
-                run_id=run_id,
-                completed_error=load_result.error_message,
-                kind="missing_metadata",
+                loaded=loaded,
+                run_input=input_stage.run_input,
+                builders=resolved_builders,
             )
+            for stage_result in whole_run_stage.stage_results:
+                _log_stage_result(loaded.run_id, stage_result)
 
-        if isinstance(load_result, EmptyPostAnalysisSamples):
-            span.set_attribute("vibesensor.failure_kind", "no_samples")
-            LOGGER.warning(
-                "Skipping post-analysis for run %s: no samples collected",
-                run_id,
-                extra=log_extra(
-                    event="post_analysis_skipped",
-                    run_id=run_id,
-                    failure_kind="no_samples",
-                ),
-            )
-            return _store_load_error(
-                db=db,
-                run_id=run_id,
-                completed_error=load_result.error_message,
-                kind="no_samples",
-            )
-
-        loaded = load_result
-        try:
-            run_input = build_post_analysis_input(loaded)
-            stored_artifact_manifest: WholeRunArtifactManifest | None = None
-            spectral_result: WholeRunSpectralBuildResult | None = None
-            spectral_bundle: WholeRunSpectralArtifactBundle | None = None
-            context_bundle: WholeRunContextArtifactBundle | None = None
-            order_trace_bundle: WholeRunOrderTraceArtifactBundle | None = None
-            order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle | None = None
-            order_family_summary_bundle: WholeRunOrderFamilySummaryArtifactBundle | None = None
-            spatial_coherence_bundle: WholeRunSpatialCoherenceArtifactBundle | None = None
-            if loaded.raw_capture is not None:
-                spectral_result = resolved_whole_run_artifact_builder(
-                    run_id=loaded.run_id,
-                    metadata=loaded.metadata,
-                    raw_capture=loaded.raw_capture,
-                )
-                spectral_bundle = spectral_result.bundle
-            if loaded.raw_capture_manifest is not None:
-                if spectral_result is not None and spectral_result.window_plan is not None:
-                    context_bundle = resolved_whole_run_context_builder(
-                        run=run_input,
-                        window_plan=spectral_result.window_plan,
-                    )
-                else:
-                    context_bundle = resolved_whole_run_context_builder(
-                        run=run_input,
-                        total_sample_count=_whole_run_total_sample_count(
-                            loaded.raw_capture_manifest
-                        ),
-                    )
-                if spectral_bundle is not None and context_bundle is not None:
-                    order_trace_bundle = resolved_whole_run_order_trace_builder(
-                        run=run_input,
-                        spectral_bundle=spectral_bundle,
-                        context_bundle=context_bundle,
-                    )
-                if order_trace_bundle is not None and context_bundle is not None:
-                    order_trace_summary_bundle = resolved_whole_run_order_trace_summary_builder(
-                        order_trace_bundle=order_trace_bundle,
-                        context_bundle=context_bundle,
-                    )
-                if (
-                    order_trace_bundle is not None
-                    and order_trace_summary_bundle is not None
-                    and context_bundle is not None
-                ):
-                    order_family_summary_bundle = resolved_whole_run_order_family_summary_builder(
-                        order_trace_bundle=order_trace_bundle,
-                        order_trace_summary_bundle=order_trace_summary_bundle,
-                        context_bundle=context_bundle,
-                    )
-                if (
-                    spectral_bundle is not None
-                    and context_bundle is not None
-                    and order_trace_bundle is not None
-                ):
-                    spatial_coherence_bundle = resolved_whole_run_spatial_coherence_builder(
-                        run=run_input,
-                        spectral_bundle=spectral_bundle,
-                        context_bundle=context_bundle,
-                        order_trace_bundle=order_trace_bundle,
-                    )
-                merged_bundle = _merge_whole_run_artifact_bundles(
-                    spectral_bundle,
-                    context_bundle,
-                    order_trace_bundle,
-                    order_trace_summary_bundle,
-                    order_family_summary_bundle,
-                    spatial_coherence_bundle,
-                )
-                if merged_bundle is not None:
-                    stored_artifact_manifest = _sync_call(
-                        db,
-                        "astore_whole_run_artifacts",
-                        loaded.run_id,
-                        merged_bundle.manifest,
-                        artifact_contents=merged_bundle.artifact_contents,
-                    )
-                    if stored_artifact_manifest is None:
-                        raise OSError(
-                            f"Failed to persist whole-run artifacts for run {loaded.run_id}"
-                        )
+            run_input = input_stage.run_input
             span.set_attribute("vibesensor.sample_count", len(run_input.samples))
-            summary = _coerce_persisted_analysis(analysis_runner(run_input))
-            if spectral_result is not None:
-                summary = _append_whole_run_spectral_metadata(
-                    summary,
-                    spectral_result.coverage_summary,
-                    spectral_bundle=spectral_bundle,
-                )
-                summary = _append_run_context_warnings(
-                    summary,
-                    spectral_result.coverage_summary.warnings,
-                )
-            if context_bundle is not None:
-                summary = _append_whole_run_context(summary, context_bundle)
-            analysis_payload = summary.to_json_object()
-            analysis_metadata_payload = analysis_payload.get("analysis_metadata")
-            analysis_metadata = (
-                dict(analysis_metadata_payload)
-                if isinstance(analysis_metadata_payload, dict)
-                else {}
+            summary, report_facts_stage = run_build_report_facts_stage(
+                run_input=run_input,
+                analysis_runner=analysis_runner,
+                whole_run_output=whole_run_stage,
+                diagnosis_summary_builder=resolved_builders.diagnosis_summary_builder,
             )
-            if order_trace_bundle is not None:
-                summary = _append_whole_run_order_trace_metadata(summary, order_trace_bundle)
-            if order_trace_summary_bundle is not None:
-                summary = _append_whole_run_order_trace_summary_metadata(
-                    summary,
-                    order_trace_summary_bundle,
-                )
-            if order_family_summary_bundle is not None:
-                summary = _append_whole_run_order_summaries(summary, order_family_summary_bundle)
-            if order_family_summary_bundle is not None:
-                summary = _append_whole_run_order_family_summary_metadata(
-                    summary,
-                    order_family_summary_bundle,
-                )
-            if spatial_coherence_bundle is not None:
-                summary = _append_whole_run_spatial_summaries(
-                    summary,
-                    spatial_coherence_bundle,
-                )
-            if spatial_coherence_bundle is not None:
-                summary = _append_whole_run_spatial_coherence_metadata(
-                    summary,
-                    spatial_coherence_bundle,
-                )
-            if context_bundle is not None and order_family_summary_bundle is not None:
-                diagnosis_summaries = resolved_whole_run_diagnosis_summary_builder(
-                    analysis_metadata=analysis_metadata,
-                    context_bundle=context_bundle,
-                    order_summaries=_ranked_whole_run_order_summaries(
-                        order_family_summary_bundle.summaries
-                    ),
-                    spatial_summaries=(
-                        _ranked_whole_run_spatial_summaries(spatial_coherence_bundle.summaries)
-                        if spatial_coherence_bundle is not None
-                        else ()
-                    ),
-                )
-                if diagnosis_summaries:
-                    summary = _append_whole_run_diagnosis_summaries(summary, diagnosis_summaries)
-                    summary = _append_whole_run_diagnosis_summary_metadata(
-                        summary,
-                        diagnosis_summaries,
-                    )
-            if stored_artifact_manifest is not None:
-                summary = _append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
-            _sync_call(db, "astore_analysis", loaded.run_id, summary)
-        except (aiosqlite.Error, OSError, MemoryError) as exc:
-            mark_span_error(span, exc)
+            _log_stage_result(loaded.run_id, report_facts_stage)
+
+            persist_summary_stage = run_persist_analysis_summary_stage(
+                db=db,
+                run_id=loaded.run_id,
+                summary=summary,
+            )
+            _log_stage_result(loaded.run_id, persist_summary_stage)
+        except PostAnalysisStageFailure as stage_failure:
+            mark_span_error(span, stage_failure.cause)
+            span.set_attribute("vibesensor.failed_stage", stage_failure.stage_result.stage_name)
+            _log_stage_result(loaded.run_id, stage_failure.stage_result)
+            exc = stage_failure.cause
             if defer_retryable_error_storage and is_retryable_post_analysis_error(exc):
                 return _retryable_failure_result(
                     run_id=loaded.run_id,
                     analysis_start=analysis_start,
                     exc=exc,
+                    stage_name=stage_failure.stage_result.stage_name,
                 )
             return _persistence_failure_result(
                 run_id=loaded.run_id,
                 analysis_start=analysis_start,
                 exc=exc,
                 db=db,
+                stage_name=stage_failure.stage_result.stage_name,
             )
 
         duration_s = time.monotonic() - analysis_start
@@ -563,6 +1172,7 @@ def _retryable_failure_result(
     run_id: str,
     analysis_start: float,
     exc: BaseException,
+    stage_name: str | None = None,
 ) -> PostAnalysisExecutionRetryableFailure:
     duration_s = time.monotonic() - analysis_start
     LOGGER.warning(
@@ -576,6 +1186,7 @@ def _retryable_failure_result(
             run_id=run_id,
             duration_s=round(duration_s, 3),
             error_message=str(exc),
+            stage_name=stage_name,
         ),
     )
     return PostAnalysisExecutionRetryableFailure(
@@ -591,6 +1202,7 @@ def _persistence_failure_result(
     analysis_start: float,
     exc: BaseException,
     db: RunPersistence,
+    stage_name: str | None = None,
 ) -> PostAnalysisExecutionResult:
     duration_s = time.monotonic() - analysis_start
     callback_error = f"post-analysis failed for run {run_id}: {exc}"
@@ -605,6 +1217,7 @@ def _persistence_failure_result(
             run_id=run_id,
             duration_s=round(duration_s, 3),
             error_message=str(exc),
+            stage_name=stage_name,
         ),
     )
     completed_error = str(exc)
@@ -621,6 +1234,7 @@ def _persistence_failure_result(
                 event="post_analysis_error_persist_failed",
                 run_id=run_id,
                 error_message=str(store_exc),
+                stage_name=stage_name,
             ),
         )
         return PostAnalysisExecutionPersistenceFailure(


### PR DESCRIPTION
## Summary
medium

Make post-analysis executor run as explicit stages instead of one long orchestration block.

- add structured stage result/output types for load, input shaping, whole-run sidecars, and summary persistence
- turn `execute_post_analysis()` into a short coordinator over named stage helpers
- keep existing builders and summary assembly logic, but add stage-aware diagnostics and failure logging
- move direct stage tests into a dedicated pipeline test module so the old executor test file stays under repo size guardrails

## Why

Issue #3202 asks for explicit pipeline stages. The old executor owned too many responsibilities in one path, which made stage-level behavior harder to test and stage-specific failure context harder to see.

## Validation

- `python -m pytest -n 0 -q apps/server/tests/use_cases/run/test_post_analysis*.py apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs / edges

- behavior should stay the same at the public outcome level; risk is internal stage wiring drift
- unexpected non-retryable analysis failures still raise; retryable/persistence boundaries still map to the existing failure outcomes
- no API or contract changes in this PR

Closes #3202