### PR TITLE
Extend stage-based orchestration for recorder finalization

### DIFF
--- a/apps/server/tests/use_cases/run/test_finalize_stages.py
+++ b/apps/server/tests/use_cases/run/test_finalize_stages.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from vibesensor.shared.types.raw_capture import RawCaptureLossStats
+from vibesensor.use_cases.run.finalize_stages import finalize_active_run
+from vibesensor.use_cases.run.persistence_writer import PersistenceStatusSnapshot
+from vibesensor.use_cases.run.raw_capture_writer import RawCaptureFinalizeResult
+
+
+def test_finalize_active_run_reports_successful_stage_results() -> None:
+    append_calls: list[tuple[str, str, float, bool]] = []
+    raw_finalize_calls: list[tuple[str, object | None]] = []
+    recorded_finalize_statuses: list[str] = []
+
+    sample_flush = SimpleNamespace(
+        pending_flush_snapshot=lambda: SimpleNamespace(
+            run_id="run-1",
+            start_time_utc="2026-04-25T06:40:00Z",
+            start_mono_s=12.5,
+        ),
+        append_records=lambda run_id, start_time_utc, start_mono_s, refresh_metrics: (
+            append_calls.append((run_id, start_time_utc, start_mono_s, refresh_metrics))
+        ),
+    )
+    persistence = SimpleNamespace(
+        status_snapshot=lambda: PersistenceStatusSnapshot(
+            write_error=None,
+            written_sample_count=12,
+            dropped_sample_count=1,
+        ),
+        ready_for_analysis=lambda run_id: run_id,
+        history_run_created=True,
+        finalize_run=lambda run_id, start_time_utc, end_time_utc: True,
+    )
+    raw_capture = SimpleNamespace(
+        finalize_run=lambda run_id, *, sensor_losses=None: (
+            raw_finalize_calls.append((run_id, sensor_losses))
+            or RawCaptureFinalizeResult(status="completed")
+        )
+    )
+
+    result = finalize_active_run(
+        run_id="run-1",
+        start_time_utc="2026-04-25T06:39:00Z",
+        stop_reason="manual",
+        ingest_drop_losses={
+            "sensor-a": RawCaptureLossStats(udp_ingest_queue_drop_count=2),
+        },
+        sample_flush=sample_flush,
+        persistence=persistence,
+        raw_capture=raw_capture,
+        record_raw_capture_finalize_result=lambda run_id, result: recorded_finalize_statuses.append(
+            result.status
+        ),
+        logger=logging.getLogger("test.finalize.success"),
+    )
+
+    assert append_calls == [("run-1", "2026-04-25T06:40:00Z", 12.5, True)]
+    assert raw_finalize_calls == [
+        (
+            "run-1",
+            {"sensor-a": RawCaptureLossStats(udp_ingest_queue_drop_count=2)},
+        )
+    ]
+    assert recorded_finalize_statuses == ["completed"]
+    assert result.run_id_to_analyze == "run-1"
+    assert [stage.stage_name for stage in result.stage_results] == [
+        "FlushPendingRowsStage",
+        "ResolvePostAnalysisCandidateStage",
+        "FinalizeRawCaptureStage",
+        "FinalizePersistenceStage",
+    ]
+    assert [stage.status for stage in result.stage_results] == ["ok", "ok", "ok", "ok"]
+
+
+def test_finalize_active_run_marks_skipped_and_degraded_stages(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = logging.getLogger("test.finalize.degraded")
+
+    sample_flush = SimpleNamespace(pending_flush_snapshot=lambda: None)
+    persistence = SimpleNamespace(
+        status_snapshot=lambda: PersistenceStatusSnapshot(
+            write_error=None,
+            written_sample_count=0,
+            dropped_sample_count=0,
+        ),
+        ready_for_analysis=lambda run_id: None,
+        history_run_created=False,
+        finalize_run=lambda run_id, start_time_utc, end_time_utc: False,
+    )
+    raw_capture = SimpleNamespace(
+        finalize_run=lambda run_id, *, sensor_losses=None: RawCaptureFinalizeResult(
+            status="timeout",
+            error="raw capture finalize timed out",
+            queue_depth=3,
+        )
+    )
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        result = finalize_active_run(
+            run_id="run-2",
+            start_time_utc="2026-04-25T06:41:00Z",
+            stop_reason="manual",
+            ingest_drop_losses=None,
+            sample_flush=sample_flush,
+            persistence=persistence,
+            raw_capture=raw_capture,
+            record_raw_capture_finalize_result=lambda run_id, result: None,
+            logger=logger,
+        )
+
+    assert [stage.status for stage in result.stage_results] == [
+        "skipped",
+        "skipped",
+        "degraded",
+        "degraded",
+    ]
+    stage_logs = {
+        getattr(record, "stage_name", ""): record
+        for record in caplog.records
+        if hasattr(record, "stage_name")
+    }
+    assert stage_logs["FinalizeRawCaptureStage"].stage_status == "degraded"
+    assert stage_logs["FinalizeRawCaptureStage"].diagnostic_context["queue_depth"] == 3
+    assert stage_logs["FinalizePersistenceStage"].stage_status == "degraded"
+
+
+def test_finalize_active_run_logs_failed_stage_and_reraises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    logger = logging.getLogger("test.finalize.failed")
+
+    sample_flush = SimpleNamespace(pending_flush_snapshot=lambda: None)
+    persistence = SimpleNamespace(
+        status_snapshot=lambda: PersistenceStatusSnapshot(
+            write_error=None,
+            written_sample_count=0,
+            dropped_sample_count=0,
+        ),
+        ready_for_analysis=lambda run_id: None,
+        history_run_created=False,
+        finalize_run=lambda run_id, start_time_utc, end_time_utc: True,
+    )
+    raw_capture = SimpleNamespace(
+        finalize_run=lambda run_id, *, sensor_losses=None: (_ for _ in ()).throw(
+            RuntimeError("raw finalize boom")
+        )
+    )
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        with pytest.raises(RuntimeError, match="raw finalize boom"):
+            finalize_active_run(
+                run_id="run-3",
+                start_time_utc="2026-04-25T06:42:00Z",
+                stop_reason="manual",
+                ingest_drop_losses=None,
+                sample_flush=sample_flush,
+                persistence=persistence,
+                raw_capture=raw_capture,
+                record_raw_capture_finalize_result=lambda run_id, result: None,
+                logger=logger,
+            )
+
+    failed_stage = next(
+        record
+        for record in caplog.records
+        if getattr(record, "stage_name", "") == "FinalizeRawCaptureStage"
+    )
+    assert failed_stage.stage_status == "failed"
+    assert failed_stage.diagnostic_context["error_message"] == "raw finalize boom"
+
+
+def test_stop_recording_logs_finalize_stage_results(
+    make_logger,
+    fake_history_db,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    recorder = make_logger(history_db=fake_history_db)
+    started = recorder.start_recording()
+    assert started.run_id is not None
+
+    snapshot = recorder._session_snapshot()
+    assert snapshot is not None
+    recorder._sample_flush.append_records(
+        snapshot.run_id,
+        snapshot.start_time_utc,
+        snapshot.start_mono_s,
+    )
+    recorder._raw_capture = SimpleNamespace(
+        finalize_run=lambda run_id, *, sensor_losses=None: RawCaptureFinalizeResult(
+            status="timeout",
+            error="raw capture finalize timed out",
+            queue_depth=4,
+        ),
+        shutdown=lambda timeout_s=5.0: True,
+    )
+    monkeypatch.setattr(recorder, "schedule_post_analysis", lambda run_id: None)
+
+    with caplog.at_level(logging.WARNING):
+        stopped = recorder.stop_recording()
+
+    assert stopped.enabled is False
+    stage_logs = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", "") == "run_finalize_stage_result"
+    ]
+    assert any(record.stage_name == "FinalizeRawCaptureStage" for record in stage_logs)
+    assert any(record.stage_status == "degraded" for record in stage_logs)

--- a/apps/server/vibesensor/use_cases/run/finalize_stages.py
+++ b/apps/server/vibesensor/use_cases/run/finalize_stages.py
@@ -1,0 +1,329 @@
+"""Explicit stage/result helpers for active-run finalization."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Literal
+
+from vibesensor.shared.structured_logging import log_extra
+from vibesensor.shared.time_utils import utc_now_iso
+from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.raw_capture import RawCaptureLossStats
+from vibesensor.use_cases.run.persistence_writer import (
+    PersistenceStatusSnapshot,
+    RunPersistenceWriter,
+)
+from vibesensor.use_cases.run.raw_capture_writer import (
+    RawCaptureFinalizeResult,
+    RunRawCaptureWriter,
+)
+from vibesensor.use_cases.run.sample_flush import SampleFlushOrchestrator
+
+type FinalizeStageStatus = Literal["ok", "skipped", "degraded", "failed"]
+
+RecordRawCaptureFinalize = Callable[[str, RawCaptureFinalizeResult], None]
+
+__all__ = ["ActiveRunFinalizeResult", "FinalizeStageResult", "finalize_active_run"]
+
+
+@dataclass(frozen=True, slots=True)
+class FinalizeStageResult:
+    """Structured result for one recorder finalization stage."""
+
+    stage_name: str
+    status: FinalizeStageStatus
+    duration_ms: int
+    artifacts_created: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    diagnostic_context: JsonObject = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveRunFinalizeResult:
+    """Resolved result of finalizing the currently active run."""
+
+    run_id: str | None
+    run_id_to_analyze: str | None
+    start_time_utc: str
+    end_time_utc: str
+    persistence_snapshot: PersistenceStatusSnapshot | None
+    stage_results: tuple[FinalizeStageResult, ...]
+
+
+def _duration_ms(stage_start: float) -> int:
+    return max(0, int(round((time.monotonic() - stage_start) * 1000)))
+
+
+def _make_stage_result(
+    *,
+    stage_name: str,
+    status: FinalizeStageStatus,
+    stage_start: float,
+    artifacts_created: tuple[str, ...] = (),
+    warnings: tuple[str, ...] = (),
+    diagnostic_context: JsonObject | None = None,
+) -> FinalizeStageResult:
+    return FinalizeStageResult(
+        stage_name=stage_name,
+        status=status,
+        duration_ms=_duration_ms(stage_start),
+        artifacts_created=artifacts_created,
+        warnings=warnings,
+        diagnostic_context={} if diagnostic_context is None else diagnostic_context,
+    )
+
+
+def _log_stage_result(
+    *,
+    logger: logging.Logger,
+    run_id: str | None,
+    stop_reason: str,
+    stage_result: FinalizeStageResult,
+) -> None:
+    if stage_result.status == "ok":
+        return
+    log_fn = logger.warning if stage_result.status in {"degraded", "failed"} else logger.info
+    log_fn(
+        "Run finalize stage %s for run %s is %s",
+        stage_result.stage_name,
+        run_id or "<none>",
+        stage_result.status,
+        extra=log_extra(
+            event="run_finalize_stage_result",
+            run_id=run_id or "",
+            stop_reason=stop_reason,
+            stage_name=stage_result.stage_name,
+            stage_status=stage_result.status,
+            duration_ms=stage_result.duration_ms,
+            artifacts_created=list(stage_result.artifacts_created),
+            warnings=list(stage_result.warnings),
+            diagnostic_context=stage_result.diagnostic_context,
+        ),
+    )
+
+
+def _log_failed_stage_and_raise(
+    *,
+    logger: logging.Logger,
+    run_id: str | None,
+    stop_reason: str,
+    stage_name: str,
+    stage_start: float,
+    exc: BaseException,
+    diagnostic_context: JsonObject | None = None,
+) -> None:
+    failure_result = _make_stage_result(
+        stage_name=stage_name,
+        status="failed",
+        stage_start=stage_start,
+        diagnostic_context=(
+            {"error_message": str(exc)}
+            if diagnostic_context is None
+            else {**diagnostic_context, "error_message": str(exc)}
+        ),
+    )
+    _log_stage_result(
+        logger=logger,
+        run_id=run_id,
+        stop_reason=stop_reason,
+        stage_result=failure_result,
+    )
+    raise exc
+
+
+def finalize_active_run(
+    *,
+    run_id: str | None,
+    start_time_utc: str | None,
+    stop_reason: str,
+    ingest_drop_losses: Mapping[str, RawCaptureLossStats] | None,
+    sample_flush: SampleFlushOrchestrator,
+    persistence: RunPersistenceWriter,
+    raw_capture: RunRawCaptureWriter,
+    record_raw_capture_finalize_result: RecordRawCaptureFinalize,
+    logger: logging.Logger,
+) -> ActiveRunFinalizeResult:
+    stage_results: list[FinalizeStageResult] = []
+
+    flush_stage_start = time.monotonic()
+    flush_snapshot = sample_flush.pending_flush_snapshot()
+    if flush_snapshot is None:
+        flush_stage = _make_stage_result(
+            stage_name="FlushPendingRowsStage",
+            status="skipped",
+            stage_start=flush_stage_start,
+            diagnostic_context={"reason": "no_pending_flush"},
+        )
+    else:
+        try:
+            sample_flush.append_records(
+                flush_snapshot.run_id,
+                flush_snapshot.start_time_utc,
+                flush_snapshot.start_mono_s,
+                refresh_metrics=True,
+            )
+        except BaseException as exc:
+            _log_failed_stage_and_raise(
+                logger=logger,
+                run_id=run_id,
+                stop_reason=stop_reason,
+                stage_name="FlushPendingRowsStage",
+                stage_start=flush_stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": flush_snapshot.run_id},
+            )
+        flush_stage = _make_stage_result(
+            stage_name="FlushPendingRowsStage",
+            status="ok",
+            stage_start=flush_stage_start,
+            artifacts_created=("pending_rows_flushed",),
+            diagnostic_context={"run_id": flush_snapshot.run_id},
+        )
+    stage_results.append(flush_stage)
+    _log_stage_result(
+        logger=logger,
+        run_id=run_id,
+        stop_reason=stop_reason,
+        stage_result=flush_stage,
+    )
+
+    resolved_start_time_utc = start_time_utc or utc_now_iso()
+    resolved_end_time_utc = utc_now_iso()
+    persistence_snapshot = persistence.status_snapshot() if run_id is not None else None
+
+    resolve_stage_start = time.monotonic()
+    run_id_to_analyze = persistence.ready_for_analysis(run_id)
+    resolve_stage = _make_stage_result(
+        stage_name="ResolvePostAnalysisCandidateStage",
+        status="ok" if run_id_to_analyze else "skipped",
+        stage_start=resolve_stage_start,
+        artifacts_created=("post_analysis_candidate",) if run_id_to_analyze else (),
+        diagnostic_context={
+            "run_id": run_id or "",
+            "history_run_created": persistence.history_run_created,
+            "written_sample_count": (
+                0 if persistence_snapshot is None else persistence_snapshot.written_sample_count
+            ),
+        },
+    )
+    stage_results.append(resolve_stage)
+    _log_stage_result(
+        logger=logger,
+        run_id=run_id,
+        stop_reason=stop_reason,
+        stage_result=resolve_stage,
+    )
+
+    raw_capture_stage_start = time.monotonic()
+    if run_id is None:
+        raw_capture_stage = _make_stage_result(
+            stage_name="FinalizeRawCaptureStage",
+            status="skipped",
+            stage_start=raw_capture_stage_start,
+            diagnostic_context={"reason": "no_active_run"},
+        )
+    else:
+        try:
+            finalize_result = raw_capture.finalize_run(
+                run_id,
+                sensor_losses=ingest_drop_losses,
+            )
+        except BaseException as exc:
+            _log_failed_stage_and_raise(
+                logger=logger,
+                run_id=run_id,
+                stop_reason=stop_reason,
+                stage_name="FinalizeRawCaptureStage",
+                stage_start=raw_capture_stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": run_id},
+            )
+        record_raw_capture_finalize_result(run_id, finalize_result)
+        raw_capture_status: FinalizeStageStatus
+        raw_capture_warnings: tuple[str, ...] = ()
+        raw_capture_artifacts: tuple[str, ...] = ()
+        if finalize_result.status == "completed":
+            raw_capture_status = "ok"
+            if finalize_result.manifest is not None:
+                raw_capture_artifacts = ("raw_capture_manifest",)
+        elif finalize_result.status == "not_configured":
+            raw_capture_status = "skipped"
+        else:
+            raw_capture_status = "degraded"
+            raw_capture_warnings = (finalize_result.error or finalize_result.status,)
+        raw_capture_stage = _make_stage_result(
+            stage_name="FinalizeRawCaptureStage",
+            status=raw_capture_status,
+            stage_start=raw_capture_stage_start,
+            artifacts_created=raw_capture_artifacts,
+            warnings=raw_capture_warnings,
+            diagnostic_context={
+                "run_id": run_id,
+                "raw_capture_status": finalize_result.status,
+                "queue_depth": finalize_result.queue_depth,
+                "sensor_loss_count": len(ingest_drop_losses or {}),
+            },
+        )
+    stage_results.append(raw_capture_stage)
+    _log_stage_result(
+        logger=logger,
+        run_id=run_id,
+        stop_reason=stop_reason,
+        stage_result=raw_capture_stage,
+    )
+
+    persistence_stage_start = time.monotonic()
+    if run_id is None:
+        persistence_stage = _make_stage_result(
+            stage_name="FinalizePersistenceStage",
+            status="skipped",
+            stage_start=persistence_stage_start,
+            diagnostic_context={"reason": "no_active_run"},
+        )
+    else:
+        try:
+            finalized = persistence.finalize_run(
+                run_id,
+                resolved_start_time_utc,
+                resolved_end_time_utc,
+            )
+        except BaseException as exc:
+            _log_failed_stage_and_raise(
+                logger=logger,
+                run_id=run_id,
+                stop_reason=stop_reason,
+                stage_name="FinalizePersistenceStage",
+                stage_start=persistence_stage_start,
+                exc=exc,
+                diagnostic_context={"run_id": run_id},
+            )
+        persistence_stage = _make_stage_result(
+            stage_name="FinalizePersistenceStage",
+            status="ok" if finalized else "degraded",
+            stage_start=persistence_stage_start,
+            artifacts_created=("history_run_finalized",) if finalized else (),
+            warnings=() if finalized else ("history_finalize_failed",),
+            diagnostic_context={
+                "run_id": run_id,
+                "post_analysis_candidate": bool(run_id_to_analyze),
+            },
+        )
+    stage_results.append(persistence_stage)
+    _log_stage_result(
+        logger=logger,
+        run_id=run_id,
+        stop_reason=stop_reason,
+        stage_result=persistence_stage,
+    )
+
+    return ActiveRunFinalizeResult(
+        run_id=run_id,
+        run_id_to_analyze=run_id_to_analyze,
+        start_time_utc=resolved_start_time_utc,
+        end_time_utc=resolved_end_time_utc,
+        persistence_snapshot=persistence_snapshot,
+        stage_results=tuple(stage_results),
+    )

--- a/apps/server/vibesensor/use_cases/run/logger.py
+++ b/apps/server/vibesensor/use_cases/run/logger.py
@@ -35,6 +35,10 @@ from vibesensor.shared.types.run_schema import RunRawCaptureFinalize, RunSensorM
 from vibesensor.shared.types.sensor_config import SensorConfigPayload
 from vibesensor.use_cases.run.capture_readiness import CaptureReadinessTracker
 from vibesensor.use_cases.run.capture_readiness_observation import observe_capture_readiness
+from vibesensor.use_cases.run.finalize_stages import (
+    ActiveRunFinalizeResult,
+    finalize_active_run,
+)
 from vibesensor.use_cases.run.lifecycle_state import RunLifecycleState
 from vibesensor.use_cases.run.persistence_writer import (
     _APPEND_RETRY_DELAYS_S,
@@ -378,6 +382,22 @@ class RunRecorder:
             extra["samples_dropped"] = samples_dropped
         LOGGER.info("run_lifecycle", extra=log_extra(**extra))
 
+    def _finalize_active_run_locked(self, *, reason: str) -> ActiveRunFinalizeResult:
+        return finalize_active_run(
+            run_id=self._run_id,
+            start_time_utc=self._lifecycle.start_time_utc,
+            stop_reason=reason,
+            ingest_drop_losses=_udp_ingest_drop_sensor_losses(
+                self.registry,
+                baseline=self._run_ingest_drop_baseline,
+            ),
+            sample_flush=self._sample_flush,
+            persistence=self._persistence,
+            raw_capture=self._raw_capture,
+            record_raw_capture_finalize_result=self._record_raw_capture_finalize_result,
+            logger=LOGGER,
+        )
+
     def start_recording(self) -> RunRecorderStatusSnapshot:
         with start_span(__name__, "run.recording.start", kind=SpanKind.INTERNAL) as span:
             completed_run_id: str | None = None
@@ -394,50 +414,23 @@ class RunRecorder:
                         span.set_attribute("vibesensor.ignored_shutdown", True)
                         return self.status()
                     if self.enabled and self._run_id:
-                        flush_snapshot = self._sample_flush.pending_flush_snapshot()
-                        if flush_snapshot is not None:
-                            self._sample_flush.append_records(
-                                flush_snapshot.run_id,
-                                flush_snapshot.start_time_utc,
-                                flush_snapshot.start_mono_s,
-                                refresh_metrics=True,
-                            )
-                    if self.enabled and self._run_id:
-                        run_id = self._run_id
-                        completed_run_id = self._persistence.ready_for_analysis(run_id)
-                        start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
-                        end_time_utc = utc_now_iso()
-                        persistence_snapshot = self._persistence.status_snapshot()
-                        ingest_drop_losses = _udp_ingest_drop_sensor_losses(
-                            self.registry,
-                            baseline=self._run_ingest_drop_baseline,
-                        )
-                        if run_id:
-                            finalize_result = self._raw_capture.finalize_run(
-                                run_id,
-                                sensor_losses=ingest_drop_losses,
-                            )
-                            self._record_raw_capture_finalize_result(run_id, finalize_result)
-                        if run_id and not self._persistence.finalize_run(
-                            run_id,
-                            start_time_utc,
-                            end_time_utc,
+                        finalize_result = self._finalize_active_run_locked(reason="restart")
+                        completed_run_id = finalize_result.run_id_to_analyze
+                        if (
+                            finalize_result.run_id is not None
+                            and finalize_result.persistence_snapshot is not None
                         ):
-                            LOGGER.warning(
-                                "finalize_run failed for %s; scheduling analysis anyway",
-                                run_id,
+                            lifecycle_events.append(
+                                (
+                                    "stopped",
+                                    finalize_result.run_id,
+                                    finalize_result.start_time_utc,
+                                    finalize_result.end_time_utc,
+                                    "restart",
+                                    finalize_result.persistence_snapshot.written_sample_count,
+                                    finalize_result.persistence_snapshot.dropped_sample_count,
+                                )
                             )
-                        lifecycle_events.append(
-                            (
-                                "stopped",
-                                run_id,
-                                start_time_utc,
-                                end_time_utc,
-                                "restart",
-                                persistence_snapshot.written_sample_count,
-                                persistence_snapshot.dropped_sample_count,
-                            )
-                        )
                     started_run = self._start_new_run_locked()
                     lifecycle_events.append(
                         (
@@ -498,50 +491,20 @@ class RunRecorder:
                     if _only_if_run_id is not None and self._run_id != _only_if_run_id:
                         span.set_attribute("vibesensor.skipped_run_id_guard", True)
                         return self.status()
-                    flush_snapshot = self._sample_flush.pending_flush_snapshot()
-                    if flush_snapshot is not None:
-                        self._sample_flush.append_records(
-                            flush_snapshot.run_id,
-                            flush_snapshot.start_time_utc,
-                            flush_snapshot.start_mono_s,
-                            refresh_metrics=True,
-                        )
-                    if _only_if_run_id is not None and self._run_id != _only_if_run_id:
-                        span.set_attribute("vibesensor.skipped_run_id_guard", True)
-                        return self.status()
-                    run_id = self._run_id
-                    run_id_to_analyze = self._persistence.ready_for_analysis(run_id)
-                    start_time_utc = self._lifecycle.start_time_utc or utc_now_iso()
-                    end_time_utc = utc_now_iso()
-                    persistence_snapshot = self._persistence.status_snapshot()
-                    ingest_drop_losses = _udp_ingest_drop_sensor_losses(
-                        self.registry,
-                        baseline=self._run_ingest_drop_baseline,
-                    )
-                    if run_id:
-                        finalize_result = self._raw_capture.finalize_run(
-                            run_id,
-                            sensor_losses=ingest_drop_losses,
-                        )
-                        self._record_raw_capture_finalize_result(run_id, finalize_result)
-                    if run_id and not self._persistence.finalize_run(
-                        run_id,
-                        start_time_utc,
-                        end_time_utc,
+                    finalize_result = self._finalize_active_run_locked(reason=reason)
+                    run_id_to_analyze = finalize_result.run_id_to_analyze
+                    if (
+                        finalize_result.run_id is not None
+                        and finalize_result.persistence_snapshot is not None
                     ):
-                        LOGGER.warning(
-                            "finalize_run failed for %s; scheduling analysis anyway",
-                            run_id,
-                        )
-                    if run_id is not None:
                         lifecycle_event = (
                             "stopped",
-                            run_id,
-                            start_time_utc,
-                            end_time_utc,
+                            finalize_result.run_id,
+                            finalize_result.start_time_utc,
+                            finalize_result.end_time_utc,
                             reason,
-                            persistence_snapshot.written_sample_count,
-                            persistence_snapshot.dropped_sample_count,
+                            finalize_result.persistence_snapshot.written_sample_count,
+                            finalize_result.persistence_snapshot.dropped_sample_count,
                         )
                     self._lifecycle.stop()
                     self._active_run_context = None

--- a/tools/dev/verify_backend_static_guards.py
+++ b/tools/dev/verify_backend_static_guards.py
@@ -417,19 +417,21 @@ def _check_recording_flow_uses_flush_and_persistence_writer() -> list[str]:
     persistence_writer_path = (
         VIBESENSOR_DIR / "use_cases" / "run" / "persistence_writer.py"
     )
+    finalize_stages_path = VIBESENSOR_DIR / "use_cases" / "run" / "finalize_stages.py"
     logger_source = _read_text(logger_path)
     sample_flush_source = _read_text(sample_flush_path)
     persistence_writer_source = _read_text(persistence_writer_path)
+    finalize_stages_source = _read_text(finalize_stages_path)
     failures: list[str] = []
     required_logger_markers = (
-        "from vibesensor.use_cases.run.sample_flush import SampleFlushOrchestrator",
-        "self._sample_flush.append_records(",
-        "self._persistence.ready_for_analysis(",
+        "from vibesensor.use_cases.run.finalize_stages import",
+        "def _finalize_active_run_locked(self, *, reason: str) -> ActiveRunFinalizeResult:",
+        "return finalize_active_run(",
     )
     for marker in required_logger_markers:
         if marker not in logger_source:
             failures.append(
-                f"{logger_path.relative_to(REPO_ROOT)} must keep the recording flow routed through sample_flush/persistence_writer ({marker})"
+                f"{logger_path.relative_to(REPO_ROOT)} must route recording finalization through the dedicated finalize helper ({marker})"
             )
     required_sample_flush_markers = (
         "from vibesensor.use_cases.run.persistence_writer import RunPersistenceWriter",
@@ -444,6 +446,16 @@ def _check_recording_flow_uses_flush_and_persistence_writer() -> list[str]:
         failures.append(
             f"{sample_flush_path.relative_to(REPO_ROOT)} must stay adapter-free; persistence_writer owns the history DB boundary"
         )
+    required_finalize_stage_markers = (
+        "sample_flush.append_records(",
+        "persistence.ready_for_analysis(run_id)",
+        "persistence.finalize_run(",
+    )
+    for marker in required_finalize_stage_markers:
+        if marker not in finalize_stages_source:
+            failures.append(
+                f"{finalize_stages_path.relative_to(REPO_ROOT)} must own the recorder finalize stages ({marker})"
+            )
     required_writer_markers = (
         "def ensure_history_run(",
         "history_db.aappend_samples(run_id, rows)",


### PR DESCRIPTION
## what changed
- add `use_cases/run/finalize_stages.py` as the explicit active-run finalize owner with per-stage results for flush, post-analysis candidate resolution, raw-capture finalize, and persistence finalize
- rewire both `stop_recording()` and the restart path in `start_recording()` through the same helper
- add focused stage-behavior tests and update the recording-flow static guard to follow the new canonical owner

## why
- removes the duplicated finalize chain from `RunRecorder`
- gives a non-post-analysis orchestration flow the same high-signal stage/result shape already used by post-analysis
- keeps degraded/failed finalize stages logged with stage name and diagnostic context

## validation
- `./.venv/bin/pytest -q apps/server/tests/use_cases/run/test_finalize_stages.py apps/server/tests/use_cases/run/test_metrics_log_helpers.py apps/server/tests/use_cases/run/test_metrics_logger_lifecycle.py`
- `make typecheck-backend`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`

## risks / tradeoffs
- scope stays on the recorder finalize seam only; shutdown/report orchestration is still separate work
- the static guard now follows the new helper owner, so future seam moves must update that guard too

Closes #3225