### PR TITLE
Add field-level car provenance

### DIFF
--- a/apps/server/tests/adapters/persistence/test_vehicle_configurations.py
+++ b/apps/server/tests/adapters/persistence/test_vehicle_configurations.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
+
 from vibesensor.adapters.persistence.car_library import (
+    _VEHICLE_CONFIG_DATA_FILE,
     load_car_library,
     load_vehicle_configurations,
     resolve_vehicle_configurations,
@@ -35,6 +38,49 @@ def test_exact_vehicle_configurations_cover_required_configuration_kinds() -> No
     )
 
 
+def test_exact_vehicle_configurations_include_field_level_provenance_for_three_bmw_rows() -> None:
+    configs = {
+        (config.model_name, config.variant_name): config for config in load_vehicle_configurations()
+    }
+
+    expected_rows = [
+        ("2 Series Active Tourer (F45, 2014-2021)", "220i"),
+        ("3 Series (G20, 2019-2025)", "330i xDrive"),
+        ("5 Series (G60, 2024-2026)", "i5 eDrive40"),
+    ]
+    for key in expected_rows:
+        config = configs[key]
+        assert config.provenance_for("drivetrain") is not None
+        assert config.provenance_for("tire_dimensions") is not None
+        assert any(
+            config.provenance_for(field_name) is not None
+            for field_name in ("final_drive_front", "final_drive_rear")
+        )
+        assert config.provenance_for("top_gear_ratio") is not None
+
+    i5 = configs[("5 Series (G60, 2024-2026)", "i5 eDrive40")]
+    assert i5.provenance_for("gear_ratios") is not None
+
+
+def test_official_exact_field_provenance_requires_source_id(tmp_path) -> None:
+    bad_payload = json.loads(_VEHICLE_CONFIG_DATA_FILE.read_text(encoding="utf-8"))
+    bad_payload[0]["field_provenance"] = [
+        {
+            "field_name": "drivetrain",
+            "confidence": "official_exact",
+            "verified_at": "2026-04-25",
+            "notes": "Broken test payload without a source ID.",
+        }
+    ]
+    bad_path = tmp_path / "vehicle_configurations.json"
+    bad_path.write_text(json.dumps(bad_payload), encoding="utf-8")
+
+    from unittest.mock import patch
+
+    with patch("vibesensor.adapters.persistence.car_library._VEHICLE_CONFIG_DATA_FILE", bad_path):
+        assert load_vehicle_configurations() == []
+
+
 def test_resolve_vehicle_configurations_uses_exact_row_for_f45_220i() -> None:
     configs = resolve_vehicle_configurations(
         _entry_for("2 Series Active Tourer (F45, 2014-2021)"),
@@ -47,6 +93,10 @@ def test_resolve_vehicle_configurations_uses_exact_row_for_f45_220i() -> None:
     assert config.transmission_name == "7-speed Steptronic dual-clutch transmission"
     assert config.final_drive_front == 3.231
     assert config.final_drive_rear is None
+    assert config.provenance_for("final_drive_front") is not None
+    assert config.provenance_for("top_gear_ratio") is not None
+    assert config.provenance_for("drivetrain") is not None
+    assert config.provenance_for("tire_dimensions") is not None
 
 
 def test_resolve_vehicle_configurations_uses_exact_row_for_g20_330i_xdrive() -> None:
@@ -61,6 +111,11 @@ def test_resolve_vehicle_configurations_uses_exact_row_for_g20_330i_xdrive() -> 
     assert config.transmission_name == "8-speed automatic (ZF 8HP)"
     assert config.final_drive_front == 2.813
     assert config.final_drive_rear == 2.813
+    assert config.provenance_for("final_drive_front") is not None
+    assert config.provenance_for("final_drive_rear") is not None
+    assert config.provenance_for("top_gear_ratio") is not None
+    assert config.provenance_for("drivetrain") is not None
+    assert config.provenance_for("tire_dimensions") is not None
 
 
 def test_resolve_vehicle_configurations_uses_exact_row_for_g60_i5_edrive40() -> None:
@@ -75,6 +130,11 @@ def test_resolve_vehicle_configurations_uses_exact_row_for_g60_i5_edrive40() -> 
     assert config.fuel_type == "EV"
     assert config.gear_ratios == (1.0,)
     assert config.final_drive_rear == 11.115
+    assert config.provenance_for("final_drive_rear") is not None
+    assert config.provenance_for("top_gear_ratio") is not None
+    assert config.provenance_for("gear_ratios") is not None
+    assert config.provenance_for("drivetrain") is not None
+    assert config.provenance_for("tire_dimensions") is not None
 
 
 def test_resolve_vehicle_configurations_projects_unmigrated_variant_per_gearbox() -> None:

--- a/apps/server/vibesensor/adapters/persistence/car_library.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library.py
@@ -14,7 +14,12 @@ from typing import Any, Literal, NotRequired, TypedDict, cast
 
 from pydantic import ConfigDict, TypeAdapter, ValidationError
 
-from vibesensor.domain import TireSpec, VehicleConfiguration, VehicleConfigurationTireOption
+from vibesensor.domain import (
+    TireSpec,
+    VehicleConfiguration,
+    VehicleConfigurationTireOption,
+    VehicleFieldProvenance,
+)
 from vibesensor.shared._data_files import resolve_static_data_file
 
 LOGGER = logging.getLogger(__name__)
@@ -100,6 +105,29 @@ class VehicleConfigurationRow(TypedDict):
     tire_aspect_pct: float
     rim_in: float
     source_status: Literal["exact_row"]
+    field_provenance: NotRequired[list[VehicleConfigurationFieldProvenanceRow]]
+
+
+class VehicleConfigurationFieldProvenanceRow(TypedDict):
+    field_name: Literal[
+        "final_drive_front",
+        "final_drive_rear",
+        "top_gear_ratio",
+        "gear_ratios",
+        "drivetrain",
+        "tire_dimensions",
+    ]
+    confidence: Literal[
+        "official_exact",
+        "official_derived",
+        "reputable_secondary_crosschecked",
+        "family_default",
+        "unverified",
+        "user_confirmed",
+    ]
+    source_id: NotRequired[str]
+    verified_at: NotRequired[str]
+    notes: NotRequired[str]
 
 
 for _typed_dict in (
@@ -108,6 +136,7 @@ for _typed_dict in (
     CarLibraryVariant,
     CarLibraryEntry,
     VehicleConfigurationRow,
+    VehicleConfigurationFieldProvenanceRow,
 ):
     cast(Any, _typed_dict).__pydantic_config__ = _STRICT_TYPEDDICT_CONFIG
 
@@ -188,7 +217,7 @@ def _tire_options_from_rows(
 
 
 def _configuration_from_row(row: VehicleConfigurationRow) -> VehicleConfiguration:
-    return VehicleConfiguration(
+    config = VehicleConfiguration(
         brand=row["brand"],
         car_type=row["type"],
         market=row["market"],
@@ -216,7 +245,41 @@ def _configuration_from_row(row: VehicleConfigurationRow) -> VehicleConfiguratio
             rim_in=row["rim_in"],
         ),
         source_status=row["source_status"],
+        field_provenance=_field_provenance_from_rows(row.get("field_provenance", [])),
     )
+    _validate_field_provenance(config)
+    return config
+
+
+def _field_provenance_from_rows(
+    rows: list[VehicleConfigurationFieldProvenanceRow],
+) -> tuple[VehicleFieldProvenance, ...]:
+    return tuple(
+        VehicleFieldProvenance(
+            field_name=row["field_name"],
+            confidence=row["confidence"],
+            source_id=row.get("source_id"),
+            verified_at=row.get("verified_at"),
+            notes=row.get("notes"),
+        )
+        for row in rows
+    )
+
+
+def _validate_field_provenance(config: VehicleConfiguration) -> None:
+    seen: set[str] = set()
+    for entry in config.field_provenance:
+        if entry.field_name in seen:
+            raise ValueError(
+                f"Duplicate field provenance {entry.field_name!r} for "
+                f"{config.brand} {config.model_name} / {config.variant_name}"
+            )
+        seen.add(entry.field_name)
+        if entry.requires_source_id and not entry.source_id:
+            raise ValueError(
+                f"{config.brand} {config.model_name} / {config.variant_name} "
+                f"marks {entry.field_name} as official_exact without a source_id"
+            )
 
 
 def _fuel_type_from_engine_name(engine_name: str | None) -> Literal["ICE", "PHEV", "EV"]:

--- a/apps/server/vibesensor/data/vehicle_configurations.json
+++ b/apps/server/vibesensor/data/vehicle_configurations.json
@@ -40,6 +40,30 @@
     "tire_width_mm": 245.0,
     "tire_aspect_pct": 40.0,
     "rim_in": 18.0,
+    "field_provenance": [
+      {
+        "field_name": "final_drive_rear",
+        "confidence": "unverified",
+        "notes": "Current exact row still carries the inherited 2.813 rear final-drive value until an official G22 ratio document is linked."
+      },
+      {
+        "field_name": "top_gear_ratio",
+        "confidence": "unverified",
+        "notes": "Current exact row keeps the inherited ZF 8HP top-gear value until a G22-specific official table is linked."
+      },
+      {
+        "field_name": "drivetrain",
+        "source_id": "variant_sources:BMW|4 Series (G22, 2021-2026):420i",
+        "confidence": "official_exact",
+        "verified_at": "2026-04-25",
+        "notes": "Official BMW market variant table confirms the 420i as the RWD petrol row in the supported G22 slice."
+      },
+      {
+        "field_name": "tire_dimensions",
+        "confidence": "family_default",
+        "notes": "Tire option dimensions still follow the supported G22 family defaults until per-variant wheel sheets are captured."
+      }
+    ],
     "source_status": "exact_row"
   },
   {
@@ -83,6 +107,34 @@
     "tire_width_mm": 205.0,
     "tire_aspect_pct": 55.0,
     "rim_in": 17.0,
+    "field_provenance": [
+      {
+        "field_name": "final_drive_front",
+        "source_id": "ratio_sources:BMW|2 Series Active Tourer (F45, 2014-2021):issue_1034_220i_ratio_reference",
+        "confidence": "reputable_secondary_crosschecked",
+        "verified_at": "2026-04-25",
+        "notes": "Numeric 220i DCT final-drive ratio uses the cross-checked secondary references captured during issue #1034."
+      },
+      {
+        "field_name": "top_gear_ratio",
+        "source_id": "ratio_sources:BMW|2 Series Active Tourer (F45, 2014-2021):issue_1034_220i_ratio_reference",
+        "confidence": "reputable_secondary_crosschecked",
+        "verified_at": "2026-04-25",
+        "notes": "Top-gear ratio follows the same cross-checked 220i DCT reference pair."
+      },
+      {
+        "field_name": "drivetrain",
+        "source_id": "variant_sources:BMW|2 Series Active Tourer (F45, 2014-2021):220i",
+        "confidence": "official_exact",
+        "verified_at": "2026-04-25",
+        "notes": "Official BMW variant table confirms the F45 220i as a FWD row."
+      },
+      {
+        "field_name": "tire_dimensions",
+        "confidence": "family_default",
+        "notes": "Tire option dimensions still follow the supported F45 family defaults until per-variant wheel sheets are captured."
+      }
+    ],
     "source_status": "exact_row"
   },
   {
@@ -126,6 +178,34 @@
     "tire_width_mm": 205.0,
     "tire_aspect_pct": 55.0,
     "rim_in": 17.0,
+    "field_provenance": [
+      {
+        "field_name": "final_drive_front",
+        "source_id": "ratio_sources:BMW|2 Series Active Tourer (F45, 2014-2021):225xe_drivetrain_and_ratios",
+        "confidence": "official_exact",
+        "verified_at": "2026-04-25",
+        "notes": "Official BMW 225xe technical data attachment confirms the front-axle transmission ratio pair."
+      },
+      {
+        "field_name": "top_gear_ratio",
+        "source_id": "ratio_sources:BMW|2 Series Active Tourer (F45, 2014-2021):225xe_drivetrain_and_ratios",
+        "confidence": "official_exact",
+        "verified_at": "2026-04-25",
+        "notes": "Official BMW 225xe technical data attachment confirms the 0.672 top-gear ratio."
+      },
+      {
+        "field_name": "drivetrain",
+        "source_id": "variant_sources:BMW|2 Series Active Tourer (F45, 2014-2021):225xe",
+        "confidence": "official_exact",
+        "verified_at": "2026-04-25",
+        "notes": "Official BMW variant table confirms the 225xe AWD drivetrain layout."
+      },
+      {
+        "field_name": "tire_dimensions",
+        "confidence": "family_default",
+        "notes": "Tire option dimensions still follow the supported F45 family defaults until per-variant wheel sheets are captured."
+      }
+    ],
     "source_status": "exact_row"
   },
   {
@@ -171,6 +251,39 @@
     "tire_width_mm": 225.0,
     "tire_aspect_pct": 40.0,
     "rim_in": 18.0,
+    "field_provenance": [
+      {
+        "field_name": "final_drive_front",
+        "source_id": "ratio_sources:BMW|3 Series (G20, 2019-2025):official_xdrive_ratio_verification",
+        "confidence": "official_exact",
+        "verified_at": "2026-04-25",
+        "notes": "Official BMW technical data confirms the xDrive front final-drive ratio at 2.813."
+      },
+      {
+        "field_name": "final_drive_rear",
+        "source_id": "ratio_sources:BMW|3 Series (G20, 2019-2025):official_xdrive_ratio_verification",
+        "confidence": "official_exact",
+        "verified_at": "2026-04-25",
+        "notes": "Official BMW technical data confirms the xDrive rear final-drive ratio at 2.813."
+      },
+      {
+        "field_name": "top_gear_ratio",
+        "confidence": "family_default",
+        "notes": "The current 0.667 top-gear value still follows the ZF 8HP family default until a retrievable variant-specific G20 gear-ratio table is linked."
+      },
+      {
+        "field_name": "drivetrain",
+        "source_id": "variant_sources:BMW|3 Series (G20, 2019-2025):330i xDrive",
+        "confidence": "official_exact",
+        "verified_at": "2026-04-25",
+        "notes": "Official BMW variant table confirms the 330i xDrive AWD drivetrain."
+      },
+      {
+        "field_name": "tire_dimensions",
+        "confidence": "family_default",
+        "notes": "Tire option dimensions still follow the supported G20 family defaults until per-variant wheel sheets are captured."
+      }
+    ],
     "source_status": "exact_row"
   },
   {
@@ -217,6 +330,41 @@
     "tire_width_mm": 245.0,
     "tire_aspect_pct": 40.0,
     "rim_in": 19.0,
+    "field_provenance": [
+      {
+        "field_name": "final_drive_rear",
+        "source_id": "ratio_sources:BMW|5 Series (G60, 2024-2026):ev_layout_confirmed_ratio_mapping_unresolved",
+        "confidence": "official_exact",
+        "verified_at": "2026-04-25",
+        "notes": "Official BMW technical data PDF lists the i5 eDrive40 overall reduction ratio at 11.115."
+      },
+      {
+        "field_name": "top_gear_ratio",
+        "source_id": "ratio_sources:BMW|5 Series (G60, 2024-2026):ev_layout_confirmed_ratio_mapping_unresolved",
+        "confidence": "official_derived",
+        "verified_at": "2026-04-25",
+        "notes": "Single-speed EV transmission implies a fixed top-gear ratio of 1.0 from the official overall reduction note."
+      },
+      {
+        "field_name": "gear_ratios",
+        "source_id": "ratio_sources:BMW|5 Series (G60, 2024-2026):ev_layout_confirmed_ratio_mapping_unresolved",
+        "confidence": "official_derived",
+        "verified_at": "2026-04-25",
+        "notes": "Single-speed EV transmission projects to a one-entry gear ratio list `[1.0]`."
+      },
+      {
+        "field_name": "drivetrain",
+        "source_id": "variant_sources:BMW|5 Series (G60, 2024-2026):i5 eDrive40",
+        "confidence": "official_exact",
+        "verified_at": "2026-04-25",
+        "notes": "Official BMW variant table confirms the i5 eDrive40 as the RWD BEV row."
+      },
+      {
+        "field_name": "tire_dimensions",
+        "confidence": "family_default",
+        "notes": "Tire option dimensions still follow the supported G60 family defaults until per-variant wheel sheets are captured."
+      }
+    ],
     "source_status": "exact_row"
   }
 ]

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -80,9 +80,12 @@ from .test_run import TestRun
 from .tire_spec import TireSpec
 from .vehicle_configuration import (
     VehicleConfiguration,
+    VehicleConfigurationField,
     VehicleConfigurationSourceStatus,
     VehicleConfigurationTireOption,
     VehicleDrivetrain,
+    VehicleFieldConfidence,
+    VehicleFieldProvenance,
     VehicleFuelType,
 )
 from .vibration_origin import VibrationOrigin
@@ -101,9 +104,12 @@ __all__ = [
     "OrderReferenceSpec",
     "TireSpec",
     "VehicleConfiguration",
+    "VehicleConfigurationField",
     "VehicleConfigurationSourceStatus",
     "VehicleConfigurationTireOption",
     "VehicleDrivetrain",
+    "VehicleFieldConfidence",
+    "VehicleFieldProvenance",
     "VehicleFuelType",
     # Value objects — snapshots
     "AnalysisSettingsSnapshot",

--- a/apps/server/vibesensor/domain/vehicle_configuration.py
+++ b/apps/server/vibesensor/domain/vehicle_configuration.py
@@ -8,6 +8,9 @@ from typing import Literal
 from .tire_spec import TireSpec
 
 __all__ = [
+    "VehicleConfigurationField",
+    "VehicleFieldConfidence",
+    "VehicleFieldProvenance",
     "VehicleConfiguration",
     "VehicleConfigurationTireOption",
     "VehicleConfigurationSourceStatus",
@@ -18,6 +21,22 @@ __all__ = [
 VehicleFuelType = Literal["ICE", "PHEV", "EV"]
 VehicleDrivetrain = Literal["FWD", "RWD", "AWD"]
 VehicleConfigurationSourceStatus = Literal["exact_row", "compat_projection"]
+VehicleFieldConfidence = Literal[
+    "official_exact",
+    "official_derived",
+    "reputable_secondary_crosschecked",
+    "family_default",
+    "unverified",
+    "user_confirmed",
+]
+VehicleConfigurationField = Literal[
+    "final_drive_front",
+    "final_drive_rear",
+    "top_gear_ratio",
+    "gear_ratios",
+    "drivetrain",
+    "tire_dimensions",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +45,23 @@ class VehicleConfigurationTireOption:
 
     name: str
     spec: TireSpec
+
+
+@dataclass(frozen=True, slots=True)
+class VehicleFieldProvenance:
+    """Machine-readable source and confidence metadata for one config field."""
+
+    field_name: VehicleConfigurationField
+    confidence: VehicleFieldConfidence
+    source_id: str | None = None
+    verified_at: str | None = None
+    notes: str | None = None
+
+    @property
+    def requires_source_id(self) -> bool:
+        """Whether this provenance entry must include a source identifier."""
+
+        return self.confidence == "official_exact"
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,6 +91,7 @@ class VehicleConfiguration:
     final_drive_rear: float | None = None
     transfer_case_ratio: float | None = None
     source_status: VehicleConfigurationSourceStatus = "exact_row"
+    field_provenance: tuple[VehicleFieldProvenance, ...] = ()
 
     @property
     def driven_final_drive_ratio(self) -> float | None:
@@ -67,3 +104,14 @@ class VehicleConfiguration:
         if self.final_drive_rear is not None:
             return self.final_drive_rear
         return self.final_drive_front
+
+    def provenance_for(
+        self,
+        field_name: VehicleConfigurationField,
+    ) -> VehicleFieldProvenance | None:
+        """Return provenance metadata for *field_name* when present."""
+
+        for entry in self.field_provenance:
+            if entry.field_name == field_name:
+                return entry
+        return None

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -18,6 +18,8 @@ configuration with:
 - vehicle identity fields such as market, model/body code, production range,
   model name, and variant name
 - drivetrain, transmission, final-drive, and fuel-type facts
+- field-level provenance and confidence for the accuracy-critical fields that
+  drive order analysis
 - the default tire plus available tire options
 - `source_status` so callers can tell exact rows from compatibility projection
 
@@ -28,6 +30,8 @@ Current migration policy:
    only when no exact row exists yet.
 3. Keep the fallback explicit: one projected row per gearbox, so broad
    inheritance does not stay hidden.
+4. Keep provenance inline with the exact row so values and source/confidence
+   metadata cannot drift into separate ledgers.
 
 Issue #3229 starts this migration with a small BMW subset:
 
@@ -40,3 +44,71 @@ Issue #3229 starts this migration with a small BMW subset:
 This is intentionally additive. The legacy picker payloads stay stable while
 diagnosis-facing code gains a typed exact-row path that can expand model by
 model without a full one-shot database rewrite.
+
+## Field-level provenance and confidence
+
+`VehicleConfiguration.field_provenance` is the machine-readable source metadata
+for the fields that most directly affect order analysis:
+
+- `final_drive_front`
+- `final_drive_rear`
+- `top_gear_ratio`
+- `gear_ratios`
+- `drivetrain`
+- `tire_dimensions`
+
+Each provenance entry stores:
+
+- the field name
+- the confidence level
+- an optional `source_id`
+- an optional `verified_at`
+- optional notes
+
+### Confidence levels
+
+- `official_exact`: official manufacturer source directly confirms the exact
+  stored field value
+- `official_derived`: the stored value is derived from official manufacturer
+  data (for example a fixed EV single-speed ratio projected to `1.0`)
+- `reputable_secondary_crosschecked`: non-official technical references were
+  cross-checked and kept because the official source only confirmed part of the
+  story
+- `family_default`: the field still follows the supported family baseline until
+  a variant-specific source is captured
+- `unverified`: the stored value is still present but should not be treated as a
+  verified source-of-truth fact
+- `user_confirmed`: reserved for future locally confirmed overrides
+
+### Source ID prefixes
+
+`source_id` stays lightweight and links back to the existing research trail:
+
+- `ratio_sources:<CAR_KEY>:<SOURCE_GROUP>` points at a source group in
+  `apps/server/vibesensor/data/car_library_ratio_sources.json`
+- `variant_sources:<CAR_KEY>:<VARIANT_NAME>` points at the variant table in
+  `apps/server/vibesensor/data/CAR_VARIANT_SOURCES.md`
+
+That keeps the old research notes intact instead of copying them into the exact
+rows.
+
+### Validation and analysis-confidence policy
+
+Rows marked `official_exact` must include a `source_id`; loader validation
+rejects exact-row data that breaks that rule.
+
+The confidence levels are the source data for future analysis-confidence
+policies:
+
+- `official_exact` and `official_derived` are the highest-confidence rows
+- `reputable_secondary_crosschecked` is usable but should rank below official
+  evidence
+- `family_default` and `unverified` are compatibility data and should lower
+  downstream confidence when order-analysis logic consumes them
+
+Issue #3231 starts this provenance path with representative BMW exact rows for:
+
+- `2 Series Active Tourer (F45, 2014-2021) / 220i`
+- `2 Series Active Tourer (F45, 2014-2021) / 225xe`
+- `3 Series (G20, 2019-2025) / 330i xDrive`
+- `5 Series (G60, 2024-2026) / i5 eDrive40`


### PR DESCRIPTION
Closes #3231.

## Summary
Small.

Add inline field-level provenance on the exact car-configuration rows.

- add `VehicleFieldProvenance` and confidence levels to `vibesensor.domain.VehicleConfiguration`
- extend representative BMW exact rows with field-level provenance in `apps/server/vibesensor/data/vehicle_configurations.json`
- validate at load time that any `official_exact` field provenance entry includes a `source_id`
- keep existing research notes linked instead of duplicated by using `ratio_sources:` and `variant_sources:` source IDs
- document the confidence levels and analysis-confidence implications in `docs/car_library_architecture.md`

## Representative BMW rows in this PR
- `2 Series Active Tourer (F45, 2014-2021) / 220i`
- `2 Series Active Tourer (F45, 2014-2021) / 225xe`
- `3 Series (G20, 2019-2025) / 330i xDrive`
- `5 Series (G60, 2024-2026) / i5 eDrive40`
- `4 Series (G22, 2021-2026) / 420i` also gets explicit lower-confidence drivetrain/tire provenance so the row no longer looks uniformly certain

## Why
#3229 created the exact-row source-of-truth path.
This PR keeps provenance on that same path so field values and field metadata cannot drift apart.
Unmigrated legacy variants still use compatibility projection; the new provenance stays on exact rows only.

## Validation
- `./.venv/bin/pytest -q apps/server/tests/adapters/persistence/test_vehicle_configurations.py apps/server/tests/adapters/persistence/test_car_library.py apps/server/tests/adapters/persistence/test_car_variants.py apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py`
- `make typecheck-backend`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `make docs-lint`

## Risks / tradeoffs
- provenance is only on the exact-row subset for now, not the full library
- tire dimensions still carry `family_default` confidence where only family-level picker data exists
- docs explain how lower-confidence fields should lower downstream analysis confidence, but this PR does not yet thread that policy through analysis scoring code
