### PR TITLE
Model staggered tire setups and axle-specific tire dimensions

### DIFF
--- a/apps/server/tests/adapters/persistence/test_car_library.py
+++ b/apps/server/tests/adapters/persistence/test_car_library.py
@@ -186,6 +186,27 @@ def test_variant_gearboxes_include_exact_vs_projected_confidence_metadata() -> N
     assert projected_gearbox["requires_manual_confirmation"] is True
 
 
+def test_migrated_staggered_tire_option_exposes_front_rear_setup() -> None:
+    suvs = get_models_for_brand_type("BMW", "SUV")
+    x5 = next(model for model in suvs if model["model"] == "X5 (G05, 2019-2026)")
+    staggered = next(option for option in x5["tire_options"] if option["name"] == 'M Sport 22"')
+
+    assert staggered["default_axle_for_speed"] == "rear"
+    assert staggered["source_confidence"] == "reputable_secondary_crosschecked"
+    assert staggered["front"] == {
+        "width_mm": pytest.approx(275.0),
+        "aspect_pct": pytest.approx(35.0),
+        "rim_in": pytest.approx(22.0),
+    }
+    assert staggered["rear"] == {
+        "width_mm": pytest.approx(315.0),
+        "aspect_pct": pytest.approx(30.0),
+        "rim_in": pytest.approx(22.0),
+    }
+    assert staggered["tire_width_mm"] == pytest.approx(315.0)
+    assert staggered["tire_aspect_pct"] == pytest.approx(30.0)
+
+
 def _make_bad_data_file(tmp_path: Path, kind: str) -> Path:
     """Return a path to a missing or malformed JSON data file."""
     if kind == "missing":

--- a/apps/server/tests/domain/test_car_domain.py
+++ b/apps/server/tests/domain/test_car_domain.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import MappingProxyType
 
 from vibesensor.domain import Car, CarSnapshot
+from vibesensor.domain.tire_spec import AxleTireSetup
 from vibesensor.shared.order_reference_settings import (
     order_reference_mapping_from_spec,
     order_reference_spec_from_mapping,
@@ -64,6 +65,41 @@ class TestOrderReferenceSpecFromSettings:
         assert spec is not None
         assert spec.tire_circumference_m > 0
         assert spec.tire_circumference_m == spec.tire_spec.circumference_m
+
+    def test_staggered_tire_setup_prefers_rear_axle_when_selected(self) -> None:
+        spec = order_reference_spec_from_mapping(
+            {
+                "front_tire_width_mm": 245.0,
+                "front_tire_aspect_pct": 40.0,
+                "front_rim_in": 21.0,
+                "rear_tire_width_mm": 275.0,
+                "rear_tire_aspect_pct": 35.0,
+                "rear_rim_in": 21.0,
+                "default_axle_for_speed": "rear",
+            }
+        )
+        assert spec is not None
+        assert spec.tire_setup.is_staggered is True
+        assert spec.tire_spec.width_mm == 275.0
+        assert spec.tire_circumference_m == spec.tire_setup.rear.circumference_m
+
+    def test_staggered_tire_setup_supports_average_effective_circumference(self) -> None:
+        spec = order_reference_spec_from_mapping(
+            {
+                "front_tire_width_mm": 245.0,
+                "front_tire_aspect_pct": 40.0,
+                "front_rim_in": 21.0,
+                "rear_tire_width_mm": 275.0,
+                "rear_tire_aspect_pct": 35.0,
+                "rear_rim_in": 21.0,
+                "default_axle_for_speed": "average",
+            }
+        )
+        assert spec is not None
+        expected = (
+            spec.tire_setup.front.circumference_m + spec.tire_setup.rear.circumference_m
+        ) / 2.0
+        assert spec.tire_circumference_m == expected
 
     def test_has_engine_reference(self) -> None:
         settings = _order_settings(current_gear_ratio=0.64)
@@ -136,6 +172,53 @@ class TestCarOrderReferenceSpec:
         assert car.tire_width_mm == 245.0
         assert car.tire_aspect_pct == 40.0
         assert car.rim_in == 18.0
+
+    def test_car_projects_staggered_tire_setup_into_boundary_and_axle_fields(self) -> None:
+        spec = order_reference_spec_from_mapping(
+            {
+                "front_tire_width_mm": 245.0,
+                "front_tire_aspect_pct": 40.0,
+                "front_rim_in": 21.0,
+                "rear_tire_width_mm": 275.0,
+                "rear_tire_aspect_pct": 35.0,
+                "rear_rim_in": 21.0,
+                "default_axle_for_speed": "rear",
+            }
+        )
+        assert spec is not None
+
+        car = Car(order_reference_spec=spec)
+
+        assert car.tire_setup == AxleTireSetup(
+            front=spec.tire_setup.front,
+            rear=spec.tire_setup.rear,
+            default_axle_for_speed="rear",
+            source_confidence=None,
+        )
+        assert dict(car.aspects) == {
+            "tire_width_mm": 275.0,
+            "tire_aspect_pct": 35.0,
+            "rim_in": 21.0,
+            "final_drive_ratio": 0.0,
+            "current_gear_ratio": 0.0,
+            "wheel_bandwidth_pct": 0.0,
+            "driveshaft_bandwidth_pct": 0.0,
+            "engine_bandwidth_pct": 0.0,
+            "speed_uncertainty_pct": 0.0,
+            "tire_diameter_uncertainty_pct": 0.0,
+            "final_drive_uncertainty_pct": 0.0,
+            "gear_uncertainty_pct": 0.0,
+            "min_abs_band_hz": 0.0,
+            "max_band_half_width_pct": 0.0,
+            "tire_deflection_factor": 1.0,
+            "front_tire_width_mm": 245.0,
+            "front_tire_aspect_pct": 40.0,
+            "front_rim_in": 21.0,
+            "rear_tire_width_mm": 275.0,
+            "rear_tire_aspect_pct": 35.0,
+            "rear_rim_in": 21.0,
+            "default_axle_for_speed": "rear",
+        }
 
     def test_car_order_reference_properties_do_not_fall_back_to_aspects(self) -> None:
         car = Car(

--- a/apps/server/tests/infra/config/test_car_settings.py
+++ b/apps/server/tests/infra/config/test_car_settings.py
@@ -128,6 +128,40 @@ def test_analysis_settings_update_marks_manual_ratio_overrides_user_confirmed() 
     assert snapshot.order_reference_status.requires_manual_confirmation is False
 
 
+def test_analysis_settings_tire_override_clears_staggered_axle_setup() -> None:
+    services = build_settings_services()
+    created = services.car_settings.add_car(
+        {
+            "name": "Staggered",
+            "aspects": {
+                "tire_width_mm": 315.0,
+                "tire_aspect_pct": 30.0,
+                "rim_in": 22.0,
+                "front_tire_width_mm": 275.0,
+                "front_tire_aspect_pct": 35.0,
+                "front_rim_in": 22.0,
+                "rear_tire_width_mm": 315.0,
+                "rear_tire_aspect_pct": 30.0,
+                "rear_rim_in": 22.0,
+                "default_axle_for_speed": "rear",
+            },
+        }
+    )
+    car_id = created.cars[0]["id"]
+    services.car_settings.set_active_car(car_id)
+
+    updated = services.analysis_settings.update_active_car_aspects(
+        {"tire_width_mm": 285.0, "tire_aspect_pct": 35.0, "rim_in": 21.0}
+    )
+
+    assert updated["tire_width_mm"] == 285.0
+    assert updated["tire_aspect_pct"] == 35.0
+    assert updated["rim_in"] == 21.0
+    assert "front_tire_width_mm" not in updated
+    assert "rear_tire_width_mm" not in updated
+    assert "default_axle_for_speed" not in updated
+
+
 def test_analysis_settings_update_active_car_aspects() -> None:
     services = build_settings_services()
     created = services.car_settings.add_car({"name": "Editable"})

--- a/apps/server/tests/shared/types/test_settings_types.py
+++ b/apps/server/tests/shared/types/test_settings_types.py
@@ -6,6 +6,7 @@ from vibesensor.adapters.http.models.settings import CarResponse, CarUpsertReque
 from vibesensor.domain import AnalysisSettingsSnapshot
 from vibesensor.infra.config.analysis_settings import ActiveCarAnalysisSettingsService
 from vibesensor.infra.config.car_settings import CarSettingsService
+from vibesensor.shared.analysis_settings_schema import ANALYSIS_SETTINGS_FIELDS
 from vibesensor.shared.types.settings_types import (
     AnalysisSettingsPayload,
     analysis_settings_payload_from_mapping,
@@ -14,7 +15,7 @@ from vibesensor.shared.types.settings_types import (
 
 def test_analysis_settings_payload_keys_match_snapshot_defaults() -> None:
     assert AnalysisSettingsPayload.__required_keys__ == frozenset()
-    assert AnalysisSettingsPayload.__optional_keys__ == frozenset(AnalysisSettingsSnapshot.DEFAULTS)
+    assert AnalysisSettingsPayload.__optional_keys__ == frozenset(ANALYSIS_SETTINGS_FIELDS)
 
 
 def test_analysis_settings_payload_projection_keeps_only_supported_keys() -> None:

--- a/apps/server/tests/use_cases/diagnostics/test_analysis_settings.py
+++ b/apps/server/tests/use_cases/diagnostics/test_analysis_settings.py
@@ -4,8 +4,8 @@ from math import inf, nan, pi
 
 import pytest
 
+from vibesensor.domain import AxleTireSetup, OrderReferenceSpec, TireSpec
 from vibesensor.domain import Car as _Car
-from vibesensor.domain import OrderReferenceSpec, TireSpec
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
 from vibesensor.shared.analysis_settings_schema import sanitize_analysis_settings
 from vibesensor.shared.order_reference_settings import order_reference_spec_from_mapping
@@ -294,7 +294,7 @@ def test_engine_hz_returns_none_without_gear() -> None:
     """engine_hz returns None when gear ratio is zero."""
     tire = TireSpec(width_mm=285.0, aspect_pct=30.0, rim_in=21.0)
     spec = OrderReferenceSpec(
-        tire_spec=tire,
+        tire_setup=AxleTireSetup.square(tire),
         final_drive_ratio=3.08,
         current_gear_ratio=0.0,
         wheel_bandwidth_pct=5.0,

--- a/apps/server/vibesensor/adapters/http/models/car_library.py
+++ b/apps/server/vibesensor/adapters/http/models/car_library.py
@@ -36,6 +36,14 @@ class CarLibraryGearboxEntry(_StrictBase):
     requires_manual_confirmation: bool | None = None
 
 
+class CarLibraryTireDimensionsEntry(_StrictBase):
+    """One axle's tire dimensions."""
+
+    width_mm: float = Field(gt=0)
+    aspect_pct: float = Field(gt=0)
+    rim_in: float = Field(gt=0)
+
+
 class CarLibraryTireOptionEntry(_StrictBase):
     """A tire size option from the car library."""
 
@@ -43,6 +51,10 @@ class CarLibraryTireOptionEntry(_StrictBase):
     tire_width_mm: float = Field(gt=0)
     tire_aspect_pct: float = Field(gt=0)
     rim_in: float = Field(gt=0)
+    front: CarLibraryTireDimensionsEntry
+    rear: CarLibraryTireDimensionsEntry | None = None
+    default_axle_for_speed: Literal["front", "rear", "average"] = "rear"
+    source_confidence: str | None = None
 
 
 class CarLibraryVariantEntry(_StrictBase):

--- a/apps/server/vibesensor/adapters/http/models/settings.py
+++ b/apps/server/vibesensor/adapters/http/models/settings.py
@@ -23,6 +23,13 @@ class AnalysisSettingsRequest(_FrozenBase):
     tire_width_mm: float | None = Field(default=None, gt=0)
     tire_aspect_pct: float | None = Field(default=None, gt=0)
     rim_in: float | None = Field(default=None, gt=0)
+    front_tire_width_mm: float | None = Field(default=None, gt=0)
+    front_tire_aspect_pct: float | None = Field(default=None, gt=0)
+    front_rim_in: float | None = Field(default=None, gt=0)
+    rear_tire_width_mm: float | None = Field(default=None, gt=0)
+    rear_tire_aspect_pct: float | None = Field(default=None, gt=0)
+    rear_rim_in: float | None = Field(default=None, gt=0)
+    default_axle_for_speed: Literal["front", "rear", "average"] | None = None
     final_drive_ratio: float | None = Field(default=None, gt=0)
     current_gear_ratio: float | None = Field(default=None, gt=0)
     wheel_bandwidth_pct: float | None = Field(default=None, gt=0)
@@ -217,6 +224,13 @@ class AnalysisSettingsResponse(BaseModel):
     tire_width_mm: float
     tire_aspect_pct: float
     rim_in: float
+    front_tire_width_mm: float | None = None
+    front_tire_aspect_pct: float | None = None
+    front_rim_in: float | None = None
+    rear_tire_width_mm: float | None = None
+    rear_tire_aspect_pct: float | None = None
+    rear_rim_in: float | None = None
+    default_axle_for_speed: Literal["front", "rear", "average"] = "rear"
     final_drive_ratio: float
     current_gear_ratio: float
     wheel_bandwidth_pct: float

--- a/apps/server/vibesensor/adapters/persistence/car_library.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library.py
@@ -15,6 +15,7 @@ from typing import Any, Literal, NotRequired, TypedDict, cast
 from pydantic import ConfigDict, TypeAdapter, ValidationError
 
 from vibesensor.domain import (
+    AxleTireSetup,
     TireSpec,
     VehicleConfiguration,
     VehicleConfigurationTireOption,
@@ -58,8 +59,18 @@ class CarLibraryGearbox(TypedDict):
 
 class CarLibraryTireOption(TypedDict):
     name: str
-    tire_width_mm: float
-    tire_aspect_pct: float
+    tire_width_mm: NotRequired[float]
+    tire_aspect_pct: NotRequired[float]
+    rim_in: NotRequired[float]
+    front: NotRequired[CarLibraryTireDimensions]
+    rear: NotRequired[CarLibraryTireDimensions]
+    default_axle_for_speed: NotRequired[Literal["front", "rear", "average"]]
+    source_confidence: NotRequired[str]
+
+
+class CarLibraryTireDimensions(TypedDict):
+    width_mm: float
+    aspect_pct: float
     rim_in: float
 
 
@@ -140,6 +151,7 @@ class VehicleConfigurationFieldProvenanceRow(TypedDict):
 
 for _typed_dict in (
     CarLibraryGearbox,
+    CarLibraryTireDimensions,
     CarLibraryTireOption,
     CarLibraryVariant,
     CarLibraryEntry,
@@ -214,13 +226,51 @@ def _tire_options_from_rows(
     return tuple(
         VehicleConfigurationTireOption(
             name=row["name"],
-            spec=_tire_spec_from_dimensions(
-                tire_width_mm=row["tire_width_mm"],
-                tire_aspect_pct=row["tire_aspect_pct"],
-                rim_in=row["rim_in"],
-            ),
+            tire_setup=_tire_setup_from_row(row),
         )
         for row in rows
+    )
+
+
+def _tire_dimensions_from_row(
+    row: CarLibraryTireOption,
+    *,
+    side: Literal["front", "rear"],
+) -> TireSpec | None:
+    nested = row.get(side)
+    if isinstance(nested, dict):
+        return _tire_spec_from_dimensions(
+            tire_width_mm=float(nested["width_mm"]),
+            tire_aspect_pct=float(nested["aspect_pct"]),
+            rim_in=float(nested["rim_in"]),
+        )
+    if side == "front":
+        width = row.get("tire_width_mm")
+        aspect = row.get("tire_aspect_pct")
+        rim = row.get("rim_in")
+        if width is None or aspect is None or rim is None:
+            return None
+        return _tire_spec_from_dimensions(
+            tire_width_mm=float(width),
+            tire_aspect_pct=float(aspect),
+            rim_in=float(rim),
+        )
+    return None
+
+
+def _tire_setup_from_row(row: CarLibraryTireOption) -> AxleTireSetup:
+    front = _tire_dimensions_from_row(row, side="front")
+    rear = _tire_dimensions_from_row(row, side="rear") or front
+    if front is None or rear is None:
+        raise ValueError(f"Invalid tire option row without usable dimensions: {row!r}")
+    default_axle_for_speed = row.get("default_axle_for_speed")
+    if default_axle_for_speed not in {"front", "rear", "average"}:
+        default_axle_for_speed = "rear"
+    return AxleTireSetup(
+        front=front,
+        rear=rear,
+        default_axle_for_speed=default_axle_for_speed,
+        source_confidence=row.get("source_confidence"),
     )
 
 
@@ -390,14 +440,36 @@ def _car_library_tire_options_from_configuration(
     config: VehicleConfiguration,
 ) -> list[CarLibraryTireOption]:
     return [
-        {
-            "name": option.name,
-            "tire_width_mm": option.spec.width_mm,
-            "tire_aspect_pct": option.spec.aspect_pct,
-            "rim_in": option.spec.rim_in,
-        }
+        _car_library_tire_option_from_setup(option.name, option.tire_setup)
         for option in config.tire_options
     ]
+
+
+def _car_library_tire_option_from_setup(
+    name: str,
+    setup: AxleTireSetup,
+) -> CarLibraryTireOption:
+    payload: CarLibraryTireOption = {
+        "name": name,
+        "tire_width_mm": setup.boundary_tire_spec.width_mm,
+        "tire_aspect_pct": setup.boundary_tire_spec.aspect_pct,
+        "rim_in": setup.boundary_tire_spec.rim_in,
+        "front": {
+            "width_mm": setup.front.width_mm,
+            "aspect_pct": setup.front.aspect_pct,
+            "rim_in": setup.front.rim_in,
+        },
+        "default_axle_for_speed": setup.default_axle_for_speed,
+    }
+    if setup.is_staggered:
+        payload["rear"] = {
+            "width_mm": setup.rear.width_mm,
+            "aspect_pct": setup.rear.aspect_pct,
+            "rim_in": setup.rear.rim_in,
+        }
+    if setup.source_confidence is not None:
+        payload["source_confidence"] = setup.source_confidence
+    return payload
 
 
 def _gearbox_row_from_configuration(config: VehicleConfiguration) -> CarLibraryGearbox | None:
@@ -452,9 +524,20 @@ def _enrich_variant_with_vehicle_configurations(
 
 def _response_entry_for_model(entry: CarLibraryEntry) -> CarLibraryEntry:
     response_entry = _deep_copy_entry(entry)
-    response_entry["variants"] = [
-        _enrich_variant_with_vehicle_configurations(entry, variant) for variant in entry["variants"]
+    response_entry["tire_options"] = [
+        _car_library_tire_option_from_setup(row["name"], _tire_setup_from_row(row))
+        for row in entry["tire_options"]
     ]
+    response_entry["variants"] = []
+    for variant in entry["variants"]:
+        enriched = _enrich_variant_with_vehicle_configurations(entry, variant)
+        tire_options = enriched.get("tire_options")
+        if tire_options:
+            enriched["tire_options"] = [
+                _car_library_tire_option_from_setup(row["name"], _tire_setup_from_row(row))
+                for row in tire_options
+            ]
+        response_entry["variants"].append(enriched)
     return response_entry
 
 

--- a/apps/server/vibesensor/data/car_library.json
+++ b/apps/server/vibesensor/data/car_library.json
@@ -1332,15 +1332,39 @@
       },
       {
         "name": "Sport Line 21\"",
-        "tire_width_mm": 255.0,
+        "tire_width_mm": 275.0,
         "tire_aspect_pct": 30.0,
-        "rim_in": 21.0
+        "rim_in": 21.0,
+        "front": {
+          "width_mm": 245.0,
+          "aspect_pct": 35.0,
+          "rim_in": 21.0
+        },
+        "rear": {
+          "width_mm": 275.0,
+          "aspect_pct": 30.0,
+          "rim_in": 21.0
+        },
+        "default_axle_for_speed": "rear",
+        "source_confidence": "reputable_secondary_crosschecked"
       },
       {
         "name": "M Sport 22\"",
-        "tire_width_mm": 265.0,
+        "tire_width_mm": 275.0,
         "tire_aspect_pct": 25.0,
-        "rim_in": 22.0
+        "rim_in": 22.0,
+        "front": {
+          "width_mm": 245.0,
+          "aspect_pct": 30.0,
+          "rim_in": 22.0
+        },
+        "rear": {
+          "width_mm": 275.0,
+          "aspect_pct": 25.0,
+          "rim_in": 22.0
+        },
+        "default_axle_for_speed": "rear",
+        "source_confidence": "reputable_secondary_crosschecked"
       }
     ],
     "tire_width_mm": 245.0,
@@ -2093,15 +2117,39 @@
       },
       {
         "name": "Sport Line 21\"",
-        "tire_width_mm": 285.0,
+        "tire_width_mm": 315.0,
         "tire_aspect_pct": 35.0,
-        "rim_in": 21.0
+        "rim_in": 21.0,
+        "front": {
+          "width_mm": 275.0,
+          "aspect_pct": 40.0,
+          "rim_in": 21.0
+        },
+        "rear": {
+          "width_mm": 315.0,
+          "aspect_pct": 35.0,
+          "rim_in": 21.0
+        },
+        "default_axle_for_speed": "rear",
+        "source_confidence": "reputable_secondary_crosschecked"
       },
       {
         "name": "M Sport 22\"",
-        "tire_width_mm": 295.0,
+        "tire_width_mm": 315.0,
         "tire_aspect_pct": 30.0,
-        "rim_in": 22.0
+        "rim_in": 22.0,
+        "front": {
+          "width_mm": 275.0,
+          "aspect_pct": 35.0,
+          "rim_in": 22.0
+        },
+        "rear": {
+          "width_mm": 315.0,
+          "aspect_pct": 30.0,
+          "rim_in": 22.0
+        },
+        "default_axle_for_speed": "rear",
+        "source_confidence": "reputable_secondary_crosschecked"
       }
     ],
     "tire_width_mm": 275.0,
@@ -2192,15 +2240,39 @@
       },
       {
         "name": "Sport Line 21\"",
-        "tire_width_mm": 285.0,
+        "tire_width_mm": 315.0,
         "tire_aspect_pct": 35.0,
-        "rim_in": 21.0
+        "rim_in": 21.0,
+        "front": {
+          "width_mm": 275.0,
+          "aspect_pct": 40.0,
+          "rim_in": 21.0
+        },
+        "rear": {
+          "width_mm": 315.0,
+          "aspect_pct": 35.0,
+          "rim_in": 21.0
+        },
+        "default_axle_for_speed": "rear",
+        "source_confidence": "reputable_secondary_crosschecked"
       },
       {
         "name": "M Sport 22\"",
-        "tire_width_mm": 295.0,
+        "tire_width_mm": 315.0,
         "tire_aspect_pct": 30.0,
-        "rim_in": 22.0
+        "rim_in": 22.0,
+        "front": {
+          "width_mm": 275.0,
+          "aspect_pct": 35.0,
+          "rim_in": 22.0
+        },
+        "rear": {
+          "width_mm": 315.0,
+          "aspect_pct": 30.0,
+          "rim_in": 22.0
+        },
+        "default_axle_for_speed": "rear",
+        "source_confidence": "reputable_secondary_crosschecked"
       }
     ],
     "tire_width_mm": 275.0,

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -77,7 +77,7 @@ from .speed_source import SpeedSource, SpeedSourceKind
 from .strength_metrics import StrengthMetrics, StrengthPeak
 from .test_plan import RecommendedAction, TestPlan, plan_test_actions
 from .test_run import TestRun
-from .tire_spec import TireSpec
+from .tire_spec import AxleTireSetup, TireSpec, TireSpeedAxle
 from .vehicle_configuration import (
     VehicleConfiguration,
     VehicleConfigurationField,
@@ -102,9 +102,11 @@ __all__ = [
     "Run",
     "TestRun",
     # Value objects — car and context
+    "AxleTireSetup",
     "CarSnapshot",
     "OrderReferenceSpec",
     "TireSpec",
+    "TireSpeedAxle",
     "VehicleConfiguration",
     "VehicleConfigurationField",
     "VehicleConfigurationSourceStatus",

--- a/apps/server/vibesensor/domain/_order_reference_helpers.py
+++ b/apps/server/vibesensor/domain/_order_reference_helpers.py
@@ -9,12 +9,19 @@ from vibesensor.domain.order_reference import (
     OrderReferenceSpec,
     order_reference_mapping_from_spec,
 )
-from vibesensor.domain.tire_spec import TireSpec
+from vibesensor.domain.tire_spec import AxleTireSetup, TireSpec, TireSpeedAxle
 
 ORDER_REFERENCE_KEYS: tuple[str, ...] = (
     "tire_width_mm",
     "tire_aspect_pct",
     "rim_in",
+    "front_tire_width_mm",
+    "front_tire_aspect_pct",
+    "front_rim_in",
+    "rear_tire_width_mm",
+    "rear_tire_aspect_pct",
+    "rear_rim_in",
+    "default_axle_for_speed",
     "final_drive_ratio",
     "current_gear_ratio",
     "wheel_bandwidth_pct",
@@ -48,24 +55,48 @@ def order_reference_spec_from_mapping(
     )
     if deflection_factor is not None and math.isfinite(deflection_factor):
         resolved_deflection = float(deflection_factor)
-    tire_inputs = {
-        key: value
-        for key in ("tire_width_mm", "tire_aspect_pct", "rim_in")
-        if (value := _coerce_finite_float(settings.get(key), default=None)) is not None
-    }
-    tire = TireSpec.from_aspects(
-        tire_inputs,
-        deflection_factor=resolved_deflection if resolved_deflection is not None else 1.0,
+    base_tire = _tire_spec_from_mapping(
+        settings,
+        width_key="tire_width_mm",
+        aspect_key="tire_aspect_pct",
+        rim_key="rim_in",
+        deflection_factor=resolved_deflection,
     )
-    if tire is None:
+    front_tire = (
+        _tire_spec_from_mapping(
+            settings,
+            width_key="front_tire_width_mm",
+            aspect_key="front_tire_aspect_pct",
+            rim_key="front_rim_in",
+            deflection_factor=resolved_deflection,
+        )
+        or base_tire
+    )
+    rear_tire = (
+        _tire_spec_from_mapping(
+            settings,
+            width_key="rear_tire_width_mm",
+            aspect_key="rear_tire_aspect_pct",
+            rim_key="rear_rim_in",
+            deflection_factor=resolved_deflection,
+        )
+        or front_tire
+    )
+    if front_tire is None or rear_tire is None:
         return None
+    default_axle_for_speed = _default_axle_for_speed(settings.get("default_axle_for_speed"))
+    tire_setup = AxleTireSetup(
+        front=front_tire,
+        rear=rear_tire,
+        default_axle_for_speed=default_axle_for_speed,
+    )
 
     def _f(key: str, default: float = 0.0) -> float:
         value = _coerce_finite_float(settings.get(key), default=default)
         return default if value is None else value
 
     return OrderReferenceSpec(
-        tire_spec=tire,
+        tire_setup=tire_setup,
         final_drive_ratio=_f("final_drive_ratio"),
         current_gear_ratio=_f("current_gear_ratio"),
         wheel_bandwidth_pct=_f("wheel_bandwidth_pct"),
@@ -80,18 +111,68 @@ def order_reference_spec_from_mapping(
     )
 
 
-def normalize_order_reference_mapping(aspects: Mapping[str, object]) -> dict[str, float]:
-    normalized: dict[str, float] = {}
+def normalize_order_reference_mapping(aspects: Mapping[str, object]) -> dict[str, float | str]:
+    normalized: dict[str, float | str] = {}
     for key in ORDER_REFERENCE_KEYS:
+        if key == "default_axle_for_speed":
+            axle = aspects.get(key)
+            if axle in {"front", "rear", "average"}:
+                normalized[key] = axle
+            continue
         value = _coerce_finite_float(aspects.get(key), default=None)
         if value is None:
             continue
-        if key in {"tire_width_mm", "tire_aspect_pct", "rim_in"} and value <= 0:
+        if (
+            key
+            in {
+                "tire_width_mm",
+                "tire_aspect_pct",
+                "rim_in",
+                "front_tire_width_mm",
+                "front_tire_aspect_pct",
+                "front_rim_in",
+                "rear_tire_width_mm",
+                "rear_tire_aspect_pct",
+                "rear_rim_in",
+            }
+            and value <= 0
+        ):
             raise ValueError(
                 f"Car.aspects[{key!r}] must be a positive finite number, got {value}",
             )
         normalized[key] = value
     return normalized
+
+
+def _tire_spec_from_mapping(
+    settings: Mapping[str, object],
+    *,
+    width_key: str,
+    aspect_key: str,
+    rim_key: str,
+    deflection_factor: float | None,
+) -> TireSpec | None:
+    tire_inputs = {
+        mapped_key: value
+        for mapped_key, raw_key in (
+            ("tire_width_mm", width_key),
+            ("tire_aspect_pct", aspect_key),
+            ("rim_in", rim_key),
+        )
+        if (value := _coerce_finite_float(settings.get(raw_key), default=None)) is not None
+    }
+    return TireSpec.from_aspects(
+        tire_inputs,
+        deflection_factor=deflection_factor if deflection_factor is not None else 1.0,
+    )
+
+
+def _default_axle_for_speed(value: object) -> TireSpeedAxle:
+    if value == "front":
+        return "front"
+    if value == "average":
+        return "average"
+    return "rear"
 
 
 def _coerce_finite_float(value: object, *, default: float | None) -> float | None:

--- a/apps/server/vibesensor/domain/analysis_settings.py
+++ b/apps/server/vibesensor/domain/analysis_settings.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 __all__ = ["AnalysisSettingsSnapshot"]
 
@@ -32,6 +32,15 @@ ANALYSIS_SETTINGS_NON_NEGATIVE_KEYS: frozenset[str] = frozenset(
     },
 )
 
+ANALYSIS_SETTINGS_OPTIONAL_TIRE_SETUP_KEYS: tuple[str, ...] = (
+    "front_tire_width_mm",
+    "front_tire_aspect_pct",
+    "front_rim_in",
+    "rear_tire_width_mm",
+    "rear_tire_aspect_pct",
+    "rear_rim_in",
+)
+
 ANALYSIS_SETTINGS_BOUNDS: dict[str, tuple[float, float]] = {
     "wheel_bandwidth_pct": (0.1, 100.0),
     "driveshaft_bandwidth_pct": (0.1, 100.0),
@@ -47,6 +56,12 @@ ANALYSIS_SETTINGS_BOUNDS: dict[str, tuple[float, float]] = {
     "tire_width_mm": (100.0, 500.0),
     "tire_aspect_pct": (10.0, 90.0),
     "rim_in": (10.0, 30.0),
+    "front_tire_width_mm": (100.0, 500.0),
+    "front_tire_aspect_pct": (10.0, 90.0),
+    "front_rim_in": (10.0, 30.0),
+    "rear_tire_width_mm": (100.0, 500.0),
+    "rear_tire_aspect_pct": (10.0, 90.0),
+    "rear_rim_in": (10.0, 30.0),
     "tire_deflection_factor": (0.85, 1.0),
 }
 
@@ -101,3 +116,10 @@ class AnalysisSettingsSnapshot:
     min_abs_band_hz: float = 0.0
     max_band_half_width_pct: float = 0.0
     tire_deflection_factor: float = 1.0
+    front_tire_width_mm: float = 0.0
+    front_tire_aspect_pct: float = 0.0
+    front_rim_in: float = 0.0
+    rear_tire_width_mm: float = 0.0
+    rear_tire_aspect_pct: float = 0.0
+    rear_rim_in: float = 0.0
+    default_axle_for_speed: Literal["front", "rear", "average"] = "rear"

--- a/apps/server/vibesensor/domain/car.py
+++ b/apps/server/vibesensor/domain/car.py
@@ -21,10 +21,11 @@ from vibesensor.domain._order_reference_helpers import (
     order_reference_spec_from_mapping,
 )
 from vibesensor.domain.order_reference import OrderReferenceSpec
-from vibesensor.domain.tire_spec import TireSpec
+from vibesensor.domain.tire_spec import AxleTireSetup, TireSpec
 from vibesensor.domain.vehicle_configuration import VehicleFieldConfidence
 
 __all__ = [
+    "AxleTireSetup",
     "Car",
     "CarOrderReferenceStatus",
     "CarOrderReferenceSourceStatus",
@@ -97,7 +98,7 @@ class CarSnapshot:
     name: str | None = None
     car_type: str | None = None
     variant: str | None = None
-    aspects: Mapping[str, float] = field(default_factory=dict)
+    aspects: Mapping[str, float | str] = field(default_factory=dict)
     order_reference_status: CarOrderReferenceStatus | None = None
 
     def __post_init__(self) -> None:
@@ -119,7 +120,7 @@ class Car:
     variant: str | None = None
     order_reference_status: CarOrderReferenceStatus | None = None
     order_reference_spec: OrderReferenceSpec | None = field(default=None, repr=False)
-    _aspects: Mapping[str, float] = field(
+    _aspects: Mapping[str, float | str] = field(
         init=False,
         repr=False,
     )
@@ -130,7 +131,7 @@ class Car:
         id: str | None = None,
         name: str = "Unnamed Car",
         car_type: str = "sedan",
-        aspects: Mapping[str, float] | None = None,
+        aspects: Mapping[str, object] | None = None,
         variant: str | None = None,
         order_reference_status: CarOrderReferenceStatus | None = None,
         order_reference_spec: OrderReferenceSpec | None = None,
@@ -146,7 +147,7 @@ class Car:
 
     def _normalize_order_reference_state(
         self,
-        aspects: Mapping[str, float] | None,
+        aspects: Mapping[str, object] | None,
     ) -> None:
         if not self.name or not self.name.strip():
             object.__setattr__(self, "name", "Unnamed Car")
@@ -158,7 +159,7 @@ class Car:
         object.__setattr__(self, "_aspects", MappingProxyType(normalized_aspects))
 
     @property
-    def aspects(self) -> Mapping[str, float]:
+    def aspects(self) -> Mapping[str, float | str]:
         return self._aspects
 
     # -- queries -----------------------------------------------------------
@@ -169,6 +170,11 @@ class Car:
         if self.car_type:
             return f"{self.name} ({self.car_type})"
         return self.name
+
+    @property
+    def tire_setup(self) -> AxleTireSetup | None:
+        spec = self.order_reference_spec
+        return spec.tire_setup if spec is not None else None
 
     @property
     def tire_spec(self) -> TireSpec | None:

--- a/apps/server/vibesensor/domain/order_reference.py
+++ b/apps/server/vibesensor/domain/order_reference.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-from vibesensor.domain.tire_spec import TireSpec
+from vibesensor.domain.tire_spec import AxleTireSetup, TireSpec
 
 __all__ = ["OrderReferenceSpec", "order_reference_mapping_from_spec"]
 
@@ -16,7 +16,7 @@ _KMH_TO_MPS = 1.0 / 3.6
 class OrderReferenceSpec:
     """Typed owner of tire geometry and driveline/reference-order math."""
 
-    tire_spec: TireSpec
+    tire_setup: AxleTireSetup
     final_drive_ratio: float
     current_gear_ratio: float
     wheel_bandwidth_pct: float
@@ -30,9 +30,19 @@ class OrderReferenceSpec:
     max_band_half_width_pct: float
 
     @property
+    def tire_spec(self) -> TireSpec:
+        """Compatibility tire spec for flat boundary consumers."""
+
+        return self.tire_setup.boundary_tire_spec
+
+    @property
+    def default_axle_for_speed(self) -> str:
+        return self.tire_setup.default_axle_for_speed
+
+    @property
     def tire_circumference_m(self) -> float:
-        """Tire circumference in metres (deflection-adjusted)."""
-        return self.tire_spec.circumference_m
+        """Resolved tire circumference in metres for order-analysis math."""
+        return self.tire_setup.effective_tire_circumference_m
 
     @property
     def has_engine_reference(self) -> bool:
@@ -179,13 +189,14 @@ def _combined_relative_uncertainty(*parts: float) -> float:
     return math.sqrt(sum_sq)
 
 
-def order_reference_mapping_from_spec(spec: OrderReferenceSpec) -> dict[str, float]:
+def order_reference_mapping_from_spec(spec: OrderReferenceSpec) -> dict[str, float | str]:
     """Project an order-reference spec into the flat settings mapping boundary."""
 
-    return {
-        "tire_width_mm": spec.tire_spec.width_mm,
-        "tire_aspect_pct": spec.tire_spec.aspect_pct,
-        "rim_in": spec.tire_spec.rim_in,
+    boundary_tire = spec.tire_spec
+    payload: dict[str, float | str] = {
+        "tire_width_mm": boundary_tire.width_mm,
+        "tire_aspect_pct": boundary_tire.aspect_pct,
+        "rim_in": boundary_tire.rim_in,
         "final_drive_ratio": spec.final_drive_ratio,
         "current_gear_ratio": spec.current_gear_ratio,
         "wheel_bandwidth_pct": spec.wheel_bandwidth_pct,
@@ -197,5 +208,19 @@ def order_reference_mapping_from_spec(spec: OrderReferenceSpec) -> dict[str, flo
         "gear_uncertainty_pct": spec.gear_uncertainty_pct,
         "min_abs_band_hz": spec.min_abs_band_hz,
         "max_band_half_width_pct": spec.max_band_half_width_pct,
-        "tire_deflection_factor": spec.tire_spec.deflection_factor,
+        "tire_deflection_factor": boundary_tire.deflection_factor,
     }
+    setup = spec.tire_setup
+    if setup.is_staggered or setup.default_axle_for_speed != "rear":
+        payload.update(
+            {
+                "front_tire_width_mm": setup.front.width_mm,
+                "front_tire_aspect_pct": setup.front.aspect_pct,
+                "front_rim_in": setup.front.rim_in,
+                "rear_tire_width_mm": setup.rear.width_mm,
+                "rear_tire_aspect_pct": setup.rear.aspect_pct,
+                "rear_rim_in": setup.rear.rim_in,
+                "default_axle_for_speed": setup.default_axle_for_speed,
+            }
+        )
+    return payload

--- a/apps/server/vibesensor/domain/tire_spec.py
+++ b/apps/server/vibesensor/domain/tire_spec.py
@@ -1,14 +1,19 @@
-"""Tire geometry value object for vehicle order analysis."""
+"""Tire geometry value objects for vehicle order analysis."""
 
 from __future__ import annotations
 
 import math
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Literal
 
 __all__ = [
+    "AxleTireSetup",
+    "TireSpeedAxle",
     "TireSpec",
 ]
+
+type TireSpeedAxle = Literal["front", "rear", "average"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,3 +61,50 @@ class TireSpec:
     def circumference_m(self) -> float:
         """Tire circumference in metres (deflection-adjusted)."""
         return self.diameter_mm / 1000.0 * math.pi * self.deflection_factor
+
+
+@dataclass(frozen=True, slots=True)
+class AxleTireSetup:
+    """Canonical tire setup that can represent square or staggered axles."""
+
+    front: TireSpec
+    rear: TireSpec
+    default_axle_for_speed: TireSpeedAxle = "rear"
+    source_confidence: str | None = None
+
+    @classmethod
+    def square(
+        cls,
+        spec: TireSpec,
+        *,
+        default_axle_for_speed: TireSpeedAxle = "rear",
+        source_confidence: str | None = None,
+    ) -> AxleTireSetup:
+        return cls(
+            front=spec,
+            rear=spec,
+            default_axle_for_speed=default_axle_for_speed,
+            source_confidence=source_confidence,
+        )
+
+    @property
+    def is_staggered(self) -> bool:
+        return self.front != self.rear
+
+    @property
+    def boundary_tire_spec(self) -> TireSpec:
+        """Compatibility tire spec for flat boundary projections."""
+
+        if self.default_axle_for_speed == "rear":
+            return self.rear
+        return self.front
+
+    @property
+    def effective_tire_circumference_m(self) -> float:
+        """Resolved tire circumference used by order-analysis math."""
+
+        if self.default_axle_for_speed == "front":
+            return self.front.circumference_m
+        if self.default_axle_for_speed == "rear":
+            return self.rear.circumference_m
+        return (self.front.circumference_m + self.rear.circumference_m) / 2.0

--- a/apps/server/vibesensor/domain/vehicle_configuration.py
+++ b/apps/server/vibesensor/domain/vehicle_configuration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from .tire_spec import TireSpec
+from .tire_spec import AxleTireSetup, TireSpec
 
 __all__ = [
     "VehicleConfigurationField",
@@ -45,7 +45,7 @@ class VehicleConfigurationTireOption:
     """Named tire option attached to one exact or projected vehicle configuration."""
 
     name: str
-    spec: TireSpec
+    tire_setup: AxleTireSetup
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/server/vibesensor/infra/config/car_settings.py
+++ b/apps/server/vibesensor/infra/config/car_settings.py
@@ -28,6 +28,18 @@ LOGGER = logging.getLogger(__name__)
 _CarSettingsSnapshotT = TypeVar("_CarSettingsSnapshotT")
 _CarSettingsResultT = TypeVar("_CarSettingsResultT")
 _ORDER_REFERENCE_ASPECT_KEYS = frozenset({"current_gear_ratio", "final_drive_ratio"})
+_FLAT_TIRE_ASPECT_KEYS = frozenset({"tire_width_mm", "tire_aspect_pct", "rim_in"})
+_AXLE_TIRE_ASPECT_KEYS = frozenset(
+    {
+        "front_tire_width_mm",
+        "front_tire_aspect_pct",
+        "front_rim_in",
+        "rear_tire_width_mm",
+        "rear_tire_aspect_pct",
+        "rear_rim_in",
+        "default_axle_for_speed",
+    }
+)
 
 
 class _UpdateWithRollback(Protocol):
@@ -188,9 +200,14 @@ class CarSettingsService:
                     clamped = _clamp_str(raw_type, 32)
                     if clamped:
                         new_car_type = clamped
-            new_aspects = dict(car.aspects)
+            new_aspects: AnalysisSettingsPayload = analysis_settings_payload_from_mapping(
+                car.aspects
+            )
             if "aspects" in car_data and isinstance(car_data["aspects"], dict):
-                new_aspects.update(sanitize_analysis_settings(car_data["aspects"]))
+                new_aspects = _merge_aspects_with_tire_setup(
+                    current=new_aspects,
+                    updates=sanitize_analysis_settings(car_data["aspects"]),
+                )
             new_variant = car.variant
             if "variant" in car_data:
                 raw_variant = car_data["variant"]
@@ -242,7 +259,10 @@ class CarSettingsService:
                 id=car.id,
                 name=car.name,
                 car_type=car.car_type,
-                aspects={**car.aspects, **sanitize_analysis_settings(aspects)},
+                aspects=_merge_aspects_with_tire_setup(
+                    current=car.aspects,
+                    updates=sanitize_analysis_settings(aspects),
+                ),
                 variant=car.variant,
                 order_reference_status=_updated_order_reference_status(
                     car.order_reference_status,
@@ -327,3 +347,23 @@ def _updated_order_reference_status(
         current_gear_ratio="current_gear_ratio" in touched_keys,
         final_drive_ratio="final_drive_ratio" in touched_keys,
     )
+
+
+def _merge_aspects_with_tire_setup(
+    *,
+    current: Mapping[str, object],
+    updates: Mapping[str, object],
+) -> AnalysisSettingsPayload:
+    merged = analysis_settings_payload_from_mapping(current)
+    if _FLAT_TIRE_ASPECT_KEYS.intersection(updates) and not _AXLE_TIRE_ASPECT_KEYS.intersection(
+        updates
+    ):
+        merged.pop("front_tire_width_mm", None)
+        merged.pop("front_tire_aspect_pct", None)
+        merged.pop("front_rim_in", None)
+        merged.pop("rear_tire_width_mm", None)
+        merged.pop("rear_tire_aspect_pct", None)
+        merged.pop("rear_rim_in", None)
+        merged.pop("default_axle_for_speed", None)
+    merged.update(analysis_settings_payload_from_mapping(updates))
+    return merged

--- a/apps/server/vibesensor/infra/config/settings_derivation.py
+++ b/apps/server/vibesensor/infra/config/settings_derivation.py
@@ -19,7 +19,7 @@ def analysis_settings_snapshot_from_aspects(
     aspects: Mapping[str, object] | None,
 ) -> AnalysisSettingsSnapshot:
     """Build the current typed analysis snapshot from active-car aspects."""
-    values = dict(AnalysisSettingsSnapshot.DEFAULTS)
+    values: dict[str, object] = dict(AnalysisSettingsSnapshot.DEFAULTS)
     if aspects:
         values.update(sanitize_analysis_settings(aspects))
     return analysis_settings_snapshot_from_mapping(values)

--- a/apps/server/vibesensor/shared/analysis_settings_schema.py
+++ b/apps/server/vibesensor/shared/analysis_settings_schema.py
@@ -8,6 +8,11 @@ from collections.abc import Mapping
 
 from vibesensor.domain._numeric import coerce_float
 from vibesensor.domain.analysis_settings import AnalysisSettingsSnapshot
+from vibesensor.shared.types.settings_types import (
+    AnalysisSettingsPayload,
+    analysis_settings_axle_from_mapping,
+    analysis_settings_payload_from_mapping,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -15,7 +20,20 @@ ANALYSIS_SETTINGS_POSITIVE_REQUIRED_KEYS = AnalysisSettingsSnapshot.POSITIVE_REQ
 ANALYSIS_SETTINGS_NON_NEGATIVE_KEYS = AnalysisSettingsSnapshot.NON_NEGATIVE_KEYS
 ANALYSIS_SETTINGS_BOUNDS = AnalysisSettingsSnapshot._BOUNDS
 ANALYSIS_SETTINGS_DEFAULTS = AnalysisSettingsSnapshot.DEFAULTS
-ANALYSIS_SETTINGS_FIELDS: tuple[str, ...] = tuple(ANALYSIS_SETTINGS_DEFAULTS)
+ANALYSIS_SETTINGS_EXTRA_NUMERIC_FIELDS: tuple[str, ...] = (
+    "front_tire_width_mm",
+    "front_tire_aspect_pct",
+    "front_rim_in",
+    "rear_tire_width_mm",
+    "rear_tire_aspect_pct",
+    "rear_rim_in",
+)
+ANALYSIS_SETTINGS_AXLE_FIELDS: tuple[str, ...] = ("default_axle_for_speed",)
+ANALYSIS_SETTINGS_FIELDS: tuple[str, ...] = (
+    *tuple(ANALYSIS_SETTINGS_DEFAULTS),
+    *ANALYSIS_SETTINGS_EXTRA_NUMERIC_FIELDS,
+    *ANALYSIS_SETTINGS_AXLE_FIELDS,
+)
 
 __all__ = [
     "ANALYSIS_SETTINGS_BOUNDS",
@@ -30,12 +48,12 @@ __all__ = [
 def sanitize_analysis_settings(
     payload: Mapping[str, object],
     allowed_keys: Mapping[str, float] | None = None,
-) -> dict[str, float]:
+) -> AnalysisSettingsPayload:
     """Validate and normalize flat analysis-settings payloads."""
 
     allowed = allowed_keys if allowed_keys is not None else ANALYSIS_SETTINGS_DEFAULTS
-    out: dict[str, float] = {}
-    for key in allowed:
+    out: dict[str, float | str] = {}
+    for key in (*allowed, *ANALYSIS_SETTINGS_EXTRA_NUMERIC_FIELDS):
         raw = payload.get(key)
         if raw is None:
             continue
@@ -63,11 +81,21 @@ def sanitize_analysis_settings(
                 LOGGER.info("Clamped analysis setting %s from %r to %r", key, value, upper)
                 value = upper
         out[key] = value
+    default_axle_for_speed = analysis_settings_axle_from_mapping(
+        payload.get("default_axle_for_speed")
+    )
+    if default_axle_for_speed is not None:
+        out["default_axle_for_speed"] = default_axle_for_speed
     attempted = [key for key in allowed if payload.get(key) is not None]
+    attempted.extend(
+        key for key in ANALYSIS_SETTINGS_EXTRA_NUMERIC_FIELDS if payload.get(key) is not None
+    )
+    if payload.get("default_axle_for_speed") is not None:
+        attempted.append("default_axle_for_speed")
     if attempted and not out:
         LOGGER.warning(
             "sanitize_analysis_settings: all %d submitted keys were invalid and dropped: %s",
             len(attempted),
             attempted,
         )
-    return out
+    return analysis_settings_payload_from_mapping(out)

--- a/apps/server/vibesensor/shared/boundaries/codecs/analysis_settings.py
+++ b/apps/server/vibesensor/shared/boundaries/codecs/analysis_settings.py
@@ -12,17 +12,25 @@ from vibesensor.shared.analysis_settings_schema import (
 )
 from vibesensor.shared.boundaries.codecs.scalars import float_or
 from vibesensor.shared.types.json_types import JsonObject
+from vibesensor.shared.types.settings_types import analysis_settings_axle_from_mapping
 
 type ScalarSettingValue = int | float | bool | str
 type ScalarSettings = tuple[tuple[str, ScalarSettingValue], ...]
 
 _ANALYSIS_SETTINGS_PAIRS: tuple[
-    tuple[str, Callable[[AnalysisSettingsSnapshot], float]],
+    tuple[str, Callable[[AnalysisSettingsSnapshot], float | str]],
     ...,
 ] = (
     ("tire_width_mm", lambda snapshot: snapshot.tire_width_mm),
     ("tire_aspect_pct", lambda snapshot: snapshot.tire_aspect_pct),
     ("rim_in", lambda snapshot: snapshot.rim_in),
+    ("front_tire_width_mm", lambda snapshot: snapshot.front_tire_width_mm),
+    ("front_tire_aspect_pct", lambda snapshot: snapshot.front_tire_aspect_pct),
+    ("front_rim_in", lambda snapshot: snapshot.front_rim_in),
+    ("rear_tire_width_mm", lambda snapshot: snapshot.rear_tire_width_mm),
+    ("rear_tire_aspect_pct", lambda snapshot: snapshot.rear_tire_aspect_pct),
+    ("rear_rim_in", lambda snapshot: snapshot.rear_rim_in),
+    ("default_axle_for_speed", lambda snapshot: snapshot.default_axle_for_speed),
     ("final_drive_ratio", lambda snapshot: snapshot.final_drive_ratio),
     ("current_gear_ratio", lambda snapshot: snapshot.current_gear_ratio),
     ("wheel_bandwidth_pct", lambda snapshot: snapshot.wheel_bandwidth_pct),
@@ -53,6 +61,16 @@ def analysis_settings_snapshot_from_mapping(payload: object) -> AnalysisSettings
         tire_width_mm=float_or(payload.get("tire_width_mm")),
         tire_aspect_pct=float_or(payload.get("tire_aspect_pct")),
         rim_in=float_or(payload.get("rim_in")),
+        front_tire_width_mm=float_or(payload.get("front_tire_width_mm")),
+        front_tire_aspect_pct=float_or(payload.get("front_tire_aspect_pct")),
+        front_rim_in=float_or(payload.get("front_rim_in")),
+        rear_tire_width_mm=float_or(payload.get("rear_tire_width_mm")),
+        rear_tire_aspect_pct=float_or(payload.get("rear_tire_aspect_pct")),
+        rear_rim_in=float_or(payload.get("rear_rim_in")),
+        default_axle_for_speed=analysis_settings_axle_from_mapping(
+            payload.get("default_axle_for_speed")
+        )
+        or "rear",
         final_drive_ratio=float_or(payload.get("final_drive_ratio")),
         current_gear_ratio=float_or(payload.get("current_gear_ratio")),
         wheel_bandwidth_pct=float_or(payload.get("wheel_bandwidth_pct")),
@@ -72,7 +90,35 @@ def analysis_settings_snapshot_to_metadata(snapshot: AnalysisSettingsSnapshot) -
     """Project a typed snapshot into the canonical persisted metadata shape."""
 
     metadata: JsonObject = {}
+    has_axle_specific_tire_setup = any(
+        value > 0.0
+        for value in (
+            snapshot.front_tire_width_mm,
+            snapshot.front_tire_aspect_pct,
+            snapshot.front_rim_in,
+            snapshot.rear_tire_width_mm,
+            snapshot.rear_tire_aspect_pct,
+            snapshot.rear_rim_in,
+        )
+    )
     for key, value in _analysis_settings_values(snapshot):
+        if isinstance(value, str):
+            if has_axle_specific_tire_setup:
+                metadata[key] = value
+            continue
+        if (
+            key
+            in {
+                "front_tire_width_mm",
+                "front_tire_aspect_pct",
+                "front_rim_in",
+                "rear_tire_width_mm",
+                "rear_tire_aspect_pct",
+                "rear_rim_in",
+            }
+            and value <= 0.0
+        ):
+            continue
         if math.isfinite(float(value)):
             metadata[key] = value
     return metadata
@@ -92,7 +138,7 @@ def analysis_settings_snapshot_items(snapshot: AnalysisSettingsSnapshot) -> Scal
 
 def _analysis_settings_values(
     snapshot: AnalysisSettingsSnapshot,
-) -> tuple[tuple[str, float], ...]:
+) -> tuple[tuple[str, float | str], ...]:
     return tuple((key, read_value(snapshot)) for key, read_value in _ANALYSIS_SETTINGS_PAIRS)
 
 

--- a/apps/server/vibesensor/shared/boundaries/settings/analysis.py
+++ b/apps/server/vibesensor/shared/boundaries/settings/analysis.py
@@ -19,10 +19,12 @@ def analysis_settings_update_payload_from_mapping(
 ) -> AnalysisSettingsPayload:
     """Project a request-like mapping into the canonical analysis update payload."""
 
-    filtered: dict[str, float] = {}
+    filtered: dict[str, float | str] = {}
     for key, value in payload.items():
         if isinstance(value, (int, float)) and not isinstance(value, bool):
             filtered[key] = float(value)
+        elif key == "default_axle_for_speed" and value in {"front", "rear", "average"}:
+            filtered[key] = value
     return analysis_settings_payload_from_mapping(filtered)
 
 

--- a/apps/server/vibesensor/shared/types/car_config.py
+++ b/apps/server/vibesensor/shared/types/car_config.py
@@ -88,9 +88,11 @@ def car_from_persistence_dict(payload: Mapping[str, object]) -> Car:
     from vibesensor.domain import Car
 
     raw_aspects = payload.get("aspects")
-    aspects: dict[str, float] = dict(ANALYSIS_SETTINGS_DEFAULTS)
+    aspects: dict[str, float | str] = dict(ANALYSIS_SETTINGS_DEFAULTS)
     if isinstance(raw_aspects, Mapping):
-        aspects.update(sanitize_analysis_settings(raw_aspects))
+        for key, value in sanitize_analysis_settings(raw_aspects).items():
+            if isinstance(value, float | str):
+                aspects[key] = value
     raw_order_reference_status = payload.get("order_reference_status")
     return Car(
         id=_text_or_default(payload.get("id"), default=new_car_id(), max_length=128),

--- a/apps/server/vibesensor/shared/types/settings_types.py
+++ b/apps/server/vibesensor/shared/types/settings_types.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from typing import Literal, TypedDict
 
+from vibesensor.domain.tire_spec import TireSpeedAxle
+
 __all__ = [
     "AnalysisSettingsPayload",
+    "analysis_settings_axle_from_mapping",
     "analysis_settings_payload_from_mapping",
     "LanguageCode",
     "SpeedUnitCode",
+    "TireSpeedAxle",
 ]
 
 
@@ -19,6 +24,13 @@ class AnalysisSettingsPayload(TypedDict, total=False):
     tire_width_mm: float
     tire_aspect_pct: float
     rim_in: float
+    front_tire_width_mm: float
+    front_tire_aspect_pct: float
+    front_rim_in: float
+    rear_tire_width_mm: float
+    rear_tire_aspect_pct: float
+    rear_rim_in: float
+    default_axle_for_speed: TireSpeedAxle
     final_drive_ratio: float
     current_gear_ratio: float
     wheel_bandwidth_pct: float
@@ -34,41 +46,91 @@ class AnalysisSettingsPayload(TypedDict, total=False):
 
 
 def analysis_settings_payload_from_mapping(
-    values: Mapping[str, float | int],
+    values: Mapping[str, object],
 ) -> AnalysisSettingsPayload:
     """Project a trusted flat mapping into the named-field settings payload."""
     payload: AnalysisSettingsPayload = {}
-    if (value := values.get("tire_width_mm")) is not None:
-        payload["tire_width_mm"] = float(value)
-    if (value := values.get("tire_aspect_pct")) is not None:
-        payload["tire_aspect_pct"] = float(value)
-    if (value := values.get("rim_in")) is not None:
-        payload["rim_in"] = float(value)
-    if (value := values.get("final_drive_ratio")) is not None:
-        payload["final_drive_ratio"] = float(value)
-    if (value := values.get("current_gear_ratio")) is not None:
-        payload["current_gear_ratio"] = float(value)
-    if (value := values.get("wheel_bandwidth_pct")) is not None:
-        payload["wheel_bandwidth_pct"] = float(value)
-    if (value := values.get("driveshaft_bandwidth_pct")) is not None:
-        payload["driveshaft_bandwidth_pct"] = float(value)
-    if (value := values.get("engine_bandwidth_pct")) is not None:
-        payload["engine_bandwidth_pct"] = float(value)
-    if (value := values.get("speed_uncertainty_pct")) is not None:
-        payload["speed_uncertainty_pct"] = float(value)
-    if (value := values.get("tire_diameter_uncertainty_pct")) is not None:
-        payload["tire_diameter_uncertainty_pct"] = float(value)
-    if (value := values.get("final_drive_uncertainty_pct")) is not None:
-        payload["final_drive_uncertainty_pct"] = float(value)
-    if (value := values.get("gear_uncertainty_pct")) is not None:
-        payload["gear_uncertainty_pct"] = float(value)
-    if (value := values.get("min_abs_band_hz")) is not None:
-        payload["min_abs_band_hz"] = float(value)
-    if (value := values.get("max_band_half_width_pct")) is not None:
-        payload["max_band_half_width_pct"] = float(value)
-    if (value := values.get("tire_deflection_factor")) is not None:
-        payload["tire_deflection_factor"] = float(value)
+    if (tire_width := _finite_float_or_none(values.get("tire_width_mm"))) is not None:
+        payload["tire_width_mm"] = tire_width
+    if (tire_aspect := _finite_float_or_none(values.get("tire_aspect_pct"))) is not None:
+        payload["tire_aspect_pct"] = tire_aspect
+    if (rim := _finite_float_or_none(values.get("rim_in"))) is not None:
+        payload["rim_in"] = rim
+    if (front_width := _finite_float_or_none(values.get("front_tire_width_mm"))) is not None:
+        payload["front_tire_width_mm"] = front_width
+    if (front_aspect := _finite_float_or_none(values.get("front_tire_aspect_pct"))) is not None:
+        payload["front_tire_aspect_pct"] = front_aspect
+    if (front_rim := _finite_float_or_none(values.get("front_rim_in"))) is not None:
+        payload["front_rim_in"] = front_rim
+    if (rear_width := _finite_float_or_none(values.get("rear_tire_width_mm"))) is not None:
+        payload["rear_tire_width_mm"] = rear_width
+    if (rear_aspect := _finite_float_or_none(values.get("rear_tire_aspect_pct"))) is not None:
+        payload["rear_tire_aspect_pct"] = rear_aspect
+    if (rear_rim := _finite_float_or_none(values.get("rear_rim_in"))) is not None:
+        payload["rear_rim_in"] = rear_rim
+    if (
+        default_axle := analysis_settings_axle_from_mapping(values.get("default_axle_for_speed"))
+    ) is not None:
+        payload["default_axle_for_speed"] = default_axle
+    if (final_drive := _finite_float_or_none(values.get("final_drive_ratio"))) is not None:
+        payload["final_drive_ratio"] = final_drive
+    if (current_gear := _finite_float_or_none(values.get("current_gear_ratio"))) is not None:
+        payload["current_gear_ratio"] = current_gear
+    if (wheel_bandwidth := _finite_float_or_none(values.get("wheel_bandwidth_pct"))) is not None:
+        payload["wheel_bandwidth_pct"] = wheel_bandwidth
+    if (
+        driveshaft_bandwidth := _finite_float_or_none(values.get("driveshaft_bandwidth_pct"))
+    ) is not None:
+        payload["driveshaft_bandwidth_pct"] = driveshaft_bandwidth
+    if (engine_bandwidth := _finite_float_or_none(values.get("engine_bandwidth_pct"))) is not None:
+        payload["engine_bandwidth_pct"] = engine_bandwidth
+    if (
+        speed_uncertainty := _finite_float_or_none(values.get("speed_uncertainty_pct"))
+    ) is not None:
+        payload["speed_uncertainty_pct"] = speed_uncertainty
+    if (
+        tire_diameter_uncertainty := _finite_float_or_none(
+            values.get("tire_diameter_uncertainty_pct")
+        )
+    ) is not None:
+        payload["tire_diameter_uncertainty_pct"] = tire_diameter_uncertainty
+    if (
+        final_drive_uncertainty := _finite_float_or_none(values.get("final_drive_uncertainty_pct"))
+    ) is not None:
+        payload["final_drive_uncertainty_pct"] = final_drive_uncertainty
+    if (gear_uncertainty := _finite_float_or_none(values.get("gear_uncertainty_pct"))) is not None:
+        payload["gear_uncertainty_pct"] = gear_uncertainty
+    if (min_abs_band := _finite_float_or_none(values.get("min_abs_band_hz"))) is not None:
+        payload["min_abs_band_hz"] = min_abs_band
+    if (
+        max_band_half_width := _finite_float_or_none(values.get("max_band_half_width_pct"))
+    ) is not None:
+        payload["max_band_half_width_pct"] = max_band_half_width
+    if (deflection := _finite_float_or_none(values.get("tire_deflection_factor"))) is not None:
+        payload["tire_deflection_factor"] = deflection
     return payload
+
+
+def analysis_settings_axle_from_mapping(value: object) -> TireSpeedAxle | None:
+    if value == "front":
+        return "front"
+    if value == "rear":
+        return "rear"
+    if value == "average":
+        return "average"
+    return None
+
+
+def _finite_float_or_none(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if not isinstance(value, int | float | str):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
 
 
 type LanguageCode = Literal["en", "nl"]

--- a/apps/server/vibesensor/use_cases/run/run_context.py
+++ b/apps/server/vibesensor/use_cases/run/run_context.py
@@ -90,14 +90,18 @@ def _build_car_settings_changed_warning(
     )
 
 
-def _normalized_recorded_order_reference(metadata: RunMetadata) -> tuple[tuple[str, float], ...]:
+def _normalized_recorded_order_reference(
+    metadata: RunMetadata,
+) -> tuple[tuple[str, float | str], ...]:
     spec = metadata.order_reference_spec
     if spec is None:
         return ()
     return tuple(sorted(order_reference_mapping_from_spec(spec).items()))
 
 
-def _normalized_current_car_settings(snapshot: CarSnapshot) -> tuple[tuple[str, float], ...]:
+def _normalized_current_car_settings(
+    snapshot: CarSnapshot,
+) -> tuple[tuple[str, float | str], ...]:
     spec = order_reference_spec_from_mapping(snapshot.aspects)
     if spec is None:
         return ()

--- a/apps/ui/src/app/features/cars_feature.ts
+++ b/apps/ui/src/app/features/cars_feature.ts
@@ -14,7 +14,7 @@ export interface CarsFeatureDeps {
   addCarFromWizard: (
     name: string,
     carType: string,
-    aspects: Record<string, number>,
+    aspects: Record<string, number | string>,
     orderReferenceStatus?: CarOrderReferenceStatus,
     variant?: string,
   ) => Promise<void>;

--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -13,6 +13,7 @@ import {
   tireInputsFromOption,
   type CarsFeatureManualInputState,
 } from "./cars_manual_input";
+import { tireSetupAspectsFromOption } from "./cars_tire_setup";
 import {
   createErrorOptionsState,
   createIdleOptionsState,
@@ -113,7 +114,7 @@ export interface CarsFeatureWorkflowDeps {
   addCarFromWizard(
     name: string,
     carType: string,
-    aspects: Record<string, number>,
+    aspects: Record<string, number | string>,
     orderReferenceStatus?: CarOrderReferenceStatus,
     variant?: string,
   ): Promise<void>;
@@ -491,9 +492,7 @@ export function createCarsFeatureWorkflow(
           {
             current_gear_ratio: gearbox.top_gear_ratio,
             final_drive_ratio: gearbox.final_drive_ratio,
-            rim_in: tire.rim_in,
-            tire_aspect_pct: tire.tire_aspect_pct,
-            tire_width_mm: tire.tire_width_mm,
+            ...tireSetupAspectsFromOption(tire),
           },
           {
             current_gear_ratio_confidence: gearbox.top_gear_ratio_confidence ?? "unverified",

--- a/apps/ui/src/app/features/cars_manual_input.ts
+++ b/apps/ui/src/app/features/cars_manual_input.ts
@@ -1,4 +1,5 @@
 import type { CarLibraryTireOption } from "../../api/types";
+import { tireOptionFront } from "./cars_tire_setup";
 import {
   DEFAULT_CARS_WIZARD_MANUAL_INPUTS,
   readWizardManualGearboxValues,
@@ -64,11 +65,15 @@ export function tireInputsFromOption(
   option: CarLibraryTireOption,
   current: CarsFeatureManualInputState,
 ): CarsFeatureManualInputState {
+  const front = tireOptionFront(option);
+  if (!front) {
+    return current;
+  }
   return {
     ...current,
-    rim: String(option.rim_in),
-    tireAspect: String(option.tire_aspect_pct),
-    tireWidth: String(option.tire_width_mm),
+    rim: String(front.rim_in),
+    tireAspect: String(front.aspect_pct),
+    tireWidth: String(front.width_mm),
   };
 }
 

--- a/apps/ui/src/app/features/cars_tire_setup.ts
+++ b/apps/ui/src/app/features/cars_tire_setup.ts
@@ -1,0 +1,136 @@
+import type { CarLibraryTireOption } from "../../api/types";
+
+type FormatNumber = (value: number, digits?: number) => string;
+
+interface TireDimensions {
+  width_mm: number;
+  aspect_pct: number;
+  rim_in: number;
+}
+
+type AspectsRecord = Record<string, number | string | null | undefined>;
+
+function isPositiveNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function formatRim(rimIn: number, fmt: FormatNumber): string {
+  return fmt(rimIn, Number.isInteger(rimIn) ? 0 : 1);
+}
+
+export function tireOptionFront(option: CarLibraryTireOption): TireDimensions | null {
+  if (option.front) {
+    return option.front;
+  }
+  if (
+    isPositiveNumber(option.tire_width_mm)
+    && isPositiveNumber(option.tire_aspect_pct)
+    && isPositiveNumber(option.rim_in)
+  ) {
+    return {
+      width_mm: option.tire_width_mm,
+      aspect_pct: option.tire_aspect_pct,
+      rim_in: option.rim_in,
+    };
+  }
+  return null;
+}
+
+export function tireOptionRear(option: CarLibraryTireOption): TireDimensions | null {
+  return option.rear ?? tireOptionFront(option);
+}
+
+export function tireOptionIsStaggered(option: CarLibraryTireOption): boolean {
+  const front = tireOptionFront(option);
+  const rear = tireOptionRear(option);
+  if (!front || !rear) {
+    return false;
+  }
+  return front.width_mm !== rear.width_mm
+    || front.aspect_pct !== rear.aspect_pct
+    || front.rim_in !== rear.rim_in;
+}
+
+function formatTireSize(size: TireDimensions, fmt: FormatNumber): string {
+  return `${fmt(size.width_mm, 0)}/${fmt(size.aspect_pct, 0)}R${formatRim(size.rim_in, fmt)}`;
+}
+
+export function formatCarLibraryTireOption(
+  option: CarLibraryTireOption,
+  fmt: FormatNumber,
+): string | null {
+  const front = tireOptionFront(option);
+  const rear = tireOptionRear(option);
+  if (!front || !rear) {
+    return null;
+  }
+  if (!tireOptionIsStaggered(option)) {
+    return formatTireSize(front, fmt);
+  }
+  return `Front ${formatTireSize(front, fmt)} · Rear ${formatTireSize(rear, fmt)}`;
+}
+
+function tireFromAspects(
+  aspects: AspectsRecord,
+  prefix: "" | "front_" | "rear_",
+): TireDimensions | null {
+  const width = aspects[`${prefix}tire_width_mm`];
+  const aspect = aspects[`${prefix}tire_aspect_pct`];
+  const rim = aspects[`${prefix}rim_in`];
+  if (!isPositiveNumber(width) || !isPositiveNumber(aspect) || !isPositiveNumber(rim)) {
+    return null;
+  }
+  return {
+    width_mm: width,
+    aspect_pct: aspect,
+    rim_in: rim,
+  };
+}
+
+export function formatSavedCarTireSummary(
+  aspects: AspectsRecord | null | undefined,
+  fmt: FormatNumber,
+  missingText: string,
+): string {
+  if (!aspects) {
+    return missingText;
+  }
+  const front = tireFromAspects(aspects, "front_") ?? tireFromAspects(aspects, "");
+  const rear = tireFromAspects(aspects, "rear_") ?? front;
+  if (!front || !rear) {
+    return missingText;
+  }
+  if (
+    front.width_mm === rear.width_mm
+    && front.aspect_pct === rear.aspect_pct
+    && front.rim_in === rear.rim_in
+  ) {
+    return formatTireSize(front, fmt);
+  }
+  return `Front ${formatTireSize(front, fmt)} · Rear ${formatTireSize(rear, fmt)}`;
+}
+
+export function tireSetupAspectsFromOption(
+  option: CarLibraryTireOption,
+): Record<string, number | string> {
+  const front = tireOptionFront(option);
+  const rear = tireOptionRear(option);
+  if (!front || !rear) {
+    return {};
+  }
+  const payload: Record<string, number | string> = {
+    rim_in: option.rim_in,
+    tire_aspect_pct: option.tire_aspect_pct,
+    tire_width_mm: option.tire_width_mm,
+  };
+  if (tireOptionIsStaggered(option) || option.default_axle_for_speed !== "rear") {
+    payload.front_tire_width_mm = front.width_mm;
+    payload.front_tire_aspect_pct = front.aspect_pct;
+    payload.front_rim_in = front.rim_in;
+    payload.rear_tire_width_mm = rear.width_mm;
+    payload.rear_tire_aspect_pct = rear.aspect_pct;
+    payload.rear_rim_in = rear.rim_in;
+    payload.default_axle_for_speed = option.default_axle_for_speed;
+  }
+  return payload;
+}

--- a/apps/ui/src/app/features/cars_wizard_state.ts
+++ b/apps/ui/src/app/features/cars_wizard_state.ts
@@ -5,6 +5,7 @@ import type {
   CarLibraryVariant,
 } from "../../api";
 import type { WizardSummaryData } from "../views/car_wizard_view";
+import { formatCarLibraryTireOption } from "./cars_tire_setup";
 
 export type WizardSpecBranch = "library" | "manual" | null;
 
@@ -174,7 +175,10 @@ function formatWizardTireLabel(
   if (!tire) {
     return null;
   }
-  const size = `${tire.tire_width_mm}/${tire.tire_aspect_pct}R${formatWizardRimSize(tire.rim_in, fmt)}`;
+  const size = formatCarLibraryTireOption(tire, fmt);
+  if (!size) {
+    return null;
+  }
   return tire.name ? `${tire.name} · ${size}` : size;
 }
 

--- a/apps/ui/src/app/features/settings_cars_module.ts
+++ b/apps/ui/src/app/features/settings_cars_module.ts
@@ -69,7 +69,7 @@ export interface SettingsCarsModule {
   addCarFromWizard(
     name: string,
     carType: string,
-    aspects: Record<string, number>,
+    aspects: Record<string, number | string>,
     orderReferenceStatus?: CarOrderReferenceStatus,
     variant?: string,
   ): Promise<void>;
@@ -189,7 +189,7 @@ export function createSettingsCarsModule(
   async function addCarFromWizard(
     name: string,
     carType: string,
-    aspects: Record<string, number>,
+    aspects: Record<string, number | string>,
     orderReferenceStatus?: CarOrderReferenceStatus,
     variant?: string,
   ): Promise<void> {

--- a/apps/ui/src/app/features/settings_feature.ts
+++ b/apps/ui/src/app/features/settings_feature.ts
@@ -62,7 +62,7 @@ export interface SettingsFeature {
   addCarFromWizard(
     name: string,
     carType: string,
-    aspects: Record<string, number>,
+    aspects: Record<string, number | string>,
     orderReferenceStatus?: CarOrderReferenceStatus,
     variant?: string,
   ): Promise<void>;

--- a/apps/ui/src/app/views/car_wizard_view.ts
+++ b/apps/ui/src/app/views/car_wizard_view.ts
@@ -8,6 +8,7 @@ import type {
 } from "../features/cars_feature_workflow";
 import type { CarsFeatureOptionsState } from "../features/cars_option_state";
 import { DEFAULT_CARS_WIZARD_MANUAL_INPUTS } from "../features/cars_wizard_state";
+import { formatCarLibraryTireOption } from "../features/cars_tire_setup";
 
 type FormatNumber = (value: number, digits?: number) => string;
 type Translate = (key: string, vars?: Record<string, unknown>) => string;
@@ -159,13 +160,14 @@ function buildVariantOptionsModel(
 function buildTireOptionsModel(
   tireOptions: readonly CarLibraryTireOption[],
   selectedTire: CarLibraryTireOption | null,
+  fmt: FormatNumber,
 ): CarsWizardOptionsRenderModel {
   return {
     attribute: "data-tire-idx",
     layout: "chips",
     messageText: null,
     options: tireOptions.map((tireOption, index) => ({
-      detailText: `${tireOption.tire_width_mm}/${tireOption.tire_aspect_pct}R${tireOption.rim_in}`,
+      detailText: formatCarLibraryTireOption(tireOption, fmt),
       labelText: tireOption.name,
       selected: tireOption === selectedTire,
       value: String(index),
@@ -273,7 +275,7 @@ export function buildCarsWizardRenderModel(
       profileNameValueText: state.summaryData.profileName ?? pending,
       rows: buildSummaryRows(state.summaryData, t),
     },
-    tireOptions: buildTireOptionsModel(state.tireOptions, state.selectedTire),
+    tireOptions: buildTireOptionsModel(state.tireOptions, state.selectedTire, fmt),
     typeOptions: buildOptionsModel(
       state.typeOptions,
       "data-value",

--- a/apps/ui/src/app/views/settings_car_list_view.ts
+++ b/apps/ui/src/app/views/settings_car_list_view.ts
@@ -1,5 +1,6 @@
 import type { CarRecord } from "../../api/types";
 import { type CarSelectionState, getCarCompleteness } from "../car_selection_state";
+import { formatSavedCarTireSummary } from "../features/cars_tire_setup";
 
 export interface CarsListHighlightedFeedback {
   carId: string;
@@ -153,17 +154,10 @@ function hasConfiguredNumber(value: unknown): value is number {
 
 function formatTireSummary(
   car: CarRecord,
+  fmt: SettingsCarListViewParams["fmt"],
   t: SettingsCarListViewParams["t"],
 ): string {
-  const aspects = car.aspects || {};
-  if (
-    hasConfiguredNumber(aspects.tire_width_mm)
-    && hasConfiguredNumber(aspects.tire_aspect_pct)
-    && hasConfiguredNumber(aspects.rim_in)
-  ) {
-    return `${aspects.tire_width_mm}/${aspects.tire_aspect_pct}R${aspects.rim_in}`;
-  }
-  return t("settings.car.tires_missing");
+  return formatSavedCarTireSummary(car.aspects, fmt, t("settings.car.tires_missing"));
 }
 
 function formatRatioValue(
@@ -297,7 +291,7 @@ export function buildSettingsCarListRenderModel(
           {
             isCode: true,
             labelText: t("settings.car.col_tires"),
-            valueText: formatTireSummary(car, t),
+            valueText: formatTireSummary(car, fmt, t),
           },
           {
             labelText: t("settings.car.col_drive"),

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -115,6 +115,9 @@
             "title": "Current Gear Ratio",
             "type": "number"
           },
+          "default_axle_for_speed": {
+            "$ref": "#/components/schemas/TireSpeedAxle"
+          },
           "driveshaft_bandwidth_pct": {
             "title": "Driveshaft Bandwidth Pct",
             "type": "number"
@@ -131,6 +134,18 @@
             "title": "Final Drive Uncertainty Pct",
             "type": "number"
           },
+          "front_rim_in": {
+            "title": "Front Rim In",
+            "type": "number"
+          },
+          "front_tire_aspect_pct": {
+            "title": "Front Tire Aspect Pct",
+            "type": "number"
+          },
+          "front_tire_width_mm": {
+            "title": "Front Tire Width Mm",
+            "type": "number"
+          },
           "gear_uncertainty_pct": {
             "title": "Gear Uncertainty Pct",
             "type": "number"
@@ -141,6 +156,18 @@
           },
           "min_abs_band_hz": {
             "title": "Min Abs Band Hz",
+            "type": "number"
+          },
+          "rear_rim_in": {
+            "title": "Rear Rim In",
+            "type": "number"
+          },
+          "rear_tire_aspect_pct": {
+            "title": "Rear Tire Aspect Pct",
+            "type": "number"
+          },
+          "rear_tire_width_mm": {
+            "title": "Rear Tire Width Mm",
             "type": "number"
           },
           "rim_in": {
@@ -190,6 +217,22 @@
             ],
             "title": "Current Gear Ratio"
           },
+          "default_axle_for_speed": {
+            "anyOf": [
+              {
+                "enum": [
+                  "front",
+                  "rear",
+                  "average"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Axle For Speed"
+          },
           "driveshaft_bandwidth_pct": {
             "anyOf": [
               {
@@ -238,6 +281,42 @@
             ],
             "title": "Final Drive Uncertainty Pct"
           },
+          "front_rim_in": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Front Rim In"
+          },
+          "front_tire_aspect_pct": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Front Tire Aspect Pct"
+          },
+          "front_tire_width_mm": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Front Tire Width Mm"
+          },
           "gear_uncertainty_pct": {
             "anyOf": [
               {
@@ -273,6 +352,42 @@
               }
             ],
             "title": "Min Abs Band Hz"
+          },
+          "rear_rim_in": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rear Rim In"
+          },
+          "rear_tire_aspect_pct": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rear Tire Aspect Pct"
+          },
+          "rear_tire_width_mm": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rear Tire Width Mm"
           },
           "rim_in": {
             "anyOf": [
@@ -370,6 +485,16 @@
             "title": "Current Gear Ratio",
             "type": "number"
           },
+          "default_axle_for_speed": {
+            "default": "rear",
+            "enum": [
+              "front",
+              "rear",
+              "average"
+            ],
+            "title": "Default Axle For Speed",
+            "type": "string"
+          },
           "driveshaft_bandwidth_pct": {
             "title": "Driveshaft Bandwidth Pct",
             "type": "number"
@@ -386,6 +511,39 @@
             "title": "Final Drive Uncertainty Pct",
             "type": "number"
           },
+          "front_rim_in": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Front Rim In"
+          },
+          "front_tire_aspect_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Front Tire Aspect Pct"
+          },
+          "front_tire_width_mm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Front Tire Width Mm"
+          },
           "gear_uncertainty_pct": {
             "title": "Gear Uncertainty Pct",
             "type": "number"
@@ -397,6 +555,39 @@
           "min_abs_band_hz": {
             "title": "Min Abs Band Hz",
             "type": "number"
+          },
+          "rear_rim_in": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rear Rim In"
+          },
+          "rear_tire_aspect_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rear Tire Aspect Pct"
+          },
+          "rear_tire_width_mm": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rear Tire Width Mm"
           },
           "rim_in": {
             "title": "Rim In",
@@ -1092,19 +1283,81 @@
         "title": "CarLibraryModelsResponse",
         "type": "object"
       },
-      "CarLibraryTireOptionEntry": {
+      "CarLibraryTireDimensionsEntry": {
         "additionalProperties": false,
-        "description": "A tire size option from the car library.",
+        "description": "One axle's tire dimensions.",
         "properties": {
-          "name": {
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
+          "aspect_pct": {
+            "exclusiveMinimum": 0.0,
+            "title": "Aspect Pct",
+            "type": "number"
           },
           "rim_in": {
             "exclusiveMinimum": 0.0,
             "title": "Rim In",
             "type": "number"
+          },
+          "width_mm": {
+            "exclusiveMinimum": 0.0,
+            "title": "Width Mm",
+            "type": "number"
+          }
+        },
+        "required": [
+          "width_mm",
+          "aspect_pct",
+          "rim_in"
+        ],
+        "title": "CarLibraryTireDimensionsEntry",
+        "type": "object"
+      },
+      "CarLibraryTireOptionEntry": {
+        "additionalProperties": false,
+        "description": "A tire size option from the car library.",
+        "properties": {
+          "default_axle_for_speed": {
+            "default": "rear",
+            "enum": [
+              "front",
+              "rear",
+              "average"
+            ],
+            "title": "Default Axle For Speed",
+            "type": "string"
+          },
+          "front": {
+            "$ref": "#/components/schemas/CarLibraryTireDimensionsEntry"
+          },
+          "name": {
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "rear": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CarLibraryTireDimensionsEntry"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "rim_in": {
+            "exclusiveMinimum": 0.0,
+            "title": "Rim In",
+            "type": "number"
+          },
+          "source_confidence": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Confidence"
           },
           "tire_aspect_pct": {
             "exclusiveMinimum": 0.0,
@@ -1121,7 +1374,8 @@
           "name",
           "tire_width_mm",
           "tire_aspect_pct",
-          "rim_in"
+          "rim_in",
+          "front"
         ],
         "title": "CarLibraryTireOptionEntry",
         "type": "object"
@@ -7969,6 +8223,14 @@
         ],
         "title": "TestPlanStepResponse",
         "type": "object"
+      },
+      "TireSpeedAxle": {
+        "enum": [
+          "front",
+          "rear",
+          "average"
+        ],
+        "type": "string"
       },
       "UpdateCancelResponse": {
         "description": "Response body confirming whether an OTA update job was cancelled.",

--- a/apps/ui/tests/car_list_state.spec.ts
+++ b/apps/ui/tests/car_list_state.spec.ts
@@ -211,6 +211,42 @@ test("buildSettingsCarListRenderModel surfaces approximate drivetrain guidance f
   });
 });
 
+test("buildSettingsCarListRenderModel shows staggered front and rear tire sizes when present", () => {
+  const model = buildSettingsCarListRenderModel({
+    cars: [
+      makeCar({
+        id: "car-staggered",
+        aspects: {
+          tire_width_mm: 315,
+          tire_aspect_pct: 30,
+          rim_in: 22,
+          front_tire_width_mm: 275,
+          front_tire_aspect_pct: 35,
+          front_rim_in: 22,
+          rear_tire_width_mm: 315,
+          rear_tire_aspect_pct: 30,
+          rear_rim_in: 22,
+          final_drive_ratio: 3.08,
+          current_gear_ratio: 0.64,
+        },
+      }),
+    ],
+    activeCarId: null,
+    t,
+    fmt,
+  });
+
+  expect(model.kind).toBe("rows");
+  if (model.kind !== "rows") {
+    throw new Error("Expected staggered car rows");
+  }
+  expect(model.rows[0].setupMetrics[0]).toEqual({
+    isCode: true,
+    labelText: "Tires",
+    valueText: "Front 275/35R22 · Rear 315/30R22",
+  });
+});
+
 test("buildSettingsCarListRenderModel produces the actionable empty state when no cars exist", () => {
   const model = buildSettingsCarListRenderModel({
     cars: [],

--- a/apps/ui/tests/car_wizard_view.spec.ts
+++ b/apps/ui/tests/car_wizard_view.spec.ts
@@ -45,8 +45,16 @@ function makeGearbox(overrides: Partial<CarLibraryGearbox> = {}): CarLibraryGear
 
 function makeTireOption(overrides: Partial<CarLibraryTireOption> = {}): CarLibraryTireOption {
   return {
+    default_axle_for_speed: "rear",
+    front: {
+      width_mm: 245,
+      aspect_pct: 40,
+      rim_in: 18,
+    },
     name: "Sport",
+    rear: null,
     rim_in: 18,
+    source_confidence: "official_exact",
     tire_aspect_pct: 40,
     tire_width_mm: 245,
     ...overrides,
@@ -216,5 +224,38 @@ describe("car wizard view helpers", () => {
       labelText: "settings.car.wizard_summary_gearbox",
       valueText: "6-speed",
     });
+  });
+
+  test("buildCarsWizardRenderModel shows front and rear sizes for staggered tire options", () => {
+    const tire = makeTireOption({
+      front: {
+        width_mm: 245,
+        aspect_pct: 40,
+        rim_in: 19,
+      },
+      rear: {
+        width_mm: 275,
+        aspect_pct: 35,
+        rim_in: 19,
+      },
+      rim_in: 19,
+      tire_aspect_pct: 35,
+      tire_width_mm: 275,
+    });
+
+    const model = buildCarsWizardRenderModel(createRenderState({
+      selectedTire: tire,
+      tireOptions: [tire],
+    }), {
+      fmt: (value, digits = 0) => Number(value).toFixed(digits),
+      t: createTranslator(),
+    });
+
+    expect(model.tireOptions.options).toEqual([{
+      detailText: "Front 245/40R19 · Rear 275/35R19",
+      labelText: "Sport",
+      selected: true,
+      value: "0",
+    }]);
   });
 });

--- a/apps/ui/tests/cars_feature_workflow.spec.ts
+++ b/apps/ui/tests/cars_feature_workflow.spec.ts
@@ -77,8 +77,16 @@ function makeGearbox(overrides: Partial<CarLibraryGearbox> = {}): CarLibraryGear
 
 function makeTireOption(overrides: Partial<CarLibraryTireOption> = {}): CarLibraryTireOption {
   return {
+    default_axle_for_speed: "rear",
+    front: {
+      width_mm: 275,
+      aspect_pct: 40,
+      rim_in: 21,
+    },
     name: "Factory staggered",
+    rear: null,
     rim_in: 21,
+    source_confidence: "official_exact",
     tire_aspect_pct: 40,
     tire_width_mm: 275,
     ...overrides,
@@ -127,7 +135,7 @@ describe("createCarsFeatureWorkflow", () => {
   test("finishes the manual branch without DOM fixtures and closes the wizard", async () => {
     const harness = createHarness();
     const addCalls: Array<{
-      aspects: Record<string, number>;
+      aspects: Record<string, number | string>;
       carType: string;
       name: string;
       orderReferenceStatus?: CarOrderReferenceStatus;
@@ -222,9 +230,20 @@ describe("createCarsFeatureWorkflow", () => {
   test("keeps manual gearbox inputs when tire autofill updates only tire fields", async () => {
     const harness = createHarness();
     const tire = makeTireOption({
-      rim_in: 20,
+      front: {
+        width_mm: 275,
+        aspect_pct: 40,
+        rim_in: 21,
+      },
+      rear: {
+        width_mm: 315,
+        aspect_pct: 35,
+        rim_in: 21,
+      },
+      default_axle_for_speed: "rear",
+      rim_in: 21,
       tire_aspect_pct: 35,
-      tire_width_mm: 285,
+      tire_width_mm: 315,
     });
     const workflow = createCarsFeatureWorkflow({
       addCarFromWizard: async () => undefined,
@@ -258,9 +277,9 @@ describe("createCarsFeatureWorkflow", () => {
 
     expect(workflow.getRenderState().manualInputs).toEqual({
       finalDrive: "4.10",
-      rim: "20",
-      tireAspect: "35",
-      tireWidth: "285",
+      rim: "21",
+      tireAspect: "40",
+      tireWidth: "275",
       topGear: "0.71",
     });
   });
@@ -390,13 +409,26 @@ describe("createCarsFeatureWorkflow", () => {
   test("keeps the library branch disabled until a gearbox is chosen and then submits the selected specs", async () => {
     const harness = createHarness();
     const addCalls: Array<{
-      aspects: Record<string, number>;
+      aspects: Record<string, number | string>;
       carType: string;
       name: string;
       orderReferenceStatus?: CarOrderReferenceStatus;
       variant?: string;
     }> = [];
-    const tire = makeTireOption();
+    const tire = makeTireOption({
+      front: {
+        width_mm: 245,
+        aspect_pct: 40,
+        rim_in: 21,
+      },
+      rear: {
+        width_mm: 275,
+        aspect_pct: 35,
+        rim_in: 21,
+      },
+      tire_aspect_pct: 35,
+      tire_width_mm: 275,
+    });
     const gearbox = makeGearbox();
     const workflow = createCarsFeatureWorkflow({
       addCarFromWizard: async (name, carType, aspects, orderReferenceStatus, variant) => {
@@ -441,9 +473,16 @@ describe("createCarsFeatureWorkflow", () => {
     expect(addCalls).toEqual([{
       aspects: {
         current_gear_ratio: 0.67,
+        default_axle_for_speed: "rear",
         final_drive_ratio: 3.15,
+        front_rim_in: 21,
+        front_tire_aspect_pct: 40,
+        front_tire_width_mm: 245,
+        rear_rim_in: 21,
+        rear_tire_aspect_pct: 35,
+        rear_tire_width_mm: 275,
         rim_in: 21,
-        tire_aspect_pct: 40,
+        tire_aspect_pct: 35,
         tire_width_mm: 275,
       },
       carType: "SUV",

--- a/apps/ui/tests/msw/handlers/settings.ts
+++ b/apps/ui/tests/msw/handlers/settings.ts
@@ -45,10 +45,11 @@ async function resolveHandlerResult<T extends JsonBodyType>(
 export function makeAnalysisSettingsPayload(
   overrides: Partial<AnalysisSettingsPayload> = {},
 ): AnalysisSettingsPayload {
-  return {
+  const payload = {
     tire_width_mm: 225,
     tire_aspect_pct: 45,
     rim_in: 18,
+    default_axle_for_speed: "rear" as const,
     final_drive_ratio: 3.08,
     current_gear_ratio: 0.64,
     driveshaft_bandwidth_pct: 10,
@@ -63,6 +64,16 @@ export function makeAnalysisSettingsPayload(
     min_abs_band_hz: 0.2,
     ...overrides,
   };
+  return {
+    ...payload,
+    default_axle_for_speed: payload.default_axle_for_speed ?? "rear",
+    front_tire_width_mm: payload.front_tire_width_mm ?? undefined,
+    front_tire_aspect_pct: payload.front_tire_aspect_pct ?? undefined,
+    front_rim_in: payload.front_rim_in ?? undefined,
+    rear_tire_width_mm: payload.rear_tire_width_mm ?? undefined,
+    rear_tire_aspect_pct: payload.rear_tire_aspect_pct ?? undefined,
+    rear_rim_in: payload.rear_rim_in ?? undefined,
+  };
 }
 
 export function makeCarRecord(overrides: Partial<CarRecord> = {}): CarRecord {
@@ -71,8 +82,57 @@ export function makeCarRecord(overrides: Partial<CarRecord> = {}): CarRecord {
     name: "Track Demo",
     type: "Coupe",
     variant: null,
-    aspects: makeAnalysisSettingsPayload(),
+    aspects: makeCarAspects(),
     ...overrides,
+  };
+}
+
+function makeCarAspects(
+  overrides: Partial<CarRecord["aspects"]> = {},
+): CarRecord["aspects"] {
+  const payload = {
+    tire_width_mm: 225,
+    tire_aspect_pct: 45,
+    rim_in: 18,
+    default_axle_for_speed: "rear" as const,
+    final_drive_ratio: 3.08,
+    current_gear_ratio: 0.64,
+    driveshaft_bandwidth_pct: 10,
+    engine_bandwidth_pct: 10,
+    final_drive_uncertainty_pct: 1,
+    gear_uncertainty_pct: 1,
+    max_band_half_width_pct: 20,
+    tire_deflection_factor: 0.95,
+    tire_diameter_uncertainty_pct: 1,
+    wheel_bandwidth_pct: 5,
+    speed_uncertainty_pct: 1,
+    min_abs_band_hz: 0.2,
+    ...overrides,
+  };
+  return {
+    ...payload,
+    current_gear_ratio: payload.current_gear_ratio ?? undefined,
+    default_axle_for_speed: payload.default_axle_for_speed ?? undefined,
+    driveshaft_bandwidth_pct: payload.driveshaft_bandwidth_pct ?? undefined,
+    engine_bandwidth_pct: payload.engine_bandwidth_pct ?? undefined,
+    final_drive_ratio: payload.final_drive_ratio ?? undefined,
+    final_drive_uncertainty_pct: payload.final_drive_uncertainty_pct ?? undefined,
+    front_tire_width_mm: payload.front_tire_width_mm ?? undefined,
+    front_tire_aspect_pct: payload.front_tire_aspect_pct ?? undefined,
+    front_rim_in: payload.front_rim_in ?? undefined,
+    gear_uncertainty_pct: payload.gear_uncertainty_pct ?? undefined,
+    max_band_half_width_pct: payload.max_band_half_width_pct ?? undefined,
+    min_abs_band_hz: payload.min_abs_band_hz ?? undefined,
+    rear_tire_width_mm: payload.rear_tire_width_mm ?? undefined,
+    rear_tire_aspect_pct: payload.rear_tire_aspect_pct ?? undefined,
+    rear_rim_in: payload.rear_rim_in ?? undefined,
+    rim_in: payload.rim_in ?? undefined,
+    speed_uncertainty_pct: payload.speed_uncertainty_pct ?? undefined,
+    tire_aspect_pct: payload.tire_aspect_pct ?? undefined,
+    tire_deflection_factor: payload.tire_deflection_factor ?? undefined,
+    tire_diameter_uncertainty_pct: payload.tire_diameter_uncertainty_pct ?? undefined,
+    tire_width_mm: payload.tire_width_mm ?? undefined,
+    wheel_bandwidth_pct: payload.wheel_bandwidth_pct ?? undefined,
   };
 }
 

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -144,3 +144,32 @@ The source of truth is the resolved `VehicleConfiguration`:
   wizard saves a car profile.
 - UI consumers should use `requires_manual_confirmation` to keep approximate
   drivetrain values visibly approximate until the user confirms them.
+
+## Axle-aware tire setups
+
+Issue #3233 extends the same one-owner rule to tire data.
+
+Car-library tire options may now be:
+
+- square, with the legacy flat `tire_width_mm` / `tire_aspect_pct` / `rim_in`
+  fields only
+- staggered, with explicit `front` and `rear` tire dimensions plus
+  `default_axle_for_speed`
+
+Rules:
+
+1. The canonical tire truth is the front/rear axle setup, not the legacy flat
+   projection.
+2. Legacy flat tire rows still load through one compatibility path by treating
+   them as square axle setups.
+3. Order-reference math resolves rolling circumference from the configured axle
+   rule: `front`, `rear`, or `average`.
+4. Saved-car aspects persist the axle-aware fields when present so staggered
+   selections do not silently flatten during save/load.
+5. Manual flat tire overrides intentionally clear any persisted axle-specific
+   tire fields so an explicit user override becomes the new square setup.
+
+The flat top-level tire fields remain in API/settings payloads only as a
+compatibility projection for callers that still expect one boundary tire size.
+When a staggered setup is present, that projection follows the selected
+`default_axle_for_speed`.


### PR DESCRIPTION
## What changed
- add one canonical `AxleTireSetup` path for square and staggered tire data, with explicit `default_axle_for_speed` support for front, rear, or average rolling behavior
- keep legacy flat tire rows loading through one compatibility path, but thread axle-aware tire fields through saved-car aspects, analysis settings, car-library persistence, HTTP models, and generated UI contracts
- migrate three real BMW model entries to front/rear tire examples: `8 Series Coupe (G15)`, `X5 (G05)`, and `X6 (G06)`
- show front/rear tire sizes in wizard and saved-car UI, and make flat manual tire overrides clear stale axle-specific setup instead of silently preserving it
- add focused backend and frontend coverage for staggered loading, effective circumference selection, UI display, and manual override behavior
- update `docs/car_library_architecture.md` for the axle-aware tire rule

## Why
- old tire options flattened everything into one `tire_width_mm/tire_aspect_pct/rim_in` triple
- that lost front/rear differences in analysis math, saved-car persistence, and UI rendering
- staggered setups need one real owner path, not display-only metadata on top of lossy runtime state

## Validation
- `make sync-contracts`
- `./.venv/bin/pytest -n0 -q apps/server/tests/domain/test_car_domain.py apps/server/tests/use_cases/diagnostics/test_analysis_settings.py apps/server/tests/shared/types/test_settings_types.py apps/server/tests/shared/boundaries/test_settings_http_payloads.py apps/server/tests/infra/config/test_car_settings.py apps/server/tests/adapters/persistence/test_car_library.py apps/server/tests/adapters/persistence/test_car_variants.py apps/server/tests/adapters/persistence/test_car_library_routes.py apps/server/tests/adapters/http/test_settings_car_endpoints.py`
- `cd apps/ui && npm run test:unit -- tests/cars_feature_workflow.spec.ts tests/settings_cars_module.spec.ts tests/car_list_state.spec.ts tests/car_wizard_view.spec.ts`
- `make typecheck-backend`
- `make ui-typecheck`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `make docs-lint`

## Risks / tradeoffs / edge cases
- flat tire fields remain as compatibility projections only; when a staggered setup exists they follow `default_axle_for_speed`
- the three migrated BMW staggered examples use `reputable_secondary_crosschecked` confidence, not exact-row provenance
- this PR updates the compatibility picker path and saved-car path together so staggered data does not get flattened between selection and persistence

## Follow-up
- broader exact-row migration for tire provenance stays out of scope here
