### PR TITLE
Tighten shared layer ownership

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,6 +26,7 @@ Architectural constraints
 - Offline-first hotspot boot: hotspot provisioning must not depend on internet connectivity. Required packages are baked into the image build stage.
 - Deterministic image outputs: custom pi-gen stage must export uniquely suffixed artifacts and self-validate rootfs contents.
 - Internal shared logic belongs in the server package (`apps/server/vibesensor/vibration_strength.py`, `apps/server/vibesensor/strength_bands.py`), not in separate packages. Generated shared TS constants are emitted to `apps/ui/src/constants.ts` from backend sources under the `vibesensor.shared.*` Python import namespace.
+- `vibesensor.shared` is for stable cross-layer contracts, ports, codecs, constants, and pure helper language. App/runtime bootstrap or subprocess orchestration belongs in `apps/server/vibesensor/app/` or the owning `use_cases/**` module, not in `vibesensor.shared`.
 - Do not create runtime file-loading mechanisms for static configuration data. Use Python constants for values that don't change between deployments.
 
 Domain model (scope: behavioral rules only; see `docs/domain-model.md` for the full domain object catalog and relationship map)

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -31,6 +31,19 @@ surfaces must stay off post-run diagnosis/report conclusion modules. When one of
 those fails, move the dependency behind the documented shared port or report
 boundary seam instead of widening the outer import.
 
+## Shared layer ownership
+
+`vibesensor.shared` is for stable cross-layer boundary language: ports and
+protocols, typed contracts, boundary codecs/projection helpers, shared
+constants/units, and pure helpers that multiple inner layers can reuse without
+pulling in runtime orchestration. Cross-cutting runtime helpers that are still
+owned by backend coordination, such as isolated server subprocess orchestration,
+belong in a focused `use_cases/**` module instead of the shared layer, while
+feature-local orchestration belongs in the owning `use_cases/**` package. The
+backend static guards keep `vibesensor.use_cases.isolated_server_runtime` as
+the owner of that runtime helper and keep `shared/subprocess_server.py`
+removed.
+
 ## State and configuration scopes
 
 Several issue reports have described the backend as one pool of global mutable

--- a/apps/server/tests/use_cases/test_isolated_server_runtime.py
+++ b/apps/server/tests/use_cases/test_isolated_server_runtime.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import yaml
 from _paths import SERVER_ROOT
 
-from vibesensor.shared.subprocess_server import (
+from vibesensor.use_cases.isolated_server_runtime import (
     build_isolated_server_config,
     build_isolated_server_env,
     build_server_subprocess_cmd,

--- a/apps/server/tests/use_cases/updates/releases/test_release_validation.py
+++ b/apps/server/tests/use_cases/updates/releases/test_release_validation.py
@@ -384,15 +384,15 @@ def _patch_release_smoke_process(
         "validate_packaged_static_assets",
         lambda: tmp_path / "index.html",
     )
-    import vibesensor.shared.subprocess_server as _subprocess_server
+    import vibesensor.use_cases.isolated_server_runtime as _isolated_server_runtime
 
     monkeypatch.setattr(
-        _subprocess_server,
+        _isolated_server_runtime,
         "start_server_subprocess",
         fake_start_server_subprocess,
     )
     monkeypatch.setattr(
-        _subprocess_server,
+        _isolated_server_runtime,
         "terminate_subprocess",
         lambda process: (process.terminate(), process.wait(timeout=10.0)),
     )

--- a/apps/server/vibesensor/use_cases/isolated_server_runtime.py
+++ b/apps/server/vibesensor/use_cases/isolated_server_runtime.py
@@ -1,4 +1,4 @@
-"""Helpers for isolated local server subprocess runs."""
+"""Helpers for isolated local server runtime subprocess runs."""
 
 from __future__ import annotations
 

--- a/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
+++ b/apps/server/vibesensor/use_cases/updates/releases/release_validation.py
@@ -43,7 +43,7 @@ def build_release_smoke_config(
     host: str,
     port: int,
 ) -> Path:
-    from vibesensor.shared.subprocess_server import build_isolated_server_config
+    from vibesensor.use_cases.isolated_server_runtime import build_isolated_server_config
 
     udp_data_port = port + 1000
     udp_control_port = port + 1001
@@ -202,7 +202,7 @@ def run_server_smoke(
 ) -> None:
     from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
-    from vibesensor.shared.subprocess_server import (
+    from vibesensor.use_cases.isolated_server_runtime import (
         build_isolated_server_env,
         start_server_subprocess,
         terminate_subprocess,

--- a/tools/dev/verify_backend_static_guards.py
+++ b/tools/dev/verify_backend_static_guards.py
@@ -1516,6 +1516,31 @@ def _check_run_context_split_owners() -> list[str]:
     return failures
 
 
+def _check_isolated_server_runtime_owner() -> list[str]:
+    failures: list[str] = []
+    old_file = VIBESENSOR_DIR / "shared" / "subprocess_server.py"
+    new_file = VIBESENSOR_DIR / "use_cases" / "isolated_server_runtime.py"
+    if old_file.exists():
+        failures.append(
+            f"{old_file.relative_to(REPO_ROOT)} should not exist; isolated server subprocess orchestration belongs in use_cases/isolated_server_runtime.py"
+        )
+    if not new_file.exists():
+        failures.append(
+            f"Missing isolated server runtime owner: {new_file.relative_to(REPO_ROOT)}"
+        )
+    scan_dirs = [VIBESENSOR_DIR, REPO_ROOT / "tools" / "tests"]
+    for scan_dir in scan_dirs:
+        for path in _python_files(scan_dir):
+            source = _read_text(path)
+            if "from vibesensor.shared.subprocess_server import" in source or (
+                "import vibesensor.shared.subprocess_server" in source
+            ):
+                failures.append(
+                    f"{path.relative_to(REPO_ROOT)} imports removed shared/subprocess_server.py; use vibesensor.use_cases.isolated_server_runtime instead"
+                )
+    return failures
+
+
 def _check_settings_snapshot_boundary_location() -> list[str]:
     failures: list[str] = []
     legacy_files = (
@@ -2429,6 +2454,10 @@ CHECKS: tuple[Check, ...] = (
     (
         "Run-context helpers stay split between shared warnings and use_cases/run",
         _check_run_context_split_owners,
+    ),
+    (
+        "Isolated server runtime stays out of shared",
+        _check_isolated_server_runtime_owner,
     ),
     (
         "Settings snapshot codec keeps a distinct filename",

--- a/tools/tests/run_e2e_parallel.py
+++ b/tools/tests/run_e2e_parallel.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
-from vibesensor.shared.subprocess_server import (
+from vibesensor.use_cases.isolated_server_runtime import (
     IsolatedRuntimePaths,
     build_isolated_server_config,
     build_isolated_server_env,


### PR DESCRIPTION
Closes #3228.

## Summary
Small.

Shared layer audit found one clear move-now cleanup.

- move isolated server subprocess/runtime helper from `vibesensor.shared.subprocess_server` to `vibesensor.use_cases.isolated_server_runtime`
- update release validation, the e2e shard runner, and affected tests to use the new owner
- add a static guard that keeps `shared/subprocess_server.py` removed and points callers at the new seam
- document the short shared-layer ownership rule in `apps/server/README.md` and `.github/copilot-instructions.md`

## Audit decisions
- **move now**: isolated server subprocess/runtime helper; it is runtime orchestration, not stable shared boundary language
- **keep**: `vibesensor.shared.process_settings`; current repo docs intentionally assign process-level env override settings there
- **defer**: `vibesensor.shared.structured_logging`; its request-context helpers are still spread across many callers, so splitting config vs helper ownership is a separate change

## Why
`vibesensor.shared` should stay focused on stable contracts, ports, codecs, constants, and pure helpers.
The isolated server runtime helper was the clearest current shared-layer leak with a cheap safe fix.

## Validation
- `./.venv/bin/pytest -q apps/server/tests/use_cases/test_isolated_server_runtime.py apps/server/tests/use_cases/updates/releases/test_release_validation.py apps/server/tests/hygiene/test_run_e2e_parallel.py`
- `make typecheck-backend`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `make docs-lint`

## Risks / tradeoffs
- guard is intentionally narrow: it locks the current owner split instead of guessing at every future shared-layer smell
- no wider refactor of logging or process-settings ownership in this PR
