### PR TITLE
Add architecture guardrails for backend and UI boundary seams

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -24,6 +24,12 @@ backend-specific setup, configuration, routes, updates, and testing.
 Package-level backend dependency direction is declared in
 `apps/server/pyproject.toml` under `[tool.importlinter]`; keep repo-specific
 root-module and structural guardrails in `tools/dev/verify_backend_static_guards.py`.
+That static-guard layer now also carries the higher-signal seam messages that
+import-linter cannot: `use_cases/**` must stay off adapter imports directly,
+analysis/history core must stay off `adapters/pdf`, and live telemetry/runtime
+surfaces must stay off post-run diagnosis/report conclusion modules. When one of
+those fails, move the dependency behind the documented shared port or report
+boundary seam instead of widening the outer import.
 
 ## State and configuration scopes
 

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -434,6 +434,8 @@ instead of controller-side variant class interpolation.
   `transport/live_models.ts`, `server_payload.ts`, `ws.ts`, and
   `ws_payload_validator.ts`; `app/**` code may import `transport/**` and
   `api/types.ts`, but not generated contract files directly.
+  `tools/dev/check_hygiene.py` enforces that boundary in the normal lint path
+  and its failure text now points at the exact replacement seam to use.
 - Normal UI rendering belongs in Preact owner surfaces. If code outside an
   island needs imperative DOM work, keep it narrowly scoped to non-render
   integrations such as download anchors, canvas/uPlot lifecycles, observers, or

--- a/tools/dev/check_hygiene.py
+++ b/tools/dev/check_hygiene.py
@@ -517,6 +517,24 @@ def _ui_boundary_allowed_description(target_rel: str) -> str:
     )
 
 
+def _ui_boundary_fix_hint(importer_rel: str, target_rel: str) -> str:
+    if importer_rel.startswith("apps/ui/src/app/"):
+        if target_rel == "apps/ui/src/generated/http_api_contracts.ts":
+            return (
+                "import HTTP contract aliases through apps/ui/src/api/types.ts instead"
+            )
+        if target_rel in {
+            "apps/ui/src/contracts/ws_payload_types.ts",
+            "apps/ui/src/contracts/ws_payload_schema.generated.ts",
+        }:
+            return (
+                "import WS contract data through apps/ui/src/transport/live_models.ts, "
+                "apps/ui/src/server_payload.ts, apps/ui/src/ws.ts, or "
+                "apps/ui/src/ws_payload_validator.ts instead"
+            )
+    return f"keep generated transport contracts behind {_ui_boundary_allowed_description(target_rel)}"
+
+
 def check_frontend_generated_contract_boundaries() -> list[str]:
     errors: list[str] = []
     for path in _ui_source_files():
@@ -530,8 +548,7 @@ def check_frontend_generated_contract_boundaries() -> list[str]:
             if _ui_boundary_import_allowed(rel, resolved_rel):
                 continue
             errors.append(
-                f"{rel} must not import {resolved_rel}; keep generated transport contracts behind "
-                f"{_ui_boundary_allowed_description(resolved_rel)}."
+                f"{rel} must not import {resolved_rel}; {_ui_boundary_fix_hint(rel, resolved_rel)}."
             )
     return errors
 

--- a/tools/dev/verify_backend_static_guards.py
+++ b/tools/dev/verify_backend_static_guards.py
@@ -511,6 +511,66 @@ def _imports_from_prefixes(path: Path, prefixes: tuple[str, ...]) -> list[str]:
     return violations
 
 
+def _check_use_cases_do_not_import_adapters_directly() -> list[str]:
+    failures: list[str] = []
+    for path in _python_files(VIBESENSOR_DIR / "use_cases"):
+        violations = _imports_from_prefixes(path, ("vibesensor.adapters",))
+        if violations:
+            failures.append(
+                f"{path.relative_to(REPO_ROOT)} must stay on shared/infra ports or adapter-local seams instead of importing adapters directly:\n"
+                + "\n".join(violations)
+            )
+    return failures
+
+
+def _check_analysis_and_history_core_do_not_import_pdf_adapter() -> list[str]:
+    roots = [
+        VIBESENSOR_DIR / "use_cases" / "diagnostics",
+        VIBESENSOR_DIR / "use_cases" / "history",
+        VIBESENSOR_DIR / "shared" / "boundaries" / "reporting",
+    ]
+    failures: list[str] = []
+    for root in roots:
+        for path in _python_files(root):
+            violations = _imports_from_prefixes(path, ("vibesensor.adapters.pdf",))
+            if violations:
+                failures.append(
+                    f"{path.relative_to(REPO_ROOT)} must not import the PDF adapter directly; keep report/analysis core on report-boundary seams such as PreparedReportInput or ReportDocument:\n"
+                    + "\n".join(violations)
+                )
+    return failures
+
+
+def _live_telemetry_surface_files() -> list[Path]:
+    files = _live_processing_files()
+    for path in (
+        VIBESENSOR_DIR / "infra" / "runtime" / "ws_payload_projection.py",
+        VIBESENSOR_DIR / "infra" / "runtime" / "ws_broadcast.py",
+        VIBESENSOR_DIR / "infra" / "runtime" / "processing_tick.py",
+    ):
+        if path.exists():
+            files.append(path)
+    return sorted(dict.fromkeys(files))
+
+
+def _check_live_surfaces_do_not_import_post_run_conclusions() -> list[str]:
+    forbidden_prefixes = (
+        "vibesensor.use_cases.diagnostics",
+        "vibesensor.use_cases.history",
+        "vibesensor.shared.boundaries.reporting",
+        "vibesensor.adapters.pdf",
+    )
+    failures: list[str] = []
+    for path in _live_telemetry_surface_files():
+        violations = _imports_from_prefixes(path, forbidden_prefixes)
+        if violations:
+            failures.append(
+                f"{path.relative_to(REPO_ROOT)} must keep live telemetry on runtime/transport seams instead of importing post-run diagnosis/report conclusion modules:\n"
+                + "\n".join(violations)
+            )
+    return failures
+
+
 def _check_history_services_do_not_import_httpexception() -> list[str]:
     service_modules = [
         VIBESENSOR_DIR / "use_cases" / "history" / "helpers.py",
@@ -2239,6 +2299,18 @@ CHECKS: tuple[Check, ...] = (
     (
         "Live processing stays analysis-free",
         _check_live_processing_does_not_import_analysis,
+    ),
+    (
+        "Use cases avoid importing adapters directly",
+        _check_use_cases_do_not_import_adapters_directly,
+    ),
+    (
+        "Analysis/history core avoids direct PDF adapter imports",
+        _check_analysis_and_history_core_do_not_import_pdf_adapter,
+    ),
+    (
+        "Live telemetry avoids post-run conclusion modules",
+        _check_live_surfaces_do_not_import_post_run_conclusions,
     ),
     ("Canonical dataflow doc stays complete", _check_canonical_dataflow_doc),
     (


### PR DESCRIPTION
## Summary
Small.

Add four high-signal seam guardrails.

- backend static guard: `use_cases/**` must not import `vibesensor.adapters.*` directly
- backend static guard: analysis/history/report core must not import `vibesensor.adapters.pdf` directly
- backend static guard: live telemetry/runtime surfaces must not import post-run diagnosis/report conclusion modules
- tighten frontend generated-contract boundary failures so `app/**` gets the exact seam file to use instead
- document the new fix paths in `apps/server/README.md` and `apps/ui/README.md`

## Why
Import-linter and the existing UI contract docs already covered broad boundaries.
This adds tighter executable checks with file/line failures and seam-specific fix guidance.

## Validation
- `make format`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `make docs-lint`

## Risks / tradeoffs
- static-guard scope is intentionally narrow to stay high-signal
- no new generic framework or duplicate broad checker added
- raw capture / replay math centralization was left alone because the current scans found no useful new rule there

## Out of scope
- changing legitimate import paths that already sit behind the approved seams
