### PR TITLE
Complete Audi/BMW 2010+ confidence remediation run

### DIFF
--- a/apps/server/vibesensor/data/car_sources/bmw_pressclub_sources.json
+++ b/apps/server/vibesensor/data/car_sources/bmw_pressclub_sources.json
@@ -70,6 +70,258 @@
       "title": "BMW PressClub G42 230i 2022 technical specifications PDF",
       "note": "Official BMW technical-data PDF used for the exact G42 230i ratios, final drive, reverse ratio, and launch-standard tire.",
       "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f25-xdrive20i-2011-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0118790EN/175706",
+      "title": "BMW PressClub F25 xDrive20i 2011 technical data PDF",
+      "note": "Official BMW 09/2011 technical-data PDF for the exact F25 X3 xDrive20i showing xDrive AWD, 6-speed manual and optional 8-speed automatic with Steptronic transmission paths, full forward gear ratios, single published final-drive ratio, and 225/60 R17 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0118790EN/175707",
+      "title": "BMW PressClub F25 xDrive28i and xDrive35i 2011 technical data PDF",
+      "note": "Official BMW 09/2011 technical-data PDF for the exact F25 X3 xDrive28i and xDrive35i states showing AWD, 8-speed automatic with Steptronic only, full forward gear ratios, single published final-drive ratio, and baseline launch tires. The same PDF also shows the 2011 xDrive28i as a 2996 cc inline-6 configuration rather than the later 2.0T identity.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0165242EN/250219",
+      "title": "BMW PressClub F25 xDrive35i 2014 technical data PDF",
+      "note": "Official BMW 04/2014 technical-data PDF cross-check for the exact F25 X3 xDrive35i AWD automatic state confirming the same forward ratios, 3.385 final drive, and 245/50 R18 baseline tire as the 09/2011 launch sheet.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0147064EN/225547",
+      "title": "BMW PressClub F32 420i xDrive 2013 technical data PDF",
+      "note": "Official BMW launch-era technical-data PDF for the F32 420i xDrive manual and automatic states, used for the exact 2014-2015 ratio, final-drive, and baseline-tire mapping.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f32-4-series-coupe-2016-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0252345EN/348119",
+      "title": "BMW PressClub F32 4 Series Coupe 2016 technical data PDF",
+      "note": "Official BMW 03/2016 technical-data PDF for the updated F32 coupe range, used for the exact 420i xDrive and 430i xDrive automatic/manual applicability, ratio, final-drive, and 225/50 R17 baseline-tire mapping.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f32-4-series-coupe-2013-tech-spec-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0147064EN/specifications-bmw-4-series-coupe-valid-from-11/2013",
+      "title": "BMW PressClub F32 4 Series Coupe 2013 specifications article",
+      "note": "Official BMW launch-era 4 Series Coupé specifications page used to confirm the original 11/2013 lineup scope, including that later 440i xDrive variants were absent from the launch-state range.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0252345EN/technical-specifications-bmw-4-series-coupe-valid-from-03/2016",
+      "title": "BMW PressClub F32 440i xDrive 2016 specifications article",
+      "note": "Official BMW 03/2016 4 Series Coupé specifications page used to confirm when the 440i xDrive Coupé first appears in the checked official lineup.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f32-440i-xdrive-2016-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0252345EN/348117",
+      "title": "BMW PressClub F32 440i xDrive 2016 technical data PDF",
+      "note": "Official BMW 03/2016 technical-data PDF for the exact F32 440i xDrive Coupé manual and automatic states, used for the retimed 2016-only top-gear, final-drive, and baseline-tire evidence.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive20i-2015-tech-spec-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0223367EN/specifications-the-new-bmw-x1-sdrive20i-xdrive20i-valid-from-07/2015",
+      "title": "BMW PressClub F48 X1 xDrive20i 2015 specifications article",
+      "note": "Official BMW launch-era X1 specifications page used to confirm the exact xDrive20i lineup scope and reach the 07/2015 technical-data attachment.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive20i-2015-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0223367EN/316338",
+      "title": "BMW PressClub F48 X1 xDrive20i 2015 technical data PDF",
+      "note": "Official BMW 07/2015 technical-data PDF for the exact F48 X1 xDrive20i state showing AWD, 8-speed Steptronic automatic only, 0.673 top gear, single 3.200 final-drive ratio, and 225/55 R17 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0291600EN/specifications-of-the-bmw-x1-xdrive20i-valid-from-03/2019",
+      "title": "BMW PressClub F48 X1 xDrive20i 2019 specifications article",
+      "note": "Official BMW 03/2019 xDrive20i specifications page used to confirm the checked later-row continuity and reach the 03/2019 technical-data attachment.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive20i-2019-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0291600EN/424226",
+      "title": "BMW PressClub F48 X1 xDrive20i 2019 technical data PDF",
+      "note": "Official BMW 03/2019 technical-data PDF for the exact F48 X1 xDrive20i state confirming AWD, 8-speed Steptronic automatic only, 0.673 top gear, single 3.200 final-drive ratio, and 225/55 R17 baseline tires again in the later checked state.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0223370EN/specifications-the-new-bmw-x1-xdrive25d-valid-from-07/2015",
+      "title": "BMW PressClub F48 X1 xDrive25d 2015 specifications article",
+      "note": "Official BMW launch-era X1 xDrive25d specifications page used to confirm the exact lineup scope and reach the 07/2015 technical-data attachment.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive25d-2015-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0223370EN/316345",
+      "title": "BMW PressClub F48 X1 xDrive25d 2015 technical data PDF",
+      "note": "Official BMW 07/2015 technical-data PDF for the exact F48 X1 xDrive25d state showing AWD, 8-speed Steptronic automatic only, single 2.955 final-drive ratio, 225/55 R17 baseline tires, and a 1995 cc inline-4 diesel layout.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0314292EN/specifications-of-the-bmw-x1-xdrive25e-valid-from-01/2020",
+      "title": "BMW PressClub F48 X1 xDrive25e 2020 specifications article",
+      "note": "Official BMW 01/2020 xDrive25e specifications page used to confirm when the plug-in-hybrid X1 xDrive25e first appears in the checked official lineup and to reach the exact technical-data attachment.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive25e-2020-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0314292EN/457889",
+      "title": "BMW PressClub F48 X1 xDrive25e 2020 technical data PDF",
+      "note": "Official BMW 01/2020 technical-data PDF for the exact F48 X1 xDrive25e PHEV state showing AWD, 6-speed Steptronic transmission, 0.672 top gear, single 3.944 final-drive ratio, and 225/55 R17 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0223371EN/specifications-bmw-x1-xdrive-25i-valid-from-07/2015",
+      "title": "BMW PressClub F48 X1 xDrive25i 2015 specifications article",
+      "note": "Official BMW 07/2015 xDrive25i specifications page used to confirm the launch-era AWD automatic-only lineup scope and to reach the exact technical-data attachment.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive25i-2015-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0223371EN/316347",
+      "title": "BMW PressClub F48 X1 xDrive25i 2015 technical data PDF",
+      "note": "Official BMW 07/2015 technical-data PDF for the exact F48 X1 xDrive25i state showing AWD, 8-speed Steptronic automatic only, 0.673 top gear, single 3.200 final-drive ratio, and 225/55 R17 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0291601EN/specifications-of-the-bmw-x1-xdrive25i-valid-from-03/2019",
+      "title": "BMW PressClub F48 X1 xDrive25i 2019 specifications article",
+      "note": "Official BMW 03/2019 xDrive25i specifications page used to confirm the checked later-state continuity and to reach the exact technical-data attachment.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-xdrive25i-2019-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0291601EN/424228",
+      "title": "BMW PressClub F48 X1 xDrive25i 2019 technical data PDF",
+      "note": "Official BMW 03/2019 technical-data PDF for the exact F48 X1 xDrive25i state confirming AWD, 8-speed Steptronic automatic only, 0.673 top gear, single 3.200 final-drive ratio, and 225/55 R17 baseline tires again in the later checked state.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-2021-tech-spec-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0327516EN/specifications-of-the-bmw-x1-valid-from-03/2021",
+      "title": "BMW PressClub F48 X1 2021 specifications article",
+      "note": "Official BMW 03/2021 X1 specifications page used to confirm the checked later-state continuity for F48 xDrive25d, xDrive25e, and xDrive25i variants and to reach the exact technical-data attachment.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f48-x1-2021-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0327516EN/473615",
+      "title": "BMW PressClub F48 X1 2021 technical data PDF",
+      "note": "Official BMW 03/2021 technical-data PDF for the later F48 X1 lineup confirming the checked xDrive25d, xDrive25e, and xDrive25i AWD automatic states, their exact top-gear and final-drive figures, and the later baseline-tire mappings used for safe narrow/split decisions.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g06-x6-2019-launch-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0297827EN/the-new-bmw-x6-a-leader-with-broad-shoulders",
+      "title": "BMW PressClub G06 X6 2019 launch article",
+      "note": "Official BMW launch article for the G06 X6 range used to confirm the launch-lineup scope and xDrive plus 8-speed Steptronic applicability for the exact X6 M50i and xDrive40i states.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g06-x6-2019-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0297827EN/435333",
+      "title": "BMW PressClub G06 X6 2019 technical data PDF",
+      "note": "Official BMW launch technical-data PDF for the G06 X6 range used for the exact X6 M50i and xDrive40i top-gear, forward-ratio, reverse-ratio, final-drive, and baseline-tire mappings.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g11-7-series-2015-spec-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0235242EN/specifications-bmw-7-series-sedan-valid-from-11/2015",
+      "title": "BMW PressClub G11 7 Series 2015 specifications article",
+      "note": "Official BMW 11/2015 7 Series Sedan specifications page used to confirm the launch-lineup scope and reach the exact 750i xDrive technical-data attachment.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g11-750i-xdrive-2015-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0235242EN/336676",
+      "title": "BMW PressClub G11 750i xDrive 2015 technical data PDF",
+      "note": "Official BMW 11/2015 technical-data PDF for the exact G11 750i xDrive state showing AWD, 8-speed Steptronic, 0.640 top gear, single 2.813 final-drive ratio, and 245/50 R18 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g14-8-series-convertible-2018-launch-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0286150EN/the-new-bmw-8-series-convertible",
+      "title": "BMW PressClub G14 8 Series Convertible launch article",
+      "note": "Official BMW launch article for the G14 8 Series Convertible used to confirm the launch-lineup scope and xDrive plus 8-speed Steptronic applicability for the exact M850i xDrive Convertible state.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g14-8-series-convertible-2018-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0286150EN/445834",
+      "title": "BMW PressClub G14 8 Series Convertible technical data PDF",
+      "note": "Official BMW launch technical-data PDF for the G14 8 Series Convertible used for the exact M850i xDrive Convertible top-gear, forward-ratio, reverse-ratio, final-drive, and baseline-tire mappings.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g15-8-series-coupe-2018-launch-article",
+      "url": "https://www.press.bmwgroup.com/global/article/detail/T0281744EN/the-all-new-bmw-8-series-coupe?language=en",
+      "title": "BMW PressClub G15 8 Series Coupe launch article",
+      "note": "Official BMW launch article for the G15 8 Series Coupé used to confirm the launch-lineup context and reach the exact 840i xDrive Coupé technical-data attachment.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:g15-840i-coupe-2018-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0281744EN/445825",
+      "title": "BMW PressClub G15 840i xDrive Coupe technical data PDF",
+      "note": "Official BMW launch technical-data PDF for the exact G15 840i xDrive Coupé state showing AWD, 8-speed Steptronic, 0.640 top gear, single 2.929 final-drive ratio, and staggered 18-inch baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f01-750i-xdrive-2012-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0131447EN/207819",
+      "title": "BMW PressClub F01 750i xDrive 2012 technical data PDF",
+      "note": "Official BMW 07/2012 technical-data PDF for the exact F01 750i xDrive state showing AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.208 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, single 2.813 final-drive ratio, and 245/50 R18 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f15-xdrive35i-2013-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0146665EN/247705",
+      "title": "BMW PressClub F15 X5 xDrive35i 2013 technical data PDF",
+      "note": "Official BMW 12/2013 technical-data PDF for the exact F15 X5 xDrive35i launch state showing AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.295, single 3.154 final-drive ratio, and 255/55 R18 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f15-xdrive50i-2014-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0179784EN/265481",
+      "title": "BMW PressClub F15 X5 xDrive50i 2014 technical data PDF",
+      "note": "Official BMW 08/2014 technical-data PDF for the exact F15 X5 xDrive50i state showing AWD, 8-speed Steptronic, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, single 3.154 final-drive ratio, and 255/50 R19 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f15-xdrive40e-2015-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0209323EN/357717",
+      "title": "BMW PressClub F15 X5 xDrive40e 2015 technical data PDF",
+      "note": "Official BMW 05/2015 technical-data PDF for the exact F15 X5 xDrive40e state showing full hybrid drive with permanent torque vectoring to all four wheels, 8-speed Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.317, single 3.154 final-drive ratio, and 255/55 R18 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f16-xdrive50i-2014-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0181707EN/283776",
+      "title": "BMW PressClub F16 X6 xDrive50i 2014 launch technical data PDF",
+      "note": "Official BMW 06/2014 launch press-kit PDF whose technical-specification pages for the exact F16 X6 xDrive50i state show AWD, 8-speed Steptronic sport transmission, forward ratios 5.000 / 3.200 / 2.143 / 1.720 / 1.313 / 1.000 / 0.823 / 0.640, reverse 3.478, single 3.154 final-drive ratio, and 255/50 R19 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f26-xdrive-petrol-2014-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0169768EN/252711",
+      "title": "BMW PressClub F26 X4 xDrive20i/xDrive28i/xDrive35i 2014 technical data PDF",
+      "note": "Official BMW 03/2014 technical-data PDF for the exact F26 X4 xDrive20i, xDrive28i, and xDrive35i launch states, valid from July 2014, showing AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, reverse 3.295, single 3.385 final-drive ratio, and baseline tires 225/60 R17 for xDrive20i/xDrive28i plus 245/50 R18 for xDrive35i.",
+      "confidence": "high"
     }
   ]
 }

--- a/apps/server/vibesensor/data/car_sources/legacy_research_sources.json
+++ b/apps/server/vibesensor/data/car_sources/legacy_research_sources.json
@@ -408,6 +408,27 @@
       "confidence": "high"
     },
     {
+      "id": "legacy_research_sources:27e3d1aa1f09",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0286569EN/419611",
+      "title": "419611",
+      "note": "Official BMW 09/2018 technical-data PDF for the G32 6 Series Gran Turismo lineup. It includes exact pages for 630d xDrive Gran Turismo and 640d xDrive Gran Turismo with xDrive AWD, 8-speed Steptronic, 0.640 top gear, 2.563 final drive, and 225/60 R17 baseline tires; it does not list a 630i xDrive row.",
+      "confidence": "high"
+    },
+    {
+      "id": "legacy_research_sources:5c1b0ad4cf7e",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0314290EN/463145",
+      "title": "463145",
+      "note": "Official BMW 11/2020 technical-data PDF for the G32 6 Series Gran Turismo lineup. It includes exact pages for 630d xDrive Gran Turismo and 640d xDrive Gran Turismo; 630d keeps xDrive AWD, Eight-speed Steptronic, 0.640 top gear, 2.563 final drive, and 225/60 R17 baseline tires, while 640d keeps xDrive AWD, Eight-speed Steptronic, 0.640 top gear, 2.563 final drive, and moves to 245/50 R18 baseline tires. The PDF still does not list a 630i xDrive row.",
+      "confidence": "high"
+    },
+    {
+      "id": "legacy_research_sources:a1a7fdd8c2e4",
+      "url": "https://www.audi-mediacenter.com/system/production/car_motorizations/1327/file_en/334999a095b61a16bcf0870c83ac92abc2332835/eTD_Audi_R8_Coupe_V10performance_RWD_419_kW_230113.pdf?disposition=attachment",
+      "title": "eTD_Audi_R8_Coupe_V10performance_RWD_419_kW_230113.pdf",
+      "note": "Official Audi MediaCenter Germany 01/2023 technical-data PDF for the later R8 Coupé V10 performance RWD: rear-wheel drive, 7-speed S tronic wording, Audi-form transmission ratios ending with 0.653 top gear, final-drive values 4.458 / 3.588, and 245/35 R19 front plus 295/35 R19 rear base tires.",
+      "confidence": "high"
+    },
+    {
       "id": "legacy_research_sources:286bb3c2fefa",
       "url": "https://www.press.bmwgroup.com/global/article/attachment/T0280350EN/406525",
       "title": "406525",
@@ -2828,6 +2849,20 @@
       "title": "Search",
       "note": "BMW Group official PressClub search page used in second-pass lookup for model-code technical data documents.",
       "confidence": "medium"
+    },
+    {
+      "id": "legacy_research_sources:6c2ebf019f9d",
+      "url": "https://press.audi.co.uk/assets/documents/original/20340-AudiUK00000079Q320TFSI170PSTechnical.pdf",
+      "title": "Q3 2 0 Tfsi 170Ps Technical",
+      "note": "Official Audi UK technical-data PDF for the exact Q3 2.0 TFSI quattro 170 PS manual state: quattro AWD, 6-speed manual transmission, top gear 0.813, grouped gearbox/final-drive values that do not map cleanly to the current front/rear schema, and basic 215/65 R16 tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "legacy_research_sources:9d7fc9f138f2",
+      "url": "https://press.audi.co.uk/assets/documents/original/20342-AudiUK00000091Q320TFSIquattroStronic.pdf",
+      "title": "Q3 2 0 Tfsi Quattro S Tronic",
+      "note": "Official Audi UK technical-data PDF for the exact Q3 2.0 TFSI quattro S tronic state: quattro AWD, 7-speed S tronic, top gear 0.667, final drives 4.769 and 3.444, and basic 235/55 R17 tires.",
+      "confidence": "high"
     }
   ]
 }

--- a/apps/server/vibesensor/data/car_sources/secondary_technical_sources.json
+++ b/apps/server/vibesensor/data/car_sources/secondary_technical_sources.json
@@ -154,6 +154,34 @@
       "title": "Auto-Data A4 B8 3.0 TFSI quattro S tronic specification entry",
       "note": "Exact secondary 2012-2014 facelift A4 3.0 TFSI 272 hp quattro S tronic sedan entry used to cross-check AWD and 7-speed S tronic transmission for the broad B8 row.",
       "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-autodata",
+      "url": "https://www.auto-data.net/en/audi-q3-i-8u-2.0-tdi-177hp-quattro-19157",
+      "title": "Auto-Data Q3 8U 2.0 TDI quattro manual specification entry",
+      "note": "Exact secondary 2012-2014 Q3 2.0 TDI 177 hp quattro manual entry used to cross-check AWD, 6-speed manual transmission, and 235/55 R17 baseline tires for the broad 8U row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:q3-8u-2-0-tdi-quattro-mt6-car-specs",
+      "url": "https://www.car-specs.net/car/Audi-Q3-(8U)/2.0-TDI-(177-Hp)-quattro/5053",
+      "title": "Car-Specs Q3 8U 2.0 TDI quattro manual specification entry",
+      "note": "Independent secondary exact Q3 2.0 TDI 177 hp quattro manual page used to corroborate AWD, 6-speed manual transmission, and 235/55 R17 baseline tires for the broad 8U row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-mt6-autodata",
+      "url": "https://www.auto-data.net/en/audi-q3-i-8u-2.0-tfsi-170hp-quattro-19150",
+      "title": "Auto-Data Q3 8U 2.0 TFSI quattro manual specification entry",
+      "note": "Exact secondary 2011-2014 Q3 2.0 TFSI 170 hp quattro manual entry used to corroborate AWD, 6-speed manual transmission, and 215/65 R16 baseline tires while the official UK sheet supplies the checked top-gear value.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:q3-8u-2-0-tfsi-quattro-dct7-autodata",
+      "url": "https://www.auto-data.net/en/audi-q3-i-8u-2.0-tfsi-211hp-quattro-s-tronic-19152",
+      "title": "Auto-Data Q3 8U 2.0 TFSI quattro S tronic specification entry",
+      "note": "Exact secondary 2011-2014 Q3 2.0 TFSI 211 hp quattro S tronic entry used to corroborate AWD, 7-speed S tronic transmission, and 235/55 R17 baseline tires while the official UK sheet supplies the checked top-gear and final-drive values.",
+      "confidence": "medium"
     }
   ]
 }

--- a/apps/server/vibesensor/data/car_sources/secondary_technical_sources.json
+++ b/apps/server/vibesensor/data/car_sources/secondary_technical_sources.json
@@ -105,6 +105,55 @@
       "title": "Ultimate Specs A5 B8 3.0 TDI quattro tiptronic specification entry",
       "note": "Independent secondary 2007-2011 A5 Coupe 3.0 TDI Quattro tiptronic DPF page used to corroborate the pre-facelift Tiptronic identity while the broad-row 8-speed mapping remains unresolved.",
       "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-carfolio",
+      "url": "https://www.carfolio.com/audi-a4-3.0-tdi-quattro-264979",
+      "title": "Carfolio A4 B8 3.0 TDI quattro manual specification entry",
+      "note": "Exact secondary 2012 A4 3.0 TDI quattro sedan page used to cross-check AWD and 6-speed manual transmission for the broad B8 row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-3-0-tdi-quattro-mt6-autodata",
+      "url": "https://www.auto-data.net/en/audi-a4-b8-8k-3.0-tdi-v6-240hp-quattro-4319",
+      "title": "Auto-Data A4 B8 3.0 TDI quattro manual specification entry",
+      "note": "Exact secondary 2007-2011 A4 3.0 TDI 240 hp quattro sedan entry used to cross-check AWD and 6-speed manual transmission for the broad B8 row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-carfolio",
+      "url": "https://www.carfolio.com/audi-a4-3.0-tdi-quattro-s-tronic-355630",
+      "title": "Carfolio A4 B8 3.0 TDI quattro S tronic specification entry",
+      "note": "Exact secondary 2015 A4 3.0 TDI quattro S-Tronic sedan page used to cross-check AWD and 7-speed automatic transmission for the broad B8 row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-3-0-tdi-quattro-dct7-autodata",
+      "url": "https://www.auto-data.net/en/audi-a4-b8-8k-facelift-2011-3.0-tdi-v6-245hp-quattro-s-tronic-18821",
+      "title": "Auto-Data A4 B8 3.0 TDI quattro S tronic specification entry",
+      "note": "Exact secondary 2011-2015 facelift A4 3.0 TDI 245 hp quattro S tronic sedan entry used to cross-check AWD and 7-speed S tronic transmission for the broad B8 row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-3-0-tdi-quattro-zf8hp-autodata",
+      "url": "https://www.auto-data.net/en/audi-a4-b8-8k-3.0-tdi-v6-240hp-quattro-tiptronic-4320",
+      "title": "Auto-Data A4 B8 3.0 TDI quattro Tiptronic specification entry",
+      "note": "Exact secondary 2007-2011 A4 3.0 TDI 240 hp quattro Tiptronic sedan entry used to document that the pre-facelift row is Tiptronic with 6 gears, which conflicts with the broad-row 8-speed ZF8HP mapping.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-carfolio",
+      "url": "https://www.carfolio.com/audi-a4-3.0-tfsi-quattro-s-tronic-264704",
+      "title": "Carfolio A4 B8 3.0 TFSI quattro S tronic specification entry",
+      "note": "Exact secondary 2012 A4 3.0 TFSI quattro S-Tronic sedan page used to cross-check AWD and 7-speed automatic transmission for the broad B8 row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-3-0-tfsi-quattro-dct7-autodata",
+      "url": "https://www.auto-data.net/en/audi-a4-b8-8k-facelift-2011-3.0-tfsi-v6-272hp-quattro-s-tronic-18843",
+      "title": "Auto-Data A4 B8 3.0 TFSI quattro S tronic specification entry",
+      "note": "Exact secondary 2012-2014 facelift A4 3.0 TFSI 272 hp quattro S tronic sedan entry used to cross-check AWD and 7-speed S tronic transmission for the broad B8 row.",
+      "confidence": "medium"
     }
   ]
 }

--- a/apps/server/vibesensor/data/car_sources/secondary_technical_sources.json
+++ b/apps/server/vibesensor/data/car_sources/secondary_technical_sources.json
@@ -56,6 +56,55 @@
       "title": "Auto-Data A5 B8 2.0 TFSI quattro Tiptronic specification entry",
       "note": "Exact secondary 2009-2011 A5 Coupe 2.0 TFSI quattro Tiptronic entry used to document AWD, Tiptronic transmission, and 245/40 R18 plus 255/35 R19 tire fitments for the broad B8 coupe row.",
       "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-carfolio",
+      "url": "https://www.carfolio.com/audi-a4-2.0-tfsi-quattro-354772",
+      "title": "Carfolio A4 B8 2.0 TFSI quattro manual specification entry",
+      "note": "Exact secondary 2013 A4 2.0 TFSI quattro sedan page used to cross-check AWD and 6-speed manual transmission for the broad B8 row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-mt6-autodata",
+      "url": "https://www.auto-data.net/en/audi-a4-b8-8k-2.0-tfsi-211hp-quattro-4316",
+      "title": "Auto-Data A4 B8 2.0 TFSI quattro manual specification entry",
+      "note": "Exact secondary 2008-2011 A4 2.0 TFSI 211 hp quattro sedan entry used to cross-check AWD and 6-speed manual transmission for the broad B8 row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-carfolio",
+      "url": "https://www.carfolio.com/audi-a4-2.0-tfsi-quattro-s-tronic-354805",
+      "title": "Carfolio A4 B8 2.0 TFSI quattro S tronic specification entry",
+      "note": "Exact secondary 2013 A4 2.0 TFSI quattro S-Tronic sedan page used to cross-check AWD and 7-speed automatic transmission for the broad B8 row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-dct7-autodata",
+      "url": "https://www.auto-data.net/en/audi-a4-b8-8k-facelift-2011-2.0-tfsi-211hp-quattro-s-tronic-26560",
+      "title": "Auto-Data A4 B8 2.0 TFSI quattro S tronic specification entry",
+      "note": "Exact secondary 2012-2015 facelift A4 2.0 TFSI 211 hp quattro S tronic sedan entry used to cross-check AWD and 7-speed S tronic transmission for the broad B8 row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-2-0-tfsi-quattro-zf8hp-autodata",
+      "url": "https://www.auto-data.net/en/audi-a4-b8-8k-2.0-tfsi-211hp-quattro-tiptronic-53527",
+      "title": "Auto-Data A4 B8 2.0 TFSI quattro Tiptronic specification entry",
+      "note": "Exact secondary 2008-2011 A4 2.0 TFSI 211 hp quattro Tiptronic sedan entry used to document that the pre-facelift row is Tiptronic with 6 gears, which conflicts with the broad-row 8-speed ZF8HP mapping.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a5-b8-3-0-tdi-quattro-zf8hp-autodata",
+      "url": "https://www.auto-data.net/en/audi-a5-coupe-8t3-3.0-tdi-240hp-quattro-tiptronic-4518",
+      "title": "Auto-Data A5 B8 3.0 TDI quattro Tiptronic specification entry",
+      "note": "Exact secondary 2007-2011 A5 Coupe 3.0 TDI 240 hp quattro Tiptronic entry used to document that the pre-facelift row is Tiptronic with 6 gears, which conflicts with the broad-row 8-speed ZF8HP mapping.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a5-b8-3-0-tdi-quattro-zf8hp-ultimatespecs",
+      "url": "https://www.ultimatespecs.com/car-specs/Audi/24159/Audi-A5-Coupe-30-TDI-Quattro-tiptronic-DPF.html",
+      "title": "Ultimate Specs A5 B8 3.0 TDI quattro tiptronic specification entry",
+      "note": "Independent secondary 2007-2011 A5 Coupe 3.0 TDI Quattro tiptronic DPF page used to corroborate the pre-facelift Tiptronic identity while the broad-row 8-speed mapping remains unresolved.",
+      "confidence": "medium"
     }
   ]
 }

--- a/apps/server/vibesensor/data/car_sources/secondary_technical_sources.json
+++ b/apps/server/vibesensor/data/car_sources/secondary_technical_sources.json
@@ -14,6 +14,48 @@
       "title": "Carfolio F45 220i Active Tourer specification entry",
       "note": "Independent secondary cross-check for the F45 220i DCT ratio pair used in the exact-row override.",
       "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-carfolio",
+      "url": "https://www.carfolio.com/audi-a4-2.0-tdi-quattro-192203",
+      "title": "Carfolio A4 B8 2.0 TDI quattro manual specification entry",
+      "note": "Exact secondary manual row for the pre-facelift A4 2.0 TDI quattro sedan showing AWD, 6-speed manual transmission, top gear 0.63, final drive 4.49, and 225/55 R16 tires.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-2-0-tdi-quattro-mt6-autodata",
+      "url": "https://www.auto-data.net/en/audi-a4-b8-8k-2.0-tdi-170hp-quattro-4311",
+      "title": "Auto-Data A4 B8 2.0 TDI quattro manual specification entry",
+      "note": "Exact secondary pre-facelift A4 2.0 TDI quattro sedan entry used to cross-check AWD, 6-speed manual transmission, and 225/55 R16 baseline tires for the manual row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-carfolio",
+      "url": "https://www.carfolio.com/audi-a4-2.0-tdi-quattro-s-tronic-435050",
+      "title": "Carfolio A4 B8 2.0 TDI quattro S tronic specification entry",
+      "note": "Exact secondary facelift A4 2.0 TDI quattro sedan row showing AWD, 7-speed S tronic, top gear 0.39, final drive 4.27, and 225/50 R17 tires.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a4-b8-2-0-tdi-quattro-dct7-autodata",
+      "url": "https://www.auto-data.net/en/audi-a4-b8-8k-facelift-2011-2.0-tdi-177hp-quattro-s-tronic-18816",
+      "title": "Auto-Data A4 B8 2.0 TDI quattro S tronic specification entry",
+      "note": "Exact secondary facelift A4 2.0 TDI quattro sedan entry used to cross-check AWD, 7-speed S tronic transmission, and 225/55 R16 tires for the S tronic row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a5-b8-2-0-tfsi-quattro-dct7-autodata",
+      "url": "https://www.auto-data.net/en/audi-a5-coupe-8t3-2.0-tfsi-211hp-quattro-s-tronic-4514",
+      "title": "Auto-Data A5 B8 2.0 TFSI quattro S tronic specification entry",
+      "note": "Exact secondary 2008-2011 A5 Coupe 2.0 TFSI quattro S tronic entry used to document AWD, 7-speed S tronic transmission, and 225/50 R17 tires for the broad B8 coupe row.",
+      "confidence": "medium"
+    },
+    {
+      "id": "secondary_technical_sources:a5-b8-2-0-tfsi-quattro-zf8hp-autodata",
+      "url": "https://www.auto-data.net/en/audi-a5-coupe-8t3-2.0-tfsi-211hp-quattro-tiptronic-53519",
+      "title": "Auto-Data A5 B8 2.0 TFSI quattro Tiptronic specification entry",
+      "note": "Exact secondary 2009-2011 A5 Coupe 2.0 TFSI quattro Tiptronic entry used to document AWD, Tiptronic transmission, and 245/40 R18 plus 255/35 R19 tire fitments for the broad B8 coupe row.",
+      "confidence": "medium"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- completes the planned **100 / 100** low-confidence Audi/BMW 2010+ target execution run from the canonical vehicle-configuration tracker
- executes all 100 planned targets and applies only exact-evidence-backed canonical data/source updates
- keeps unresolved rows conservative when official launch-to-row continuity could not be proven

## Outcome counts
| Metric | Count |
| --- | ---: |
| Planned low-confidence targets | 100 |
| Executed target results | 100 |
| Upgraded to `high_confidence` | 23 |
| Upgraded to `medium_confidence` | 5 |
| Field-only confidence upgrades | 24 |
| Unchanged due to insufficient evidence | 33 |
| Downgraded due to conflicting evidence | 8 |
| Not applicable / invalid-row outcomes | 7 |
| Production value corrections | 39 |
| Source metadata additions | 45 |

## Source quality breakdown
- Checked sources recorded in the tracker: **266** total
- Official OEM sources: **213**
- Secondary technical sources: **49**
- Community/archive leads used only as leads: **4**
- Accepted production upgrades/corrections were limited to exact or clearly-derived official evidence; secondary/community material was used only for corroboration or unresolved documentation.

## Most important confidence upgrades and corrections
| Configuration | Field | Old confidence | New confidence | Value changed? | Evidence |
| --- | --- | --- | --- | --- | --- |
| Audi Q7 55 TFSI e quattro | drivetrain / transmission | `unverified` / `family_default` | `official_exact` / `official_exact` | No | exact Audi Germany technical-data PDFs |
| Audi A8 D5 50 TFSI | configuration validity | `low_confidence` | `no_confidence` | Yes | exact Audi Germany market material contradicting the stored petrol D5 mapping |
| BMW X3 F25 xDrive20i ZF8HP | gear ratios / final drives / tire | `family_default` | `official_exact` / `official_derived` / `official_exact` | Yes | BMW 09/2011 technical-data PDF |
| BMW 4 Series F32 420i xDrive ZF8HP | row span / transmission-era mapping | `low_confidence` | split to `high_confidence` + `medium_confidence` | Yes | BMW 11/2013 and 03/2016 technical-data PDFs |
| BMW X1 F48 xDrive25e automatic | row identity / tire continuity | `low_confidence` | split to `high_confidence` states | Yes | BMW 01/2020 and 03/2021 technical-data PDFs |
| BMW X6 G06 M50i | top gear / final drives / staggered tires | `family_default` | `official_exact` / `official_derived` / `official_exact` | Yes | BMW 2019 launch article + technical-data PDF |
| BMW X5 F15 xDrive40e | row timing / gear ratios / tire | `low_confidence` | `high_confidence` | Yes | BMW 05/2015 technical-data PDF |
| BMW X4 F26 xDrive20i | final drives / tire / row span | `family_default` | `official_derived` / `official_exact` / `high_confidence` | Yes | BMW 03/2014 technical-data PDF |

## Validation
- `.venv/bin/python -c "import json; json.load(open('apps/server/vibesensor/data/vehicle_configurations.json')); json.load(open('apps/server/vibesensor/data/car_sources/bmw_pressclub_sources.json')); json.load(open('apps/server/vibesensor/data/car_sources/legacy_research_sources.json')); json.load(open('apps/server/vibesensor/data/car_sources/secondary_technical_sources.json')); print('json-ok')"`
- `.venv/bin/python -m pytest -q apps/server/tests/adapters/persistence/test_car_library.py apps/server/tests/adapters/persistence/test_car_library_routes.py apps/server/tests/adapters/persistence/test_car_library_source_evidence.py apps/server/tests/adapters/persistence/test_car_library_coverage_policy.py apps/server/tests/adapters/persistence/test_car_library_validation.py apps/server/tests/domain/test_vehicle_configuration_coverage_policy.py apps/server/tests/use_cases/diagnostics/test_whole_run_diagnosis_car_data_confidence.py`
- Result: **42 passed**

## Notes
- Tests were unchanged because this PR only updates canonical data/source files.
- The 100-target tracker includes source lists, confidence decisions, changed files, and unresolved follow-ups for every executed target.
