### PR TITLE
Support user-confirmed car override provenance

### DIFF
--- a/apps/server/tests/domain/test_car_order_reference_status.py
+++ b/apps/server/tests/domain/test_car_order_reference_status.py
@@ -1,0 +1,18 @@
+"""Focused tests for car order-reference provenance rules."""
+
+from __future__ import annotations
+
+from vibesensor.domain import CarOrderReferenceStatus
+
+
+def test_requires_manual_confirmation_includes_tire_confidence() -> None:
+    assert (
+        CarOrderReferenceStatus(
+            selection_source_status="exact_row",
+            tire_dimensions_confidence="family_default",
+            final_drive_ratio_confidence="official_exact",
+            current_gear_ratio_confidence="official_exact",
+            transmission_confidence="official_exact",
+        ).requires_manual_confirmation
+        is True
+    )

--- a/apps/server/tests/infra/config/test_car_settings.py
+++ b/apps/server/tests/infra/config/test_car_settings.py
@@ -84,6 +84,7 @@ def test_car_settings_update_car_decodes_order_reference_status_payload() -> Non
         {
             "order_reference_status": {
                 "selection_source_status": "compat_projection",
+                "tire_dimensions_confidence": "family_default",
                 "final_drive_ratio_confidence": "family_default",
                 "current_gear_ratio_confidence": "family_default",
                 "transmission_name": "8-speed automatic",
@@ -94,6 +95,7 @@ def test_car_settings_update_car_decodes_order_reference_status_payload() -> Non
 
     persisted = next(car for car in updated.cars if car["id"] == car_id)["order_reference_status"]
     assert persisted["selection_source_status"] == "compat_projection"
+    assert persisted["tire_dimensions_confidence"] == "family_default"
     assert persisted["requires_manual_confirmation"] is True
     assert persisted["transmission_name"] == "8-speed automatic"
 
@@ -105,6 +107,7 @@ def test_analysis_settings_update_marks_manual_ratio_overrides_user_confirmed() 
             "name": "Approximate",
             "order_reference_status": {
                 "selection_source_status": "exact_row",
+                "tire_dimensions_confidence": "official_exact",
                 "final_drive_ratio_confidence": "family_default",
                 "current_gear_ratio_confidence": "family_default",
                 "transmission_name": "8-speed automatic",
@@ -122,8 +125,41 @@ def test_analysis_settings_update_marks_manual_ratio_overrides_user_confirmed() 
     snapshot = services.car_settings.active_car_snapshot()
     assert snapshot is not None
     assert snapshot.order_reference_status is not None
+    assert snapshot.order_reference_status.selection_source_status == "manual_entry"
+    assert snapshot.order_reference_status.tire_dimensions_confidence == "official_exact"
     assert snapshot.order_reference_status.final_drive_ratio_confidence == "user_confirmed"
     assert snapshot.order_reference_status.current_gear_ratio_confidence == "user_confirmed"
+    assert snapshot.order_reference_status.transmission_confidence == "official_exact"
+    assert snapshot.order_reference_status.requires_manual_confirmation is False
+
+
+def test_analysis_settings_update_marks_manual_tire_overrides_user_confirmed() -> None:
+    services = build_settings_services()
+    created = services.car_settings.add_car(
+        {
+            "name": "Approximate",
+            "order_reference_status": {
+                "selection_source_status": "exact_row",
+                "tire_dimensions_confidence": "family_default",
+                "final_drive_ratio_confidence": "official_exact",
+                "current_gear_ratio_confidence": "official_exact",
+                "transmission_name": "8-speed automatic",
+                "transmission_confidence": "official_exact",
+            },
+        }
+    )
+    car_id = created.cars[0]["id"]
+    services.car_settings.set_active_car(car_id)
+
+    services.analysis_settings.update_active_car_aspects({"tire_width_mm": 245.0})
+
+    snapshot = services.car_settings.active_car_snapshot()
+    assert snapshot is not None
+    assert snapshot.order_reference_status is not None
+    assert snapshot.order_reference_status.selection_source_status == "manual_entry"
+    assert snapshot.order_reference_status.tire_dimensions_confidence == "user_confirmed"
+    assert snapshot.order_reference_status.final_drive_ratio_confidence == "official_exact"
+    assert snapshot.order_reference_status.current_gear_ratio_confidence == "official_exact"
     assert snapshot.order_reference_status.transmission_confidence == "official_exact"
     assert snapshot.order_reference_status.requires_manual_confirmation is False
 

--- a/apps/server/tests/shared/boundaries/test_run_car_codec.py
+++ b/apps/server/tests/shared/boundaries/test_run_car_codec.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from vibesensor.domain import CarOrderReferenceStatus
 from vibesensor.shared.boundaries.runs.car import (
     run_car_metadata_from_mapping,
     run_car_metadata_to_json_object,
@@ -49,4 +50,49 @@ def test_run_car_metadata_to_json_object_keeps_identity_only() -> None:
         "name": "Track Car",
         "type": "coupe",
         "variant": "sport",
+    }
+
+
+def test_run_car_metadata_round_trips_order_reference_status() -> None:
+    run_car = run_car_metadata_from_mapping(
+        {
+            "id": "car-1",
+            "name": "Track Car",
+            "type": "coupe",
+            "variant": "sport",
+            "order_reference_status": {
+                "selection_source_status": "manual_entry",
+                "tire_dimensions_confidence": "user_confirmed",
+                "final_drive_ratio_confidence": "user_confirmed",
+                "current_gear_ratio_confidence": "user_confirmed",
+                "requires_manual_confirmation": False,
+            },
+        }
+    )
+
+    assert run_car == RunCarMetadata(
+        car_id="car-1",
+        name="Track Car",
+        car_type="coupe",
+        variant="sport",
+        order_reference_status=CarOrderReferenceStatus(
+            selection_source_status="manual_entry",
+            tire_dimensions_confidence="user_confirmed",
+            final_drive_ratio_confidence="user_confirmed",
+            current_gear_ratio_confidence="user_confirmed",
+        ),
+    )
+    assert run_car is not None
+    assert run_car_metadata_to_json_object(run_car) == {
+        "id": "car-1",
+        "name": "Track Car",
+        "type": "coupe",
+        "variant": "sport",
+        "order_reference_status": {
+            "selection_source_status": "manual_entry",
+            "tire_dimensions_confidence": "user_confirmed",
+            "final_drive_ratio_confidence": "user_confirmed",
+            "current_gear_ratio_confidence": "user_confirmed",
+            "requires_manual_confirmation": False,
+        },
     }

--- a/apps/server/tests/use_cases/run/test_run_metadata_builder.py
+++ b/apps/server/tests/use_cases/run/test_run_metadata_builder.py
@@ -1,0 +1,54 @@
+"""Focused tests for run metadata assembly."""
+
+from __future__ import annotations
+
+from vibesensor.domain import AnalysisSettingsSnapshot, CarOrderReferenceStatus, CarSnapshot
+from vibesensor.shared.types.run_schema import RunCarMetadata
+from vibesensor.use_cases.run.run_metadata_builder import build_run_metadata
+
+
+def test_build_run_metadata_carries_active_car_override_provenance() -> None:
+    metadata = build_run_metadata(
+        run_id="run-1",
+        start_time_utc="2026-04-25T00:00:00Z",
+        analysis_settings_snapshot=AnalysisSettingsSnapshot(
+            tire_width_mm=245.0,
+            tire_aspect_pct=40.0,
+            rim_in=18.0,
+            final_drive_ratio=3.91,
+            current_gear_ratio=0.82,
+        ),
+        sensor_model="fixture-sensor",
+        firmware_version="1.2.3",
+        default_sample_rate_hz=800,
+        metrics_log_hz=10,
+        fft_window_size_samples=1024,
+        accel_scale_g_per_lsb=0.001,
+        active_car_snapshot=CarSnapshot(
+            car_id="car-1",
+            name="Track Car",
+            car_type="coupe",
+            order_reference_status=CarOrderReferenceStatus(
+                selection_source_status="manual_entry",
+                tire_dimensions_confidence="user_confirmed",
+                final_drive_ratio_confidence="user_confirmed",
+                current_gear_ratio_confidence="user_confirmed",
+                transmission_name="8-speed automatic",
+                transmission_confidence="official_exact",
+            ),
+        ),
+    )
+
+    assert metadata.car == RunCarMetadata(
+        car_id="car-1",
+        name="Track Car",
+        car_type="coupe",
+        order_reference_status=CarOrderReferenceStatus(
+            selection_source_status="manual_entry",
+            tire_dimensions_confidence="user_confirmed",
+            final_drive_ratio_confidence="user_confirmed",
+            current_gear_ratio_confidence="user_confirmed",
+            transmission_name="8-speed automatic",
+            transmission_confidence="official_exact",
+        ),
+    )

--- a/apps/server/vibesensor/adapters/http/models/settings.py
+++ b/apps/server/vibesensor/adapters/http/models/settings.py
@@ -70,6 +70,7 @@ class CarOrderReferenceStatus(BaseModel):
     """Confidence metadata for saved drivetrain order-reference values."""
 
     selection_source_status: Literal["compat_projection", "exact_row", "manual_entry"]
+    tire_dimensions_confidence: str | None = None
     final_drive_ratio_confidence: str | None = None
     current_gear_ratio_confidence: str | None = None
     transmission_name: str | None = None

--- a/apps/server/vibesensor/domain/car.py
+++ b/apps/server/vibesensor/domain/car.py
@@ -42,6 +42,7 @@ class CarOrderReferenceStatus:
     """Persisted confidence metadata for selected drivetrain order-reference values."""
 
     selection_source_status: CarOrderReferenceSourceStatus
+    tire_dimensions_confidence: VehicleFieldConfidence | None = None
     final_drive_ratio_confidence: VehicleFieldConfidence | None = None
     current_gear_ratio_confidence: VehicleFieldConfidence | None = None
     transmission_name: str | None = None
@@ -54,6 +55,7 @@ class CarOrderReferenceStatus:
         return any(
             confidence in {"family_default", "unverified"}
             for confidence in (
+                self.tire_dimensions_confidence,
                 self.final_drive_ratio_confidence,
                 self.current_gear_ratio_confidence,
                 self.transmission_confidence,
@@ -63,13 +65,21 @@ class CarOrderReferenceStatus:
     def with_user_confirmed_fields(
         self,
         *,
+        tire_dimensions: bool = False,
         current_gear_ratio: bool = False,
         final_drive_ratio: bool = False,
     ) -> CarOrderReferenceStatus:
         """Return a copy with the selected order-reference fields user-confirmed."""
 
         return CarOrderReferenceStatus(
-            selection_source_status=self.selection_source_status,
+            selection_source_status=(
+                "manual_entry"
+                if tire_dimensions or current_gear_ratio or final_drive_ratio
+                else self.selection_source_status
+            ),
+            tire_dimensions_confidence=(
+                "user_confirmed" if tire_dimensions else self.tire_dimensions_confidence
+            ),
             final_drive_ratio_confidence=(
                 "user_confirmed" if final_drive_ratio else self.final_drive_ratio_confidence
             ),

--- a/apps/server/vibesensor/infra/config/car_settings.py
+++ b/apps/server/vibesensor/infra/config/car_settings.py
@@ -40,6 +40,7 @@ _AXLE_TIRE_ASPECT_KEYS = frozenset(
         "default_axle_for_speed",
     }
 )
+_TIRE_REFERENCE_ASPECT_KEYS = _FLAT_TIRE_ASPECT_KEYS | _AXLE_TIRE_ASPECT_KEYS
 
 
 class _UpdateWithRollback(Protocol):
@@ -331,11 +332,13 @@ def _updated_order_reference_status(
     aspects: AnalysisSettingsPayload,
 ) -> CarOrderReferenceStatus | None:
     touched_keys = _ORDER_REFERENCE_ASPECT_KEYS.intersection(aspects)
-    if not touched_keys:
+    touched_tire_keys = _TIRE_REFERENCE_ASPECT_KEYS.intersection(aspects)
+    if not touched_keys and not touched_tire_keys:
         return existing
     if existing is None:
         return CarOrderReferenceStatus(
             selection_source_status="manual_entry",
+            tire_dimensions_confidence="user_confirmed" if touched_tire_keys else None,
             current_gear_ratio_confidence=(
                 "user_confirmed" if "current_gear_ratio" in touched_keys else None
             ),
@@ -344,6 +347,7 @@ def _updated_order_reference_status(
             ),
         )
     return existing.with_user_confirmed_fields(
+        tire_dimensions=bool(touched_tire_keys),
         current_gear_ratio="current_gear_ratio" in touched_keys,
         final_drive_ratio="final_drive_ratio" in touched_keys,
     )

--- a/apps/server/vibesensor/shared/boundaries/runs/car.py
+++ b/apps/server/vibesensor/shared/boundaries/runs/car.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from vibesensor.shared.boundaries.codecs.scalars import text_or_none
+from vibesensor.shared.types.car_config import (
+    car_order_reference_status_from_mapping,
+    car_order_reference_status_json_object_from_domain,
+)
 from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.run_schema import RunCarMetadata
 
@@ -24,6 +28,14 @@ def run_car_metadata_from_mapping(payload: object) -> RunCarMetadata | None:
         name=text_or_none(payload.get("name")),
         car_type=text_or_none(payload.get("type")),
         variant=text_or_none(payload.get("variant")),
+        order_reference_status=(
+            car_order_reference_status_from_mapping(order_reference_status)
+            if isinstance(
+                (order_reference_status := payload.get("order_reference_status")),
+                Mapping,
+            )
+            else None
+        ),
     )
     if (
         run_car.car_id is None
@@ -40,9 +52,14 @@ def run_car_metadata_to_json_object(run_car: RunCarMetadata | None) -> JsonObjec
 
     if run_car is None:
         return None
-    return {
+    payload: JsonObject = {
         "id": run_car.car_id,
         "name": run_car.name,
         "type": run_car.car_type,
         "variant": run_car.variant,
     }
+    if run_car.order_reference_status is not None:
+        payload["order_reference_status"] = car_order_reference_status_json_object_from_domain(
+            run_car.order_reference_status
+        )
+    return payload

--- a/apps/server/vibesensor/shared/boundaries/settings/cars.py
+++ b/apps/server/vibesensor/shared/boundaries/settings/cars.py
@@ -76,6 +76,7 @@ def _car_order_reference_status_payload_from_mapping(
             selection_source_status,
         )
     for key in (
+        "tire_dimensions_confidence",
         "current_gear_ratio_confidence",
         "final_drive_ratio_confidence",
         "transmission_confidence",

--- a/apps/server/vibesensor/shared/types/car_config.py
+++ b/apps/server/vibesensor/shared/types/car_config.py
@@ -16,6 +16,7 @@ from vibesensor.shared.analysis_settings_schema import (
     ANALYSIS_SETTINGS_DEFAULTS,
     sanitize_analysis_settings,
 )
+from vibesensor.shared.types.json_types import JsonObject
 from vibesensor.shared.types.settings_types import (
     AnalysisSettingsPayload,
     analysis_settings_payload_from_mapping,
@@ -30,6 +31,8 @@ __all__ = [
     "CarOrderReferenceStatusPayload",
     "CarsSnapshot",
     "car_from_persistence_dict",
+    "car_order_reference_status_json_object_from_domain",
+    "car_order_reference_status_payload_from_domain",
     "car_order_reference_status_from_mapping",
     "car_to_persistence_dict",
     "new_car_id",
@@ -51,6 +54,7 @@ class CarOrderReferenceStatusPayload(TypedDict, total=False):
     """Persisted confidence metadata for selected drivetrain order-reference values."""
 
     selection_source_status: CarOrderReferenceSourceStatus
+    tire_dimensions_confidence: VehicleFieldConfidence
     final_drive_ratio_confidence: VehicleFieldConfidence
     current_gear_ratio_confidence: VehicleFieldConfidence
     transmission_name: str
@@ -119,7 +123,7 @@ def car_to_persistence_dict(car: Car) -> CarConfigPayload:
     if car.variant:
         payload["variant"] = car.variant
     if car.order_reference_status is not None:
-        payload["order_reference_status"] = _car_order_reference_status_payload(
+        payload["order_reference_status"] = car_order_reference_status_payload_from_domain(
             car.order_reference_status
         )
     return payload
@@ -133,6 +137,7 @@ def car_order_reference_status_from_mapping(
         selection_source_status = "manual_entry"
     return CarOrderReferenceStatus(
         selection_source_status=cast(CarOrderReferenceSourceStatus, selection_source_status),
+        tire_dimensions_confidence=_optional_confidence(payload.get("tire_dimensions_confidence")),
         final_drive_ratio_confidence=_optional_confidence(
             payload.get("final_drive_ratio_confidence")
         ),
@@ -144,13 +149,15 @@ def car_order_reference_status_from_mapping(
     )
 
 
-def _car_order_reference_status_payload(
+def car_order_reference_status_payload_from_domain(
     status: CarOrderReferenceStatus,
 ) -> CarOrderReferenceStatusPayload:
     payload: CarOrderReferenceStatusPayload = {
         "selection_source_status": status.selection_source_status,
         "requires_manual_confirmation": status.requires_manual_confirmation,
     }
+    if status.tire_dimensions_confidence is not None:
+        payload["tire_dimensions_confidence"] = status.tire_dimensions_confidence
     if status.final_drive_ratio_confidence is not None:
         payload["final_drive_ratio_confidence"] = status.final_drive_ratio_confidence
     if status.current_gear_ratio_confidence is not None:
@@ -160,6 +167,27 @@ def _car_order_reference_status_payload(
     if status.transmission_confidence is not None:
         payload["transmission_confidence"] = status.transmission_confidence
     return payload
+
+
+def car_order_reference_status_json_object_from_domain(
+    status: CarOrderReferenceStatus,
+) -> JsonObject:
+    payload = car_order_reference_status_payload_from_domain(status)
+    json_payload: JsonObject = {
+        "selection_source_status": payload["selection_source_status"],
+        "requires_manual_confirmation": payload["requires_manual_confirmation"],
+    }
+    if "tire_dimensions_confidence" in payload:
+        json_payload["tire_dimensions_confidence"] = payload["tire_dimensions_confidence"]
+    if "final_drive_ratio_confidence" in payload:
+        json_payload["final_drive_ratio_confidence"] = payload["final_drive_ratio_confidence"]
+    if "current_gear_ratio_confidence" in payload:
+        json_payload["current_gear_ratio_confidence"] = payload["current_gear_ratio_confidence"]
+    if "transmission_name" in payload:
+        json_payload["transmission_name"] = payload["transmission_name"]
+    if "transmission_confidence" in payload:
+        json_payload["transmission_confidence"] = payload["transmission_confidence"]
+    return json_payload
 
 
 def _text_or_default(value: object, *, default: str, max_length: int) -> str:

--- a/apps/server/vibesensor/shared/types/run_schema.py
+++ b/apps/server/vibesensor/shared/types/run_schema.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from typing import Literal
 
-from vibesensor.domain import AnalysisSettingsSnapshot, OrderReferenceSpec, Symptom
+from vibesensor.domain import (
+    AnalysisSettingsSnapshot,
+    CarOrderReferenceStatus,
+    OrderReferenceSpec,
+    Symptom,
+)
 from vibesensor.shared.order_reference_settings import order_reference_spec_from_snapshot
 
 from .json_types import JsonObject
@@ -51,6 +56,7 @@ class RunCarMetadata:
     name: str | None = None
     car_type: str | None = None
     variant: str | None = None
+    order_reference_status: CarOrderReferenceStatus | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/server/vibesensor/use_cases/run/run_metadata_builder.py
+++ b/apps/server/vibesensor/use_cases/run/run_metadata_builder.py
@@ -177,6 +177,7 @@ def _run_car_metadata_for_run(
             name=active_car_snapshot.name,
             car_type=active_car_snapshot.car_type,
             variant=active_car_snapshot.variant,
+            order_reference_status=active_car_snapshot.order_reference_status,
         )
     tokens = [token.strip().lower() for token in str(firmware_version or "").split(",")]
     if any(token.startswith("sim-") for token in tokens if token):

--- a/apps/ui/src/app/features/car_confidence_summary.ts
+++ b/apps/ui/src/app/features/car_confidence_summary.ts
@@ -40,6 +40,11 @@ export function describeOrderReferenceConfidence(
   }
   const parts = [
     buildConfidencePart(
+      "settings.car.confidence.part_tires",
+      status.tire_dimensions_confidence,
+      t,
+    ),
+    buildConfidencePart(
       "settings.car.confidence.part_drive",
       status.final_drive_ratio_confidence,
       t,

--- a/apps/ui/src/app/features/cars_feature_workflow.ts
+++ b/apps/ui/src/app/features/cars_feature_workflow.ts
@@ -495,6 +495,7 @@ export function createCarsFeatureWorkflow(
             ...tireSetupAspectsFromOption(tire),
           },
           {
+            tire_dimensions_confidence: tire.source_confidence ?? "unverified",
             current_gear_ratio_confidence: gearbox.top_gear_ratio_confidence ?? "unverified",
             final_drive_ratio_confidence: gearbox.final_drive_ratio_confidence ?? "unverified",
             requires_manual_confirmation: gearbox.requires_manual_confirmation ?? true,
@@ -514,20 +515,21 @@ export function createCarsFeatureWorkflow(
         return false;
       }
 
-      await deps.addCarFromWizard(
-        buildWizardCarName(state.brand, state.model, state.selectedVariant),
-        state.carType || "Custom",
+        await deps.addCarFromWizard(
+          buildWizardCarName(state.brand, state.model, state.selectedVariant),
+          state.carType || "Custom",
         {
           current_gear_ratio: Number(inputs.topGear),
           final_drive_ratio: Number(inputs.finalDrive),
           rim_in: Number(inputs.rim),
           tire_aspect_pct: Number(inputs.tireAspect),
           tire_width_mm: Number(inputs.tireWidth),
-        },
-        {
-          current_gear_ratio_confidence: "user_confirmed",
-          final_drive_ratio_confidence: "user_confirmed",
-          requires_manual_confirmation: false,
+          },
+          {
+            tire_dimensions_confidence: "user_confirmed",
+            current_gear_ratio_confidence: "user_confirmed",
+            final_drive_ratio_confidence: "user_confirmed",
+            requires_manual_confirmation: false,
           selection_source_status: "manual_entry",
         },
         state.selectedVariant?.name,

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -1536,6 +1536,17 @@
             "title": "Selection Source Status",
             "type": "string"
           },
+          "tire_dimensions_confidence": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tire Dimensions Confidence"
+          },
           "transmission_confidence": {
             "anyOf": [
               {

--- a/apps/ui/src/i18n/catalogs/en.json
+++ b/apps/ui/src/i18n/catalogs/en.json
@@ -332,6 +332,7 @@
   "settings.car.finish_manual_ready": "Manual path selected. Add Car will use the values entered below.",
   "settings.car.finish_manual_missing": "Enter positive tire and gearbox values to finish.",
   "settings.car.approximate_detail": "This car still uses approximate drivetrain ratios from a family-default library match. Review or override them in Analysis before trusting driveshaft or engine order results.",
+  "settings.car.confidence.part_tires": "Tires {value}",
   "settings.car.confidence.part_drive": "Drive {value}",
   "settings.car.confidence.part_gear": "Top gear {value}",
   "settings.car.confidence.part_transmission": "Transmission {value}",

--- a/apps/ui/src/i18n/catalogs/nl.json
+++ b/apps/ui/src/i18n/catalogs/nl.json
@@ -332,6 +332,7 @@
   "settings.car.finish_manual_ready": "Handmatige route gekozen. Auto toevoegen gebruikt de hieronder ingevulde waarden.",
   "settings.car.finish_manual_missing": "Voer positieve band- en overbrengingswaarden in om af te ronden.",
   "settings.car.approximate_detail": "Deze auto gebruikt nog benaderde aandrijflijnverhoudingen uit een family-default bibliotheekmatch. Controleer of overschrijf ze in Analyse voordat je driveshaft- of motorordes vertrouwt.",
+  "settings.car.confidence.part_tires": "Banden {value}",
   "settings.car.confidence.part_drive": "Aandrijving {value}",
   "settings.car.confidence.part_gear": "Hoogste versnelling {value}",
   "settings.car.confidence.part_transmission": "Versnellingsbak {value}",

--- a/apps/ui/tests/car_confidence_summary.spec.ts
+++ b/apps/ui/tests/car_confidence_summary.spec.ts
@@ -11,6 +11,7 @@ import {
 import { buildSettingsCarListRenderModel } from "../src/app/views/settings_car_list_view";
 
 const labels: Record<string, string> = {
+  "settings.car.confidence.part_tires": "Tires {value}",
   "settings.car.confidence.part_drive": "Drive {value}",
   "settings.car.confidence.part_gear": "Top gear {value}",
   "settings.car.confidence.part_transmission": "Transmission {value}",
@@ -56,6 +57,7 @@ function makeOrderStatus(
 ): CarOrderReferenceStatus {
   return {
     selection_source_status: "exact_row",
+    tire_dimensions_confidence: "official_exact",
     final_drive_ratio_confidence: "official_exact",
     current_gear_ratio_confidence: "official_exact",
     transmission_name: "8-speed automatic",
@@ -98,27 +100,29 @@ function makeCar(overrides: Partial<CarRecord> = {}): CarRecord {
 
 test("buildOrderReferenceConfidenceDetail distinguishes exact and approximate status", () => {
   expect(buildOrderReferenceConfidenceDetail(makeOrderStatus(), t)).toBe(
-    "Drive official source · Top gear official source · Transmission official source",
+    "Tires official source · Drive official source · Top gear official source · Transmission official source",
   );
   expect(buildOrderReferenceConfidenceDetail(makeOrderStatus({
+    tire_dimensions_confidence: "family_default",
     final_drive_ratio_confidence: "family_default",
     current_gear_ratio_confidence: "family_default",
     transmission_confidence: "family_default",
     requires_manual_confirmation: true,
   }), t)).toBe(
-    "Drive family default · Top gear family default · Transmission family default. Review or override in Analysis before trusting driveshaft or engine order results.",
+    "Tires family default · Drive family default · Top gear family default · Transmission family default. Review or override in Analysis before trusting driveshaft or engine order results.",
   );
 });
 
 test("buildOrderReferenceConfidenceDetail preserves user-confirmed manual values", () => {
   expect(buildOrderReferenceConfidenceDetail(makeOrderStatus({
     selection_source_status: "manual_entry",
+    tire_dimensions_confidence: "user_confirmed",
     final_drive_ratio_confidence: "user_confirmed",
     current_gear_ratio_confidence: "user_confirmed",
     transmission_name: null,
     transmission_confidence: null,
   }), t)).toBe(
-    "Drive user confirmed · Top gear user confirmed",
+    "Tires user confirmed · Drive user confirmed · Top gear user confirmed",
   );
 });
 
@@ -171,6 +175,6 @@ test("buildSettingsCarListRenderModel shows exact confidence detail for ready ca
     throw new Error("Expected rows");
   }
   expect(model.rows[0].completionDetailText).toBe(
-    "Drive official source · Top gear official source · Transmission official source",
+    "Tires official source · Drive official source · Top gear official source · Transmission official source",
   );
 });

--- a/apps/ui/tests/car_list_state.spec.ts
+++ b/apps/ui/tests/car_list_state.spec.ts
@@ -39,6 +39,7 @@ const labels: Record<string, string> = {
   "settings.car.tires_missing": "Tire size not set",
   "settings.car.incomplete_detail": "Open Analysis to finish the missing tire and drivetrain specs before using this car.",
   "settings.car.approximate_detail": "Approximate drivetrain ratios need review.",
+  "settings.car.confidence.part_tires": "Tires {value}",
   "settings.car.confidence.part_drive": "Drive {value}",
   "settings.car.confidence.part_gear": "Top gear {value}",
   "settings.car.confidence.part_transmission": "Transmission {value}",
@@ -60,6 +61,9 @@ const labels: Record<string, string> = {
 function t(key: string, vars?: Record<string, unknown>): string {
   if (key === "settings.car.created_body") {
     return `${vars?.name ?? "Unknown"} was added and selected for this setup.`;
+  }
+  if (key === "settings.car.confidence.part_tires") {
+    return `Tires ${vars?.value ?? ""}`.trim();
   }
   if (key === "settings.car.confidence.part_drive") {
     return `Drive ${vars?.value ?? ""}`.trim();

--- a/apps/ui/tests/cars_feature_workflow.spec.ts
+++ b/apps/ui/tests/cars_feature_workflow.spec.ts
@@ -185,6 +185,7 @@ describe("createCarsFeatureWorkflow", () => {
       carType: "SUV",
       name: "BMW X5 M60i",
       orderReferenceStatus: {
+        tire_dimensions_confidence: "user_confirmed",
         current_gear_ratio_confidence: "user_confirmed",
         final_drive_ratio_confidence: "user_confirmed",
         requires_manual_confirmation: false,
@@ -492,6 +493,7 @@ describe("createCarsFeatureWorkflow", () => {
         final_drive_ratio_confidence: "official_exact",
         requires_manual_confirmation: false,
         selection_source_status: "exact_row",
+        tire_dimensions_confidence: "official_exact",
         transmission_confidence: "official_exact",
         transmission_name: "8-speed automatic",
       },

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -92,7 +92,8 @@ Each provenance entry stores:
   a variant-specific source is captured
 - `unverified`: the stored value is still present but should not be treated as a
   verified source-of-truth fact
-- `user_confirmed`: reserved for future locally confirmed overrides
+- `user_confirmed`: a locally edited saved-car field that the user explicitly
+  confirmed in Analysis
 
 ### Source ID prefixes
 


### PR DESCRIPTION
Closes #3238

## What changed
- persist tire override provenance alongside existing final-drive and top-gear provenance in saved car settings
- promote local tire/final-drive/top-gear edits to `manual_entry` + `user_confirmed` without mutating built-in library rows
- carry saved-car override provenance into run/export metadata
- show tire confidence in the current saved-car and wizard confidence copy
- add focused backend and UI regressions for persistence, metadata, and manual-confirmation rules

## Why
- weak library defaults are not enough for real cars with known local specs
- analysis and exports need to show when user-confirmed values overrode approximate built-in data
- one provenance path is cleaner than bolting on a second override model

## Validation
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" python -m pytest -q apps/server/tests/domain/test_car_order_reference_status.py apps/server/tests/infra/config/test_car_settings.py apps/server/tests/shared/boundaries/test_run_car_codec.py apps/server/tests/use_cases/run/test_run_metadata_builder.py`
- `cd apps/ui && npm run test:unit -- tests/car_confidence_summary.spec.ts tests/car_list_state.spec.ts tests/cars_feature_workflow.spec.ts`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make sync-contracts`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make typecheck-backend`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make ui-typecheck`
- `cd apps/ui && npm run build`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make docs-lint`

## Risk / edge
- scope stays narrow on purpose: existing editable fields only
- transmission-name/full-gear/drivetrain-note editing is still future work
- UI unit runs still print an existing localhost connection refusal stderr from unrelated test setup, but assertions are green
