### PR TITLE
Add physical plausibility and consistency validation for car-library rows

### DIFF
--- a/apps/server/tests/adapters/persistence/test_car_library_validation.py
+++ b/apps/server/tests/adapters/persistence/test_car_library_validation.py
@@ -1,0 +1,342 @@
+"""Focused regression coverage for car-library plausibility validation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+
+from vibesensor.adapters.persistence.car_library import (
+    _DATA_FILE,
+    load_car_library,
+    load_vehicle_configurations,
+)
+from vibesensor.adapters.persistence.car_library_validation import (
+    load_car_library_validation_allowlist,
+    validate_car_library_rows,
+    validate_vehicle_configurations,
+)
+from vibesensor.domain import (
+    AxleTireSetup,
+    TireSpec,
+    VehicleConfiguration,
+    VehicleConfigurationTireOption,
+    VehicleFieldProvenance,
+)
+
+
+def _make_valid_legacy_entry() -> dict[str, object]:
+    return {
+        "brand": "BMW",
+        "type": "SUV",
+        "model": "Validation Test Model",
+        "gearboxes": [
+            {
+                "name": "8-speed automatic (ZF 8HP)",
+                "final_drive_ratio": 3.15,
+                "top_gear_ratio": 0.67,
+            }
+        ],
+        "tire_options": [
+            {
+                "name": 'Standard 18"',
+                "tire_width_mm": 225.0,
+                "tire_aspect_pct": 45.0,
+                "rim_in": 18.0,
+            },
+            {
+                "name": 'Sport 19"',
+                "tire_width_mm": 245.0,
+                "tire_aspect_pct": 40.0,
+                "rim_in": 19.0,
+            },
+        ],
+        "tire_width_mm": 225.0,
+        "tire_aspect_pct": 45.0,
+        "rim_in": 18.0,
+        "variants": [
+            {
+                "name": "xDrive30i",
+                "engine": "B48 2.0L I4 Turbo",
+                "drivetrain": "AWD",
+            }
+        ],
+    }
+
+
+def _make_valid_exact_configuration() -> VehicleConfiguration:
+    tire = TireSpec.from_aspects(
+        {
+            "tire_width_mm": 225.0,
+            "tire_aspect_pct": 45.0,
+            "rim_in": 18.0,
+        }
+    )
+    assert tire is not None
+    return VehicleConfiguration(
+        brand="BMW",
+        car_type="SUV",
+        model_name="Validation Test Model",
+        variant_name="xDrive30i",
+        drivetrain="AWD",
+        transmission_name="8-speed automatic (ZF 8HP)",
+        top_gear_ratio=0.67,
+        default_tire=tire,
+        tire_options=(
+            VehicleConfigurationTireOption(
+                name='Standard 18"',
+                tire_setup=AxleTireSetup.square(tire),
+            ),
+        ),
+        fuel_type="ICE",
+        final_drive_front=3.15,
+        final_drive_rear=3.15,
+        field_provenance=(
+            VehicleFieldProvenance("final_drive_front", "official_exact", source_id="src:front"),
+            VehicleFieldProvenance("final_drive_rear", "official_exact", source_id="src:rear"),
+            VehicleFieldProvenance("top_gear_ratio", "official_exact", source_id="src:gear"),
+            VehicleFieldProvenance("transmission_name", "official_exact", source_id="src:gear"),
+            VehicleFieldProvenance("drivetrain", "official_exact", source_id="src:drive"),
+            VehicleFieldProvenance("tire_dimensions", "family_default"),
+        ),
+    )
+
+
+def test_current_car_library_rows_validate_with_documented_allowlist() -> None:
+    assert validate_car_library_rows(load_car_library()) == ()
+
+
+def test_current_exact_vehicle_configurations_validate_cleanly() -> None:
+    assert validate_vehicle_configurations(load_vehicle_configurations()) == ()
+
+
+def test_current_allowlist_matches_current_raw_legacy_ev_exceptions() -> None:
+    with _DATA_FILE.open(encoding="utf-8") as fh:
+        raw_rows = json.load(fh)
+
+    issues = validate_car_library_rows(raw_rows, allowlist={})
+    observed = {(issue.rule, issue.entity) for issue in issues}
+    expected = set(load_car_library_validation_allowlist())
+
+    assert (
+        observed
+        == expected
+        == {
+            ("pure_ev_requires_single_speed", "BMW|X1 (U11, 2023-2026)|iX1 xDrive30"),
+            ("pure_ev_requires_single_speed", "BMW|X2 (U10, 2024-2026)|iX2 xDrive30"),
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_rule", "message_snippet"),
+    [
+        (
+            lambda entry: entry["variants"].append(
+                {
+                    "name": "xDrive30i",
+                    "engine": "B58 3.0L I6 Turbo",
+                    "drivetrain": "AWD",
+                }
+            ),
+            "duplicate_variant_name",
+            "duplicates a variant name",
+        ),
+        (
+            lambda entry: entry["variants"][0].update({"drivetrain": "RWD"}),
+            "badge_requires_awd",
+            "AWD badge",
+        ),
+        (
+            lambda entry: entry["variants"][0].update({"name": "eDrive40", "drivetrain": "AWD"}),
+            "edrive_requires_rwd",
+            "eDrive badge",
+        ),
+        (
+            lambda entry: entry["variants"][0].update({"name": "Manual Edition"}),
+            "manual_claim_mismatch",
+            "claims manual",
+        ),
+        (
+            lambda entry: entry["variants"][0].update(
+                {
+                    "name": "eDrive40",
+                    "drivetrain": "RWD",
+                    "engine": "Electric Single Motor",
+                }
+            ),
+            "pure_ev_requires_single_speed",
+            "is EV",
+        ),
+        (
+            lambda entry: entry["variants"][0].update(
+                {
+                    "name": "330i",
+                    "drivetrain": "RWD",
+                    "gearboxes": [
+                        {
+                            "name": "Single-speed fixed gear (EV)",
+                            "final_drive_ratio": 9.1,
+                            "top_gear_ratio": 1.0,
+                        }
+                    ],
+                }
+            ),
+            "ice_must_not_use_single_speed",
+            "is ICE",
+        ),
+        (
+            lambda entry: entry["gearboxes"][0].update({"final_drive_ratio": 20.0}),
+            "final_drive_ratio_range",
+            "implausible final_drive_ratio",
+        ),
+        (
+            lambda entry: entry["gearboxes"][0].update({"top_gear_ratio": 1.5}),
+            "top_gear_ratio_range",
+            "implausible top_gear_ratio",
+        ),
+        (
+            lambda entry: entry["gearboxes"][0].update({"gear_ratios": [3.5, 3.6, 1.1]}),
+            "gear_ratio_order",
+            "descending gear ratios",
+        ),
+        (
+            lambda entry: entry["tire_options"][1].update({"rim_in": 18.0}),
+            "tire_option_name_rim_mismatch",
+            "name suffix says 19",
+        ),
+        (
+            lambda entry: entry.update(
+                {
+                    "tire_width_mm": 145.0,
+                    "tire_aspect_pct": 25.0,
+                    "rim_in": 14.0,
+                }
+            ),
+            "tire_diameter_range",
+            "default tire has implausible diameter",
+        ),
+    ],
+)
+def test_validate_car_library_rows_flags_major_invariant_breaks(
+    mutate,
+    expected_rule: str,
+    message_snippet: str,
+) -> None:
+    entry = _make_valid_legacy_entry()
+    mutate(entry)
+
+    issues = validate_car_library_rows([entry], allowlist={})
+
+    assert [issue.rule for issue in issues] == [expected_rule]
+    assert message_snippet in issues[0].message
+    assert issues[0].entity.startswith("BMW|Validation Test Model")
+
+
+def test_validate_vehicle_configurations_flags_missing_provenance_for_populated_fields() -> None:
+    config = _make_valid_exact_configuration()
+    broken = replace(
+        config,
+        field_provenance=tuple(
+            entry for entry in config.field_provenance if entry.field_name != "final_drive_rear"
+        ),
+    )
+
+    issues = validate_vehicle_configurations([broken], allowlist={})
+
+    assert [issue.rule for issue in issues] == ["missing_field_provenance"]
+    assert "final_drive_rear" in issues[0].message
+
+
+def test_validate_vehicle_configurations_flags_layout_mismatch() -> None:
+    config = _make_valid_exact_configuration()
+    broken = replace(
+        config,
+        variant_name="330i",
+        drivetrain="RWD",
+        final_drive_front=3.15,
+        final_drive_rear=None,
+    )
+
+    issues = validate_vehicle_configurations([broken], allowlist={})
+
+    assert {issue.rule for issue in issues} == {"drivetrain_final_drive_layout"}
+    assert any("final_drive_front" in issue.message for issue in issues)
+    assert any("does not expose any driven final-drive ratio" in issue.message for issue in issues)
+
+
+def test_load_car_library_fails_closed_on_validation_error(tmp_path) -> None:
+    bad_file = tmp_path / "bad-library.json"
+    entry = _make_valid_legacy_entry()
+    entry["gearboxes"][0]["final_drive_ratio"] = 20.0
+    bad_file.write_text(json.dumps([entry]), encoding="utf-8")
+
+    with patch("vibesensor.adapters.persistence.car_library._DATA_FILE", bad_file):
+        assert load_car_library() == []
+
+
+def test_load_vehicle_configurations_fails_closed_on_validation_error(tmp_path) -> None:
+    bad_file = tmp_path / "bad-configs.json"
+    row = {
+        "brand": "BMW",
+        "type": "SUV",
+        "market": "EU",
+        "model_code": "TEST",
+        "body_code": "TEST",
+        "production_start_year": 2024,
+        "production_end_year": 2026,
+        "model_name": "Validation Test Model",
+        "variant_name": "xDrive30i",
+        "engine_code": "B48",
+        "engine_name": "B48 2.0L I4 Turbo",
+        "fuel_type": "ICE",
+        "drivetrain": "RWD",
+        "transmission_code": "AUTO8",
+        "transmission_name": "8-speed automatic (ZF 8HP)",
+        "top_gear_ratio": 0.67,
+        "final_drive_front": 3.15,
+        "tire_options": [
+            {
+                "name": 'Standard 18"',
+                "tire_width_mm": 225.0,
+                "tire_aspect_pct": 45.0,
+                "rim_in": 18.0,
+            }
+        ],
+        "tire_width_mm": 225.0,
+        "tire_aspect_pct": 45.0,
+        "rim_in": 18.0,
+        "source_status": "exact_row",
+        "field_provenance": [
+            {
+                "field_name": "top_gear_ratio",
+                "confidence": "official_exact",
+                "source_id": "src:gear",
+            },
+            {
+                "field_name": "transmission_name",
+                "confidence": "official_exact",
+                "source_id": "src:gear",
+            },
+            {
+                "field_name": "drivetrain",
+                "confidence": "official_exact",
+                "source_id": "src:drive",
+            },
+            {
+                "field_name": "tire_dimensions",
+                "confidence": "family_default",
+            },
+            {
+                "field_name": "final_drive_front",
+                "confidence": "official_exact",
+                "source_id": "src:front",
+            },
+        ],
+    }
+    bad_file.write_text(json.dumps([row]), encoding="utf-8")
+
+    with patch("vibesensor.adapters.persistence.car_library._VEHICLE_CONFIG_DATA_FILE", bad_file):
+        assert load_vehicle_configurations() == []

--- a/apps/server/vibesensor/adapters/persistence/car_library.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library.py
@@ -24,6 +24,11 @@ from vibesensor.domain import (
 )
 from vibesensor.shared._data_files import resolve_static_data_file
 
+from .car_library_validation import (
+    ensure_valid_car_library_rows,
+    ensure_valid_vehicle_configurations,
+)
+
 LOGGER = logging.getLogger(__name__)
 
 __all__ = [
@@ -188,13 +193,16 @@ def _load_library() -> list[CarLibraryEntry]:
     try:
         with _DATA_FILE.open(encoding="utf-8") as fh:
             data = json.load(fh)
-        return _CAR_LIBRARY_ADAPTER.validate_python(data)
+        rows = _CAR_LIBRARY_ADAPTER.validate_python(data)
+        ensure_valid_car_library_rows(rows)
+        return rows
     except (
         FileNotFoundError,
         json.JSONDecodeError,
         PermissionError,
         OSError,
         ValidationError,
+        ValueError,
     ) as exc:
         LOGGER.warning("Could not load car library from %s: %s", _DATA_FILE, exc)
         return []
@@ -546,7 +554,9 @@ def _load_vehicle_configurations_snapshot() -> list[VehicleConfiguration]:
         with _VEHICLE_CONFIG_DATA_FILE.open(encoding="utf-8") as fh:
             data = json.load(fh)
         rows = _VEHICLE_CONFIGURATION_ADAPTER.validate_python(data)
-        return [_configuration_from_row(row) for row in rows]
+        configs = [_configuration_from_row(row) for row in rows]
+        ensure_valid_vehicle_configurations(configs)
+        return configs
     except (
         FileNotFoundError,
         json.JSONDecodeError,

--- a/apps/server/vibesensor/adapters/persistence/car_library_validation.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library_validation.py
@@ -1,0 +1,732 @@
+"""Physical plausibility and consistency validation for bundled car data."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from vibesensor.domain import (
+    AxleTireSetup,
+    TireSpec,
+    VehicleConfiguration,
+    VehicleConfigurationField,
+)
+from vibesensor.shared._data_files import resolve_static_data_file
+
+__all__ = [
+    "CarLibraryValidationIssue",
+    "ensure_valid_car_library_rows",
+    "ensure_valid_vehicle_configurations",
+    "load_car_library_validation_allowlist",
+    "validate_car_library_rows",
+    "validate_vehicle_configurations",
+]
+
+_ALLOWLIST_FILE = resolve_static_data_file("car_library_validation_allowlist.json")
+_AWD_BADGE_TOKENS = ("xdrive", "quattro", "4matic")
+_RWD_BADGE_TOKENS = ("edrive",)
+_FINAL_DRIVE_RANGE = (2.0, 15.0)
+_TOP_GEAR_RANGE = (0.5, 1.1)
+_GEAR_RATIO_RANGE = (0.4, 8.0)
+_TIRE_DIAMETER_RANGE_MM = (550.0, 850.0)
+_RIM_SUFFIX_RE = re.compile(r'(?P<rim>\d+)"$')
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedTireSetup:
+    front: TireSpec
+    rear: TireSpec
+
+
+@dataclass(frozen=True, slots=True)
+class CarLibraryValidationIssue:
+    """One machine-readable validation failure for bundled car data."""
+
+    rule: str
+    entity: str
+    message: str
+
+
+def load_car_library_validation_allowlist(
+    path: Path = _ALLOWLIST_FILE,
+) -> dict[tuple[str, str], str]:
+    """Load the documented validation allowlist keyed by ``(rule, entity)``."""
+
+    try:
+        with path.open(encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        raise ValueError(
+            f"Could not load car-library validation allowlist from {path}: {exc}"
+        ) from exc
+
+    rows = payload.get("allowances")
+    if not isinstance(rows, list):
+        raise ValueError(f"{path} must contain an 'allowances' list")
+
+    allowlist: dict[tuple[str, str], str] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"{path} allowance #{index} must be an object")
+        rule = row.get("rule")
+        entity = row.get("entity")
+        reason = row.get("reason")
+        if not isinstance(rule, str) or not rule.strip():
+            raise ValueError(f"{path} allowance #{index} missing non-empty rule")
+        if not isinstance(entity, str) or not entity.strip():
+            raise ValueError(f"{path} allowance #{index} missing non-empty entity")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError(f"{path} allowance #{index} missing non-empty reason")
+        key = (rule.strip(), entity.strip())
+        if key in allowlist:
+            raise ValueError(f"{path} duplicates allowance for rule={rule!r} entity={entity!r}")
+        allowlist[key] = reason.strip()
+    return allowlist
+
+
+def ensure_valid_car_library_rows(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    allowlist: Mapping[tuple[str, str], str] | None = None,
+) -> None:
+    """Raise ``ValueError`` when legacy car-library rows fail validation."""
+
+    issues = validate_car_library_rows(rows, allowlist=allowlist)
+    if issues:
+        raise ValueError(_format_issue_summary("car library", issues))
+
+
+def ensure_valid_vehicle_configurations(
+    configs: Sequence[VehicleConfiguration],
+    *,
+    allowlist: Mapping[tuple[str, str], str] | None = None,
+) -> None:
+    """Raise ``ValueError`` when exact vehicle configuration rows fail validation."""
+
+    issues = validate_vehicle_configurations(configs, allowlist=allowlist)
+    if issues:
+        raise ValueError(_format_issue_summary("vehicle configurations", issues))
+
+
+def validate_car_library_rows(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    allowlist: Mapping[tuple[str, str], str] | None = None,
+) -> tuple[CarLibraryValidationIssue, ...]:
+    """Return all validation issues for legacy ``car_library.json`` rows."""
+
+    issues: list[CarLibraryValidationIssue] = []
+    for entry in rows:
+        _validate_legacy_entry(entry, issues)
+    return _filter_allowlisted_issues(issues, allowlist)
+
+
+def validate_vehicle_configurations(
+    configs: Sequence[VehicleConfiguration],
+    *,
+    allowlist: Mapping[tuple[str, str], str] | None = None,
+) -> tuple[CarLibraryValidationIssue, ...]:
+    """Return all validation issues for exact vehicle configuration rows."""
+
+    issues: list[CarLibraryValidationIssue] = []
+    for config in configs:
+        _validate_vehicle_configuration(config, issues)
+    return _filter_allowlisted_issues(issues, allowlist)
+
+
+def _validate_legacy_entry(
+    entry: Mapping[str, object],
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    brand = _text(entry.get("brand"))
+    model = _text(entry.get("model"))
+    entry_entity = _model_entity(brand, model)
+    entry_label = f"{brand} {model}".strip()
+
+    _validate_gearboxes(
+        entry.get("gearboxes"),
+        entity=entry_entity,
+        label=entry_label,
+        issues=issues,
+    )
+    _validate_default_tire(
+        entity=entry_entity,
+        label=f"{entry_label} default tire",
+        width=entry.get("tire_width_mm"),
+        aspect=entry.get("tire_aspect_pct"),
+        rim=entry.get("rim_in"),
+        issues=issues,
+    )
+    _validate_tire_options(
+        entry.get("tire_options"),
+        entity=entry_entity,
+        label=entry_label,
+        issues=issues,
+    )
+
+    variants = entry.get("variants")
+    if not isinstance(variants, list):
+        return
+
+    seen_variants: set[str] = set()
+    for variant in variants:
+        if not isinstance(variant, Mapping):
+            continue
+        variant_name = _text(variant.get("name"))
+        variant_entity = _variant_entity(brand, model, variant_name)
+        variant_label = f"{entry_label} / {variant_name}".strip(" /")
+
+        if variant_name in seen_variants:
+            issues.append(
+                CarLibraryValidationIssue(
+                    rule="duplicate_variant_name",
+                    entity=variant_entity,
+                    message=f"{variant_label} duplicates a variant name within the same model",
+                )
+            )
+        seen_variants.add(variant_name)
+
+        _validate_drivetrain_badges(
+            variant_name,
+            drivetrain=_text(variant.get("drivetrain")),
+            entity=variant_entity,
+            label=variant_label,
+            issues=issues,
+        )
+        variant_gearboxes = variant.get("gearboxes")
+        effective_gearboxes = (
+            variant_gearboxes if isinstance(variant_gearboxes, list) else entry.get("gearboxes")
+        )
+        if isinstance(variant_gearboxes, list):
+            _validate_gearboxes(
+                variant_gearboxes,
+                entity=variant_entity,
+                label=variant_label,
+                issues=issues,
+            )
+        _validate_powertrain_gearbox_consistency(
+            engine_name=_text(variant.get("engine")),
+            gearboxes=effective_gearboxes,
+            entity=variant_entity,
+            label=variant_label,
+            issues=issues,
+        )
+        _validate_manual_or_automatic_claims(
+            variant_name=variant_name,
+            gearboxes=effective_gearboxes,
+            entity=variant_entity,
+            label=variant_label,
+            issues=issues,
+        )
+        if "tire_width_mm" in variant or "tire_aspect_pct" in variant or "rim_in" in variant:
+            _validate_default_tire(
+                entity=variant_entity,
+                label=f"{variant_label} default tire",
+                width=variant.get("tire_width_mm", entry.get("tire_width_mm")),
+                aspect=variant.get("tire_aspect_pct", entry.get("tire_aspect_pct")),
+                rim=variant.get("rim_in", entry.get("rim_in")),
+                issues=issues,
+            )
+        if isinstance(variant.get("tire_options"), list):
+            _validate_tire_options(
+                variant.get("tire_options"),
+                entity=variant_entity,
+                label=variant_label,
+                issues=issues,
+            )
+
+
+def _validate_vehicle_configuration(
+    config: VehicleConfiguration,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    entity = _variant_entity(config.brand, config.model_name, config.variant_name)
+    label = f"{config.brand} {config.model_name} / {config.variant_name}".strip(" /")
+
+    _validate_drivetrain_badges(
+        config.variant_name,
+        drivetrain=config.drivetrain,
+        entity=entity,
+        label=label,
+        issues=issues,
+    )
+    _validate_single_gearbox(
+        config.transmission_name,
+        final_drive_ratio=config.driven_final_drive_ratio,
+        top_gear_ratio=config.top_gear_ratio,
+        gear_ratios=config.gear_ratios,
+        entity=entity,
+        label=label,
+        issues=issues,
+    )
+    _validate_powertrain_gearbox_consistency(
+        engine_name=config.engine_name,
+        gearboxes=[
+            {
+                "name": config.transmission_name,
+                "top_gear_ratio": config.top_gear_ratio,
+            }
+        ],
+        entity=entity,
+        label=label,
+        issues=issues,
+    )
+    _validate_final_drive_layout(config, entity=entity, label=label, issues=issues)
+    _validate_tire_spec(
+        config.default_tire,
+        entity=entity,
+        label=f"{label} default tire",
+        issues=issues,
+    )
+    for option in config.tire_options:
+        _validate_tire_setup(
+            option.tire_setup,
+            entity=entity,
+            label=f"{label} / {option.name}",
+            issues=issues,
+        )
+    if config.source_status == "exact_row":
+        _validate_exact_row_provenance(config, entity=entity, label=label, issues=issues)
+
+
+def _validate_gearboxes(
+    gearboxes: object,
+    *,
+    entity: str,
+    label: str,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    if not isinstance(gearboxes, list):
+        return
+    for gearbox in gearboxes:
+        if not isinstance(gearbox, Mapping):
+            continue
+        _validate_single_gearbox(
+            _text(gearbox.get("name")),
+            final_drive_ratio=gearbox.get("final_drive_ratio"),
+            top_gear_ratio=gearbox.get("top_gear_ratio"),
+            gear_ratios=gearbox.get("gear_ratios"),
+            entity=entity,
+            label=label,
+            issues=issues,
+        )
+
+
+def _validate_single_gearbox(
+    gearbox_name: str,
+    *,
+    final_drive_ratio: object,
+    top_gear_ratio: object,
+    gear_ratios: object,
+    entity: str,
+    label: str,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    final_drive = _float_or_none(final_drive_ratio)
+    if final_drive is not None and not _in_range(final_drive, _FINAL_DRIVE_RANGE):
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="final_drive_ratio_range",
+                entity=entity,
+                message=(
+                    f"{label} gearbox {gearbox_name!r} has implausible "
+                    f"final_drive_ratio={final_drive}"
+                ),
+            )
+        )
+    top_gear = _float_or_none(top_gear_ratio)
+    if top_gear is not None and not _in_range(top_gear, _TOP_GEAR_RANGE):
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="top_gear_ratio_range",
+                entity=entity,
+                message=(
+                    f"{label} gearbox {gearbox_name!r} has implausible top_gear_ratio={top_gear}"
+                ),
+            )
+        )
+    if not isinstance(gear_ratios, list):
+        return
+    parsed_ratios = [_float_or_none(value) for value in gear_ratios]
+    if any(value is None or not _in_range(value, _GEAR_RATIO_RANGE) for value in parsed_ratios):
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="gear_ratio_range",
+                entity=entity,
+                message=(
+                    f"{label} gearbox {gearbox_name!r} has implausible gear_ratios={gear_ratios!r}"
+                ),
+            )
+        )
+        return
+    ratios = [value for value in parsed_ratios if value is not None]
+    if any(
+        next_ratio >= current_ratio
+        for current_ratio, next_ratio in zip(ratios, ratios[1:], strict=False)
+    ):
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="gear_ratio_order",
+                entity=entity,
+                message=f"{label} gearbox {gearbox_name!r} must keep descending gear ratios",
+            )
+        )
+
+
+def _validate_drivetrain_badges(
+    variant_name: str,
+    *,
+    drivetrain: str,
+    entity: str,
+    label: str,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    normalized_name = variant_name.lower()
+    if any(token in normalized_name for token in _AWD_BADGE_TOKENS) and drivetrain != "AWD":
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="badge_requires_awd",
+                entity=entity,
+                message=(
+                    f"{label} uses an AWD badge in the variant name but drivetrain={drivetrain!r}"
+                ),
+            )
+        )
+    if any(token in normalized_name for token in _RWD_BADGE_TOKENS) and drivetrain != "RWD":
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="edrive_requires_rwd",
+                entity=entity,
+                message=(
+                    f"{label} uses an eDrive badge in the variant name "
+                    f"but drivetrain={drivetrain!r}"
+                ),
+            )
+        )
+
+
+def _validate_powertrain_gearbox_consistency(
+    *,
+    engine_name: str | None,
+    gearboxes: object,
+    entity: str,
+    label: str,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    if not isinstance(gearboxes, list):
+        return
+    fuel_type = _classify_fuel_type(engine_name)
+    for gearbox in gearboxes:
+        if not isinstance(gearbox, Mapping):
+            continue
+        gearbox_name = _text(gearbox.get("name"))
+        is_single_speed = _is_single_speed_gearbox(gearbox_name)
+        if fuel_type == "EV" and not is_single_speed:
+            issues.append(
+                CarLibraryValidationIssue(
+                    rule="pure_ev_requires_single_speed",
+                    entity=entity,
+                    message=f"{label} is EV but gearbox {gearbox_name!r} is not single-speed",
+                )
+            )
+        if fuel_type == "ICE" and is_single_speed:
+            issues.append(
+                CarLibraryValidationIssue(
+                    rule="ice_must_not_use_single_speed",
+                    entity=entity,
+                    message=f"{label} is ICE but gearbox {gearbox_name!r} is single-speed",
+                )
+            )
+
+
+def _validate_manual_or_automatic_claims(
+    *,
+    variant_name: str,
+    gearboxes: object,
+    entity: str,
+    label: str,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    if not isinstance(gearboxes, list):
+        return
+    normalized_name = variant_name.lower()
+    gearbox_names = [
+        _text(gearbox.get("name")).lower() for gearbox in gearboxes if isinstance(gearbox, Mapping)
+    ]
+    if "manual" in normalized_name and not any("manual" in name for name in gearbox_names):
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="manual_claim_mismatch",
+                entity=entity,
+                message=f"{label} claims manual in the variant name but exposes no manual gearbox",
+            )
+        )
+    claims_automatic = any(
+        token in normalized_name for token in ("automatic", "steptronic", "dkg", "s tronic")
+    )
+    if claims_automatic and any("manual" in name for name in gearbox_names):
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="automatic_claim_mismatch",
+                entity=entity,
+                message=f"{label} claims automatic transmission but still exposes a manual gearbox",
+            )
+        )
+
+
+def _validate_final_drive_layout(
+    config: VehicleConfiguration,
+    *,
+    entity: str,
+    label: str,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    if config.drivetrain == "FWD" and config.final_drive_rear is not None:
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="drivetrain_final_drive_layout",
+                entity=entity,
+                message=f"{label} is FWD but still sets final_drive_rear",
+            )
+        )
+    if config.drivetrain == "RWD" and config.final_drive_front is not None:
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="drivetrain_final_drive_layout",
+                entity=entity,
+                message=f"{label} is RWD but still sets final_drive_front",
+            )
+        )
+    if config.driven_final_drive_ratio is None:
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="drivetrain_final_drive_layout",
+                entity=entity,
+                message=f"{label} does not expose any driven final-drive ratio",
+            )
+        )
+
+
+def _validate_exact_row_provenance(
+    config: VehicleConfiguration,
+    *,
+    entity: str,
+    label: str,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    required_fields: set[VehicleConfigurationField] = {
+        "top_gear_ratio",
+        "transmission_name",
+        "drivetrain",
+        "tire_dimensions",
+    }
+    if config.final_drive_front is not None:
+        required_fields.add("final_drive_front")
+    if config.final_drive_rear is not None:
+        required_fields.add("final_drive_rear")
+    if config.gear_ratios is not None:
+        required_fields.add("gear_ratios")
+    missing = sorted(field for field in required_fields if config.provenance_for(field) is None)
+    if missing:
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="missing_field_provenance",
+                entity=entity,
+                message=f"{label} exact row is missing field_provenance for {', '.join(missing)}",
+            )
+        )
+
+
+def _validate_default_tire(
+    *,
+    entity: str,
+    label: str,
+    width: object,
+    aspect: object,
+    rim: object,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    spec = _tire_spec_from_values(width=width, aspect=aspect, rim=rim)
+    if spec is None:
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="tire_dimensions_invalid",
+                entity=entity,
+                message=f"{label} does not expose usable tire dimensions",
+            )
+        )
+        return
+    _validate_tire_spec(spec, entity=entity, label=label, issues=issues)
+
+
+def _validate_tire_options(
+    options: object,
+    *,
+    entity: str,
+    label: str,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    if not isinstance(options, list):
+        return
+    for option in options:
+        if not isinstance(option, Mapping):
+            continue
+        option_name = _text(option.get("name"))
+        option_label = f"{label} / {option_name}".strip(" /")
+        setup = _tire_setup_from_row(option)
+        if setup is None:
+            issues.append(
+                CarLibraryValidationIssue(
+                    rule="tire_dimensions_invalid",
+                    entity=entity,
+                    message=f"{option_label} does not expose usable tire dimensions",
+                )
+            )
+            continue
+        _validate_tire_setup(setup, entity=entity, label=option_label, issues=issues)
+        match = _RIM_SUFFIX_RE.search(option_name)
+        if match is not None and setup.front.rim_in != float(match.group("rim")):
+            issues.append(
+                CarLibraryValidationIssue(
+                    rule="tire_option_name_rim_mismatch",
+                    entity=entity,
+                    message=(
+                        f'{option_label} name suffix says {match.group("rim")}" '
+                        f"but front rim is {setup.front.rim_in}"
+                    ),
+                )
+            )
+
+
+def _validate_tire_setup(
+    setup: AxleTireSetup | _ResolvedTireSetup,
+    *,
+    entity: str,
+    label: str,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    _validate_tire_spec(setup.front, entity=entity, label=f"{label} front tire", issues=issues)
+    _validate_tire_spec(setup.rear, entity=entity, label=f"{label} rear tire", issues=issues)
+
+
+def _validate_tire_spec(
+    spec: TireSpec,
+    *,
+    entity: str,
+    label: str,
+    issues: list[CarLibraryValidationIssue],
+) -> None:
+    diameter = spec.diameter_mm
+    if not _in_range(diameter, _TIRE_DIAMETER_RANGE_MM):
+        issues.append(
+            CarLibraryValidationIssue(
+                rule="tire_diameter_range",
+                entity=entity,
+                message=f"{label} has implausible diameter_mm={diameter:.1f}",
+            )
+        )
+
+
+def _tire_setup_from_row(row: Mapping[str, object]) -> _ResolvedTireSetup | None:
+    front = _tire_spec_from_dimensions_mapping(row.get("front"))
+    rear = _tire_spec_from_dimensions_mapping(row.get("rear"))
+    flat = _tire_spec_from_values(
+        width=row.get("tire_width_mm"),
+        aspect=row.get("tire_aspect_pct"),
+        rim=row.get("rim_in"),
+    )
+    if front is None:
+        front = flat
+    if rear is None:
+        rear = flat
+    if front is None or rear is None:
+        return None
+
+    return _ResolvedTireSetup(front=front, rear=rear)
+
+
+def _tire_spec_from_dimensions_mapping(payload: object) -> TireSpec | None:
+    if not isinstance(payload, Mapping):
+        return None
+    return _tire_spec_from_values(
+        width=payload.get("width_mm"),
+        aspect=payload.get("aspect_pct"),
+        rim=payload.get("rim_in"),
+    )
+
+
+def _tire_spec_from_values(*, width: object, aspect: object, rim: object) -> TireSpec | None:
+    width_value = _float_or_none(width)
+    aspect_value = _float_or_none(aspect)
+    rim_value = _float_or_none(rim)
+    if width_value is None or aspect_value is None or rim_value is None:
+        return None
+    return TireSpec.from_aspects(
+        {
+            "tire_width_mm": width_value,
+            "tire_aspect_pct": aspect_value,
+            "rim_in": rim_value,
+        }
+    )
+
+
+def _filter_allowlisted_issues(
+    issues: Sequence[CarLibraryValidationIssue],
+    allowlist: Mapping[tuple[str, str], str] | None,
+) -> tuple[CarLibraryValidationIssue, ...]:
+    allowances = load_car_library_validation_allowlist() if allowlist is None else dict(allowlist)
+    return tuple(issue for issue in issues if (issue.rule, issue.entity) not in allowances)
+
+
+def _format_issue_summary(label: str, issues: Sequence[CarLibraryValidationIssue]) -> str:
+    lines = [f"Invalid {label}: {len(issues)} issue(s)"]
+    lines.extend(f"- [{issue.rule}] {issue.message}" for issue in issues[:10])
+    remaining = len(issues) - 10
+    if remaining > 0:
+        lines.append(f"- ... and {remaining} more")
+    return "\n".join(lines)
+
+
+def _classify_fuel_type(engine_name: str | None) -> str:
+    normalized = (engine_name or "").lower()
+    if "phev" in normalized:
+        return "PHEV"
+    if "electric" in normalized or normalized.startswith("ev "):
+        return "EV"
+    return "ICE"
+
+
+def _is_single_speed_gearbox(gearbox_name: str) -> bool:
+    return "single-speed" in gearbox_name.lower()
+
+
+def _model_entity(brand: str, model: str) -> str:
+    return f"{brand}|{model}"
+
+
+def _variant_entity(brand: str, model: str, variant_name: str) -> str:
+    return f"{brand}|{model}|{variant_name}"
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _float_or_none(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if not isinstance(value, int | float | str):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed
+
+
+def _in_range(value: float, bounds: tuple[float, float]) -> bool:
+    lower, upper = bounds
+    return lower <= value <= upper

--- a/apps/server/vibesensor/data/car_library_validation_allowlist.json
+++ b/apps/server/vibesensor/data/car_library_validation_allowlist.json
@@ -1,0 +1,14 @@
+{
+  "allowances": [
+    {
+      "rule": "pure_ev_requires_single_speed",
+      "entity": "BMW|X1 (U11, 2023-2026)|iX1 xDrive30",
+      "reason": "Legacy row still inherits shared non-EV gearbox data until an exact EV drivetrain row is captured."
+    },
+    {
+      "rule": "pure_ev_requires_single_speed",
+      "entity": "BMW|X2 (U10, 2024-2026)|iX2 xDrive30",
+      "reason": "Legacy row still inherits shared non-EV gearbox data until an exact EV drivetrain row is captured."
+    }
+  ]
+}

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -111,6 +111,18 @@ rows.
 Rows marked `official_exact` must include a `source_id`; loader validation
 rejects exact-row data that breaks that rule.
 
+Issue #3234 expands loader validation beyond schema checks:
+
+- `apps/server/vibesensor/adapters/persistence/car_library_validation.py`
+  is the one owner for bundled car-data plausibility checks
+- the legacy `car_library.json` rows and resolved
+  `vehicle_configurations.json` rows both run through that validator before the
+  cached library snapshot is accepted
+- documented exceptions live in
+  `apps/server/vibesensor/data/car_library_validation_allowlist.json`, so
+  temporary carve-outs stay explicit and machine-readable instead of hiding in
+  scattered tests
+
 The confidence levels are the source data for future analysis-confidence
 policies:
 


### PR DESCRIPTION
## What changed
- add one backend-owned car-library validator for legacy `car_library.json` rows and resolved exact `vehicle_configurations.json` rows
- fail the loader closed on duplicate variant names, drivetrain badge mismatches, EV/ICE gearbox mismatches, manual-vs-automatic claim conflicts, implausible ratio/tire values, missing exact-row provenance, and bad final-drive layout
- keep the current known exceptions in one machine-readable allowlist with reasons
- add focused bad-fixture tests plus loader fail-closed coverage
- document the validator and allowlist owner path in `docs/car_library_architecture.md`

## Why
- current car-library coverage had spot checks for known rows, but bad drivetrain or tire data could still load silently
- this puts one clear invariant guard in normal backend validation and loader startup

## Validation
- `./.venv/bin/pytest -n0 -q apps/server/tests/adapters/persistence/test_car_library_validation.py apps/server/tests/adapters/persistence/test_car_library.py apps/server/tests/adapters/persistence/test_bmw_car_library_mismatches.py apps/server/tests/adapters/persistence/test_car_library_routes.py`
- `./.venv/bin/pytest -n0 -q apps/server/tests/adapters/persistence/`
- `make typecheck-backend`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `make docs-lint`

## Risks / tradeoffs
- loader now fails closed on invalid bundled car data, so future rows must satisfy the validator or enter the explicit allowlist
- allowlist stays small and machine-readable; current documented carve-outs are the two legacy iX1/iX2 EV rows still inheriting shared gearbox data
- follow-up source-pack work stays out of this PR

Closes #3234