### PR TITLE
Stream whole-run spectra chunk processing results

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_spectra_chunk_execution.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_spectra_chunk_execution.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+import time
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.use_cases.diagnostics import whole_run_spectra as spectra
+
+
+def _metadata() -> RunMetadata:
+    return run_metadata_from_mapping(
+        {
+            "run_id": "run-spectra",
+            "start_time_utc": "2025-01-01T00:00:00Z",
+            "sensor_model": "fixture-sensor",
+            "raw_sample_rate_hz": 8,
+            "sample_rate_hz": 8,
+            "feature_interval_s": 0.5,
+            "fft_window_size_samples": 8,
+            "accel_scale_g_per_lsb": 0.001,
+        }
+    )
+
+
+def _chunk(sensor_id: str, chunk_index: int) -> spectra._SpectralChunk:
+    return spectra._SpectralChunk(
+        sensor_data=SimpleNamespace(manifest=SimpleNamespace(client_id=sensor_id)),
+        timeline=None,
+        chunk_index=chunk_index,
+        windows=(),
+    )
+
+
+def _chunk_result(sensor_id: str, chunk_index: int) -> spectra._SpectralChunkResult:
+    return spectra._SpectralChunkResult(
+        sensor_id=sensor_id,
+        chunk_index=chunk_index,
+        freq_hz=(1.0,),
+        spectrum_rows=np.zeros((1, 1), dtype=np.float32),
+        summaries=(),
+    )
+
+
+def test_execute_chunks_preserves_input_order_while_logging_progress(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    chunks = tuple(_chunk("sensor-a", chunk_index) for chunk_index in range(3))
+
+    def fake_process_chunk(*, chunk, metadata):
+        time.sleep(0.02 if chunk.chunk_index == 0 else 0.0)
+        return _chunk_result(
+            sensor_id=chunk.sensor_data.manifest.client_id,
+            chunk_index=chunk.chunk_index,
+        )
+
+    monkeypatch.setattr(spectra, "_process_chunk", fake_process_chunk)
+
+    with caplog.at_level(logging.INFO, logger=spectra.LOGGER.name):
+        results = spectra._execute_chunks(
+            chunks=chunks,
+            metadata=_metadata(),
+            max_workers=2,
+        )
+
+    assert [result.chunk_index for result in results] == [0, 1, 2]
+    progress_records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "whole_run_spectral_chunk_progress"
+    ]
+    assert progress_records
+    assert progress_records[-1].completed_chunks == 3
+    assert progress_records[-1].total_chunks == 3
+
+
+def test_execute_chunks_raises_on_first_completed_failure_without_submitting_full_backlog(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    chunks = tuple(_chunk("sensor-a", chunk_index) for chunk_index in range(4))
+    started: list[int] = []
+
+    def fake_process_chunk(*, chunk, metadata):
+        started.append(chunk.chunk_index)
+        if chunk.chunk_index == 0:
+            time.sleep(0.05)
+            return _chunk_result(sensor_id=chunk.sensor_data.manifest.client_id, chunk_index=0)
+        if chunk.chunk_index == 1:
+            raise RuntimeError("chunk boom")
+        return _chunk_result(
+            sensor_id=chunk.sensor_data.manifest.client_id,
+            chunk_index=chunk.chunk_index,
+        )
+
+    monkeypatch.setattr(spectra, "_process_chunk", fake_process_chunk)
+
+    with caplog.at_level(logging.INFO, logger=spectra.LOGGER.name):
+        with pytest.raises(RuntimeError, match="chunk boom"):
+            spectra._execute_chunks(
+                chunks=chunks,
+                metadata=_metadata(),
+                max_workers=2,
+            )
+
+    assert 2 not in started
+    assert 3 not in started
+    failure_records = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "whole_run_spectral_chunk_failed"
+    ]
+    assert len(failure_records) == 1
+    assert failure_records[0].chunk_index == 1
+    assert failure_records[0].total_chunks == 4

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from io import BytesIO
 from typing import Literal, cast
@@ -26,6 +27,7 @@ from vibesensor.shared.run_context_warning import (
     WARNING_CODE_WHOLE_RUN_ALIGNMENT_INCOMPLETE,
     RunContextWarning,
 )
+from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.time_utils import utc_now_iso
 from vibesensor.shared.types.json_types import JsonObject, is_json_object
 from vibesensor.shared.types.raw_capture import (
@@ -44,6 +46,8 @@ from vibesensor.shared.types.whole_run_analysis import (
 )
 from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
 from vibesensor.vibration_strength import StrengthPeak
+
+LOGGER = logging.getLogger(__name__)
 
 DEFAULT_WHOLE_RUN_MAX_WORKERS = 1
 _DEFAULT_CHUNK_WINDOW_COUNT = 32
@@ -482,19 +486,95 @@ def _execute_chunks(
             )
             for chunk in chunks
         )
-    with ThreadPoolExecutor(
+    total_chunks = len(chunks)
+    max_pending_chunks = min(total_chunks, max(1, int(max_workers)))
+    ordered_results: list[_SpectralChunkResult | None] = [None] * total_chunks
+    pending: dict[Future[_SpectralChunkResult], int] = {}
+    next_chunk_position = 0
+    completed_chunks = 0
+    shutdown_wait = True
+    LOGGER.info(
+        "Starting whole-run spectral chunk executor for run %s with %s chunks",
+        metadata.run_id,
+        total_chunks,
+        extra=log_extra(
+            event="whole_run_spectral_chunk_executor_started",
+            run_id=metadata.run_id,
+            total_chunks=total_chunks,
+            max_workers=max_pending_chunks,
+        ),
+    )
+    pool = ThreadPoolExecutor(
         max_workers=max_workers,
         thread_name_prefix="vibesensor-whole-run",
-    ) as pool:
-        submitted = [
-            pool.submit(
-                _process_chunk,
-                chunk=chunk,
-                metadata=metadata,
+    )
+    try:
+        while pending or next_chunk_position < total_chunks:
+            while next_chunk_position < total_chunks and len(pending) < max_pending_chunks:
+                pending[
+                    pool.submit(
+                        _process_chunk,
+                        chunk=chunks[next_chunk_position],
+                        metadata=metadata,
+                    )
+                ] = next_chunk_position
+                next_chunk_position += 1
+            if not pending:
+                continue
+            done, _ = wait(tuple(pending), return_when=FIRST_COMPLETED)
+            batch_completed = 0
+            for future in done:
+                chunk_position = pending.pop(future)
+                chunk = chunks[chunk_position]
+                try:
+                    ordered_results[chunk_position] = future.result()
+                except Exception:
+                    for pending_future in pending:
+                        pending_future.cancel()
+                    LOGGER.warning(
+                        "Whole-run spectral chunk failed for run %s",
+                        metadata.run_id,
+                        extra=log_extra(
+                            event="whole_run_spectral_chunk_failed",
+                            run_id=metadata.run_id,
+                            sensor_id=chunk.sensor_data.manifest.client_id,
+                            chunk_index=chunk.chunk_index,
+                            chunk_position=chunk_position,
+                            completed_chunks=completed_chunks,
+                            total_chunks=total_chunks,
+                        ),
+                        exc_info=True,
+                    )
+                    shutdown_wait = False
+                    pool.shutdown(wait=False, cancel_futures=True)
+                    raise
+                batch_completed += 1
+            completed_chunks += batch_completed
+            LOGGER.info(
+                "Whole-run spectral chunk progress for run %s: %s/%s chunks complete",
+                metadata.run_id,
+                completed_chunks,
+                total_chunks,
+                extra=log_extra(
+                    event="whole_run_spectral_chunk_progress",
+                    run_id=metadata.run_id,
+                    completed_chunks=completed_chunks,
+                    batch_completed=batch_completed,
+                    total_chunks=total_chunks,
+                    active_chunks=len(pending),
+                    queued_chunks=(total_chunks - next_chunk_position),
+                ),
             )
-            for chunk in chunks
-        ]
-        return tuple(future.result() for future in submitted)
+        missing_results = [index for index, result in enumerate(ordered_results) if result is None]
+        if missing_results:
+            raise RuntimeError(
+                "whole-run spectral executor completed without results for "
+                f"chunk positions {missing_results}"
+            )
+        return tuple(cast(_SpectralChunkResult, result) for result in ordered_results)
+    finally:
+        if shutdown_wait:
+            pool.shutdown(wait=True)
 
 
 def _process_chunk(


### PR DESCRIPTION
## Summary
medium

Make whole-run spectra chunk execution stream results instead of submitting the full backlog first.

- keep only a bounded in-flight chunk set in the thread pool
- consume completed chunks as they finish, log chunk progress, and re-raise the first completed chunk failure with chunk context
- keep returned chunk results in deterministic input order so downstream artifact assembly stays stable
- add focused executor tests for ordering, progress logging, and prompt failure surfacing

## Why

Issue #3203 calls out the batch-style executor path in `whole_run_spectra.py`. The old code submitted every chunk before collecting any result, which delayed failure visibility and let executor backlog grow with total chunk count.

## Validation

- `python -m pytest -n 0 -q apps/server/tests/use_cases/diagnostics/test_whole_run_*.py apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_*.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs / edges

- chunk workers already running when a failure surfaces may finish in the background, but new backlog submission stops immediately and pending futures are cancelled
- final artifact semantics stay deterministic because `_execute_chunks()` still returns results in original input order
- no spectral math or output schema changes in this PR

Closes #3203