### PR TITLE
Split whole-run builders and projection helpers

### DIFF
--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_spectral_projection.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_spectral_projection.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spectral_projection import (
+    WholeRunWindowSpectralSummary,
+    whole_run_spectral_summaries_by_sensor,
+    whole_run_window_spectral_summaries_from_jsonl_bytes,
+    whole_run_window_spectral_summaries_to_jsonl_bytes,
+)
+
+
+def _window_policy() -> WholeRunWindowPolicy:
+    return WholeRunWindowPolicy(
+        sample_rate_hz=800,
+        window_size_samples=2048,
+        stride_samples=200,
+        overlap_samples=1848,
+        feature_interval_s=0.25,
+    )
+
+
+def test_spectral_projection_summary_jsonl_round_trips() -> None:
+    summaries = (
+        WholeRunWindowSpectralSummary(
+            window_index=0,
+            coverage_state="full",
+            returned_sample_start=0,
+            returned_sample_count=2048,
+            dominant_freq_hz=14.5,
+            vibration_strength_db=11.2,
+            strength_peak_amp_g=0.21,
+            strength_floor_amp_g=0.03,
+            strength_bucket="moderate",
+        ),
+        WholeRunWindowSpectralSummary(
+            window_index=1,
+            coverage_state="partial",
+            returned_sample_start=200,
+            returned_sample_count=1900,
+            coverage_reason="gap",
+        ),
+    )
+
+    payload = whole_run_window_spectral_summaries_to_jsonl_bytes(summaries)
+
+    assert whole_run_window_spectral_summaries_from_jsonl_bytes(payload) == summaries
+
+
+def test_spectral_projection_groups_summary_rows_by_sensor() -> None:
+    summaries = (
+        WholeRunWindowSpectralSummary(
+            window_index=0,
+            coverage_state="full",
+            returned_sample_start=0,
+            returned_sample_count=2048,
+        ),
+        WholeRunWindowSpectralSummary(
+            window_index=1,
+            coverage_state="missing",
+            returned_sample_start=None,
+            returned_sample_count=0,
+            coverage_reason="sensor_missing",
+        ),
+    )
+    manifest = WholeRunArtifactManifest(
+        run_id="run-1",
+        relative_dir="whole-run-artifacts/run-1",
+        window_policy=_window_policy(),
+        total_window_count=2,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-a",
+                relative_path="spectra/sensor-a/windows.jsonl",
+                file_format="jsonl",
+                record_count=2,
+                sensor_id="sensor-a",
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+
+    grouped = whole_run_spectral_summaries_by_sensor(
+        manifest=manifest,
+        artifact_contents={
+            "spectral-summary:sensor-a": whole_run_window_spectral_summaries_to_jsonl_bytes(
+                summaries
+            )
+        },
+    )
+
+    assert grouped == {"sensor-a": summaries}

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_builders.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_builders.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.run.post_analysis_whole_run_builders import (
+    StoredWholeRunArtifactBundle,
+    merge_whole_run_artifact_bundles,
+)
+
+
+def _window_policy() -> WholeRunWindowPolicy:
+    return WholeRunWindowPolicy(
+        sample_rate_hz=800,
+        window_size_samples=2048,
+        stride_samples=200,
+        overlap_samples=1848,
+        feature_interval_s=0.25,
+    )
+
+
+def _bundle(*, artifact_key: str, relative_path: str) -> StoredWholeRunArtifactBundle:
+    manifest = WholeRunArtifactManifest(
+        run_id="run-1",
+        relative_dir="whole-run-artifacts/run-1",
+        window_policy=_window_policy(),
+        total_window_count=4,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key=artifact_key,
+                relative_path=relative_path,
+                file_format="jsonl",
+                record_count=4,
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+    return StoredWholeRunArtifactBundle(
+        manifest=manifest,
+        artifact_contents={artifact_key: artifact_key.encode("utf-8")},
+    )
+
+
+def test_merge_whole_run_artifact_bundles_combines_manifests_and_bytes() -> None:
+    merged = merge_whole_run_artifact_bundles(
+        _bundle(artifact_key="spectral-summary:sensor-a", relative_path="spectra/a.jsonl"),
+        _bundle(artifact_key="context-labels", relative_path="context/labels.jsonl"),
+    )
+
+    assert merged is not None
+    assert [artifact.artifact_key for artifact in merged.manifest.artifacts] == [
+        "spectral-summary:sensor-a",
+        "context-labels",
+    ]
+    assert merged.artifact_contents == {
+        "spectral-summary:sensor-a": b"spectral-summary:sensor-a",
+        "context-labels": b"context-labels",
+    }
+
+
+def test_merge_whole_run_artifact_bundles_rejects_duplicate_keys() -> None:
+    with pytest.raises(ValueError, match="must not reuse artifact keys"):
+        merge_whole_run_artifact_bundles(
+            _bundle(artifact_key="shared", relative_path="first.jsonl"),
+            _bundle(artifact_key="shared", relative_path="second.jsonl"),
+        )

--- a/apps/server/tests/use_cases/run/test_post_analysis_whole_run_projection.py
+++ b/apps/server/tests/use_cases/run/test_post_analysis_whole_run_projection.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from test_support.persisted_analysis import make_persisted_analysis
+
+from vibesensor.shared.run_context_warning import RunContextWarning
+from vibesensor.shared.types.whole_run_analysis import (
+    WholeRunArtifactFile,
+    WholeRunArtifactManifest,
+    WholeRunWindowPolicy,
+)
+from vibesensor.use_cases.run.post_analysis_whole_run_projection import (
+    append_run_context_warnings,
+    append_whole_run_analysis_metadata,
+)
+
+
+def _window_policy() -> WholeRunWindowPolicy:
+    return WholeRunWindowPolicy(
+        sample_rate_hz=800,
+        window_size_samples=2048,
+        stride_samples=200,
+        overlap_samples=1848,
+        feature_interval_s=0.25,
+    )
+
+
+def test_append_whole_run_analysis_metadata_records_sensor_and_artifact_counts() -> None:
+    summary = make_persisted_analysis({"analysis_metadata": {}})
+    manifest = WholeRunArtifactManifest(
+        run_id="run-1",
+        relative_dir="whole-run-artifacts/run-1",
+        window_policy=_window_policy(),
+        total_window_count=4,
+        artifacts=(
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-a",
+                relative_path="spectra/sensor-a/windows.jsonl",
+                file_format="jsonl",
+                record_count=4,
+                sensor_id="sensor-a",
+            ),
+            WholeRunArtifactFile(
+                artifact_key="spectral-summary:sensor-b",
+                relative_path="spectra/sensor-b/windows.jsonl",
+                file_format="jsonl",
+                record_count=4,
+                sensor_id="sensor-b",
+            ),
+            WholeRunArtifactFile(
+                artifact_key="context-labels",
+                relative_path="context/window-labels.jsonl",
+                file_format="jsonl",
+                record_count=4,
+            ),
+        ),
+        created_at="2025-01-01T00:00:00Z",
+    )
+
+    result = append_whole_run_analysis_metadata(summary, manifest).to_json_object()
+
+    assert result["analysis_metadata"] == {
+        "whole_run_artifacts_available": True,
+        "whole_run_window_count": 4,
+        "whole_run_sensor_count": 2,
+        "whole_run_artifact_count": 3,
+    }
+
+
+def test_append_run_context_warnings_preserves_existing_warning_rows() -> None:
+    summary = make_persisted_analysis(
+        {
+            "warnings": [
+                {
+                    "code": "existing",
+                    "severity": "warn",
+                    "applies_to": "order_analysis",
+                    "title": "Existing",
+                }
+            ]
+        }
+    )
+
+    result = append_run_context_warnings(
+        summary,
+        (
+            RunContextWarning(
+                code="whole_run_alignment_incomplete",
+                severity="warn",
+                applies_to="whole_run",
+                title="Whole-run warning",
+                detail="Incomplete alignment",
+            ),
+        ),
+    ).to_json_object()
+
+    assert result["warnings"] == [
+        {
+            "code": "existing",
+            "severity": "warn",
+            "applies_to": "order_analysis",
+            "title": "Existing",
+        },
+        {
+            "code": "whole_run_alignment_incomplete",
+            "severity": "warn",
+            "applies_to": "whole_run",
+            "title": "Whole-run warning",
+            "detail": "Incomplete alignment",
+        },
+    ]

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectra.py
@@ -8,28 +8,20 @@ from collections.abc import Mapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Literal, cast
+from typing import cast
 
 import numpy as np
 
 from vibesensor.shared.constants.dsp import SPECTRUM_MAX_HZ, SPECTRUM_MIN_HZ
 from vibesensor.shared.fft_analysis import SpectralAnalysisComputer, float_list, medfilt3
-from vibesensor.shared.json_utils import i18n_ref, safe_json_dumps, safe_json_loads
 from vibesensor.shared.raw_capture_timeline import (
     RawSensorTimeline,
     assemble_raw_window_samples,
     build_raw_sensor_timeline,
-    raw_timeline_has_unverified_sync,
-    raw_timeline_is_legacy,
     resolve_raw_window_end_time,
-)
-from vibesensor.shared.run_context_warning import (
-    WARNING_CODE_WHOLE_RUN_ALIGNMENT_INCOMPLETE,
-    RunContextWarning,
 )
 from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.time_utils import utc_now_iso
-from vibesensor.shared.types.json_types import JsonObject, is_json_object
 from vibesensor.shared.types.raw_capture import (
     RawCaptureCoverageState,
     RawCaptureSensorData,
@@ -44,6 +36,14 @@ from vibesensor.shared.types.whole_run_analysis import (
     WholeRunWindowDescriptor,
     WholeRunWindowPolicy,
 )
+from vibesensor.use_cases.diagnostics.whole_run_spectral_projection import (
+    WholeRunSpectralCoverageSummary,
+    WholeRunWindowSpectralSummary,
+    build_coverage_summary,
+    whole_run_spectral_summaries_by_sensor,
+    whole_run_window_spectral_summaries_from_jsonl_bytes,
+    whole_run_window_spectral_summaries_to_jsonl_bytes,
+)
 from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
 from vibesensor.vibration_strength import StrengthPeak
 
@@ -51,7 +51,6 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_WHOLE_RUN_MAX_WORKERS = 1
 _DEFAULT_CHUNK_WINDOW_COUNT = 32
-type WholeRunCoverageConfidence = Literal["full", "partial", "unavailable"]
 
 __all__ = [
     "WholeRunSpectralArtifactBundle",
@@ -66,130 +65,11 @@ __all__ = [
 
 
 @dataclass(frozen=True, slots=True)
-class WholeRunWindowSpectralSummary:
-    """Compact per-window spectral facts persisted alongside dense spectrum matrices."""
-
-    window_index: int
-    coverage_state: RawCaptureCoverageState
-    returned_sample_start: int | None
-    returned_sample_count: int
-    window_start_t_s: float | None = None
-    window_end_t_s: float | None = None
-    coverage_reason: str | None = None
-    dominant_freq_hz: float | None = None
-    vibration_strength_db: float | None = None
-    strength_peak_amp_g: float | None = None
-    strength_floor_amp_g: float | None = None
-    strength_bucket: str | None = None
-    top_peaks: tuple[StrengthPeak, ...] = ()
-
-    def to_json_object(self) -> JsonObject:
-        payload: JsonObject = {
-            "window_index": self.window_index,
-            "coverage_state": self.coverage_state,
-            "returned_sample_start": self.returned_sample_start,
-            "returned_sample_count": self.returned_sample_count,
-        }
-        if self.window_start_t_s is not None:
-            payload["window_start_t_s"] = self.window_start_t_s
-        if self.window_end_t_s is not None:
-            payload["window_end_t_s"] = self.window_end_t_s
-        if self.coverage_reason is not None:
-            payload["coverage_reason"] = self.coverage_reason
-        payload["top_peaks"] = [
-            {
-                "hz": float(peak["hz"]),
-                "amp": float(peak["amp"]),
-                "vibration_strength_db": float(peak["vibration_strength_db"]),
-                "strength_bucket": peak["strength_bucket"],
-            }
-            for peak in self.top_peaks
-            if peak["hz"] > 0 and peak["amp"] > 0
-        ]
-        if self.dominant_freq_hz is not None:
-            payload["dominant_freq_hz"] = self.dominant_freq_hz
-        if self.vibration_strength_db is not None:
-            payload["vibration_strength_db"] = self.vibration_strength_db
-        if self.strength_peak_amp_g is not None:
-            payload["strength_peak_amp_g"] = self.strength_peak_amp_g
-        if self.strength_floor_amp_g is not None:
-            payload["strength_floor_amp_g"] = self.strength_floor_amp_g
-        if self.strength_bucket is not None:
-            payload["strength_bucket"] = self.strength_bucket
-        return payload
-
-    @classmethod
-    def from_mapping(cls, data: JsonObject) -> WholeRunWindowSpectralSummary:
-        top_peaks_raw = data.get("top_peaks")
-        top_peaks: list[StrengthPeak] = []
-        if isinstance(top_peaks_raw, list):
-            for item in top_peaks_raw:
-                if not is_json_object(item):
-                    continue
-                hz = _float_or_none(item.get("hz"))
-                amp = _float_or_none(item.get("amp"))
-                vibration_strength_db = _float_or_none(item.get("vibration_strength_db"))
-                if hz is None or amp is None or vibration_strength_db is None:
-                    continue
-                top_peaks.append(
-                    {
-                        "hz": hz,
-                        "amp": amp,
-                        "vibration_strength_db": vibration_strength_db,
-                        "strength_bucket": _text_or_none(item.get("strength_bucket")),
-                    }
-                )
-        return cls(
-            window_index=_int_or_default(data.get("window_index"), default=0),
-            coverage_state=_coverage_state(data.get("coverage_state")),
-            returned_sample_start=_int_or_none(data.get("returned_sample_start")),
-            returned_sample_count=_int_or_default(data.get("returned_sample_count"), default=0),
-            window_start_t_s=_float_or_none(data.get("window_start_t_s")),
-            window_end_t_s=_float_or_none(data.get("window_end_t_s")),
-            coverage_reason=_text_or_none(data.get("coverage_reason")),
-            dominant_freq_hz=_float_or_none(data.get("dominant_freq_hz")),
-            vibration_strength_db=_float_or_none(data.get("vibration_strength_db")),
-            strength_peak_amp_g=_float_or_none(data.get("strength_peak_amp_g")),
-            strength_floor_amp_g=_float_or_none(data.get("strength_floor_amp_g")),
-            strength_bucket=_text_or_none(data.get("strength_bucket")),
-            top_peaks=tuple(top_peaks),
-        )
-
-
-@dataclass(frozen=True, slots=True)
 class WholeRunSpectralArtifactBundle:
     """In-memory whole-run artifact payload ready for sidecar persistence."""
 
     manifest: WholeRunArtifactManifest
     artifact_contents: dict[str, bytes]
-
-
-@dataclass(frozen=True, slots=True)
-class WholeRunSpectralCoverageSummary:
-    """Rolled-up coverage facts for time-aligned whole-run spectral windows."""
-
-    total_sensor_window_count: int
-    full_sensor_window_count: int
-    partial_sensor_window_count: int
-    missing_sensor_window_count: int
-    empty_sensor_window_count: int
-    gap_count: int
-    overlap_count: int
-    dropped_chunk_count: int
-    late_packet_chunk_count: int
-    queue_overflow_chunk_count: int
-    invalid_chunk_count: int
-    write_error_chunk_count: int
-    sample_rate_mismatch_sensor_count: int
-    sample_rate_unverified_sensor_count: int
-    unanchored_sensor_count: int
-    legacy_sensor_count: int
-    sync_unverified_sensor_count: int
-    stale_sync_sensor_count: int
-    high_rtt_sensor_count: int
-    coverage_confidence: WholeRunCoverageConfidence
-    udp_ingest_queue_drop_count: int = 0
-    warnings: tuple[RunContextWarning, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -264,7 +144,7 @@ def build_whole_run_spectral_artifact_bundle(
     }
     plan = _build_time_domain_window_plan(metadata=metadata, timelines=timelines)
     if plan is None or plan.total_window_count <= 0:
-        coverage_summary = _build_coverage_summary(
+        coverage_summary = build_coverage_summary(
             raw_capture=raw_capture,
             plan=None,
             sensors=sensors,
@@ -291,7 +171,7 @@ def build_whole_run_spectral_artifact_bundle(
         sensor_id: tuple(summary for result in sensor_results for summary in result.summaries)
         for sensor_id, sensor_results in _chunk_results_by_sensor(chunk_results).items()
     }
-    coverage_summary = _build_coverage_summary(
+    coverage_summary = build_coverage_summary(
         raw_capture=raw_capture,
         plan=plan,
         sensors=sensors,
@@ -896,243 +776,6 @@ def _chunk_results_by_sensor(
     return results_by_sensor
 
 
-def _build_coverage_summary(
-    *,
-    raw_capture: RawRunCapture,
-    plan: WholeRunWindowPlan | None,
-    sensors: Sequence[RawCaptureSensorData],
-    timelines: Mapping[str, RawSensorTimeline],
-    summaries_by_sensor: Mapping[str, Sequence[WholeRunWindowSpectralSummary]],
-) -> WholeRunSpectralCoverageSummary:
-    total_sensor_window_count = 0
-    full_sensor_window_count = 0
-    partial_sensor_window_count = 0
-    missing_sensor_window_count = 0
-    empty_sensor_window_count = 0
-    for sensor in sensors:
-        summaries = summaries_by_sensor.get(sensor.manifest.client_id, ())
-        if not summaries and plan is not None:
-            total_sensor_window_count += plan.total_window_count
-            missing_sensor_window_count += plan.total_window_count
-            continue
-        for summary in summaries:
-            total_sensor_window_count += 1
-            if summary.coverage_state == "full":
-                full_sensor_window_count += 1
-            elif summary.coverage_state == "partial":
-                partial_sensor_window_count += 1
-            elif summary.coverage_state == "empty":
-                empty_sensor_window_count += 1
-            else:
-                missing_sensor_window_count += 1
-    gap_count = sum(len(timeline.gap_intervals) for timeline in timelines.values())
-    overlap_count = sum(len(timeline.overlap_intervals) for timeline in timelines.values())
-    sample_rate_mismatch_sensor_count = sum(
-        1
-        for sensor in sensors
-        if sensor.manifest.sample_rate_corrected
-        or sensor.manifest.sample_rate_proof_state == "timing_inconsistent"
-    )
-    sample_rate_unverified_sensor_count = sum(
-        1 for sensor in sensors if sensor.manifest.sample_rate_unverified
-    )
-    unanchored_sensor_count = sum(1 for timeline in timelines.values() if not timeline.anchored)
-    legacy_sensor_count = sum(
-        1 for timeline in timelines.values() if raw_timeline_is_legacy(timeline)
-    )
-    sync_unverified_sensor_count = sum(
-        1 for timeline in timelines.values() if raw_timeline_has_unverified_sync(timeline)
-    )
-    stale_sync_sensor_count = sum(
-        1
-        for timeline in timelines.values()
-        if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "stale_sync"
-    )
-    high_rtt_sensor_count = sum(
-        1
-        for timeline in timelines.values()
-        if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "high_rtt"
-    )
-    dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
-    late_packet_chunk_count = raw_capture.manifest.total_late_packet_chunk_count
-    udp_ingest_queue_drop_count = raw_capture.manifest.losses.udp_ingest_queue_drop_count
-    queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
-    invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
-    write_error_chunk_count = raw_capture.manifest.losses.write_error_chunk_count
-    coverage_confidence = _coverage_confidence(
-        total_sensor_window_count=total_sensor_window_count,
-        partial_sensor_window_count=partial_sensor_window_count,
-        missing_sensor_window_count=missing_sensor_window_count,
-        empty_sensor_window_count=empty_sensor_window_count,
-        gap_count=gap_count,
-        overlap_count=overlap_count,
-        dropped_chunk_count=dropped_chunk_count,
-        late_packet_chunk_count=late_packet_chunk_count,
-        sample_rate_mismatch_sensor_count=sample_rate_mismatch_sensor_count,
-        sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
-        unanchored_sensor_count=unanchored_sensor_count,
-        sync_unverified_sensor_count=sync_unverified_sensor_count,
-    )
-    warnings = _build_whole_run_warnings(
-        total_sensor_window_count=total_sensor_window_count,
-        partial_sensor_window_count=partial_sensor_window_count,
-        missing_sensor_window_count=missing_sensor_window_count,
-        empty_sensor_window_count=empty_sensor_window_count,
-        gap_count=gap_count,
-        overlap_count=overlap_count,
-        dropped_chunk_count=dropped_chunk_count,
-        late_packet_chunk_count=late_packet_chunk_count,
-        udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
-        queue_overflow_chunk_count=queue_overflow_chunk_count,
-        invalid_chunk_count=invalid_chunk_count,
-        write_error_chunk_count=write_error_chunk_count,
-        sample_rate_mismatch_sensor_count=sample_rate_mismatch_sensor_count,
-        sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
-        legacy_sensor_count=legacy_sensor_count,
-        unanchored_sensor_count=unanchored_sensor_count,
-        sync_unverified_sensor_count=sync_unverified_sensor_count,
-        stale_sync_sensor_count=stale_sync_sensor_count,
-        high_rtt_sensor_count=high_rtt_sensor_count,
-    )
-    return WholeRunSpectralCoverageSummary(
-        total_sensor_window_count=total_sensor_window_count,
-        full_sensor_window_count=full_sensor_window_count,
-        partial_sensor_window_count=partial_sensor_window_count,
-        missing_sensor_window_count=missing_sensor_window_count,
-        empty_sensor_window_count=empty_sensor_window_count,
-        gap_count=gap_count,
-        overlap_count=overlap_count,
-        dropped_chunk_count=dropped_chunk_count,
-        late_packet_chunk_count=late_packet_chunk_count,
-        udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
-        queue_overflow_chunk_count=queue_overflow_chunk_count,
-        invalid_chunk_count=invalid_chunk_count,
-        write_error_chunk_count=write_error_chunk_count,
-        sample_rate_mismatch_sensor_count=sample_rate_mismatch_sensor_count,
-        sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
-        unanchored_sensor_count=unanchored_sensor_count,
-        legacy_sensor_count=legacy_sensor_count,
-        sync_unverified_sensor_count=sync_unverified_sensor_count,
-        stale_sync_sensor_count=stale_sync_sensor_count,
-        high_rtt_sensor_count=high_rtt_sensor_count,
-        coverage_confidence=coverage_confidence,
-        warnings=warnings,
-    )
-
-
-def _coverage_confidence(
-    *,
-    total_sensor_window_count: int,
-    partial_sensor_window_count: int,
-    missing_sensor_window_count: int,
-    empty_sensor_window_count: int,
-    gap_count: int,
-    overlap_count: int,
-    dropped_chunk_count: int,
-    late_packet_chunk_count: int,
-    sample_rate_mismatch_sensor_count: int,
-    sample_rate_unverified_sensor_count: int,
-    unanchored_sensor_count: int,
-    sync_unverified_sensor_count: int,
-) -> WholeRunCoverageConfidence:
-    if total_sensor_window_count <= 0:
-        return "unavailable"
-    if (
-        partial_sensor_window_count <= 0
-        and missing_sensor_window_count <= 0
-        and empty_sensor_window_count <= 0
-        and gap_count <= 0
-        and overlap_count <= 0
-        and dropped_chunk_count <= 0
-        and late_packet_chunk_count <= 0
-        and sample_rate_mismatch_sensor_count <= 0
-        and sample_rate_unverified_sensor_count <= 0
-        and unanchored_sensor_count <= 0
-        and sync_unverified_sensor_count <= 0
-    ):
-        return "full"
-    return "partial"
-
-
-def _build_whole_run_warnings(
-    *,
-    total_sensor_window_count: int,
-    partial_sensor_window_count: int,
-    missing_sensor_window_count: int,
-    empty_sensor_window_count: int,
-    gap_count: int,
-    overlap_count: int,
-    dropped_chunk_count: int,
-    late_packet_chunk_count: int,
-    udp_ingest_queue_drop_count: int,
-    queue_overflow_chunk_count: int,
-    invalid_chunk_count: int,
-    write_error_chunk_count: int,
-    sample_rate_mismatch_sensor_count: int,
-    sample_rate_unverified_sensor_count: int,
-    legacy_sensor_count: int,
-    unanchored_sensor_count: int,
-    sync_unverified_sensor_count: int,
-    stale_sync_sensor_count: int,
-    high_rtt_sensor_count: int,
-) -> tuple[RunContextWarning, ...]:
-    if (
-        partial_sensor_window_count <= 0
-        and missing_sensor_window_count <= 0
-        and empty_sensor_window_count <= 0
-        and gap_count <= 0
-        and overlap_count <= 0
-        and dropped_chunk_count <= 0
-        and late_packet_chunk_count <= 0
-        and sample_rate_mismatch_sensor_count <= 0
-        and sample_rate_unverified_sensor_count <= 0
-        and sync_unverified_sensor_count <= 0
-        and unanchored_sensor_count <= 0
-        and legacy_sensor_count <= 0
-    ):
-        return ()
-    missing_sync_sensor_count = max(
-        0,
-        sync_unverified_sensor_count
-        - max(0, stale_sync_sensor_count)
-        - max(0, high_rtt_sensor_count),
-    )
-    detail_key = (
-        "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_UNAVAILABLE_DETAIL"
-        if total_sensor_window_count <= 0
-        else "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_INCOMPLETE_DETAIL"
-    )
-    return (
-        RunContextWarning(
-            code=WARNING_CODE_WHOLE_RUN_ALIGNMENT_INCOMPLETE,
-            severity="warn",
-            applies_to="whole_run",
-            title=i18n_ref("RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_INCOMPLETE_TITLE"),
-            detail=i18n_ref(
-                detail_key,
-                partial=str(max(0, partial_sensor_window_count)),
-                missing=str(max(0, missing_sensor_window_count + empty_sensor_window_count)),
-                gaps=str(max(0, gap_count)),
-                overlaps=str(max(0, overlap_count)),
-                dropped=str(max(0, dropped_chunk_count)),
-                late=str(max(0, late_packet_chunk_count)),
-                udp_ingest=str(max(0, udp_ingest_queue_drop_count)),
-                queue_overflow=str(max(0, queue_overflow_chunk_count)),
-                invalid=str(max(0, invalid_chunk_count)),
-                write_errors=str(max(0, write_error_chunk_count)),
-                mismatches=str(max(0, sample_rate_mismatch_sensor_count)),
-                unverified_rates=str(max(0, sample_rate_unverified_sensor_count)),
-                legacy=str(max(0, legacy_sensor_count)),
-                unanchored=str(max(0, unanchored_sensor_count)),
-                sync_unverified=str(max(0, sync_unverified_sensor_count)),
-                missing_sync=str(max(0, missing_sync_sensor_count)),
-                stale=str(max(0, stale_sync_sensor_count)),
-                high_rtt=str(max(0, high_rtt_sensor_count)),
-            ),
-        ),
-    )
-
-
 def _default_frequency_grid(*, sample_rate_hz: int, fft_n: int) -> np.ndarray:
     fft_computer = SpectralAnalysisComputer(
         fft_n=fft_n,
@@ -1148,97 +791,9 @@ def _npy_bytes(array: np.ndarray) -> bytes:
     return buffer.getvalue()
 
 
-def whole_run_window_spectral_summaries_to_jsonl_bytes(
-    summaries: Sequence[WholeRunWindowSpectralSummary],
-) -> bytes:
-    if not summaries:
-        return b""
-    lines = [safe_json_dumps(summary.to_json_object()).encode("utf-8") for summary in summaries]
-    return b"\n".join(lines) + b"\n"
-
-
-def whole_run_window_spectral_summaries_from_jsonl_bytes(
-    payload: bytes,
-) -> tuple[WholeRunWindowSpectralSummary, ...]:
-    """Reconstruct persisted whole-run spectral summaries from sidecar JSONL bytes."""
-
-    if not payload:
-        return ()
-    summaries: list[WholeRunWindowSpectralSummary] = []
-    text = payload.decode("utf-8")
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        parsed = safe_json_loads(line, context="whole-run spectral summaries")
-        if not is_json_object(parsed):
-            raise ValueError("whole-run spectral summary line must decode to a JSON object")
-        summaries.append(WholeRunWindowSpectralSummary.from_mapping(parsed))
-    return tuple(summaries)
-
-
-def whole_run_spectral_summaries_by_sensor(
-    *,
-    manifest: WholeRunArtifactManifest,
-    artifact_contents: Mapping[str, bytes],
-) -> dict[str, tuple[WholeRunWindowSpectralSummary, ...]]:
-    """Load deterministic whole-run spectral summary rows keyed by sensor id."""
-
-    summaries_by_sensor: dict[str, tuple[WholeRunWindowSpectralSummary, ...]] = {}
-    summary_artifacts = sorted(
-        (
-            artifact
-            for artifact in manifest.artifacts
-            if artifact.artifact_key.startswith("spectral-summary:")
-        ),
-        key=lambda artifact: (artifact.sensor_id or "", artifact.artifact_key),
-    )
-    for artifact in summary_artifacts:
-        if artifact.sensor_id is None:
-            raise ValueError("whole-run spectral summary artifacts require sensor_id for loading")
-        payload = artifact_contents.get(artifact.artifact_key)
-        if payload is None:
-            raise ValueError(
-                f"whole-run spectral summaries missing bytes for {artifact.artifact_key}"
-            )
-        summaries = whole_run_window_spectral_summaries_from_jsonl_bytes(payload)
-        if len(summaries) != manifest.total_window_count:
-            raise ValueError(
-                "whole-run spectral summaries require one row per window "
-                f"for {artifact.artifact_key}"
-            )
-        summaries_by_sensor[artifact.sensor_id] = summaries
-    return summaries_by_sensor
-
-
-def _int_or_none(value: object) -> int | None:
-    if isinstance(value, bool) or value is None:
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float) and value.is_integer():
-        return int(value)
-    return None
-
-
-def _int_or_default(value: object, *, default: int) -> int:
-    parsed = _int_or_none(value)
-    return parsed if parsed is not None else default
-
-
 def _float_or_none(value: object) -> float | None:
     if isinstance(value, bool) or value is None:
         return None
     if isinstance(value, int | float):
         return float(value)
     return None
-
-
-def _text_or_none(value: object) -> str | None:
-    return value if isinstance(value, str) and value else None
-
-
-def _coverage_state(value: object) -> RawCaptureCoverageState:
-    if value in {"missing", "empty", "partial", "full"}:
-        return cast(RawCaptureCoverageState, value)
-    return "missing"

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectral_projection.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_spectral_projection.py
@@ -1,0 +1,481 @@
+"""Coverage and sidecar projection helpers for whole-run spectral artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from vibesensor.shared.json_utils import i18n_ref, safe_json_dumps, safe_json_loads
+from vibesensor.shared.raw_capture_timeline import (
+    RawSensorTimeline,
+    raw_timeline_has_unverified_sync,
+    raw_timeline_is_legacy,
+)
+from vibesensor.shared.run_context_warning import (
+    WARNING_CODE_WHOLE_RUN_ALIGNMENT_INCOMPLETE,
+    RunContextWarning,
+)
+from vibesensor.shared.types.json_types import JsonObject, is_json_object
+from vibesensor.shared.types.raw_capture import (
+    RawCaptureCoverageState,
+    RawCaptureSensorData,
+    RawRunCapture,
+)
+from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
+from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
+from vibesensor.vibration_strength import StrengthPeak
+
+type WholeRunCoverageConfidence = Literal["full", "partial", "unavailable"]
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunWindowSpectralSummary:
+    """Compact per-window spectral facts persisted alongside dense spectrum matrices."""
+
+    window_index: int
+    coverage_state: RawCaptureCoverageState
+    returned_sample_start: int | None
+    returned_sample_count: int
+    window_start_t_s: float | None = None
+    window_end_t_s: float | None = None
+    coverage_reason: str | None = None
+    dominant_freq_hz: float | None = None
+    vibration_strength_db: float | None = None
+    strength_peak_amp_g: float | None = None
+    strength_floor_amp_g: float | None = None
+    strength_bucket: str | None = None
+    top_peaks: tuple[StrengthPeak, ...] = ()
+
+    def to_json_object(self) -> JsonObject:
+        payload: JsonObject = {
+            "window_index": self.window_index,
+            "coverage_state": self.coverage_state,
+            "returned_sample_start": self.returned_sample_start,
+            "returned_sample_count": self.returned_sample_count,
+        }
+        if self.window_start_t_s is not None:
+            payload["window_start_t_s"] = self.window_start_t_s
+        if self.window_end_t_s is not None:
+            payload["window_end_t_s"] = self.window_end_t_s
+        if self.coverage_reason is not None:
+            payload["coverage_reason"] = self.coverage_reason
+        payload["top_peaks"] = [
+            {
+                "hz": float(peak["hz"]),
+                "amp": float(peak["amp"]),
+                "vibration_strength_db": float(peak["vibration_strength_db"]),
+                "strength_bucket": peak["strength_bucket"],
+            }
+            for peak in self.top_peaks
+            if peak["hz"] > 0 and peak["amp"] > 0
+        ]
+        if self.dominant_freq_hz is not None:
+            payload["dominant_freq_hz"] = self.dominant_freq_hz
+        if self.vibration_strength_db is not None:
+            payload["vibration_strength_db"] = self.vibration_strength_db
+        if self.strength_peak_amp_g is not None:
+            payload["strength_peak_amp_g"] = self.strength_peak_amp_g
+        if self.strength_floor_amp_g is not None:
+            payload["strength_floor_amp_g"] = self.strength_floor_amp_g
+        if self.strength_bucket is not None:
+            payload["strength_bucket"] = self.strength_bucket
+        return payload
+
+    @classmethod
+    def from_mapping(cls, data: JsonObject) -> WholeRunWindowSpectralSummary:
+        top_peaks_raw = data.get("top_peaks")
+        top_peaks: list[StrengthPeak] = []
+        if isinstance(top_peaks_raw, list):
+            for item in top_peaks_raw:
+                if not is_json_object(item):
+                    continue
+                hz = _float_or_none(item.get("hz"))
+                amp = _float_or_none(item.get("amp"))
+                vibration_strength_db = _float_or_none(item.get("vibration_strength_db"))
+                if hz is None or amp is None or vibration_strength_db is None:
+                    continue
+                top_peaks.append(
+                    {
+                        "hz": hz,
+                        "amp": amp,
+                        "vibration_strength_db": vibration_strength_db,
+                        "strength_bucket": _text_or_none(item.get("strength_bucket")),
+                    }
+                )
+        return cls(
+            window_index=_int_or_default(data.get("window_index"), default=0),
+            coverage_state=_coverage_state(data.get("coverage_state")),
+            returned_sample_start=_int_or_none(data.get("returned_sample_start")),
+            returned_sample_count=_int_or_default(data.get("returned_sample_count"), default=0),
+            window_start_t_s=_float_or_none(data.get("window_start_t_s")),
+            window_end_t_s=_float_or_none(data.get("window_end_t_s")),
+            coverage_reason=_text_or_none(data.get("coverage_reason")),
+            dominant_freq_hz=_float_or_none(data.get("dominant_freq_hz")),
+            vibration_strength_db=_float_or_none(data.get("vibration_strength_db")),
+            strength_peak_amp_g=_float_or_none(data.get("strength_peak_amp_g")),
+            strength_floor_amp_g=_float_or_none(data.get("strength_floor_amp_g")),
+            strength_bucket=_text_or_none(data.get("strength_bucket")),
+            top_peaks=tuple(top_peaks),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRunSpectralCoverageSummary:
+    """Rolled-up coverage facts for time-aligned whole-run spectral windows."""
+
+    total_sensor_window_count: int
+    full_sensor_window_count: int
+    partial_sensor_window_count: int
+    missing_sensor_window_count: int
+    empty_sensor_window_count: int
+    gap_count: int
+    overlap_count: int
+    dropped_chunk_count: int
+    late_packet_chunk_count: int
+    queue_overflow_chunk_count: int
+    invalid_chunk_count: int
+    write_error_chunk_count: int
+    sample_rate_mismatch_sensor_count: int
+    sample_rate_unverified_sensor_count: int
+    unanchored_sensor_count: int
+    legacy_sensor_count: int
+    sync_unverified_sensor_count: int
+    stale_sync_sensor_count: int
+    high_rtt_sensor_count: int
+    coverage_confidence: WholeRunCoverageConfidence
+    udp_ingest_queue_drop_count: int = 0
+    warnings: tuple[RunContextWarning, ...] = ()
+
+
+def build_coverage_summary(
+    *,
+    raw_capture: RawRunCapture,
+    plan: WholeRunWindowPlan | None,
+    sensors: Sequence[RawCaptureSensorData],
+    timelines: Mapping[str, RawSensorTimeline],
+    summaries_by_sensor: Mapping[str, Sequence[WholeRunWindowSpectralSummary]],
+) -> WholeRunSpectralCoverageSummary:
+    total_sensor_window_count = 0
+    full_sensor_window_count = 0
+    partial_sensor_window_count = 0
+    missing_sensor_window_count = 0
+    empty_sensor_window_count = 0
+    for sensor in sensors:
+        summaries = summaries_by_sensor.get(sensor.manifest.client_id, ())
+        if not summaries and plan is not None:
+            total_sensor_window_count += plan.total_window_count
+            missing_sensor_window_count += plan.total_window_count
+            continue
+        for summary in summaries:
+            total_sensor_window_count += 1
+            if summary.coverage_state == "full":
+                full_sensor_window_count += 1
+            elif summary.coverage_state == "partial":
+                partial_sensor_window_count += 1
+            elif summary.coverage_state == "empty":
+                empty_sensor_window_count += 1
+            else:
+                missing_sensor_window_count += 1
+    gap_count = sum(len(timeline.gap_intervals) for timeline in timelines.values())
+    overlap_count = sum(len(timeline.overlap_intervals) for timeline in timelines.values())
+    sample_rate_mismatch_sensor_count = sum(
+        1
+        for sensor in sensors
+        if sensor.manifest.sample_rate_corrected
+        or sensor.manifest.sample_rate_proof_state == "timing_inconsistent"
+    )
+    sample_rate_unverified_sensor_count = sum(
+        1 for sensor in sensors if sensor.manifest.sample_rate_unverified
+    )
+    unanchored_sensor_count = sum(1 for timeline in timelines.values() if not timeline.anchored)
+    legacy_sensor_count = sum(
+        1 for timeline in timelines.values() if raw_timeline_is_legacy(timeline)
+    )
+    sync_unverified_sensor_count = sum(
+        1 for timeline in timelines.values() if raw_timeline_has_unverified_sync(timeline)
+    )
+    stale_sync_sensor_count = sum(
+        1
+        for timeline in timelines.values()
+        if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "stale_sync"
+    )
+    high_rtt_sensor_count = sum(
+        1
+        for timeline in timelines.values()
+        if timeline.clock_sync is not None and timeline.clock_sync.proof_state == "high_rtt"
+    )
+    dropped_chunk_count = raw_capture.manifest.total_dropped_chunk_count
+    late_packet_chunk_count = raw_capture.manifest.total_late_packet_chunk_count
+    udp_ingest_queue_drop_count = raw_capture.manifest.losses.udp_ingest_queue_drop_count
+    queue_overflow_chunk_count = raw_capture.manifest.losses.queue_overflow_chunk_count
+    invalid_chunk_count = raw_capture.manifest.losses.invalid_chunk_count
+    write_error_chunk_count = raw_capture.manifest.losses.write_error_chunk_count
+    coverage_confidence = build_coverage_confidence(
+        total_sensor_window_count=total_sensor_window_count,
+        partial_sensor_window_count=partial_sensor_window_count,
+        missing_sensor_window_count=missing_sensor_window_count,
+        empty_sensor_window_count=empty_sensor_window_count,
+        gap_count=gap_count,
+        overlap_count=overlap_count,
+        dropped_chunk_count=dropped_chunk_count,
+        late_packet_chunk_count=late_packet_chunk_count,
+        sample_rate_mismatch_sensor_count=sample_rate_mismatch_sensor_count,
+        sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
+        unanchored_sensor_count=unanchored_sensor_count,
+        sync_unverified_sensor_count=sync_unverified_sensor_count,
+    )
+    warnings = build_whole_run_warnings(
+        total_sensor_window_count=total_sensor_window_count,
+        partial_sensor_window_count=partial_sensor_window_count,
+        missing_sensor_window_count=missing_sensor_window_count,
+        empty_sensor_window_count=empty_sensor_window_count,
+        gap_count=gap_count,
+        overlap_count=overlap_count,
+        dropped_chunk_count=dropped_chunk_count,
+        late_packet_chunk_count=late_packet_chunk_count,
+        udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
+        queue_overflow_chunk_count=queue_overflow_chunk_count,
+        invalid_chunk_count=invalid_chunk_count,
+        write_error_chunk_count=write_error_chunk_count,
+        sample_rate_mismatch_sensor_count=sample_rate_mismatch_sensor_count,
+        sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
+        legacy_sensor_count=legacy_sensor_count,
+        unanchored_sensor_count=unanchored_sensor_count,
+        sync_unverified_sensor_count=sync_unverified_sensor_count,
+        stale_sync_sensor_count=stale_sync_sensor_count,
+        high_rtt_sensor_count=high_rtt_sensor_count,
+    )
+    return WholeRunSpectralCoverageSummary(
+        total_sensor_window_count=total_sensor_window_count,
+        full_sensor_window_count=full_sensor_window_count,
+        partial_sensor_window_count=partial_sensor_window_count,
+        missing_sensor_window_count=missing_sensor_window_count,
+        empty_sensor_window_count=empty_sensor_window_count,
+        gap_count=gap_count,
+        overlap_count=overlap_count,
+        dropped_chunk_count=dropped_chunk_count,
+        late_packet_chunk_count=late_packet_chunk_count,
+        udp_ingest_queue_drop_count=udp_ingest_queue_drop_count,
+        queue_overflow_chunk_count=queue_overflow_chunk_count,
+        invalid_chunk_count=invalid_chunk_count,
+        write_error_chunk_count=write_error_chunk_count,
+        sample_rate_mismatch_sensor_count=sample_rate_mismatch_sensor_count,
+        sample_rate_unverified_sensor_count=sample_rate_unverified_sensor_count,
+        unanchored_sensor_count=unanchored_sensor_count,
+        legacy_sensor_count=legacy_sensor_count,
+        sync_unverified_sensor_count=sync_unverified_sensor_count,
+        stale_sync_sensor_count=stale_sync_sensor_count,
+        high_rtt_sensor_count=high_rtt_sensor_count,
+        coverage_confidence=coverage_confidence,
+        warnings=warnings,
+    )
+
+
+def build_coverage_confidence(
+    *,
+    total_sensor_window_count: int,
+    partial_sensor_window_count: int,
+    missing_sensor_window_count: int,
+    empty_sensor_window_count: int,
+    gap_count: int,
+    overlap_count: int,
+    dropped_chunk_count: int,
+    late_packet_chunk_count: int,
+    sample_rate_mismatch_sensor_count: int,
+    sample_rate_unverified_sensor_count: int,
+    unanchored_sensor_count: int,
+    sync_unverified_sensor_count: int,
+) -> WholeRunCoverageConfidence:
+    if total_sensor_window_count <= 0:
+        return "unavailable"
+    if (
+        partial_sensor_window_count <= 0
+        and missing_sensor_window_count <= 0
+        and empty_sensor_window_count <= 0
+        and gap_count <= 0
+        and overlap_count <= 0
+        and dropped_chunk_count <= 0
+        and late_packet_chunk_count <= 0
+        and sample_rate_mismatch_sensor_count <= 0
+        and sample_rate_unverified_sensor_count <= 0
+        and unanchored_sensor_count <= 0
+        and sync_unverified_sensor_count <= 0
+    ):
+        return "full"
+    return "partial"
+
+
+def build_whole_run_warnings(
+    *,
+    total_sensor_window_count: int,
+    partial_sensor_window_count: int,
+    missing_sensor_window_count: int,
+    empty_sensor_window_count: int,
+    gap_count: int,
+    overlap_count: int,
+    dropped_chunk_count: int,
+    late_packet_chunk_count: int,
+    udp_ingest_queue_drop_count: int,
+    queue_overflow_chunk_count: int,
+    invalid_chunk_count: int,
+    write_error_chunk_count: int,
+    sample_rate_mismatch_sensor_count: int,
+    sample_rate_unverified_sensor_count: int,
+    legacy_sensor_count: int,
+    unanchored_sensor_count: int,
+    sync_unverified_sensor_count: int,
+    stale_sync_sensor_count: int,
+    high_rtt_sensor_count: int,
+) -> tuple[RunContextWarning, ...]:
+    if (
+        partial_sensor_window_count <= 0
+        and missing_sensor_window_count <= 0
+        and empty_sensor_window_count <= 0
+        and gap_count <= 0
+        and overlap_count <= 0
+        and dropped_chunk_count <= 0
+        and late_packet_chunk_count <= 0
+        and sample_rate_mismatch_sensor_count <= 0
+        and sample_rate_unverified_sensor_count <= 0
+        and sync_unverified_sensor_count <= 0
+        and unanchored_sensor_count <= 0
+        and legacy_sensor_count <= 0
+    ):
+        return ()
+    missing_sync_sensor_count = max(
+        0,
+        sync_unverified_sensor_count
+        - max(0, stale_sync_sensor_count)
+        - max(0, high_rtt_sensor_count),
+    )
+    detail_key = (
+        "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_UNAVAILABLE_DETAIL"
+        if total_sensor_window_count <= 0
+        else "RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_INCOMPLETE_DETAIL"
+    )
+    return (
+        RunContextWarning(
+            code=WARNING_CODE_WHOLE_RUN_ALIGNMENT_INCOMPLETE,
+            severity="warn",
+            applies_to="whole_run",
+            title=i18n_ref("RUN_CONTEXT_WARNING_WHOLE_RUN_ALIGNMENT_INCOMPLETE_TITLE"),
+            detail=i18n_ref(
+                detail_key,
+                partial=str(max(0, partial_sensor_window_count)),
+                missing=str(max(0, missing_sensor_window_count + empty_sensor_window_count)),
+                gaps=str(max(0, gap_count)),
+                overlaps=str(max(0, overlap_count)),
+                dropped=str(max(0, dropped_chunk_count)),
+                late=str(max(0, late_packet_chunk_count)),
+                udp_ingest=str(max(0, udp_ingest_queue_drop_count)),
+                queue_overflow=str(max(0, queue_overflow_chunk_count)),
+                invalid=str(max(0, invalid_chunk_count)),
+                write_errors=str(max(0, write_error_chunk_count)),
+                mismatches=str(max(0, sample_rate_mismatch_sensor_count)),
+                unverified_rates=str(max(0, sample_rate_unverified_sensor_count)),
+                legacy=str(max(0, legacy_sensor_count)),
+                unanchored=str(max(0, unanchored_sensor_count)),
+                sync_unverified=str(max(0, sync_unverified_sensor_count)),
+                missing_sync=str(max(0, missing_sync_sensor_count)),
+                stale=str(max(0, stale_sync_sensor_count)),
+                high_rtt=str(max(0, high_rtt_sensor_count)),
+            ),
+        ),
+    )
+
+
+def whole_run_window_spectral_summaries_to_jsonl_bytes(
+    summaries: Sequence[WholeRunWindowSpectralSummary],
+) -> bytes:
+    if not summaries:
+        return b""
+    lines = [safe_json_dumps(summary.to_json_object()).encode("utf-8") for summary in summaries]
+    return b"\n".join(lines) + b"\n"
+
+
+def whole_run_window_spectral_summaries_from_jsonl_bytes(
+    payload: bytes,
+) -> tuple[WholeRunWindowSpectralSummary, ...]:
+    """Reconstruct persisted whole-run spectral summaries from sidecar JSONL bytes."""
+
+    if not payload:
+        return ()
+    summaries: list[WholeRunWindowSpectralSummary] = []
+    text = payload.decode("utf-8")
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parsed = safe_json_loads(line, context="whole-run spectral summaries")
+        if not is_json_object(parsed):
+            raise ValueError("whole-run spectral summary line must decode to a JSON object")
+        summaries.append(WholeRunWindowSpectralSummary.from_mapping(parsed))
+    return tuple(summaries)
+
+
+def whole_run_spectral_summaries_by_sensor(
+    *,
+    manifest: WholeRunArtifactManifest,
+    artifact_contents: Mapping[str, bytes],
+) -> dict[str, tuple[WholeRunWindowSpectralSummary, ...]]:
+    """Load deterministic whole-run spectral summary rows keyed by sensor id."""
+
+    summaries_by_sensor: dict[str, tuple[WholeRunWindowSpectralSummary, ...]] = {}
+    summary_artifacts = sorted(
+        (
+            artifact
+            for artifact in manifest.artifacts
+            if artifact.artifact_key.startswith("spectral-summary:")
+        ),
+        key=lambda artifact: (artifact.sensor_id or "", artifact.artifact_key),
+    )
+    for artifact in summary_artifacts:
+        if artifact.sensor_id is None:
+            raise ValueError("whole-run spectral summary artifacts require sensor_id for loading")
+        payload = artifact_contents.get(artifact.artifact_key)
+        if payload is None:
+            raise ValueError(
+                f"whole-run spectral summaries missing bytes for {artifact.artifact_key}"
+            )
+        summaries = whole_run_window_spectral_summaries_from_jsonl_bytes(payload)
+        if len(summaries) != manifest.total_window_count:
+            raise ValueError(
+                "whole-run spectral summaries require one row per window "
+                f"for {artifact.artifact_key}"
+            )
+        summaries_by_sensor[artifact.sensor_id] = summaries
+    return summaries_by_sensor
+
+
+def _int_or_none(value: object) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def _int_or_default(value: object, *, default: int) -> int:
+    parsed = _int_or_none(value)
+    return parsed if parsed is not None else default
+
+
+def _float_or_none(value: object) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _text_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _coverage_state(value: object) -> RawCaptureCoverageState:
+    if value in {"missing", "empty", "partial", "full"}:
+        return cast(RawCaptureCoverageState, value)
+    return "missing"

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -13,57 +13,38 @@ import aiosqlite
 from opentelemetry.trace import SpanKind
 
 from vibesensor.shared.ports import RunPersistence
-from vibesensor.shared.run_context_warning import (
-    RunContextWarningsInput,
-    normalize_run_context_warnings,
-)
 from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.tracing import mark_span_error, start_span
-from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
+from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
-from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
+from vibesensor.shared.types.raw_capture import RawRunCapture
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
 from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTraceSummary
 from vibesensor.use_cases.diagnostics.orders.whole_run_family_summaries import (
-    WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY,
     WholeRunOrderFamilySummaryArtifactBundle,
-    build_whole_run_order_family_summary_artifact_bundle,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
-    WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY,
     WholeRunOrderTraceSummaryArtifactBundle,
-    build_whole_run_order_trace_summary_artifact_bundle,
 )
 from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
-    WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
     WholeRunOrderTraceArtifactBundle,
-    build_whole_run_order_trace_artifact_bundle,
 )
 from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
     SpatialEvidenceSummary,
 )
 from vibesensor.use_cases.diagnostics.whole_run_context import (
-    WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
     WholeRunContextArtifactBundle,
-    build_whole_run_context_artifact_bundle,
 )
 from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
     WholeRunDiagnosisSummary,
 )
-from vibesensor.use_cases.diagnostics.whole_run_diagnosis_ranking import (
-    build_whole_run_diagnosis_summaries,
-)
 from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
-    WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
     WholeRunSpatialCoherenceArtifactBundle,
-    build_whole_run_spatial_coherence_artifact_bundle,
 )
 from vibesensor.use_cases.diagnostics.whole_run_spectra import (
     WholeRunSpectralArtifactBundle,
     WholeRunSpectralBuildResult,
-    WholeRunSpectralCoverageSummary,
-    build_whole_run_spectral_artifact_bundle,
 )
 from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
 from vibesensor.use_cases.run.post_analysis_input import (
@@ -86,6 +67,33 @@ from vibesensor.use_cases.run.post_analysis_outcomes import (
     PostAnalysisExecutionRetryableFailure,
     PostAnalysisExecutionSuccess,
     is_retryable_post_analysis_error,
+)
+from vibesensor.use_cases.run.post_analysis_whole_run_builders import (
+    build_whole_run_artifacts,
+    build_whole_run_context_artifacts,
+    build_whole_run_order_family_summary_artifacts,
+    build_whole_run_order_trace_artifacts,
+    build_whole_run_order_trace_summary_artifacts,
+    build_whole_run_spatial_coherence_artifacts,
+    merge_whole_run_artifact_bundles,
+    whole_run_total_sample_count,
+)
+from vibesensor.use_cases.run.post_analysis_whole_run_projection import (
+    append_run_context_warnings,
+    append_whole_run_analysis_metadata,
+    append_whole_run_context,
+    append_whole_run_diagnosis_summaries,
+    append_whole_run_diagnosis_summary_metadata,
+    append_whole_run_order_family_summary_metadata,
+    append_whole_run_order_summaries,
+    append_whole_run_order_trace_metadata,
+    append_whole_run_order_trace_summary_metadata,
+    append_whole_run_spatial_coherence_metadata,
+    append_whole_run_spatial_summaries,
+    append_whole_run_spectral_metadata,
+    build_diagnosis_summary_rows,
+    ranked_whole_run_order_summaries,
+    ranked_whole_run_spatial_summaries,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -217,14 +225,6 @@ class WholeRunDiagnosisSummaryBuilder(Protocol):
         order_summaries: tuple[OrderTraceSummary, ...],
         spatial_summaries: tuple[SpatialEvidenceSummary, ...],
     ) -> tuple[WholeRunDiagnosisSummary, ...]: ...
-
-
-@dataclass(frozen=True, slots=True)
-class _StoredWholeRunArtifactBundle:
-    """Generic sidecar bundle shape for final manifest persistence."""
-
-    manifest: WholeRunArtifactManifest
-    artifact_contents: dict[str, bytes]
 
 
 type PostAnalysisStageStatus = Literal["ok", "skipped", "degraded", "failed"]
@@ -390,37 +390,37 @@ def resolve_whole_run_builders(
 ) -> ResolvedWholeRunBuilders:
     return ResolvedWholeRunBuilders(
         artifact_builder=(
-            _build_whole_run_artifacts
+            build_whole_run_artifacts
             if whole_run_artifact_builder is None
             else whole_run_artifact_builder
         ),
         context_builder=(
-            _build_whole_run_context_artifacts
+            build_whole_run_context_artifacts
             if whole_run_context_builder is None
             else whole_run_context_builder
         ),
         order_trace_builder=(
-            _build_whole_run_order_trace_artifacts
+            build_whole_run_order_trace_artifacts
             if whole_run_order_trace_builder is None
             else whole_run_order_trace_builder
         ),
         order_trace_summary_builder=(
-            _build_whole_run_order_trace_summary_artifacts
+            build_whole_run_order_trace_summary_artifacts
             if whole_run_order_trace_summary_builder is None
             else whole_run_order_trace_summary_builder
         ),
         order_family_summary_builder=(
-            _build_whole_run_order_family_summary_artifacts
+            build_whole_run_order_family_summary_artifacts
             if whole_run_order_family_summary_builder is None
             else whole_run_order_family_summary_builder
         ),
         spatial_coherence_builder=(
-            _build_whole_run_spatial_coherence_artifacts
+            build_whole_run_spatial_coherence_artifacts
             if whole_run_spatial_coherence_builder is None
             else whole_run_spatial_coherence_builder
         ),
         diagnosis_summary_builder=(
-            _build_whole_run_diagnosis_summaries
+            build_diagnosis_summary_rows
             if whole_run_diagnosis_summary_builder is None
             else whole_run_diagnosis_summary_builder
         ),
@@ -633,7 +633,7 @@ def run_whole_run_pipeline_stages(
             else:
                 context_bundle = builders.context_builder(
                     run=run_input,
-                    total_sample_count=_whole_run_total_sample_count(loaded.raw_capture_manifest),
+                    total_sample_count=whole_run_total_sample_count(loaded.raw_capture_manifest),
                 )
                 context_status = "degraded"
                 context_diagnostic = {"build_mode": "total_sample_count_fallback"}
@@ -822,7 +822,7 @@ def run_whole_run_pipeline_stages(
         )
 
     persist_artifacts_stage_start = time.monotonic()
-    merged_bundle = _merge_whole_run_artifact_bundles(
+    merged_bundle = merge_whole_run_artifact_bundles(
         spectral_bundle,
         context_bundle,
         order_trace_bundle,
@@ -914,14 +914,14 @@ def run_build_report_facts_stage(
     stored_artifact_manifest = whole_run_output.stored_artifact_manifest
 
     if spectral_result is not None:
-        summary = _append_whole_run_spectral_metadata(
+        summary = append_whole_run_spectral_metadata(
             summary,
             spectral_result.coverage_summary,
             spectral_bundle=spectral_bundle,
         )
-        summary = _append_run_context_warnings(summary, spectral_result.coverage_summary.warnings)
+        summary = append_run_context_warnings(summary, spectral_result.coverage_summary.warnings)
     if context_bundle is not None:
-        summary = _append_whole_run_context(summary, context_bundle)
+        summary = append_whole_run_context(summary, context_bundle)
 
     analysis_payload = summary.to_json_object()
     analysis_metadata_payload = analysis_payload.get("analysis_metadata")
@@ -930,21 +930,21 @@ def run_build_report_facts_stage(
     )
 
     if order_trace_bundle is not None:
-        summary = _append_whole_run_order_trace_metadata(summary, order_trace_bundle)
+        summary = append_whole_run_order_trace_metadata(summary, order_trace_bundle)
     if order_trace_summary_bundle is not None:
-        summary = _append_whole_run_order_trace_summary_metadata(
+        summary = append_whole_run_order_trace_summary_metadata(
             summary,
             order_trace_summary_bundle,
         )
     if order_family_summary_bundle is not None:
-        summary = _append_whole_run_order_summaries(summary, order_family_summary_bundle)
-        summary = _append_whole_run_order_family_summary_metadata(
+        summary = append_whole_run_order_summaries(summary, order_family_summary_bundle)
+        summary = append_whole_run_order_family_summary_metadata(
             summary,
             order_family_summary_bundle,
         )
     if spatial_coherence_bundle is not None:
-        summary = _append_whole_run_spatial_summaries(summary, spatial_coherence_bundle)
-        summary = _append_whole_run_spatial_coherence_metadata(
+        summary = append_whole_run_spatial_summaries(summary, spatial_coherence_bundle)
+        summary = append_whole_run_spatial_coherence_metadata(
             summary,
             spatial_coherence_bundle,
         )
@@ -952,23 +952,21 @@ def run_build_report_facts_stage(
         diagnosis_summaries = diagnosis_summary_builder(
             analysis_metadata=analysis_metadata,
             context_bundle=context_bundle,
-            order_summaries=_ranked_whole_run_order_summaries(
-                order_family_summary_bundle.summaries
-            ),
+            order_summaries=ranked_whole_run_order_summaries(order_family_summary_bundle.summaries),
             spatial_summaries=(
-                _ranked_whole_run_spatial_summaries(spatial_coherence_bundle.summaries)
+                ranked_whole_run_spatial_summaries(spatial_coherence_bundle.summaries)
                 if spatial_coherence_bundle is not None
                 else ()
             ),
         )
         if diagnosis_summaries:
-            summary = _append_whole_run_diagnosis_summaries(summary, diagnosis_summaries)
-            summary = _append_whole_run_diagnosis_summary_metadata(
+            summary = append_whole_run_diagnosis_summaries(summary, diagnosis_summaries)
+            summary = append_whole_run_diagnosis_summary_metadata(
                 summary,
                 diagnosis_summaries,
             )
     if stored_artifact_manifest is not None:
-        summary = _append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
+        summary = append_whole_run_analysis_metadata(summary, stored_artifact_manifest)
 
     return summary, _make_stage_result(
         stage_name=stage_name,
@@ -1248,488 +1246,4 @@ def _persistence_failure_result(
         run_id=run_id,
         completed_error=completed_error,
         callback_errors=callback_errors,
-    )
-
-
-def _build_whole_run_artifacts(
-    *,
-    run_id: str,
-    metadata: RunMetadata,
-    raw_capture: RawRunCapture,
-) -> WholeRunSpectralBuildResult:
-    return build_whole_run_spectral_artifact_bundle(
-        run_id=run_id,
-        metadata=metadata,
-        raw_capture=raw_capture,
-    )
-
-
-def _build_whole_run_context_artifacts(
-    *,
-    run: PostAnalysisRunInput,
-    total_sample_count: int | None = None,
-    window_plan: WholeRunWindowPlan | None = None,
-) -> WholeRunContextArtifactBundle | None:
-    if total_sample_count is not None and total_sample_count < 0:
-        raise ValueError("whole-run context builder requires total_sample_count >= 0")
-    return build_whole_run_context_artifact_bundle(
-        run_id=run.run_id,
-        metadata=run.context,
-        samples=run.context_samples,
-        total_sample_count=total_sample_count,
-        window_plan=window_plan,
-    )
-
-
-def _whole_run_total_sample_count(manifest: RawCaptureManifest) -> int:
-    if manifest.sensors:
-        return max(int(sensor.sample_count) for sensor in manifest.sensors)
-    return max(0, int(manifest.total_samples))
-
-
-def _build_whole_run_order_trace_artifacts(
-    *,
-    run: PostAnalysisRunInput,
-    spectral_bundle: WholeRunSpectralArtifactBundle,
-    context_bundle: WholeRunContextArtifactBundle,
-) -> WholeRunOrderTraceArtifactBundle | None:
-    return build_whole_run_order_trace_artifact_bundle(
-        run_id=run.run_id,
-        metadata=run.context,
-        spectral_manifest=spectral_bundle.manifest,
-        spectral_artifact_contents=spectral_bundle.artifact_contents,
-        context_labels=context_bundle.labels,
-        samples=run.context_samples,
-        lang=run.language,
-    )
-
-
-def _build_whole_run_order_trace_summary_artifacts(
-    *,
-    order_trace_bundle: WholeRunOrderTraceArtifactBundle,
-    context_bundle: WholeRunContextArtifactBundle,
-) -> WholeRunOrderTraceSummaryArtifactBundle | None:
-    return build_whole_run_order_trace_summary_artifact_bundle(
-        order_trace_bundle=order_trace_bundle,
-        context_labels=context_bundle.labels,
-    )
-
-
-def _build_whole_run_order_family_summary_artifacts(
-    *,
-    order_trace_bundle: WholeRunOrderTraceArtifactBundle,
-    order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle,
-    context_bundle: WholeRunContextArtifactBundle,
-) -> WholeRunOrderFamilySummaryArtifactBundle | None:
-    return build_whole_run_order_family_summary_artifact_bundle(
-        order_trace_bundle=order_trace_bundle,
-        order_trace_summary_bundle=order_trace_summary_bundle,
-        context_labels=context_bundle.labels,
-    )
-
-
-def _build_whole_run_spatial_coherence_artifacts(
-    *,
-    run: PostAnalysisRunInput,
-    spectral_bundle: WholeRunSpectralArtifactBundle,
-    context_bundle: WholeRunContextArtifactBundle,
-    order_trace_bundle: WholeRunOrderTraceArtifactBundle,
-) -> WholeRunSpatialCoherenceArtifactBundle | None:
-    if not order_trace_bundle.points:
-        return None
-    return build_whole_run_spatial_coherence_artifact_bundle(
-        order_trace_bundle=order_trace_bundle,
-        spectral_manifest=spectral_bundle.manifest,
-        spectral_artifact_contents=spectral_bundle.artifact_contents,
-        context_labels=context_bundle.labels,
-        samples=run.samples,
-        lang=run.language,
-    )
-
-
-def _merge_whole_run_artifact_bundles(
-    *bundles: (
-        WholeRunSpectralArtifactBundle
-        | WholeRunContextArtifactBundle
-        | WholeRunOrderTraceArtifactBundle
-        | WholeRunOrderTraceSummaryArtifactBundle
-        | WholeRunOrderFamilySummaryArtifactBundle
-        | WholeRunSpatialCoherenceArtifactBundle
-        | None
-    ),
-) -> _StoredWholeRunArtifactBundle | None:
-    active_bundles = [bundle for bundle in bundles if bundle is not None]
-    if not active_bundles:
-        return None
-    base_manifest = active_bundles[0].manifest
-    merged_artifacts = list(base_manifest.artifacts)
-    merged_contents = dict(active_bundles[0].artifact_contents)
-    for bundle in active_bundles[1:]:
-        manifest = bundle.manifest
-        if (
-            manifest.run_id != base_manifest.run_id
-            or manifest.relative_dir != base_manifest.relative_dir
-            or manifest.window_policy != base_manifest.window_policy
-            or manifest.total_window_count != base_manifest.total_window_count
-        ):
-            raise ValueError("whole-run artifact bundles must share the same run/window plan")
-        for artifact in manifest.artifacts:
-            if artifact.artifact_key in merged_contents:
-                raise ValueError(
-                    "whole-run artifact bundles must not reuse artifact keys: "
-                    f"{artifact.artifact_key}"
-                )
-            if artifact.artifact_key not in bundle.artifact_contents:
-                raise ValueError(
-                    f"whole-run artifact bundle missing bytes for {artifact.artifact_key}"
-                )
-            merged_artifacts.append(artifact)
-        merged_contents.update(bundle.artifact_contents)
-    return _StoredWholeRunArtifactBundle(
-        manifest=WholeRunArtifactManifest(
-            run_id=base_manifest.run_id,
-            relative_dir=base_manifest.relative_dir,
-            window_policy=base_manifest.window_policy,
-            total_window_count=base_manifest.total_window_count,
-            artifacts=tuple(merged_artifacts),
-            created_at=base_manifest.created_at,
-            schema_version=base_manifest.schema_version,
-            storage_type=base_manifest.storage_type,
-        ),
-        artifact_contents=merged_contents,
-    )
-
-
-def _append_whole_run_analysis_metadata(
-    summary: PersistedAnalysis,
-    manifest: WholeRunArtifactManifest,
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    analysis_metadata = payload.get("analysis_metadata")
-    if not isinstance(analysis_metadata, dict):
-        analysis_metadata = {}
-        payload["analysis_metadata"] = analysis_metadata
-    sensor_ids = sorted(
-        {artifact.sensor_id for artifact in manifest.artifacts if artifact.sensor_id is not None}
-    )
-    analysis_metadata["whole_run_artifacts_available"] = True
-    analysis_metadata["whole_run_window_count"] = int(manifest.total_window_count)
-    analysis_metadata["whole_run_sensor_count"] = len(sensor_ids)
-    analysis_metadata["whole_run_artifact_count"] = len(manifest.artifacts)
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_whole_run_spectral_metadata(
-    summary: PersistedAnalysis,
-    coverage_summary: WholeRunSpectralCoverageSummary,
-    *,
-    spectral_bundle: WholeRunSpectralArtifactBundle | None,
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    analysis_metadata = payload.get("analysis_metadata")
-    if not isinstance(analysis_metadata, dict):
-        analysis_metadata = {}
-        payload["analysis_metadata"] = analysis_metadata
-    analysis_metadata["whole_run_spectral_available"] = spectral_bundle is not None
-    analysis_metadata["whole_run_spectral_window_count"] = (
-        spectral_bundle.manifest.total_window_count if spectral_bundle is not None else 0
-    )
-    analysis_metadata["whole_run_spectral_sensor_window_count"] = (
-        coverage_summary.total_sensor_window_count
-    )
-    analysis_metadata["whole_run_spectral_full_sensor_window_count"] = (
-        coverage_summary.full_sensor_window_count
-    )
-    analysis_metadata["whole_run_spectral_partial_sensor_window_count"] = (
-        coverage_summary.partial_sensor_window_count
-    )
-    analysis_metadata["whole_run_spectral_missing_sensor_window_count"] = (
-        coverage_summary.missing_sensor_window_count
-    )
-    analysis_metadata["whole_run_spectral_empty_sensor_window_count"] = (
-        coverage_summary.empty_sensor_window_count
-    )
-    analysis_metadata["whole_run_spectral_gap_count"] = coverage_summary.gap_count
-    analysis_metadata["whole_run_spectral_overlap_count"] = coverage_summary.overlap_count
-    analysis_metadata["whole_run_spectral_dropped_chunk_count"] = (
-        coverage_summary.dropped_chunk_count
-    )
-    analysis_metadata["whole_run_spectral_late_packet_chunk_count"] = getattr(
-        coverage_summary, "late_packet_chunk_count", 0
-    )
-    analysis_metadata["whole_run_spectral_udp_ingest_queue_drop_count"] = getattr(
-        coverage_summary, "udp_ingest_queue_drop_count", 0
-    )
-    analysis_metadata["whole_run_spectral_queue_overflow_chunk_count"] = (
-        coverage_summary.queue_overflow_chunk_count
-    )
-    analysis_metadata["whole_run_spectral_invalid_chunk_count"] = (
-        coverage_summary.invalid_chunk_count
-    )
-    analysis_metadata["whole_run_spectral_write_error_chunk_count"] = (
-        coverage_summary.write_error_chunk_count
-    )
-    analysis_metadata["whole_run_spectral_sample_rate_mismatch_sensor_count"] = (
-        coverage_summary.sample_rate_mismatch_sensor_count
-    )
-    analysis_metadata["whole_run_spectral_sample_rate_unverified_sensor_count"] = (
-        coverage_summary.sample_rate_unverified_sensor_count
-    )
-    analysis_metadata["whole_run_spectral_unanchored_sensor_count"] = (
-        coverage_summary.unanchored_sensor_count
-    )
-    analysis_metadata["whole_run_spectral_legacy_sensor_count"] = (
-        coverage_summary.legacy_sensor_count
-    )
-    analysis_metadata["whole_run_spectral_sync_unverified_sensor_count"] = (
-        coverage_summary.sync_unverified_sensor_count
-    )
-    analysis_metadata["whole_run_spectral_stale_sync_sensor_count"] = (
-        coverage_summary.stale_sync_sensor_count
-    )
-    analysis_metadata["whole_run_spectral_high_rtt_sensor_count"] = (
-        coverage_summary.high_rtt_sensor_count
-    )
-    analysis_metadata["whole_run_spectral_coverage_confidence"] = (
-        coverage_summary.coverage_confidence
-    )
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_run_context_warnings(
-    summary: PersistedAnalysis,
-    warnings: RunContextWarningsInput,
-) -> PersistedAnalysis:
-    if not warnings:
-        return summary
-    payload = summary.to_json_object()
-    existing = payload.get("warnings")
-    warnings_payload: list[JsonValue] = []
-    if isinstance(existing, list):
-        warnings_payload.extend(item for item in existing if is_json_object(item))
-    for warning in normalize_run_context_warnings(warnings):
-        warning_payload: JsonObject = {
-            "code": warning.code,
-            "severity": warning.severity,
-            "applies_to": warning.applies_to,
-            "title": warning.title,
-            "detail": warning.detail,
-        }
-        warnings_payload.append(warning_payload)
-    payload["warnings"] = warnings_payload
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_whole_run_context(
-    summary: PersistedAnalysis,
-    bundle: WholeRunContextArtifactBundle,
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    payload["whole_run_context_intervals"] = [
-        interval.to_json_object() for interval in bundle.intervals
-    ]
-    analysis_metadata = payload.get("analysis_metadata")
-    if not isinstance(analysis_metadata, dict):
-        analysis_metadata = {}
-        payload["analysis_metadata"] = analysis_metadata
-    analysis_metadata["whole_run_context_available"] = True
-    analysis_metadata["whole_run_context_window_count"] = int(bundle.manifest.total_window_count)
-    analysis_metadata["whole_run_context_interval_count"] = len(bundle.intervals)
-    analysis_metadata["whole_run_context_full_window_count"] = sum(
-        1 for label in bundle.labels if label.context_coverage == "full"
-    )
-    analysis_metadata["whole_run_context_partial_window_count"] = sum(
-        1 for label in bundle.labels if label.context_coverage == "partial"
-    )
-    analysis_metadata["whole_run_context_missing_window_count"] = sum(
-        1 for label in bundle.labels if label.context_coverage == "missing"
-    )
-    analysis_metadata["whole_run_context_missing_speed_window_count"] = sum(
-        1 for label in bundle.labels if label.speed_validity == "missing"
-    )
-    analysis_metadata["whole_run_context_missing_rpm_window_count"] = sum(
-        1 for label in bundle.labels if label.rpm_validity == "missing"
-    )
-    analysis_metadata["whole_run_context_stale_speed_window_count"] = sum(
-        1 for label in bundle.labels if label.speed_is_stale
-    )
-    analysis_metadata["whole_run_context_stale_rpm_window_count"] = sum(
-        1 for label in bundle.labels if label.rpm_is_stale
-    )
-    analysis_metadata["whole_run_context_labels_artifact_key"] = (
-        WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY
-    )
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_whole_run_order_trace_metadata(
-    summary: PersistedAnalysis,
-    bundle: WholeRunOrderTraceArtifactBundle,
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    analysis_metadata = payload.get("analysis_metadata")
-    if not isinstance(analysis_metadata, dict):
-        analysis_metadata = {}
-        payload["analysis_metadata"] = analysis_metadata
-    analysis_metadata["whole_run_order_traces_available"] = True
-    analysis_metadata["whole_run_order_trace_point_count"] = len(bundle.points)
-    analysis_metadata["whole_run_order_trace_candidate_count"] = len(
-        {point.hypothesis_key for point in bundle.points}
-    )
-    analysis_metadata["whole_run_order_trace_artifact_key"] = WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_whole_run_order_trace_summary_metadata(
-    summary: PersistedAnalysis,
-    bundle: WholeRunOrderTraceSummaryArtifactBundle,
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    analysis_metadata = payload.get("analysis_metadata")
-    if not isinstance(analysis_metadata, dict):
-        analysis_metadata = {}
-        payload["analysis_metadata"] = analysis_metadata
-    analysis_metadata["whole_run_order_trace_summaries_available"] = True
-    analysis_metadata["whole_run_order_trace_summary_count"] = len(bundle.summaries)
-    analysis_metadata["whole_run_order_trace_summary_artifact_key"] = (
-        WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY
-    )
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_whole_run_order_family_summary_metadata(
-    summary: PersistedAnalysis,
-    bundle: WholeRunOrderFamilySummaryArtifactBundle,
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    analysis_metadata = payload.get("analysis_metadata")
-    if not isinstance(analysis_metadata, dict):
-        analysis_metadata = {}
-        payload["analysis_metadata"] = analysis_metadata
-    analysis_metadata["whole_run_order_family_summaries_available"] = True
-    analysis_metadata["whole_run_order_family_summary_count"] = len(bundle.summaries)
-    analysis_metadata["whole_run_order_family_summary_artifact_key"] = (
-        WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY
-    )
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_whole_run_spatial_coherence_metadata(
-    summary: PersistedAnalysis,
-    bundle: WholeRunSpatialCoherenceArtifactBundle,
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    analysis_metadata = payload.get("analysis_metadata")
-    if not isinstance(analysis_metadata, dict):
-        analysis_metadata = {}
-        payload["analysis_metadata"] = analysis_metadata
-    analysis_metadata["whole_run_spatial_coherence_available"] = True
-    analysis_metadata["whole_run_spatial_coherence_window_count"] = len(bundle.windows)
-    analysis_metadata["whole_run_spatial_coherence_candidate_count"] = len(
-        {row.candidate_key for row in bundle.windows}
-    )
-    analysis_metadata["whole_run_spatial_coherence_summary_count"] = len(bundle.summaries)
-    analysis_metadata["whole_run_spatial_coherence_artifact_key"] = (
-        WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY
-    )
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_whole_run_order_summaries(
-    summary: PersistedAnalysis,
-    bundle: WholeRunOrderFamilySummaryArtifactBundle,
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    payload["whole_run_order_summaries"] = [
-        row.to_json_object() for row in _ranked_whole_run_order_summaries(bundle.summaries)
-    ]
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_whole_run_spatial_summaries(
-    summary: PersistedAnalysis,
-    bundle: WholeRunSpatialCoherenceArtifactBundle,
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    payload["whole_run_spatial_summaries"] = [
-        row.to_json_object() for row in _ranked_whole_run_spatial_summaries(bundle.summaries)
-    ]
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_whole_run_diagnosis_summaries(
-    summary: PersistedAnalysis,
-    diagnosis_summaries: tuple[WholeRunDiagnosisSummary, ...],
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    payload["whole_run_diagnosis_summaries"] = [row.to_json_object() for row in diagnosis_summaries]
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _append_whole_run_diagnosis_summary_metadata(
-    summary: PersistedAnalysis,
-    diagnosis_summaries: tuple[WholeRunDiagnosisSummary, ...],
-) -> PersistedAnalysis:
-    payload = summary.to_json_object()
-    analysis_metadata = payload.get("analysis_metadata")
-    if not isinstance(analysis_metadata, dict):
-        analysis_metadata = {}
-        payload["analysis_metadata"] = analysis_metadata
-    analysis_metadata["whole_run_diagnosis_summaries_available"] = True
-    analysis_metadata["whole_run_diagnosis_summary_count"] = len(diagnosis_summaries)
-    return PersistedAnalysis.from_json_object(payload)
-
-
-def _build_whole_run_diagnosis_summaries(
-    *,
-    analysis_metadata: Mapping[str, object],
-    context_bundle: WholeRunContextArtifactBundle,
-    order_summaries: tuple[OrderTraceSummary, ...],
-    spatial_summaries: tuple[SpatialEvidenceSummary, ...],
-) -> tuple[WholeRunDiagnosisSummary, ...]:
-    return build_whole_run_diagnosis_summaries(
-        analysis_metadata=analysis_metadata,
-        context_intervals=context_bundle.intervals,
-        order_summaries=order_summaries,
-        spatial_summaries=spatial_summaries,
-    )
-
-
-def _ranked_whole_run_order_summaries(
-    summaries: tuple[OrderTraceSummary, ...],
-) -> tuple[OrderTraceSummary, ...]:
-    return tuple(
-        sorted(
-            summaries,
-            key=lambda summary: (
-                -summary.lock_score,
-                -summary.matched_window_count,
-                -summary.support_ratio,
-                -(summary.peak_intensity_db if summary.peak_intensity_db is not None else -1.0),
-                -summary.reference_coverage_ratio,
-                summary.hypothesis_key,
-            ),
-        )
-    )
-
-
-def _ranked_whole_run_spatial_summaries(
-    summaries: tuple[SpatialEvidenceSummary, ...],
-) -> tuple[SpatialEvidenceSummary, ...]:
-    return tuple(
-        sorted(
-            summaries,
-            key=lambda summary: (
-                -summary.coherent_window_count,
-                -summary.supporting_window_count,
-                -(summary.coherence_ratio if summary.coherence_ratio is not None else -1.0),
-                -(
-                    summary.location_separation_db
-                    if summary.location_separation_db is not None
-                    else -1.0
-                ),
-                -(summary.dominance_ratio if summary.dominance_ratio is not None else -1.0),
-                summary.candidate_key,
-            ),
-        )
     )

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_builders.py
@@ -1,0 +1,193 @@
+"""Whole-run artifact bundle builders used by the post-analysis executor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibesensor.shared.types.raw_capture import RawCaptureManifest, RawRunCapture
+from vibesensor.shared.types.run_schema import RunMetadata
+from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
+from vibesensor.use_cases.diagnostics.orders.whole_run_family_summaries import (
+    WholeRunOrderFamilySummaryArtifactBundle,
+    build_whole_run_order_family_summary_artifact_bundle,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
+    WholeRunOrderTraceSummaryArtifactBundle,
+    build_whole_run_order_trace_summary_artifact_bundle,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WholeRunOrderTraceArtifactBundle,
+    build_whole_run_order_trace_artifact_bundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_context import (
+    WholeRunContextArtifactBundle,
+    build_whole_run_context_artifact_bundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
+    WholeRunSpatialCoherenceArtifactBundle,
+    build_whole_run_spatial_coherence_artifact_bundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    WholeRunSpectralArtifactBundle,
+    WholeRunSpectralBuildResult,
+    build_whole_run_spectral_artifact_bundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_windows import WholeRunWindowPlan
+from vibesensor.use_cases.run.post_analysis_input import PostAnalysisRunInput
+
+
+@dataclass(frozen=True, slots=True)
+class StoredWholeRunArtifactBundle:
+    """Generic sidecar bundle shape for final manifest persistence."""
+
+    manifest: WholeRunArtifactManifest
+    artifact_contents: dict[str, bytes]
+
+
+def build_whole_run_artifacts(
+    *,
+    run_id: str,
+    metadata: RunMetadata,
+    raw_capture: RawRunCapture,
+) -> WholeRunSpectralBuildResult:
+    return build_whole_run_spectral_artifact_bundle(
+        run_id=run_id,
+        metadata=metadata,
+        raw_capture=raw_capture,
+    )
+
+
+def build_whole_run_context_artifacts(
+    *,
+    run: PostAnalysisRunInput,
+    total_sample_count: int | None = None,
+    window_plan: WholeRunWindowPlan | None = None,
+) -> WholeRunContextArtifactBundle | None:
+    if total_sample_count is not None and total_sample_count < 0:
+        raise ValueError("whole-run context builder requires total_sample_count >= 0")
+    return build_whole_run_context_artifact_bundle(
+        run_id=run.run_id,
+        metadata=run.context,
+        samples=run.context_samples,
+        total_sample_count=total_sample_count,
+        window_plan=window_plan,
+    )
+
+
+def whole_run_total_sample_count(manifest: RawCaptureManifest) -> int:
+    if manifest.sensors:
+        return max(int(sensor.sample_count) for sensor in manifest.sensors)
+    return max(0, int(manifest.total_samples))
+
+
+def build_whole_run_order_trace_artifacts(
+    *,
+    run: PostAnalysisRunInput,
+    spectral_bundle: WholeRunSpectralArtifactBundle,
+    context_bundle: WholeRunContextArtifactBundle,
+) -> WholeRunOrderTraceArtifactBundle | None:
+    return build_whole_run_order_trace_artifact_bundle(
+        run_id=run.run_id,
+        metadata=run.context,
+        spectral_manifest=spectral_bundle.manifest,
+        spectral_artifact_contents=spectral_bundle.artifact_contents,
+        context_labels=context_bundle.labels,
+        samples=run.context_samples,
+        lang=run.language,
+    )
+
+
+def build_whole_run_order_trace_summary_artifacts(
+    *,
+    order_trace_bundle: WholeRunOrderTraceArtifactBundle,
+    context_bundle: WholeRunContextArtifactBundle,
+) -> WholeRunOrderTraceSummaryArtifactBundle | None:
+    return build_whole_run_order_trace_summary_artifact_bundle(
+        order_trace_bundle=order_trace_bundle,
+        context_labels=context_bundle.labels,
+    )
+
+
+def build_whole_run_order_family_summary_artifacts(
+    *,
+    order_trace_bundle: WholeRunOrderTraceArtifactBundle,
+    order_trace_summary_bundle: WholeRunOrderTraceSummaryArtifactBundle,
+    context_bundle: WholeRunContextArtifactBundle,
+) -> WholeRunOrderFamilySummaryArtifactBundle | None:
+    return build_whole_run_order_family_summary_artifact_bundle(
+        order_trace_bundle=order_trace_bundle,
+        order_trace_summary_bundle=order_trace_summary_bundle,
+        context_labels=context_bundle.labels,
+    )
+
+
+def build_whole_run_spatial_coherence_artifacts(
+    *,
+    run: PostAnalysisRunInput,
+    spectral_bundle: WholeRunSpectralArtifactBundle,
+    context_bundle: WholeRunContextArtifactBundle,
+    order_trace_bundle: WholeRunOrderTraceArtifactBundle,
+) -> WholeRunSpatialCoherenceArtifactBundle | None:
+    if not order_trace_bundle.points:
+        return None
+    return build_whole_run_spatial_coherence_artifact_bundle(
+        order_trace_bundle=order_trace_bundle,
+        spectral_manifest=spectral_bundle.manifest,
+        spectral_artifact_contents=spectral_bundle.artifact_contents,
+        context_labels=context_bundle.labels,
+        samples=run.samples,
+        lang=run.language,
+    )
+
+
+def merge_whole_run_artifact_bundles(
+    *bundles: (
+        WholeRunSpectralArtifactBundle
+        | WholeRunContextArtifactBundle
+        | WholeRunOrderTraceArtifactBundle
+        | WholeRunOrderTraceSummaryArtifactBundle
+        | WholeRunOrderFamilySummaryArtifactBundle
+        | WholeRunSpatialCoherenceArtifactBundle
+        | None
+    ),
+) -> StoredWholeRunArtifactBundle | None:
+    active_bundles = [bundle for bundle in bundles if bundle is not None]
+    if not active_bundles:
+        return None
+    base_manifest = active_bundles[0].manifest
+    merged_artifacts = list(base_manifest.artifacts)
+    merged_contents = dict(active_bundles[0].artifact_contents)
+    for bundle in active_bundles[1:]:
+        manifest = bundle.manifest
+        if (
+            manifest.run_id != base_manifest.run_id
+            or manifest.relative_dir != base_manifest.relative_dir
+            or manifest.window_policy != base_manifest.window_policy
+            or manifest.total_window_count != base_manifest.total_window_count
+        ):
+            raise ValueError("whole-run artifact bundles must share the same run/window plan")
+        for artifact in manifest.artifacts:
+            if artifact.artifact_key in merged_contents:
+                raise ValueError(
+                    "whole-run artifact bundles must not reuse artifact keys: "
+                    f"{artifact.artifact_key}"
+                )
+            if artifact.artifact_key not in bundle.artifact_contents:
+                raise ValueError(
+                    f"whole-run artifact bundle missing bytes for {artifact.artifact_key}"
+                )
+            merged_artifacts.append(artifact)
+        merged_contents.update(bundle.artifact_contents)
+    return StoredWholeRunArtifactBundle(
+        manifest=WholeRunArtifactManifest(
+            run_id=base_manifest.run_id,
+            relative_dir=base_manifest.relative_dir,
+            window_policy=base_manifest.window_policy,
+            total_window_count=base_manifest.total_window_count,
+            artifacts=tuple(merged_artifacts),
+            created_at=base_manifest.created_at,
+            schema_version=base_manifest.schema_version,
+            storage_type=base_manifest.storage_type,
+        ),
+        artifact_contents=merged_contents,
+    )

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
@@ -1,0 +1,380 @@
+"""Whole-run summary projection helpers for post-analysis persistence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from vibesensor.shared.run_context_warning import (
+    RunContextWarningsInput,
+    normalize_run_context_warnings,
+)
+from vibesensor.shared.types.json_types import JsonObject, JsonValue, is_json_object
+from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import OrderTraceSummary
+from vibesensor.use_cases.diagnostics.orders.whole_run_family_summaries import (
+    WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY,
+    WholeRunOrderFamilySummaryArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_scoring import (
+    WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY,
+    WholeRunOrderTraceSummaryArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.orders.whole_run_traces import (
+    WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY,
+    WholeRunOrderTraceArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import SpatialEvidenceSummary
+from vibesensor.use_cases.diagnostics.whole_run_context import (
+    WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY,
+    WholeRunContextArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
+    WholeRunDiagnosisSummary,
+)
+from vibesensor.use_cases.diagnostics.whole_run_diagnosis_ranking import (
+    build_whole_run_diagnosis_summaries,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spatial_coherence import (
+    WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY,
+    WholeRunSpatialCoherenceArtifactBundle,
+)
+from vibesensor.use_cases.diagnostics.whole_run_spectra import (
+    WholeRunSpectralArtifactBundle,
+    WholeRunSpectralCoverageSummary,
+)
+
+
+def append_whole_run_analysis_metadata(
+    summary: PersistedAnalysis,
+    manifest: WholeRunArtifactManifest,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    sensor_ids = sorted(
+        {artifact.sensor_id for artifact in manifest.artifacts if artifact.sensor_id is not None}
+    )
+    analysis_metadata["whole_run_artifacts_available"] = True
+    analysis_metadata["whole_run_window_count"] = int(manifest.total_window_count)
+    analysis_metadata["whole_run_sensor_count"] = len(sensor_ids)
+    analysis_metadata["whole_run_artifact_count"] = len(manifest.artifacts)
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_whole_run_spectral_metadata(
+    summary: PersistedAnalysis,
+    coverage_summary: WholeRunSpectralCoverageSummary,
+    *,
+    spectral_bundle: WholeRunSpectralArtifactBundle | None,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    analysis_metadata["whole_run_spectral_available"] = spectral_bundle is not None
+    analysis_metadata["whole_run_spectral_window_count"] = (
+        spectral_bundle.manifest.total_window_count if spectral_bundle is not None else 0
+    )
+    analysis_metadata["whole_run_spectral_sensor_window_count"] = (
+        coverage_summary.total_sensor_window_count
+    )
+    analysis_metadata["whole_run_spectral_full_sensor_window_count"] = (
+        coverage_summary.full_sensor_window_count
+    )
+    analysis_metadata["whole_run_spectral_partial_sensor_window_count"] = (
+        coverage_summary.partial_sensor_window_count
+    )
+    analysis_metadata["whole_run_spectral_missing_sensor_window_count"] = (
+        coverage_summary.missing_sensor_window_count
+    )
+    analysis_metadata["whole_run_spectral_empty_sensor_window_count"] = (
+        coverage_summary.empty_sensor_window_count
+    )
+    analysis_metadata["whole_run_spectral_gap_count"] = coverage_summary.gap_count
+    analysis_metadata["whole_run_spectral_overlap_count"] = coverage_summary.overlap_count
+    analysis_metadata["whole_run_spectral_dropped_chunk_count"] = (
+        coverage_summary.dropped_chunk_count
+    )
+    analysis_metadata["whole_run_spectral_late_packet_chunk_count"] = getattr(
+        coverage_summary, "late_packet_chunk_count", 0
+    )
+    analysis_metadata["whole_run_spectral_udp_ingest_queue_drop_count"] = getattr(
+        coverage_summary, "udp_ingest_queue_drop_count", 0
+    )
+    analysis_metadata["whole_run_spectral_queue_overflow_chunk_count"] = (
+        coverage_summary.queue_overflow_chunk_count
+    )
+    analysis_metadata["whole_run_spectral_invalid_chunk_count"] = (
+        coverage_summary.invalid_chunk_count
+    )
+    analysis_metadata["whole_run_spectral_write_error_chunk_count"] = (
+        coverage_summary.write_error_chunk_count
+    )
+    analysis_metadata["whole_run_spectral_sample_rate_mismatch_sensor_count"] = (
+        coverage_summary.sample_rate_mismatch_sensor_count
+    )
+    analysis_metadata["whole_run_spectral_sample_rate_unverified_sensor_count"] = (
+        coverage_summary.sample_rate_unverified_sensor_count
+    )
+    analysis_metadata["whole_run_spectral_unanchored_sensor_count"] = (
+        coverage_summary.unanchored_sensor_count
+    )
+    analysis_metadata["whole_run_spectral_legacy_sensor_count"] = (
+        coverage_summary.legacy_sensor_count
+    )
+    analysis_metadata["whole_run_spectral_sync_unverified_sensor_count"] = (
+        coverage_summary.sync_unverified_sensor_count
+    )
+    analysis_metadata["whole_run_spectral_stale_sync_sensor_count"] = (
+        coverage_summary.stale_sync_sensor_count
+    )
+    analysis_metadata["whole_run_spectral_high_rtt_sensor_count"] = (
+        coverage_summary.high_rtt_sensor_count
+    )
+    analysis_metadata["whole_run_spectral_coverage_confidence"] = (
+        coverage_summary.coverage_confidence
+    )
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_run_context_warnings(
+    summary: PersistedAnalysis,
+    warnings: RunContextWarningsInput,
+) -> PersistedAnalysis:
+    if not warnings:
+        return summary
+    payload = summary.to_json_object()
+    existing = payload.get("warnings")
+    warnings_payload: list[JsonValue] = []
+    if isinstance(existing, list):
+        warnings_payload.extend(item for item in existing if is_json_object(item))
+    for warning in normalize_run_context_warnings(warnings):
+        warning_payload: JsonObject = {
+            "code": warning.code,
+            "severity": warning.severity,
+            "applies_to": warning.applies_to,
+            "title": warning.title,
+            "detail": warning.detail,
+        }
+        warnings_payload.append(warning_payload)
+    payload["warnings"] = warnings_payload
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_whole_run_context(
+    summary: PersistedAnalysis,
+    bundle: WholeRunContextArtifactBundle,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    payload["whole_run_context_intervals"] = [
+        interval.to_json_object() for interval in bundle.intervals
+    ]
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    analysis_metadata["whole_run_context_available"] = True
+    analysis_metadata["whole_run_context_window_count"] = int(bundle.manifest.total_window_count)
+    analysis_metadata["whole_run_context_interval_count"] = len(bundle.intervals)
+    analysis_metadata["whole_run_context_full_window_count"] = sum(
+        1 for label in bundle.labels if label.context_coverage == "full"
+    )
+    analysis_metadata["whole_run_context_partial_window_count"] = sum(
+        1 for label in bundle.labels if label.context_coverage == "partial"
+    )
+    analysis_metadata["whole_run_context_missing_window_count"] = sum(
+        1 for label in bundle.labels if label.context_coverage == "missing"
+    )
+    analysis_metadata["whole_run_context_missing_speed_window_count"] = sum(
+        1 for label in bundle.labels if label.speed_validity == "missing"
+    )
+    analysis_metadata["whole_run_context_missing_rpm_window_count"] = sum(
+        1 for label in bundle.labels if label.rpm_validity == "missing"
+    )
+    analysis_metadata["whole_run_context_stale_speed_window_count"] = sum(
+        1 for label in bundle.labels if label.speed_is_stale
+    )
+    analysis_metadata["whole_run_context_stale_rpm_window_count"] = sum(
+        1 for label in bundle.labels if label.rpm_is_stale
+    )
+    analysis_metadata["whole_run_context_labels_artifact_key"] = (
+        WHOLE_RUN_CONTEXT_LABEL_ARTIFACT_KEY
+    )
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_whole_run_order_trace_metadata(
+    summary: PersistedAnalysis,
+    bundle: WholeRunOrderTraceArtifactBundle,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    analysis_metadata["whole_run_order_traces_available"] = True
+    analysis_metadata["whole_run_order_trace_point_count"] = len(bundle.points)
+    analysis_metadata["whole_run_order_trace_candidate_count"] = len(
+        {point.hypothesis_key for point in bundle.points}
+    )
+    analysis_metadata["whole_run_order_trace_artifact_key"] = WHOLE_RUN_ORDER_TRACE_ARTIFACT_KEY
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_whole_run_order_trace_summary_metadata(
+    summary: PersistedAnalysis,
+    bundle: WholeRunOrderTraceSummaryArtifactBundle,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    analysis_metadata["whole_run_order_trace_summaries_available"] = True
+    analysis_metadata["whole_run_order_trace_summary_count"] = len(bundle.summaries)
+    analysis_metadata["whole_run_order_trace_summary_artifact_key"] = (
+        WHOLE_RUN_ORDER_TRACE_SUMMARY_ARTIFACT_KEY
+    )
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_whole_run_order_family_summary_metadata(
+    summary: PersistedAnalysis,
+    bundle: WholeRunOrderFamilySummaryArtifactBundle,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    analysis_metadata["whole_run_order_family_summaries_available"] = True
+    analysis_metadata["whole_run_order_family_summary_count"] = len(bundle.summaries)
+    analysis_metadata["whole_run_order_family_summary_artifact_key"] = (
+        WHOLE_RUN_ORDER_FAMILY_SUMMARY_ARTIFACT_KEY
+    )
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_whole_run_spatial_coherence_metadata(
+    summary: PersistedAnalysis,
+    bundle: WholeRunSpatialCoherenceArtifactBundle,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    analysis_metadata["whole_run_spatial_coherence_available"] = True
+    analysis_metadata["whole_run_spatial_coherence_window_count"] = len(bundle.windows)
+    analysis_metadata["whole_run_spatial_coherence_candidate_count"] = len(
+        {row.candidate_key for row in bundle.windows}
+    )
+    analysis_metadata["whole_run_spatial_coherence_summary_count"] = len(bundle.summaries)
+    analysis_metadata["whole_run_spatial_coherence_artifact_key"] = (
+        WHOLE_RUN_SPATIAL_COHERENCE_ARTIFACT_KEY
+    )
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_whole_run_order_summaries(
+    summary: PersistedAnalysis,
+    bundle: WholeRunOrderFamilySummaryArtifactBundle,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    payload["whole_run_order_summaries"] = [
+        row.to_json_object() for row in ranked_whole_run_order_summaries(bundle.summaries)
+    ]
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_whole_run_spatial_summaries(
+    summary: PersistedAnalysis,
+    bundle: WholeRunSpatialCoherenceArtifactBundle,
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    payload["whole_run_spatial_summaries"] = [
+        row.to_json_object() for row in ranked_whole_run_spatial_summaries(bundle.summaries)
+    ]
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_whole_run_diagnosis_summaries(
+    summary: PersistedAnalysis,
+    diagnosis_summaries: tuple[WholeRunDiagnosisSummary, ...],
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    payload["whole_run_diagnosis_summaries"] = [row.to_json_object() for row in diagnosis_summaries]
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def append_whole_run_diagnosis_summary_metadata(
+    summary: PersistedAnalysis,
+    diagnosis_summaries: tuple[WholeRunDiagnosisSummary, ...],
+) -> PersistedAnalysis:
+    payload = summary.to_json_object()
+    analysis_metadata = payload.get("analysis_metadata")
+    if not isinstance(analysis_metadata, dict):
+        analysis_metadata = {}
+        payload["analysis_metadata"] = analysis_metadata
+    analysis_metadata["whole_run_diagnosis_summaries_available"] = True
+    analysis_metadata["whole_run_diagnosis_summary_count"] = len(diagnosis_summaries)
+    return PersistedAnalysis.from_json_object(payload)
+
+
+def build_diagnosis_summary_rows(
+    *,
+    analysis_metadata: Mapping[str, object],
+    context_bundle: WholeRunContextArtifactBundle,
+    order_summaries: tuple[OrderTraceSummary, ...],
+    spatial_summaries: tuple[SpatialEvidenceSummary, ...],
+) -> tuple[WholeRunDiagnosisSummary, ...]:
+    return build_whole_run_diagnosis_summaries(
+        analysis_metadata=analysis_metadata,
+        context_intervals=context_bundle.intervals,
+        order_summaries=order_summaries,
+        spatial_summaries=spatial_summaries,
+    )
+
+
+def ranked_whole_run_order_summaries(
+    summaries: tuple[OrderTraceSummary, ...],
+) -> tuple[OrderTraceSummary, ...]:
+    return tuple(
+        sorted(
+            summaries,
+            key=lambda summary: (
+                -summary.lock_score,
+                -summary.matched_window_count,
+                -summary.support_ratio,
+                -(summary.peak_intensity_db if summary.peak_intensity_db is not None else -1.0),
+                -summary.reference_coverage_ratio,
+                summary.hypothesis_key,
+            ),
+        )
+    )
+
+
+def ranked_whole_run_spatial_summaries(
+    summaries: tuple[SpatialEvidenceSummary, ...],
+) -> tuple[SpatialEvidenceSummary, ...]:
+    return tuple(
+        sorted(
+            summaries,
+            key=lambda summary: (
+                -summary.coherent_window_count,
+                -summary.supporting_window_count,
+                -(summary.coherence_ratio if summary.coherence_ratio is not None else -1.0),
+                -(
+                    summary.location_separation_db
+                    if summary.location_separation_db is not None
+                    else -1.0
+                ),
+                -(summary.dominance_ratio if summary.dominance_ratio is not None else -1.0),
+                summary.candidate_key,
+            ),
+        )
+    )


### PR DESCRIPTION
## What changed
- split whole-run artifact building and manifest merge logic out of `post_analysis_executor.py` into `post_analysis_whole_run_builders.py`
- split persisted-analysis projection and whole-run ranking/diagnosis projection logic into `post_analysis_whole_run_projection.py`
- split whole-run spectral coverage and JSONL summary projection into `whole_run_spectral_projection.py`
- added focused tests for the extracted modules while keeping executor and spectra flow tests green

## Why
- #3209 asks for responsibility-based splits, not tiny helper churn
- `post_analysis_executor.py` now stays on orchestration and stage flow
- `whole_run_spectra.py` now stays on planning, chunk execution, and artifact assembly

## Validation
- `pytest -q apps/server/tests/use_cases/diagnostics/test_whole_run_spectral_projection.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_builders.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_projection.py apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py apps/server/tests/use_cases/run/test_post_analysis_executor.py apps/server/tests/use_cases/run/test_post_analysis_executor_whole_run_warnings.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_order_traces.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_spatial_coherence.py apps/server/tests/use_cases/run/test_post_analysis_whole_run_diagnosis_ranking.py apps/server/tests/use_cases/diagnostics/test_whole_run_spectra.py apps/server/tests/use_cases/diagnostics/test_whole_run_spectra_chunk_execution.py`
- `make typecheck-backend`
- `make lint`

## Risks / tradeoffs
- behavior should stay stable; this is an ownership refactor, not a contract change
- the new modules are larger than micro-helpers on purpose so each split keeps one real responsibility

Closes #3209