### PR TITLE
Define canonical run/artifact lifecycle model

### DIFF
--- a/apps/server/tests/adapters/http/_history_endpoint_helpers.py
+++ b/apps/server/tests/adapters/http/_history_endpoint_helpers.py
@@ -42,6 +42,7 @@ from vibesensor.shared.types.history_records import (
     StoredHistoryRun,
 )
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
+from vibesensor.shared.types.run_lifecycle import derive_run_artifact_lifecycle
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.shared.types.sensor_frame import SensorFrame
 from vibesensor.use_cases.history.exports import HistoryExportService
@@ -131,14 +132,35 @@ class FakeHistoryDB:
     analysis: dict[str, Any] | AnalysisSummary | PersistedAnalysis
     analysis_completed_at: str | None = "2026-01-01T00:01:00Z"
 
+    @staticmethod
+    def _artifact_availability_from_lifecycle(
+        raw_capture: str,
+        whole_run_artifacts: str,
+    ) -> HistoryArtifactAvailability:
+        return HistoryArtifactAvailability(
+            raw_capture="available" if raw_capture == "ready" else raw_capture,
+            whole_run_artifacts=(
+                "available" if whole_run_artifacts == "ready" else whole_run_artifacts
+            ),
+        )
+
     async def aget_run(self, run_id: str) -> StoredHistoryRun | None:
         if run_id != "run-1":
             return None
         metadata = _coerce_metadata(self.metadata)
-        artifact_availability = (
-            HistoryArtifactAvailability(raw_capture="degraded")
-            if metadata.raw_capture_finalize is not None and metadata.raw_capture_finalize.degraded
-            else None
+        lifecycle = derive_run_artifact_lifecycle(
+            status=RunStatus.COMPLETE,
+            has_raw_capture_manifest=False,
+            raw_capture_artifacts_present=False,
+            has_whole_run_artifact_manifest=False,
+            whole_run_artifacts_present=False,
+            raw_capture_finalize=metadata.raw_capture_finalize,
+            has_analysis=True,
+            analysis_corrupt=False,
+        )
+        artifact_availability = self._artifact_availability_from_lifecycle(
+            lifecycle.raw_capture,
+            lifecycle.whole_run_artifacts,
         )
         return StoredHistoryRun(
             run_id=run_id,
@@ -146,6 +168,7 @@ class FakeHistoryDB:
             start_time_utc=metadata.start_time_utc,
             end_time_utc=metadata.end_time_utc,
             metadata=metadata,
+            lifecycle=lifecycle,
             raw_capture_finalize=metadata.raw_capture_finalize,
             artifact_availability=artifact_availability,
             analysis=_coerce_analysis(metadata, self.samples, self.analysis),
@@ -174,10 +197,19 @@ class FakeHistoryDB:
 
     async def alist_runs(self, limit: int = 500) -> list[HistoryRunListEntry]:
         metadata = _coerce_metadata(self.metadata)
-        artifact_availability = (
-            HistoryArtifactAvailability(raw_capture="degraded")
-            if metadata.raw_capture_finalize is not None and metadata.raw_capture_finalize.degraded
-            else None
+        lifecycle = derive_run_artifact_lifecycle(
+            status=RunStatus.COMPLETE,
+            has_raw_capture_manifest=False,
+            raw_capture_artifacts_present=False,
+            has_whole_run_artifact_manifest=False,
+            whole_run_artifacts_present=False,
+            raw_capture_finalize=metadata.raw_capture_finalize,
+            has_analysis=True,
+            analysis_corrupt=False,
+        )
+        artifact_availability = self._artifact_availability_from_lifecycle(
+            lifecycle.raw_capture,
+            lifecycle.whole_run_artifacts,
         )
         return [
             HistoryRunListEntry(
@@ -188,6 +220,7 @@ class FakeHistoryDB:
                 created_at=metadata.start_time_utc,
                 sample_count=len(self.samples),
                 car_name=metadata.car_name,
+                lifecycle=lifecycle,
                 artifact_availability=artifact_availability,
                 raw_capture_finalize=metadata.raw_capture_finalize,
             )

--- a/apps/server/tests/adapters/http/test_api_history_route_state.py
+++ b/apps/server/tests/adapters/http/test_api_history_route_state.py
@@ -227,11 +227,25 @@ async def test_history_endpoints_include_degraded_raw_capture_finalize_state() -
     list_payload = response_payload(await route_endpoint(router, "/api/history")())
     run_payload = response_payload(await route_endpoint(router, "/api/history/{run_id}")("run-1"))
 
+    assert list_payload["runs"][0]["lifecycle"] == {
+        "stage": "post_analysis_ready",
+        "raw_capture": "degraded",
+        "whole_run_artifacts": "not_recorded",
+        "post_analysis": "ready",
+        "report": "ready",
+    }
     assert list_payload["runs"][0]["artifact_availability"]["raw_capture"] == "degraded"
     assert list_payload["runs"][0]["raw_capture_finalize"] == {
         "status": "timeout",
         "queue_depth": 4,
         "error_summary": "raw capture finalize timed out",
+    }
+    assert run_payload["lifecycle"] == {
+        "stage": "post_analysis_ready",
+        "raw_capture": "degraded",
+        "whole_run_artifacts": "not_recorded",
+        "post_analysis": "ready",
+        "report": "ready",
     }
     assert run_payload["artifact_availability"]["raw_capture"] == "degraded"
     assert run_payload["raw_capture_finalize"] == {

--- a/apps/server/tests/adapters/persistence/history_db/test_history_db_list_runs.py
+++ b/apps/server/tests/adapters/persistence/history_db/test_history_db_list_runs.py
@@ -147,6 +147,9 @@ def test_list_runs_projects_degraded_raw_capture_finalize_state(tmp_path: Path) 
 
     run = db.run_repository.list_runs()[0]
 
+    assert run.lifecycle is not None
+    assert run.lifecycle.raw_capture == "degraded"
+    assert run.lifecycle.post_analysis == "pending"
     assert run.artifact_availability is not None
     assert run.artifact_availability.raw_capture == "degraded"
     assert run.raw_capture_finalize is not None
@@ -173,6 +176,9 @@ def test_get_run_projects_raw_capture_finalize_state(tmp_path: Path) -> None:
     run = db.run_repository.get_run("run-degraded")
 
     assert run is not None
+    assert run.lifecycle is not None
+    assert run.lifecycle.raw_capture == "degraded"
+    assert run.lifecycle.post_analysis == "pending"
     assert run.artifact_availability is not None
     assert run.artifact_availability.raw_capture == "degraded"
     assert run.raw_capture_finalize is not None

--- a/apps/server/tests/shared/types/test_run_lifecycle.py
+++ b/apps/server/tests/shared/types/test_run_lifecycle.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from vibesensor.domain import RunStatus
+from vibesensor.shared.types.run_lifecycle import derive_run_artifact_lifecycle
+from vibesensor.shared.types.run_schema import RunRawCaptureFinalize
+
+
+def test_derive_run_artifact_lifecycle_marks_recording_run_pending() -> None:
+    lifecycle = derive_run_artifact_lifecycle(
+        status=RunStatus.RECORDING,
+        has_raw_capture_manifest=False,
+        raw_capture_artifacts_present=False,
+        has_whole_run_artifact_manifest=False,
+        whole_run_artifacts_present=False,
+        raw_capture_finalize=None,
+        has_analysis=False,
+        analysis_corrupt=False,
+    )
+
+    assert lifecycle.stage == "recording"
+    assert lifecycle.raw_capture == "pending"
+    assert lifecycle.whole_run_artifacts == "pending"
+    assert lifecycle.post_analysis == "pending"
+    assert lifecycle.report == "pending"
+
+
+def test_derive_run_artifact_lifecycle_marks_ready_complete_run() -> None:
+    lifecycle = derive_run_artifact_lifecycle(
+        status=RunStatus.COMPLETE,
+        has_raw_capture_manifest=False,
+        raw_capture_artifacts_present=False,
+        has_whole_run_artifact_manifest=False,
+        whole_run_artifacts_present=False,
+        raw_capture_finalize=RunRawCaptureFinalize(status="not_configured"),
+        has_analysis=True,
+        analysis_corrupt=False,
+    )
+
+    assert lifecycle.stage == "post_analysis_ready"
+    assert lifecycle.raw_capture == "not_recorded"
+    assert lifecycle.whole_run_artifacts == "not_recorded"
+    assert lifecycle.post_analysis == "ready"
+    assert lifecycle.report == "ready"
+
+
+def test_derive_run_artifact_lifecycle_marks_missing_and_degraded_artifacts() -> None:
+    lifecycle = derive_run_artifact_lifecycle(
+        status=RunStatus.ERROR,
+        has_raw_capture_manifest=True,
+        raw_capture_artifacts_present=False,
+        has_whole_run_artifact_manifest=False,
+        whole_run_artifacts_present=False,
+        raw_capture_finalize=RunRawCaptureFinalize(
+            status="failed",
+            queue_depth=2,
+            error_summary="writer crashed",
+        ),
+        has_analysis=False,
+        analysis_corrupt=False,
+    )
+
+    assert lifecycle.stage == "post_analysis_degraded"
+    assert lifecycle.raw_capture == "missing"
+    assert lifecycle.whole_run_artifacts == "degraded"
+    assert lifecycle.post_analysis == "degraded"
+    assert lifecycle.report == "degraded"

--- a/apps/server/tests/use_cases/history/test_history_service_edges.py
+++ b/apps/server/tests/use_cases/history/test_history_service_edges.py
@@ -87,7 +87,7 @@ def _stored_run(run: dict[str, Any]) -> StoredHistoryRun:
                 "status": "recording",
                 "analysis": None,
             },
-            "active",
+            "unavailable",
             "Analysis is not available while recording is still active",
         ),
         (

--- a/apps/server/tests/use_cases/history/test_history_service_edges.py
+++ b/apps/server/tests/use_cases/history/test_history_service_edges.py
@@ -84,6 +84,14 @@ def _stored_run(run: dict[str, Any]) -> StoredHistoryRun:
     [
         (
             {
+                "status": "recording",
+                "analysis": None,
+            },
+            "active",
+            "Analysis is not available while recording is still active",
+        ),
+        (
+            {
                 "status": "analyzing",
                 "analysis": {"lang": "en", "findings": []},
             },

--- a/apps/server/vibesensor/adapters/history/projection.py
+++ b/apps/server/vibesensor/adapters/history/projection.py
@@ -63,6 +63,8 @@ def project_history_run_record(run: StoredHistoryRun) -> JsonObject:
     }
     if run.error_message is not None:
         payload["error_message"] = run.error_message
+    if run.lifecycle is not None:
+        payload["lifecycle"] = run.lifecycle.to_json_object()
     if run.artifact_availability is not None:
         payload["artifact_availability"] = run.artifact_availability.to_json_object()
     if run.raw_capture_finalize is not None:

--- a/apps/server/vibesensor/adapters/http/models/history.py
+++ b/apps/server/vibesensor/adapters/http/models/history.py
@@ -103,8 +103,24 @@ __all__ = [
 class HistoryArtifactAvailabilityResponse(BaseModel):
     """Response body describing persisted artifact availability for a history run."""
 
-    raw_capture: Literal["not_recorded", "available", "missing", "degraded"]
-    whole_run_artifacts: Literal["not_recorded", "available", "missing"]
+    raw_capture: Literal["not_recorded", "pending", "available", "missing", "degraded"]
+    whole_run_artifacts: Literal["not_recorded", "pending", "available", "missing", "degraded"]
+
+
+class HistoryRunLifecycleResponse(BaseModel):
+    """Response body describing the canonical derived lifecycle for a history run."""
+
+    stage: Literal[
+        "recording",
+        "post_analysis_pending",
+        "post_analysis_running",
+        "post_analysis_ready",
+        "post_analysis_degraded",
+    ]
+    raw_capture: Literal["not_recorded", "pending", "ready", "degraded", "missing"]
+    whole_run_artifacts: Literal["not_recorded", "pending", "ready", "degraded", "missing"]
+    post_analysis: Literal["pending", "running", "ready", "degraded"]
+    report: Literal["pending", "ready", "degraded"]
 
 
 class HistoryRawCaptureFinalizeResponse(BaseModel):
@@ -126,6 +142,7 @@ class HistoryListEntryResponse(BaseModel):
     sample_count: int
     car_name: str | None = None
     error_message: str | None = None
+    lifecycle: HistoryRunLifecycleResponse | None = None
     artifact_availability: HistoryArtifactAvailabilityResponse | None = None
     raw_capture_finalize: HistoryRawCaptureFinalizeResponse | None = None
 
@@ -151,6 +168,7 @@ class HistoryRunResponse(_StrictBase):
     error_message: str | None = None
     metadata: ApiPayloadObject = Field(default_factory=dict)
     analysis: _HistoryRunAnalysisResponse | None = None
+    lifecycle: HistoryRunLifecycleResponse | None = None
     artifact_availability: HistoryArtifactAvailabilityResponse | None = None
     raw_capture_finalize: HistoryRawCaptureFinalizeResponse | None = None
 

--- a/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
+++ b/apps/server/vibesensor/adapters/persistence/history_db/_queries.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Awaitable
 from contextlib import AbstractAsyncContextManager
 from datetime import UTC, datetime
-from typing import TypeVar
+from typing import TypeVar, cast
 
 import aiosqlite
 
@@ -25,6 +25,7 @@ from vibesensor.shared.boundaries.runs.metadata import run_metadata_from_mapping
 from vibesensor.shared.json_utils import safe_json_loads
 from vibesensor.shared.types.history_records import (
     AnalyzingRunHealth,
+    ArtifactAvailabilityState,
     HistoryArtifactAvailability,
     HistoryRunListEntry,
     StoredHistoryRun,
@@ -35,6 +36,10 @@ from vibesensor.shared.types.raw_capture import (
     RawCaptureManifest,
     RawCaptureSensorRange,
     RawRunCapture,
+)
+from vibesensor.shared.types.run_lifecycle import (
+    RunArtifactLifecycle,
+    derive_run_artifact_lifecycle,
 )
 from vibesensor.shared.types.run_schema import RunMetadata, RunRawCaptureFinalize
 from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
@@ -54,34 +59,23 @@ class _HistoryDBQueryMixin:
     def _run_sync(self, coro: Awaitable[_T]) -> _T:
         raise NotImplementedError
 
+    @staticmethod
+    def _artifact_availability_state(
+        state: str,
+    ) -> ArtifactAvailabilityState:
+        return cast(
+            ArtifactAvailabilityState,
+            "available" if state == "ready" else state,
+        )
+
     def _artifact_availability(
         self,
         *,
-        run_id: str,
-        has_raw_capture_manifest: bool,
-        has_whole_run_artifact_manifest: bool,
-        raw_capture_finalize: RunRawCaptureFinalize | None = None,
+        lifecycle: RunArtifactLifecycle,
     ) -> HistoryArtifactAvailability:
         return HistoryArtifactAvailability(
-            raw_capture=(
-                "available"
-                if has_raw_capture_manifest and self._raw_capture_store.has_run_artifacts(run_id)
-                else "missing"
-                if has_raw_capture_manifest
-                else "degraded"
-                if raw_capture_finalize is not None and raw_capture_finalize.degraded
-                else "not_recorded"
-            ),
-            whole_run_artifacts=(
-                "available"
-                if (
-                    has_whole_run_artifact_manifest
-                    and self._whole_run_artifact_store.has_run_artifacts(run_id)
-                )
-                else "missing"
-                if has_whole_run_artifact_manifest
-                else "not_recorded"
-            ),
+            raw_capture=self._artifact_availability_state(lifecycle.raw_capture),
+            whole_run_artifacts=self._artifact_availability_state(lifecycle.whole_run_artifacts),
         )
 
     @staticmethod
@@ -191,6 +185,62 @@ class _HistoryDBQueryMixin:
         )
         return None if metadata is None else metadata.raw_capture_finalize
 
+    def _coerce_analysis(
+        self,
+        *,
+        run_id: str,
+        analysis_json: str | None,
+        source: str,
+    ) -> tuple[PersistedAnalysis | None, bool]:
+        if not analysis_json:
+            return None, False
+        parsed_analysis = safe_json_loads(analysis_json, context=f"run {run_id} analysis")
+        if not is_json_object(parsed_analysis):
+            LOGGER.warning(
+                "%s: run %s analysis_json parsed to %s, expected dict",
+                source,
+                run_id,
+                type(parsed_analysis).__name__,
+            )
+            return None, True
+        try:
+            return persisted_analysis_from_storage_json_object(parsed_analysis), False
+        except ValueError:
+            LOGGER.warning(
+                "%s: analysis for run %s used an unsupported storage schema version",
+                source,
+                run_id,
+                exc_info=True,
+            )
+            return None, True
+
+    def _run_lifecycle(
+        self,
+        *,
+        run_id: str,
+        status: RunStatus,
+        has_raw_capture_manifest: bool,
+        has_whole_run_artifact_manifest: bool,
+        raw_capture_finalize: RunRawCaptureFinalize | None,
+        has_analysis: bool,
+        analysis_corrupt: bool,
+    ) -> RunArtifactLifecycle:
+        return derive_run_artifact_lifecycle(
+            status=status,
+            has_raw_capture_manifest=has_raw_capture_manifest,
+            raw_capture_artifacts_present=(
+                has_raw_capture_manifest and self._raw_capture_store.has_run_artifacts(run_id)
+            ),
+            has_whole_run_artifact_manifest=has_whole_run_artifact_manifest,
+            whole_run_artifacts_present=(
+                has_whole_run_artifact_manifest
+                and self._whole_run_artifact_store.has_run_artifacts(run_id)
+            ),
+            raw_capture_finalize=raw_capture_finalize,
+            has_analysis=has_analysis,
+            analysis_corrupt=analysis_corrupt,
+        )
+
     def list_runs(self, limit: int = 500) -> list[HistoryRunListEntry]:
         return self._run_sync(self.alist_runs(limit))
 
@@ -201,7 +251,7 @@ class _HistoryDBQueryMixin:
                 await cur.execute(
                     "SELECT r.run_id, r.status, r.start_time_utc, r.end_time_utc, "
                     "r.created_at, r.error_message, r.sample_count, r.car_name, "
-                    "r.metadata_json, r.raw_capture_manifest_json, "
+                    "r.metadata_json, r.analysis_json, r.raw_capture_manifest_json, "
                     "r.whole_run_artifact_manifest_json "
                     "FROM runs r ORDER BY r.created_at DESC LIMIT ?",
                     (limit,),
@@ -210,7 +260,7 @@ class _HistoryDBQueryMixin:
                 await cur.execute(
                     "SELECT r.run_id, r.status, r.start_time_utc, r.end_time_utc, "
                     "r.created_at, r.error_message, r.sample_count, r.car_name, "
-                    "r.metadata_json, r.raw_capture_manifest_json, "
+                    "r.metadata_json, r.analysis_json, r.raw_capture_manifest_json, "
                     "r.whole_run_artifact_manifest_json "
                     "FROM runs r ORDER BY r.created_at DESC",
                 )
@@ -227,6 +277,7 @@ class _HistoryDBQueryMixin:
                 sample_count,
                 car_name,
                 metadata_json,
+                analysis_json,
                 raw_capture_manifest_json,
                 whole_run_artifact_manifest_json,
             ) = row
@@ -238,23 +289,33 @@ class _HistoryDBQueryMixin:
                 metadata_json=str(metadata_json) if metadata_json is not None else None,
                 source="list_runs",
             )
+            status = RunStatus(status_raw)
+            analysis, analysis_corrupt = self._coerce_analysis(
+                run_id=normalized_run_id,
+                analysis_json=str(analysis_json) if analysis_json is not None else None,
+                source="list_runs",
+            )
+            lifecycle = self._run_lifecycle(
+                run_id=normalized_run_id,
+                status=status,
+                has_raw_capture_manifest=raw_capture_manifest_json is not None,
+                has_whole_run_artifact_manifest=whole_run_artifact_manifest_json is not None,
+                raw_capture_finalize=raw_capture_finalize,
+                has_analysis=analysis is not None,
+                analysis_corrupt=analysis_corrupt,
+            )
             result.append(
                 HistoryRunListEntry(
                     run_id=normalized_run_id,
-                    status=RunStatus(status_raw),
+                    status=status,
                     start_time_utc=normalized_start,
                     end_time_utc=normalized_end,
                     created_at=str(created),
                     sample_count=int(sample_count or 0),
                     car_name=str(car_name) if car_name else None,
                     error_message=str(error) if error else None,
-                    artifact_availability=self._artifact_availability(
-                        run_id=normalized_run_id,
-                        has_raw_capture_manifest=raw_capture_manifest_json is not None,
-                        has_whole_run_artifact_manifest=whole_run_artifact_manifest_json
-                        is not None,
-                        raw_capture_finalize=raw_capture_finalize,
-                    ),
+                    lifecycle=lifecycle,
+                    artifact_availability=self._artifact_availability(lifecycle=lifecycle),
                     raw_capture_finalize=raw_capture_finalize,
                 )
             )
@@ -320,22 +381,20 @@ class _HistoryDBQueryMixin:
             else None,
             source="get_run",
         )
-        analysis: PersistedAnalysis | None = None
-        analysis_corrupt = False
-        if analysis_json:
-            parsed_analysis = safe_json_loads(analysis_json, context=f"run {run_id} analysis")
-            if is_json_object(parsed_analysis):
-                try:
-                    analysis = persisted_analysis_from_storage_json_object(parsed_analysis)
-                except ValueError:
-                    LOGGER.warning(
-                        "get_run: analysis for run %s used an unsupported storage schema version",
-                        run_id,
-                        exc_info=True,
-                    )
-                    analysis_corrupt = True
-            else:
-                analysis_corrupt = True
+        analysis, analysis_corrupt = self._coerce_analysis(
+            run_id=normalized_run_id,
+            analysis_json=str(analysis_json) if analysis_json is not None else None,
+            source="get_run",
+        )
+        lifecycle = self._run_lifecycle(
+            run_id=normalized_run_id,
+            status=status,
+            has_raw_capture_manifest=has_raw_capture_manifest,
+            has_whole_run_artifact_manifest=has_whole_run_artifact_manifest,
+            raw_capture_finalize=metadata.raw_capture_finalize,
+            has_analysis=analysis is not None,
+            analysis_corrupt=analysis_corrupt,
+        )
         return StoredHistoryRun(
             run_id=normalized_run_id,
             case_id=str(case_id) if case_id is not None else None,
@@ -346,12 +405,8 @@ class _HistoryDBQueryMixin:
             analysis=analysis,
             raw_capture_manifest=raw_capture_manifest,
             whole_run_artifact_manifest=whole_run_artifact_manifest,
-            artifact_availability=self._artifact_availability(
-                run_id=normalized_run_id,
-                has_raw_capture_manifest=has_raw_capture_manifest,
-                has_whole_run_artifact_manifest=has_whole_run_artifact_manifest,
-                raw_capture_finalize=metadata.raw_capture_finalize,
-            ),
+            lifecycle=lifecycle,
+            artifact_availability=self._artifact_availability(lifecycle=lifecycle),
             raw_capture_finalize=metadata.raw_capture_finalize,
             analysis_corrupt=analysis_corrupt,
             error_message=str(error) if error else None,

--- a/apps/server/vibesensor/shared/types/history_records.py
+++ b/apps/server/vibesensor/shared/types/history_records.py
@@ -10,6 +10,7 @@ from vibesensor.shared.boundaries.runs.metadata import run_metadata_to_json_obje
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.persisted_analysis import PersistedAnalysis
 from vibesensor.shared.types.raw_capture import RawCaptureManifest
+from vibesensor.shared.types.run_lifecycle import RunArtifactLifecycle
 from vibesensor.shared.types.run_schema import RunMetadata, RunRawCaptureFinalize
 from vibesensor.shared.types.whole_run_analysis import WholeRunArtifactManifest
 
@@ -21,7 +22,9 @@ __all__ = [
     "StoredHistoryRun",
 ]
 
-type ArtifactAvailabilityState = Literal["not_recorded", "available", "missing", "degraded"]
+type ArtifactAvailabilityState = Literal[
+    "not_recorded", "pending", "available", "missing", "degraded"
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,6 +53,7 @@ class HistoryRunListEntry:
     sample_count: int
     car_name: str | None = None
     error_message: str | None = None
+    lifecycle: RunArtifactLifecycle | None = None
     artifact_availability: HistoryArtifactAvailability | None = None
     raw_capture_finalize: RunRawCaptureFinalize | None = None
 
@@ -67,6 +71,8 @@ class HistoryRunListEntry:
             payload["car_name"] = self.car_name
         if self.error_message is not None:
             payload["error_message"] = self.error_message
+        if self.lifecycle is not None:
+            payload["lifecycle"] = self.lifecycle.to_json_object()
         if self.artifact_availability is not None:
             payload["artifact_availability"] = self.artifact_availability.to_json_object()
         if self.raw_capture_finalize is not None:
@@ -89,6 +95,7 @@ class StoredHistoryRun:
     analysis: PersistedAnalysis | None = None
     raw_capture_manifest: RawCaptureManifest | None = None
     whole_run_artifact_manifest: WholeRunArtifactManifest | None = None
+    lifecycle: RunArtifactLifecycle | None = None
     artifact_availability: HistoryArtifactAvailability | None = None
     raw_capture_finalize: RunRawCaptureFinalize | None = None
     analysis_corrupt: bool = False
@@ -117,6 +124,8 @@ class StoredHistoryRun:
             payload["whole_run_artifact_manifest"] = (
                 self.whole_run_artifact_manifest.to_json_object()
             )
+        if self.lifecycle is not None:
+            payload["lifecycle"] = self.lifecycle.to_json_object()
         if self.artifact_availability is not None:
             payload["artifact_availability"] = self.artifact_availability.to_json_object()
         if self.raw_capture_finalize is not None:

--- a/apps/server/vibesensor/shared/types/run_lifecycle.py
+++ b/apps/server/vibesensor/shared/types/run_lifecycle.py
@@ -1,0 +1,160 @@
+"""Canonical derived lifecycle model for persisted runs and artifact readiness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from vibesensor.domain import RunStatus
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.run_schema import RunRawCaptureFinalize
+
+__all__ = [
+    "ArtifactLifecycleState",
+    "PostAnalysisLifecycleState",
+    "ReportLifecycleState",
+    "RunArtifactLifecycle",
+    "RunLifecycleStage",
+    "derive_run_artifact_lifecycle",
+]
+
+type RunLifecycleStage = Literal[
+    "recording",
+    "post_analysis_pending",
+    "post_analysis_running",
+    "post_analysis_ready",
+    "post_analysis_degraded",
+]
+type ArtifactLifecycleState = Literal["not_recorded", "pending", "ready", "degraded", "missing"]
+type PostAnalysisLifecycleState = Literal["pending", "running", "ready", "degraded"]
+type ReportLifecycleState = Literal["pending", "ready", "degraded"]
+
+
+@dataclass(frozen=True, slots=True)
+class RunArtifactLifecycle:
+    """Derived run stage plus explicit artifact/report readiness states."""
+
+    stage: RunLifecycleStage
+    raw_capture: ArtifactLifecycleState
+    whole_run_artifacts: ArtifactLifecycleState
+    post_analysis: PostAnalysisLifecycleState
+    report: ReportLifecycleState
+
+    def to_json_object(self) -> JsonObject:
+        return {
+            "stage": self.stage,
+            "raw_capture": self.raw_capture,
+            "whole_run_artifacts": self.whole_run_artifacts,
+            "post_analysis": self.post_analysis,
+            "report": self.report,
+        }
+
+
+def derive_run_artifact_lifecycle(
+    *,
+    status: RunStatus | str,
+    has_raw_capture_manifest: bool,
+    raw_capture_artifacts_present: bool,
+    has_whole_run_artifact_manifest: bool,
+    whole_run_artifacts_present: bool,
+    raw_capture_finalize: RunRawCaptureFinalize | None,
+    has_analysis: bool,
+    analysis_corrupt: bool,
+    post_analysis_running: bool = False,
+) -> RunArtifactLifecycle:
+    """Derive one canonical lifecycle object from persisted/runtime truth."""
+    normalized_status = RunStatus(status)
+    post_analysis = _derive_post_analysis_state(
+        status=normalized_status,
+        has_analysis=has_analysis,
+        analysis_corrupt=analysis_corrupt,
+        post_analysis_running=post_analysis_running,
+    )
+    return RunArtifactLifecycle(
+        stage=_derive_stage(normalized_status, post_analysis),
+        raw_capture=_derive_raw_capture_state(
+            status=normalized_status,
+            has_manifest=has_raw_capture_manifest,
+            artifacts_present=raw_capture_artifacts_present,
+            raw_capture_finalize=raw_capture_finalize,
+        ),
+        whole_run_artifacts=_derive_whole_run_artifact_state(
+            has_manifest=has_whole_run_artifact_manifest,
+            artifacts_present=whole_run_artifacts_present,
+            post_analysis=post_analysis,
+        ),
+        post_analysis=post_analysis,
+        report=_derive_report_state(post_analysis),
+    )
+
+
+def _derive_stage(
+    status: RunStatus,
+    post_analysis: PostAnalysisLifecycleState,
+) -> RunLifecycleStage:
+    if status == RunStatus.RECORDING:
+        return "recording"
+    if post_analysis == "running":
+        return "post_analysis_running"
+    if post_analysis == "ready":
+        return "post_analysis_ready"
+    if post_analysis == "degraded":
+        return "post_analysis_degraded"
+    return "post_analysis_pending"
+
+
+def _derive_post_analysis_state(
+    *,
+    status: RunStatus,
+    has_analysis: bool,
+    analysis_corrupt: bool,
+    post_analysis_running: bool,
+) -> PostAnalysisLifecycleState:
+    if has_analysis and not analysis_corrupt:
+        return "ready"
+    if status == RunStatus.RECORDING:
+        return "pending"
+    if status == RunStatus.ANALYZING:
+        return "running" if post_analysis_running else "pending"
+    return "degraded"
+
+
+def _derive_raw_capture_state(
+    *,
+    status: RunStatus,
+    has_manifest: bool,
+    artifacts_present: bool,
+    raw_capture_finalize: RunRawCaptureFinalize | None,
+) -> ArtifactLifecycleState:
+    if has_manifest:
+        return "ready" if artifacts_present else "missing"
+    if raw_capture_finalize is not None:
+        if raw_capture_finalize.degraded:
+            return "degraded"
+        return "not_recorded"
+    if status == RunStatus.RECORDING:
+        return "pending"
+    return "not_recorded"
+
+
+def _derive_whole_run_artifact_state(
+    *,
+    has_manifest: bool,
+    artifacts_present: bool,
+    post_analysis: PostAnalysisLifecycleState,
+) -> ArtifactLifecycleState:
+    if has_manifest:
+        return "ready" if artifacts_present else "missing"
+    if post_analysis in {"pending", "running"}:
+        return "pending"
+    if post_analysis == "degraded":
+        return "degraded"
+    return "not_recorded"
+
+
+def _derive_report_state(post_analysis: PostAnalysisLifecycleState) -> ReportLifecycleState:
+    if post_analysis in {"pending", "running"}:
+        return "pending"
+    if post_analysis == "ready":
+        return "ready"
+    return "degraded"

--- a/apps/server/vibesensor/use_cases/history/helpers.py
+++ b/apps/server/vibesensor/use_cases/history/helpers.py
@@ -59,7 +59,6 @@ def require_analysis_ready(run: StoredHistoryRun) -> PersistedAnalysis:
     if run.status == RunStatus.RECORDING:
         raise AnalysisNotReadyError(
             "Analysis is not available while recording is still active",
-            status="active",
         )
     if run.status == RunStatus.ANALYZING:
         raise AnalysisNotReadyError("Analysis is still in progress", status="in_progress")

--- a/apps/server/vibesensor/use_cases/history/helpers.py
+++ b/apps/server/vibesensor/use_cases/history/helpers.py
@@ -49,12 +49,19 @@ def strip_internal_fields(analysis: Mapping[str, object]) -> JsonObject:
 
 def require_analysis_ready(run: StoredHistoryRun) -> PersistedAnalysis:
     """Return the internal persisted-analysis object or raise a domain exception."""
+    lifecycle = run.lifecycle
+    if lifecycle is not None and lifecycle.post_analysis in {"pending", "running"}:
+        raise AnalysisNotReadyError("Analysis is still in progress", status="in_progress")
     if run.status == RunStatus.ANALYZING:
         raise AnalysisNotReadyError("Analysis is still in progress", status="in_progress")
     if run.status == RunStatus.ERROR:
         raise AnalysisNotReadyError(
             str(run.error_message or "Analysis failed"),
             status="error",
+        )
+    if run.analysis_corrupt:
+        raise AnalysisNotReadyError(
+            "Report data unavailable for this run. Re-analyze to regenerate the PDF."
         )
     analysis = run.analysis
     if analysis is None:

--- a/apps/server/vibesensor/use_cases/history/helpers.py
+++ b/apps/server/vibesensor/use_cases/history/helpers.py
@@ -50,8 +50,17 @@ def strip_internal_fields(analysis: Mapping[str, object]) -> JsonObject:
 def require_analysis_ready(run: StoredHistoryRun) -> PersistedAnalysis:
     """Return the internal persisted-analysis object or raise a domain exception."""
     lifecycle = run.lifecycle
-    if lifecycle is not None and lifecycle.post_analysis in {"pending", "running"}:
+    if (
+        lifecycle is not None
+        and lifecycle.stage != "recording"
+        and lifecycle.post_analysis in {"pending", "running"}
+    ):
         raise AnalysisNotReadyError("Analysis is still in progress", status="in_progress")
+    if run.status == RunStatus.RECORDING:
+        raise AnalysisNotReadyError(
+            "Analysis is not available while recording is still active",
+            status="active",
+        )
     if run.status == RunStatus.ANALYZING:
         raise AnalysisNotReadyError("Analysis is still in progress", status="in_progress")
     if run.status == RunStatus.ERROR:

--- a/apps/server/vibesensor/use_cases/history/report_loader.py
+++ b/apps/server/vibesensor/use_cases/history/report_loader.py
@@ -7,13 +7,11 @@ from hashlib import sha256
 
 from opentelemetry.trace import SpanKind
 
-from vibesensor.domain import RunStatus
 from vibesensor.shared.boundaries.reporting import (
     PreparedReportInput,
     prepare_persisted_report_input,
 )
 from vibesensor.shared.boundaries.runs.metadata import run_metadata_to_json_object
-from vibesensor.shared.exceptions import AnalysisNotReadyError
 from vibesensor.shared.filenames import safe_filename
 from vibesensor.shared.json_utils import json_text_dumps
 from vibesensor.shared.ports import RunPersistence
@@ -24,6 +22,7 @@ from vibesensor.shared.types.report_cache import ReportPdfCacheKey
 from vibesensor.shared.types.run_schema import RunMetadata
 from vibesensor.use_cases.history.helpers import (
     async_require_run,
+    require_analysis_ready,
     resolve_run_language,
 )
 
@@ -72,22 +71,7 @@ class HistoryReportRequestLoader:
         ) as span:
             try:
                 run = await async_require_run(self._history_db, run_id)
-                if run.status == RunStatus.ANALYZING:
-                    raise AnalysisNotReadyError(
-                        "Analysis is still in progress", status="in_progress"
-                    )
-                if run.status == RunStatus.ERROR:
-                    raise AnalysisNotReadyError(
-                        str(run.error_message or "Analysis failed"),
-                        status="error",
-                    )
-                if run.analysis_corrupt:
-                    raise AnalysisNotReadyError(
-                        "Report data unavailable for this run. Re-analyze to regenerate the PDF."
-                    )
-                analysis = run.analysis
-                if analysis is None:
-                    raise AnalysisNotReadyError("No analysis available for this run")
+                analysis = require_analysis_ready(run)
 
                 requested_lang = self._analysis_language(run, requested_lang)
                 report_language = self._report_pdf_cache_lang(run, requested_lang)

--- a/apps/server/vibesensor/use_cases/history/runs.py
+++ b/apps/server/vibesensor/use_cases/history/runs.py
@@ -71,10 +71,11 @@ class HistoryRunService:
         ) as span:
             try:
                 run = await async_require_run(self._history_db, run_id)
-                if run.lifecycle is not None and run.lifecycle.post_analysis in {
-                    "pending",
-                    "running",
-                }:
+                if (
+                    run.lifecycle is not None
+                    and run.lifecycle.stage != "recording"
+                    and run.lifecycle.post_analysis in {"pending", "running"}
+                ):
                     span.set_attribute("vibesensor.analysis_ready", False)
                     return None
                 if run.status == RunStatus.ANALYZING:

--- a/apps/server/vibesensor/use_cases/history/runs.py
+++ b/apps/server/vibesensor/use_cases/history/runs.py
@@ -71,6 +71,12 @@ class HistoryRunService:
         ) as span:
             try:
                 run = await async_require_run(self._history_db, run_id)
+                if run.lifecycle is not None and run.lifecycle.post_analysis in {
+                    "pending",
+                    "running",
+                }:
+                    span.set_attribute("vibesensor.analysis_ready", False)
+                    return None
                 if run.status == RunStatus.ANALYZING:
                     span.set_attribute("vibesensor.analysis_ready", False)
                     return None

--- a/apps/ui/src/app/features/history_feature.ts
+++ b/apps/ui/src/app/features/history_feature.ts
@@ -8,11 +8,7 @@ import {
   historyReportPdfUrl,
 } from "../../api";
 import type { FeatureFormatting, FeatureServices } from "../feature_deps_base";
-import type {
-  HistoryState,
-  RunDetail,
-  ShellState,
-} from "../ui_app_state";
+import type { HistoryState, RunDetail, ShellState } from "../ui_app_state";
 import { computed, effectOnChange, untracked } from "../ui_signals";
 import type {
   HistoryPanelRenderModel,
@@ -23,6 +19,7 @@ import {
   buildHistoryRowsTableRenderModel,
   createHistoryTableRowsMemo,
 } from "../views/history_table_presenters";
+import { historyPostAnalysisReady } from "../views/history_presenter_shared";
 import { downloadBlobFile } from "./history_download";
 import { serverStateQueryKeys } from "./server_state_query_keys";
 
@@ -109,10 +106,11 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     const runs = history.runs.value;
     const deleteAllRunsDisabled =
       history.deleteAllRunsInFlight.value || runs.length === 0;
-    const expandedRunId = history.expandedRunId.value
-      && runs.some((row) => row.run_id === history.expandedRunId.value)
-      ? history.expandedRunId.value
-      : null;
+    const expandedRunId =
+      history.expandedRunId.value &&
+      runs.some((row) => row.run_id === history.expandedRunId.value)
+        ? history.expandedRunId.value
+        : null;
     if (!runs.length) {
       return {
         historySummaryText: services.t("history.none"),
@@ -163,7 +161,10 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     try {
       const response = await ctx.queryClient.fetchQuery({
         queryFn: () => getHistoryInsights(runId, shell.lang.value),
-        queryKey: serverStateQueryKeys.history.insights(runId, shell.lang.value),
+        queryKey: serverStateQueryKeys.history.insights(
+          runId,
+          shell.lang.value,
+        ),
         staleTime: 0,
       });
       updateRunDetail(runId, (current) => ({
@@ -173,9 +174,10 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     } catch (err) {
       updateRunDetail(runId, (current) => ({
         ...current,
-        previewError: err instanceof Error
-          ? err.message
-          : services.t("report.unable_load_insights"),
+        previewError:
+          err instanceof Error
+            ? err.message
+            : services.t("report.unable_load_insights"),
       }));
     } finally {
       updateRunDetail(runId, (current) => ({
@@ -201,7 +203,10 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     try {
       const response = await ctx.queryClient.fetchQuery({
         queryFn: () => getHistoryInsights(runId, shell.lang.value),
-        queryKey: serverStateQueryKeys.history.insights(runId, shell.lang.value),
+        queryKey: serverStateQueryKeys.history.insights(
+          runId,
+          shell.lang.value,
+        ),
         staleTime: 0,
       });
       updateRunDetail(runId, (current) => ({
@@ -211,9 +216,10 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     } catch (err) {
       updateRunDetail(runId, (current) => ({
         ...current,
-        insightsError: err instanceof Error
-          ? err.message
-          : services.t("report.unable_load_insights"),
+        insightsError:
+          err instanceof Error
+            ? err.message
+            : services.t("report.unable_load_insights"),
       }));
     } finally {
       updateRunDetail(runId, (current) => ({
@@ -262,22 +268,22 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
   function prefetchCollapsedRunContext(): void {
     const token = ++previewPrefetchToken;
     void (async () => {
-      const completedRuns = history.runs.value.filter((run) => run.status === "complete");
+      const readyRuns = history.runs.value.filter((run) =>
+        historyPostAnalysisReady(run),
+      );
       for (
         let index = 0;
-        index < completedRuns.length;
+        index < readyRuns.length;
         index += COLLAPSED_RUN_PREVIEW_PREFETCH_CONCURRENCY
       ) {
         if (token !== previewPrefetchToken) {
           return;
         }
-        const batch = completedRuns.slice(
+        const batch = readyRuns.slice(
           index,
           index + COLLAPSED_RUN_PREVIEW_PREFETCH_CONCURRENCY,
         );
-        await Promise.all(batch.map((run) =>
-          loadRunPreview(run.run_id)
-        ));
+        await Promise.all(batch.map((run) => loadRunPreview(run.run_id)));
       }
     })();
   }
@@ -310,14 +316,18 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       await deleteHistoryRunApi(runId);
     } catch (err) {
       services.showError(
-        err instanceof Error ? err.message : services.t("history.delete_failed"),
+        err instanceof Error
+          ? err.message
+          : services.t("history.delete_failed"),
       );
       return;
     }
     if (history.expandedRunId.value === runId) {
       collapseExpandedRun();
     }
-    await ctx.queryClient.invalidateQueries({ queryKey: serverStateQueryKeys.history.runs() });
+    await ctx.queryClient.invalidateQueries({
+      queryKey: serverStateQueryKeys.history.runs(),
+    });
     await refreshHistory();
   }
 
@@ -348,14 +358,17 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
       } catch (err) {
         failed += 1;
         if (!firstError) {
-          firstError = err instanceof Error
-            ? err.message
-            : services.t("history.delete_failed");
+          firstError =
+            err instanceof Error
+              ? err.message
+              : services.t("history.delete_failed");
         }
       }
     }
     history.deleteAllRunsInFlight.value = false;
-    await ctx.queryClient.invalidateQueries({ queryKey: serverStateQueryKeys.history.runs() });
+    await ctx.queryClient.invalidateQueries({
+      queryKey: serverStateQueryKeys.history.runs(),
+    });
     await refreshHistory();
     if (failed > 0) {
       const summary = services.t("history.delete_all_partial", {
@@ -385,9 +398,8 @@ export function createHistoryFeature(ctx: HistoryFeatureDeps): HistoryFeature {
     } catch (err) {
       updateRunDetail(runId, (current) => ({
         ...current,
-        pdfError: err instanceof Error
-          ? err.message
-          : services.t("history.pdf_failed"),
+        pdfError:
+          err instanceof Error ? err.message : services.t("history.pdf_failed"),
       }));
     } finally {
       updateRunDetail(runId, (current) => ({

--- a/apps/ui/src/app/views/history_detail_presenter.ts
+++ b/apps/ui/src/app/views/history_detail_presenter.ts
@@ -12,6 +12,7 @@ import {
   findingSpeedBandText,
   findingTone,
   formatSourceLabel,
+  historyRawCaptureState,
   historyRunDisplayTitle,
   isInconclusiveFinding,
   summarizeFindings,
@@ -37,9 +38,9 @@ function shouldShowNextStep(finding: FindingPayload | null): boolean {
     return true;
   }
   return (
-    typeof finding.confidence === "number"
-    && Number.isFinite(finding.confidence)
-    && finding.confidence >= 0.85
+    typeof finding.confidence === "number" &&
+    Number.isFinite(finding.confidence) &&
+    finding.confidence >= 0.85
   );
 }
 
@@ -56,14 +57,15 @@ function buildPrimaryFinding(
   const inconclusive = isInconclusiveFinding(primary);
   const location = findingLocationText(primary, summary, t);
   const signature = findingSignatureText(primary, params);
-  const nextStep =
-    inconclusive
-      ? t("history.inconclusive_next_step")
-      : shouldShowNextStep(primary) && location !== t("report.missing")
-        ? t("history.findings_next_step", { location })
-        : null;
+  const nextStep = inconclusive
+    ? t("history.inconclusive_next_step")
+    : shouldShowNextStep(primary) && location !== t("report.missing")
+      ? t("history.findings_next_step", { location })
+      : null;
   return {
-    eyebrow: inconclusive ? t("history.capture_verdict") : t("history.primary_diagnosis"),
+    eyebrow: inconclusive
+      ? t("history.capture_verdict")
+      : t("history.primary_diagnosis"),
     headline: inconclusive
       ? t("history.inconclusive_title")
       : formatSourceLabel(primary.suspected_source, t),
@@ -71,9 +73,9 @@ function buildPrimaryFinding(
     confidence: confidenceText(primary, params),
     tone: findingTone(primary),
     explanation: String(
-      primary.evidence_summary
-        ?? summary.most_likely_origin?.explanation
-        ?? (inconclusive ? t("history.inconclusive_body") : ""),
+      primary.evidence_summary ??
+        summary.most_likely_origin?.explanation ??
+        (inconclusive ? t("history.inconclusive_body") : ""),
     ),
     chips: [
       { label: t("history.findings_location"), value: location },
@@ -117,11 +119,15 @@ function buildHistoryInsightsViewModel(
 ): HistoryInsightsViewModel {
   const { t } = params;
   const loadedInsights = detail.insights ?? detail.preview;
-  const loading = detail.insightsLoading || (detail.previewLoading && loadedInsights === null);
+  const loading =
+    detail.insightsLoading ||
+    (detail.previewLoading && loadedInsights === null);
   if (loadedInsights === null) {
     return {
       headerEyebrow: t("history.findings_title"),
-      stateMessage: loading ? t("history.loading_insights") : t("history.findings_pending"),
+      stateMessage: loading
+        ? t("history.loading_insights")
+        : t("history.findings_pending"),
       primary: null,
       secondaryTitle: null,
       visibleSecondary: [],
@@ -144,14 +150,16 @@ function buildHistoryInsightsViewModel(
     };
   }
   const secondaryFindings = findings.slice(1);
-  const hiddenSecondary = secondaryFindings.slice(2).map((finding) =>
-    buildSecondaryFinding(finding, loadedInsights, params),
-  );
+  const hiddenSecondary = secondaryFindings
+    .slice(2)
+    .map((finding) => buildSecondaryFinding(finding, loadedInsights, params));
   return {
     headerEyebrow: t("history.findings_title"),
     stateMessage: null,
     primary: buildPrimaryFinding(loadedInsights, params),
-    secondaryTitle: secondaryFindings.length ? t("history.secondary_candidates_title") : null,
+    secondaryTitle: secondaryFindings.length
+      ? t("history.secondary_candidates_title")
+      : null,
     visibleSecondary: secondaryFindings
       .slice(0, 2)
       .map((finding) => buildSecondaryFinding(finding, loadedInsights, params)),
@@ -163,10 +171,18 @@ function buildHistoryInsightsViewModel(
   };
 }
 
-function buildHistoryWarnings(detail: RunDetail): HistoryWarningBannerViewModel[] {
-  const warnings = summarizeWarnings(detail.preview).concat(summarizeWarnings(detail.insights));
+function buildHistoryWarnings(
+  detail: RunDetail,
+): HistoryWarningBannerViewModel[] {
+  const warnings = summarizeWarnings(detail.preview).concat(
+    summarizeWarnings(detail.insights),
+  );
   return warnings
-    .filter((warning, index) => warnings.findIndex((candidate) => candidate.code === warning.code) === index)
+    .filter(
+      (warning, index) =>
+        warnings.findIndex((candidate) => candidate.code === warning.code) ===
+        index,
+    )
     .map((warning) => ({
       severity: String(warning.severity),
       title: String(warning.title),
@@ -178,7 +194,8 @@ function buildArtifactWarnings(
   run: HistoryEntry,
   t: PresenterParams["t"],
 ): HistoryWarningBannerViewModel[] {
-  if (run.artifact_availability?.raw_capture === "missing") {
+  const rawCaptureState = historyRawCaptureState(run);
+  if (rawCaptureState === "missing") {
     return [
       {
         severity: "warn",
@@ -187,7 +204,7 @@ function buildArtifactWarnings(
       },
     ];
   }
-  if (run.artifact_availability?.raw_capture !== "degraded" || run.raw_capture_finalize == null) {
+  if (rawCaptureState !== "degraded" || run.raw_capture_finalize == null) {
     return [];
   }
   let detailKey: string | null = null;
@@ -210,7 +227,8 @@ function buildArtifactWarnings(
       title: t("history.raw_capture_degraded_title"),
       detail: t(detailKey, {
         queueDepth: run.raw_capture_finalize.queue_depth ?? "unknown",
-        errorSummary: run.raw_capture_finalize.error_summary ?? t("history.not_reported"),
+        errorSummary:
+          run.raw_capture_finalize.error_summary ?? t("history.not_reported"),
       }),
     },
   ];
@@ -225,7 +243,8 @@ export function buildHistoryDetailsViewModel(
   const summary = detail.insights ?? detail.preview;
   const hasDiagnosis = Boolean(detail.insights || detail.preview);
   const showReloadAction = hasDiagnosis || Boolean(detail.insightsError);
-  const showLoadingStatus = detail.insightsLoading || (detail.previewLoading && !hasDiagnosis);
+  const showLoadingStatus =
+    detail.insightsLoading || (detail.previewLoading && !hasDiagnosis);
   const runSummary = summary
     ? [
         `${t("report.run_id")}: ${run.run_id}`,
@@ -269,7 +288,9 @@ export function buildHistoryDetailsViewModel(
         ? t("history.loading_insights")
         : null,
     insightsError: detail.insightsError || null,
-    warnings: buildArtifactWarnings(run, t).concat(buildHistoryWarnings(detail)),
+    warnings: buildArtifactWarnings(run, t).concat(
+      buildHistoryWarnings(detail),
+    ),
     insights: buildHistoryInsightsViewModel(detail, params),
     heatmap,
     footerEyebrow: t("history.run_actions_title"),

--- a/apps/ui/src/app/views/history_presenter_shared.ts
+++ b/apps/ui/src/app/views/history_presenter_shared.ts
@@ -5,12 +5,21 @@ import type {
   HistoryInsightsPayload,
 } from "../../api/types";
 import type { RunDetail } from "../ui_app_state";
-import type { HistoryFindingTone, HistorySummaryChipTone } from "./history_table_models";
+import type {
+  HistoryFindingTone,
+  HistorySummaryChipTone,
+} from "./history_table_models";
 import type { HistoryTableViewParams } from "./history_table_view";
 
 export type PresenterParams = Pick<
   HistoryTableViewParams,
-  "expandedRunId" | "fmt" | "fmtTs" | "formatInt" | "runDetailsById" | "runs" | "t"
+  | "expandedRunId"
+  | "fmt"
+  | "fmtTs"
+  | "formatInt"
+  | "runDetailsById"
+  | "runs"
+  | "t"
 >;
 
 export type HistoryRowStatusBadge = {
@@ -45,7 +54,9 @@ export const EMPTY_RUN_DETAIL: RunDetail = {
   pdfError: "",
 };
 
-export function summarizeFindings(summary: HistoryInsightsPayload | null): FindingPayload[] {
+export function summarizeFindings(
+  summary: HistoryInsightsPayload | null,
+): FindingPayload[] {
   return summary?.findings?.slice(0, VISIBLE_FINDING_LIMIT) ?? [];
 }
 
@@ -56,7 +67,9 @@ export function summarizeWarnings(
 }
 
 function normalizedSourceKey(source: unknown): string {
-  return String(source ?? "").trim().toLowerCase();
+  return String(source ?? "")
+    .trim()
+    .toLowerCase();
 }
 
 function humanizeSourceFallback(sourceKey: string): string {
@@ -67,7 +80,10 @@ function humanizeSourceFallback(sourceKey: string): string {
     .join(" ");
 }
 
-export function formatSourceLabel(source: unknown, t: PresenterParams["t"]): string {
+export function formatSourceLabel(
+  source: unknown,
+  t: PresenterParams["t"],
+): string {
   const raw = String(source ?? "").trim();
   const key = normalizedSourceKey(source);
   if (!key) {
@@ -97,13 +113,16 @@ export function confidenceText(
   const value =
     typeof finding.confidence_pct === "string" && finding.confidence_pct.trim()
       ? finding.confidence_pct
-      : typeof finding.confidence === "number" && Number.isFinite(finding.confidence)
+      : typeof finding.confidence === "number" &&
+          Number.isFinite(finding.confidence)
         ? fmt(finding.confidence, 2)
         : "--";
   return t("report.confidence", { value });
 }
 
-export function findingTone(finding: FindingPayload | null): HistoryFindingTone {
+export function findingTone(
+  finding: FindingPayload | null,
+): HistoryFindingTone {
   const tone = String(finding?.confidence_tone ?? "").toLowerCase();
   if (tone === "success" || tone === "warn") {
     return tone;
@@ -128,7 +147,11 @@ export function findingLocationText(
   summary: HistoryInsightsPayload | null,
   t: PresenterParams["t"],
 ): string {
-  return finding.strongest_location || summary?.most_likely_origin?.location || t("report.missing");
+  return (
+    finding.strongest_location ||
+    summary?.most_likely_origin?.location ||
+    t("report.missing")
+  );
 }
 
 export function findingSpeedBandText(
@@ -137,14 +160,38 @@ export function findingSpeedBandText(
   t: PresenterParams["t"],
 ): string {
   return (
-    finding.strongest_speed_band
-    || summary?.most_likely_origin?.speed_band
-    || t("report.missing")
+    finding.strongest_speed_band ||
+    summary?.most_likely_origin?.speed_band ||
+    t("report.missing")
   );
 }
 
-export function historyRowSummary(detail: RunDetail): HistoryInsightsPayload | null {
+export function historyRowSummary(
+  detail: RunDetail,
+): HistoryInsightsPayload | null {
   return detail.insights ?? detail.preview;
+}
+
+export function historyPostAnalysisReady(run: HistoryEntry): boolean {
+  return (
+    run.lifecycle?.post_analysis === "ready" ||
+    (run.lifecycle == null && run.status === "complete")
+  );
+}
+
+export function historyReportReady(run: HistoryEntry): boolean {
+  return (
+    run.lifecycle?.report === "ready" ||
+    (run.lifecycle == null && run.status === "complete")
+  );
+}
+
+export function historyRawCaptureState(run: HistoryEntry): string {
+  return (
+    run.lifecycle?.raw_capture ??
+    run.artifact_availability?.raw_capture ??
+    "not_recorded"
+  );
 }
 
 export function historyRowStatusBadge(
@@ -153,6 +200,19 @@ export function historyRowStatusBadge(
   t: PresenterParams["t"],
 ): HistoryRowStatusBadge {
   const summary = historyRowSummary(detail);
+  switch (run.lifecycle?.stage) {
+    case "recording":
+      return { label: t("history.row_status.recording"), tone: "warn" };
+    case "post_analysis_pending":
+    case "post_analysis_running":
+      return summary !== null
+        ? { label: t("history.row_status.preview_ready"), tone: "ok" }
+        : { label: t("history.row_status.analyzing"), tone: "warn" };
+    case "post_analysis_ready":
+      return { label: t("history.row_status.complete"), tone: "ok" };
+    case "post_analysis_degraded":
+      return { label: t("history.row_status.error"), tone: "bad" };
+  }
   switch (run.status) {
     case "complete":
       return { label: t("history.row_status.complete"), tone: "ok" };
@@ -169,7 +229,10 @@ export function historyRowStatusBadge(
   }
 }
 
-export function historyRowDurationSeconds(run: HistoryEntry, detail: RunDetail): number | null {
+export function historyRowDurationSeconds(
+  run: HistoryEntry,
+  detail: RunDetail,
+): number | null {
   const summary = historyRowSummary(detail);
   const summaryDuration = Number(summary?.duration_s);
   if (Number.isFinite(summaryDuration) && summaryDuration >= 0) {
@@ -184,12 +247,18 @@ export function historyRowDurationSeconds(run: HistoryEntry, detail: RunDetail):
   return (endMs - startMs) / 1000;
 }
 
-export function historyRowCarName(run: HistoryEntry, t: PresenterParams["t"]): string {
+export function historyRowCarName(
+  run: HistoryEntry,
+  t: PresenterParams["t"],
+): string {
   const value = typeof run.car_name === "string" ? run.car_name.trim() : "";
   return value || t("history.car_missing");
 }
 
-export function historyRunDisplayTitle(run: HistoryEntry, t: PresenterParams["t"]): string {
+export function historyRunDisplayTitle(
+  run: HistoryEntry,
+  t: PresenterParams["t"],
+): string {
   const carName = historyRowCarName(run, t);
   return carName === t("history.car_missing") ? run.run_id : carName;
 }

--- a/apps/ui/src/app/views/history_table_presenters.ts
+++ b/apps/ui/src/app/views/history_table_presenters.ts
@@ -7,7 +7,9 @@ import {
   formatSourceLabel,
   historyRowCarName,
   historyRowDurationSeconds,
+  historyReportReady,
   historyRowStatusBadge,
+  historyPostAnalysisReady,
   historyRowSummary,
   isInconclusiveFinding,
   summarizeFindings,
@@ -19,7 +21,10 @@ import type {
   HistoryRowViewModel,
   HistorySummaryChipViewModel,
 } from "./history_table_models";
-import type { HistoryPanelTableRenderModel, HistoryTableViewParams } from "./history_table_view";
+import type {
+  HistoryPanelTableRenderModel,
+  HistoryTableViewParams,
+} from "./history_table_view";
 
 function buildSummaryChips(
   run: HistoryEntry,
@@ -31,8 +36,16 @@ function buildSummaryChips(
   const chips: HistorySummaryChipViewModel[] = [
     { key: "status", text: statusBadge.label, tone: statusBadge.tone },
   ];
-  if (run.status === "error" && run.error_message) {
-    chips.push({ key: "error-message", text: run.error_message, tone: "muted" });
+  if (
+    (run.lifecycle?.stage === "post_analysis_degraded" ||
+      run.status === "error") &&
+    run.error_message
+  ) {
+    chips.push({
+      key: "error-message",
+      text: run.error_message,
+      tone: "muted",
+    });
   }
   return chips;
 }
@@ -45,17 +58,23 @@ function buildHistoryRowSummary(
   const { fmt, formatInt, t } = params;
   const summary = historyRowSummary(detail);
   const primaryFinding = summarizeFindings(summary)[0] ?? null;
-  const source = summary?.most_likely_origin?.suspected_source || primaryFinding?.suspected_source || "";
+  const source =
+    summary?.most_likely_origin?.suspected_source ||
+    primaryFinding?.suspected_source ||
+    "";
   const sourceLabel =
     primaryFinding && isInconclusiveFinding(primaryFinding)
       ? t("history.row_source_inconclusive")
       : source
         ? formatSourceLabel(source, t)
         : "";
-  const headline = sourceLabel
-    || (run.status === "complete" && (detail.previewLoading || detail.insightsLoading || summary === null)
+  const analysisReady = historyPostAnalysisReady(run);
+  const headline =
+    sourceLabel ||
+    (analysisReady &&
+    (detail.previewLoading || detail.insightsLoading || summary === null)
       ? t("history.row_summary_loading")
-      : run.status === "complete" && summary
+      : analysisReady && summary
         ? t("history.row_no_findings")
         : historyRowStatusBadge(run, detail, t).label);
   const metaParts: string[] = [];
@@ -64,11 +83,15 @@ function buildHistoryRowSummary(
   }
   const durationSeconds = historyRowDurationSeconds(run, detail);
   if (durationSeconds !== null) {
-    metaParts.push(`${t("history.summary_size")}: ${fmt(durationSeconds, 1)} s`);
+    metaParts.push(
+      `${t("history.summary_size")}: ${fmt(durationSeconds, 1)} s`,
+    );
   }
   const sensorCount = Number(summary?.sensor_count_used);
   if (Number.isFinite(sensorCount) && sensorCount > 0) {
-    metaParts.push(`${t("history.summary_sensor_count")}: ${formatInt(sensorCount)}`);
+    metaParts.push(
+      `${t("history.summary_sensor_count")}: ${formatInt(sensorCount)}`,
+    );
   }
   if (metaParts.length === 0 && run.status === "error" && run.error_message) {
     metaParts.push(run.error_message);
@@ -84,8 +107,7 @@ function buildCollapsedAction(
   detail: RunDetail,
   t: PresenterParams["t"],
 ): HistoryCollapsedActionViewModel {
-  const reportReady = run.status === "complete";
-  if (!reportReady) {
+  if (!historyReportReady(run)) {
     return {
       hintText: t("history.quick_report_pending"),
       pdfLabel: null,
@@ -94,12 +116,18 @@ function buildCollapsedAction(
   }
   return {
     hintText: null,
-    pdfLabel: detail.pdfLoading ? t("history.generating_pdf") : t("history.generate_pdf"),
+    pdfLabel: detail.pdfLoading
+      ? t("history.generating_pdf")
+      : t("history.generate_pdf"),
     pdfLoading: detail.pdfLoading,
   };
 }
 
-function buildRowViewModel(run: HistoryEntry, detail: RunDetail, params: PresenterParams): HistoryRowViewModel {
+function buildRowViewModel(
+  run: HistoryEntry,
+  detail: RunDetail,
+  params: PresenterParams,
+): HistoryRowViewModel {
   const { expandedRunId, formatInt, fmtTs, t } = params;
   const isExpanded = expandedRunId === run.run_id;
   const rowSummary = buildHistoryRowSummary(run, detail, params);
@@ -111,7 +139,9 @@ function buildRowViewModel(run: HistoryEntry, detail: RunDetail, params: Present
     summaryChips: buildSummaryChips(run, detail, params),
     summaryHeadline: rowSummary.headline,
     summaryMeta: rowSummary.meta,
-    toggleLabel: isExpanded ? t("history.close_diagnosis") : t("history.open_diagnosis"),
+    toggleLabel: isExpanded
+      ? t("history.close_diagnosis")
+      : t("history.open_diagnosis"),
     toggleTitle: isExpanded
       ? t("history.close_diagnosis_for_run", { runId: run.run_id })
       : t("history.open_diagnosis_for_run", { runId: run.run_id }),
@@ -122,13 +152,21 @@ function buildRowViewModel(run: HistoryEntry, detail: RunDetail, params: Present
     quickReportLabel: t("history.quick_report"),
     collapsedAction: buildCollapsedAction(run, detail, t),
     pdfError: detail.pdfError || null,
-    details: isExpanded ? buildHistoryDetailsViewModel(run, detail, params) : null,
+    details: isExpanded
+      ? buildHistoryDetailsViewModel(run, detail, params)
+      : null,
   };
 }
 
-export function buildHistoryTableRowsViewModel(params: PresenterParams): HistoryRowViewModel[] {
+export function buildHistoryTableRowsViewModel(
+  params: PresenterParams,
+): HistoryRowViewModel[] {
   return params.runs.map((run) =>
-    buildRowViewModel(run, params.runDetailsById[run.run_id] ?? EMPTY_RUN_DETAIL, params),
+    buildRowViewModel(
+      run,
+      params.runDetailsById[run.run_id] ?? EMPTY_RUN_DETAIL,
+      params,
+    ),
   );
 }
 
@@ -180,15 +218,18 @@ function buildHistoryRowsMemoKey(params: PresenterParams): HistoryRowsMemoKey {
     fmt: params.fmt,
     fmtTs: params.fmtTs,
     formatInt: params.formatInt,
-    runState: params.runs.map((run) => [
-      run,
-      run.run_id,
-      run.status,
-      run.error_message,
-      run.sample_count,
-      run.start_time_utc,
-      run.car_name,
-    ] as const),
+    runState: params.runs.map(
+      (run) =>
+        [
+          run,
+          run.run_id,
+          run.status,
+          run.error_message,
+          run.sample_count,
+          run.start_time_utc,
+          run.car_name,
+        ] as const,
+    ),
     detailState: params.runs.map((run) => {
       const detail = params.runDetailsById[run.run_id] ?? EMPTY_RUN_DETAIL;
       return [
@@ -206,7 +247,10 @@ function buildHistoryRowsMemoKey(params: PresenterParams): HistoryRowsMemoKey {
   };
 }
 
-function shallowTupleListEqual<T extends readonly unknown[]>(left: T[], right: T[]): boolean {
+function shallowTupleListEqual<T extends readonly unknown[]>(
+  left: T[],
+  right: T[],
+): boolean {
   if (left.length !== right.length) {
     return false;
   }
@@ -225,18 +269,25 @@ function shallowTupleListEqual<T extends readonly unknown[]>(left: T[], right: T
   return true;
 }
 
-function sameHistoryRowsMemoKey(left: HistoryRowsMemoKey | null, right: HistoryRowsMemoKey): boolean {
-  return left !== null
-    && left.expandedRunId === right.expandedRunId
-    && left.t === right.t
-    && left.fmt === right.fmt
-    && left.fmtTs === right.fmtTs
-    && left.formatInt === right.formatInt
-    && shallowTupleListEqual(left.runState, right.runState)
-    && shallowTupleListEqual(left.detailState, right.detailState);
+function sameHistoryRowsMemoKey(
+  left: HistoryRowsMemoKey | null,
+  right: HistoryRowsMemoKey,
+): boolean {
+  return (
+    left !== null &&
+    left.expandedRunId === right.expandedRunId &&
+    left.t === right.t &&
+    left.fmt === right.fmt &&
+    left.fmtTs === right.fmtTs &&
+    left.formatInt === right.formatInt &&
+    shallowTupleListEqual(left.runState, right.runState) &&
+    shallowTupleListEqual(left.detailState, right.detailState)
+  );
 }
 
-export function createHistoryTableRowsMemo(): (params: PresenterParams) => HistoryRowViewModel[] {
+export function createHistoryTableRowsMemo(): (
+  params: PresenterParams,
+) => HistoryRowViewModel[] {
   let previousKey: HistoryRowsMemoKey | null = null;
   let previousRows: HistoryRowViewModel[] = [];
 

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -3623,6 +3623,7 @@
           "raw_capture": {
             "enum": [
               "not_recorded",
+              "pending",
               "available",
               "missing",
               "degraded"
@@ -3633,8 +3634,10 @@
           "whole_run_artifacts": {
             "enum": [
               "not_recorded",
+              "pending",
               "available",
-              "missing"
+              "missing",
+              "degraded"
             ],
             "title": "Whole Run Artifacts",
             "type": "string"
@@ -4146,6 +4149,16 @@
             ],
             "title": "Error Message"
           },
+          "lifecycle": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HistoryRunLifecycleResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "raw_capture_finalize": {
             "anyOf": [
               {
@@ -4243,6 +4256,72 @@
         "title": "HistoryRawCaptureFinalizeResponse",
         "type": "object"
       },
+      "HistoryRunLifecycleResponse": {
+        "description": "Response body describing the canonical derived lifecycle for a history run.",
+        "properties": {
+          "post_analysis": {
+            "enum": [
+              "pending",
+              "running",
+              "ready",
+              "degraded"
+            ],
+            "title": "Post Analysis",
+            "type": "string"
+          },
+          "raw_capture": {
+            "enum": [
+              "not_recorded",
+              "pending",
+              "ready",
+              "degraded",
+              "missing"
+            ],
+            "title": "Raw Capture",
+            "type": "string"
+          },
+          "report": {
+            "enum": [
+              "pending",
+              "ready",
+              "degraded"
+            ],
+            "title": "Report",
+            "type": "string"
+          },
+          "stage": {
+            "enum": [
+              "recording",
+              "post_analysis_pending",
+              "post_analysis_running",
+              "post_analysis_ready",
+              "post_analysis_degraded"
+            ],
+            "title": "Stage",
+            "type": "string"
+          },
+          "whole_run_artifacts": {
+            "enum": [
+              "not_recorded",
+              "pending",
+              "ready",
+              "degraded",
+              "missing"
+            ],
+            "title": "Whole Run Artifacts",
+            "type": "string"
+          }
+        },
+        "required": [
+          "stage",
+          "raw_capture",
+          "whole_run_artifacts",
+          "post_analysis",
+          "report"
+        ],
+        "title": "HistoryRunLifecycleResponse",
+        "type": "object"
+      },
       "HistoryRunResponse": {
         "additionalProperties": false,
         "description": "Response body for a single history run with metadata and optional analysis.",
@@ -4277,6 +4356,16 @@
               }
             ],
             "title": "Error Message"
+          },
+          "lifecycle": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HistoryRunLifecycleResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/ApiPayloadObject"

--- a/apps/ui/tests/history_table_presenters.spec.ts
+++ b/apps/ui/tests/history_table_presenters.spec.ts
@@ -16,6 +16,13 @@ function historyListRun(runId: string): HistoryEntry {
     status: "complete",
     car_name: "Track Car",
     error_message: null,
+    lifecycle: {
+      stage: "post_analysis_ready",
+      raw_capture: "not_recorded",
+      whole_run_artifacts: "ready",
+      post_analysis: "ready",
+      report: "ready",
+    },
   } as HistoryEntry;
 }
 
@@ -76,8 +83,18 @@ function populatedInsights(runId: string): HistoryInsightsPayload {
       },
     ],
     warnings: [
-      { code: "speed-gap", severity: "warn", title: "history.warning.speed_gap", detail: "Gap" },
-      { code: "speed-gap", severity: "warn", title: "history.warning.speed_gap", detail: "Gap" },
+      {
+        code: "speed-gap",
+        severity: "warn",
+        title: "history.warning.speed_gap",
+        detail: "Gap",
+      },
+      {
+        code: "speed-gap",
+        severity: "warn",
+        title: "history.warning.speed_gap",
+        detail: "Gap",
+      },
     ],
     sensor_intensity_by_location: [
       { location: "front-right wheel", p95_intensity_db: 32 },
@@ -103,6 +120,10 @@ function defaultDetail(detail: Partial<RunDetail>): RunDetail {
 
 test("history table presenter builds typed diagnosis models from raw insights", () => {
   const run = historyListRun("run-001");
+  run.lifecycle = {
+    ...run.lifecycle,
+    raw_capture: "missing",
+  };
   run.artifact_availability = {
     raw_capture: "missing",
     whole_run_artifacts: "available",
@@ -124,7 +145,9 @@ test("history table presenter builds typed diagnosis models from raw insights", 
 
   expect(rows).toHaveLength(1);
   const row = rows[0];
-  expect(row.summaryChips.map((chip) => chip.text)).toContain("history.row_status.complete");
+  expect(row.summaryChips.map((chip) => chip.text)).toContain(
+    "history.row_status.complete",
+  );
   expect(row.summaryHeadline).toBe("history.source.wheel_tire");
   expect(row.summaryMeta).toContain('report.confidence:{"value":"92%"}');
   expect(row.summaryMeta).toContain("history.summary_size: 12.3 s");
@@ -149,7 +172,9 @@ test("history table presenter builds typed diagnosis models from raw insights", 
       detail: "Gap",
     },
   ]);
-  const frontRightZone = row.details?.heatmap.zones.find((zone) => zone.key === "front-right wheel");
+  const frontRightZone = row.details?.heatmap.zones.find(
+    (zone) => zone.key === "front-right wheel",
+  );
   expect(frontRightZone).toMatchObject({
     label: "front-right wheel",
     valueLabel: "32.0 dB",
@@ -196,6 +221,13 @@ test("history table presenter keeps PDF pending until analysis completes", () =>
   const run = {
     ...historyListRun("run-003"),
     status: "analyzing" as const,
+    lifecycle: {
+      stage: "post_analysis_pending",
+      raw_capture: "not_recorded",
+      whole_run_artifacts: "pending",
+      post_analysis: "pending",
+      report: "pending",
+    },
   };
   const rows = buildHistoryTableRowsViewModel({
     runs: [run],
@@ -212,8 +244,41 @@ test("history table presenter keeps PDF pending until analysis completes", () =>
   });
 
   const row = rows[0];
-  expect(row.summaryChips.map((chip) => chip.text)).toContain("history.row_status.preview_ready");
+  expect(row.summaryChips.map((chip) => chip.text)).toContain(
+    "history.row_status.preview_ready",
+  );
   expect(row.collapsedAction).toEqual({
+    hintText: "history.quick_report_pending",
+    pdfLabel: null,
+    pdfLoading: false,
+  });
+});
+
+test("history table presenter keeps PDF pending from lifecycle even when run status is complete", () => {
+  const run = {
+    ...historyListRun("run-003b"),
+    lifecycle: {
+      stage: "post_analysis_degraded",
+      raw_capture: "not_recorded",
+      whole_run_artifacts: "degraded",
+      post_analysis: "degraded",
+      report: "degraded",
+    },
+  };
+  const rows = buildHistoryTableRowsViewModel({
+    runs: [run],
+    expandedRunId: null,
+    runDetailsById: {},
+    t: testTranslation,
+    fmt: (value, digits = 0) => Number(value).toFixed(digits),
+    fmtTs: (iso) => iso,
+    formatInt: (value) => String(value),
+  });
+
+  expect(rows[0]?.summaryChips.map((chip) => chip.text)).toContain(
+    "history.row_status.error",
+  );
+  expect(rows[0]?.collapsedAction).toEqual({
     hintText: "history.quick_report_pending",
     pdfLabel: null,
     pdfLoading: false,
@@ -222,6 +287,13 @@ test("history table presenter keeps PDF pending until analysis completes", () =>
 
 test("history table presenter shows degraded raw capture warning details", () => {
   const run = historyListRun("run-004");
+  run.lifecycle = {
+    stage: "post_analysis_ready",
+    raw_capture: "degraded",
+    whole_run_artifacts: "ready",
+    post_analysis: "ready",
+    report: "ready",
+  };
   run.artifact_availability = {
     raw_capture: "degraded",
     whole_run_artifacts: "available",

--- a/docs/run_lifecycle.md
+++ b/docs/run_lifecycle.md
@@ -91,6 +91,38 @@ If `finalize_run()` fails, `RunRecorder` still schedules post-analysis when the
 run was otherwise ready. The persistence layer handles that fallback path by
 storing the later analysis result or analysis error explicitly.
 
+## Canonical read-side lifecycle projection
+
+History/report/UI read paths do not infer readiness from ad hoc combinations of
+`run.status`, `analysis_started_at`, nullable analysis payloads, manifest
+presence, and raw-capture finalize metadata anymore. The one read-side owner is
+`RunArtifactLifecycle` in `apps/server/vibesensor/shared/types/run_lifecycle.py`.
+
+That model is **derived**, not stored in a separate table or column. It projects
+five fields:
+
+- `stage`: `recording`, `post_analysis_pending`, `post_analysis_running`,
+  `post_analysis_ready`, or `post_analysis_degraded`
+- `raw_capture`: `not_recorded`, `pending`, `ready`, `degraded`, or `missing`
+- `whole_run_artifacts`: `not_recorded`, `pending`, `ready`, `degraded`, or
+  `missing`
+- `post_analysis`: `pending`, `running`, `ready`, or `degraded`
+- `report`: `pending`, `ready`, or `degraded`
+
+Transition ownership stays split by subsystem, but projection ownership is now
+centralized:
+
+| Lifecycle fact | Source of truth | Transition owner |
+|----------------|-----------------|------------------|
+| recording vs stopped | in-memory `RunLifecycleState` while live; persisted `RunStatus` after handoff | `RunRecorder` + `RunPersistenceWriter` |
+| raw capture ready/degraded/missing | raw manifest/files plus `RunMetadata.raw_capture_finalize` | `RunRawCaptureWriter` + history raw-capture store |
+| post-analysis pending/ready/degraded | persisted `RunStatus` plus stored analysis/corruption state | `PostAnalysisWorker` + `execute_post_analysis()` + history DB lifecycle writes |
+| report ready/degraded | derived directly from post-analysis readiness | `RunArtifactLifecycle` projection only |
+
+History DB queries, history HTTP payloads, report loading, and history UI
+presenters should consume that derived lifecycle object instead of rebuilding
+their own readiness heuristics.
+
 ## Persistence and retry rules
 
 `RunPersistenceWriter.ensure_history_run()` creates the persisted run record


### PR DESCRIPTION
Closes #3223

## What changed
- add one backend-owned `RunArtifactLifecycle` projection for run stage, raw capture, whole-run artifacts, post-analysis, and report readiness
- derive that lifecycle in history DB list/get reads, expose it in history HTTP payloads, and keep older runs loadable from existing persisted fields
- switch history report loading and insights readiness checks to the lifecycle model instead of separate `status`/nullable-analysis heuristics
- update history UI quick-report gating, status badges, preview prefetch, and raw-capture warnings to read lifecycle truth
- add focused backend lifecycle projection tests, UI presenter tests, and brief lifecycle ownership docs

## Why
- lifecycle truth was split across `run.status`, manifests, raw-capture finalize metadata, nullable analysis payloads, and UI-only readiness guesses
- #3219 added degraded raw-capture finalize state; this plugs that state into one canonical model instead of leaving it as another one-off flag

## Validation
- `make sync-contracts`
- `./.venv/bin/pytest -q apps/server/tests/shared/types/test_run_lifecycle.py apps/server/tests/adapters/persistence/history_db/test_history_db_list_runs.py apps/server/tests/adapters/http/test_api_history_route_state.py apps/server/tests/use_cases/history/test_history_service_edges.py apps/server/tests/use_cases/history/test_history_http_services.py`
- `cd apps/ui && npm run test:unit -- history_table_presenters.spec.ts`
- `make typecheck-backend`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `make ui-typecheck`
- `cd apps/ui && npm run build`
- `make docs-lint`

## Risks / tradeoffs / edge cases
- history list reads now parse analysis JSON to distinguish ready vs degraded lifecycle states; that is a little heavier, but it keeps report/API/UI lifecycle projections consistent
- persisted history rows still cannot prove queued vs actively running post-analysis on their own, so analyzing rows project as pending unless a live owner adds stronger runtime evidence later
- history contracts now carry a new `lifecycle` object and broader artifact-availability enums; the UI is updated in the same PR