### PR TITLE
Apply car-data confidence policy to diagnosis confidence

### DIFF
--- a/apps/server/tests/domain/test_car_order_reference_status.py
+++ b/apps/server/tests/domain/test_car_order_reference_status.py
@@ -16,3 +16,29 @@ def test_requires_manual_confirmation_includes_tire_confidence() -> None:
         ).requires_manual_confirmation
         is True
     )
+
+
+def test_order_analysis_car_data_confidence_uses_relevant_scope_fields() -> None:
+    status = CarOrderReferenceStatus(
+        selection_source_status="exact_row",
+        tire_dimensions_confidence="user_confirmed",
+        final_drive_ratio_confidence="reputable_secondary_crosschecked",
+        current_gear_ratio_confidence="family_default",
+        transmission_confidence="official_exact",
+    )
+
+    wheel = status.order_analysis_car_data_confidence(ref_sources=("speed+tire",))
+    driveline = status.order_analysis_car_data_confidence(ref_sources=("speed+tire+final_drive",))
+    engine = status.order_analysis_car_data_confidence(ref_sources=("speed+engine",))
+    direct_engine = status.order_analysis_car_data_confidence(ref_sources=("obd2",))
+
+    assert wheel is not None
+    assert wheel.scope == "tire"
+    assert wheel.confidence == "user_confirmed"
+    assert driveline is not None
+    assert driveline.scope == "driveline"
+    assert driveline.confidence == "reputable_secondary_crosschecked"
+    assert engine is not None
+    assert engine.scope == "engine_speed_derived"
+    assert engine.confidence == "family_default"
+    assert direct_engine is None

--- a/apps/server/tests/shared/test_report_presentation_vehicle_data_confidence.py
+++ b/apps/server/tests/shared/test_report_presentation_vehicle_data_confidence.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from vibesensor.domain import (
+    DiagnosisAssessmentFactor,
+    DiagnosisAssessmentFactorDetails,
+    diagnosis_assessment_from_components,
+)
+from vibesensor.report_i18n import tr as report_tr
+from vibesensor.shared.report_presentation import confidence_caveat_text, confidence_reason_text
+
+
+def test_confidence_reason_text_mentions_user_confirmed_vehicle_data_scope() -> None:
+    confidence = diagnosis_assessment_from_components(
+        score_0_to_1=0.75,
+        data_basis="raw_backed",
+        raw_backed_sample_count=0,
+        supporting_window_count=0,
+        supporting_duration_s=None,
+        stable_frequency_min_hz=None,
+        stable_frequency_max_hz=None,
+        supporting_location_count=0,
+        top_support_location=None,
+        top_support_share=None,
+        mean_relative_error=None,
+        snr_db=None,
+        alternative_source=None,
+        has_reference_gap=False,
+        speed_gap_window_count=0,
+        rpm_gap_window_count=0,
+        car_data_reference_scope="tire",
+        car_data_confidence="user_confirmed",
+        uses_summary_fallback=False,
+        fallback_reason=None,
+        support_factors=(
+            DiagnosisAssessmentFactor(
+                factor_key="user_confirmed_vehicle_data",
+                polarity="support",
+                severity="low",
+                weight=0.04,
+                details=DiagnosisAssessmentFactorDetails(
+                    car_data_reference_scope="tire",
+                    car_data_confidence="user_confirmed",
+                ),
+            ),
+        ),
+        counterevidence_factors=(),
+    )
+
+    text = confidence_reason_text(confidence, tr=_tr)
+
+    assert "user-confirmed vehicle data" in text
+    assert "wheel-speed" in text
+
+
+def test_confidence_caveat_text_mentions_approximate_vehicle_data_scope() -> None:
+    confidence = diagnosis_assessment_from_components(
+        score_0_to_1=0.45,
+        data_basis="raw_backed",
+        raw_backed_sample_count=0,
+        supporting_window_count=0,
+        supporting_duration_s=None,
+        stable_frequency_min_hz=None,
+        stable_frequency_max_hz=None,
+        supporting_location_count=0,
+        top_support_location=None,
+        top_support_share=None,
+        mean_relative_error=None,
+        snr_db=None,
+        alternative_source=None,
+        has_reference_gap=False,
+        speed_gap_window_count=0,
+        rpm_gap_window_count=0,
+        car_data_reference_scope="engine_speed_derived",
+        car_data_confidence="family_default",
+        uses_summary_fallback=False,
+        fallback_reason=None,
+        support_factors=(),
+        counterevidence_factors=(
+            DiagnosisAssessmentFactor(
+                factor_key="approximate_vehicle_data",
+                polarity="counterevidence",
+                severity="medium",
+                weight=0.06,
+                details=DiagnosisAssessmentFactorDetails(
+                    car_data_reference_scope="engine_speed_derived",
+                    car_data_confidence="family_default",
+                ),
+            ),
+        ),
+    )
+
+    text = confidence_caveat_text(confidence, tr=_tr)
+
+    assert text is not None
+    assert "approximate vehicle data" in text
+    assert "speed-derived engine" in text
+
+
+def _tr(key: str, **kwargs) -> str:
+    return report_tr("en", key, **kwargs)

--- a/apps/server/tests/test_support/whole_run_diagnosis_scenarios.py
+++ b/apps/server/tests/test_support/whole_run_diagnosis_scenarios.py
@@ -47,6 +47,7 @@ class WholeRunDiagnosisScenario:
             context_intervals=self.context_intervals,
             order_summaries=self.order_summaries,
             spatial_summaries=self.spatial_summaries,
+            car_order_reference_status=None,
         )
 
     def build_report_summary(self) -> dict[str, object]:

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_car_data_confidence.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_car_data_confidence.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from vibesensor.domain import CarOrderReferenceStatus, DrivingPhase, VehicleFieldConfidence
+from vibesensor.shared.types.whole_run_analysis import WholeRunContextInterval
+from vibesensor.use_cases.diagnostics.orders.whole_run_contracts import (
+    OrderTraceSummary,
+    OrderTraceSupportInterval,
+)
+from vibesensor.use_cases.diagnostics.spatial_evidence_contracts import (
+    SpatialEvidenceSummary,
+    SpatialLocationSummary,
+)
+from vibesensor.use_cases.diagnostics.whole_run_diagnosis_contracts import (
+    WholeRunDiagnosisSummary,
+)
+from vibesensor.use_cases.diagnostics.whole_run_diagnosis_ranking import (
+    build_whole_run_diagnosis_summaries,
+)
+
+
+def test_build_whole_run_diagnosis_summaries_adds_user_confirmed_vehicle_data_signal() -> None:
+    summaries = _build_ranked_summaries(
+        car_order_reference_status=CarOrderReferenceStatus(
+            selection_source_status="manual_entry",
+            tire_dimensions_confidence="user_confirmed",
+            final_drive_ratio_confidence="official_exact",
+            current_gear_ratio_confidence="official_exact",
+            transmission_confidence="official_exact",
+        ),
+        ref_sources=("speed+tire",),
+        suspected_source="wheel/tire",
+    )
+
+    factor = next(
+        factor
+        for factor in summaries[0].support_factors
+        if factor.factor_key == "user_confirmed_vehicle_data"
+    )
+    assert factor.details.car_data_reference_scope == "tire"
+    assert factor.details.car_data_confidence == "user_confirmed"
+
+
+@pytest.mark.parametrize(
+    ("field_confidence", "ref_sources", "suspected_source", "expected_factor", "expected_scope"),
+    [
+        (
+            "reputable_secondary_crosschecked",
+            ("speed+tire+final_drive",),
+            "driveshaft",
+            "secondary_vehicle_data",
+            "driveline",
+        ),
+        (
+            "family_default",
+            ("speed+engine",),
+            "engine",
+            "approximate_vehicle_data",
+            "engine_speed_derived",
+        ),
+        (
+            "unverified",
+            ("speed+tire",),
+            "wheel/tire",
+            "unverified_vehicle_data",
+            "tire",
+        ),
+    ],
+)
+def test_build_whole_run_diagnosis_summaries_projects_vehicle_data_caveats(
+    field_confidence: str,
+    ref_sources: tuple[str, ...],
+    suspected_source: str,
+    expected_factor: str,
+    expected_scope: str,
+) -> None:
+    typed_confidence = cast(VehicleFieldConfidence, field_confidence)
+    summaries = _build_ranked_summaries(
+        car_order_reference_status=CarOrderReferenceStatus(
+            selection_source_status="exact_row",
+            tire_dimensions_confidence=(
+                typed_confidence if "tire" in ref_sources[0] else "official_exact"
+            ),
+            final_drive_ratio_confidence=(
+                typed_confidence
+                if "final_drive" in ref_sources[0] or suspected_source == "driveshaft"
+                else "official_exact"
+            ),
+            current_gear_ratio_confidence=(
+                typed_confidence if ref_sources == ("speed+engine",) else "official_exact"
+            ),
+            transmission_confidence="official_exact",
+        ),
+        ref_sources=ref_sources,
+        suspected_source=suspected_source,
+    )
+
+    factor = next(
+        factor
+        for factor in summaries[0].counterevidence_factors
+        if factor.factor_key == expected_factor
+    )
+    assert factor.details.car_data_reference_scope == expected_scope
+    assert factor.details.car_data_confidence == typed_confidence
+
+
+def test_build_whole_run_diagnosis_summaries_does_not_penalize_direct_engine_reference() -> None:
+    summaries = _build_ranked_summaries(
+        car_order_reference_status=CarOrderReferenceStatus(
+            selection_source_status="exact_row",
+            tire_dimensions_confidence="unverified",
+            final_drive_ratio_confidence="unverified",
+            current_gear_ratio_confidence="unverified",
+            transmission_confidence="official_exact",
+        ),
+        ref_sources=("obd2",),
+        suspected_source="engine",
+    )
+
+    factor_keys = {factor.factor_key for factor in summaries[0].counterevidence_factors}
+    assert "unverified_vehicle_data" not in factor_keys
+    assert "approximate_vehicle_data" not in factor_keys
+    assert "secondary_vehicle_data" not in factor_keys
+
+
+def _build_ranked_summaries(
+    *,
+    car_order_reference_status: CarOrderReferenceStatus,
+    ref_sources: tuple[str, ...],
+    suspected_source: str,
+) -> tuple[WholeRunDiagnosisSummary, ...]:
+    order_family = (
+        "wheel"
+        if suspected_source == "wheel/tire"
+        else "driveshaft"
+        if suspected_source in {"driveshaft", "driveline"}
+        else "engine"
+    )
+    return build_whole_run_diagnosis_summaries(
+        analysis_metadata={
+            "raw_backed_sample_count": 64,
+            "raw_capture_mode": "raw_backed",
+            "whole_run_context_available": True,
+        },
+        context_intervals=(
+            WholeRunContextInterval(
+                segment_index=0,
+                phase=DrivingPhase.CRUISE,
+                load_state="steady",
+                start_window_index=0,
+                end_window_index=5,
+                start_t_s=0.0,
+                end_t_s=3.0,
+                speed_band="60-80 km/h",
+                full_context_window_count=6,
+            ),
+        ),
+        order_summaries=(
+            OrderTraceSummary(
+                hypothesis_key="candidate_1x",
+                suspected_source=suspected_source,
+                order_family=order_family,
+                order_label="candidate",
+                total_window_count=6,
+                eligible_window_count=6,
+                matched_window_count=5,
+                support_ratio=0.84,
+                reference_coverage_ratio=0.92,
+                longest_contiguous_support_window_count=4,
+                contiguous_support_ratio=0.67,
+                support_intervals=(
+                    OrderTraceSupportInterval(
+                        interval_index=0,
+                        start_window_index=1,
+                        end_window_index=4,
+                        matched_window_count=4,
+                        support_ratio=1.0,
+                        start_t_s=0.5,
+                        end_t_s=2.0,
+                        phase="cruise",
+                        speed_band="60-80 km/h",
+                        mean_relative_error=0.03,
+                    ),
+                ),
+                stable_frequency_min_hz=13.1,
+                stable_frequency_max_hz=13.4,
+                exemplar_interval_index=0,
+                dominant_phase="cruise",
+                dominant_speed_band="60-80 km/h",
+                strongest_location="front-left",
+                mean_relative_error=0.03,
+                drift_score=0.08,
+                lock_score=0.86,
+                peak_intensity_db=18.0,
+                mean_vibration_strength_db=11.0,
+                ref_sources=ref_sources,
+            ),
+        ),
+        spatial_summaries=(
+            SpatialEvidenceSummary(
+                candidate_key="candidate_1x",
+                suspected_source=suspected_source,
+                proof_basis="supporting_windows_raw_backed",
+                total_window_count=6,
+                supporting_window_count=5,
+                supporting_sensor_count=2,
+                coherent_window_count=4,
+                coherence_ratio=0.8,
+                dominant_location="front-left",
+                runner_up_location="front-right",
+                location_separation_db=3.0,
+                dominance_ratio=1.6,
+                location_summaries=(
+                    SpatialLocationSummary(
+                        location="front-left",
+                        sensor_ids=("front",),
+                        supporting_window_count=4,
+                        support_ratio=0.8,
+                        coherent_window_count=3,
+                        coherence_ratio=0.75,
+                    ),
+                    SpatialLocationSummary(
+                        location="front-right",
+                        sensor_ids=("right",),
+                        supporting_window_count=1,
+                        support_ratio=0.2,
+                        coherent_window_count=1,
+                        coherence_ratio=1.0,
+                    ),
+                ),
+            ),
+        ),
+        car_order_reference_status=car_order_reference_status,
+    )

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py
@@ -127,6 +127,8 @@ def test_history_diagnosis_response_contracts_expose_named_summary_fields() -> N
         "speed_gap_window_count",
         "rpm_gap_window_count",
         "fallback_reason",
+        "car_data_reference_scope",
+        "car_data_confidence",
     }
     assert set(DiagnosisFactorResponse.__annotations__) == {
         "factor_key",

--- a/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_ranking.py
+++ b/apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_ranking.py
@@ -183,6 +183,7 @@ def test_build_whole_run_diagnosis_summaries_ranks_candidates_and_projects_exemp
                 ),
             ),
         ),
+        car_order_reference_status=None,
     )
 
     assert [summary.diagnosis_key for summary in summaries] == ["wheel_1x", "driveshaft_1x"]
@@ -310,6 +311,7 @@ def test_diagnosis_ranking_marks_context_gaps_and_weak_spatial_as_suspicious() -
                 ),
             ),
         ),
+        car_order_reference_status=None,
     )
 
     assert len(summaries) == 1

--- a/apps/server/vibesensor/data/report_i18n.json
+++ b/apps/server/vibesensor/data/report_i18n.json
@@ -251,6 +251,18 @@
     "en": "the signal stayed close to the noise floor",
     "nl": "het signaal bleef dicht bij de ruisvloer"
   },
+  "REPORT_CONFIDENCE_CAVEAT_SECONDARY_VEHICLE_DATA": {
+    "en": "this {scope} reference depends on secondary vehicle data",
+    "nl": "deze {scope}-referentie steunt op secundaire voertuigdata"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_APPROXIMATE_VEHICLE_DATA": {
+    "en": "this {scope} reference depends on approximate vehicle data",
+    "nl": "deze {scope}-referentie steunt op benaderde voertuigdata"
+  },
+  "REPORT_CONFIDENCE_CAVEAT_UNVERIFIED_VEHICLE_DATA": {
+    "en": "this {scope} reference depends on unverifiable vehicle data",
+    "nl": "deze {scope}-referentie steunt op niet-geverifieerde voertuigdata"
+  },
   "REPORT_CONFIDENCE_CAVEAT_REFERENCE_GAP": {
     "en": "reference data was incomplete for this path",
     "nl": "referentiedata was onvolledig voor dit pad"
@@ -295,9 +307,25 @@
     "en": "the matched signal stood clear of the noise floor",
     "nl": "het gematchte signaal stond duidelijk boven de ruisvloer"
   },
+  "REPORT_CONFIDENCE_SIGNAL_USER_CONFIRMED_VEHICLE_DATA": {
+    "en": "user-confirmed vehicle data backs this {scope} reference",
+    "nl": "door de gebruiker bevestigde voertuigdata ondersteunt deze {scope}-referentie"
+  },
   "REPORT_CONFIDENCE_SIGNAL_LOCALIZED_SUPPORT": {
     "en": "support stayed concentrated at {location}",
     "nl": "de steun bleef geconcentreerd bij {location}"
+  },
+  "REPORT_CONFIDENCE_CAR_SCOPE_TIRE": {
+    "en": "wheel-speed",
+    "nl": "wielsnelheids"
+  },
+  "REPORT_CONFIDENCE_CAR_SCOPE_DRIVELINE": {
+    "en": "driveline-speed",
+    "nl": "aandrijflijnsnelheids"
+  },
+  "REPORT_CONFIDENCE_CAR_SCOPE_ENGINE_SPEED_DERIVED": {
+    "en": "speed-derived engine",
+    "nl": "uit snelheid afgeleide motor"
   },
   "REPORT_CONFIDENCE_SIGNAL_RAW_BACKED": {
     "en": "raw-backed replay confirmed the match from {samples} retained samples",

--- a/apps/server/vibesensor/domain/__init__.py
+++ b/apps/server/vibesensor/domain/__init__.py
@@ -37,7 +37,14 @@ RunSuitability
 from ._numeric import coerce_float, coerce_int
 from .analysis_settings import AnalysisSettingsSnapshot
 from .capture_readiness import CaptureReadiness, CaptureReadinessCheck, CaptureReadinessPolicy
-from .car import Car, CarOrderReferenceSourceStatus, CarOrderReferenceStatus, CarSnapshot
+from .car import (
+    Car,
+    CarOrderReferenceSourceStatus,
+    CarOrderReferenceStatus,
+    CarSnapshot,
+    OrderAnalysisCarDataConfidence,
+    OrderAnalysisCarDataScope,
+)
 from .confidence_assessment import ConfidenceAssessment
 from .diagnosis_assessment import (
     DIAGNOSIS_AMBIGUOUS_SCORE_GAP,
@@ -105,6 +112,8 @@ __all__ = [
     # Value objects — car and context
     "AxleTireSetup",
     "CarSnapshot",
+    "OrderAnalysisCarDataConfidence",
+    "OrderAnalysisCarDataScope",
     "OrderReferenceSpec",
     "TireSpec",
     "TireSpeedAxle",

--- a/apps/server/vibesensor/domain/car.py
+++ b/apps/server/vibesensor/domain/car.py
@@ -27,6 +27,8 @@ from vibesensor.domain.vehicle_configuration import VehicleFieldConfidence
 __all__ = [
     "AxleTireSetup",
     "Car",
+    "OrderAnalysisCarDataConfidence",
+    "OrderAnalysisCarDataScope",
     "CarOrderReferenceStatus",
     "CarOrderReferenceSourceStatus",
     "CarSnapshot",
@@ -35,6 +37,24 @@ __all__ = [
 ]
 
 CarOrderReferenceSourceStatus = Literal["compat_projection", "exact_row", "manual_entry"]
+OrderAnalysisCarDataScope = Literal["tire", "driveline", "engine_speed_derived"]
+
+_ORDER_ANALYSIS_CONFIDENCE_RANK = {
+    "official_exact": 0,
+    "official_derived": 1,
+    "user_confirmed": 2,
+    "reputable_secondary_crosschecked": 3,
+    "family_default": 4,
+    "unverified": 5,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class OrderAnalysisCarDataConfidence:
+    """The saved-car confidence that backs one order-analysis reference path."""
+
+    scope: OrderAnalysisCarDataScope
+    confidence: VehicleFieldConfidence
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,6 +110,36 @@ class CarOrderReferenceStatus:
             transmission_confidence=self.transmission_confidence,
         )
 
+    def order_analysis_car_data_confidence(
+        self,
+        *,
+        ref_sources: tuple[str, ...] = (),
+        suspected_source: str | None = None,
+    ) -> OrderAnalysisCarDataConfidence | None:
+        """Return the relevant saved-car confidence for one order-analysis path."""
+
+        scope = _order_analysis_scope(ref_sources=ref_sources, suspected_source=suspected_source)
+        if scope is None:
+            return None
+        confidences: tuple[VehicleFieldConfidence | None, ...]
+        if scope == "tire":
+            confidences = (self.tire_dimensions_confidence,)
+        elif scope == "driveline":
+            confidences = (
+                self.tire_dimensions_confidence,
+                self.final_drive_ratio_confidence,
+            )
+        else:
+            confidences = (
+                self.tire_dimensions_confidence,
+                self.final_drive_ratio_confidence,
+                self.current_gear_ratio_confidence,
+            )
+        return OrderAnalysisCarDataConfidence(
+            scope=scope,
+            confidence=_weakest_vehicle_field_confidence(confidences),
+        )
+
 
 # ---------------------------------------------------------------------------
 # CarSnapshot — typed internal car context attached to a run
@@ -114,6 +164,44 @@ class CarSnapshot:
     def __post_init__(self) -> None:
         if not isinstance(self.aspects, MappingProxyType):
             object.__setattr__(self, "aspects", MappingProxyType(dict(self.aspects)))
+
+
+def _order_analysis_scope(
+    *,
+    ref_sources: tuple[str, ...],
+    suspected_source: str | None,
+) -> OrderAnalysisCarDataScope | None:
+    normalized_sources = {
+        str(source).strip().lower() for source in ref_sources if str(source).strip()
+    }
+    if "speed+engine" in normalized_sources:
+        return "engine_speed_derived"
+    if "speed+tire+final_drive" in normalized_sources or "speed+driveshaft" in normalized_sources:
+        return "driveline"
+    if "speed+tire" in normalized_sources:
+        return "tire"
+    if normalized_sources:
+        return None
+    normalized_source = str(suspected_source or "").strip().lower()
+    if normalized_source == "wheel/tire":
+        return "tire"
+    if normalized_source in {"driveline", "driveshaft"}:
+        return "driveline"
+    if normalized_source == "engine":
+        return "engine_speed_derived"
+    return None
+
+
+def _weakest_vehicle_field_confidence(
+    confidences: tuple[VehicleFieldConfidence | None, ...],
+) -> VehicleFieldConfidence:
+    effective_confidences = [
+        confidence if confidence is not None else "unverified" for confidence in confidences
+    ]
+    return max(
+        effective_confidences,
+        key=lambda confidence: _ORDER_ANALYSIS_CONFIDENCE_RANK[confidence],
+    )
 
 
 @dataclass(frozen=True, slots=True, init=False)

--- a/apps/server/vibesensor/domain/diagnosis_assessment.py
+++ b/apps/server/vibesensor/domain/diagnosis_assessment.py
@@ -50,6 +50,8 @@ class DiagnosisAssessmentFactorDetails:
     speed_gap_window_count: int | None = None
     rpm_gap_window_count: int | None = None
     fallback_reason: str | None = None
+    car_data_reference_scope: str | None = None
+    car_data_confidence: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -88,6 +90,8 @@ class DiagnosisAssessmentInputs:
     context_source: str
     speed_gap_window_count: int
     rpm_gap_window_count: int
+    car_data_reference_scope: str | None = None
+    car_data_confidence: str | None = None
     confidence_gap_to_alternative: float | None = None
 
 
@@ -114,6 +118,8 @@ class DiagnosisAssessment:
     has_reference_gap: bool
     speed_gap_window_count: int
     rpm_gap_window_count: int
+    car_data_reference_scope: str | None
+    car_data_confidence: str | None
     uses_summary_fallback: bool
     fallback_reason: str | None
     signal_keys: tuple[str, ...]
@@ -227,6 +233,18 @@ def score_diagnosis_assessment_inputs(inputs: DiagnosisAssessmentInputs) -> Diag
     if inputs.has_reference_gap:
         score -= 0.06
         caveat_keys.append("incomplete_reference")
+    if inputs.car_data_confidence == "user_confirmed":
+        score += 0.03
+        signal_keys.append("user_confirmed_vehicle_data")
+    elif inputs.car_data_confidence == "reputable_secondary_crosschecked":
+        score -= 0.05
+        caveat_keys.append("secondary_vehicle_data")
+    elif inputs.car_data_confidence == "family_default":
+        score -= 0.10
+        caveat_keys.append("approximate_vehicle_data")
+    elif inputs.car_data_confidence == "unverified":
+        score -= 0.15
+        caveat_keys.append("unverified_vehicle_data")
 
     return _assessment_from_keys(
         score_0_to_1=_rounded_score(score),
@@ -245,6 +263,8 @@ def score_diagnosis_assessment_inputs(inputs: DiagnosisAssessmentInputs) -> Diag
         has_reference_gap=inputs.has_reference_gap,
         speed_gap_window_count=inputs.speed_gap_window_count,
         rpm_gap_window_count=inputs.rpm_gap_window_count,
+        car_data_reference_scope=inputs.car_data_reference_scope,
+        car_data_confidence=inputs.car_data_confidence,
         uses_summary_fallback=False,
         fallback_reason=None,
         signal_keys=tuple(dict.fromkeys(signal_keys)),
@@ -282,6 +302,8 @@ def apply_diagnosis_assessment_fallback(
         has_reference_gap=assessment.has_reference_gap,
         speed_gap_window_count=assessment.speed_gap_window_count,
         rpm_gap_window_count=assessment.rpm_gap_window_count,
+        car_data_reference_scope=assessment.car_data_reference_scope,
+        car_data_confidence=assessment.car_data_confidence,
         uses_summary_fallback=True,
         fallback_reason=fallback_reason,
         signal_keys=assessment.signal_keys,
@@ -310,6 +332,8 @@ def diagnosis_assessment_from_components(
     has_reference_gap: bool,
     speed_gap_window_count: int,
     rpm_gap_window_count: int,
+    car_data_reference_scope: str | None,
+    car_data_confidence: str | None,
     uses_summary_fallback: bool,
     fallback_reason: str | None,
     support_factors: tuple[DiagnosisAssessmentFactor, ...],
@@ -354,6 +378,8 @@ def diagnosis_assessment_from_components(
         has_reference_gap=has_reference_gap,
         speed_gap_window_count=speed_gap_window_count,
         rpm_gap_window_count=rpm_gap_window_count,
+        car_data_reference_scope=car_data_reference_scope,
+        car_data_confidence=car_data_confidence,
         uses_summary_fallback=uses_summary_fallback,
         fallback_reason=fallback_reason,
         signal_keys=signal_keys,
@@ -386,6 +412,8 @@ def _assessment_from_keys(
     has_reference_gap: bool,
     speed_gap_window_count: int,
     rpm_gap_window_count: int,
+    car_data_reference_scope: str | None,
+    car_data_confidence: str | None,
     uses_summary_fallback: bool,
     fallback_reason: str | None,
     signal_keys: tuple[str, ...],
@@ -418,6 +446,8 @@ def _assessment_from_keys(
         has_reference_gap=has_reference_gap,
         speed_gap_window_count=speed_gap_window_count,
         rpm_gap_window_count=rpm_gap_window_count,
+        car_data_reference_scope=car_data_reference_scope,
+        car_data_confidence=car_data_confidence,
         uses_summary_fallback=uses_summary_fallback,
         fallback_reason=fallback_reason,
         signal_keys=signal_keys,
@@ -445,6 +475,8 @@ def _assessment_from_keys(
         has_reference_gap=has_reference_gap,
         speed_gap_window_count=speed_gap_window_count,
         rpm_gap_window_count=rpm_gap_window_count,
+        car_data_reference_scope=car_data_reference_scope,
+        car_data_confidence=car_data_confidence,
         uses_summary_fallback=uses_summary_fallback,
         fallback_reason=fallback_reason,
         support_factors=support_factors,
@@ -519,6 +551,8 @@ def _support_factor_weight(factor_key: str, assessment: DiagnosisAssessment) -> 
         return 0.08
     if factor_key == "clean_signal":
         return 0.05
+    if factor_key == "user_confirmed_vehicle_data":
+        return 0.03
     raise ValueError(f"unsupported support factor key: {factor_key}")
 
 
@@ -527,6 +561,8 @@ def _counter_factor_weight(factor_key: str) -> float:
         return 0.05
     if factor_key in {"speed_context_gaps", "rpm_context_gaps"}:
         return 0.04
+    if factor_key == "secondary_vehicle_data":
+        return 0.05
     if factor_key in {
         "brief_support",
         "drifting_frequency",
@@ -540,8 +576,11 @@ def _counter_factor_weight(factor_key: str) -> float:
         "mixed_support_locations",
         "weak_spatial",
         "close_alternative",
+        "approximate_vehicle_data",
     }:
         return 0.10 if factor_key != "loose_order_lock" else 0.08
+    if factor_key == "unverified_vehicle_data":
+        return 0.15
     raise ValueError(f"unsupported counterevidence factor key: {factor_key}")
 
 
@@ -577,6 +616,17 @@ def _factor_details(
         )
     if factor_key in {"clean_signal", "noisy_signal"}:
         return replace(details, snr_db=assessment.snr_db)
+    if factor_key in {
+        "user_confirmed_vehicle_data",
+        "secondary_vehicle_data",
+        "approximate_vehicle_data",
+        "unverified_vehicle_data",
+    }:
+        return replace(
+            details,
+            car_data_reference_scope=assessment.car_data_reference_scope,
+            car_data_confidence=assessment.car_data_confidence,
+        )
     if factor_key == "close_alternative":
         return replace(details, alternative_source=assessment.alternative_source)
     if factor_key == "speed_context_gaps":
@@ -620,6 +670,9 @@ def _tier_for_score(*, label_key: str, score_0_to_1: float, caveat_keys: tuple[s
             "speed_context_gaps",
             "rpm_context_gaps",
             "noisy_signal",
+            "secondary_vehicle_data",
+            "approximate_vehicle_data",
+            "unverified_vehicle_data",
         }
     ):
         return "B"

--- a/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/confidence_facts.py
@@ -141,6 +141,8 @@ def report_confidence_from_diagnosis_summary(
         has_reference_gap=diagnosis_summary.has_reference_gap,
         speed_gap_window_count=_speed_gap_window_count(diagnosis_summary),
         rpm_gap_window_count=_rpm_gap_window_count(diagnosis_summary),
+        car_data_reference_scope=_car_data_reference_scope(diagnosis_summary),
+        car_data_confidence=_car_data_confidence(diagnosis_summary),
         uses_summary_fallback=diagnosis_summary.uses_summary_fallback,
         fallback_reason=diagnosis_summary.fallback_reason,
         support_factors=tuple(
@@ -251,6 +253,8 @@ def _summary_fallback_confidence(
         has_reference_gap=evidence_facts.has_reference_gap,
         speed_gap_window_count=0,
         rpm_gap_window_count=0,
+        car_data_reference_scope=None,
+        car_data_confidence=None,
         uses_summary_fallback=True,
         fallback_reason=(assessment.reason if assessment is not None else "") or None,
         signal_keys=(),
@@ -323,6 +327,10 @@ def _factor_details_payload(
         payload["rpm_gap_window_count"] = details.rpm_gap_window_count
     if details.fallback_reason is not None:
         payload["fallback_reason"] = details.fallback_reason
+    if details.car_data_reference_scope is not None:
+        payload["car_data_reference_scope"] = details.car_data_reference_scope
+    if details.car_data_confidence is not None:
+        payload["car_data_confidence"] = details.car_data_confidence
     return payload
 
 
@@ -351,6 +359,8 @@ def _assessment_factor_from_summary_factor(
         speed_gap_window_count=raw_details.speed_gap_window_count,
         rpm_gap_window_count=raw_details.rpm_gap_window_count,
         fallback_reason=raw_details.fallback_reason,
+        car_data_reference_scope=raw_details.car_data_reference_scope,
+        car_data_confidence=raw_details.car_data_confidence,
     )
     return DiagnosisAssessmentFactor(
         factor_key=factor_key,
@@ -448,6 +458,26 @@ def _rpm_gap_window_count(diagnosis_summary: ReportWholeRunDiagnosisSummary) -> 
         if isinstance(value, int | float):
             return int(value)
     return 0
+
+
+def _car_data_reference_scope(
+    diagnosis_summary: ReportWholeRunDiagnosisSummary,
+) -> str | None:
+    for factor in (*diagnosis_summary.support_factors, *diagnosis_summary.counterevidence_factors):
+        value = factor.details.car_data_reference_scope
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _car_data_confidence(
+    diagnosis_summary: ReportWholeRunDiagnosisSummary,
+) -> str | None:
+    for factor in (*diagnosis_summary.support_factors, *diagnosis_summary.counterevidence_factors):
+        value = factor.details.car_data_confidence
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
 
 
 def _label_key_for_score(score: float) -> str:

--- a/apps/server/vibesensor/shared/boundaries/reporting/summary.py
+++ b/apps/server/vibesensor/shared/boundaries/reporting/summary.py
@@ -195,6 +195,8 @@ class ReportDiagnosisFactorDetails:
     speed_gap_window_count: int | None
     rpm_gap_window_count: int | None
     fallback_reason: str | None
+    car_data_reference_scope: str | None
+    car_data_confidence: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -813,6 +815,10 @@ class ReportSummaryNormalizer:
                             details_row.get("rpm_gap_window_count")
                         ),
                         fallback_reason=text_or_none(details_row.get("fallback_reason")),
+                        car_data_reference_scope=text_or_none(
+                            details_row.get("car_data_reference_scope")
+                        ),
+                        car_data_confidence=text_or_none(details_row.get("car_data_confidence")),
                     ),
                 )
             )

--- a/apps/server/vibesensor/shared/report_presentation.py
+++ b/apps/server/vibesensor/shared/report_presentation.py
@@ -402,6 +402,13 @@ def _confidence_signal_texts(
             )
         elif key == "clean_signal":
             parts.append(tr("REPORT_CONFIDENCE_SIGNAL_CLEAN_SIGNAL"))
+        elif key == "user_confirmed_vehicle_data":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_SIGNAL_USER_CONFIRMED_VEHICLE_DATA",
+                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
+                )
+            )
     return tuple(parts)
 
 
@@ -465,7 +472,40 @@ def _confidence_caveat_texts(
             parts.append(tr("REPORT_CONFIDENCE_CAVEAT_REFERENCE_GAP"))
         elif key == "noisy_signal":
             parts.append(tr("REPORT_CONFIDENCE_CAVEAT_NOISY_SIGNAL"))
+        elif key == "secondary_vehicle_data":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_SECONDARY_VEHICLE_DATA",
+                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
+                )
+            )
+        elif key == "approximate_vehicle_data":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_APPROXIMATE_VEHICLE_DATA",
+                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
+                )
+            )
+        elif key == "unverified_vehicle_data":
+            parts.append(
+                tr(
+                    "REPORT_CONFIDENCE_CAVEAT_UNVERIFIED_VEHICLE_DATA",
+                    scope=_vehicle_data_scope_text(confidence_facts, tr=tr),
+                )
+            )
     return tuple(parts)
+
+
+def _vehicle_data_scope_text(
+    confidence_facts: ReportConfidenceFacts,
+    *,
+    tr: Callable[..., str],
+) -> str:
+    if confidence_facts.car_data_reference_scope == "driveline":
+        return tr("REPORT_CONFIDENCE_CAR_SCOPE_DRIVELINE")
+    if confidence_facts.car_data_reference_scope == "engine_speed_derived":
+        return tr("REPORT_CONFIDENCE_CAR_SCOPE_ENGINE_SPEED_DERIVED")
+    return tr("REPORT_CONFIDENCE_CAR_SCOPE_TIRE")
 
 
 def append_unique_line(lines: list[str], text: object) -> None:

--- a/apps/server/vibesensor/shared/types/history_analysis_contracts.py
+++ b/apps/server/vibesensor/shared/types/history_analysis_contracts.py
@@ -96,6 +96,7 @@ type DiagnosisFactorKey = Literal[
     "tight_order_lock",
     "localized_support",
     "clean_signal",
+    "user_confirmed_vehicle_data",
     "summary_only",
     "raw_replay_incomplete",
     "legacy_context",
@@ -110,6 +111,9 @@ type DiagnosisFactorKey = Literal[
     "weak_spatial",
     "close_alternative",
     "incomplete_reference",
+    "secondary_vehicle_data",
+    "approximate_vehicle_data",
+    "unverified_vehicle_data",
 ]
 type DiagnosisFactorPolarity = Literal["support", "counterevidence"]
 type DiagnosisFactorSeverity = Literal["low", "medium", "high"]
@@ -335,6 +339,8 @@ class DiagnosisFactorDetailsResponse(TypedDict, total=False):
     speed_gap_window_count: int | None
     rpm_gap_window_count: int | None
     fallback_reason: str | None
+    car_data_reference_scope: str | None
+    car_data_confidence: str | None
 
 
 class DiagnosisFactorResponse(TypedDict, total=False):

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_contracts.py
@@ -100,6 +100,8 @@ class DiagnosisFactorDetails:
     speed_gap_window_count: int | None = None
     rpm_gap_window_count: int | None = None
     fallback_reason: str | None = None
+    car_data_reference_scope: str | None = None
+    car_data_confidence: str | None = None
 
     def __post_init__(self) -> None:
         if self.raw_backed_sample_count is not None:
@@ -133,6 +135,8 @@ class DiagnosisFactorDetails:
         _set_optional(payload, "speed_gap_window_count", self.speed_gap_window_count)
         _set_optional(payload, "rpm_gap_window_count", self.rpm_gap_window_count)
         _set_optional(payload, "fallback_reason", self.fallback_reason)
+        _set_optional(payload, "car_data_reference_scope", self.car_data_reference_scope)
+        _set_optional(payload, "car_data_confidence", self.car_data_confidence)
         return payload
 
     @classmethod
@@ -153,6 +157,8 @@ class DiagnosisFactorDetails:
             speed_gap_window_count=_optional_int(data.get("speed_gap_window_count")),
             rpm_gap_window_count=_optional_int(data.get("rpm_gap_window_count")),
             fallback_reason=_optional_text(data.get("fallback_reason")),
+            car_data_reference_scope=_optional_text(data.get("car_data_reference_scope")),
+            car_data_confidence=_optional_text(data.get("car_data_confidence")),
         )
 
 
@@ -419,6 +425,7 @@ def _required_factor_key(value: object) -> DiagnosisFactorKey:
         "tight_order_lock",
         "localized_support",
         "clean_signal",
+        "user_confirmed_vehicle_data",
         "summary_only",
         "raw_replay_incomplete",
         "legacy_context",
@@ -433,6 +440,9 @@ def _required_factor_key(value: object) -> DiagnosisFactorKey:
         "weak_spatial",
         "close_alternative",
         "incomplete_reference",
+        "secondary_vehicle_data",
+        "approximate_vehicle_data",
+        "unverified_vehicle_data",
     }:
         raise ValueError("factor_key must be a supported diagnosis factor key")
     return cast(DiagnosisFactorKey, value)

--- a/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
+++ b/apps/server/vibesensor/use_cases/diagnostics/whole_run_diagnosis_ranking.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from vibesensor.domain import (
     DIAGNOSIS_CLOSE_ALTERNATIVE_REEVALUATION_GAP,
+    CarOrderReferenceStatus,
     DiagnosisAssessment,
     DiagnosisAssessmentFactor,
     DiagnosisAssessmentInputs,
@@ -39,6 +40,7 @@ def build_whole_run_diagnosis_summaries(
     context_intervals: tuple[WholeRunContextInterval, ...],
     order_summaries: tuple[OrderTraceSummary, ...],
     spatial_summaries: tuple[SpatialEvidenceSummary, ...],
+    car_order_reference_status: CarOrderReferenceStatus | None,
 ) -> tuple[WholeRunDiagnosisSummary, ...]:
     """Rank persisted whole-run candidates into compact diagnosis summaries."""
 
@@ -50,13 +52,20 @@ def build_whole_run_diagnosis_summaries(
             analysis_metadata=analysis_metadata,
             order_summary=order_summary,
             spatial_summary=spatial_by_key.get(order_summary.hypothesis_key),
+            car_order_reference_status=car_order_reference_status,
             alternative_source=None,
             confidence_gap_to_alternative=None,
         )
         for order_summary in order_summaries
     )
     final = tuple(
-        _reevaluate_with_alternative(candidate, initial, analysis_metadata) for candidate in initial
+        _reevaluate_with_alternative(
+            candidate,
+            initial,
+            analysis_metadata,
+            car_order_reference_status,
+        )
+        for candidate in initial
     )
     ranked = sorted(
         final,
@@ -159,6 +168,7 @@ def _reevaluate_with_alternative(
     candidate: _CandidateEvaluation,
     initial: tuple[_CandidateEvaluation, ...],
     analysis_metadata: Mapping[str, object],
+    car_order_reference_status: CarOrderReferenceStatus | None,
 ) -> _CandidateEvaluation:
     alternative = _closest_alternative_candidate(candidate, initial)
     if alternative is None:
@@ -170,6 +180,7 @@ def _reevaluate_with_alternative(
         analysis_metadata=analysis_metadata,
         order_summary=candidate.order_summary,
         spatial_summary=candidate.spatial_summary,
+        car_order_reference_status=car_order_reference_status,
         alternative_source=alternative.order_summary.suspected_source,
         confidence_gap_to_alternative=round(score_gap, 2),
     )
@@ -202,9 +213,18 @@ def _evaluate_candidate(
     analysis_metadata: Mapping[str, object],
     order_summary: OrderTraceSummary,
     spatial_summary: SpatialEvidenceSummary | None,
+    car_order_reference_status: CarOrderReferenceStatus | None,
     alternative_source: str | None,
     confidence_gap_to_alternative: float | None,
 ) -> _CandidateEvaluation:
+    order_analysis_car_data = (
+        car_order_reference_status.order_analysis_car_data_confidence(
+            ref_sources=order_summary.ref_sources,
+            suspected_source=order_summary.suspected_source,
+        )
+        if car_order_reference_status is not None
+        else None
+    )
     assessment = score_diagnosis_assessment_inputs(
         DiagnosisAssessmentInputs(
             base_confidence=_base_confidence(order_summary, spatial_summary),
@@ -232,6 +252,12 @@ def _evaluate_candidate(
                 analysis_metadata.get("whole_run_context_missing_rpm_window_count")
             )
             + _count(analysis_metadata.get("whole_run_context_stale_rpm_window_count")),
+            car_data_reference_scope=(
+                order_analysis_car_data.scope if order_analysis_car_data is not None else None
+            ),
+            car_data_confidence=(
+                order_analysis_car_data.confidence if order_analysis_car_data is not None else None
+            ),
             confidence_gap_to_alternative=confidence_gap_to_alternative,
         )
     )
@@ -362,6 +388,8 @@ def _diagnosis_factor_from_assessment_factor(factor: DiagnosisAssessmentFactor) 
             speed_gap_window_count=factor.details.speed_gap_window_count,
             rpm_gap_window_count=factor.details.rpm_gap_window_count,
             fallback_reason=factor.details.fallback_reason,
+            car_data_reference_scope=factor.details.car_data_reference_scope,
+            car_data_confidence=factor.details.car_data_confidence,
         ),
     )
 

--- a/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_executor.py
@@ -12,6 +12,7 @@ from typing import Any, Literal, NoReturn, Protocol
 import aiosqlite
 from opentelemetry.trace import SpanKind
 
+from vibesensor.domain import CarOrderReferenceStatus
 from vibesensor.shared.ports import RunPersistence
 from vibesensor.shared.structured_logging import log_extra
 from vibesensor.shared.tracing import mark_span_error, start_span
@@ -224,6 +225,7 @@ class WholeRunDiagnosisSummaryBuilder(Protocol):
         context_bundle: WholeRunContextArtifactBundle,
         order_summaries: tuple[OrderTraceSummary, ...],
         spatial_summaries: tuple[SpatialEvidenceSummary, ...],
+        car_order_reference_status: CarOrderReferenceStatus | None,
     ) -> tuple[WholeRunDiagnosisSummary, ...]: ...
 
 
@@ -957,6 +959,11 @@ def run_build_report_facts_stage(
                 ranked_whole_run_spatial_summaries(spatial_coherence_bundle.summaries)
                 if spatial_coherence_bundle is not None
                 else ()
+            ),
+            car_order_reference_status=(
+                run_input.context.car.order_reference_status
+                if run_input.context.car is not None
+                else None
             ),
         )
         if diagnosis_summaries:

--- a/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
+++ b/apps/server/vibesensor/use_cases/run/post_analysis_whole_run_projection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+from vibesensor.domain import CarOrderReferenceStatus
 from vibesensor.shared.run_context_warning import (
     RunContextWarningsInput,
     normalize_run_context_warnings,
@@ -331,12 +332,14 @@ def build_diagnosis_summary_rows(
     context_bundle: WholeRunContextArtifactBundle,
     order_summaries: tuple[OrderTraceSummary, ...],
     spatial_summaries: tuple[SpatialEvidenceSummary, ...],
+    car_order_reference_status: CarOrderReferenceStatus | None,
 ) -> tuple[WholeRunDiagnosisSummary, ...]:
     return build_whole_run_diagnosis_summaries(
         analysis_metadata=analysis_metadata,
         context_intervals=context_bundle.intervals,
         order_summaries=order_summaries,
         spatial_summaries=spatial_summaries,
+        car_order_reference_status=car_order_reference_status,
     )
 
 

--- a/apps/ui/src/contracts/http_api_schema.json
+++ b/apps/ui/src/contracts/http_api_schema.json
@@ -2264,6 +2264,28 @@
             ],
             "title": "Alternative Source"
           },
+          "car_data_confidence": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Car Data Confidence"
+          },
+          "car_data_reference_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Car Data Reference Scope"
+          },
           "fallback_reason": {
             "anyOf": [
               {
@@ -2431,6 +2453,7 @@
           "tight_order_lock",
           "localized_support",
           "clean_signal",
+          "user_confirmed_vehicle_data",
           "summary_only",
           "raw_replay_incomplete",
           "legacy_context",
@@ -2444,7 +2467,10 @@
           "noisy_signal",
           "weak_spatial",
           "close_alternative",
-          "incomplete_reference"
+          "incomplete_reference",
+          "secondary_vehicle_data",
+          "approximate_vehicle_data",
+          "unverified_vehicle_data"
         ],
         "type": "string"
       },

--- a/docs/car_library_architecture.md
+++ b/docs/car_library_architecture.md
@@ -205,6 +205,22 @@ The source of truth is the resolved `VehicleConfiguration`:
 - UI consumers should use `requires_manual_confirmation` to keep approximate
   drivetrain values visibly approximate until the user confirms them.
 
+Issue #3239 extends that same provenance policy into whole-run diagnosis
+confidence:
+
+- wheel-order matches use tire confidence only
+- driveshaft/driveline matches use the weakest of tire and final-drive
+  confidence
+- speed-derived engine-order matches use the weakest of tire, final-drive, and
+  current-gear confidence
+- direct engine references that do not depend on speed-derived car data (for
+  example OBD2-backed RPM) do not inherit saved-car confidence penalties
+
+That policy feeds the canonical diagnosis assessment, so persisted diagnosis
+factor rows and report wording now surface when a match depended on
+`user_confirmed`, `reputable_secondary_crosschecked`, `family_default`, or
+`unverified` vehicle data.
+
 ## Axle-aware tire setups
 
 Issue #3233 extends the same one-owner rule to tire data.


### PR DESCRIPTION
Size: medium

## What changed
- derive scope-aware order-analysis car-data confidence from `CarOrderReferenceStatus` for wheel, driveline, and speed-derived engine paths
- feed that confidence into canonical diagnosis scoring and persist stable vehicle-data factor rows through whole-run summaries and report reload boundaries
- add report wording for user-confirmed, secondary, approximate, and unverified vehicle data, and document the policy
- add focused regression coverage for scope resolution, diagnosis ranking, report wording, contracts, and persisted report surfaces

## Why
- order matches should not read the same when tire or drivetrain inputs are official, user-confirmed, approximate, or unverified
- direct engine references that do not depend on speed-derived car data should stay neutral

## Validation
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" python -m pytest -q apps/server/tests/domain/test_car_order_reference_status.py apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_ranking.py apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_car_data_confidence.py apps/server/tests/use_cases/history/test_whole_run_diagnosis_factors.py apps/server/tests/shared/test_report_presentation_vehicle_data_confidence.py`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" python -m pytest -q apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_document.py apps/server/tests/use_cases/history/test_report_whole_run_diagnosis_scenarios.py apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_contracts.py apps/server/tests/use_cases/run/test_post_analysis_stage_pipeline.py apps/server/tests/test_support/whole_run_diagnosis_scenarios.py`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make sync-contracts`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make typecheck-backend`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make lint`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make ui-typecheck`
- `PATH="/workspace/VibeSensor/.venv/bin:$PATH" make docs-lint`

## Risks / tradeoffs / edge cases
- diagnosis scores and tiers now shift when a candidate depends on weak saved-car data; this is intentional honesty, not a blanket penalty
- direct OBD2-style engine references skip car-data penalties on purpose
- persisted diagnosis factor details now include optional `car_data_reference_scope` and `car_data_confidence` fields

Closes #3239