### PR TITLE
Generate shared analysis defaults for backend and UI

### DIFF
--- a/apps/server/tests/hygiene/test_analysis_settings_sync.py
+++ b/apps/server/tests/hygiene/test_analysis_settings_sync.py
@@ -7,31 +7,29 @@ import re
 from tests._paths import REPO_ROOT
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 
+_UI_CONSTANTS_TS = REPO_ROOT / "apps" / "ui" / "src" / "constants.ts"
 _UI_APP_STATE_TS = REPO_ROOT / "apps" / "ui" / "src" / "app" / "ui_app_state.ts"
 
 
-def _parse_ts_numeric_block(name: str, type_name: str) -> dict[str, float]:
-    """Extract a numeric object literal block from ui_app_state.ts."""
-    text = _UI_APP_STATE_TS.read_text()
+def _parse_generated_numeric_export(name: str) -> dict[str, float]:
+    """Extract a numeric object literal export from constants.ts."""
+    text = _UI_CONSTANTS_TS.read_text()
     match = re.search(
-        rf"{name}:\s*Readonly<{type_name}>\s*=\s*\{{([^}}]+)\}}",
+        rf"export const {name}\s*=\s*\{{([^}}]+)\}} as const;",
         text,
         re.DOTALL,
     )
-    assert match, f"Could not find {name} block in ui_app_state.ts"
+    assert match, f"Could not find {name} export in constants.ts"
     block = match.group(1)
     pairs: dict[str, float] = {}
-    for line_match in re.finditer(r"(\w+):\s*([0-9.]+)", block):
+    for line_match in re.finditer(r'"?(\w+)"?:\s*([0-9.]+)', block):
         pairs[line_match.group(1)] = float(line_match.group(2))
     return pairs
 
 
 def _parse_ui_vehicle_defaults() -> dict[str, float]:
-    """Extract the composed vehicle defaults from ui_app_state.ts."""
-    return {
-        **_parse_ts_numeric_block("defaultCarAspectSettings", "CarAspectSettings"),
-        **_parse_ts_numeric_block("defaultAnalysisTuningSettings", "AnalysisTuningSettings"),
-    }
+    """Extract the generated backend-owned vehicle defaults from constants.ts."""
+    return _parse_generated_numeric_export("defaultAnalysisSettings")
 
 
 def _parse_ts_string_array(name: str) -> list[str]:

--- a/apps/server/tests/hygiene/test_analysis_settings_sync.py
+++ b/apps/server/tests/hygiene/test_analysis_settings_sync.py
@@ -3,23 +3,35 @@
 from __future__ import annotations
 
 import re
+import subprocess
+import sys
 
 from tests._paths import REPO_ROOT
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 
-_UI_CONSTANTS_TS = REPO_ROOT / "apps" / "ui" / "src" / "constants.ts"
 _UI_APP_STATE_TS = REPO_ROOT / "apps" / "ui" / "src" / "app" / "ui_app_state.ts"
+_GENERATOR = REPO_ROOT / "tools" / "config" / "generate_ui_shared_constants.py"
+
+
+def _generated_constants_ts() -> str:
+    result = subprocess.run(
+        [sys.executable, str(_GENERATOR)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
 
 
 def _parse_generated_numeric_export(name: str) -> dict[str, float]:
-    """Extract a numeric object literal export from constants.ts."""
-    text = _UI_CONSTANTS_TS.read_text()
+    """Extract a numeric object literal export from generated constants output."""
+    text = _generated_constants_ts()
     match = re.search(
         rf"export const {name}\s*=\s*\{{([^}}]+)\}} as const;",
         text,
         re.DOTALL,
     )
-    assert match, f"Could not find {name} export in constants.ts"
+    assert match, f"Could not find {name} export in generated constants output"
     block = match.group(1)
     pairs: dict[str, float] = {}
     for line_match in re.finditer(r'"?(\w+)"?:\s*([0-9.]+)', block):

--- a/apps/server/tests/hygiene/test_location_codes_sync.py
+++ b/apps/server/tests/hygiene/test_location_codes_sync.py
@@ -8,8 +8,18 @@ import subprocess
 import sys
 
 from tests._paths import REPO_ROOT
+from vibesensor.app.config_defaults import documented_default_config
+from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 from vibesensor.domain.sensor import _LOCATION_CODES as DOMAIN_LOCATION_CODES
+from vibesensor.shared.constants.dsp import FFT_N, SPECTRUM_MAX_HZ, SPECTRUM_MIN_HZ
 from vibesensor.shared.locations import LOCATION_CODES
+from vibesensor.vibration_strength import (
+    CALIBRATION_PROFILE_ID,
+    PEAK_BANDWIDTH_HZ,
+    PEAK_DETECTOR_VERSION,
+    PEAK_SEPARATION_HZ,
+    STRENGTH_ALGORITHM_VERSION,
+)
 
 _GENERATOR = REPO_ROOT / "tools" / "config" / "generate_ui_shared_constants.py"
 
@@ -37,9 +47,36 @@ def _extract_export_json(module_text: str, export_name: str) -> object:
 def test_generated_ui_constants_encode_backend_locations() -> None:
     """The shared constants generator must reflect backend location literals only."""
     generated = _generated_constants_ts()
-    assert "export const METRIC_FIELDS" not in generated
-    assert "export const LOCATION_CODES" not in generated
     assert _extract_export_json(generated, "defaultLocationCodes") == list(LOCATION_CODES.keys())
+
+
+def test_generated_ui_constants_encode_backend_analysis_defaults() -> None:
+    """Generated UI defaults must come from backend analysis-settings defaults."""
+    generated = _generated_constants_ts()
+    assert _extract_export_json(generated, "defaultAnalysisSettings") == (
+        AnalysisSettingsSnapshot.DEFAULTS
+    )
+
+
+def test_generated_ui_constants_encode_backend_live_analysis_config() -> None:
+    """Generated live-analysis constants must stay aligned with backend owners."""
+    generated = _generated_constants_ts()
+    config = documented_default_config()
+    processing = config.get("processing")
+    assert isinstance(processing, dict)
+    sample_rate_hz = processing.get("sample_rate_hz")
+    assert isinstance(sample_rate_hz, (int, float))
+    assert _extract_export_json(generated, "defaultLiveAnalysisConfig") == {
+        "sampleRateHz": sample_rate_hz,
+        "fftWindowSizeSamples": FFT_N,
+        "spectrumMinHz": SPECTRUM_MIN_HZ,
+        "spectrumMaxHz": SPECTRUM_MAX_HZ,
+        "peakBandwidthHz": PEAK_BANDWIDTH_HZ,
+        "peakSeparationHz": PEAK_SEPARATION_HZ,
+        "strengthAlgorithmVersion": STRENGTH_ALGORITHM_VERSION,
+        "peakDetectorVersion": PEAK_DETECTOR_VERSION,
+        "calibrationProfileId": CALIBRATION_PROFILE_ID,
+    }
 
 
 def test_domain_location_codes_match_shared() -> None:

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -322,7 +322,7 @@ budget, attach the analyzer output to the PR review and explain the growth.
 | `diagnostics.ts` | Strength band normalization and vibration matrix helpers |
 | `vehicle_math.ts` | Tire diameter, order tolerance, and uncertainty calculations |
 | `format.ts` | Number, byte, and timestamp formatting utilities |
-| `constants.ts` | Generated sensor location codes and shared strength field names from backend sources |
+| `constants.ts` | Generated backend-owned UI constants such as sensor location codes, analysis defaults, and live-analysis metadata |
 | `theme.ts` | Chart color palette and order band fill colors |
 | `styles/app.css` | Thin stylesheet aggregator that imports the UI style modules in cascade order |
 | `styles/{tokens,shell,components,maintenance-*,realtime-*,history-*,settings-*,adaptive,theme}.css` | Shared tokens/primitives plus feature-scoped and cross-cutting style ownership for shell, updater, realtime, history, settings, responsive, and theme overrides |

--- a/apps/ui/src/app/demo_mode.ts
+++ b/apps/ui/src/app/demo_mode.ts
@@ -1,3 +1,4 @@
+import { defaultLiveAnalysisConfig } from "../constants";
 import { EXPECTED_LIVE_PAYLOAD_SCHEMA_VERSION } from "../transport/live_models";
 import { composeVehicleSettings, type AppState } from "./ui_app_state";
 import { batch } from "./ui_signals";
@@ -15,6 +16,8 @@ declare global {
 
 export function runDemoMode(deps: DemoDeps): void {
   const { state } = deps;
+  const demoSampleRateHz = defaultLiveAnalysisConfig.sampleRateHz;
+  const spectrumMaxHz = defaultLiveAnalysisConfig.spectrumMaxHz;
 
   const demoClients = [
     {
@@ -28,7 +31,7 @@ export function runDemoMode(deps: DemoDeps): void {
       frame_samples: 200,
       location_code: "front_left_wheel",
       firmware_version: "demo-1.0.0",
-      sample_rate_hz: 800,
+      sample_rate_hz: demoSampleRateHz,
     },
     {
       id: "aabbcc001133",
@@ -41,7 +44,7 @@ export function runDemoMode(deps: DemoDeps): void {
       frame_samples: 200,
       location_code: "front_right_wheel",
       firmware_version: "demo-1.0.0",
-      sample_rate_hz: 800,
+      sample_rate_hz: demoSampleRateHz,
     },
     {
       id: "aabbcc001144",
@@ -54,7 +57,7 @@ export function runDemoMode(deps: DemoDeps): void {
       frame_samples: 200,
       location_code: "rear_left_wheel",
       firmware_version: "demo-1.0.0",
-      sample_rate_hz: 800,
+      sample_rate_hz: demoSampleRateHz,
     },
     {
       id: "aabbcc001155",
@@ -67,7 +70,7 @@ export function runDemoMode(deps: DemoDeps): void {
       frame_samples: 200,
       location_code: "rear_right_wheel",
       firmware_version: "demo-1.0.0",
-      sample_rate_hz: 800,
+      sample_rate_hz: demoSampleRateHz,
     },
     {
       id: "aabbcc001166",
@@ -80,12 +83,12 @@ export function runDemoMode(deps: DemoDeps): void {
       frame_samples: 200,
       location_code: "engine_bay",
       firmware_version: "demo-1.0.0",
-      sample_rate_hz: 800,
+      sample_rate_hz: demoSampleRateHz,
     },
   ];
 
   const freqCount = 256;
-  const freqArr = Array.from({ length: freqCount }, (_, i) => (i / freqCount) * 250);
+  const freqArr = Array.from({ length: freqCount }, (_, i) => (i / freqCount) * spectrumMaxHz);
 
   function sineSpectrum(baseAmps: number[], peakHz: number, peakAmp: number): number[] {
     return freqArr.map((hz, i) => {

--- a/apps/ui/src/app/ui_app_state.ts
+++ b/apps/ui/src/app/ui_app_state.ts
@@ -7,7 +7,7 @@ import type {
   SpectrumFrameData,
   SpectrumClientData,
 } from "../transport/live_models";
-import { defaultLocationCodes } from "../constants";
+import { defaultAnalysisSettings, defaultLocationCodes } from "../constants";
 import type {
   CarRecord,
   HistoryEntry,
@@ -42,30 +42,27 @@ export interface AnalysisTuningSettings {
 export interface VehicleSettings extends CarAspectSettings, AnalysisTuningSettings {}
 
 export const defaultCarAspectSettings: Readonly<CarAspectSettings> = {
-  tire_width_mm: 285.0,
-  tire_aspect_pct: 30.0,
-  rim_in: 21.0,
-  final_drive_ratio: 3.08,
-  current_gear_ratio: 0.64,
-  tire_deflection_factor: 0.97,
+  tire_width_mm: defaultAnalysisSettings.tire_width_mm,
+  tire_aspect_pct: defaultAnalysisSettings.tire_aspect_pct,
+  rim_in: defaultAnalysisSettings.rim_in,
+  final_drive_ratio: defaultAnalysisSettings.final_drive_ratio,
+  current_gear_ratio: defaultAnalysisSettings.current_gear_ratio,
+  tire_deflection_factor: defaultAnalysisSettings.tire_deflection_factor,
 };
 
 export const defaultAnalysisTuningSettings: Readonly<AnalysisTuningSettings> = {
-  wheel_bandwidth_pct: 5.0,
-  driveshaft_bandwidth_pct: 4.5,
-  engine_bandwidth_pct: 5.2,
-  speed_uncertainty_pct: 1.0,
-  tire_diameter_uncertainty_pct: 1.0,
-  final_drive_uncertainty_pct: 0.1,
-  gear_uncertainty_pct: 0.2,
-  min_abs_band_hz: 0.2,
-  max_band_half_width_pct: 6.0,
+  wheel_bandwidth_pct: defaultAnalysisSettings.wheel_bandwidth_pct,
+  driveshaft_bandwidth_pct: defaultAnalysisSettings.driveshaft_bandwidth_pct,
+  engine_bandwidth_pct: defaultAnalysisSettings.engine_bandwidth_pct,
+  speed_uncertainty_pct: defaultAnalysisSettings.speed_uncertainty_pct,
+  tire_diameter_uncertainty_pct: defaultAnalysisSettings.tire_diameter_uncertainty_pct,
+  final_drive_uncertainty_pct: defaultAnalysisSettings.final_drive_uncertainty_pct,
+  gear_uncertainty_pct: defaultAnalysisSettings.gear_uncertainty_pct,
+  min_abs_band_hz: defaultAnalysisSettings.min_abs_band_hz,
+  max_band_half_width_pct: defaultAnalysisSettings.max_band_half_width_pct,
 };
 
-export const defaultVehicleSettings: Readonly<VehicleSettings> = {
-  ...defaultCarAspectSettings,
-  ...defaultAnalysisTuningSettings,
-};
+export const defaultVehicleSettings: Readonly<VehicleSettings> = defaultAnalysisSettings;
 
 export const carAspectSettingKeys = [
   "tire_width_mm",

--- a/apps/ui/tests/demo_mode.spec.ts
+++ b/apps/ui/tests/demo_mode.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test } from "vitest";
+import { defaultLiveAnalysisConfig } from "../src/constants";
 import { runDemoMode } from "../src/app/demo_mode";
 import { createAppState } from "../src/app/ui_app_state";
 import { adaptServerPayload } from "../src/server_payload";
@@ -28,6 +29,11 @@ describe("runDemoMode", () => {
     expect(state.transport.hasReceivedPayload.value).toBe(false);
     expect(state.transport.pendingPayload.value).toBeNull();
     expect(adaptedPayload.clients).toHaveLength(5);
+    expect(
+      adaptedPayload.clients.every(
+        (client) => client.sample_rate_hz === defaultLiveAnalysisConfig.sampleRateHz,
+      ),
+    ).toBe(true);
     expect(adaptedPayload.spectra?.clients[selectedClientId]).toMatchObject({
       freq: expect.any(Array),
       combined: expect.any(Array),

--- a/apps/ui/tests/ui_app_state.spec.ts
+++ b/apps/ui/tests/ui_app_state.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { defaultAnalysisSettings } from "../src/constants";
 import {
   createAppState,
 } from "../src/app/ui_app_state";
@@ -74,6 +75,15 @@ describe("ui_app_state reactivity", () => {
     expect(seenRatios).toEqual([0.64, 0.72]);
 
     dispose();
+  });
+
+  test("hydrates vehicle defaults from generated backend constants", () => {
+    const state = createAppState();
+
+    expect({
+      ...state.settings.car.activeVehicleSettings.value,
+      ...state.settings.analysis.vehicleSettings.value,
+    }).toEqual(defaultAnalysisSettings);
   });
 
   test("keeps slice notifications isolated", () => {

--- a/tools/config/generate_ui_shared_constants.py
+++ b/tools/config/generate_ui_shared_constants.py
@@ -1,4 +1,4 @@
-"""Generate frontend constants from shared backend location definitions."""
+"""Generate frontend constants from shared backend-owned definitions."""
 
 from __future__ import annotations
 
@@ -10,7 +10,14 @@ from typing import TypeGuard
 
 ROOT = Path(__file__).resolve().parents[2]
 SHARED_ROOT = ROOT / "apps" / "server" / "vibesensor" / "shared"
+DOMAIN_ROOT = ROOT / "apps" / "server" / "vibesensor" / "domain"
+APP_ROOT = ROOT / "apps" / "server" / "vibesensor" / "app"
+SERVER_ROOT = ROOT / "apps" / "server" / "vibesensor"
 LOCATIONS_PATH = SHARED_ROOT / "locations.py"
+ANALYSIS_SETTINGS_PATH = DOMAIN_ROOT / "analysis_settings.py"
+DSP_CONSTANTS_PATH = SHARED_ROOT / "constants" / "dsp.py"
+CONFIG_DEFAULTS_PATH = APP_ROOT / "config_defaults.py"
+VIBRATION_STRENGTH_PATH = SERVER_ROOT / "vibration_strength.py"
 
 
 def _is_string_dict(value: object) -> TypeGuard[dict[str, str]]:
@@ -19,7 +26,16 @@ def _is_string_dict(value: object) -> TypeGuard[dict[str, str]]:
     )
 
 
-def _load_dict_constant(module_path: Path, constant_name: str) -> dict[str, str]:
+def _is_numeric_dict(value: object) -> TypeGuard[dict[str, int | float]]:
+    return isinstance(value, dict) and all(
+        isinstance(key, str)
+        and isinstance(item, (int, float))
+        and not isinstance(item, bool)
+        for key, item in value.items()
+    )
+
+
+def _load_literal_constant(module_path: Path, constant_name: str) -> object:
     tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
     for node in tree.body:
         value_node: ast.expr | None = None
@@ -38,21 +54,102 @@ def _load_dict_constant(module_path: Path, constant_name: str) -> dict[str, str]
                     break
         if value_node is None:
             continue
-        value = ast.literal_eval(value_node)
-        if not _is_string_dict(value):
-            msg = f"{module_path}::{constant_name} must be a dict[str, str] literal"
-            raise ValueError(msg)
-        return dict(value)
+        return ast.literal_eval(value_node)
     msg = f"Could not find {constant_name} in {module_path}"
     raise ValueError(msg)
 
 
+def _load_string_dict_constant(module_path: Path, constant_name: str) -> dict[str, str]:
+    value = _load_literal_constant(module_path, constant_name)
+    if not _is_string_dict(value):
+        msg = f"{module_path}::{constant_name} must be a dict[str, str] literal"
+        raise ValueError(msg)
+    return dict(value)
+
+
+def _load_numeric_dict_constant(
+    module_path: Path, constant_name: str
+) -> dict[str, int | float]:
+    value = _load_literal_constant(module_path, constant_name)
+    if not _is_numeric_dict(value):
+        msg = f"{module_path}::{constant_name} must be a dict[str, number] literal"
+        raise ValueError(msg)
+    return dict(value)
+
+
+def _load_number_constant(module_path: Path, constant_name: str) -> int | float:
+    value = _load_literal_constant(module_path, constant_name)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        msg = f"{module_path}::{constant_name} must be a numeric literal"
+        raise ValueError(msg)
+    return value
+
+
+def _load_string_constant(module_path: Path, constant_name: str) -> str:
+    value = _load_literal_constant(module_path, constant_name)
+    if not isinstance(value, str):
+        msg = f"{module_path}::{constant_name} must be a string literal"
+        raise ValueError(msg)
+    return value
+
+
+def _load_processing_sample_rate_hz() -> int | float:
+    value = _load_literal_constant(CONFIG_DEFAULTS_PATH, "DEFAULT_CONFIG")
+    if not isinstance(value, dict):
+        msg = f"{CONFIG_DEFAULTS_PATH}::DEFAULT_CONFIG must be a dict literal"
+        raise ValueError(msg)
+    processing = value.get("processing")
+    if not isinstance(processing, dict):
+        msg = f"{CONFIG_DEFAULTS_PATH}::DEFAULT_CONFIG['processing'] must be a dict literal"
+        raise ValueError(msg)
+    sample_rate_hz = processing.get("sample_rate_hz")
+    if not isinstance(sample_rate_hz, (int, float)) or isinstance(sample_rate_hz, bool):
+        msg = (
+            f"{CONFIG_DEFAULTS_PATH}::DEFAULT_CONFIG['processing']['sample_rate_hz'] "
+            "must be numeric"
+        )
+        raise ValueError(msg)
+    return sample_rate_hz
+
+
+def _render_export(name: str, value: object) -> str:
+    return f"export const {name} = {json.dumps(value, indent=2)} as const;\n"
+
+
 def render_ui_shared_constants_module() -> str:
-    location_codes = _load_dict_constant(LOCATIONS_PATH, "LOCATION_CODES")
+    location_codes = _load_string_dict_constant(LOCATIONS_PATH, "LOCATION_CODES")
+    analysis_settings = _load_numeric_dict_constant(
+        ANALYSIS_SETTINGS_PATH, "ANALYSIS_SETTINGS_DEFAULTS"
+    )
+    live_analysis_config = {
+        "sampleRateHz": _load_processing_sample_rate_hz(),
+        "fftWindowSizeSamples": _load_number_constant(DSP_CONSTANTS_PATH, "FFT_N"),
+        "spectrumMinHz": _load_number_constant(DSP_CONSTANTS_PATH, "SPECTRUM_MIN_HZ"),
+        "spectrumMaxHz": _load_number_constant(DSP_CONSTANTS_PATH, "SPECTRUM_MAX_HZ"),
+        "peakBandwidthHz": _load_number_constant(
+            VIBRATION_STRENGTH_PATH, "PEAK_BANDWIDTH_HZ"
+        ),
+        "peakSeparationHz": _load_number_constant(
+            VIBRATION_STRENGTH_PATH, "PEAK_SEPARATION_HZ"
+        ),
+        "strengthAlgorithmVersion": _load_string_constant(
+            VIBRATION_STRENGTH_PATH, "STRENGTH_ALGORITHM_VERSION"
+        ),
+        "peakDetectorVersion": _load_string_constant(
+            VIBRATION_STRENGTH_PATH, "PEAK_DETECTOR_VERSION"
+        ),
+        "calibrationProfileId": _load_string_constant(
+            VIBRATION_STRENGTH_PATH, "CALIBRATION_PROFILE_ID"
+        ),
+    }
     return (
-        "// Generated from apps/server/vibesensor/shared/locations.py\n"
+        "// Generated from backend-owned shared constants\n"
         "// Do not edit manually; run make sync-contracts\n\n"
-        f"export const defaultLocationCodes = {json.dumps(list(location_codes.keys()), indent=2)} as const;\n"
+        + _render_export("defaultLocationCodes", list(location_codes.keys()))
+        + "\n"
+        + _render_export("defaultAnalysisSettings", analysis_settings)
+        + "\n"
+        + _render_export("defaultLiveAnalysisConfig", live_analysis_config)
     )
 
 


### PR DESCRIPTION
## What changed
- extend the existing UI shared-constants generator to emit backend-owned analysis defaults plus live-analysis metadata: sample rate, FFT/spectrum bounds, peak defaults, and interpretation version ids
- remove handwritten UI copies of vehicle and analysis default numbers from `ui_app_state.ts`; the UI now builds its default slices from generated backend values
- make demo mode use generated live-analysis defaults for client sample rate and spectrum range
- replace the old regex drift guard with backend tests that validate generated constants output directly, plus focused UI tests that prove app-state/demo-mode defaults consume the generated values

## Why
- backend already owned the real defaults in Python, but the UI carried a second handwritten numeric copy
- that meant drift was prevented by a brittle regex test instead of an actual shared source
- this change makes `make sync-contracts` the one path for backend-to-UI default propagation

## Validation
- `make sync-contracts`
- `.venv/bin/python -m pytest -q apps/server/tests/hygiene/test_location_codes_sync.py apps/server/tests/hygiene/test_analysis_settings_sync.py`
- `cd apps/ui && npm run test:unit -- --run tests/ui_app_state.spec.ts tests/demo_mode.spec.ts`
- `make typecheck-backend`
- `make ui-typecheck`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`

## Risks / tradeoffs
- `apps/ui/src/constants.ts` stays generated and gitignored by design; the PR changes the generator and consumers, not the local derivative artifact
- UI still owns field grouping (`car` vs `analysis tuning`) because that is presentation/runtime structure, but it no longer owns the underlying numeric defaults
- pre-existing non-blocking UI Biome warnings still exist outside this scope

## Follow-ups / out of scope
- no new runtime API surface added here
- no broader refactor of every potential analysis-related UI constant; this PR fixes the concrete duplicated default path and live demo defaults first

Closes #3208
