### PR TITLE
Use spectrum frame fingerprints in the UI hot path

### DIFF
--- a/apps/server/tests/adapters/websocket/test_ws_models.py
+++ b/apps/server/tests/adapters/websocket/test_ws_models.py
@@ -59,7 +59,13 @@ def test_schema_export_check_passes() -> None:
     }
 
     spectra = parsed["$defs"]["SpectraPayload"]
-    assert set(spectra["properties"]) == {"alignment", "clients", "freq", "warning"}
+    assert set(spectra["properties"]) == {
+        "alignment",
+        "clients",
+        "frame_fingerprint",
+        "freq",
+        "warning",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/tests/infra/processing/test_processing_extended.py
+++ b/apps/server/tests/infra/processing/test_processing_extended.py
@@ -226,6 +226,28 @@ def test_multi_spectrum_payload_compares_freq_axes_without_np_asarray(
     assert result["freq"]
 
 
+def test_multi_spectrum_payload_fingerprint_is_order_stable_and_changes_with_new_compute() -> None:
+    proc = _make_processor(sample_rate_hz=200, fft_n=128, spectrum_max_hz=100)
+    samples = _random_samples(300)
+
+    proc.ingest("c1", samples, sample_rate_hz=200)
+    proc.ingest("c2", samples, sample_rate_hz=200)
+    proc.compute_metrics("c1", sample_rate_hz=200)
+    proc.compute_metrics("c2", sample_rate_hz=200)
+
+    first = proc.multi_spectrum_payload(["c1", "c2"])
+    reordered = proc.multi_spectrum_payload(["c2", "c1"])
+
+    assert first["frame_fingerprint"] == reordered["frame_fingerprint"]
+
+    proc.ingest("c1", samples, sample_rate_hz=200)
+    proc.compute_metrics("c1", sample_rate_hz=200)
+
+    updated = proc.multi_spectrum_payload(["c1", "c2"])
+
+    assert updated["frame_fingerprint"] != first["frame_fingerprint"]
+
+
 def test_multi_spectrum_payload_skips_allclose_for_shared_freq_object(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/server/tests/infra/runtime/test_ws_payload_projection.py
+++ b/apps/server/tests/infra/runtime/test_ws_payload_projection.py
@@ -40,6 +40,7 @@ def _build_projector() -> tuple[LiveWsPayloadProjector, MagicMock, MagicMock, Ma
     processor = MagicMock()
     processor.clients_with_recent_data.return_value = ["aaaaaaaaaaaa"]
     processor.multi_spectrum_payload.return_value = {
+        "frame_fingerprint": "aaaaaaaaaaaa:0:0:0",
         "freq": [],
         "clients": {"aaaaaaaaaaaa": {}},
     }
@@ -72,6 +73,7 @@ def test_build_shared_payload_projects_live_rows_without_broadcaster() -> None:
     assert payload["clients"][0]["name"] == "front-left"
     assert payload["rotational_speeds"]["basis_speed_source"] == "gps"
     assert "spectra" in payload
+    assert payload["spectra"]["frame_fingerprint"] == "aaaaaaaaaaaa:0:0:0"
     registry.client_snapshots.assert_called_once_with(
         now=None,
         now_mono=None,

--- a/apps/server/vibesensor/infra/processing/payload.py
+++ b/apps/server/vibesensor/infra/processing/payload.py
@@ -51,6 +51,21 @@ def _axis_data_or_empty(
     return latest_spectrum.get(axis, {"freq": _EMPTY_F32, "amp": _EMPTY_F32})
 
 
+def _build_spectrum_frame_fingerprint(
+    buffers: dict[str, ClientBuffer],
+    client_ids: list[str],
+) -> str:
+    parts: list[str] = []
+    for client_id in sorted(dict.fromkeys(client_ids)):
+        buf = buffers.get(client_id)
+        if buf is None or not buf.latest_spectrum:
+            continue
+        parts.append(
+            f"{client_id}:{buf.buffer_epoch}:{buf.reset_generation}:{buf.spectrum_generation}"
+        )
+    return "|".join(parts)
+
+
 def build_spectrum_payload(buf: ClientBuffer) -> SpectrumSeriesPayload:
     """Build a per-client spectrum payload from the buffer's cached spectrum.
 
@@ -228,6 +243,7 @@ def build_multi_spectrum_payload(
         shared_freq_list = float_list(shared_freq) if shared_freq is not None else []
 
     payload: SpectraPayload = {
+        "frame_fingerprint": _build_spectrum_frame_fingerprint(buffers, client_ids),
         "freq": shared_freq_list,
         "clients": clients,
     }

--- a/apps/server/vibesensor/shared/types/payload_types.py
+++ b/apps/server/vibesensor/shared/types/payload_types.py
@@ -101,6 +101,7 @@ class FrequencyWarningPayload(TypedDict):
 
 
 class SpectraPayload(TypedDict, total=False):
+    frame_fingerprint: str
     freq: list[float]
     clients: dict[str, SpectrumSeriesPayload]
     alignment: AlignmentInfoPayload

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -4,6 +4,7 @@ import type {
   AdaptedClient,
   AdaptedPayload,
   RotationalSpeeds,
+  SpectrumFrameData,
   SpectrumClientData,
 } from "../transport/live_models";
 import { defaultLocationCodes } from "../constants";
@@ -148,7 +149,7 @@ export interface ChartBand {
 }
 
 export interface SpectrumTickUpdate {
-  spectra: { clients: Record<string, SpectrumClientData> };
+  spectra: SpectrumFrameData;
   hasSpectrumData: boolean;
   hasNewSpectrumFrame: boolean;
 }
@@ -165,8 +166,14 @@ export interface LivePayloadUpdateResult {
   hasNewSpectrumFrame: boolean;
 }
 
-function hasRenderableSpectrumData(spectra: { clients: Record<string, SpectrumClientData> }): boolean {
+function hasRenderableSpectrumData(spectra: SpectrumFrameData): boolean {
   return Object.values(spectra.clients).some((clientSpec) => clientSpec.freq.length > 0 && clientSpec.combined.length > 0);
+}
+
+function hasSpectrumFingerprint(
+  spectra: SpectrumFrameData,
+): spectra is SpectrumFrameData & { frame_fingerprint: string } {
+  return typeof spectra.frame_fingerprint === "string";
 }
 
 function areNumberArraysEqual(left: readonly number[], right: readonly number[]): boolean {
@@ -221,8 +228,8 @@ function areSpectrumClientDataEqual(left: SpectrumClientData, right: SpectrumCli
 }
 
 export function areSpectrumFramesEqual(
-  left: { clients: Record<string, SpectrumClientData> },
-  right: { clients: Record<string, SpectrumClientData> },
+  left: SpectrumFrameData,
+  right: SpectrumFrameData,
 ): boolean {
   const leftClientIds = Object.keys(left.clients);
   const rightClientIds = Object.keys(right.clients);
@@ -240,15 +247,29 @@ export function areSpectrumFramesEqual(
 }
 
 export function applySpectrumTick(
-  previousSpectra: { clients: Record<string, SpectrumClientData> },
+  previousSpectra: SpectrumFrameData,
   previousHasSpectrumData: boolean,
-  incomingSpectra: { clients: Record<string, SpectrumClientData> } | null,
+  incomingSpectra: SpectrumFrameData | null,
 ): SpectrumTickUpdate {
   if (!incomingSpectra) {
     return {
       spectra: previousSpectra,
       hasSpectrumData: previousHasSpectrumData,
       hasNewSpectrumFrame: false,
+    };
+  }
+  if (hasSpectrumFingerprint(previousSpectra) && hasSpectrumFingerprint(incomingSpectra)) {
+    if (previousSpectra.frame_fingerprint === incomingSpectra.frame_fingerprint) {
+      return {
+        spectra: previousSpectra,
+        hasSpectrumData: previousHasSpectrumData,
+        hasNewSpectrumFrame: false,
+      };
+    }
+    return {
+      spectra: incomingSpectra,
+      hasSpectrumData: hasRenderableSpectrumData(incomingSpectra),
+      hasNewSpectrumFrame: true,
     };
   }
   if (areSpectrumFramesEqual(previousSpectra, incomingSpectra)) {
@@ -370,7 +391,7 @@ export interface SpeedSettingsValue {
 
 export interface SpectrumStateValue {
   spectrumPlot: SpectrumChart | null;
-  spectra: { clients: Record<string, SpectrumClientData> };
+  spectra: SpectrumFrameData;
   chartBands: ChartBand[];
   hasSpectrumData: boolean;
   chartLoading: boolean;
@@ -465,7 +486,7 @@ export function createAppState(): AppState {
     },
     spectrum: {
       spectrumPlot: signal<SpectrumChart | null>(null),
-      spectra: signal<{ clients: Record<string, SpectrumClientData> }>({ clients: {} }),
+      spectra: signal<SpectrumFrameData>({ clients: {} }),
       chartBands: signal<ChartBand[]>([]),
       hasSpectrumData: signal(false),
       chartLoading: signal(false),

--- a/apps/ui/src/contracts/ws_payload_schema.json
+++ b/apps/ui/src/contracts/ws_payload_schema.json
@@ -359,6 +359,10 @@
           "title": "Clients",
           "type": "object"
         },
+        "frame_fingerprint": {
+          "title": "Frame Fingerprint",
+          "type": "string"
+        },
         "freq": {
           "items": {
             "type": "number"

--- a/apps/ui/src/server_payload.ts
+++ b/apps/ui/src/server_payload.ts
@@ -2,7 +2,12 @@ import {
   EXPECTED_SCHEMA_VERSION,
   type LiveWsPayload,
 } from "./contracts/ws_payload_types";
-import type { AdaptedClient, AdaptedPayload, SpectrumClientData } from "./transport/live_models";
+import type {
+  AdaptedClient,
+  AdaptedPayload,
+  SpectrumClientData,
+  SpectrumFrameData,
+} from "./transport/live_models";
 import { validateLiveWsPayload } from "./ws_payload_validator";
 
 function hasCompleteSpectrumData(
@@ -33,7 +38,13 @@ function adaptSpectra(spectra: LiveWsPayload["spectra"]): AdaptedPayload["spectr
     };
   }
 
-  return { clients: adaptedClients };
+  const adaptedSpectra: SpectrumFrameData = {
+    clients: adaptedClients,
+  };
+  if (typeof spectra.frame_fingerprint === "string") {
+    adaptedSpectra.frame_fingerprint = spectra.frame_fingerprint;
+  }
+  return adaptedSpectra;
 }
 
 let schemaWarningLogged = false;

--- a/apps/ui/src/transport/live_models.ts
+++ b/apps/ui/src/transport/live_models.ts
@@ -15,6 +15,11 @@ export interface SpectrumClientData {
   combined: number[];
 }
 
+export interface SpectrumFrameData {
+  frame_fingerprint?: string | null;
+  clients: Record<string, SpectrumClientData>;
+}
+
 export type AdaptedClient = Pick<
   WsClientInfo,
   | "id"
@@ -36,7 +41,5 @@ export interface AdaptedPayload {
   clients: AdaptedClient[];
   speed_mps: number | null;
   rotational_speeds: RotationalSpeeds | null;
-  spectra: {
-    clients: Record<string, SpectrumClientData>;
-  } | null;
+  spectra: SpectrumFrameData | null;
 }

--- a/apps/ui/src/ws_payload_validator.ts
+++ b/apps/ui/src/ws_payload_validator.ts
@@ -106,6 +106,7 @@ const alignmentSchema = v.looseObject({
 });
 
 const spectraSchema = v.looseObject({
+  frame_fingerprint: v.optional(v.string()),
   freq: v.optional(finiteNumberArraySchema),
   clients: v.optional(v.record(v.string(), spectrumSeriesSchema)),
   warning: v.optional(warningSchema),

--- a/apps/ui/tests/ui_live_payload_application.spec.ts
+++ b/apps/ui/tests/ui_live_payload_application.spec.ts
@@ -149,4 +149,55 @@ describe("applyLivePayloadUpdate", () => {
     expect(state.spectrum.spectra.value).toBe(previousSpectra);
     expect(update.hasNewSpectrumFrame).toBe(false);
   });
+
+  test("treats a new frame fingerprint as a new spectrum frame without deep equality fallback", () => {
+    const state = createAppState();
+    const previousSpectra = {
+      frame_fingerprint: "client-1:0:0:1",
+      clients: {
+        "client-1": {
+          freq: [1, 2, 3],
+          combined: [0.01, 0.02, 0.03],
+          strength_metrics: {
+            vibration_strength_db: 5,
+            peak_amp_g: 0,
+            noise_floor_amp_g: 0,
+            strength_bucket: null,
+            top_peaks: [],
+          },
+        },
+      },
+    };
+    state.spectrum.spectra.value = previousSpectra;
+    state.spectrum.hasSpectrumData.value = true;
+
+    const incomingSpectra = {
+      frame_fingerprint: "client-1:0:0:2",
+      clients: {
+        "client-1": {
+          freq: [1, 2, 3],
+          combined: [0.01, 0.02, 0.03],
+          strength_metrics: {
+            vibration_strength_db: 5,
+            peak_amp_g: 0,
+            noise_floor_amp_g: 0,
+            strength_bucket: null,
+            top_peaks: [],
+          },
+        },
+      },
+    };
+
+    const update = applyLivePayloadUpdate({
+      realtime: state.realtime,
+      spectrum: state.spectrum,
+      adaptedPayload: makeAdaptedPayload({
+        clients: [makeClient("client-1")],
+        spectra: incomingSpectra,
+      }),
+    });
+
+    expect(state.spectrum.spectra.value).toBe(incomingSpectra);
+    expect(update.hasNewSpectrumFrame).toBe(true);
+  });
 });

--- a/apps/ui/tests/ws_contract.spec.ts
+++ b/apps/ui/tests/ws_contract.spec.ts
@@ -149,6 +149,7 @@ describe("shared freq optimization", () => {
     const adapted = adaptServerPayload({
       ...basePayload,
       spectra: {
+        frame_fingerprint: "sensor1:0:0:1|sensor2:1:0:2",
         freq: [10, 20, 30],
         clients: {
           sensor1: {
@@ -165,6 +166,7 @@ describe("shared freq optimization", () => {
       },
     });
     const spectra = requireSpectra(adapted);
+    expect(spectra.frame_fingerprint).toBe("sensor1:0:0:1|sensor2:1:0:2");
     expect(spectra.clients.sensor1.freq).toEqual([10, 20, 30]);
     expect(spectra.clients.sensor2.freq).toEqual([10, 20, 30]);
     expect(spectra.clients.sensor1.strength_metrics.peak_amp_g).toBe(0);

--- a/apps/ui/tests/ws_payload_validator.spec.ts
+++ b/apps/ui/tests/ws_payload_validator.spec.ts
@@ -47,6 +47,7 @@ describe("validateLiveWsPayload", () => {
       validateLiveWsPayload({
         ...basePayload,
         spectra: {
+          frame_fingerprint: "sensor-1:0:0:1",
           freq: [10, 20, 30],
           clients: {
             "sensor-1": {
@@ -59,6 +60,7 @@ describe("validateLiveWsPayload", () => {
     ).toMatchObject({
       schema_version: "1",
       clients: [{ id: "sensor-1" }],
+      spectra: { frame_fingerprint: "sensor-1:0:0:1" },
     });
   });
 
@@ -132,5 +134,16 @@ describe("validateLiveWsPayload", () => {
         },
       }),
     ).toThrow(/Invalid websocket payload: \/rotational_speeds\/order_bands\/0\/tolerance/);
+  });
+
+  test("reports malformed spectrum frame fingerprint", () => {
+    expect(() =>
+      validateLiveWsPayload({
+        ...basePayload,
+        spectra: {
+          frame_fingerprint: 123,
+        },
+      }),
+    ).toThrow(/Invalid websocket payload: \/spectra\/frame_fingerprint/);
   });
 });


### PR DESCRIPTION
Closes #3206

## What changed
- add a backend-owned `spectra.frame_fingerprint` built from per-client buffer epoch, reset generation, and spectrum generation
- thread the fingerprint through the WS schema and UI payload adapter
- make `applySpectrumTick()` trust fingerprinted frames first, with deep equality kept only as fallback for payloads that do not carry fingerprint metadata yet
- add backend and UI coverage for fingerprint stability, validator/schema wiring, and duplicate-vs-new frame behavior

## Why
- the live UI hot path was still deep-comparing full frequency and amplitude arrays on normal ticks
- backend already owns the real spectrum lifecycle, so frame identity belongs there too
- this keeps the common path O(1) on frame identity instead of O(N) over bins

## Validation
- `make sync-contracts`
- `.venv/bin/python -m pytest -q apps/server/tests/infra/runtime/test_ws_payload_projection.py apps/server/tests/infra/processing/test_processing_extended.py`
- `cd apps/ui && npm exec vitest run tests/ws_contract.spec.ts tests/ws_payload_validator.spec.ts tests/ui_live_payload_application.spec.ts tests/cycle2_fixes.spec.ts`
- `make typecheck-backend`
- `make ui-typecheck`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`

## Risks / tradeoffs
- fingerprint trust is intentional: if backend emits a reused fingerprint for changed data, UI will reuse the old frame
- fallback deep compare stays for legacy/no-fingerprint payloads only; normal fingerprinted ticks no longer pay that cost
- schema JSON changes are tracked; generated TS contract files stay generated, not committed
