### PR TITLE
Document canonical live/recording/raw/report dataflows

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ links onward to the scoped instruction files and repo map below.
 | File | Description |
 |------|-------------|
 | `docs/domain-model.md` | Domain object graph, modeling rules, and adapter inventory. |
+| `docs/dataflows.md` | Canonical four-flow map for live, recording, raw capture, and report paths. |
 | `docs/analysis_pipeline.md` | Post-stop diagnostics pipeline: steps, modules, and data flow. |
 | `docs/order_tracking.md` | Order-reference math, tolerance bands, and order-finding flow. |
 | `docs/report_pipeline.md` | Report generation flow from analysis to PDF. |

--- a/docs/dataflows.md
+++ b/docs/dataflows.md
@@ -1,0 +1,85 @@
+# Canonical Dataflows
+
+This page is the short canonical map for the four server-side dataflows. Use it
+to answer "where does this data come from, where does it cross a boundary, and
+who consumes it?" Then follow the linked deep dives for step-by-step details.
+
+## Live dataflow
+
+| Field | Value |
+|------|-------------|
+| Source | UDP sensor datagrams from the ESP32 fleet |
+| Main path | `adapters/udp/udp_data_rx.py` -> registry + `infra/processing/*` -> `infra/runtime/ws_payload_projection.py` -> `infra/runtime/ws_broadcast.py` |
+| Boundary | Live WebSocket payload projection only; no history DB or post-stop analysis in this path |
+| Final consumer | Dashboard live UI |
+| Data shape | Live and transient, not replayable |
+
+Live flow is for "what is happening right now". It may expose connectivity,
+speed, spectra, and strength metrics, but it does not carry persisted findings
+or PDF/report facts. If live data is stale or absent, the UI shows that state
+directly; it does not synthesize history/report readiness from the live path.
+
+Deep dive: `docs/intake_buffering.md`
+
+## Recording dataflow
+
+| Field | Value |
+|------|-------------|
+| Source | The same UDP stream while a run is active |
+| Main path | registry + `infra/processing/*` -> `use_cases/run/sample_flush.py` -> `use_cases/run/persistence_writer.py` -> history DB |
+| Boundary | `SampleFlushOrchestrator` owns row building/flush timing; `RunPersistenceWriter` owns the history DB boundary |
+| Final consumer | Persisted run samples, run metadata, and post-stop queueing |
+| Data shape | Persisted summary/sample rows, not replayable raw sensor capture |
+
+Recording flow turns live samples into durable run history. It is the only path
+that writes run rows into the history DB during an active run. Missing or
+degraded recording artifacts propagate later through persisted run status,
+lifecycle, and history/report warnings rather than through the live transport.
+
+Deep dive: `docs/run_lifecycle.md`
+
+## Raw capture dataflow
+
+| Field | Value |
+|------|-------------|
+| Source | Optional per-run raw capture written alongside an active recording |
+| Main path | `use_cases/run/raw_capture_writer.py` -> raw capture manifest/store -> `use_cases/run/post_analysis_loader.py` -> `use_cases/run/post_analysis_input.py` + `raw_capture_replay.py` |
+| Boundary | Raw capture is loaded through `RunPersistence`; replay stays inside the post-analysis pipeline |
+| Final consumer | Offline post-stop analysis, especially whole-run/replay-backed analysis |
+| Data shape | Persisted and replayable |
+
+Raw capture is not the report path and not the live UI path. Post-analysis may
+use raw replay when the manifest/store exists, or fall back to persisted summary
+rows when it does not. That degraded or missing raw state must propagate forward
+as lifecycle/artifact status and report context instead of triggering a second
+ad hoc recovery path in history or PDF code.
+
+Deep dives: `docs/run_lifecycle.md`, `docs/analysis_pipeline.md`
+
+## Report dataflow
+
+| Field | Value |
+|------|-------------|
+| Source | Persisted run metadata, persisted analysis outputs, and already-derived report facts |
+| Main path | history DB -> `use_cases/history/report_loader.py` -> shared report boundaries/fact builders -> `app/container.py::_build_pdf_bytes` -> PDF/UI consumers |
+| Boundary | History/report loading reads persisted truth only; it does not rerun live processing or raw replay directly |
+| Final consumer | History detail UI, quick report readiness, and generated PDFs |
+| Data shape | Persisted, replay-free report state |
+
+Report flow is the read-side consumer of completed run truth. It can surface
+degraded or missing analysis/raw artifacts, but it must do so from persisted
+lifecycle/artifact/report state rather than by bypassing back into recording or
+raw-capture internals.
+
+Deep dives: `docs/analysis_pipeline.md`, `docs/report_pipeline.md`, `docs/run_lifecycle.md`
+
+## Guard mapping
+
+Each flow has at least one automated architecture/static guard:
+
+| Flow | Guard owner |
+|------|-------------|
+| Live | `tools/dev/verify_backend_static_guards.py`: live processing stays analysis-free; `WsBroadcast` stays behind `ws_payload_projection` |
+| Recording | `tools/dev/verify_backend_static_guards.py`: recording flow uses `sample_flush` and `persistence_writer` |
+| Raw capture | `tools/dev/verify_backend_static_guards.py`: raw capture replay stays in post-analysis boundaries |
+| Report | `tools/dev/verify_backend_static_guards.py`: report loader avoids boundary re-wraps; PDF entrypoint renders `ReportDocument` |

--- a/tools/dev/verify_backend_static_guards.py
+++ b/tools/dev/verify_backend_static_guards.py
@@ -381,6 +381,81 @@ def _check_live_processing_does_not_import_analysis() -> list[str]:
     return failures
 
 
+def _check_canonical_dataflow_doc() -> list[str]:
+    path = REPO_ROOT / "docs" / "dataflows.md"
+    if not path.exists():
+        return [
+            f"{path.relative_to(REPO_ROOT)} must exist as the canonical four-flow map"
+        ]
+    source = _read_text(path)
+    required_markers = (
+        "# Canonical Dataflows",
+        "## Live dataflow",
+        "## Recording dataflow",
+        "## Raw capture dataflow",
+        "## Report dataflow",
+        "docs/intake_buffering.md",
+        "docs/run_lifecycle.md",
+        "docs/analysis_pipeline.md",
+        "docs/report_pipeline.md",
+        "degraded",
+        "missing",
+        "replayable",
+    )
+    failures: list[str] = []
+    for marker in required_markers:
+        if marker not in source:
+            failures.append(
+                f"{path.relative_to(REPO_ROOT)} must document the canonical flow map marker: {marker}"
+            )
+    return failures
+
+
+def _check_recording_flow_uses_flush_and_persistence_writer() -> list[str]:
+    logger_path = VIBESENSOR_DIR / "use_cases" / "run" / "logger.py"
+    sample_flush_path = VIBESENSOR_DIR / "use_cases" / "run" / "sample_flush.py"
+    persistence_writer_path = (
+        VIBESENSOR_DIR / "use_cases" / "run" / "persistence_writer.py"
+    )
+    logger_source = _read_text(logger_path)
+    sample_flush_source = _read_text(sample_flush_path)
+    persistence_writer_source = _read_text(persistence_writer_path)
+    failures: list[str] = []
+    required_logger_markers = (
+        "from vibesensor.use_cases.run.sample_flush import SampleFlushOrchestrator",
+        "self._sample_flush.append_records(",
+        "self._persistence.ready_for_analysis(",
+    )
+    for marker in required_logger_markers:
+        if marker not in logger_source:
+            failures.append(
+                f"{logger_path.relative_to(REPO_ROOT)} must keep the recording flow routed through sample_flush/persistence_writer ({marker})"
+            )
+    required_sample_flush_markers = (
+        "from vibesensor.use_cases.run.persistence_writer import RunPersistenceWriter",
+        "self._persistence.append_rows(",
+    )
+    for marker in required_sample_flush_markers:
+        if marker not in sample_flush_source:
+            failures.append(
+                f"{sample_flush_path.relative_to(REPO_ROOT)} must keep sample flush as the recording-to-persistence boundary ({marker})"
+            )
+    if "from vibesensor.adapters.persistence.history_db" in sample_flush_source:
+        failures.append(
+            f"{sample_flush_path.relative_to(REPO_ROOT)} must stay adapter-free; persistence_writer owns the history DB boundary"
+        )
+    required_writer_markers = (
+        "def ensure_history_run(",
+        "history_db.aappend_samples(run_id, rows)",
+    )
+    for marker in required_writer_markers:
+        if marker not in persistence_writer_source:
+            failures.append(
+                f"{persistence_writer_path.relative_to(REPO_ROOT)} must own the history DB append path for recorded rows ({marker})"
+            )
+    return failures
+
+
 def _check_metrics_log_reads_live_start_under_lock() -> list[str]:
     path = VIBESENSOR_DIR / "use_cases" / "run" / "_recorder_runtime.py"
     source = _read_text(path)
@@ -975,6 +1050,47 @@ def _check_report_pdf_entrypoint_renders_report_document() -> list[str]:
             f"{path.relative_to(REPO_ROOT)}: missing _build_pdf_bytes entrypoint"
         )
     return violations
+
+
+def _check_raw_capture_flow_stays_post_analysis_only() -> list[str]:
+    post_analysis_input_path = (
+        VIBESENSOR_DIR / "use_cases" / "run" / "post_analysis_input.py"
+    )
+    post_analysis_loader_path = (
+        VIBESENSOR_DIR / "use_cases" / "run" / "post_analysis_loader.py"
+    )
+    report_surfaces = [
+        *sorted(_python_files(VIBESENSOR_DIR / "use_cases" / "history")),
+        *sorted(_python_files(VIBESENSOR_DIR / "adapters" / "pdf")),
+    ]
+    post_analysis_input_source = _read_text(post_analysis_input_path)
+    post_analysis_loader_source = _read_text(post_analysis_loader_path)
+    failures: list[str] = []
+    if "from .raw_capture_replay import" not in post_analysis_input_source:
+        failures.append(
+            f"{post_analysis_input_path.relative_to(REPO_ROOT)} must keep raw replay assembly in the post-analysis input path"
+        )
+    for marker in (
+        'getattr(db, "aget_raw_capture_manifest", None)',
+        'getattr(db, "aload_raw_capture", None)',
+    ):
+        if marker not in post_analysis_loader_source:
+            failures.append(
+                f"{post_analysis_loader_path.relative_to(REPO_ROOT)} must load raw capture through RunPersistence ({marker})"
+            )
+    forbidden_prefixes = (
+        "vibesensor.use_cases.run.raw_capture_replay",
+        "vibesensor.use_cases.run.raw_capture_writer",
+        "vibesensor.adapters.persistence.history_db._raw_capture_store",
+    )
+    for path in report_surfaces:
+        violations = _imports_from_prefixes(path, forbidden_prefixes)
+        if violations:
+            failures.append(
+                f"{path.relative_to(REPO_ROOT)} must not bypass the post-analysis/raw persistence boundary:\n"
+                + "\n".join(violations)
+            )
+    return failures
 
 
 _FORBIDDEN_DOMAIN_IMPORTS = (
@@ -2112,6 +2228,11 @@ CHECKS: tuple[Check, ...] = (
         "Live processing stays analysis-free",
         _check_live_processing_does_not_import_analysis,
     ),
+    ("Canonical dataflow doc stays complete", _check_canonical_dataflow_doc),
+    (
+        "Recording flow uses sample flush and persistence writer",
+        _check_recording_flow_uses_flush_and_persistence_writer,
+    ),
     (
         "Recorder live-start snapshot stays under lock",
         _check_metrics_log_reads_live_start_under_lock,
@@ -2179,6 +2300,10 @@ CHECKS: tuple[Check, ...] = (
     (
         "Report PDF entrypoint renders report document",
         _check_report_pdf_entrypoint_renders_report_document,
+    ),
+    (
+        "Raw capture flow stays in post-analysis boundaries",
+        _check_raw_capture_flow_stays_post_analysis_only,
     ),
     ("Domain modules avoid outer-layer imports", _collect_domain_import_violations),
     (


### PR DESCRIPTION
## what changed
- add `docs/dataflows.md` as the short canonical map for the live, recording, raw-capture, and report paths
- index the new page in `docs/README.md`
- add static guards for canonical-doc completeness, recording-flow ownership through `sample_flush` + `persistence_writer`, and raw-capture replay confinement to post-analysis

## why
- makes the four intended flows explicit in one place
- gives each flow at least one executable architecture guard
- keeps degraded/missing artifact propagation documented instead of re-inferred ad hoc

## validation
- `make format`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `make docs-lint`

## risks / tradeoffs
- the new guards are source-shape checks, so legitimate seam refactors will need guard updates too
- scope stays docs/contracts only; no runtime behavior change

Closes #3224