### PR TITLE
Fix firmware sample timing drift for non-divisor sample rates

### DIFF
--- a/firmware/esp/lib/reliability/reliability.h
+++ b/firmware/esp/lib/reliability/reliability.h
@@ -19,6 +19,38 @@ constexpr uint16_t clamp_sample_rate(uint16_t configured_hz,
              : (configured_hz > max_hz ? max_hz : configured_hz);
 }
 
+struct SamplingIntervalSchedule {
+  uint32_t sample_rate_hz = 0;
+  uint64_t base_interval_us = 0;
+  uint32_t remainder_us = 0;
+  uint32_t accumulated_remainder_us = 0;
+};
+
+inline SamplingIntervalSchedule make_sampling_interval_schedule(uint32_t sample_rate_hz) {
+  SamplingIntervalSchedule schedule{};
+  schedule.sample_rate_hz = sample_rate_hz;
+  if (sample_rate_hz == 0U) {
+    return schedule;
+  }
+  schedule.base_interval_us = 1000000ULL / sample_rate_hz;
+  schedule.remainder_us = static_cast<uint32_t>(1000000ULL % sample_rate_hz);
+  return schedule;
+}
+
+inline uint64_t sampling_schedule_advance_us(SamplingIntervalSchedule& schedule,
+                                             uint64_t slot_count = 1U) {
+  if (slot_count == 0U || schedule.sample_rate_hz == 0U) {
+    return 0;
+  }
+  const uint64_t total_remainder =
+      static_cast<uint64_t>(schedule.accumulated_remainder_us) +
+      (static_cast<uint64_t>(schedule.remainder_us) * slot_count);
+  const uint64_t carry_us = total_remainder / schedule.sample_rate_hz;
+  schedule.accumulated_remainder_us =
+      static_cast<uint32_t>(total_remainder % schedule.sample_rate_hz);
+  return (schedule.base_interval_us * slot_count) + carry_us;
+}
+
 inline uint64_t sampling_slots_due(uint64_t now_us,
                                    uint64_t next_due_us,
                                    uint64_t step_us) {
@@ -26,6 +58,21 @@ inline uint64_t sampling_slots_due(uint64_t now_us,
     return 0;
   }
   return ((now_us - next_due_us) / step_us) + 1;
+}
+
+inline uint64_t sampling_slots_due(uint64_t now_us,
+                                   uint64_t next_due_us,
+                                   SamplingIntervalSchedule schedule) {
+  if (schedule.sample_rate_hz == 0U || next_due_us == 0U || now_us < next_due_us) {
+    return 0;
+  }
+  uint64_t due_slots = 1;
+  uint64_t candidate_due_us = next_due_us + sampling_schedule_advance_us(schedule);
+  while (candidate_due_us <= now_us) {
+    due_slots++;
+    candidate_due_us += sampling_schedule_advance_us(schedule);
+  }
+  return due_slots;
 }
 
 enum class SensorFailureClass : uint8_t {

--- a/firmware/esp/src/runtime_sampling.cpp
+++ b/firmware/esp/src/runtime_sampling.cpp
@@ -389,12 +389,15 @@ size_t current_handoff_headroom(SamplingState& state) {
   return free_slots;
 }
 
+uint64_t advance_due_schedule(SamplingState& state, uint64_t slot_count = 1U) {
+  return vibesensor::reliability::sampling_schedule_advance_us(state.due_schedule, slot_count);
+}
+
 void process_due_samples(SamplingState& state, uint32_t due_slots) {
   if (due_slots == 0) {
     return;
   }
 
-  const uint64_t step_us = 1000000ULL / kSampleRateHz;
   maybe_refill_sensor_prefetch(state, due_slots);
   const vibesensor::reliability::SamplingRecoveryPlan recovery =
       vibesensor::reliability::sampling_recovery_plan(due_slots,
@@ -410,11 +413,11 @@ void process_due_samples(SamplingState& state, uint32_t due_slots) {
     if (!sample_once(state, remaining_due, &sample) || !publish_sample(state, sample)) {
       const uint32_t missed_samples = static_cast<uint32_t>(remaining_due);
       note_missed_samples(state, missed_samples, remaining_due > 1);
-      state.next_sample_due_us += static_cast<uint64_t>(missed_samples) * step_us;
+      state.next_sample_due_us += advance_due_schedule(state, missed_samples);
       return;
     }
     produced++;
-    state.next_sample_due_us += step_us;
+    state.next_sample_due_us += advance_due_schedule(state);
   }
 
   if (recovery.missed_slots > 0) {
@@ -422,14 +425,26 @@ void process_due_samples(SamplingState& state, uint32_t due_slots) {
         state,
         static_cast<uint32_t>(recovery.missed_slots),
         vibesensor::reliability::sampling_recovery_abandoned(recovery.missed_slots));
-    state.next_sample_due_us += static_cast<uint64_t>(recovery.missed_slots) * step_us;
+    state.next_sample_due_us += advance_due_schedule(state, recovery.missed_slots);
   }
 }
 
 void sampling_timer_callback(void* arg) {
-  (void)arg;
+  auto& state = *static_cast<SamplingState*>(arg);
   if (g_sampling_task_handle != nullptr) {
     xTaskNotifyGive(g_sampling_task_handle);
+  }
+  if (g_sampling_timer_handle == nullptr) {
+    return;
+  }
+  const uint64_t next_step_us =
+      vibesensor::reliability::sampling_schedule_advance_us(state.timer_schedule);
+  if (next_step_us == 0U) {
+    return;
+  }
+  const esp_err_t rearm_err = esp_timer_start_once(g_sampling_timer_handle, next_step_us);
+  if (rearm_err != ESP_OK) {
+    Serial.printf("WARN: failed to rearm sampling timer (%d)\n", static_cast<int>(rearm_err));
   }
 }
 
@@ -480,8 +495,13 @@ bool begin_sampling(SamplingState& state) {
                 static_cast<int>(xPortGetCoreID()),
                 kSamplingTaskCore);
 
-  const uint64_t step_us = 1000000ULL / kSampleRateHz;
-  state.next_sample_due_us = esp_timer_get_time() + step_us;
+  state.due_schedule = vibesensor::reliability::make_sampling_interval_schedule(kSampleRateHz);
+  state.timer_schedule = vibesensor::reliability::make_sampling_interval_schedule(kSampleRateHz);
+  const uint64_t first_due_step_us =
+      vibesensor::reliability::sampling_schedule_advance_us(state.due_schedule);
+  const uint64_t first_timer_step_us =
+      vibesensor::reliability::sampling_schedule_advance_us(state.timer_schedule);
+  state.next_sample_due_us = esp_timer_get_time() + first_due_step_us;
 
   esp_timer_create_args_t timer_args = {};
   timer_args.callback = &sampling_timer_callback;
@@ -497,7 +517,7 @@ bool begin_sampling(SamplingState& state) {
     return false;
   }
 
-  const esp_err_t start_err = esp_timer_start_periodic(g_sampling_timer_handle, step_us);
+  const esp_err_t start_err = esp_timer_start_once(g_sampling_timer_handle, first_timer_step_us);
   if (start_err != ESP_OK) {
     Serial.printf("WARN: failed to start sampling timer (%d)\n", static_cast<int>(start_err));
     esp_timer_delete(g_sampling_timer_handle);

--- a/firmware/esp/src/runtime_sampling.h
+++ b/firmware/esp/src/runtime_sampling.h
@@ -4,6 +4,7 @@
 #include <Wire.h>
 
 #include "adxl345.h"
+#include "reliability.h"
 #include "runtime_config.h"
 #include "runtime_queue.h"
 #include "runtime_sample_handoff.h"
@@ -25,6 +26,8 @@ struct SamplingState {
   uint8_t sensor_consecutive_errors = 0;
   uint32_t last_sensor_reinit_ms = 0;
   uint64_t next_sample_due_us = 0;
+  vibesensor::reliability::SamplingIntervalSchedule due_schedule = {};
+  vibesensor::reliability::SamplingIntervalSchedule timer_schedule = {};
   size_t last_refill_request = 0;
   size_t last_refill_count = 0;
   bool recent_refill_shortfall = false;

--- a/firmware/esp/test/native_support/esp_timer.h
+++ b/firmware/esp/test/native_support/esp_timer.h
@@ -27,6 +27,8 @@ inline esp_err_t esp_timer_create(const esp_timer_create_args_t*, esp_timer_hand
   return ESP_OK;
 }
 
+inline esp_err_t esp_timer_start_once(esp_timer_handle_t, uint64_t) { return ESP_OK; }
+
 inline esp_err_t esp_timer_start_periodic(esp_timer_handle_t, uint64_t) { return ESP_OK; }
 
 inline esp_err_t esp_timer_delete(esp_timer_handle_t) { return ESP_OK; }

--- a/firmware/esp/test/test_loop_timing/test_main.cpp
+++ b/firmware/esp/test/test_loop_timing/test_main.cpp
@@ -13,7 +13,6 @@ namespace {
 using vibesensor::runtime::PendingSample;
 using vibesensor::runtime::SampleHandoffState;
 
-constexpr uint64_t kStepUs = 1000000ULL / vibesensor::runtime::kSampleRateHz;
 constexpr uint64_t kRunDurationUs = 12000000ULL;
 constexpr uint64_t kStatusSpikeIntervalUs = 10000000ULL;
 constexpr uint32_t kPreLoopWorkUs = 120;
@@ -45,9 +44,15 @@ struct ProducerState {
   size_t last_refill_request = 0;
   size_t last_refill_count = 0;
   bool recent_refill_shortfall = false;
-  uint64_t next_due_us = kStepUs;
+  vibesensor::reliability::SamplingIntervalSchedule due_schedule =
+      vibesensor::reliability::make_sampling_interval_schedule(vibesensor::runtime::kSampleRateHz);
+  uint64_t next_due_us = 0;
   uint64_t producer_now_us = 0;
 };
+
+void initialize_schedule(ProducerState& state) {
+  state.next_due_us = vibesensor::reliability::sampling_schedule_advance_us(state.due_schedule);
+}
 
 void update_refill_metrics(SimulationMetrics& metrics, size_t refill_count) {
   if (refill_count == 0) {
@@ -142,14 +147,15 @@ void produce_due_slots(ProducerState& state,
 
     metrics.samples_produced++;
     state.producer_now_us += kProduceSampleCostUs;
-    state.next_due_us += kStepUs;
+    state.next_due_us += vibesensor::reliability::sampling_schedule_advance_us(state.due_schedule);
     produced++;
   }
 
   const size_t missed_slots = due_slots - produced;
   if (missed_slots > 0) {
     metrics.missed_samples += missed_slots;
-    state.next_due_us += static_cast<uint64_t>(missed_slots) * kStepUs;
+    state.next_due_us +=
+        vibesensor::reliability::sampling_schedule_advance_us(state.due_schedule, missed_slots);
   }
   metrics.handoff_overflow_drops = state.handoff.overflow_drops;
 }
@@ -164,7 +170,7 @@ void advance_dedicated_producer_to(uint64_t wall_time_us,
     const size_t due_slots = static_cast<size_t>(vibesensor::reliability::sampling_slots_due(
         state.producer_now_us,
         state.next_due_us,
-        kStepUs));
+        state.due_schedule));
     produce_due_slots(state, due_slots, true, metrics);
   }
 }
@@ -178,6 +184,7 @@ void drain_handoff(ProducerState& state, SimulationMetrics& metrics) {
 
 SimulationMetrics run_cooperative_simulation() {
   ProducerState state{};
+  initialize_schedule(state);
   SimulationMetrics metrics{};
   uint64_t loop_now_us = 0;
   uint64_t next_status_spike_us = kStatusSpikeIntervalUs;
@@ -190,7 +197,7 @@ SimulationMetrics run_cooperative_simulation() {
       const size_t due_slots = static_cast<size_t>(vibesensor::reliability::sampling_slots_due(
           state.producer_now_us,
           state.next_due_us,
-          kStepUs));
+          state.due_schedule));
       produce_due_slots(state, due_slots, false, metrics);
       loop_now_us = state.producer_now_us;
     }
@@ -209,6 +216,7 @@ SimulationMetrics run_cooperative_simulation() {
 
 SimulationMetrics run_dedicated_simulation() {
   ProducerState state{};
+  initialize_schedule(state);
   SimulationMetrics metrics{};
   uint64_t loop_now_us = 0;
   uint64_t next_status_spike_us = kStatusSpikeIntervalUs;

--- a/firmware/esp/test/test_sampling_schedule/test_main.cpp
+++ b/firmware/esp/test/test_sampling_schedule/test_main.cpp
@@ -1,0 +1,55 @@
+#include <unity.h>
+
+#include "reliability.h"
+
+namespace {
+
+void test_divisor_rate_schedule_stays_exact() {
+  auto schedule = vibesensor::reliability::make_sampling_interval_schedule(800);
+  uint64_t total_elapsed_us = 0;
+
+  for (size_t i = 0; i < 800; ++i) {
+    const uint64_t step_us = vibesensor::reliability::sampling_schedule_advance_us(schedule);
+    TEST_ASSERT_EQUAL_UINT64(1250, step_us);
+    total_elapsed_us += step_us;
+  }
+
+  TEST_ASSERT_EQUAL_UINT64(1000000ULL, total_elapsed_us);
+}
+
+void test_non_divisor_rate_schedule_distributes_fractional_remainder_without_drift() {
+  auto schedule = vibesensor::reliability::make_sampling_interval_schedule(3200);
+  uint64_t total_elapsed_us = 0;
+
+  TEST_ASSERT_EQUAL_UINT64(312, vibesensor::reliability::sampling_schedule_advance_us(schedule));
+  TEST_ASSERT_EQUAL_UINT64(313, vibesensor::reliability::sampling_schedule_advance_us(schedule));
+  TEST_ASSERT_EQUAL_UINT64(312, vibesensor::reliability::sampling_schedule_advance_us(schedule));
+  TEST_ASSERT_EQUAL_UINT64(313, vibesensor::reliability::sampling_schedule_advance_us(schedule));
+
+  total_elapsed_us += 1250;
+  for (size_t i = 4; i < 3200; ++i) {
+    total_elapsed_us += vibesensor::reliability::sampling_schedule_advance_us(schedule);
+  }
+
+  TEST_ASSERT_EQUAL_UINT64(1000000ULL, total_elapsed_us);
+}
+
+void test_non_divisor_rate_due_slots_follow_fractional_schedule() {
+  auto schedule = vibesensor::reliability::make_sampling_interval_schedule(3200);
+  const uint64_t next_due_us = vibesensor::reliability::sampling_schedule_advance_us(schedule);
+
+  TEST_ASSERT_EQUAL_UINT64(0, vibesensor::reliability::sampling_slots_due(311, next_due_us, schedule));
+  TEST_ASSERT_EQUAL_UINT64(1, vibesensor::reliability::sampling_slots_due(624, next_due_us, schedule));
+  TEST_ASSERT_EQUAL_UINT64(2, vibesensor::reliability::sampling_slots_due(625, next_due_us, schedule));
+  TEST_ASSERT_EQUAL_UINT64(4, vibesensor::reliability::sampling_slots_due(1250, next_due_us, schedule));
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  UNITY_BEGIN();
+  RUN_TEST(test_divisor_rate_schedule_stays_exact);
+  RUN_TEST(test_non_divisor_rate_schedule_distributes_fractional_remainder_without_drift);
+  RUN_TEST(test_non_divisor_rate_due_slots_follow_fractional_schedule);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary
medium

Make firmware sampling cadence exact even when the target sample rate does not divide 1,000,000 microseconds cleanly.

- add a shared fractional-aware sampling interval schedule in firmware reliability helpers
- switch runtime sampling from a truncated periodic timer to one-shot rearming that follows that schedule for both timer wakeups and due timestamps
- update the loop-timing model to use the same schedule math and add focused schedule tests that cover exact 800 Hz and non-divisor 3200 Hz behavior

## Why

Issue #3204 calls out the integer `1000000 / sample_rate_hz` truncation in firmware sampling. The old code used that truncated interval for both `next_sample_due_us` and the ESP timer period, so non-divisor rates could never stay on the true average cadence.

## Validation

- `cd firmware/esp && python -m platformio test -e native`
- `cd firmware/esp && python -m platformio run`

## Risks / tradeoffs / edges

- one-shot timer rearming is a behavior change in the live scheduler, so the main risk is timer restart failure; the code now logs explicit rearm/start failures
- exact cadence now depends on the shared schedule helper, so the loop-timing model and live runtime both use the same source of truth
- no transport or protocol payload changes in this PR

Closes #3204