### PR TITLE
Split car-library research notes into machine-checkable source packs

### DIFF
--- a/apps/server/tests/adapters/persistence/test_car_library_source_evidence.py
+++ b/apps/server/tests/adapters/persistence/test_car_library_source_evidence.py
@@ -1,0 +1,116 @@
+"""Regression coverage for machine-checkable car source evidence."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from vibesensor.adapters.persistence.car_library import load_vehicle_configurations
+from vibesensor.adapters.persistence.car_library_source_evidence import (
+    _EVIDENCE_FILE,
+    load_car_source_registry,
+    validate_vehicle_configuration_source_evidence,
+)
+
+
+def _config_for(model_name: str, variant_name: str):
+    for config in load_vehicle_configurations():
+        if config.model_name == model_name and config.variant_name == variant_name:
+            return config
+    raise AssertionError(f"Vehicle configuration not found: {model_name} / {variant_name}")
+
+
+def test_current_car_source_registry_covers_current_exact_vehicle_source_ids() -> None:
+    registry = load_car_source_registry()
+    configs = load_vehicle_configurations()
+
+    assert validate_vehicle_configuration_source_evidence(configs, registry=registry) == ()
+    referenced_source_ids = {
+        entry.source_id
+        for config in configs
+        for entry in config.field_provenance
+        if entry.source_id is not None
+    }
+    assert referenced_source_ids == set(registry.evidence)
+
+
+def test_validate_vehicle_configuration_source_evidence_flags_missing_required_source_id() -> None:
+    config = _config_for("3 Series (G20, 2019-2025)", "330i xDrive")
+    broken = replace(
+        config,
+        field_provenance=tuple(
+            replace(entry, source_id=None) if entry.field_name == "drivetrain" else entry
+            for entry in config.field_provenance
+        ),
+    )
+
+    issues = validate_vehicle_configuration_source_evidence(
+        [broken],
+        registry=load_car_source_registry(),
+    )
+
+    assert [issue.rule for issue in issues] == ["missing_required_source_id"]
+    assert "drivetrain" in issues[0].message
+
+
+def test_load_car_source_registry_rejects_unknown_source_reference(tmp_path: Path) -> None:
+    source_dir = tmp_path / "car_sources"
+    source_dir.mkdir()
+    (source_dir / "demo_pack.json").write_text(
+        json.dumps(
+            {
+                "pack_id": "demo_pack",
+                "sources": [
+                    {
+                        "id": "demo_pack:known-source",
+                        "url": "https://example.com/source",
+                        "title": "Known source",
+                        "note": "Machine-checkable demo source.",
+                        "confidence": "high",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    evidence_file = tmp_path / "car_library_evidence.json"
+    evidence_file.write_text(
+        json.dumps(
+            {
+                "evidence": [
+                    {
+                        "id": "demo:evidence",
+                        "summary": "Broken evidence entry.",
+                        "source_refs": ["demo_pack:missing-source"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="references unknown source"):
+        load_car_source_registry(source_packs_dir=source_dir, evidence_file=evidence_file)
+
+
+def test_load_vehicle_configurations_fails_closed_when_source_evidence_is_missing(
+    tmp_path: Path,
+) -> None:
+    payload = json.loads(_EVIDENCE_FILE.read_text(encoding="utf-8"))
+    payload["evidence"] = [
+        row
+        for row in payload["evidence"]
+        if row["id"] != "variant_sources:BMW|3 Series (G20, 2019-2025):330i xDrive"
+    ]
+    bad_evidence_file = tmp_path / "car_library_evidence.json"
+    bad_evidence_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    with patch(
+        "vibesensor.adapters.persistence.car_library_source_evidence._EVIDENCE_FILE",
+        bad_evidence_file,
+    ):
+        assert load_vehicle_configurations() == []

--- a/apps/server/vibesensor/adapters/persistence/car_library.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library.py
@@ -24,6 +24,9 @@ from vibesensor.domain import (
 )
 from vibesensor.shared._data_files import resolve_static_data_file
 
+from .car_library_source_evidence import (
+    ensure_valid_vehicle_configuration_source_evidence,
+)
 from .car_library_validation import (
     ensure_valid_car_library_rows,
     ensure_valid_vehicle_configurations,
@@ -556,6 +559,7 @@ def _load_vehicle_configurations_snapshot() -> list[VehicleConfiguration]:
         rows = _VEHICLE_CONFIGURATION_ADAPTER.validate_python(data)
         configs = [_configuration_from_row(row) for row in rows]
         ensure_valid_vehicle_configurations(configs)
+        ensure_valid_vehicle_configuration_source_evidence(configs)
         return configs
     except (
         FileNotFoundError,

--- a/apps/server/vibesensor/adapters/persistence/car_library_source_evidence.py
+++ b/apps/server/vibesensor/adapters/persistence/car_library_source_evidence.py
@@ -1,0 +1,274 @@
+"""Machine-checkable source packs and provenance evidence for exact car rows."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from vibesensor.domain import VehicleConfiguration, VehicleFieldConfidence
+from vibesensor.shared._data_files import resolve_static_data_file
+
+__all__ = [
+    "CarEvidenceRecord",
+    "CarSourceDocument",
+    "CarSourceEvidenceIssue",
+    "CarSourceRegistry",
+    "ensure_valid_vehicle_configuration_source_evidence",
+    "load_car_source_registry",
+    "validate_vehicle_configuration_source_evidence",
+]
+
+_SOURCE_PACKS_DIR = resolve_static_data_file("car_sources")
+_EVIDENCE_FILE = resolve_static_data_file("car_library_evidence.json")
+_EVIDENCE_REQUIRED_CONFIDENCES: set[VehicleFieldConfidence] = {
+    "official_exact",
+    "official_derived",
+    "reputable_secondary_crosschecked",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CarSourceDocument:
+    """One canonical source record from a machine-checkable source pack."""
+
+    id: str
+    url: str
+    title: str
+    note: str
+    confidence: str
+
+
+@dataclass(frozen=True, slots=True)
+class CarEvidenceRecord:
+    """One provenance evidence entry keyed by ``VehicleFieldProvenance.source_id``."""
+
+    id: str
+    summary: str
+    source_refs: tuple[str, ...]
+    legacy_refs: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CarSourceRegistry:
+    """Resolved source documents and evidence entries for exact vehicle rows."""
+
+    sources: dict[str, CarSourceDocument]
+    evidence: dict[str, CarEvidenceRecord]
+
+
+@dataclass(frozen=True, slots=True)
+class CarSourceEvidenceIssue:
+    """One machine-readable provenance evidence validation failure."""
+
+    rule: str
+    entity: str
+    message: str
+
+
+def load_car_source_registry(
+    source_packs_dir: Path | None = None,
+    evidence_file: Path | None = None,
+) -> CarSourceRegistry:
+    """Load and validate the machine-checkable source registry."""
+
+    resolved_source_packs_dir = _SOURCE_PACKS_DIR if source_packs_dir is None else source_packs_dir
+    resolved_evidence_file = _EVIDENCE_FILE if evidence_file is None else evidence_file
+    sources: dict[str, CarSourceDocument] = {}
+    if not resolved_source_packs_dir.is_dir():
+        raise ValueError(f"Car source pack directory is missing: {resolved_source_packs_dir}")
+
+    pack_paths = sorted(resolved_source_packs_dir.glob("*.json"))
+    if not pack_paths:
+        raise ValueError(f"Car source pack directory is empty: {resolved_source_packs_dir}")
+
+    for path in pack_paths:
+        payload = _load_json_object(path)
+        pack_id = _required_non_empty_string(payload, "pack_id", path=path)
+        rows = payload.get("sources")
+        if not isinstance(rows, list) or not rows:
+            raise ValueError(f"{path} must contain a non-empty 'sources' list")
+        for index, row in enumerate(rows):
+            if not isinstance(row, Mapping):
+                raise ValueError(f"{path} source #{index} must be an object")
+            source_id = _required_non_empty_string(
+                row,
+                "id",
+                path=path,
+                index=index,
+            )
+            if not source_id.startswith(f"{pack_id}:"):
+                raise ValueError(
+                    f"{path} source #{index} id={source_id!r} must start with {pack_id!r}:"
+                )
+            if source_id in sources:
+                raise ValueError(f"{path} duplicates source id {source_id!r}")
+            sources[source_id] = CarSourceDocument(
+                id=source_id,
+                url=_required_non_empty_string(row, "url", path=path, index=index),
+                title=_required_non_empty_string(row, "title", path=path, index=index),
+                note=_required_non_empty_string(row, "note", path=path, index=index),
+                confidence=_required_non_empty_string(
+                    row,
+                    "confidence",
+                    path=path,
+                    index=index,
+                ),
+            )
+
+    payload = _load_json_object(resolved_evidence_file)
+    rows = payload.get("evidence")
+    if not isinstance(rows, list) or not rows:
+        raise ValueError(f"{resolved_evidence_file} must contain a non-empty 'evidence' list")
+
+    evidence: dict[str, CarEvidenceRecord] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            raise ValueError(f"{resolved_evidence_file} evidence #{index} must be an object")
+        evidence_id = _required_non_empty_string(
+            row,
+            "id",
+            path=resolved_evidence_file,
+            index=index,
+        )
+        if evidence_id in evidence:
+            raise ValueError(f"{resolved_evidence_file} duplicates evidence id {evidence_id!r}")
+        source_refs = _required_string_list(
+            row,
+            "source_refs",
+            path=resolved_evidence_file,
+            index=index,
+        )
+        for source_ref in source_refs:
+            if source_ref not in sources:
+                raise ValueError(
+                    f"{resolved_evidence_file} evidence id={evidence_id!r} references unknown "
+                    f"source {source_ref!r}"
+                )
+        evidence[evidence_id] = CarEvidenceRecord(
+            id=evidence_id,
+            summary=_required_non_empty_string(
+                row,
+                "summary",
+                path=resolved_evidence_file,
+                index=index,
+            ),
+            source_refs=source_refs,
+            legacy_refs=_optional_string_list(row, "legacy_refs"),
+        )
+
+    return CarSourceRegistry(sources=sources, evidence=evidence)
+
+
+def ensure_valid_vehicle_configuration_source_evidence(
+    configs: Sequence[VehicleConfiguration],
+    *,
+    registry: CarSourceRegistry | None = None,
+) -> None:
+    """Raise ``ValueError`` when exact vehicle configurations lack resolvable evidence."""
+
+    issues = validate_vehicle_configuration_source_evidence(configs, registry=registry)
+    if issues:
+        raise ValueError(_format_issue_summary(issues))
+
+
+def validate_vehicle_configuration_source_evidence(
+    configs: Sequence[VehicleConfiguration],
+    *,
+    registry: CarSourceRegistry | None = None,
+) -> tuple[CarSourceEvidenceIssue, ...]:
+    """Return all provenance-evidence validation issues for exact vehicle rows."""
+
+    resolved_registry = load_car_source_registry() if registry is None else registry
+    issues: list[CarSourceEvidenceIssue] = []
+    for config in configs:
+        entity = f"{config.brand}|{config.model_name}|{config.variant_name}"
+        label = f"{config.brand} {config.model_name} / {config.variant_name}"
+        for entry in config.field_provenance:
+            if entry.confidence in _EVIDENCE_REQUIRED_CONFIDENCES and not entry.source_id:
+                issues.append(
+                    CarSourceEvidenceIssue(
+                        rule="missing_required_source_id",
+                        entity=entity,
+                        message=(
+                            f"{label} field {entry.field_name!r} uses confidence "
+                            f"{entry.confidence!r} but has no source_id"
+                        ),
+                    )
+                )
+                continue
+            if entry.source_id and entry.source_id not in resolved_registry.evidence:
+                issues.append(
+                    CarSourceEvidenceIssue(
+                        rule="missing_source_evidence",
+                        entity=entity,
+                        message=(
+                            f"{label} field {entry.field_name!r} references unknown "
+                            f"source_id {entry.source_id!r}"
+                        ),
+                    )
+                )
+    return tuple(issues)
+
+
+def _load_json_object(path: Path) -> Mapping[str, object]:
+    try:
+        with path.open(encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"Could not load car source metadata from {path}: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"{path} must contain a top-level object")
+    return payload
+
+
+def _required_non_empty_string(
+    row: Mapping[str, object],
+    key: str,
+    *,
+    path: Path,
+    index: int | None = None,
+) -> str:
+    value = row.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    location = f"{path} #{index}" if index is not None else str(path)
+    raise ValueError(f"{location} missing non-empty {key!r}")
+
+
+def _required_string_list(
+    row: Mapping[str, object],
+    key: str,
+    *,
+    path: Path,
+    index: int,
+) -> tuple[str, ...]:
+    value = row.get(key)
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{path} #{index} must contain a non-empty {key!r} list")
+    items = tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+    if len(items) != len(value):
+        raise ValueError(f"{path} #{index} contains an invalid {key!r} entry")
+    return items
+
+
+def _optional_string_list(row: Mapping[str, object], key: str) -> tuple[str, ...]:
+    value = row.get(key)
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError(f"Optional field {key!r} must be a list when present")
+    items = tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+    if len(items) != len(value):
+        raise ValueError(f"Optional field {key!r} contains an invalid entry")
+    return items
+
+
+def _format_issue_summary(issues: Sequence[CarSourceEvidenceIssue]) -> str:
+    lines = [f"Invalid car source evidence: {len(issues)} issue(s)"]
+    lines.extend(f"- [{issue.rule}] {issue.message}" for issue in issues[:10])
+    remaining = len(issues) - 10
+    if remaining > 0:
+        lines.append(f"- ... and {remaining} more")
+    return "\n".join(lines)

--- a/apps/server/vibesensor/data/car_library_evidence.json
+++ b/apps/server/vibesensor/data/car_library_evidence.json
@@ -1,0 +1,106 @@
+{
+  "evidence": [
+    {
+      "id": "variant_sources:BMW|4 Series (G22, 2021-2026):420i",
+      "summary": "Official BMW EU-market technical-data pages used to confirm the supported G22 420i variant and drivetrain slice.",
+      "source_refs": [
+        "bmw_market_pages:g22-4-series-technical-data-de",
+        "bmw_market_pages:g22-4-series-technical-data-ie"
+      ],
+      "legacy_refs": [
+        "CAR_VARIANT_SOURCES.md#4-series-g22-2021-2026",
+        "car_library_ratio_sources.json:cars.BMW|4 Series (G22, 2021-2026).sources.eu_variant_presence_and_naming"
+      ]
+    },
+    {
+      "id": "ratio_sources:BMW|2 Series Active Tourer (F45, 2014-2021):issue_1034_220i_ratio_reference",
+      "summary": "Cross-checked F45 220i DCT ratio evidence combining official BMW transmission-type context with reputable secondary numeric ratio references.",
+      "source_refs": [
+        "bmw_pressclub_sources:f45-220i-2018-press-kit",
+        "bmw_pressclub_sources:f45-220i-2018-spec-pdf",
+        "secondary_technical_sources:f45-220i-dct-autodata",
+        "secondary_technical_sources:f45-220i-dct-carfolio"
+      ],
+      "legacy_refs": [
+        "car_library_ratio_sources.json:cars.BMW|2 Series Active Tourer (F45, 2014-2021).sources.issue_1034_220i_ratio_reference"
+      ]
+    },
+    {
+      "id": "variant_sources:BMW|2 Series Active Tourer (F45, 2014-2021):220i",
+      "summary": "Official BMW PressClub F45 variant context used to support the exact-row 220i drivetrain assignment.",
+      "source_refs": [
+        "bmw_pressclub_sources:f45-220i-2018-press-kit"
+      ],
+      "legacy_refs": [
+        "CAR_VARIANT_SOURCES.md#2-series-active-tourer-f45-2014-2021"
+      ]
+    },
+    {
+      "id": "ratio_sources:BMW|2 Series Active Tourer (F45, 2014-2021):225xe_drivetrain_and_ratios",
+      "summary": "Official BMW 225xe drivetrain and ratio evidence used for the exact-row front final drive, top gear, transmission name, and drivetrain support.",
+      "source_refs": [
+        "bmw_pressclub_sources:f45-225xe-launch-release",
+        "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
+        "bmw_pressclub_sources:f45-2018-spec-pdf"
+      ],
+      "legacy_refs": [
+        "car_library_ratio_sources.json:cars.BMW|2 Series Active Tourer (F45, 2014-2021).sources.225xe_drivetrain_and_ratios"
+      ]
+    },
+    {
+      "id": "variant_sources:BMW|2 Series Active Tourer (F45, 2014-2021):225xe",
+      "summary": "Official BMW 225xe launch material used to support the exact-row AWD drivetrain assignment.",
+      "source_refs": [
+        "bmw_pressclub_sources:f45-225xe-launch-release"
+      ],
+      "legacy_refs": [
+        "CAR_VARIANT_SOURCES.md#2-series-active-tourer-f45-2014-2021"
+      ]
+    },
+    {
+      "id": "ratio_sources:BMW|3 Series (G20, 2019-2025):official_xdrive_ratio_verification",
+      "summary": "Official BMW G20 technical data attachment used for the exact-row 330i xDrive final-drive verification.",
+      "source_refs": [
+        "bmw_pressclub_sources:g20-330i-xdrive-ratio-pdf"
+      ],
+      "legacy_refs": [
+        "car_library_ratio_sources.json:cars.BMW|3 Series (G20, 2019-2025).sources.official_xdrive_ratio_verification"
+      ]
+    },
+    {
+      "id": "variant_sources:BMW|3 Series (G20, 2019-2025):330i xDrive",
+      "summary": "Official BMW market pages used for the supported G20 330i xDrive variant and drivetrain context.",
+      "source_refs": [
+        "bmw_market_pages:g20-3-series-uk-listing",
+        "bmw_market_pages:g20-3-series-de-overview"
+      ],
+      "legacy_refs": [
+        "CAR_VARIANT_SOURCES.md#3-series-g20-2019-2025",
+        "car_library_ratio_sources.json:cars.BMW|3 Series (G20, 2019-2025).sources.eu_variant_presence_and_drivetrain_context"
+      ]
+    },
+    {
+      "id": "ratio_sources:BMW|5 Series (G60, 2024-2026):ev_layout_confirmed_ratio_mapping_unresolved",
+      "summary": "Official BMW G60 EV technical data used for the exact-row i5 eDrive40 single-speed ratio and drivetrain-layout support.",
+      "source_refs": [
+        "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
+        "bmw_pressclub_sources:g60-5-series-launch-press-kit"
+      ],
+      "legacy_refs": [
+        "car_library_ratio_sources.json:cars.BMW|5 Series (G60, 2024-2026).sources.ev_layout_confirmed_ratio_mapping_unresolved"
+      ]
+    },
+    {
+      "id": "variant_sources:BMW|5 Series (G60, 2024-2026):i5 eDrive40",
+      "summary": "Official BMW G60 launch and technical-data material used for the exact-row i5 eDrive40 RWD variant support.",
+      "source_refs": [
+        "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
+        "bmw_pressclub_sources:g60-5-series-launch-press-kit"
+      ],
+      "legacy_refs": [
+        "CAR_VARIANT_SOURCES.md#5-series-g60-2024-2026",
+        "car_library_ratio_sources.json:cars.BMW|5 Series (G60, 2024-2026).sources.eu_scope_and_variant_filtering"
+      ]
+    }
+  ]
+}

--- a/apps/server/vibesensor/data/car_sources/bmw_market_pages.json
+++ b/apps/server/vibesensor/data/car_sources/bmw_market_pages.json
@@ -1,0 +1,33 @@
+{
+  "pack_id": "bmw_market_pages",
+  "sources": [
+    {
+      "id": "bmw_market_pages:g22-4-series-technical-data-de",
+      "url": "https://www.bmw.de/de/neufahrzeuge/4er/coupe/bmw-4er-coupe-technische-daten.html",
+      "title": "BMW Germany 4 Series Coupe technical data page",
+      "note": "Official BMW Germany technical-data page used for the supported G22 EU variant naming and drivetrain slice.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_market_pages:g22-4-series-technical-data-ie",
+      "url": "https://www.bmw.ie/en/all-models/4-series/4-series-coupe/bmw-4-series-coupe-technical-data.html",
+      "title": "BMW Ireland 4 Series Coupe technical data page",
+      "note": "Official BMW Ireland page used as a second EU-market cross-check for the supported G22 variant context.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_market_pages:g20-3-series-uk-listing",
+      "url": "https://www.bmw.co.uk/en/all-models.html?series=3",
+      "title": "BMW UK 3 Series model listing",
+      "note": "Official BMW UK listing used for the G20 variant and drivetrain context around the supported 330i xDrive row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "bmw_market_pages:g20-3-series-de-overview",
+      "url": "https://www.bmw.de/de/neufahrzeuge/3er.html",
+      "title": "BMW Germany 3 Series overview page",
+      "note": "Official BMW Germany overview used as a market cross-check for the supported G20 variant context.",
+      "confidence": "medium"
+    }
+  ]
+}

--- a/apps/server/vibesensor/data/car_sources/bmw_pressclub_sources.json
+++ b/apps/server/vibesensor/data/car_sources/bmw_pressclub_sources.json
@@ -1,0 +1,61 @@
+{
+  "pack_id": "bmw_pressclub_sources",
+  "sources": [
+    {
+      "id": "bmw_pressclub_sources:f45-220i-2018-press-kit",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0277458EN/the-new-bmw-2-series-active-tourer-the-new-bmw-2-series-gran-tourer",
+      "title": "BMW PressClub F45 Active Tourer 2018 press kit",
+      "note": "Official BMW PressClub article used for the F45 220i transmission and drivetrain context.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f45-220i-2018-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0277458EN/401747",
+      "title": "BMW PressClub F45 Active Tourer 2018 specifications PDF",
+      "note": "Official BMW specifications PDF used to confirm the F45 transmission table context while the 220i numeric ratio mapping remained ambiguous in extracted text.",
+      "confidence": "medium"
+    },
+    {
+      "id": "bmw_pressclub_sources:f45-225xe-launch-release",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0299792EN/more-versatile-and-efficient-than-ever:-market-launch-of-the-new-bmw-225xe-active-tourer",
+      "title": "BMW PressClub 225xe Active Tourer launch release",
+      "note": "Official BMW release used for the 225xe drivetrain layout and transmission path.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f45-225xe-2019-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0299792EN/436732",
+      "title": "BMW PressClub 225xe Active Tourer 2019 specifications PDF",
+      "note": "Official BMW 225xe specifications PDF with the documented top-gear and final-drive values used in the exact row.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f45-2018-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0277458EN/401747",
+      "title": "BMW PressClub F45 Active Tourer 2018 specifications PDF cross-check",
+      "note": "Official BMW PDF reused as a cross-check for the F45 225xe ratio pair and transmission naming.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g20-330i-xdrive-ratio-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0285128EN/425813",
+      "title": "BMW PressClub G20 3 Series technical data attachment",
+      "note": "Official BMW attachment used for the G20 330i xDrive automatic final-drive verification.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g60-5-series-launch-press-kit",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0416261EN/the-new-bmw-5-series-sedan",
+      "title": "BMW PressClub G60 5 Series launch press kit",
+      "note": "Official BMW launch press kit used for the EU variant scope and EV drivetrain layout context of the G60 range.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g60-2025-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0443474EN/629035",
+      "title": "BMW PressClub G60 5 Series 2025 technical specifications PDF",
+      "note": "Official BMW technical specifications PDF used for the i5 eDrive40 overall ratio and single-speed transmission evidence.",
+      "confidence": "high"
+    }
+  ]
+}

--- a/apps/server/vibesensor/data/car_sources/secondary_technical_sources.json
+++ b/apps/server/vibesensor/data/car_sources/secondary_technical_sources.json
@@ -1,0 +1,19 @@
+{
+  "pack_id": "secondary_technical_sources",
+  "sources": [
+    {
+      "id": "secondary_technical_sources:f45-220i-dct-autodata",
+      "url": "https://www.auto-data.net/en/bmw-2-series-active-tourer-f45-lci-facelift-2018-220i-192hp-dct-32491",
+      "title": "Auto-Data F45 220i DCT specification entry",
+      "note": "Reputable secondary source used for the F45 220i DCT numeric final-drive and top-gear pair after official BMW sources confirmed transmission type only.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:f45-220i-dct-carfolio",
+      "url": "https://www.carfolio.com/bmw-220i-active-tourer-543939",
+      "title": "Carfolio F45 220i Active Tourer specification entry",
+      "note": "Independent secondary cross-check for the F45 220i DCT ratio pair used in the exact-row override.",
+      "confidence": "medium"
+    }
+  ]
+}

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -96,15 +96,23 @@ Each provenance entry stores:
 
 ### Source ID prefixes
 
-`source_id` stays lightweight and links back to the existing research trail:
+`source_id` now resolves through
+`apps/server/vibesensor/data/car_library_evidence.json`.
 
-- `ratio_sources:<CAR_KEY>:<SOURCE_GROUP>` points at a source group in
-  `apps/server/vibesensor/data/car_library_ratio_sources.json`
-- `variant_sources:<CAR_KEY>:<VARIANT_NAME>` points at the variant table in
-  `apps/server/vibesensor/data/CAR_VARIANT_SOURCES.md`
+That evidence ledger is the machine-checkable owner for exact-row provenance:
 
-That keeps the old research notes intact instead of copying them into the exact
-rows.
+1. Each evidence entry keeps the canonical `source_id` string used by
+   `VehicleFieldProvenance`.
+2. Each evidence entry points at one or more structured source-pack records
+   under `apps/server/vibesensor/data/car_sources/*.json`.
+3. Legacy human-readable research ledgers such as
+   `car_library_ratio_sources.json` and `CAR_VARIANT_SOURCES.md` may still be
+   linked from the evidence entry for historical traceability, but they are not
+   the machine-checkable source of truth for exact-row evidence anymore.
+
+The current migrated BMW subset keeps the older `ratio_sources:` and
+`variant_sources:` prefixes as stable evidence IDs, but those IDs now resolve
+through the evidence ledger instead of pointing directly at ad hoc note files.
 
 ### Validation and analysis-confidence policy
 
@@ -118,10 +126,15 @@ Issue #3234 expands loader validation beyond schema checks:
 - the legacy `car_library.json` rows and resolved
   `vehicle_configurations.json` rows both run through that validator before the
   cached library snapshot is accepted
+- `apps/server/vibesensor/adapters/persistence/car_library_source_evidence.py`
+  is the one owner for exact-row source-pack and evidence resolution checks
 - documented exceptions live in
   `apps/server/vibesensor/data/car_library_validation_allowlist.json`, so
   temporary carve-outs stay explicit and machine-readable instead of hiding in
   scattered tests
+- trusted exact-row provenance now also fails closed when `source_id` is
+  missing for source-backed confidence levels or when the referenced evidence
+  entry does not resolve through the source-pack registry
 
 The confidence levels are the source data for future analysis-confidence
 policies:


### PR DESCRIPTION
## What changed
- add one machine-checkable source registry for exact car rows: structured source packs under `apps/server/vibesensor/data/car_sources/` plus `car_library_evidence.json` keyed by the current provenance `source_id` values
- validate that trusted exact-row provenance (`official_exact`, `official_derived`, `reputable_secondary_crosschecked`) keeps a `source_id` and that each referenced evidence entry resolves to real source-pack records
- wire the exact vehicle loader to fail closed when source evidence is missing or broken
- migrate the current BMW exact-row subset into the new evidence registry and keep links back to the legacy note files for traceability
- add focused source-registry tests and update the architecture doc to explain the new owner path

## Why
- current `source_id` fields existed, but CI could only check presence, not whether the ID resolved to real evidence
- this gives one machine-checkable source-evidence path for the exact rows already used by runtime analysis

## Validation
- `./.venv/bin/pytest -n0 -q apps/server/tests/adapters/persistence/test_car_library_source_evidence.py apps/server/tests/adapters/persistence/test_vehicle_configurations.py apps/server/tests/adapters/persistence/test_car_library_validation.py apps/server/tests/adapters/persistence/test_car_library_ratio_sources.py`
- `./.venv/bin/pytest -n0 -q apps/server/tests/adapters/persistence/`
- `make typecheck-backend`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `make docs-lint`

## Risks / tradeoffs
- this PR keeps the current exact-row `source_id` strings stable and resolves them through the new evidence ledger; broader ID renaming stays out of scope
- the migrated machine-checkable subset is the currently referenced BMW exact rows, not every legacy research note in the repo
- exact-row loading now fails closed on broken evidence references, which is the intended CI/runtime guard

Closes #3235