### PR TITLE
Add validated Audi/BMW vehicle configuration research updates

### DIFF
--- a/apps/server/vibesensor/data/car_sources/audi_mediacenter_sources.json
+++ b/apps/server/vibesensor/data/car_sources/audi_mediacenter_sources.json
@@ -420,6 +420,76 @@
       "title": "Audi MediaCenter 2025 Q5 e-hybrid launch release",
       "note": "Official Audi launch release for the successor Q5 SUV e-hybrid quattro and Q5 Sportback e-hybrid quattro models, used to document the mid-2025 product-cycle handover away from FY 55 TFSI e quattro naming.",
       "confidence": "high"
+    },
+    {
+      "id": "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf",
+      "url": "https://uploads.audi-mediacenter.com/system/production/car_motorizations/808/file_en/38cfda37fdcdc7930ef9e317e384c05f8d2a16b4/eTD_Audi_TT_Coupe_45_TFSI_S_tronic_180kW_230113.pdf?1698933763&disposition=attachment",
+      "title": "Audi MediaCenter TT Coupe 45 TFSI 2023 technical-data PDF",
+      "note": "Official Audi MediaCenter Germany-program technical-data PDF for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state showing front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304 under the 'final drive ratio 1-2 / 2-3' label, and basic 225/50 R17 tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf",
+      "url": "https://uploads.audi-mediacenter.com/system/production/car_motorizations/1243/file_en/0963f4ffa97bc4da673e65ee635a8d8df16b1481/eTD_Audi_TT_Coupe_45_TFSI_quattro_S_tronic_180kW_230113.pdf?1698933948&disposition=attachment",
+      "title": "Audi MediaCenter TT Coupe 45 TFSI quattro 2023 technical-data PDF",
+      "note": "Official Audi MediaCenter Germany-program technical-data PDF for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state showing on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304 under the 'final drive ratio 1-2 / 2-3' label, and basic 225/50 R17 tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf",
+      "url": "https://uploads.audi-mediacenter.com/system/production/car_motorizations/423/file_en/58c1b878a5f8fb1ac9d8a5d390f94d8ff2dce2d1/eTD_Audi_TT_Roadster_40_TFSI_S_tronic_145kW_230113.pdf?1698933715&disposition=attachment",
+      "title": "Audi MediaCenter TT Roadster 40 TFSI 2023 technical-data PDF",
+      "note": "Official Audi MediaCenter Germany-program technical-data PDF for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state showing front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304 under the 'final drive ratio 1-2 / 2-3' label, and basic 225/50 R17 tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf",
+      "url": "https://uploads.audi-mediacenter.com/system/production/car_motorizations/805/file_en/d9e951c7fea84aedba25c67982c3f0ad503b5044/eTD_Audi_TT_Roadster_45_TFSI_S_tronic_180kW_221104.pdf?1698933764&disposition=attachment",
+      "title": "Audi MediaCenter TT Roadster 45 TFSI 2022 technical-data PDF",
+      "note": "Official Audi MediaCenter Germany-program technical-data PDF for the exact TT Roadster 45 TFSI S tronic 180 kW state showing front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304 under the 'final drive ratio 1-2 / 2-3' label, and basic 225/50 R17 tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf",
+      "url": "https://uploads.audi-mediacenter.com/system/production/car_motorizations/1250/file_en/d045c55e23e1c059e4e40479363b5bd5ae38520a/eTD_Audi_TT_Roadster_45_TFSI_quattro_S_tronic_180kW_230113.pdf?1698933958&disposition=attachment",
+      "title": "Audi MediaCenter TT Roadster 45 TFSI quattro 2023 technical-data PDF",
+      "note": "Official Audi MediaCenter Germany-program technical-data PDF for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state showing on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304 under the 'final drive ratio 1-2 / 2-3' label, and basic 225/50 R17 tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf",
+      "url": "https://uploads.audi-mediacenter.com/system/production/car_motorizations/117/file_en/47310967d3234d1373d6646cf8bcab32998f3b5b/eTD_Audi_TTS_Coupe_TFSI_230113.pdf?1698933679&disposition=attachment",
+      "title": "Audi MediaCenter TTS Coupe 2023 technical-data PDF",
+      "note": "Official Audi MediaCenter Germany-program technical-data PDF for the exact late-cycle TTS Coupe state showing on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661, Audi's published dual final-drive values 4.471 / 3.304 under the 'final drive ratio 1-2 / 2-3' label, and basic 245/40 R18 tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf",
+      "url": "https://uploads.audi-mediacenter.com/system/production/car_motorizations/118/file_en/fab69b320fc15e43b1e281004ad57ebe60732fd7/eTD_Audi_TTS_Roadster_TFSI_230113.pdf?1698933679&disposition=attachment",
+      "title": "Audi MediaCenter TTS Roadster 2023 technical-data PDF",
+      "note": "Official Audi MediaCenter Germany-program technical-data PDF for the exact late-cycle TTS Roadster state showing on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661, Audi's published dual final-drive values 4.471 / 3.304 under the 'final drive ratio 1-2 / 2-3' label, and basic 245/40 R18 tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf",
+      "url": "https://uploads.audi-mediacenter.com/system/production/car_motorizations/837/file_en/ab1a688414eda4f444a9a7fad976f57fbe0061a8/eTD_Audi_TTRS_Coupe_TFSI_221102.pdf?1698933785&disposition=attachment",
+      "title": "Audi MediaCenter TT RS Coupe 2022 technical-data PDF",
+      "note": "Official Audi MediaCenter Germany-program technical-data PDF for the exact TT RS Coupe state showing all-wheel drive, 7-speed S tronic, forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635, and basic 245/35 R19 tires while not publishing a final-drive value.",
+      "confidence": "high"
+    },
+    {
+      "id": "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf",
+      "url": "https://uploads.audi-mediacenter.com/system/production/car_motorizations/454/file_en/3bb1572551ab62836b2df3341b915afa09a5a0d0/eTD_Audi_TTRS_Roadster_TFSI_221102.pdf?1698933727&disposition=attachment",
+      "title": "Audi MediaCenter TT RS Roadster 2022 technical-data PDF",
+      "note": "Official Audi MediaCenter Germany-program technical-data PDF for the exact TT RS Roadster state showing all-wheel drive, 7-speed S tronic, forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635, and basic 245/35 R19 tires while not publishing a final-drive value.",
+      "confidence": "high"
+    },
+    {
+      "id": "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf",
+      "url": "https://uploads.audi-mediacenter.com/system/production/uploaded_files/873/file/07b84e9ae43aafe66c235dacc447a2b7194ef0eb/enBasisinfo_Audi_TT_RS.pdf?1473325640&disposition=attachment",
+      "title": "Audi MediaCenter TT RS basic info 2016 PDF",
+      "note": "Official Audi MediaCenter basic-info PDF for the TT RS Coupe and TT RS Roadster stating that both body styles use quattro AWD with a 7-speed S tronic and documenting the standard 245/35 R19 tire package plus the optional 255/30 R20 package.",
+      "confidence": "high"
     }
   ]
 }

--- a/apps/server/vibesensor/data/car_sources/bmw_pressclub_sources.json
+++ b/apps/server/vibesensor/data/car_sources/bmw_pressclub_sources.json
@@ -408,6 +408,48 @@
       "confidence": "high"
     },
     {
+      "id": "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0094837EN/144304",
+      "title": "BMW PressClub F25 xDrive20d and xDrive30d 2011 technical data PDF",
+      "note": "Official BMW 03/2011 technical-data PDF for the exact F25 X3 xDrive20d manual and optional 8-speed automatic launch states plus the xDrive30d automatic launch state, showing the full forward gear ratios, single published final-drive ratios, and 225/60 R17 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0094837EN/144305",
+      "title": "BMW PressClub F25 xDrive28i and xDrive35i 2011 launch technical data PDF",
+      "note": "Official BMW 03/2011 technical-data PDF for the launch F25 X3 xDrive28i and xDrive35i states showing the early xDrive28i as a 2996 cc inline-6 automatic with a 3.727 final-drive ratio and 225/60 R17 baseline tires, alongside the launch xDrive35i row.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0118790EN/175708",
+      "title": "BMW PressClub F25 xDrive30d and xDrive35d 2011 technical data PDF",
+      "note": "Official BMW 09/2011 technical-data PDF for the exact F25 X3 xDrive30d and xDrive35d automatic states showing AWD, 8-speed automatic with Steptronic, the full forward gear ratios, single published 2.813 final-drive ratios, and baseline tires of 225/60 R17 for xDrive30d and 245/50 R18 for xDrive35d.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0125202EN/185371",
+      "title": "BMW PressClub F25 xDrive28i and xDrive35i 2012 technical data PDF",
+      "note": "Official BMW 03/2012 technical-data PDF for the refreshed F25 X3 xDrive28i and xDrive35i states showing that xDrive28i changes to a 1997 cc inline-4 turbo configuration with the same 8-speed automatic ratio set but a lower 3.385 final-drive ratio and 225/60 R17 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0130268EN/204356",
+      "title": "BMW PressClub F25 sDrive18d 2012 technical data PDF",
+      "note": "Official BMW 11/2012 technical-data PDF for the exact F25 X3 sDrive18d rear-wheel-drive manual and optional 8-speed automatic states, showing the full forward gear ratios, final-drive ratios 3.462 and 3.077, and 225/60 R17 baseline tires.",
+      "confidence": "high"
+    },
+    {
+      "id": "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf",
+      "url": "https://www.press.bmwgroup.com/global/article/attachment/T0165242EN/250218",
+      "title": "BMW PressClub F25 sDrive20i and xDrive20i 2014 technical data PDF",
+      "note": "Official BMW 04/2014 facelift technical-data PDF for the exact F25 X3 sDrive20i automatic state and the xDrive20i manual and optional 8-speed automatic cross-check, showing the full forward gear ratios, final-drive ratios, and 225/60 R17 baseline tires.",
+      "confidence": "high"
+    },
+    {
       "id": "bmw_pressclub_sources:f32-420i-xdrive-2013-tech-spec-pdf",
       "url": "https://www.press.bmwgroup.com/global/article/attachment/T0147064EN/225547",
       "title": "BMW PressClub F32 420i xDrive 2013 technical data PDF",

--- a/apps/server/vibesensor/data/vehicle_configurations/audi/tt/8S.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/audi/tt/8S.json
@@ -1111,7 +1111,1107 @@
     "configuration_confidence": "medium_confidence",
     "order_analysis_policy": {
       "usable_for_engine_order": true,
-      "usable_for_driveshaft_order": true,
+      "usable_for_driveshaft_order": false,
+      "usable_for_wheel_order": false,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "audi-8s-45-tfsi-eu-2023-dct7-fwd",
+    "brand": "Audi",
+    "type": "Coupe",
+    "market": "EU",
+    "model_code": "8S",
+    "body_code": "8S",
+    "production_start_year": 2023,
+    "production_end_year": 2023,
+    "model_name": "TT (8S, 2023)",
+    "variant_name": "45 TFSI",
+    "engine_code": "2.0L",
+    "engine_name": "2.0L I4 TFSI Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms front-wheel drive for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
+      "value": "FWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Coupe 45 TFSI 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+      "code": "DCT7",
+      "name": "7-speed S tronic"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
+        "value": 0.635
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
+        "value": [
+          3.4,
+          2.75,
+          1.767,
+          0.925,
+          0.705,
+          0.755,
+          0.635
+        ]
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 50.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
+          ],
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW state represented by this 2023-only row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Coupe 45 TFSI S tronic 180 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. Production JSON keeps this as a 2023-only exact row because the checked official evidence in this run is late-cycle only.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "Schema-safe encoding of the exact Audi TT 45 TFSI dual final-drive values",
+        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
+        ]
+      },
+      {
+        "item": "Audi TT 45 TFSI exact transmission-code and optional wheel/tire coverage",
+        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "medium_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": false,
+      "usable_for_wheel_order": false,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "audi-8s-45-tfsi-quattro-eu-2023-dct7-awd",
+    "brand": "Audi",
+    "type": "Coupe",
+    "market": "EU",
+    "model_code": "8S",
+    "body_code": "8S",
+    "production_start_year": 2023,
+    "production_end_year": 2023,
+    "model_name": "TT (8S, 2023)",
+    "variant_name": "45 TFSI quattro",
+    "engine_code": "2.0L",
+    "engine_name": "2.0L I4 TFSI Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Coupe 45 TFSI quattro 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+      "code": "DCT7",
+      "name": "7-speed S tronic"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+        "value": 0.635
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+        "value": [
+          3.4,
+          2.75,
+          1.767,
+          0.925,
+          0.705,
+          0.755,
+          0.635
+        ]
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 50.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+          ],
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Coupe 45 TFSI quattro S tronic 180 kW mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire. Production JSON keeps this as a 2023-only exact row because the checked official evidence in this run is late-cycle only.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "Schema-safe encoding of the exact Audi TT 45 TFSI quattro dual final-drive values",
+        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+        ]
+      },
+      {
+        "item": "Audi TT 45 TFSI quattro exact transmission-code and optional wheel/tire coverage",
+        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-coupe-45-tfsi-quattro-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "medium_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": false,
+      "usable_for_wheel_order": false,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "audi-8s-40-tfsi-roadster-eu-2023-dct7-fwd",
+    "brand": "Audi",
+    "type": "Roadster",
+    "market": "EU",
+    "model_code": "8S",
+    "body_code": "8S",
+    "production_start_year": 2023,
+    "production_end_year": 2023,
+    "model_name": "TT Roadster (8S, 2023)",
+    "variant_name": "40 TFSI",
+    "engine_code": "2.0L",
+    "engine_name": "2.0L I4 TFSI Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms front-wheel drive for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
+      "value": "FWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Roadster 40 TFSI 145 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+      "code": "DCT7",
+      "name": "7-speed S tronic"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
+        "value": 0.635
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
+        "value": [
+          3.4,
+          2.75,
+          1.767,
+          0.925,
+          0.705,
+          0.755,
+          0.635
+        ]
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 50.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
+          ],
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW state represented by this 2023-only row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Roadster 40 TFSI S tronic 145 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "Schema-safe encoding of the exact Audi TT Roadster 40 TFSI dual final-drive values",
+        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
+        ]
+      },
+      {
+        "item": "Audi TT Roadster 40 TFSI exact transmission-code and optional wheel/tire coverage",
+        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-40-tfsi-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "medium_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": false,
+      "usable_for_wheel_order": false,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "audi-8s-45-tfsi-roadster-eu-2022-dct7-fwd",
+    "brand": "Audi",
+    "type": "Roadster",
+    "market": "EU",
+    "model_code": "8S",
+    "body_code": "8S",
+    "production_start_year": 2022,
+    "production_end_year": 2022,
+    "model_name": "TT Roadster (8S, 2022)",
+    "variant_name": "45 TFSI",
+    "engine_code": "2.0L",
+    "engine_name": "2.0L I4 TFSI Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 11/2022 technical-data PDF confirms front-wheel drive for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
+      "value": "FWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 11/2022 technical-data PDF confirms 7-speed S tronic wording for the exact TT Roadster 45 TFSI 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+      "code": "DCT7",
+      "name": "7-speed S tronic"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
+        "value": 0.635
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
+        "value": [
+          3.4,
+          2.75,
+          1.767,
+          0.925,
+          0.705,
+          0.755,
+          0.635
+        ]
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 225/50 R17 as the basic tire for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 50.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
+          ],
+          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 225/50 R17 as the basic tire for the exact TT Roadster 45 TFSI S tronic 180 kW state represented by this 2022-only row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "Official Audi MediaCenter 11/2022 technical-data PDF confirms the exact TT Roadster 45 TFSI S tronic 180 kW mapping: front-wheel drive, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "Schema-safe encoding of the exact Audi TT Roadster 45 TFSI dual final-drive values",
+        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
+        ]
+      },
+      {
+        "item": "Audi TT Roadster 45 TFSI exact transmission-code and optional wheel/tire coverage",
+        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2022 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-2022-tech-data-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "medium_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": false,
+      "usable_for_wheel_order": false,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "audi-8s-45-tfsi-quattro-roadster-eu-2023-dct7-awd",
+    "brand": "Audi",
+    "type": "Roadster",
+    "market": "EU",
+    "model_code": "8S",
+    "body_code": "8S",
+    "production_start_year": 2023,
+    "production_end_year": 2023,
+    "model_name": "TT Roadster (8S, 2023)",
+    "variant_name": "45 TFSI quattro",
+    "engine_code": "2.0L",
+    "engine_name": "2.0L I4 TFSI Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TT Roadster 45 TFSI quattro 180 kW state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+      "code": "DCT7",
+      "name": "7-speed S tronic"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+        "value": 0.635
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635 for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+        "value": [
+          3.4,
+          2.75,
+          1.767,
+          0.925,
+          0.705,
+          0.755,
+          0.635
+        ]
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 50.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
+          ],
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 225/50 R17 as the basic tire for the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW state represented by this 2023-only row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 50.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TT Roadster 45 TFSI quattro S tronic 180 kW mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.400 / 2.750 / 1.767 / 0.925 / 0.705 / 0.755 / 0.635, Audi's published dual final-drive values 4.471 / 3.304, and a 225/50 R17 basic tire.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "Schema-safe encoding of the exact Audi TT Roadster 45 TFSI quattro dual final-drive values",
+        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
+        ]
+      },
+      {
+        "item": "Audi TT Roadster 45 TFSI quattro exact transmission-code and optional wheel/tire coverage",
+        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 225/50 R17 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tt-roadster-45-tfsi-quattro-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "medium_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": false,
+      "usable_for_wheel_order": false,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "audi-8s-tts-coupe-eu-2023-dct7-awd",
+    "brand": "Audi",
+    "type": "Coupe",
+    "market": "EU",
+    "model_code": "8S",
+    "body_code": "8S",
+    "production_start_year": 2023,
+    "production_end_year": 2023,
+    "model_name": "TTS Coupe (8S, 2023)",
+    "variant_name": "TTS",
+    "engine_code": "2.0L",
+    "engine_name": "2.0L I4 TFSI Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TTS Coupe state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+      "code": "DCT7",
+      "name": "7-speed S tronic"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.661 as the 7th-gear ratio for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
+        "value": 0.661
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661 for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
+        "value": [
+          3.19,
+          2.75,
+          1.897,
+          1.04,
+          0.793,
+          0.86,
+          0.661
+        ]
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 245/40 R18 as the basic tire for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
+        "front": {
+          "width_mm": 245.0,
+          "aspect_pct": 40.0,
+          "rim_in": 18.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
+          ],
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 245/40 R18 as the basic tire for the exact late-cycle TTS Coupe state represented by this 2023-only row.",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 18\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TTS Coupe mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661, Audi's published dual final-drive values 4.471 / 3.304, and a 245/40 R18 basic tire.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "Schema-safe encoding of the exact Audi TTS dual final-drive values",
+        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
+        ]
+      },
+      {
+        "item": "Audi TTS exact transmission-code and optional wheel/tire coverage",
+        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 245/40 R18 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-coupe-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "medium_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": false,
+      "usable_for_wheel_order": false,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "audi-8s-tts-roadster-eu-2023-dct7-awd",
+    "brand": "Audi",
+    "type": "Roadster",
+    "market": "EU",
+    "model_code": "8S",
+    "body_code": "8S",
+    "production_start_year": 2023,
+    "production_end_year": 2023,
+    "model_name": "TTS Roadster (8S, 2023)",
+    "variant_name": "TTS",
+    "engine_code": "2.0L",
+    "engine_name": "2.0L I4 TFSI Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms on-demand quattro AWD with electronically controlled multi-plate clutch for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
+      ],
+      "notes": "Official Audi MediaCenter 01/2023 technical-data PDF confirms 7-speed S tronic wording for the exact late-cycle TTS Roadster state. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDF does not publish a gearbox-family code.",
+      "code": "DCT7",
+      "name": "7-speed S tronic"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 0.661 as the 7th-gear ratio for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
+        "value": 0.661
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists the forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661 for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
+        "value": [
+          3.19,
+          2.75,
+          1.897,
+          1.04,
+          0.793,
+          0.86,
+          0.661
+        ]
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 245/40 R18 as the basic tire for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
+        "front": {
+          "width_mm": 245.0,
+          "aspect_pct": 40.0,
+          "rim_in": 18.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
+          ],
+          "notes": "Official Audi MediaCenter 01/2023 technical-data PDF lists 245/40 R18 as the basic tire for the exact late-cycle TTS Roadster state represented by this 2023-only row.",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 40.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 18\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "Official Audi MediaCenter 01/2023 technical-data PDF confirms the exact late-cycle TTS Roadster mapping: on-demand quattro AWD with electronically controlled multi-plate clutch, 7-speed S tronic, forward ratios 3.190 / 2.750 / 1.897 / 1.040 / 0.793 / 0.860 / 0.661, Audi's published dual final-drive values 4.471 / 3.304, and a 245/40 R18 basic tire.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "Schema-safe encoding of the exact Audi TTS Roadster dual final-drive values",
+        "reason": "The checked exact Audi technical-data PDF publishes two final-drive values 4.471 / 3.304 under Audi's 'final drive ratio 1-2 / 2-3' label, and this pass does not assume those map cleanly to the canonical front/rear final-drive fields.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
+        ]
+      },
+      {
+        "item": "Audi TTS Roadster exact transmission-code and optional wheel/tire coverage",
+        "reason": "Official Audi sources prove 7-speed S tronic wording, the full ratio set, and the 245/40 R18 basic tire for the exact 2023 state, but they do not publish the gearbox-family code or the full optional wheel/tire matrix for the exact target.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-tts-roadster-2023-tech-data-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "medium_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": false,
+      "usable_for_wheel_order": false,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "audi-8s-tt-rs-coupe-eu-2022-dct7-awd",
+    "brand": "Audi",
+    "type": "Coupe",
+    "market": "EU",
+    "model_code": "8S",
+    "body_code": "8S",
+    "production_start_year": 2022,
+    "production_end_year": 2022,
+    "model_name": "TT RS Coupe (8S, 2022)",
+    "variant_name": "TT RS",
+    "engine_code": "2.5L",
+    "engine_name": "2.5L I5 TFSI Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf",
+        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+      ],
+      "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm all-wheel drive for the exact TT RS Coupe state represented by this 2022-only row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf",
+        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+      ],
+      "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm 7-speed S tronic wording for the exact TT RS Coupe state represented by this 2022-only row. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDFs do not publish a gearbox-family code.",
+      "code": "DCT7",
+      "name": "7-speed S tronic"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT RS Coupe state represented by this 2022-only row.",
+        "value": 0.635
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists the forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635 for the exact TT RS Coupe state represented by this 2022-only row.",
+        "value": [
+          3.563,
+          2.526,
+          1.679,
+          1.022,
+          0.788,
+          0.761,
+          0.635
+        ]
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 245/35 R19 as the basic tire for the exact TT RS Coupe state represented by this 2022-only row.",
+        "front": {
+          "width_mm": 245.0,
+          "aspect_pct": 35.0,
+          "rim_in": 19.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
+          ],
+          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 245/35 R19 as the basic tire for the exact TT RS Coupe state represented by this 2022-only row.",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 19\""
+        },
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+          ],
+          "notes": "Official Audi MediaCenter TT RS basic-info PDF states that the TT RS Coupe is optionally available with 255/30 R20 tires.",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 30.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Optional 20\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "Official Audi MediaCenter technical-data and basic-info PDFs confirm the exact TT RS Coupe mapping: all-wheel drive, 7-speed S tronic, forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635, 245/35 R19 basic tires, and the optional 255/30 R20 package.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf",
+          "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "Audi TT RS Coupe exact final-drive value",
+        "reason": "The checked exact Audi technical-data PDF does not publish a final-drive value for the TT RS Coupe.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-ttrs-coupe-2022-tech-data-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "medium_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": false,
+      "usable_for_driveshaft_order": false,
+      "usable_for_wheel_order": false,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "audi-8s-tt-rs-roadster-eu-2022-dct7-awd",
+    "brand": "Audi",
+    "type": "Roadster",
+    "market": "EU",
+    "model_code": "8S",
+    "body_code": "8S",
+    "production_start_year": 2022,
+    "production_end_year": 2022,
+    "model_name": "TT RS Roadster (8S, 2022)",
+    "variant_name": "TT RS",
+    "engine_code": "2.5L",
+    "engine_name": "2.5L I5 TFSI Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf",
+        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+      ],
+      "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm all-wheel drive for the exact TT RS Roadster state represented by this 2022-only row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf",
+        "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+      ],
+      "notes": "Official Audi MediaCenter technical-data and basic-info PDFs confirm 7-speed S tronic wording for the exact TT RS Roadster state represented by this 2022-only row. The repo keeps DCT7 as the canonical gearbox-family mapping because the official Audi PDFs do not publish a gearbox-family code.",
+      "code": "DCT7",
+      "name": "7-speed S tronic"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 0.635 as the 7th-gear ratio for the exact TT RS Roadster state represented by this 2022-only row.",
+        "value": 0.635
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists the forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635 for the exact TT RS Roadster state represented by this 2022-only row.",
+        "value": [
+          3.563,
+          2.526,
+          1.679,
+          1.022,
+          0.788,
+          0.761,
+          0.635
+        ]
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
+        ],
+        "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 245/35 R19 as the basic tire for the exact TT RS Roadster state represented by this 2022-only row.",
+        "front": {
+          "width_mm": 245.0,
+          "aspect_pct": 35.0,
+          "rim_in": 19.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
+          ],
+          "notes": "Official Audi MediaCenter 11/2022 technical-data PDF lists 245/35 R19 as the basic tire for the exact TT RS Roadster state represented by this 2022-only row.",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 35.0,
+            "rim_in": 19.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 19\""
+        },
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+          ],
+          "notes": "Official Audi MediaCenter TT RS basic-info PDF states that the TT RS Roadster is optionally available with 255/30 R20 tires.",
+          "front": {
+            "width_mm": 255.0,
+            "aspect_pct": 30.0,
+            "rim_in": 20.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Optional 20\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "Official Audi MediaCenter technical-data and basic-info PDFs confirm the exact TT RS Roadster mapping: all-wheel drive, 7-speed S tronic, forward ratios 3.563 / 2.526 / 1.679 / 1.022 / 0.788 / 0.761 / 0.635, 245/35 R19 basic tires, and the optional 255/30 R20 package.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf",
+          "audi_mediacenter_sources:8s-ttrs-basic-info-2016-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "Audi TT RS Roadster exact final-drive value",
+        "reason": "The checked exact Audi technical-data PDF does not publish a final-drive value for the TT RS Roadster.",
+        "evidence_refs": [
+          "audi_mediacenter_sources:8s-ttrs-roadster-2022-tech-data-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "medium_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": false,
+      "usable_for_driveshaft_order": false,
       "usable_for_wheel_order": false,
       "requires_manual_confirmation": true
     }

--- a/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/F25.json
+++ b/apps/server/vibesensor/data/vehicle_configurations/bmw/x3/F25.json
@@ -1,5 +1,277 @@
 [
   {
+    "id": "bmw-f25-xdrive20d-eu-2011-mt6-awd",
+    "brand": "BMW",
+    "type": "SUV",
+    "market": "EU",
+    "model_code": "F25",
+    "body_code": "F25",
+    "production_start_year": 2011,
+    "production_end_year": 2011,
+    "model_name": "X3 (F25, 2011)",
+    "variant_name": "xDrive20d",
+    "engine_code": "2.0D",
+    "engine_name": "2.0L I4 Turbo Diesel",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive20d 6-speed manual launch state represented by this narrowed 2011 row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 03/2011 technical-data PDF confirms a 6-speed manual transmission for the exact X3 xDrive20d launch state represented by this narrowed 2011 row. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission.",
+      "code": "MT6",
+      "name": "6-speed manual"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF lists 0.659 as the top-gear ratio for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row.",
+        "value": 0.659
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row.",
+        "value": [
+          4.11,
+          2.248,
+          1.403,
+          1.0,
+          0.802,
+          0.659
+        ]
+      },
+      "final_drive_front": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "value": 3.727
+      },
+      "final_drive_rear": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "value": 3.727
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 60.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+          ],
+          "notes": "The official BMW 03/2011 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive20d 6-speed manual configuration represented by this narrowed row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "The official BMW 03/2011 technical-data PDF establishes the exact launch-state X3 xDrive20d manual row: AWD, 6-speed manual, forward ratios 4.110 / 2.248 / 1.403 / 1.000 / 0.802 / 0.659, a single published 3.727 final-drive ratio, and 225/60 R17 baseline tires.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "BMW X3 xDrive20d exact optional wheel/tire matrix for the narrowed 2011 row",
+        "reason": "The checked official BMW technical-data sheet closes the baseline fitment for this exact row, but it does not prove one exact optional wheel/tire matrix.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ]
+      },
+      {
+        "item": "BMW X3 xDrive20d separate front/rear final-drive publication",
+        "reason": "BMW publishes one exact final-drive ratio for this AWD state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "high_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": true,
+      "usable_for_wheel_order": true,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "bmw-f25-xdrive20d-eu-2011-zf8hp-awd",
+    "brand": "BMW",
+    "type": "SUV",
+    "market": "EU",
+    "model_code": "F25",
+    "body_code": "F25",
+    "production_start_year": 2011,
+    "production_end_year": 2011,
+    "model_name": "X3 (F25, 2011)",
+    "variant_name": "xDrive20d",
+    "engine_code": "2.0D",
+    "engine_name": "2.0L I4 Turbo Diesel",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive20d 8-speed automatic launch state represented by this narrowed 2011 row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 03/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive20d launch state represented by this narrowed 2011 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+      "code": "ZF8HP",
+      "name": "8-speed automatic (ZF 8HP)"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row.",
+        "value": 0.667
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row.",
+        "value": [
+          4.714,
+          3.143,
+          2.106,
+          1.667,
+          1.285,
+          1.0,
+          0.839,
+          0.667
+        ]
+      },
+      "final_drive_front": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.077 final-drive ratio for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "value": 3.077
+      },
+      "final_drive_rear": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.077 final-drive ratio for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "value": 3.077
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 60.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+          ],
+          "notes": "The official BMW 03/2011 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive20d 8-speed automatic configuration represented by this narrowed row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "The official BMW 03/2011 technical-data PDF establishes the exact launch-state X3 xDrive20d automatic row: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 3.077 final-drive ratio, and 225/60 R17 baseline tires.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "BMW X3 xDrive20d exact optional wheel/tire matrix for the narrowed 2011 row",
+        "reason": "The checked official BMW technical-data sheet closes the baseline fitment for this exact row, but it does not prove one exact optional wheel/tire matrix.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ]
+      },
+      {
+        "item": "BMW X3 xDrive20d separate front/rear final-drive publication",
+        "reason": "BMW publishes one exact final-drive ratio for this AWD state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "high_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": true,
+      "usable_for_wheel_order": true,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
     "id": "bmw-f25-xdrive20i-eu-2011-mt6-awd",
     "brand": "BMW",
     "type": "SUV",
@@ -357,8 +629,8 @@
     "model_code": "F25",
     "body_code": "F25",
     "production_start_year": 2011,
-    "production_end_year": 2017,
-    "model_name": "X3 (F25, 2011-2017)",
+    "production_end_year": 2011,
+    "model_name": "X3 (F25, 2011)",
     "variant_name": "xDrive28i",
     "engine_code": "3.0L",
     "engine_name": "3.0L I6",
@@ -366,17 +638,17 @@
     "drivetrain": {
       "confidence": "official_exact",
       "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+        "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
       ],
-      "notes": "The official BMW 09/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive28i automatic configuration.",
+      "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive28i automatic configuration.",
       "value": "AWD"
     },
     "transmission": {
       "confidence": "official_derived",
       "evidence_refs": [
-        "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+        "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
       ],
-      "notes": "The official BMW 09/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive28i automatic configuration. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
+      "notes": "The official BMW 03/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive28i automatic configuration. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official 8-speed automatic.",
       "code": "ZF8HP",
       "name": "8-speed automatic (ZF 8HP)"
     },
@@ -384,17 +656,17 @@
       "top_gear_ratio": {
         "confidence": "official_exact",
         "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
         ],
-        "notes": "The official BMW 09/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive28i 8-speed automatic configuration.",
+        "notes": "The official BMW 03/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive28i 8-speed automatic configuration.",
         "value": 0.667
       },
       "gear_ratios": {
         "confidence": "official_exact",
         "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
         ],
-        "notes": "The official BMW 09/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive28i 8-speed automatic configuration.",
+        "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive28i 8-speed automatic configuration.",
         "value": [
           4.714,
           3.143,
@@ -409,17 +681,17 @@
       "final_drive_front": {
         "confidence": "official_derived",
         "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
         ],
-        "notes": "The official BMW 09/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive28i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive28i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
         "value": 3.727
       },
       "final_drive_rear": {
         "confidence": "official_derived",
         "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
         ],
-        "notes": "The official BMW 09/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive28i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 3.727 final-drive ratio for the exact X3 xDrive28i automatic configuration. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
         "value": 3.727
       }
     },
@@ -427,9 +699,9 @@
       "default": {
         "confidence": "official_exact",
         "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
         ],
-        "notes": "The official BMW 09/2011 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive28i automatic configuration.",
+        "notes": "The official BMW 03/2011 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive28i automatic configuration.",
         "front": {
           "width_mm": 225.0,
           "aspect_pct": 60.0,
@@ -441,9 +713,9 @@
         {
           "confidence": "official_exact",
           "evidence_refs": [
-            "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+            "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
           ],
-          "notes": "The official BMW 09/2011 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive28i automatic configuration.",
+          "notes": "The official BMW 03/2011 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive28i automatic configuration.",
           "front": {
             "width_mm": 225.0,
             "aspect_pct": 60.0,
@@ -492,28 +764,437 @@
     },
     "verification_notes": [
       {
-        "note": "The official BMW 09/2011 technical-data PDF now confirms the exact X3 xDrive28i automatic configuration: xDrive AWD, 8-speed automatic with Steptronic wording, 2996 cc inline-6 engine identity, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published final-drive ratio of 3.727, and 225/60 R17 baseline tires.",
+        "note": "The official BMW 03/2011 technical-data PDF shows that the exact early X3 xDrive28i row is a 2996 cc inline-6 AWD automatic configuration with the 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667 ratio set, a single published 3.727 final-drive ratio, and 225/60 R17 baseline tires. The official 03/2012 refresh sheet then changes xDrive28i to a 1997 cc four-cylinder state with a 3.385 final drive, so the old 2011-2017 broad row was split instead of preserving one mixed-era mapping.",
         "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf",
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
         ]
-      },
-      {
-        "note": "Legacy variant-source research previously recorded this variant as BMW press release with High confidence."
       }
     ],
     "unresolved": [
       {
-        "item": "BMW X3 (F25, 2011-2017) EU ratio-relevant variant mapping",
-        "reason": "The official BMW 09/2011 technical-data PDF safely resolves the exact xDrive28i automatic launch-state ratio package, but this row still lacks exact optional wheel-package continuity across the broader represented span.",
+        "item": "BMW X3 xDrive28i exact optional wheel/tire matrix for the narrowed 2011 row",
+        "reason": "The checked official BMW 03/2011 launch technical-data sheet close the baseline 17-inch fitment, but they do not prove one exact optional wheel/tire matrix for the narrowed row.",
         "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
         ]
       },
       {
-        "item": "BMW X3 (F25, 2011-2017) variant-level final_drive_ratio and top_gear_ratio confirmation",
-        "reason": "The official BMW 09/2011 technical-data PDF publishes one exact final-drive ratio for the xDrive28i automatic state; the repo duplicates that value across front and rear final-drive fields because BMW does not publish separate axle ratios in this sheet.",
+        "item": "BMW X3 xDrive28i separate front/rear final-drive publication",
+        "reason": "BMW publishes one exact final-drive ratio for this AWD automatic state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
         "evidence_refs": [
-          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf"
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2011-03-tech-spec-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "high_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": true,
+      "usable_for_wheel_order": true,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "bmw-f25-xdrive28i-eu-2012-zf8hp-awd",
+    "brand": "BMW",
+    "type": "SUV",
+    "market": "EU",
+    "model_code": "F25",
+    "body_code": "F25",
+    "production_start_year": 2012,
+    "production_end_year": 2012,
+    "model_name": "X3 (F25, 2012)",
+    "variant_name": "xDrive28i",
+    "engine_code": "N20",
+    "engine_name": "N20 2.0L I4 Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 03/2012 technical-data PDF confirms xDrive all-wheel drive for the refreshed X3 xDrive28i automatic state represented by this narrowed 2012 row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 03/2012 technical-data PDF confirms 8-speed automatic with Steptronic wording for the refreshed X3 xDrive28i state represented by this narrowed 2012 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+      "code": "ZF8HP",
+      "name": "8-speed automatic (ZF 8HP)"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2012 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row.",
+        "value": 0.667
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2012 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row.",
+        "value": [
+          4.714,
+          3.143,
+          2.106,
+          1.667,
+          1.285,
+          1.0,
+          0.839,
+          0.667
+        ]
+      },
+      "final_drive_front": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2012 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "value": 3.385
+      },
+      "final_drive_rear": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2012 technical-data PDF publishes a single 3.385 final-drive ratio for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "value": 3.385
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2012 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 60.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+          ],
+          "notes": "The official BMW 03/2012 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive28i 8-speed automatic configuration represented by this narrowed row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "The official BMW 03/2012 technical-data PDF establishes the corrected X3 xDrive28i automatic row for the four-cylinder era: AWD, 8-speed automatic with Steptronic, 1997 cc inline-4 turbo engine identity, the same forward ratio set, a lower 3.385 final-drive ratio, and 225/60 R17 baseline tires.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "BMW X3 xDrive28i exact optional wheel/tire matrix for the narrowed 2012 row",
+        "reason": "The checked official BMW technical-data sheet closes the baseline fitment for this exact row, but it does not prove one exact optional wheel/tire matrix.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+        ]
+      },
+      {
+        "item": "BMW X3 xDrive28i separate front/rear final-drive publication",
+        "reason": "BMW publishes one exact final-drive ratio for this AWD state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive28i-35i-2012-03-tech-spec-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "high_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": true,
+      "usable_for_wheel_order": true,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "bmw-f25-xdrive30d-eu-2011-zf8hp-awd",
+    "brand": "BMW",
+    "type": "SUV",
+    "market": "EU",
+    "model_code": "F25",
+    "body_code": "F25",
+    "production_start_year": 2011,
+    "production_end_year": 2011,
+    "model_name": "X3 (F25, 2011)",
+    "variant_name": "xDrive30d",
+    "engine_code": "3.0D",
+    "engine_name": "3.0L I6 Turbo Diesel",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 03/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive30d 8-speed automatic launch state represented by this narrowed 2011 row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 03/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive30d launch state represented by this narrowed 2011 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+      "code": "ZF8HP",
+      "name": "8-speed automatic (ZF 8HP)"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row.",
+        "value": 0.667
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row.",
+        "value": [
+          4.714,
+          3.143,
+          2.106,
+          1.667,
+          1.285,
+          1.0,
+          0.839,
+          0.667
+        ]
+      },
+      "final_drive_front": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 2.813 final-drive ratio for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "value": 2.813
+      },
+      "final_drive_rear": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF publishes a single 2.813 final-drive ratio for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "value": 2.813
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 03/2011 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 60.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+          ],
+          "notes": "The official BMW 03/2011 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 xDrive30d 8-speed automatic configuration represented by this narrowed row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "The official BMW 03/2011 technical-data PDF establishes the exact launch-state X3 xDrive30d automatic row: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 2.813 final-drive ratio, and 225/60 R17 baseline tires.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "BMW X3 xDrive30d exact optional wheel/tire matrix for the narrowed 2011 row",
+        "reason": "The checked official BMW technical-data sheet closes the baseline fitment for this exact row, but it does not prove one exact optional wheel/tire matrix.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ]
+      },
+      {
+        "item": "BMW X3 xDrive30d separate front/rear final-drive publication",
+        "reason": "BMW publishes one exact final-drive ratio for this AWD state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive20d-xdrive30d-2011-03-tech-spec-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "high_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": true,
+      "usable_for_wheel_order": true,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "bmw-f25-xdrive35d-eu-2011-zf8hp-awd",
+    "brand": "BMW",
+    "type": "SUV",
+    "market": "EU",
+    "model_code": "F25",
+    "body_code": "F25",
+    "production_start_year": 2011,
+    "production_end_year": 2011,
+    "model_name": "X3 (F25, 2011)",
+    "variant_name": "xDrive35d",
+    "engine_code": "3.0D",
+    "engine_name": "3.0L I6 Turbo Diesel",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 09/2011 technical-data PDF confirms xDrive all-wheel drive for the exact X3 xDrive35d 8-speed automatic state represented by this narrowed 2011 row.",
+      "value": "AWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 09/2011 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 xDrive35d state represented by this narrowed 2011 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+      "code": "ZF8HP",
+      "name": "8-speed automatic (ZF 8HP)"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 09/2011 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row.",
+        "value": 0.667
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 09/2011 technical-data PDF lists the full forward gear-ratio set for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row.",
+        "value": [
+          4.714,
+          3.143,
+          2.106,
+          1.667,
+          1.285,
+          1.0,
+          0.839,
+          0.667
+        ]
+      },
+      "final_drive_front": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 09/2011 technical-data PDF publishes a single 2.813 final-drive ratio for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "value": 2.813
+      },
+      "final_drive_rear": {
+        "confidence": "official_derived",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 09/2011 technical-data PDF publishes a single 2.813 final-drive ratio for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row. The repo duplicates that exact published ratio across the front and rear final-drive fields for the canonical AWD representation.",
+        "value": 2.813
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 09/2011 technical-data PDF lists 245/50 R18 as the baseline tire for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row.",
+        "front": {
+          "width_mm": 245.0,
+          "aspect_pct": 50.0,
+          "rim_in": 18.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
+          ],
+          "notes": "The official BMW 09/2011 technical-data PDF lists 245/50 R18 as the baseline tire for the exact X3 xDrive35d 8-speed automatic configuration represented by this narrowed row.",
+          "front": {
+            "width_mm": 245.0,
+            "aspect_pct": 50.0,
+            "rim_in": 18.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 18\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "The official BMW 09/2011 technical-data PDF establishes the exact X3 xDrive35d row: AWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, a single published 2.813 final-drive ratio, and 245/50 R18 baseline tires.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "BMW X3 xDrive35d exact optional wheel/tire matrix for the narrowed 2011 row",
+        "reason": "The checked official BMW technical-data sheet closes the baseline fitment for this exact row, but it does not prove one exact optional wheel/tire matrix.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
+        ]
+      },
+      {
+        "item": "BMW X3 xDrive35d separate front/rear final-drive publication",
+        "reason": "BMW publishes one exact final-drive ratio for this AWD state; the repo duplicates that value across front and rear axle fields because the source does not expose separate axle-specific numbers.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-xdrive30d-xdrive35d-2011-09-tech-spec-pdf"
         ]
       }
     ],
@@ -698,6 +1379,370 @@
         "evidence_refs": [
           "bmw_pressclub_sources:f25-xdrive28i-35i-2011-tech-spec-pdf",
           "bmw_pressclub_sources:f25-xdrive35i-2014-tech-spec-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "high_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": true,
+      "usable_for_wheel_order": true,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "bmw-f25-sdrive18d-eu-2012-mt6-rwd",
+    "brand": "BMW",
+    "type": "SUV",
+    "market": "EU",
+    "model_code": "F25",
+    "body_code": "F25",
+    "production_start_year": 2012,
+    "production_end_year": 2012,
+    "model_name": "X3 (F25, 2012)",
+    "variant_name": "sDrive18d",
+    "engine_code": "2.0D",
+    "engine_name": "2.0L I4 Turbo Diesel",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 11/2012 technical-data PDF confirms rear-wheel drive for the exact X3 sDrive18d 6-speed manual state represented by this narrowed 2012 row.",
+      "value": "RWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 11/2012 technical-data PDF confirms a 6-speed manual transmission for the exact X3 sDrive18d state represented by this narrowed 2012 row. The repo keeps MT6 as the canonical gearbox-family mapping for that official manual transmission.",
+      "code": "MT6",
+      "name": "6-speed manual"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 11/2012 technical-data PDF lists 0.659 as the top-gear ratio for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
+        "value": 0.659
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 11/2012 technical-data PDF lists the full forward gear-ratio set for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
+        "value": [
+          4.11,
+          2.248,
+          1.403,
+          1.0,
+          0.802,
+          0.659
+        ]
+      },
+      "final_drive_rear": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 11/2012 technical-data PDF lists 3.462 as the final-drive ratio for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
+        "value": 3.462
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 11/2012 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 60.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+          ],
+          "notes": "The official BMW 11/2012 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 sDrive18d 6-speed manual configuration represented by this narrowed row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "The official BMW 11/2012 technical-data PDF establishes the exact X3 sDrive18d manual row: RWD, 6-speed manual, forward ratios 4.110 / 2.248 / 1.403 / 1.000 / 0.802 / 0.659, rear final drive 3.462, and 225/60 R17 baseline tires.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "BMW X3 sDrive18d exact optional wheel/tire matrix for the narrowed 2012 row",
+        "reason": "The checked official BMW technical-data sheet closes the baseline fitment for this exact row, but it does not prove one exact optional wheel/tire matrix.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "high_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": true,
+      "usable_for_wheel_order": true,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "bmw-f25-sdrive18d-eu-2012-zf8hp-rwd",
+    "brand": "BMW",
+    "type": "SUV",
+    "market": "EU",
+    "model_code": "F25",
+    "body_code": "F25",
+    "production_start_year": 2012,
+    "production_end_year": 2012,
+    "model_name": "X3 (F25, 2012)",
+    "variant_name": "sDrive18d",
+    "engine_code": "2.0D",
+    "engine_name": "2.0L I4 Turbo Diesel",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 11/2012 technical-data PDF confirms rear-wheel drive for the exact X3 sDrive18d 8-speed automatic state represented by this narrowed 2012 row.",
+      "value": "RWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 11/2012 technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 sDrive18d state represented by this narrowed 2012 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+      "code": "ZF8HP",
+      "name": "8-speed automatic (ZF 8HP)"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 11/2012 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
+        "value": 0.667
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 11/2012 technical-data PDF lists the full forward gear-ratio set for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
+        "value": [
+          4.714,
+          3.143,
+          2.106,
+          1.667,
+          1.285,
+          1.0,
+          0.839,
+          0.667
+        ]
+      },
+      "final_drive_rear": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 11/2012 technical-data PDF lists 3.077 as the final-drive ratio for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
+        "value": 3.077
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 11/2012 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 60.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+          ],
+          "notes": "The official BMW 11/2012 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 sDrive18d 8-speed automatic configuration represented by this narrowed row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "The official BMW 11/2012 technical-data PDF establishes the exact X3 sDrive18d automatic row: RWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.077, and 225/60 R17 baseline tires.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "BMW X3 sDrive18d exact optional wheel/tire matrix for the narrowed 2012 row",
+        "reason": "The checked official BMW technical-data sheet closes the baseline fitment for this exact row, but it does not prove one exact optional wheel/tire matrix.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive18d-2012-11-tech-spec-pdf"
+        ]
+      }
+    ],
+    "configuration_confidence": "high_confidence",
+    "order_analysis_policy": {
+      "usable_for_engine_order": true,
+      "usable_for_driveshaft_order": true,
+      "usable_for_wheel_order": true,
+      "requires_manual_confirmation": true
+    }
+  },
+  {
+    "id": "bmw-f25-sdrive20i-eu-2014-zf8hp-rwd",
+    "brand": "BMW",
+    "type": "SUV",
+    "market": "EU",
+    "model_code": "F25",
+    "body_code": "F25",
+    "production_start_year": 2014,
+    "production_end_year": 2014,
+    "model_name": "X3 (F25, 2014)",
+    "variant_name": "sDrive20i",
+    "engine_code": "N20",
+    "engine_name": "N20 2.0L I4 Turbo",
+    "fuel_type": "ICE",
+    "drivetrain": {
+      "confidence": "official_exact",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 04/2014 facelift technical-data PDF confirms rear-wheel drive for the exact X3 sDrive20i automatic state represented by this narrowed 2014 row.",
+      "value": "RWD"
+    },
+    "transmission": {
+      "confidence": "official_derived",
+      "evidence_refs": [
+        "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
+      ],
+      "notes": "The official BMW 04/2014 facelift technical-data PDF confirms 8-speed automatic with Steptronic wording for the exact X3 sDrive20i state represented by this narrowed 2014 row. The repo keeps ZF8HP as the canonical gearbox-family mapping for that official automatic transmission.",
+      "code": "ZF8HP",
+      "name": "8-speed automatic (ZF 8HP)"
+    },
+    "ratios": {
+      "top_gear_ratio": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 04/2014 technical-data PDF lists 0.667 as the top-gear ratio for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
+        "value": 0.667
+      },
+      "gear_ratios": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 04/2014 technical-data PDF lists the full forward gear-ratio set for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
+        "value": [
+          4.714,
+          3.143,
+          2.106,
+          1.667,
+          1.285,
+          1.0,
+          0.839,
+          0.667
+        ]
+      },
+      "final_drive_rear": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 04/2014 technical-data PDF lists 3.385 as the final-drive ratio for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
+        "value": 3.385
+      }
+    },
+    "tires": {
+      "default": {
+        "confidence": "official_exact",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
+        ],
+        "notes": "The official BMW 04/2014 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
+        "front": {
+          "width_mm": 225.0,
+          "aspect_pct": 60.0,
+          "rim_in": 17.0
+        },
+        "default_axle_for_speed": "rear"
+      },
+      "options": [
+        {
+          "confidence": "official_exact",
+          "evidence_refs": [
+            "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
+          ],
+          "notes": "The official BMW 04/2014 technical-data PDF lists 225/60 R17 as the baseline tire for the exact X3 sDrive20i 8-speed automatic configuration represented by this narrowed row.",
+          "front": {
+            "width_mm": 225.0,
+            "aspect_pct": 60.0,
+            "rim_in": 17.0
+          },
+          "default_axle_for_speed": "rear",
+          "name": "Standard 17\""
+        }
+      ]
+    },
+    "verification_notes": [
+      {
+        "note": "The official BMW 04/2014 facelift technical-data PDF establishes the exact X3 sDrive20i automatic row: RWD, 8-speed automatic with Steptronic, forward ratios 4.714 / 3.143 / 2.106 / 1.667 / 1.285 / 1.000 / 0.839 / 0.667, rear final drive 3.385, and 225/60 R17 baseline tires.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
+        ]
+      }
+    ],
+    "unresolved": [
+      {
+        "item": "BMW X3 sDrive20i exact optional wheel/tire matrix for the narrowed 2014 row",
+        "reason": "The checked official BMW technical-data sheet closes the baseline fitment for this exact row, but it does not prove one exact optional wheel/tire matrix.",
+        "evidence_refs": [
+          "bmw_pressclub_sources:f25-sdrive20i-xdrive20i-2014-04-tech-spec-pdf"
         ]
       }
     ],


### PR DESCRIPTION
# Summary

- Researched **exactly 100 counted Audi/BMW 2010+ exact configurations** for this run and kept the independent tracker at `100 / 100`.
- Applied the first validated production-safe canonical updates for:
  - `apps/server/vibesensor/data/vehicle_configurations/bmw/x3/F25.json`
  - `apps/server/vibesensor/data/vehicle_configurations/audi/tt/8S.json`
- Added the supporting machine-checkable source-pack records in:
  - `apps/server/vibesensor/data/car_sources/bmw_pressclub_sources.json`
  - `apps/server/vibesensor/data/car_sources/audi_mediacenter_sources.json`

## Subagent targets assigned

Concurrency cap was **5 active source-finding subagents max** for the whole run.

| Assignment | Counted exact configs | Outcome |
| --- | ---: | --- |
| BMW 4 Series Coupe F32 | 24 | counted |
| BMW 5 Series Sedan G30 | 15 | counted |
| Audi A4 Sedan B8 / B8.5 | 2 | counted |
| Audi A3 8V | 0 | not_counted / insufficient exact support |
| BMW 3 Series Sedan F30 | 15 | counted |
| BMW 5 Series Sedan F10 | 13 | counted |
| Audi A4 Sedan B9 / B9.5 | 8 | counted |
| BMW X3 F25 | 12 | counted |
| BMW 3 Series Sedan G20 | 11 | counted to reach exactly 100 |
| Audi TT / TTS / TT RS 8S | 0 | post-cap greedy production packet |
| BMW 4 Series G22/G23/G26 | 0 | post-cap greedy production packet |
| Audi A6 / S6 / RS6 C8 | 0 | post-cap greedy production packet |
| Audi Q5 / SQ5 8R | 0 | post-cap greedy production packet |
| Audi Q3 8U | 0 | post-cap tracker-only leads |

## Production data corrections

- **BMW X3 F25**
  - split the contradicted broad `xDrive28i` state into a **2011** early-I6 row and a **2012** later-2.0T row
  - added exact missing rows for `xDrive20d` MT6/ZF8HP, `xDrive30d`, `xDrive35d`, `sDrive18d` MT6/ZF8HP, and `sDrive20i`
- **Audi TT 8S**
  - added exact late-cycle rows for TT Coupé `45 TFSI` and `45 TFSI quattro`
  - added exact TT Roadster `40 TFSI`, `45 TFSI`, and `45 TFSI quattro` rows
  - added exact **TTS Coupé / TTS Roadster** rows
  - added exact **TT RS Coupé / TT RS Roadster** rows
  - kept TT/TTS dual-final-drive publication as explicit unresolved schema notes instead of guessing a front/rear mapping
  - kept TT RS final drive unresolved and marked the new TT RS rows manual-only for order analysis where required by the validator

## Source-pack updates

- Added BMW PressClub source records for the F25 exact launch / update PDFs used by the new and split X3 rows.
- Added Audi MediaCenter source records for exact TT/TTS/TT RS late-cycle technical-data PDFs and the TT RS basic-info PDF used for the 20-inch `255/30 R20` package.

## Confidence breakdown

Counted exact configurations only:

| Confidence | Count |
| --- | ---: |
| `high_confidence` | 90 |
| `medium_confidence` | 10 |
| `low_confidence` | 0 |
| `no_confidence` | 0 |

## Source quality breakdown

| Primary counted-evidence basis | Count |
| --- | ---: |
| Official BMW/Audi technical data, press kits, brochures, price lists, or homologation-style docs | 100 |
| Secondary-only counted configs | 0 |

Secondary sources were used only as corroboration or unresolved-note support for deferred packets; they were **not** used as the sole basis for counted configurations in this run.

## Unresolved / deferred configurations

- **Audi Q3 8U**: two strong official UK PDF leads identified, but the PDFs were not freshly reopened from this environment, so no canonical production edits were made.
- **Audi Q5 8R**: strong exact packet, but several exact final-drive/full-ratio mappings remain unresolved; kept as a deferred production candidate.
- **Audi A6 C8** and **BMW G22/G23/G26**: strong post-cap packets with useful contradictions and missing exact rows, but not included in this production patch.
- **Audi TT 45 manual / Roadster 45 manual**: facelift-era existence is supported, but exact ratio/final-drive/tire details remain incomplete.
- **Audi TT 45 quattro manual** and **TT 40 manual**: checked official evidence contradicts the broad legacy claims; they were not silently re-modeled in this patch without a full early-year replacement plan.

## Greedy same-source updates

### Accepted

| Area | Accepted greedy update | Why accepted |
| --- | --- | --- |
| Audi TT 8S | Added Roadster exact rows from the same late-cycle TT PDF family | exact body/style-specific official PDFs were already in hand |
| Audi TT 8S | Added TTS Coupé / Roadster exact rows from the same late-cycle Audi MediaCenter block | exact official drivetrain, ratio, and tire data were directly published |
| Audi TT 8S | Added TT RS optional `255/30 R20` tire package | exact package explicitly published in the official TT RS basic-info PDF |
| BMW X3 F25 | Added missing diesel / sDrive exact rows from the same PressClub PDF set | exact launch/update sheets clearly mapped to variant + gearbox + tire baseline |

### Rejected / deferred

| Area | Rejected / deferred update | Why deferred |
| --- | --- | --- |
| Audi Q3 8U | Promote UK PDF leads into canonical rows | official URLs identified, but no fresh PDF body/page capture from this environment |
| Audi Q5 8R | Rewrite broad ratio/final-drive rows | exact ratio/final-drive mapping still incomplete |
| Audi A6 C8 | Apply the post-cap contradiction packet | strong packet, but outside the current coherent patch batch |
| BMW G22/G23/G26 | Apply the post-cap exact packet | strong packet, but outside the current coherent patch batch |
| Audi TT / TTS | Encode `4.471 / 3.304` as front/rear final drives | official label is `final drive ratio 1-2 / 2-3`; front/rear mapping would be guessy |

## Important corrected / newly verified configurations

| Configuration | Change |
| --- | --- |
| BMW X3 F25 `xDrive28i` ZF8HP AWD | split broad row into distinct 2011 and 2012 exact states |
| BMW X3 F25 `xDrive20d` MT6 / ZF8HP AWD | added missing exact rows |
| BMW X3 F25 `sDrive18d` MT6 / ZF8HP RWD | added missing exact rows |
| Audi TT 8S Coupé `45 TFSI` 2023 DCT7 FWD | added exact late-cycle row with official ratios and 225/50 R17 baseline |
| Audi TT 8S Coupé `45 TFSI quattro` 2023 DCT7 AWD | added exact late-cycle row with official drivetrain wording and ratios |
| Audi TTS 8S Coupé / Roadster 2023 DCT7 AWD | added exact late-cycle rows missing from production data |
| Audi TT RS 8S Coupé / Roadster 2022 DCT7 AWD | added exact rows plus the official optional `255/30 R20` package |

## Important greedy updates

| Configuration area | Greedy update |
| --- | --- |
| Audi TT Roadster 8S | exact `40 TFSI`, `45 TFSI`, and `45 TFSI quattro` rows added from the same official source family |
| Audi TTS 8S | exact Coupé and Roadster rows added from the same official source family |
| Audi TT RS 8S | explicit `245/35 R19` standard and `255/30 R20` optional package captured |

## Validation run

- JSON parse and evidence-ref resolution for the changed source-pack and vehicle-configuration shards
- direct canonical load checks:
  - `load_vehicle_configurations()`
  - `load_car_library()`
- focused backend data tests under disposable Python `3.13` venv:
  - `apps/server/tests/adapters/persistence/test_vehicle_configurations.py`
  - `apps/server/tests/adapters/persistence/test_car_library.py`
  - `apps/server/tests/adapters/persistence/test_car_library_source_evidence.py`
  - `apps/server/tests/adapters/persistence/test_car_library_validation.py`
  - `apps/server/tests/hygiene/test_packaged_runtime_data_sync.py`
- `ruff format --check apps/server/vibesensor apps/server/tests tools`
- `git diff --check`

## Notes

- Tests were unchanged because this was a **data/source-only** change set.
- `.tmp/audi-bmw-ratio-research-20260427-1035/` remains gitignored and was not committed.
