### PR TITLE
Add exact vehicle configuration rows

### DIFF
--- a/apps/server/tests/adapters/persistence/test_vehicle_configurations.py
+++ b/apps/server/tests/adapters/persistence/test_vehicle_configurations.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from vibesensor.adapters.persistence.car_library import (
+    load_car_library,
+    load_vehicle_configurations,
+    resolve_vehicle_configurations,
+)
+
+
+def _entry_for(model: str) -> dict[str, object]:
+    for entry in load_car_library():
+        if entry["brand"] == "BMW" and entry["model"] == model:
+            return entry
+    raise AssertionError(f"BMW model not found: {model}")
+
+
+def test_exact_vehicle_configurations_cover_required_configuration_kinds() -> None:
+    configs = load_vehicle_configurations()
+    assert any(
+        config.variant_name == "420i" and config.drivetrain == "RWD" and config.fuel_type == "ICE"
+        for config in configs
+    )
+    assert any(
+        config.variant_name == "330i xDrive"
+        and config.drivetrain == "AWD"
+        and config.fuel_type == "ICE"
+        for config in configs
+    )
+    assert any(config.variant_name == "225xe" and config.fuel_type == "PHEV" for config in configs)
+    assert any(
+        config.variant_name == "i5 eDrive40"
+        and config.fuel_type == "EV"
+        and config.transmission_name == "Single-speed fixed gear (EV)"
+        for config in configs
+    )
+
+
+def test_resolve_vehicle_configurations_uses_exact_row_for_f45_220i() -> None:
+    configs = resolve_vehicle_configurations(
+        _entry_for("2 Series Active Tourer (F45, 2014-2021)"),
+        "220i",
+    )
+
+    assert len(configs) == 1
+    config = configs[0]
+    assert config.source_status == "exact_row"
+    assert config.transmission_name == "7-speed Steptronic dual-clutch transmission"
+    assert config.final_drive_front == 3.231
+    assert config.final_drive_rear is None
+
+
+def test_resolve_vehicle_configurations_uses_exact_row_for_g20_330i_xdrive() -> None:
+    configs = resolve_vehicle_configurations(
+        _entry_for("3 Series (G20, 2019-2025)"),
+        "330i xDrive",
+    )
+
+    assert len(configs) == 1
+    config = configs[0]
+    assert config.source_status == "exact_row"
+    assert config.transmission_name == "8-speed automatic (ZF 8HP)"
+    assert config.final_drive_front == 2.813
+    assert config.final_drive_rear == 2.813
+
+
+def test_resolve_vehicle_configurations_uses_exact_row_for_g60_i5_edrive40() -> None:
+    configs = resolve_vehicle_configurations(
+        _entry_for("5 Series (G60, 2024-2026)"),
+        "i5 eDrive40",
+    )
+
+    assert len(configs) == 1
+    config = configs[0]
+    assert config.source_status == "exact_row"
+    assert config.fuel_type == "EV"
+    assert config.gear_ratios == (1.0,)
+    assert config.final_drive_rear == 11.115
+
+
+def test_resolve_vehicle_configurations_projects_unmigrated_variant_per_gearbox() -> None:
+    configs = resolve_vehicle_configurations(
+        _entry_for("3 Series (G20, 2019-2025)"),
+        "330i",
+    )
+
+    assert len(configs) == 2
+    assert {config.source_status for config in configs} == {"compat_projection"}
+    assert {config.transmission_name for config in configs} == {
+        "8-speed automatic (ZF 8HP)",
+        "6-speed manual",
+    }

--- a/apps/server/vibesensor/adapters/persistence/car_library.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library.py
@@ -14,6 +14,7 @@ from typing import Any, Literal, NotRequired, TypedDict, cast
 
 from pydantic import ConfigDict, TypeAdapter, ValidationError
 
+from vibesensor.domain import TireSpec, VehicleConfiguration, VehicleConfigurationTireOption
 from vibesensor.shared._data_files import resolve_static_data_file
 
 LOGGER = logging.getLogger(__name__)
@@ -24,11 +25,15 @@ __all__ = [
     "get_models_for_brand_type",
     "get_types_for_brand",
     "load_car_library",
+    "load_vehicle_configurations",
     "get_variants_for_model",
+    "get_exact_configurations_for_variant",
     "resolve_variant",
+    "resolve_vehicle_configurations",
 ]
 
 _DATA_FILE = resolve_static_data_file("car_library.json")
+_VEHICLE_CONFIG_DATA_FILE = resolve_static_data_file("vehicle_configurations.json")
 _STRICT_TYPEDDICT_CONFIG = ConfigDict(extra="forbid")
 
 
@@ -69,15 +74,45 @@ class CarLibraryEntry(TypedDict):
     variants: list[CarLibraryVariant]
 
 
+class VehicleConfigurationRow(TypedDict):
+    brand: str
+    type: str
+    market: str
+    model_code: str
+    body_code: str
+    production_start_year: int
+    production_end_year: int
+    model_name: str
+    variant_name: str
+    engine_code: str
+    engine_name: str
+    fuel_type: Literal["ICE", "PHEV", "EV"]
+    drivetrain: Literal["FWD", "RWD", "AWD"]
+    transmission_code: str
+    transmission_name: str
+    top_gear_ratio: float
+    gear_ratios: NotRequired[list[float]]
+    final_drive_front: NotRequired[float]
+    final_drive_rear: NotRequired[float]
+    transfer_case_ratio: NotRequired[float]
+    tire_options: list[CarLibraryTireOption]
+    tire_width_mm: float
+    tire_aspect_pct: float
+    rim_in: float
+    source_status: Literal["exact_row"]
+
+
 for _typed_dict in (
     CarLibraryGearbox,
     CarLibraryTireOption,
     CarLibraryVariant,
     CarLibraryEntry,
+    VehicleConfigurationRow,
 ):
     cast(Any, _typed_dict).__pydantic_config__ = _STRICT_TYPEDDICT_CONFIG
 
 _CAR_LIBRARY_ADAPTER = TypeAdapter(list[CarLibraryEntry])
+_VEHICLE_CONFIGURATION_ADAPTER = TypeAdapter(list[VehicleConfigurationRow])
 
 
 def _entry_matches_identity(
@@ -116,15 +151,167 @@ def _load_library() -> list[CarLibraryEntry]:
         return []
 
 
+def _tire_spec_from_dimensions(
+    *,
+    tire_width_mm: float,
+    tire_aspect_pct: float,
+    rim_in: float,
+) -> TireSpec:
+    spec = TireSpec.from_aspects(
+        {
+            "tire_width_mm": tire_width_mm,
+            "tire_aspect_pct": tire_aspect_pct,
+            "rim_in": rim_in,
+        }
+    )
+    if spec is None:
+        raise ValueError(
+            f"Invalid tire dimensions width={tire_width_mm} aspect={tire_aspect_pct} rim={rim_in}"
+        )
+    return spec
+
+
+def _tire_options_from_rows(
+    rows: list[CarLibraryTireOption],
+) -> tuple[VehicleConfigurationTireOption, ...]:
+    return tuple(
+        VehicleConfigurationTireOption(
+            name=row["name"],
+            spec=_tire_spec_from_dimensions(
+                tire_width_mm=row["tire_width_mm"],
+                tire_aspect_pct=row["tire_aspect_pct"],
+                rim_in=row["rim_in"],
+            ),
+        )
+        for row in rows
+    )
+
+
+def _configuration_from_row(row: VehicleConfigurationRow) -> VehicleConfiguration:
+    return VehicleConfiguration(
+        brand=row["brand"],
+        car_type=row["type"],
+        market=row["market"],
+        model_code=row["model_code"],
+        body_code=row["body_code"],
+        production_start_year=row["production_start_year"],
+        production_end_year=row["production_end_year"],
+        model_name=row["model_name"],
+        variant_name=row["variant_name"],
+        engine_code=row["engine_code"],
+        engine_name=row["engine_name"],
+        fuel_type=row["fuel_type"],
+        drivetrain=row["drivetrain"],
+        transmission_code=row["transmission_code"],
+        transmission_name=row["transmission_name"],
+        top_gear_ratio=row["top_gear_ratio"],
+        gear_ratios=tuple(row["gear_ratios"]) if "gear_ratios" in row else None,
+        final_drive_front=row.get("final_drive_front"),
+        final_drive_rear=row.get("final_drive_rear"),
+        transfer_case_ratio=row.get("transfer_case_ratio"),
+        tire_options=_tire_options_from_rows(row["tire_options"]),
+        default_tire=_tire_spec_from_dimensions(
+            tire_width_mm=row["tire_width_mm"],
+            tire_aspect_pct=row["tire_aspect_pct"],
+            rim_in=row["rim_in"],
+        ),
+        source_status=row["source_status"],
+    )
+
+
+def _fuel_type_from_engine_name(engine_name: str | None) -> Literal["ICE", "PHEV", "EV"]:
+    normalized = (engine_name or "").lower()
+    if "electric" in normalized or normalized.startswith("ev "):
+        return "EV"
+    if "phev" in normalized:
+        return "PHEV"
+    return "ICE"
+
+
+def _project_legacy_variant_rows(
+    base_entry: CarLibraryEntry,
+    variant_name: str,
+) -> tuple[VehicleConfiguration, ...]:
+    selected_variant = next(
+        (variant for variant in base_entry["variants"] if variant["name"] == variant_name),
+        None,
+    )
+    if selected_variant is None:
+        return ()
+    resolved = resolve_variant(base_entry, variant_name)
+    tire_options = _tire_options_from_rows(resolved["tire_options"])
+    default_tire = _tire_spec_from_dimensions(
+        tire_width_mm=resolved["tire_width_mm"],
+        tire_aspect_pct=resolved["tire_aspect_pct"],
+        rim_in=resolved["rim_in"],
+    )
+    engine_name = selected_variant.get("engine")
+    drivetrain = selected_variant["drivetrain"]
+    configs: list[VehicleConfiguration] = []
+    for gearbox in resolved["gearboxes"]:
+        final_drive_ratio = gearbox["final_drive_ratio"]
+        configs.append(
+            VehicleConfiguration(
+                brand=base_entry["brand"],
+                car_type=base_entry["type"],
+                model_name=base_entry["model"],
+                variant_name=variant_name,
+                drivetrain=drivetrain,
+                transmission_name=gearbox["name"],
+                top_gear_ratio=gearbox["top_gear_ratio"],
+                default_tire=default_tire,
+                tire_options=tire_options,
+                fuel_type=_fuel_type_from_engine_name(engine_name),
+                engine_code=engine_name,
+                engine_name=engine_name,
+                gear_ratios=tuple(gearbox["gear_ratios"]) if "gear_ratios" in gearbox else None,
+                final_drive_front=final_drive_ratio if drivetrain in {"FWD", "AWD"} else None,
+                final_drive_rear=final_drive_ratio if drivetrain in {"RWD", "AWD"} else None,
+                transfer_case_ratio=1.0 if drivetrain == "AWD" else None,
+                source_status="compat_projection",
+            )
+        )
+    return tuple(configs)
+
+
+def _load_vehicle_configurations_snapshot() -> list[VehicleConfiguration]:
+    try:
+        with _VEHICLE_CONFIG_DATA_FILE.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+        rows = _VEHICLE_CONFIGURATION_ADAPTER.validate_python(data)
+        return [_configuration_from_row(row) for row in rows]
+    except (
+        FileNotFoundError,
+        json.JSONDecodeError,
+        PermissionError,
+        OSError,
+        ValidationError,
+        ValueError,
+    ) as exc:
+        LOGGER.warning(
+            "Could not load exact vehicle configurations from %s: %s",
+            _VEHICLE_CONFIG_DATA_FILE,
+            exc,
+        )
+        return []
+
+
 # Query helpers reuse one import-time snapshot; explicit loaders can call
 # ``load_car_library()`` when they need a fresh validated read from disk.
 _CAR_LIBRARY: list[CarLibraryEntry] = _load_library()
+_VEHICLE_CONFIGURATIONS: list[VehicleConfiguration] = _load_vehicle_configurations_snapshot()
 
 
 def load_car_library() -> list[CarLibraryEntry]:
     """Load and return a fresh validated car-library snapshot."""
 
     return _load_library()
+
+
+def load_vehicle_configurations() -> list[VehicleConfiguration]:
+    """Load and return a fresh validated exact-configuration snapshot."""
+
+    return _load_vehicle_configurations_snapshot()
 
 
 def get_brands() -> list[str]:
@@ -160,6 +347,24 @@ def get_variants_for_model(brand: str, car_type: str, model: str) -> list[CarLib
     return []
 
 
+def get_exact_configurations_for_variant(
+    brand: str,
+    car_type: str,
+    model: str,
+    variant_name: str,
+) -> tuple[VehicleConfiguration, ...]:
+    """Return exact configuration rows for one selected legacy variant."""
+
+    return tuple(
+        config
+        for config in _VEHICLE_CONFIGURATIONS
+        if config.brand == brand
+        and config.car_type == car_type
+        and config.model_name == model
+        and config.variant_name == variant_name
+    )
+
+
 def resolve_variant(
     base_entry: CarLibraryEntry,
     variant_name: str | None,
@@ -188,3 +393,27 @@ def resolve_variant(
                 result["rim_in"] = variant["rim_in"]
             break
     return result
+
+
+def resolve_vehicle_configurations(
+    base_entry: CarLibraryEntry,
+    variant_name: str | None,
+) -> tuple[VehicleConfiguration, ...]:
+    """Resolve one selected variant to explicit configuration rows.
+
+    Exact configuration rows win when present. Otherwise the legacy model/variant
+    data is projected into one compatibility row per available gearbox so broad
+    inheritance does not stay implicit.
+    """
+
+    if not variant_name:
+        return ()
+    exact_rows = get_exact_configurations_for_variant(
+        base_entry["brand"],
+        base_entry["type"],
+        base_entry["model"],
+        variant_name,
+    )
+    if exact_rows:
+        return exact_rows
+    return _project_legacy_variant_rows(base_entry, variant_name)

--- a/apps/server/vibesensor/data/vehicle_configurations.json
+++ b/apps/server/vibesensor/data/vehicle_configurations.json
@@ -1,0 +1,222 @@
+[
+  {
+    "brand": "BMW",
+    "type": "Coupe",
+    "market": "EU",
+    "model_code": "G22",
+    "body_code": "G22",
+    "production_start_year": 2021,
+    "production_end_year": 2026,
+    "model_name": "4 Series (G22, 2021-2026)",
+    "variant_name": "420i",
+    "engine_code": "B48",
+    "engine_name": "B48 2.0L I4 Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": "RWD",
+    "transmission_code": "ZF8HP",
+    "transmission_name": "8-speed automatic (ZF 8HP)",
+    "top_gear_ratio": 0.667,
+    "final_drive_rear": 2.813,
+    "tire_options": [
+      {
+        "name": "Standard 18\"",
+        "tire_width_mm": 245.0,
+        "tire_aspect_pct": 40.0,
+        "rim_in": 18.0
+      },
+      {
+        "name": "Sport Line 19\"",
+        "tire_width_mm": 255.0,
+        "tire_aspect_pct": 35.0,
+        "rim_in": 19.0
+      },
+      {
+        "name": "M Sport 20\"",
+        "tire_width_mm": 265.0,
+        "tire_aspect_pct": 30.0,
+        "rim_in": 20.0
+      }
+    ],
+    "tire_width_mm": 245.0,
+    "tire_aspect_pct": 40.0,
+    "rim_in": 18.0,
+    "source_status": "exact_row"
+  },
+  {
+    "brand": "BMW",
+    "type": "Hatchback",
+    "market": "EU",
+    "model_code": "F45",
+    "body_code": "F45",
+    "production_start_year": 2014,
+    "production_end_year": 2021,
+    "model_name": "2 Series Active Tourer (F45, 2014-2021)",
+    "variant_name": "220i",
+    "engine_code": "B48",
+    "engine_name": "B48 2.0L I4 Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": "FWD",
+    "transmission_code": "DCT7",
+    "transmission_name": "7-speed Steptronic dual-clutch transmission",
+    "top_gear_ratio": 0.698,
+    "final_drive_front": 3.231,
+    "tire_options": [
+      {
+        "name": "Standard 17\"",
+        "tire_width_mm": 205.0,
+        "tire_aspect_pct": 55.0,
+        "rim_in": 17.0
+      },
+      {
+        "name": "Sport Line 18\"",
+        "tire_width_mm": 215.0,
+        "tire_aspect_pct": 50.0,
+        "rim_in": 18.0
+      },
+      {
+        "name": "M Sport 19\"",
+        "tire_width_mm": 225.0,
+        "tire_aspect_pct": 45.0,
+        "rim_in": 19.0
+      }
+    ],
+    "tire_width_mm": 205.0,
+    "tire_aspect_pct": 55.0,
+    "rim_in": 17.0,
+    "source_status": "exact_row"
+  },
+  {
+    "brand": "BMW",
+    "type": "Hatchback",
+    "market": "EU",
+    "model_code": "F45",
+    "body_code": "F45",
+    "production_start_year": 2014,
+    "production_end_year": 2021,
+    "model_name": "2 Series Active Tourer (F45, 2014-2021)",
+    "variant_name": "225xe",
+    "engine_code": "B38",
+    "engine_name": "B38 1.5L I3 Turbo PHEV",
+    "fuel_type": "PHEV",
+    "drivetrain": "AWD",
+    "transmission_code": "AUTO6-PHEV",
+    "transmission_name": "6-speed Steptronic (225xe iPerformance)",
+    "top_gear_ratio": 0.672,
+    "final_drive_front": 3.944,
+    "tire_options": [
+      {
+        "name": "Standard 17\"",
+        "tire_width_mm": 205.0,
+        "tire_aspect_pct": 55.0,
+        "rim_in": 17.0
+      },
+      {
+        "name": "Sport Line 18\"",
+        "tire_width_mm": 215.0,
+        "tire_aspect_pct": 50.0,
+        "rim_in": 18.0
+      },
+      {
+        "name": "M Sport 19\"",
+        "tire_width_mm": 225.0,
+        "tire_aspect_pct": 45.0,
+        "rim_in": 19.0
+      }
+    ],
+    "tire_width_mm": 205.0,
+    "tire_aspect_pct": 55.0,
+    "rim_in": 17.0,
+    "source_status": "exact_row"
+  },
+  {
+    "brand": "BMW",
+    "type": "Sedan",
+    "market": "EU",
+    "model_code": "G20",
+    "body_code": "G20",
+    "production_start_year": 2019,
+    "production_end_year": 2025,
+    "model_name": "3 Series (G20, 2019-2025)",
+    "variant_name": "330i xDrive",
+    "engine_code": "B48",
+    "engine_name": "B48 2.0L I4 Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": "AWD",
+    "transmission_code": "ZF8HP",
+    "transmission_name": "8-speed automatic (ZF 8HP)",
+    "top_gear_ratio": 0.667,
+    "final_drive_front": 2.813,
+    "final_drive_rear": 2.813,
+    "transfer_case_ratio": 1.0,
+    "tire_options": [
+      {
+        "name": "Standard 18\"",
+        "tire_width_mm": 225.0,
+        "tire_aspect_pct": 40.0,
+        "rim_in": 18.0
+      },
+      {
+        "name": "Sport Line 19\"",
+        "tire_width_mm": 235.0,
+        "tire_aspect_pct": 35.0,
+        "rim_in": 19.0
+      },
+      {
+        "name": "M Sport 20\"",
+        "tire_width_mm": 245.0,
+        "tire_aspect_pct": 30.0,
+        "rim_in": 20.0
+      }
+    ],
+    "tire_width_mm": 225.0,
+    "tire_aspect_pct": 40.0,
+    "rim_in": 18.0,
+    "source_status": "exact_row"
+  },
+  {
+    "brand": "BMW",
+    "type": "Sedan",
+    "market": "EU",
+    "model_code": "G60",
+    "body_code": "G60",
+    "production_start_year": 2024,
+    "production_end_year": 2026,
+    "model_name": "5 Series (G60, 2024-2026)",
+    "variant_name": "i5 eDrive40",
+    "engine_code": "GEN5_SINGLE_MOTOR",
+    "engine_name": "Electric Single Motor",
+    "fuel_type": "EV",
+    "drivetrain": "RWD",
+    "transmission_code": "EV-1SPEED",
+    "transmission_name": "Single-speed fixed gear (EV)",
+    "top_gear_ratio": 1.0,
+    "gear_ratios": [
+      1.0
+    ],
+    "final_drive_rear": 11.115,
+    "tire_options": [
+      {
+        "name": "Standard 19\"",
+        "tire_width_mm": 245.0,
+        "tire_aspect_pct": 40.0,
+        "rim_in": 19.0
+      },
+      {
+        "name": "Sport Line 20\"",
+        "tire_width_mm": 255.0,
+        "tire_aspect_pct": 35.0,
+        "rim_in": 20.0
+      },
+      {
+        "name": "M Sport 21\"",
+        "tire_width_mm": 265.0,
+        "tire_aspect_pct": 30.0,
+        "rim_in": 21.0
+      }
+    ],
+    "tire_width_mm": 245.0,
+    "tire_aspect_pct": 40.0,
+    "rim_in": 19.0,
+    "source_status": "exact_row"
+  }
+]

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -78,6 +78,13 @@ from .strength_metrics import StrengthMetrics, StrengthPeak
 from .test_plan import RecommendedAction, TestPlan, plan_test_actions
 from .test_run import TestRun
 from .tire_spec import TireSpec
+from .vehicle_configuration import (
+    VehicleConfiguration,
+    VehicleConfigurationSourceStatus,
+    VehicleConfigurationTireOption,
+    VehicleDrivetrain,
+    VehicleFuelType,
+)
 from .vibration_origin import VibrationOrigin
 
 __all__ = [
@@ -93,6 +100,11 @@ __all__ = [
     "CarSnapshot",
     "OrderReferenceSpec",
     "TireSpec",
+    "VehicleConfiguration",
+    "VehicleConfigurationSourceStatus",
+    "VehicleConfigurationTireOption",
+    "VehicleDrivetrain",
+    "VehicleFuelType",
     # Value objects — snapshots
     "AnalysisSettingsSnapshot",
     "DrivingPhaseSummary",

--- a/apps/server/vibesensor/domain/vehicle_configuration.py
+++ b/apps/server/vibesensor/domain/vehicle_configuration.py
@@ -1,0 +1,69 @@
+"""Exact vehicle configuration rows for drivetrain and order-analysis reference data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from .tire_spec import TireSpec
+
+__all__ = [
+    "VehicleConfiguration",
+    "VehicleConfigurationTireOption",
+    "VehicleConfigurationSourceStatus",
+    "VehicleDrivetrain",
+    "VehicleFuelType",
+]
+
+VehicleFuelType = Literal["ICE", "PHEV", "EV"]
+VehicleDrivetrain = Literal["FWD", "RWD", "AWD"]
+VehicleConfigurationSourceStatus = Literal["exact_row", "compat_projection"]
+
+
+@dataclass(frozen=True, slots=True)
+class VehicleConfigurationTireOption:
+    """Named tire option attached to one exact or projected vehicle configuration."""
+
+    name: str
+    spec: TireSpec
+
+
+@dataclass(frozen=True, slots=True)
+class VehicleConfiguration:
+    """One typed drivetrain configuration row used as order-analysis source data."""
+
+    brand: str
+    car_type: str
+    model_name: str
+    variant_name: str
+    drivetrain: VehicleDrivetrain
+    transmission_name: str
+    top_gear_ratio: float
+    default_tire: TireSpec
+    tire_options: tuple[VehicleConfigurationTireOption, ...]
+    fuel_type: VehicleFuelType = "ICE"
+    market: str | None = None
+    model_code: str | None = None
+    body_code: str | None = None
+    production_start_year: int | None = None
+    production_end_year: int | None = None
+    engine_code: str | None = None
+    engine_name: str | None = None
+    transmission_code: str | None = None
+    gear_ratios: tuple[float, ...] | None = None
+    final_drive_front: float | None = None
+    final_drive_rear: float | None = None
+    transfer_case_ratio: float | None = None
+    source_status: VehicleConfigurationSourceStatus = "exact_row"
+
+    @property
+    def driven_final_drive_ratio(self) -> float | None:
+        """Return the most relevant driven final-drive ratio for the configuration."""
+
+        if self.drivetrain == "FWD":
+            return self.final_drive_front
+        if self.drivetrain == "RWD":
+            return self.final_drive_rear
+        if self.final_drive_rear is not None:
+            return self.final_drive_rear
+        return self.final_drive_front

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ links onward to the scoped instruction files and repo map below.
 |------|-------------|
 | `docs/domain-model.md` | Domain object graph, modeling rules, and adapter inventory. |
 | `docs/dataflows.md` | Canonical four-flow map for live, recording, raw capture, and report paths. |
+| `docs/car_library_architecture.md` | Exact vehicle-configuration rows, legacy picker compatibility, and car-library source-of-truth rules. |
 | `docs/analysis_pipeline.md` | Post-stop diagnostics pipeline: steps, modules, and data flow. |
 | `docs/order_tracking.md` | Order-reference math, tolerance bands, and order-finding flow. |
 | `docs/report_pipeline.md` | Report generation flow from analysis to PDF. |

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -1,0 +1,42 @@
+# Car library architecture
+
+The legacy car library in `apps/server/vibesensor/data/car_library.json` is
+still the compatibility source for the current API/UI picker: brand, type,
+model, and variant selection continue to flow through the existing
+model-plus-variant shapes.
+
+For drivetrain and order-analysis accuracy, that legacy structure is **not**
+the source of truth anymore when an exact row exists. Broad model defaults plus
+optional variant overrides are convenient for the picker, but they can silently
+inherit a gearbox or final-drive assumption that does not belong to the exact
+configuration under analysis.
+
+`apps/server/vibesensor/data/vehicle_configurations.json` is the new exact-row
+source of truth for the migrated subset. Each row names one exact drivetrain
+configuration with:
+
+- vehicle identity fields such as market, model/body code, production range,
+  model name, and variant name
+- drivetrain, transmission, final-drive, and fuel-type facts
+- the default tire plus available tire options
+- `source_status` so callers can tell exact rows from compatibility projection
+
+Current migration policy:
+
+1. Prefer exact configuration rows when they exist for the selected variant.
+2. Fall back to a compatibility projection from the legacy model/variant entry
+   only when no exact row exists yet.
+3. Keep the fallback explicit: one projected row per gearbox, so broad
+   inheritance does not stay hidden.
+
+Issue #3229 starts this migration with a small BMW subset:
+
+- `4 Series (G22, 2021-2026) / 420i` for an exact ICE RWD row
+- `2 Series Active Tourer (F45, 2014-2021) / 220i` and `225xe` for exact
+  FWD/PHEV override rows
+- `3 Series (G20, 2019-2025) / 330i xDrive` for an exact AWD/xDrive row
+- `5 Series (G60, 2024-2026) / i5 eDrive40` for an exact EV single-speed row
+
+This is intentionally additive. The legacy picker payloads stay stable while
+diagnosis-facing code gains a typed exact-row path that can expand model by
+model without a full one-shot database rewrite.


### PR DESCRIPTION
Closes #3229.

## Summary
Medium.

Add an exact vehicle-configuration row path for the car library.

- add `vibesensor.domain.VehicleConfiguration` as the typed exact-row model
- add additive BMW exact rows in `apps/server/vibesensor/data/vehicle_configurations.json`
- add exact-row load/query helpers plus `resolve_vehicle_configurations()` in `adapters/persistence/car_library.py`
- exact rows win when present; otherwise legacy model/variant data falls back to an explicit one-row-per-gearbox compatibility projection
- document exact rows as the drivetrain/order-analysis source of truth in `docs/car_library_architecture.md`

## BMW subset in this PR
- `4 Series (G22, 2021-2026) / 420i` for exact ICE RWD coverage
- `2 Series Active Tourer (F45, 2014-2021) / 220i` and `225xe` for exact override rows
- `3 Series (G20, 2019-2025) / 330i xDrive` for exact ICE AWD/xDrive coverage
- `5 Series (G60, 2024-2026) / i5 eDrive40` for exact EV single-speed coverage

## Why
Model defaults plus optional variant overrides are still fine for the picker.
They are too broad to pretend they are exact drivetrain truth.
This PR adds a typed exact-row source of truth without forcing a full library rewrite or breaking current API/UI behavior.

## Validation
- `./.venv/bin/pytest -q apps/server/tests/adapters/persistence/test_car_library.py apps/server/tests/adapters/persistence/test_car_variants.py apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py apps/server/tests/adapters/persistence/test_vehicle_configurations.py`
- `make typecheck-backend`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `make docs-lint`

## Risks / tradeoffs
- exact rows are still a subset, not a full migration
- compatibility projection stays in place for unmigrated variants, but it is now explicit instead of silently inherited
- no API/UI contract change in this PR; current picker flow stays variant-based until later issues narrow that further
